### PR TITLE
Hadoop profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,10 +250,11 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
           <version>${hadoop.version}</version>
-	  <optional>true</optional>
+          <optional>true</optional>
         </dependency>
       </dependencies>
     </profile>
+
     <profile>
       <id>hadoop2</id>
       <properties>
@@ -262,24 +263,24 @@
         <classifier>hadoop2</classifier>
       </properties>
       <dependencies>
-	<dependency>
-	  <groupId>org.apache.hadoop</groupId>
-	  <artifactId>hadoop-core</artifactId>
-	  <version>${hadoop.version}</version>
-	  <optional>true</optional>
-	</dependency>
-	<dependency>
-	  <groupId>org.apache.hadoop</groupId>
-	  <artifactId>hadoop-client</artifactId>
-	  <version>${hadoop.version}</version>
-	  <optional>true</optional>
-	</dependency>
-	<dependency>
-	  <groupId>org.apache.ant</groupId>
-	  <artifactId>ant</artifactId>
-	  <version>1.9.0</version>
-	  <optional>true</optional>
-	</dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-core</artifactId>
+          <version>${hadoop.version}</version>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <version>${hadoop.version}</version>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+          <version>1.9.0</version>
+          <optional>true</optional>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
Refactored the pom.xml to incorporate the usage of profiles allowing building with different versions of Hadoop.  Similar to Spark, the Maven command line now ends up looking like:

  mvn -Phadoop1 package

or

  mvn -Phadoop2 package

Except for a bump of the log4j version, the hadoop1 profile builds exactly the same configuration as the pom.xml did before this PR.
