### PR TITLE
space information for HDFS fix

### DIFF
--- a/src/main/java/tachyon/MasterInfo.java
+++ b/src/main/java/tachyon/MasterInfo.java
@@ -1101,8 +1101,8 @@ public class MasterInfo {
   }
   
   public long getUnderFsFreeBytes() throws IOException {
-	    UnderFileSystem ufs = UnderFileSystem.get(CommonConf.get().UNDERFS_DATA_FOLDER);
-	    return ufs.getSpace(CommonConf.get().UNDERFS_DATA_FOLDER, SpaceType.SPACE_FREE);
+    UnderFileSystem ufs = UnderFileSystem.get(CommonConf.get().UNDERFS_DATA_FOLDER);
+    return ufs.getSpace(CommonConf.get().UNDERFS_DATA_FOLDER, SpaceType.SPACE_FREE);
   }
 
   public long getUsedBytes() {

--- a/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -189,28 +189,19 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
 
   @Override
   public long getSpace(String path, SpaceType type) throws IOException {
-	// Using ContentSummary from Hadoop available across Hadoop 1 and 2. 
-	// Using SpaceQuota and SpaceConsumed for info 
-	ContentSummary summary = mFs.getContentSummary(new Path(path));
-	switch(type) {
-	case SPACE_TOTAL:
-		long capacity = summary.getSpaceQuota();
-		// if there is no SpaceQuota on the Tachyon root directory in HDFS, 
-		// then default capacity to the capacity of the entire HDFS cluster
-		if (capacity < 0 && mFs instanceof DistributedFileSystem) {
-			capacity = ((DistributedFileSystem)mFs).getDiskStatus().getCapacity();
-		}
-		return capacity;
-	case SPACE_USED:
-		return summary.getSpaceConsumed();
-	case SPACE_FREE:
-		capacity = summary.getSpaceQuota();
-		if (capacity < 0 && mFs instanceof DistributedFileSystem) {
-			return ((DistributedFileSystem)mFs).getDiskStatus().getRemaining();
-		}
-		return capacity - summary.getSpaceConsumed();
-	}
-	return -1;
+    // Ignoring the path given, will give information for entire cluster
+    // as Tachyon can load/store data out of entire HDFS cluster
+    if (mFs instanceof DistributedFileSystem) {
+      switch(type) {
+        case SPACE_TOTAL:
+          return ((DistributedFileSystem) mFs).getDiskStatus().getCapacity();
+        case SPACE_USED:
+          return ((DistributedFileSystem) mFs).getDiskStatus().getDfsUsed();
+        case SPACE_FREE:
+          return ((DistributedFileSystem) mFs).getDiskStatus().getRemaining();
+      }
+    }
+    return -1;
   }
 
   @Override

--- a/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
+++ b/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
@@ -113,6 +113,8 @@ public class WebInterfaceGeneralServlet extends HttpServlet {
 
     request.setAttribute("usedCapacity", CommonUtils.getSizeFromBytes(mMasterInfo.getUsedBytes()));
       
+    request.setAttribute("freeCapacity", CommonUtils.getSizeFromBytes((mMasterInfo.getCapacityBytes()
+      - mMasterInfo.getUsedBytes()));
 
     long sizeBytes = mMasterInfo.getUnderFsCapacityBytes();
     if (sizeBytes >= 0) {
@@ -128,14 +130,6 @@ public class WebInterfaceGeneralServlet extends HttpServlet {
       request.setAttribute("diskUsedCapacity", "UNKNOWN");
     }
       
-    sizeBytes = mMasterInfo.getUnderFsFreeBytes();
-    if (sizeBytes >= 0) {
-      request.setAttribute("diskFreeCapacity", CommonUtils.getSizeFromBytes(sizeBytes));
-    } else {
-      request.setAttribute("diskFreeCapacity", "UNKNOWN");
-    }
-
-
     List<ClientWorkerInfo> workerInfos = mMasterInfo.getWorkersInfo();
     for (int i = 0; i < workerInfos.size(); i ++) {
       for (int j = i + 1; j < workerInfos.size(); j ++) {

--- a/src/main/java/tachyon/web/resources/general.jsp
+++ b/src/main/java/tachyon/web/resources/general.jsp
@@ -83,14 +83,19 @@
                   <th><%= request.getAttribute("usedCapacity") %></th>
                 </tr>
                 <tr>
+                  <th>Memory Free:</th>
+                  <!-- <th>${freeCapacity}</th> -->
+                  <th><%= request.getAttribute("freeCapacity") %></th>
+                </tr>
+                <tr>
                   <th>Disk Capacity:</th>
                   <!-- <th>${capacity}</th> -->
                   <th><%= request.getAttribute("diskCapacity") %></th>
                 </tr>
                 <tr>
-                  <th>Disk Used:</th>
+                  <th>Disk Free:</th>
                   <!-- <th>${usedCapacity}</th> -->
-                  <th><%= request.getAttribute("diskUsedCapacity") %></th>
+                  <th><%= request.getAttribute("diskFreeCapacity") %></th>
                 </tr>
 		<tr>
 		  <th>Disk Free:</th>


### PR DESCRIPTION
Not sure which API the comments were referring to, but using ContentSummary provided by Hadoop FileSystem APIs, we can get the space quotas for a given directory and the space consumed for a given directory, which should be satisfactory. 
