### PR TITLE
changes to allow fixed checkpoint for files for underlayer fs

### DIFF
--- a/src/main/java/tachyon/EditLog.java
+++ b/src/main/java/tachyon/EditLog.java
@@ -81,7 +81,7 @@ public class EditLog {
         }
         case OP_CREATE_FILE: {
           info._createFile(is.readBoolean(), Utils.readString(is), is.readBoolean(), is.readInt(), 
-              Utils.readByteBuffer(is), is.readLong(), is.readLong());
+	      Utils.readByteBuffer(is), is.readLong(), is.readLong(), is.readBoolean());
           break;
         }
         case OP_DELETE: {
@@ -165,7 +165,8 @@ public class EditLog {
   }
 
   public synchronized void createFile(boolean recursive, String path, boolean directory,
-      int columns, ByteBuffer metadata, long blockSizeByte, long creationTimeMs) {
+      int columns, ByteBuffer metadata, long blockSizeByte, long creationTimeMs, 
+        boolean transparent) {
     if (INACTIVE) {
       return;
     }
@@ -180,6 +181,7 @@ public class EditLog {
       Utils.writeByteBuffer(metadata, DOS);
       DOS.writeLong(blockSizeByte);
       DOS.writeLong(creationTimeMs);
+      DOS.writeBoolean(transparent);
     } catch (IOException e) {
       CommonUtils.runtimeException(e);
     }

--- a/src/main/java/tachyon/InodeFile.java
+++ b/src/main/java/tachyon/InodeFile.java
@@ -19,6 +19,7 @@ public class InodeFile extends Inode {
   private boolean mIsComplete = false;
   private boolean mPin = false;
   private boolean mCache = false;
+  private boolean mIsTransparent = false;
   private String mCheckpointPath = "";
   private List<BlockInfo> mBlocks = new ArrayList<BlockInfo>(3);
 
@@ -61,6 +62,18 @@ public class InodeFile extends Inode {
   public synchronized void setComplete(boolean complete) {
     mIsComplete = complete;
   }
+
+  public synchronized boolean isTransparent() {
+    return mIsTransparent;
+  }
+
+  public synchronized void setTransparent() {
+    mIsTransparent = true;
+  }
+
+  public synchronized void setTransparent(boolean transparent) {
+    mIsTransparent = transparent;
+  } 
 
   @Override
   public String toString() {
@@ -235,6 +248,7 @@ public class InodeFile extends Inode {
     ret.needPin = mPin;
     ret.needCache = mCache;
     ret.blockIds = getBlockIds();
+    ret.transparent = mIsTransparent;
 
     return ret;
   }

--- a/src/main/java/tachyon/MasterClient.java
+++ b/src/main/java/tachyon/MasterClient.java
@@ -242,12 +242,12 @@ public class MasterClient {
     }
   }
 
-  public synchronized int user_createFile(String path, long blockSizeByte) 
+  public synchronized int user_createFile(String path, long blockSizeByte, boolean transparent) 
       throws IOException, TException {
     while (true) {
       connect();
       try {
-        return mClient.user_createFile(path, blockSizeByte);
+	return mClient.user_createFile(path, blockSizeByte, transparent);
       } catch (FileAlreadyExistException | InvalidPathException | BlockInfoException e) {
         throw new IOException(e);
       } catch (TachyonException e) {
@@ -578,7 +578,8 @@ public class MasterClient {
       try {
         mClient.user_rename(srcPath, dstPath);
         return;
-      } catch (FileAlreadyExistException | FileDoesNotExistException | InvalidPathException e) {
+      } catch (FileAlreadyExistException | FileDoesNotExistException | InvalidPathException | 
+          TachyonException e) {
         throw new IOException(e);
       } catch (TTransportException e) {
         LOG.error(e.getMessage());
@@ -593,7 +594,8 @@ public class MasterClient {
       try {
         mClient.user_renameTo(fId, path);
         return;
-      } catch (FileAlreadyExistException | FileDoesNotExistException | InvalidPathException e) {
+      } catch (FileAlreadyExistException | FileDoesNotExistException | InvalidPathException |
+          TachyonException e) {
         throw new IOException(e);
       } catch (TTransportException e) {
         LOG.error(e.getMessage());

--- a/src/main/java/tachyon/MasterInfo.java
+++ b/src/main/java/tachyon/MasterInfo.java
@@ -352,7 +352,12 @@ public class MasterInfo {
 
   public int createFile(String path, long blockSizeByte)
       throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException {
-    return createFile(true, path, false, -1, null, blockSizeByte);
+    return createFile(path, blockSizeByte, false);
+  }
+
+  public int createFile(String path, long blockSizeByte, boolean transparent)
+      throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException {
+    return createFile(true, path, false, -1, null, blockSizeByte, transparent);
   }
 
   // TODO Make this API better.
@@ -372,11 +377,24 @@ public class MasterInfo {
    * @throws TachyonException
    */
   int _createFile(boolean recursive, String path, boolean directory, int columns,
-      ByteBuffer metadata, long blockSizeByte, long creationTimeMs)
+      ByteBuffer metadata, long blockSizeByte, long creationTimeMs, boolean transparent)
           throws FileAlreadyExistException, InvalidPathException, BlockInfoException,
           TachyonException {
     if (!directory && blockSizeByte < 1) {
       throw new BlockInfoException("Invalid block size " + blockSizeByte);
+    }
+
+    if (!directory && transparent) {
+      try {
+	String underFSPath = CommonConf.get().UNDERFS_ADDRESS + path;
+        UnderFileSystem ufs = UnderFileSystem.get(underFSPath);
+        if (ufs.exists(path)) {
+	  throw new FileAlreadyExistException("File is transparent and path: " + underFSPath +
+	    				         " already exists in the underlayer filesystem");
+        }
+      } catch (IOException e) {
+        throw new TachyonException(e.getMessage());
+      }
     }
 
     LOG.debug("createFile" + CommonUtils.parametersToString(path));
@@ -404,7 +422,7 @@ public class MasterInfo {
       if (inode == null) {
         int succeed = 0;
         if (recursive) {
-          succeed = createFile(true, folderPath, true, -1, null, blockSizeByte);
+	  succeed = createFile(true, folderPath, true, -1, null, blockSizeByte, false);
         }
         if (!recursive || succeed <= 0) {
           LOG.info("InvalidPathException: File " + path + " creation failed. Folder "
@@ -444,6 +462,7 @@ public class MasterInfo {
         if (mWhiteList.inList(curPath)) {
           ((InodeFile) ret).setCache(true);
         }
+         ((InodeFile) ret).setTransparent(transparent);
       }
 
       mInodes.put(ret.getId(), ret);
@@ -456,14 +475,15 @@ public class MasterInfo {
 
 
   public int createFile(boolean recursive, String path, boolean directory, int columns,
-      ByteBuffer metadata, long blockSizeByte)
+      ByteBuffer metadata, long blockSizeByte, boolean transparent)
           throws FileAlreadyExistException, InvalidPathException, BlockInfoException,
           TachyonException {
     long creationTimeMs = System.currentTimeMillis();
     int ret =
-        _createFile(recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
+        _createFile(recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs, 
+            transparent);
     mJournal.getEditLog().createFile(
-        recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
+        recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs, transparent);
     mJournal.getEditLog().flush();
     return ret;
   }
@@ -533,6 +553,7 @@ public class MasterInfo {
           boolean isPin = is.readBoolean();
           boolean isCache = is.readBoolean();
           String checkpointPath = Utils.readString(is);
+          boolean isTransparent = is.readBoolean();
 
           InodeFile tInode =
               new InodeFile(fileName, fileId, parentId, blockSizeByte, creationTimeMs);
@@ -546,6 +567,7 @@ public class MasterInfo {
           tInode.setPin(isPin);
           tInode.setCache(isCache);
           tInode.setCheckpointPath(checkpointPath);
+          tInode.setTransparent(isTransparent);
           inode = tInode;
         } else {
           int numberOfChildren = is.readInt();
@@ -601,6 +623,7 @@ public class MasterInfo {
       os.writeBoolean(file.isPin());
       os.writeBoolean(file.isCache());
       Utils.writeString(file.getCheckpointPath(), os);
+      os.writeBoolean(file.isTransparent());
     } else {
       InodeFolder folder = (InodeFolder) inode;
       if (folder.isRawTable()) {
@@ -672,7 +695,7 @@ public class MasterInfo {
 
     int id;
     try {
-      id = createFile(true, path, true, columns, metadata, 0);
+      id = createFile(true, path, true, columns, metadata, 0, false);
     } catch (BlockInfoException e) {
       throw new FileAlreadyExistException(e.getMessage());
     }
@@ -1248,7 +1271,7 @@ public class MasterInfo {
   public boolean mkdir(String path)
       throws FileAlreadyExistException, InvalidPathException, TachyonException {
     try {
-      return createFile(true, path, true, -1, null, 0) > 0;
+      return createFile(true, path, true, -1, null, 0, false) > 0;
     } catch (BlockInfoException e) {
       throw new FileAlreadyExistException(e.getMessage());
     }
@@ -1300,7 +1323,8 @@ public class MasterInfo {
   }
 
   private void rename(Inode srcInode, String dstPath)
-      throws FileAlreadyExistException, InvalidPathException, FileDoesNotExistException {
+      throws FileAlreadyExistException, InvalidPathException, FileDoesNotExistException,
+      TachyonException {
     if (getInode(dstPath) != null) {
       throw new FileAlreadyExistException("Failed to rename: " + dstPath + " already exist");
     }
@@ -1319,6 +1343,20 @@ public class MasterInfo {
           " does not exist.");
     }
 
+    if (!srcInode.isDirectory() && ((InodeFile)srcInode).isTransparent()) {
+      try {
+	String underFSPath = CommonConf.get().UNDERFS_ADDRESS + dstPath;
+        UnderFileSystem ufs = UnderFileSystem.get(underFSPath);
+        if (ufs.exists(dstPath)) {
+	  throw new FileAlreadyExistException("File is transparent and dst path: " + underFSPath +
+	    				         " already exists in the underlayer filesystem");
+        }
+	ufs.rename(((InodeFile) srcInode).getCheckpointPath(), underFSPath);
+      } catch (IOException e) {
+          throw new TachyonException(e.getMessage());
+      }
+    }
+
     srcInode.setName(dstName);
     InodeFolder parent = (InodeFolder) mInodes.get(srcInode.getParentId());
     parent.removeChild(srcInode.getId());
@@ -1330,7 +1368,8 @@ public class MasterInfo {
   }
 
   public void rename(int fileId, String dstPath)
-      throws FileDoesNotExistException, FileAlreadyExistException, InvalidPathException {
+      throws FileDoesNotExistException, FileAlreadyExistException, InvalidPathException,
+      TachyonException {
     synchronized (mRoot) {
       Inode inode = mInodes.get(fileId);
       if (inode == null) {
@@ -1342,7 +1381,8 @@ public class MasterInfo {
   }
 
   public void rename(String srcPath, String dstPath)
-      throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException {
+       throws FileAlreadyExistException, InvalidPathException, FileDoesNotExistException,
+       TachyonException {
     synchronized (mRoot) {
       Inode inode = getInode(srcPath);
       if (inode == null) {

--- a/src/main/java/tachyon/MasterServiceHandler.java
+++ b/src/main/java/tachyon/MasterServiceHandler.java
@@ -70,10 +70,10 @@ public class MasterServiceHandler implements MasterService.Iface {
   }
 
   @Override
-  public int user_createFile(String path, long blockSizeByte)
+    public int user_createFile(String path, long blockSizeByte, boolean transparent)
       throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException,
       TException {
-    return mMasterInfo.createFile(path, blockSizeByte);
+    return mMasterInfo.createFile(path, blockSizeByte, transparent);
   }
 
   @Override
@@ -249,13 +249,15 @@ public class MasterServiceHandler implements MasterService.Iface {
 
   @Override
   public void user_rename(String srcPath, String dstPath)
-      throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TException{
+      throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, 
+      TachyonException, TException {
     mMasterInfo.rename(srcPath, dstPath);
   }
 
   @Override
   public void user_renameTo(int fileId, String dstPath)
-      throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TException{
+      throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, 
+      TachyonException, TException {
     mMasterInfo.rename(fileId, dstPath);
   }
 

--- a/src/main/java/tachyon/WorkerStorage.java
+++ b/src/main/java/tachyon/WorkerStorage.java
@@ -25,6 +25,8 @@ import tachyon.thrift.FailedToCheckpointException;
 import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.NetAddress;
 import tachyon.thrift.SuspectedFileSizeException;
+import tachyon.thrift.ClientFileInfo;
+
 
 /**
  * The structure to store a worker's information in worker node.
@@ -135,8 +137,8 @@ public class WorkerStorage {
     // TODO This part need to be changed.
     String srcPath = getUserUnderfsTempFolder(userId) + "/" + fileId;
     String dstPath = COMMON_CONF.UNDERFS_DATA_FOLDER + "/" + fileId;
-    if (COMMON_CONF.USE_FIXED_CHECKPOINT) {
-      ClientFileInfo info = fetchClientFileInfo(fileId);
+    ClientFileInfo info = fetchClientFileInfo(fileId);
+    if (info.transparent) {
       dstPath = COMMON_CONF.UNDERFS_ADDRESS + info.path;
     }
     try {

--- a/src/main/java/tachyon/client/TachyonFS.java
+++ b/src/main/java/tachyon/client/TachyonFS.java
@@ -330,6 +330,15 @@ public class TachyonFS {
   }
 
   public synchronized int createFile(String path, long blockSizeByte) throws IOException {
+    boolean transparent = UserConf.get().TRANSPARENT_UNDERLAYER_FILE;
+    return createFile(path, blockSizeByte, transparent);
+  }
+
+  public synchronized int createFile(String path, boolean transparent) throws IOException {
+    return createFile(path, UserConf.get().DEFAULT_BLOCK_SIZE_BYTE, transparent);
+  }
+
+  public synchronized int createFile(String path, long blockSizeByte, boolean transparent) throws IOException {
     if (blockSizeByte > (long) Constants.GB * 2) {
       throw new IOException("Block size must be less than 2GB: " + blockSizeByte);
     }
@@ -341,7 +350,7 @@ public class TachyonFS {
     path = CommonUtils.cleanPath(path);
     int fid = -1;
     try {
-      fid = mMasterClient.user_createFile(path, blockSizeByte);
+      fid = mMasterClient.user_createFile(path, blockSizeByte, transparent);
     } catch (TException e) {
       mConnected = false;
       throw new IOException(e);

--- a/src/main/java/tachyon/conf/CommonConf.java
+++ b/src/main/java/tachyon/conf/CommonConf.java
@@ -10,7 +10,6 @@ public class CommonConf extends Utils {
   public final String UNDERFS_ADDRESS;
   public final String UNDERFS_DATA_FOLDER;
   public final String UNDERFS_WORKERS_FOLDER;
-  public final boolean USE_FIXED_CHECKPOINT;
 
   public final boolean USE_ZOOKEEPER;
   public final String ZOOKEEPER_ADDRESS;
@@ -23,7 +22,6 @@ public class CommonConf extends Utils {
     UNDERFS_DATA_FOLDER = UNDERFS_ADDRESS + getProperty("tachyon.data.folder", "/tachyon/data");
     UNDERFS_WORKERS_FOLDER = 
         UNDERFS_ADDRESS + getProperty("tachyon.workers.folder", "/tachyon/workers");
-    FIXED_CHECKPOINT = getBooleanProperty("tachyon.fixed.checkpoint", false); 
 
     USE_ZOOKEEPER = getBooleanProperty("tachyon.usezookeeper", false);
     if (USE_ZOOKEEPER) {

--- a/src/main/java/tachyon/conf/UserConf.java
+++ b/src/main/java/tachyon/conf/UserConf.java
@@ -12,6 +12,7 @@ public class UserConf extends Utils {
   public final long MASTER_CLIENT_TIMEOUT_MS;
   public final long DEFAULT_BLOCK_SIZE_BYTE;
   public final int REMOTE_READ_BUFFER_SIZE_BYTE;
+  public final boolean TRANSPARENT_UNDERLAYER_FILE;
 
   private UserConf() {
     FAILED_SPACE_REQUEST_LIMITS = getIntProperty("tachyon.user.failed.space.request.limits", 3);
@@ -23,6 +24,8 @@ public class UserConf extends Utils {
         getLongProperty("tachyon.user.default.block.size.byte", Constants.GB);
     REMOTE_READ_BUFFER_SIZE_BYTE =
         getIntProperty("tachyon.user.remote.read.buffer.size.byte", Constants.MB);
+    TRANSPARENT_UNDERLAYER_FILE = getBooleanProperty("tachyon.user.file.underlayer.transparent", false); 
+
   }
 
   public static synchronized UserConf get() {

--- a/src/main/java/tachyon/thrift/ClientFileInfo.java
+++ b/src/main/java/tachyon/thrift/ClientFileInfo.java
@@ -33,9 +33,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   private static final org.apache.thrift.protocol.TField COMPLETE_FIELD_DESC = new org.apache.thrift.protocol.TField("complete", org.apache.thrift.protocol.TType.BOOL, (short)8);
   private static final org.apache.thrift.protocol.TField FOLDER_FIELD_DESC = new org.apache.thrift.protocol.TField("folder", org.apache.thrift.protocol.TType.BOOL, (short)9);
   private static final org.apache.thrift.protocol.TField IN_MEMORY_FIELD_DESC = new org.apache.thrift.protocol.TField("inMemory", org.apache.thrift.protocol.TType.BOOL, (short)10);
-  private static final org.apache.thrift.protocol.TField NEED_PIN_FIELD_DESC = new org.apache.thrift.protocol.TField("needPin", org.apache.thrift.protocol.TType.BOOL, (short)11);
-  private static final org.apache.thrift.protocol.TField NEED_CACHE_FIELD_DESC = new org.apache.thrift.protocol.TField("needCache", org.apache.thrift.protocol.TType.BOOL, (short)12);
-  private static final org.apache.thrift.protocol.TField BLOCK_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("blockIds", org.apache.thrift.protocol.TType.LIST, (short)13);
+  private static final org.apache.thrift.protocol.TField TRANSPARENT_FIELD_DESC = new org.apache.thrift.protocol.TField("transparent", org.apache.thrift.protocol.TType.BOOL, (short)11);
+  private static final org.apache.thrift.protocol.TField NEED_PIN_FIELD_DESC = new org.apache.thrift.protocol.TField("needPin", org.apache.thrift.protocol.TType.BOOL, (short)12);
+  private static final org.apache.thrift.protocol.TField NEED_CACHE_FIELD_DESC = new org.apache.thrift.protocol.TField("needCache", org.apache.thrift.protocol.TType.BOOL, (short)13);
+  private static final org.apache.thrift.protocol.TField BLOCK_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("blockIds", org.apache.thrift.protocol.TType.LIST, (short)14);
 
   public int id; // required
   public String name; // required
@@ -47,6 +48,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   public boolean complete; // required
   public boolean folder; // required
   public boolean inMemory; // required
+  public boolean transparent; // required
   public boolean needPin; // required
   public boolean needCache; // required
   public List<Long> blockIds; // required
@@ -63,9 +65,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     COMPLETE((short)8, "complete"),
     FOLDER((short)9, "folder"),
     IN_MEMORY((short)10, "inMemory"),
-    NEED_PIN((short)11, "needPin"),
-    NEED_CACHE((short)12, "needCache"),
-    BLOCK_IDS((short)13, "blockIds");
+    TRANSPARENT((short)11, "transparent"),
+    NEED_PIN((short)12, "needPin"),
+    NEED_CACHE((short)13, "needCache"),
+    BLOCK_IDS((short)14, "blockIds");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -100,11 +103,13 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
           return FOLDER;
         case 10: // IN_MEMORY
           return IN_MEMORY;
-        case 11: // NEED_PIN
+        case 11: // TRANSPARENT
+          return TRANSPARENT;
+        case 12: // NEED_PIN
           return NEED_PIN;
-        case 12: // NEED_CACHE
+        case 13: // NEED_CACHE
           return NEED_CACHE;
-        case 13: // BLOCK_IDS
+        case 14: // BLOCK_IDS
           return BLOCK_IDS;
         default:
           return null;
@@ -153,9 +158,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   private static final int __COMPLETE_ISSET_ID = 4;
   private static final int __FOLDER_ISSET_ID = 5;
   private static final int __INMEMORY_ISSET_ID = 6;
-  private static final int __NEEDPIN_ISSET_ID = 7;
-  private static final int __NEEDCACHE_ISSET_ID = 8;
-  private BitSet __isset_bit_vector = new BitSet(9);
+  private static final int __TRANSPARENT_ISSET_ID = 7;
+  private static final int __NEEDPIN_ISSET_ID = 8;
+  private static final int __NEEDCACHE_ISSET_ID = 9;
+  private BitSet __isset_bit_vector = new BitSet(10);
 
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
@@ -179,6 +185,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     tmpMap.put(_Fields.FOLDER, new org.apache.thrift.meta_data.FieldMetaData("folder", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.IN_MEMORY, new org.apache.thrift.meta_data.FieldMetaData("inMemory", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.TRANSPARENT, new org.apache.thrift.meta_data.FieldMetaData("transparent", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.NEED_PIN, new org.apache.thrift.meta_data.FieldMetaData("needPin", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
@@ -205,6 +213,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     boolean complete,
     boolean folder,
     boolean inMemory,
+    boolean transparent,
     boolean needPin,
     boolean needCache,
     List<Long> blockIds)
@@ -227,6 +236,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     setFolderIsSet(true);
     this.inMemory = inMemory;
     setInMemoryIsSet(true);
+    this.transparent = transparent;
+    setTransparentIsSet(true);
     this.needPin = needPin;
     setNeedPinIsSet(true);
     this.needCache = needCache;
@@ -256,6 +267,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     this.complete = other.complete;
     this.folder = other.folder;
     this.inMemory = other.inMemory;
+    this.transparent = other.transparent;
     this.needPin = other.needPin;
     this.needCache = other.needCache;
     if (other.isSetBlockIds()) {
@@ -290,6 +302,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     this.folder = false;
     setInMemoryIsSet(false);
     this.inMemory = false;
+    setTransparentIsSet(false);
+    this.transparent = false;
     setNeedPinIsSet(false);
     this.needPin = false;
     setNeedCacheIsSet(false);
@@ -530,6 +544,29 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     __isset_bit_vector.set(__INMEMORY_ISSET_ID, value);
   }
 
+  public boolean isTransparent() {
+    return this.transparent;
+  }
+
+  public ClientFileInfo setTransparent(boolean transparent) {
+    this.transparent = transparent;
+    setTransparentIsSet(true);
+    return this;
+  }
+
+  public void unsetTransparent() {
+    __isset_bit_vector.clear(__TRANSPARENT_ISSET_ID);
+  }
+
+  /** Returns true if field transparent is set (has been assigned a value) and false otherwise */
+  public boolean isSetTransparent() {
+    return __isset_bit_vector.get(__TRANSPARENT_ISSET_ID);
+  }
+
+  public void setTransparentIsSet(boolean value) {
+    __isset_bit_vector.set(__TRANSPARENT_ISSET_ID, value);
+  }
+
   public boolean isNeedPin() {
     return this.needPin;
   }
@@ -697,6 +734,14 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       }
       break;
 
+    case TRANSPARENT:
+      if (value == null) {
+        unsetTransparent();
+      } else {
+        setTransparent((Boolean)value);
+      }
+      break;
+
     case NEED_PIN:
       if (value == null) {
         unsetNeedPin();
@@ -756,6 +801,9 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     case IN_MEMORY:
       return Boolean.valueOf(isInMemory());
 
+    case TRANSPARENT:
+      return Boolean.valueOf(isTransparent());
+
     case NEED_PIN:
       return Boolean.valueOf(isNeedPin());
 
@@ -796,6 +844,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       return isSetFolder();
     case IN_MEMORY:
       return isSetInMemory();
+    case TRANSPARENT:
+      return isSetTransparent();
     case NEED_PIN:
       return isSetNeedPin();
     case NEED_CACHE:
@@ -906,6 +956,15 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       if (!(this_present_inMemory && that_present_inMemory))
         return false;
       if (this.inMemory != that.inMemory)
+        return false;
+    }
+
+    boolean this_present_transparent = true;
+    boolean that_present_transparent = true;
+    if (this_present_transparent || that_present_transparent) {
+      if (!(this_present_transparent && that_present_transparent))
+        return false;
+      if (this.transparent != that.transparent)
         return false;
     }
 
@@ -1052,6 +1111,16 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetTransparent()).compareTo(typedOther.isSetTransparent());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetTransparent()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.transparent, typedOther.transparent);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     lastComparison = Boolean.valueOf(isSetNeedPin()).compareTo(typedOther.isSetNeedPin());
     if (lastComparison != 0) {
       return lastComparison;
@@ -1176,7 +1245,15 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
           }
           break;
-        case 11: // NEED_PIN
+        case 11: // TRANSPARENT
+          if (field.type == org.apache.thrift.protocol.TType.BOOL) {
+            this.transparent = iprot.readBool();
+            setTransparentIsSet(true);
+          } else { 
+            org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 12: // NEED_PIN
           if (field.type == org.apache.thrift.protocol.TType.BOOL) {
             this.needPin = iprot.readBool();
             setNeedPinIsSet(true);
@@ -1184,7 +1261,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
           }
           break;
-        case 12: // NEED_CACHE
+        case 13: // NEED_CACHE
           if (field.type == org.apache.thrift.protocol.TType.BOOL) {
             this.needCache = iprot.readBool();
             setNeedCacheIsSet(true);
@@ -1192,7 +1269,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
           }
           break;
-        case 13: // BLOCK_IDS
+        case 14: // BLOCK_IDS
           if (field.type == org.apache.thrift.protocol.TType.LIST) {
             {
               org.apache.thrift.protocol.TList _list4 = iprot.readListBegin();
@@ -1259,6 +1336,9 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     oprot.writeFieldEnd();
     oprot.writeFieldBegin(IN_MEMORY_FIELD_DESC);
     oprot.writeBool(this.inMemory);
+    oprot.writeFieldEnd();
+    oprot.writeFieldBegin(TRANSPARENT_FIELD_DESC);
+    oprot.writeBool(this.transparent);
     oprot.writeFieldEnd();
     oprot.writeFieldBegin(NEED_PIN_FIELD_DESC);
     oprot.writeBool(this.needPin);
@@ -1337,6 +1417,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     if (!first) sb.append(", ");
     sb.append("inMemory:");
     sb.append(this.inMemory);
+    first = false;
+    if (!first) sb.append(", ");
+    sb.append("transparent:");
+    sb.append(this.transparent);
     first = false;
     if (!first) sb.append(", ");
     sb.append("needPin:");

--- a/src/main/java/tachyon/thrift/CoordinatorService.java
+++ b/src/main/java/tachyon/thrift/CoordinatorService.java
@@ -746,6 +746,8 @@ public class CoordinatorService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -1551,6 +1553,8 @@ public class CoordinatorService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);

--- a/src/main/java/tachyon/thrift/MasterService.java
+++ b/src/main/java/tachyon/thrift/MasterService.java
@@ -46,7 +46,7 @@ public class MasterService {
 
     public Set<Integer> worker_getPinIdList() throws org.apache.thrift.TException;
 
-    public int user_createFile(String path, long blockSizeByte) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException;
+    public int user_createFile(String path, long blockSizeByte, boolean transparent) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException;
 
     public int user_createFileOnCheckpoint(String path, String checkpointPath) throws FileAlreadyExistException, InvalidPathException, SuspectedFileSizeException, BlockInfoException, TachyonException, org.apache.thrift.TException;
 
@@ -108,9 +108,9 @@ public class MasterService {
 
     public void user_outOfMemoryForPinFile(int fileId) throws org.apache.thrift.TException;
 
-    public void user_rename(String srcPath, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException;
+    public void user_rename(String srcPath, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException;
 
-    public void user_renameTo(int fileId, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException;
+    public void user_renameTo(int fileId, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException;
 
     public void user_unpinFile(int fileId) throws FileDoesNotExistException, org.apache.thrift.TException;
 
@@ -148,7 +148,7 @@ public class MasterService {
 
     public void worker_getPinIdList(org.apache.thrift.async.AsyncMethodCallback<AsyncClient.worker_getPinIdList_call> resultHandler) throws org.apache.thrift.TException;
 
-    public void user_createFile(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFile_call> resultHandler) throws org.apache.thrift.TException;
+    public void user_createFile(String path, long blockSizeByte, boolean transparent, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFile_call> resultHandler) throws org.apache.thrift.TException;
 
     public void user_createFileOnCheckpoint(String path, String checkpointPath, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFileOnCheckpoint_call> resultHandler) throws org.apache.thrift.TException;
 
@@ -425,17 +425,18 @@ public class MasterService {
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "worker_getPinIdList failed: unknown result");
     }
 
-    public int user_createFile(String path, long blockSizeByte) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException
+    public int user_createFile(String path, long blockSizeByte, boolean transparent) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException
     {
-      send_user_createFile(path, blockSizeByte);
+      send_user_createFile(path, blockSizeByte, transparent);
       return recv_user_createFile();
     }
 
-    public void send_user_createFile(String path, long blockSizeByte) throws org.apache.thrift.TException
+    public void send_user_createFile(String path, long blockSizeByte, boolean transparent) throws org.apache.thrift.TException
     {
       user_createFile_args args = new user_createFile_args();
       args.setPath(path);
       args.setBlockSizeByte(blockSizeByte);
+      args.setTransparent(transparent);
       sendBase("user_createFile", args);
     }
 
@@ -924,7 +925,7 @@ public class MasterService {
       return;
     }
 
-    public void user_rename(String srcPath, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException
+    public void user_rename(String srcPath, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException
     {
       send_user_rename(srcPath, dstPath);
       recv_user_rename();
@@ -938,7 +939,7 @@ public class MasterService {
       sendBase("user_rename", args);
     }
 
-    public void recv_user_rename() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException
+    public void recv_user_rename() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException
     {
       user_rename_result result = new user_rename_result();
       receiveBase(result, "user_rename");
@@ -951,10 +952,13 @@ public class MasterService {
       if (result.eI != null) {
         throw result.eI;
       }
+      if (result.eTa != null) {
+        throw result.eTa;
+      }
       return;
     }
 
-    public void user_renameTo(int fileId, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException
+    public void user_renameTo(int fileId, String dstPath) throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException
     {
       send_user_renameTo(fileId, dstPath);
       recv_user_renameTo();
@@ -968,7 +972,7 @@ public class MasterService {
       sendBase("user_renameTo", args);
     }
 
-    public void recv_user_renameTo() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException
+    public void recv_user_renameTo() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException
     {
       user_renameTo_result result = new user_renameTo_result();
       receiveBase(result, "user_renameTo");
@@ -980,6 +984,9 @@ public class MasterService {
       }
       if (result.eI != null) {
         throw result.eI;
+      }
+      if (result.eTa != null) {
+        throw result.eTa;
       }
       return;
     }
@@ -1504,9 +1511,9 @@ public class MasterService {
       }
     }
 
-    public void user_createFile(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler) throws org.apache.thrift.TException {
+    public void user_createFile(String path, long blockSizeByte, boolean transparent, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler) throws org.apache.thrift.TException {
       checkReady();
-      user_createFile_call method_call = new user_createFile_call(path, blockSizeByte, resultHandler, this, ___protocolFactory, ___transport);
+      user_createFile_call method_call = new user_createFile_call(path, blockSizeByte, transparent, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
@@ -1514,10 +1521,12 @@ public class MasterService {
     public static class user_createFile_call extends org.apache.thrift.async.TAsyncMethodCall {
       private String path;
       private long blockSizeByte;
-      public user_createFile_call(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      private boolean transparent;
+      public user_createFile_call(String path, long blockSizeByte, boolean transparent, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.path = path;
         this.blockSizeByte = blockSizeByte;
+        this.transparent = transparent;
       }
 
       public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
@@ -1525,6 +1534,7 @@ public class MasterService {
         user_createFile_args args = new user_createFile_args();
         args.setPath(path);
         args.setBlockSizeByte(blockSizeByte);
+        args.setTransparent(transparent);
         args.write(prot);
         prot.writeMessageEnd();
       }
@@ -2126,7 +2136,7 @@ public class MasterService {
         prot.writeMessageEnd();
       }
 
-      public void getResult() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException {
+      public void getResult() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new IllegalStateException("Method call not finished!");
         }
@@ -2161,7 +2171,7 @@ public class MasterService {
         prot.writeMessageEnd();
       }
 
-      public void getResult() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, org.apache.thrift.TException {
+      public void getResult() throws FileAlreadyExistException, FileDoesNotExistException, InvalidPathException, TachyonException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new IllegalStateException("Method call not finished!");
         }
@@ -2673,7 +2683,7 @@ public class MasterService {
       protected user_createFile_result getResult(I iface, user_createFile_args args) throws org.apache.thrift.TException {
         user_createFile_result result = new user_createFile_result();
         try {
-          result.success = iface.user_createFile(args.path, args.blockSizeByte);
+          result.success = iface.user_createFile(args.path, args.blockSizeByte, args.transparent);
           result.setSuccessIsSet(true);
         } catch (FileAlreadyExistException eR) {
           result.eR = eR;
@@ -3064,6 +3074,8 @@ public class MasterService {
           result.eF = eF;
         } catch (InvalidPathException eI) {
           result.eI = eI;
+        } catch (TachyonException eTa) {
+          result.eTa = eTa;
         }
         return result;
       }
@@ -3088,6 +3100,8 @@ public class MasterService {
           result.eF = eF;
         } catch (InvalidPathException eI) {
           result.eI = eI;
+        } catch (TachyonException eTa) {
+          result.eTa = eTa;
         }
         return result;
       }
@@ -4400,6 +4414,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -6727,6 +6743,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -9192,14 +9210,17 @@ public class MasterService {
 
     private static final org.apache.thrift.protocol.TField PATH_FIELD_DESC = new org.apache.thrift.protocol.TField("path", org.apache.thrift.protocol.TType.STRING, (short)1);
     private static final org.apache.thrift.protocol.TField BLOCK_SIZE_BYTE_FIELD_DESC = new org.apache.thrift.protocol.TField("blockSizeByte", org.apache.thrift.protocol.TType.I64, (short)2);
+    private static final org.apache.thrift.protocol.TField TRANSPARENT_FIELD_DESC = new org.apache.thrift.protocol.TField("transparent", org.apache.thrift.protocol.TType.BOOL, (short)3);
 
     public String path; // required
     public long blockSizeByte; // required
+    public boolean transparent; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       PATH((short)1, "path"),
-      BLOCK_SIZE_BYTE((short)2, "blockSizeByte");
+      BLOCK_SIZE_BYTE((short)2, "blockSizeByte"),
+      TRANSPARENT((short)3, "transparent");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -9218,6 +9239,8 @@ public class MasterService {
             return PATH;
           case 2: // BLOCK_SIZE_BYTE
             return BLOCK_SIZE_BYTE;
+          case 3: // TRANSPARENT
+            return TRANSPARENT;
           default:
             return null;
         }
@@ -9259,7 +9282,8 @@ public class MasterService {
 
     // isset id assignments
     private static final int __BLOCKSIZEBYTE_ISSET_ID = 0;
-    private BitSet __isset_bit_vector = new BitSet(1);
+    private static final int __TRANSPARENT_ISSET_ID = 1;
+    private BitSet __isset_bit_vector = new BitSet(2);
 
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
@@ -9268,6 +9292,8 @@ public class MasterService {
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
       tmpMap.put(_Fields.BLOCK_SIZE_BYTE, new org.apache.thrift.meta_data.FieldMetaData("blockSizeByte", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+      tmpMap.put(_Fields.TRANSPARENT, new org.apache.thrift.meta_data.FieldMetaData("transparent", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(user_createFile_args.class, metaDataMap);
     }
@@ -9277,12 +9303,15 @@ public class MasterService {
 
     public user_createFile_args(
       String path,
-      long blockSizeByte)
+      long blockSizeByte,
+      boolean transparent)
     {
       this();
       this.path = path;
       this.blockSizeByte = blockSizeByte;
       setBlockSizeByteIsSet(true);
+      this.transparent = transparent;
+      setTransparentIsSet(true);
     }
 
     /**
@@ -9295,6 +9324,7 @@ public class MasterService {
         this.path = other.path;
       }
       this.blockSizeByte = other.blockSizeByte;
+      this.transparent = other.transparent;
     }
 
     public user_createFile_args deepCopy() {
@@ -9306,6 +9336,8 @@ public class MasterService {
       this.path = null;
       setBlockSizeByteIsSet(false);
       this.blockSizeByte = 0;
+      setTransparentIsSet(false);
+      this.transparent = false;
     }
 
     public String getPath() {
@@ -9355,6 +9387,29 @@ public class MasterService {
       __isset_bit_vector.set(__BLOCKSIZEBYTE_ISSET_ID, value);
     }
 
+    public boolean isTransparent() {
+      return this.transparent;
+    }
+
+    public user_createFile_args setTransparent(boolean transparent) {
+      this.transparent = transparent;
+      setTransparentIsSet(true);
+      return this;
+    }
+
+    public void unsetTransparent() {
+      __isset_bit_vector.clear(__TRANSPARENT_ISSET_ID);
+    }
+
+    /** Returns true if field transparent is set (has been assigned a value) and false otherwise */
+    public boolean isSetTransparent() {
+      return __isset_bit_vector.get(__TRANSPARENT_ISSET_ID);
+    }
+
+    public void setTransparentIsSet(boolean value) {
+      __isset_bit_vector.set(__TRANSPARENT_ISSET_ID, value);
+    }
+
     public void setFieldValue(_Fields field, Object value) {
       switch (field) {
       case PATH:
@@ -9373,6 +9428,14 @@ public class MasterService {
         }
         break;
 
+      case TRANSPARENT:
+        if (value == null) {
+          unsetTransparent();
+        } else {
+          setTransparent((Boolean)value);
+        }
+        break;
+
       }
     }
 
@@ -9383,6 +9446,9 @@ public class MasterService {
 
       case BLOCK_SIZE_BYTE:
         return Long.valueOf(getBlockSizeByte());
+
+      case TRANSPARENT:
+        return Boolean.valueOf(isTransparent());
 
       }
       throw new IllegalStateException();
@@ -9399,6 +9465,8 @@ public class MasterService {
         return isSetPath();
       case BLOCK_SIZE_BYTE:
         return isSetBlockSizeByte();
+      case TRANSPARENT:
+        return isSetTransparent();
       }
       throw new IllegalStateException();
     }
@@ -9431,6 +9499,15 @@ public class MasterService {
         if (!(this_present_blockSizeByte && that_present_blockSizeByte))
           return false;
         if (this.blockSizeByte != that.blockSizeByte)
+          return false;
+      }
+
+      boolean this_present_transparent = true;
+      boolean that_present_transparent = true;
+      if (this_present_transparent || that_present_transparent) {
+        if (!(this_present_transparent && that_present_transparent))
+          return false;
+        if (this.transparent != that.transparent)
           return false;
       }
 
@@ -9470,6 +9547,16 @@ public class MasterService {
           return lastComparison;
         }
       }
+      lastComparison = Boolean.valueOf(isSetTransparent()).compareTo(typedOther.isSetTransparent());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetTransparent()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.transparent, typedOther.transparent);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -9502,6 +9589,14 @@ public class MasterService {
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
             }
             break;
+          case 3: // TRANSPARENT
+            if (field.type == org.apache.thrift.protocol.TType.BOOL) {
+              this.transparent = iprot.readBool();
+              setTransparentIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
         }
@@ -9525,6 +9620,9 @@ public class MasterService {
       oprot.writeFieldBegin(BLOCK_SIZE_BYTE_FIELD_DESC);
       oprot.writeI64(this.blockSizeByte);
       oprot.writeFieldEnd();
+      oprot.writeFieldBegin(TRANSPARENT_FIELD_DESC);
+      oprot.writeBool(this.transparent);
+      oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -9544,6 +9642,10 @@ public class MasterService {
       if (!first) sb.append(", ");
       sb.append("blockSizeByte:");
       sb.append(this.blockSizeByte);
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("transparent:");
+      sb.append(this.transparent);
       first = false;
       sb.append(")");
       return sb.toString();
@@ -10217,6 +10319,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -11344,6 +11448,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -12026,6 +12132,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -13302,6 +13410,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -13800,6 +13910,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -14566,6 +14678,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -21654,6 +21768,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -22425,6 +22541,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -23323,16 +23441,19 @@ public class MasterService {
     private static final org.apache.thrift.protocol.TField E_A_FIELD_DESC = new org.apache.thrift.protocol.TField("eA", org.apache.thrift.protocol.TType.STRUCT, (short)1);
     private static final org.apache.thrift.protocol.TField E_F_FIELD_DESC = new org.apache.thrift.protocol.TField("eF", org.apache.thrift.protocol.TType.STRUCT, (short)2);
     private static final org.apache.thrift.protocol.TField E_I_FIELD_DESC = new org.apache.thrift.protocol.TField("eI", org.apache.thrift.protocol.TType.STRUCT, (short)3);
+    private static final org.apache.thrift.protocol.TField E_TA_FIELD_DESC = new org.apache.thrift.protocol.TField("eTa", org.apache.thrift.protocol.TType.STRUCT, (short)4);
 
     public FileAlreadyExistException eA; // required
     public FileDoesNotExistException eF; // required
     public InvalidPathException eI; // required
+    public TachyonException eTa; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       E_A((short)1, "eA"),
       E_F((short)2, "eF"),
-      E_I((short)3, "eI");
+      E_I((short)3, "eI"),
+      E_TA((short)4, "eTa");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -23353,6 +23474,8 @@ public class MasterService {
             return E_F;
           case 3: // E_I
             return E_I;
+          case 4: // E_TA
+            return E_TA;
           default:
             return null;
         }
@@ -23403,6 +23526,8 @@ public class MasterService {
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       tmpMap.put(_Fields.E_I, new org.apache.thrift.meta_data.FieldMetaData("eI", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
+      tmpMap.put(_Fields.E_TA, new org.apache.thrift.meta_data.FieldMetaData("eTa", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(user_rename_result.class, metaDataMap);
     }
@@ -23413,12 +23538,14 @@ public class MasterService {
     public user_rename_result(
       FileAlreadyExistException eA,
       FileDoesNotExistException eF,
-      InvalidPathException eI)
+      InvalidPathException eI,
+      TachyonException eTa)
     {
       this();
       this.eA = eA;
       this.eF = eF;
       this.eI = eI;
+      this.eTa = eTa;
     }
 
     /**
@@ -23434,6 +23561,9 @@ public class MasterService {
       if (other.isSetEI()) {
         this.eI = new InvalidPathException(other.eI);
       }
+      if (other.isSetETa()) {
+        this.eTa = new TachyonException(other.eTa);
+      }
     }
 
     public user_rename_result deepCopy() {
@@ -23445,6 +23575,7 @@ public class MasterService {
       this.eA = null;
       this.eF = null;
       this.eI = null;
+      this.eTa = null;
     }
 
     public FileAlreadyExistException getEA() {
@@ -23519,6 +23650,30 @@ public class MasterService {
       }
     }
 
+    public TachyonException getETa() {
+      return this.eTa;
+    }
+
+    public user_rename_result setETa(TachyonException eTa) {
+      this.eTa = eTa;
+      return this;
+    }
+
+    public void unsetETa() {
+      this.eTa = null;
+    }
+
+    /** Returns true if field eTa is set (has been assigned a value) and false otherwise */
+    public boolean isSetETa() {
+      return this.eTa != null;
+    }
+
+    public void setETaIsSet(boolean value) {
+      if (!value) {
+        this.eTa = null;
+      }
+    }
+
     public void setFieldValue(_Fields field, Object value) {
       switch (field) {
       case E_A:
@@ -23545,6 +23700,14 @@ public class MasterService {
         }
         break;
 
+      case E_TA:
+        if (value == null) {
+          unsetETa();
+        } else {
+          setETa((TachyonException)value);
+        }
+        break;
+
       }
     }
 
@@ -23558,6 +23721,9 @@ public class MasterService {
 
       case E_I:
         return getEI();
+
+      case E_TA:
+        return getETa();
 
       }
       throw new IllegalStateException();
@@ -23576,6 +23742,8 @@ public class MasterService {
         return isSetEF();
       case E_I:
         return isSetEI();
+      case E_TA:
+        return isSetETa();
       }
       throw new IllegalStateException();
     }
@@ -23617,6 +23785,15 @@ public class MasterService {
         if (!(this_present_eI && that_present_eI))
           return false;
         if (!this.eI.equals(that.eI))
+          return false;
+      }
+
+      boolean this_present_eTa = true && this.isSetETa();
+      boolean that_present_eTa = true && that.isSetETa();
+      if (this_present_eTa || that_present_eTa) {
+        if (!(this_present_eTa && that_present_eTa))
+          return false;
+        if (!this.eTa.equals(that.eTa))
           return false;
       }
 
@@ -23666,6 +23843,16 @@ public class MasterService {
           return lastComparison;
         }
       }
+      lastComparison = Boolean.valueOf(isSetETa()).compareTo(typedOther.isSetETa());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetETa()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.eTa, typedOther.eTa);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -23707,6 +23894,14 @@ public class MasterService {
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
             }
             break;
+          case 4: // E_TA
+            if (field.type == org.apache.thrift.protocol.TType.STRUCT) {
+              this.eTa = new TachyonException();
+              this.eTa.read(iprot);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
         }
@@ -23732,6 +23927,10 @@ public class MasterService {
       } else if (this.isSetEI()) {
         oprot.writeFieldBegin(E_I_FIELD_DESC);
         this.eI.write(oprot);
+        oprot.writeFieldEnd();
+      } else if (this.isSetETa()) {
+        oprot.writeFieldBegin(E_TA_FIELD_DESC);
+        this.eTa.write(oprot);
         oprot.writeFieldEnd();
       }
       oprot.writeFieldStop();
@@ -23764,6 +23963,14 @@ public class MasterService {
         sb.append("null");
       } else {
         sb.append(this.eI);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("eTa:");
+      if (this.eTa == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.eTa);
       }
       first = false;
       sb.append(")");
@@ -24184,16 +24391,19 @@ public class MasterService {
     private static final org.apache.thrift.protocol.TField E_A_FIELD_DESC = new org.apache.thrift.protocol.TField("eA", org.apache.thrift.protocol.TType.STRUCT, (short)1);
     private static final org.apache.thrift.protocol.TField E_F_FIELD_DESC = new org.apache.thrift.protocol.TField("eF", org.apache.thrift.protocol.TType.STRUCT, (short)2);
     private static final org.apache.thrift.protocol.TField E_I_FIELD_DESC = new org.apache.thrift.protocol.TField("eI", org.apache.thrift.protocol.TType.STRUCT, (short)3);
+    private static final org.apache.thrift.protocol.TField E_TA_FIELD_DESC = new org.apache.thrift.protocol.TField("eTa", org.apache.thrift.protocol.TType.STRUCT, (short)4);
 
     public FileAlreadyExistException eA; // required
     public FileDoesNotExistException eF; // required
     public InvalidPathException eI; // required
+    public TachyonException eTa; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       E_A((short)1, "eA"),
       E_F((short)2, "eF"),
-      E_I((short)3, "eI");
+      E_I((short)3, "eI"),
+      E_TA((short)4, "eTa");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -24214,6 +24424,8 @@ public class MasterService {
             return E_F;
           case 3: // E_I
             return E_I;
+          case 4: // E_TA
+            return E_TA;
           default:
             return null;
         }
@@ -24264,6 +24476,8 @@ public class MasterService {
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       tmpMap.put(_Fields.E_I, new org.apache.thrift.meta_data.FieldMetaData("eI", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
+      tmpMap.put(_Fields.E_TA, new org.apache.thrift.meta_data.FieldMetaData("eTa", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(user_renameTo_result.class, metaDataMap);
     }
@@ -24274,12 +24488,14 @@ public class MasterService {
     public user_renameTo_result(
       FileAlreadyExistException eA,
       FileDoesNotExistException eF,
-      InvalidPathException eI)
+      InvalidPathException eI,
+      TachyonException eTa)
     {
       this();
       this.eA = eA;
       this.eF = eF;
       this.eI = eI;
+      this.eTa = eTa;
     }
 
     /**
@@ -24295,6 +24511,9 @@ public class MasterService {
       if (other.isSetEI()) {
         this.eI = new InvalidPathException(other.eI);
       }
+      if (other.isSetETa()) {
+        this.eTa = new TachyonException(other.eTa);
+      }
     }
 
     public user_renameTo_result deepCopy() {
@@ -24306,6 +24525,7 @@ public class MasterService {
       this.eA = null;
       this.eF = null;
       this.eI = null;
+      this.eTa = null;
     }
 
     public FileAlreadyExistException getEA() {
@@ -24380,6 +24600,30 @@ public class MasterService {
       }
     }
 
+    public TachyonException getETa() {
+      return this.eTa;
+    }
+
+    public user_renameTo_result setETa(TachyonException eTa) {
+      this.eTa = eTa;
+      return this;
+    }
+
+    public void unsetETa() {
+      this.eTa = null;
+    }
+
+    /** Returns true if field eTa is set (has been assigned a value) and false otherwise */
+    public boolean isSetETa() {
+      return this.eTa != null;
+    }
+
+    public void setETaIsSet(boolean value) {
+      if (!value) {
+        this.eTa = null;
+      }
+    }
+
     public void setFieldValue(_Fields field, Object value) {
       switch (field) {
       case E_A:
@@ -24406,6 +24650,14 @@ public class MasterService {
         }
         break;
 
+      case E_TA:
+        if (value == null) {
+          unsetETa();
+        } else {
+          setETa((TachyonException)value);
+        }
+        break;
+
       }
     }
 
@@ -24419,6 +24671,9 @@ public class MasterService {
 
       case E_I:
         return getEI();
+
+      case E_TA:
+        return getETa();
 
       }
       throw new IllegalStateException();
@@ -24437,6 +24692,8 @@ public class MasterService {
         return isSetEF();
       case E_I:
         return isSetEI();
+      case E_TA:
+        return isSetETa();
       }
       throw new IllegalStateException();
     }
@@ -24478,6 +24735,15 @@ public class MasterService {
         if (!(this_present_eI && that_present_eI))
           return false;
         if (!this.eI.equals(that.eI))
+          return false;
+      }
+
+      boolean this_present_eTa = true && this.isSetETa();
+      boolean that_present_eTa = true && that.isSetETa();
+      if (this_present_eTa || that_present_eTa) {
+        if (!(this_present_eTa && that_present_eTa))
+          return false;
+        if (!this.eTa.equals(that.eTa))
           return false;
       }
 
@@ -24527,6 +24793,16 @@ public class MasterService {
           return lastComparison;
         }
       }
+      lastComparison = Boolean.valueOf(isSetETa()).compareTo(typedOther.isSetETa());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetETa()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.eTa, typedOther.eTa);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -24568,6 +24844,14 @@ public class MasterService {
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
             }
             break;
+          case 4: // E_TA
+            if (field.type == org.apache.thrift.protocol.TType.STRUCT) {
+              this.eTa = new TachyonException();
+              this.eTa.read(iprot);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
         }
@@ -24593,6 +24877,10 @@ public class MasterService {
       } else if (this.isSetEI()) {
         oprot.writeFieldBegin(E_I_FIELD_DESC);
         this.eI.write(oprot);
+        oprot.writeFieldEnd();
+      } else if (this.isSetETa()) {
+        oprot.writeFieldBegin(E_TA_FIELD_DESC);
+        this.eTa.write(oprot);
         oprot.writeFieldEnd();
       }
       oprot.writeFieldStop();
@@ -24625,6 +24913,14 @@ public class MasterService {
         sb.append("null");
       } else {
         sb.append(this.eI);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("eTa:");
+      if (this.eTa == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.eTa);
       }
       first = false;
       sb.append(")");
@@ -26099,6 +26395,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -27237,6 +27535,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -27919,6 +28219,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -30926,6 +31228,8 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);

--- a/src/main/java/tachyon/thrift/WorkerService.java
+++ b/src/main/java/tachyon/thrift/WorkerService.java
@@ -6777,6 +6777,8 @@ public class WorkerService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);

--- a/src/test/java/tachyon/MasterClientTest.java
+++ b/src/test/java/tachyon/MasterClientTest.java
@@ -40,7 +40,7 @@ public class MasterClientTest {
     Assert.assertFalse(masterClient.isConnected());
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
-    masterClient.user_createFile("/file", Constants.DEFAULT_BLOCK_SIZE_BYTE);
+    masterClient.user_createFile("/file", Constants.DEFAULT_BLOCK_SIZE_BYTE, false);
     Assert.assertTrue(masterClient.user_getFileId("/file") != -1);
     masterClient.cleanConnect();
     Assert.assertFalse(masterClient.isConnected());

--- a/src/thrift/tachyon.thrift
+++ b/src/thrift/tachyon.thrift
@@ -33,9 +33,10 @@ struct ClientFileInfo {
   8: bool complete
   9: bool folder
   10: bool inMemory
-  11: bool needPin
-  12: bool needCache
-  13: list<i64> blockIds
+  11: bool transparent
+  12: bool needPin
+  13: bool needCache
+  14: list<i64> blockIds
 }
 
 struct ClientRawTableInfo {
@@ -136,7 +137,7 @@ service MasterService {
   set<i32> worker_getPinIdList()
 
   // Services to Users
-  i32 user_createFile(1: string path, 2: i64 blockSizeByte)
+  i32 user_createFile(1: string path, 2: i64 blockSizeByte, 3: bool transparent)
     throws (1: FileAlreadyExistException eR, 2: InvalidPathException eI, 3: BlockInfoException eB, 4: TachyonException eT)
   i32 user_createFileOnCheckpoint(1: string path, 2: string checkpointPath)
     throws (1: FileAlreadyExistException eR, 2: InvalidPathException eI, 3: SuspectedFileSizeException eS, 4: BlockInfoException eB, 5: TachyonException eT)
@@ -186,9 +187,9 @@ service MasterService {
     throws (1: TachyonException e)
   void user_outOfMemoryForPinFile(1: i32 fileId)
   void user_rename(1: string srcPath, 2: string dstPath)
-    throws (1:FileAlreadyExistException eA, 2: FileDoesNotExistException eF, 3: InvalidPathException eI)
+    throws (1:FileAlreadyExistException eA, 2: FileDoesNotExistException eF, 3: InvalidPathException eI, 4: TachyonException eTa)
   void user_renameTo(1: i32 fileId, 2: string dstPath)
-    throws (1:FileAlreadyExistException eA, 2: FileDoesNotExistException eF, 3: InvalidPathException eI)
+    throws (1:FileAlreadyExistException eA, 2: FileDoesNotExistException eF, 3: InvalidPathException eI, 4: TachyonException eTa)
   void user_unpinFile(1: i32 fileId)
     throws (1: FileDoesNotExistException e)   // Remove file from memory
   bool user_mkdir(1: string path)


### PR DESCRIPTION
Patch for allowing users to specify if they want a fixed checkpoint for their file. By setting "tachyon.fixed.checkpoint" to be true, the Tachyon file will be written to "COMMON_CONF.UNDERFS_ADDRESS + info.path" where info.path is the substring "x" in "tachyon:master:port/x" that the user requests to write to. So if user wants to write to "tachyon://localhost:19998/user1/file.txt" and HDFS is the backing fs, then the file "hdfs://hdfsmaster:port/user1/file.txt" will be created. 

This is the checkpoint path reported to the master, so all further reads to this file will be handled appropriately. One issue though is that this is a system wide setting that could be toggled on or off by user at any point in time, which may lead to some confusion. Some of this confusion can be cleared up if we make the user specify PER file if they want fixed checkpoint or not. This is not that big of a deal though. 
