### PR TITLE
exclude org.jboss.netty in org.apache.curator.curator-recipes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,12 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${apache.curator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
To exclude org.jboss.netty in the pom.xml file, which is introduced by org.apache.curator.curator-recipes(actually from the zookeeper). This netty version conflicts with the spark's netty, and causes akka not to work after adding the tachyon-*-jar-with-dependencies.jar into the SPARK_CLASSPATH. The Spark's error message is listed below.

<pre>
java.lang.NoSuchMethodError: org.jboss.netty.channel.ChannelLocal.<init>(Z)V
        at akka.remote.netty.RemoteServerHandler$$anon$1.<init>(Server.scala:141)
        at akka.remote.netty.RemoteServerHandler.<init>(Server.scala:141)
        at akka.remote.netty.RemoteServerPipelineFactory.getPipeline(Server.scala:96)
        at org.jboss.netty.channel.socket.nio.NioServerSocketPipelineSink$Boss.
</pre>
