### PR TITLE
Update scripts to integrate with system using variable override, similar to hadoop

### DIFF
--- a/bin/mount.sh
+++ b/bin/mount.sh
@@ -26,25 +26,22 @@ Usage="Usage: mount.sh [Mount|SudoMount] [MACHINE]
   local\t\t\tMount local marchine\n
   workers\t\tMount all the workers on slaves"
 
+bin=`cd "$( dirname "$0" )"; pwd`
+
 function init_env() {
-  bin=`cd "$( dirname "$1" )"; pwd`
 
-  # Load the Tachyon configuration
-  . "$bin/tachyon-config.sh"
+  DEFAULT_LIBEXEC_DIR="$bin"/../libexec
+  TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
+  . $TACHYON_LIBEXEC_DIR/tachyon-config.sh
 
-  # Lower case memory size.
-  if [ -e $TACHYON_HOME/conf/tachyon-env.sh ] ; then
-    . $TACHYON_HOME/conf/tachyon-env.sh
-  else
-    echo -e "$TACHYON_HOME/conf/tachyon-env.sh was not configured, set TACHYON_WORKER_MEMORY_SIZE=128MB"
+  if [ -z TACHYON_WORKER_MEMORY_SIZE ] ; then
     TACHYON_WORKER_MEMORY_SIZE=128MB
-  fi
+  fi 
 
   MEM_SIZE=$(echo "$TACHYON_WORKER_MEMORY_SIZE" | tr -s '[:upper:]' '[:lower:]')
 }
 
 function mount_ramfs_linux() {
-  init_env $1
   if [ -z $TACHYON_RAM_FOLDER ] ; then
     TACHYON_RAM_FOLDER=/mnt/ramdisk
     echo "TACHYON_RAM_FOLDER was not set. Using the default one: $TACHYON_RAM_FOLDER"
@@ -64,7 +61,6 @@ function mount_ramfs_linux() {
 #enable the regexp case match
 shopt -s extglob
 function mount_ramfs_mac() {
-  init_env $0
   if [ -z $TACHYON_RAM_FOLDER ] ; then
     TACHYON_RAM_FOLDER=/Volumes/ramdisk
     echo "TACHYON_RAM_FOLDER was not set. Using the default one: $TACHYON_RAM_FOLDER"
@@ -124,6 +120,8 @@ function mount_local() {
     fi
   fi
 }
+
+init_env
 
 case "${1}" in
   Mount|SudoMount)

--- a/bin/slaves.sh
+++ b/bin/slaves.sh
@@ -26,8 +26,11 @@ if [ $# -le 0 ]; then
 fi
 
 bin=`cd "$( dirname "$0" )"; pwd`
+DEFAULT_LIBEXEC_DIR="$bin"/../libexec
+TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
+. $TACHYON_LIBEXEC_DIR/tachyon-config.sh
 
-HOSTLIST=$bin/../conf/slaves
+HOSTLIST=$TACHYON_CONF_DIR/slaves
 
 for slave in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
   ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no $slave $"${@// /\\ }" 2>&1 | sed "s/^/$slave: /" &

--- a/bin/tachyon
+++ b/bin/tachyon
@@ -25,12 +25,9 @@ shift
 
 bin=`cd "$( dirname "$0" )"; pwd`
 
-# Load the Tachyon configuration
-. "$bin/tachyon-config.sh"
-
-if [ -e $TACHYON_HOME/conf/tachyon-env.sh ] ; then
-  . $TACHYON_HOME/conf/tachyon-env.sh
-fi
+DEFAULT_LIBEXEC_DIR="$bin"/../libexec
+TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
+. $TACHYON_LIBEXEC_DIR/tachyon-config.sh
 
 function runTest {
   Usage="Usage: tachyon runTest <Basic|BasicRawTable> <MUST_CACHE|TRY_CACHE|CACHE_THROUGH|THROUGH>"
@@ -46,10 +43,10 @@ function runTest {
   fi
 
   if [[ "$1" == "Basic" ]]; then
-    $JAVA_HOME/bin/java -cp $bin/../conf/:$TACHYON_JAR tachyon.examples.BasicOperations $MASTER_ADDRESS:19998 /Basic_File_$2 $2
+    $JAVA -cp $TACHYON_CONF_DIR/:$TACHYON_JAR tachyon.examples.BasicOperations $MASTER_ADDRESS:19998 /Basic_File_$2 $2
     exit 0
   elif [[ "$1" == "BasicRawTable" ]]; then
-    $JAVA_HOME/bin/java -cp $bin/../conf/:$TACHYON_JAR tachyon.examples.BasicRawTableOperations $MASTER_ADDRESS:19998 /Basic_Raw_Table_$2 $2
+    $JAVA -cp $TACHYON_CONF_DIR/:$TACHYON_JAR tachyon.examples.BasicRawTableOperations $MASTER_ADDRESS:19998 /Basic_Raw_Table_$2 $2
     exit 0
   fi
 
@@ -79,7 +76,7 @@ function copyDir {
   fi
 
   bin=`cd "$( dirname "$0" )"; pwd`
-  SLAVES=`cat $bin/../conf/slaves`
+  SLAVES=`cat $TACHYON_CONF_DIR/slaves`
 
   DIR=`readlink -f "$1"`
   DIR=`echo "$DIR"|sed 's@/$@@'`
@@ -138,4 +135,4 @@ else
   exit 1
 fi
 
-$JAVA_HOME/bin/java -cp $TACHYON_JAR -Dtachyon.home=$TACHYON_HOME -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $@
+$JAVA -cp $TACHYON_JAR -Dtachyon.home=$TACHYON_HOME -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $@

--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -33,8 +33,23 @@ script=`basename "$this"`
 config_bin=`cd "$config_bin"; pwd`
 this="$config_bin/$script"
 
-export TACHYON_PREFIX=`dirname "$this"`/..
-export TACHYON_HOME=${TACHYON_PREFIX}
-export TACHYON_CONF_DIR="$TACHYON_HOME/conf"
-export TACHYON_LOGS_DIR="$TACHYON_HOME/logs"
-export TACHYON_JAR=$TACHYON_HOME/target/tachyon-0.4.0-SNAPSHOT-jar-with-dependencies.jar
+# Allow for a script which overrides the default settings for system
+# integration folks.
+[ -f "$common_bin/tachyon-layout.sh" ] && . "$common_bin/tachyon-layout.sh"
+
+# this will set the default installation for a tarball installation
+# while os distributors can create their own tachyon-layout.sh file 
+# to set system installation locations.
+if [ -z "TACHYON_SYSTEM_INSTALLATION" ]; then
+  export TACHYON_PREFIX=`dirname "$this"`/..
+  export TACHYON_HOME=${TACHYON_PREFIX}
+  export TACHYON_CONF_DIR="$TACHYON_HOME/conf"
+  export TACHYON_LOGS_DIR="$TACHYON_HOME/logs"
+  export TACHYON_JAR=$TACHYON_HOME/target/tachyon-0.4.0-SNAPSHOT-jar-with-dependencies.jar
+  export JAVA="$JAVA_HOME/bin/java"
+fi
+
+# Environment settings should override * and are adminstrator controlled.
+if [ -e $TACHYON_CONF_DIR/tachyon-env.sh ] ; then
+  . $TACHYON_CONF_DIR/tachyon-env.sh
+fi

--- a/libexec/tachyon-layout.sh.linux.template
+++ b/libexec/tachyon-layout.sh.linux.template
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+export TACHYON_SYSTEM_INSTALLATION="TRUE"
+export TACHYON_PREFIX="/var/lib/tachyon"
+export TACHYON_HOME=${TACHYON_PREFIX}
+export TACHYON_CONF_DIR="/etc/tachyon"
+export TACHYON_LOGS_DIR="/var/log/tachyon"
+export TACHYON_DATA_DIR="/var/run/tachyon"
+
+# generate via mvn dependency:build-classpath
+# export TACHYON_JAR=""
+
+if [ -z "JAVA_HOME" ]; then
+  export JAVA="/usr/bin/java"
+else
+  export JAVA="$JAVA_HOME/bin/java"
+fi


### PR DESCRIPTION
Currently the scripts rely on an implied tarball structure which != system paths.  This modification should allow for a simple tachyon-layout.sh to override settings.  The config & layout have been shifted to libexec as that is the typical location for such files and matches parity with hadoop. 
