### PR TITLE
Fix the NPE in getClientBlockInfo while INode is a DIR

### DIFF
--- a/src/main/java/tachyon/client/TachyonFS.java
+++ b/src/main/java/tachyon/client/TachyonFS.java
@@ -459,7 +459,7 @@ public class TachyonFS {
     ClientFileInfo info = null;
     if (!fetch) {
       info = mClientFileInfos.get(fId);
-      if (!info.isFolder() && info.blockIds.size() <= blockIndex) {
+      if (info.isFolder() || info.blockIds.size() <= blockIndex) {
         fetch = true;
       }
     }


### PR DESCRIPTION
info.blockIds.size() doesn't check null pointer in getClientBlockInfo. It causes NPE while trying to getClientBlockInfo for a DIR. This problem can be reproduced by running following command:

```
$> bin/tachyon tfs location /
```

Now, it will check the INode type and return back an exception like

```
FileDoesNotExistException(message: File 1 is a folder.)
```

Any comment?
