### PR TITLE
Script renaming to allow for system installation as not to collide with other packages

### DIFF
--- a/bin/tachyon-mount.sh
+++ b/bin/tachyon-mount.sh
@@ -21,7 +21,7 @@
 # Starts the master on this node.
 # Starts a worker on each node specified in conf/slaves
 
-Usage="Usage: mount.sh [Mount|SudoMount] [MACHINE]
+Usage="Usage: tachyon-mount.sh [Mount|SudoMount] [MACHINE]
 \nIf ommited, MARCHINE is default to be 'local'. MARCHINE is one of:\n
   local\t\t\tMount local marchine\n
   workers\t\tMount all the workers on slaves"
@@ -131,7 +131,7 @@ case "${1}" in
         mount_local $1
         ;;
       workers)
-        $bin/slaves.sh $bin/mount.sh $1
+        $bin/tachyon-slaves.sh $bin/tachyon-mount.sh $1
         ;;
     esac
     ;;

--- a/bin/tachyon-slaves.sh
+++ b/bin/tachyon-slaves.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-usage="Usage: slaves.sh command..."
+usage="Usage: tachyon-slaves.sh command..."
 
 # if no args specified, show usage
 if [ $# -le 0 ]; then

--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -19,7 +19,7 @@
 
 #start up tachyon
 
-Usage="Usage: start.sh [-h] WHAT [MOPT]
+Usage="Usage: tachyon-start.sh [-h] WHAT [MOPT]
 Where WHAT is one of:
   all MOPT\t\tStart master and all slaves.
   local\t\t\tStart a master and slave locally
@@ -72,10 +72,10 @@ check_mount_mode() {
 do_mount() {
   case "${1}" in
     Mount)
-      $bin/mount.sh $1
+      $bin/tachyon-mount.sh $1
       ;;
     SudoMount)
-      $bin/mount.sh $1
+      $bin/tachyon-mount.sh $1
       ;;
     NoMount)
       ;;
@@ -87,7 +87,7 @@ do_mount() {
 }
 
 stop() {
-  $bin/stop.sh
+  $bin/tachyon-stop.sh
 }
 
 
@@ -171,12 +171,12 @@ case "${WHAT}" in
     stop $bin
     start_master
     sleep 2
-    run_on_slaves $bin/start.sh worker $2
+    run_on_slaves $bin/tachyon-start.sh worker $2
     ;;
   local)
     stop $bin
     sleep 1
-    $bin/mount.sh SudoMount
+    $bin/tachyon-mount.sh SudoMount
     start_master
     sleep 2
     start_worker NoMount
@@ -193,13 +193,13 @@ case "${WHAT}" in
     ;;
   workers)
     check_mount_mode $2
-    run_on_slaves $bin/start.sh worker $2
+    run_on_slaves $bin/tachyon-start.sh worker $2
     ;;
   restart_worker)
     restart_worker
     ;;
   restart_workers)
-    run_on_slaves $bin/start.sh restart_worker
+    run_on_slaves $bin/tachyon-start.sh restart_worker
     ;;
   *)
     echo "Error: Invalid WHAT: $WHAT"

--- a/bin/tachyon-stop.sh
+++ b/bin/tachyon-stop.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-usage="Usage: stop.sh"
+usage="Usage: tachyon-stop.sh"
 
 if [ "$#" -ne 0 ]; then
   echo $Usage
@@ -29,4 +29,4 @@ bin=`cd "$( dirname "$0" )"; pwd`
 $bin/tachyon killAll tachyon.Master
 $bin/tachyon killAll tachyon.Worker
 
-$bin/slaves.sh $bin/tachyon killAll tachyon.Worker
+$bin/tachyon-slaves.sh $bin/tachyon killAll tachyon.Worker


### PR DESCRIPTION
Currently tachyon leverages scripts with names like (mount, start, stop) which are heavily overloaded.  This modification is to simply prefix the scripts to allow it to be installed on the system without worry of collision.  
