### PR TITLE
HDFS implementation now configurable from tachyon-env.sh

### DIFF
--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -9,6 +9,8 @@
 # - TACHYON_UNDERFS_ADDRESS, to set the under filesystem address.
 # - TACHYON_WORKER_MEMORY_SIZE, to set how much memory to use (e.g. 1000mb, 2gb) per worker
 # - TACHYON_RAM_FOLDER, to set where worker stores in memory data
+# - TACHYON_UNDERFS_HDFS_IMPL, to set which HDFS implementation to use (e.g. com.mapr.fs.MapRFileSystem, 
+#   org.apache.hadoop.hdfs.DistributedFileSystem)
 #
 # The following gives an example:
 
@@ -34,6 +36,7 @@ export TACHYON_JAVA_OPTS+="
   -Dlog4j.configuration=file:$CONF_DIR/log4j.properties
   -Dtachyon.debug=false
   -Dtachyon.underfs.address=$TACHYON_UNDERFS_ADDRESS
+  -Dtachyon.underfs.hdfs.impl=$TACHYON_UNDERFS_HDFS_IMPL
   -Dtachyon.worker.memory.size=$TACHYON_WORKER_MEMORY_SIZE
   -Dtachyon.worker.data.folder=$TACHYON_RAM_FOLDER/tachyonworker/
   -Dtachyon.master.worker.timeout.ms=60000

--- a/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.log4j.Logger;
 
+import tachyon.conf.CommonConf;
+
 /**
  * HDFS UnderFilesystem implementation.
  */
@@ -51,7 +53,7 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       mUfsPrefix = fsDefaultName;
       Configuration tConf = new Configuration();
       tConf.set("fs.defaultFS", fsDefaultName);
-      tConf.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
+      tConf.set("fs.hdfs.impl", CommonConf.get().UNDERFS_HDFS_IMPL);
       if (System.getProperty("fs.s3n.awsAccessKeyId") != null) {
         tConf.set("fs.s3n.awsAccessKeyId", System.getProperty("fs.s3n.awsAccessKeyId"));
       }

--- a/src/main/java/tachyon/conf/CommonConf.java
+++ b/src/main/java/tachyon/conf/CommonConf.java
@@ -26,6 +26,7 @@ public class CommonConf extends Utils {
   public final String UNDERFS_ADDRESS;
   public final String UNDERFS_DATA_FOLDER;
   public final String UNDERFS_WORKERS_FOLDER;
+  public final String UNDERFS_HDFS_IMPL;
 
   public final boolean USE_ZOOKEEPER;
   public final String ZOOKEEPER_ADDRESS;
@@ -35,6 +36,7 @@ public class CommonConf extends Utils {
   private CommonConf() {
     TACHYON_HOME = getProperty("tachyon.home");
     UNDERFS_ADDRESS = getProperty("tachyon.underfs.address", TACHYON_HOME);
+    UNDERFS_HDFS_IMPL = getProperty("tachyon.underfs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
     UNDERFS_DATA_FOLDER = UNDERFS_ADDRESS + getProperty("tachyon.data.folder", "/tachyon/data");
     UNDERFS_WORKERS_FOLDER = 
         UNDERFS_ADDRESS + getProperty("tachyon.workers.folder", "/tachyon/workers");


### PR DESCRIPTION
In existing version, default under file system hdfs implementation was  "org.apache.hadoop.hdfs.DistributedFileSystem", now it can be configured from tachyon-env.sh with parameter "TACHYON_UNDERFS_HDFS_IMPL". 
