### PR TITLE
Change logic for deleting logs.

### DIFF
--- a/src/main/java/tachyon/Journal.java
+++ b/src/main/java/tachyon/Journal.java
@@ -65,8 +65,9 @@ public class Journal {
   }
 
   public void createImage(MasterInfo info) throws IOException {
-    if (!EditLog.getIsBackUpCurrentLog() || mStandbyImagePath == "") {
+    if (mStandbyImagePath == "") {
       Image.create(info, mImagePath);
+      EditLog.markUpToDate();
     } else {
       Image.rename(mStandbyImagePath, mImagePath);
     }
@@ -78,7 +79,6 @@ public class Journal {
   }
 
   public void createEditLog(long transactionId) throws IOException {
-    EditLog.deleteCompletedLogs(mEditLogPath);
     mEditLog = new EditLog(mEditLogPath, false, transactionId);
   }
 


### PR DESCRIPTION
Completed logs are now deleted when they have been incorporated into the image. Therefore the current log will always be backed up during a failover but will not be during the first image write.
