### PR TITLE
Fix IAE in TachyonFS.createAndGetUserUnderfsTempFolder

### DIFF
--- a/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.log4j.Logger;
 
-import tachyon.conf.CommonConf;
-
 /**
  * HDFS UnderFilesystem implementation.
  */
@@ -57,7 +55,8 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       mUfsPrefix = fsDefaultName;
       Configuration tConf = new Configuration();
       tConf.set("fs.defaultFS", fsDefaultName);
-      tConf.set("fs.hdfs.impl", CommonConf.get().UNDERFS_HDFS_IMPL);
+      tConf.set("fs.hdfs.impl", System.getProperty("tachyon.underfs.hdfs.impl",
+          "org.apache.hadoop.hdfs.DistributedFileSystem"));
       if (System.getProperty("fs.s3n.awsAccessKeyId") != null) {
         tConf.set("fs.s3n.awsAccessKeyId", System.getProperty("fs.s3n.awsAccessKeyId"));
       }

--- a/src/main/java/tachyon/conf/CommonConf.java
+++ b/src/main/java/tachyon/conf/CommonConf.java
@@ -26,7 +26,6 @@ public class CommonConf extends Utils {
   public final String UNDERFS_ADDRESS;
   public final String UNDERFS_DATA_FOLDER;
   public final String UNDERFS_WORKERS_FOLDER;
-  public final String UNDERFS_HDFS_IMPL;
 
   public final boolean USE_ZOOKEEPER;
   public final String ZOOKEEPER_ADDRESS;
@@ -36,7 +35,6 @@ public class CommonConf extends Utils {
   private CommonConf() {
     TACHYON_HOME = getProperty("tachyon.home");
     UNDERFS_ADDRESS = getProperty("tachyon.underfs.address", TACHYON_HOME);
-    UNDERFS_HDFS_IMPL = getProperty("tachyon.underfs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
     UNDERFS_DATA_FOLDER = UNDERFS_ADDRESS + getProperty("tachyon.data.folder", "/tachyon/data");
     UNDERFS_WORKERS_FOLDER = 
         UNDERFS_ADDRESS + getProperty("tachyon.workers.folder", "/tachyon/workers");


### PR DESCRIPTION
Now if the user tries to write some files with TRY_TRHOUGH (i.e., onto the under file system HDFS), some java.lang.IllegalArgumentException is there,  introduced by PR#77. here lists the stack trace.

```
java.lang.IllegalArgumentException (java.lang.IllegalArgumentException: tachyon.home is not configured.)

tachyon.CommonUtils.illegalArgumentException(CommonUtils.java:167)
tachyon.conf.Utils.getProperty(Utils.java:32)tachyon.conf.CommonConf.<init>(CommonConf.java:37)
tachyon.conf.CommonConf.get(CommonConf.java:58)
tachyon.UnderFileSystemHdfs.<init>(UnderFileSystemHdfs.java:60)
tachyon.UnderFileSystemHdfs.getClient(UnderFileSystemHdfs.java:52)
tachyon.UnderFileSystem.get(UnderFileSystem.java:51)
tachyon.client.TachyonFS.createAndGetUserUnderfsTempFolder(TachyonFS.java:311)
tachyon.client.FileOutStream.<init>(FileOutStream.java:60)tachyon.client.TachyonFile.getOutStream(TachyonFile.java:77)
```

The problem is that TachyonFS tries to createAndGetUserUnderfsTempFolder over the underFS according to the scheme. Then, it read the fs.hdfs.impl using CommonUtils. However, CommonUtils only work for both Master and Worker instance, the tachyon.home is not necessary for the client side. Consequently, we will see the IAE above.

Here submits quick fix on this problem to make the client workable. 
