### PR TITLE
Make file creation and deletion sychronized

### DIFF
--- a/src/main/java/tachyon/MasterInfo.java
+++ b/src/main/java/tachyon/MasterInfo.java
@@ -481,12 +481,14 @@ public class MasterInfo {
           throws FileAlreadyExistException, InvalidPathException, BlockInfoException,
           TachyonException {
     long creationTimeMs = System.currentTimeMillis();
-    int ret =
-        _createFile(recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
-    mJournal.getEditLog().createFile(
-        recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
-    mJournal.getEditLog().flush();
-    return ret;
+    synchronized (mRoot) {
+      int ret =
+          _createFile(recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
+      mJournal.getEditLog().createFile(
+          recursive, path, directory, columns, metadata, blockSizeByte, creationTimeMs);
+      mJournal.getEditLog().flush();
+      return ret;
+    }
   }
 
   public void createImage(DataOutputStream os) throws IOException {
@@ -773,10 +775,12 @@ public class MasterInfo {
    * @throws TachyonException
    */
   public boolean delete(int fileId, boolean recursive) throws TachyonException {
-    boolean ret = _delete(fileId, recursive);
-    mJournal.getEditLog().delete(fileId, recursive);
-    mJournal.getEditLog().flush();
-    return ret;
+    synchronized (mRoot) {
+      boolean ret = _delete(fileId, recursive);
+      mJournal.getEditLog().delete(fileId, recursive);
+      mJournal.getEditLog().flush();
+      return ret;
+    }
   }
 
   public boolean delete(String path, boolean recursive) throws TachyonException {


### PR DESCRIPTION
Currently, there is no synchronization on file creation and deletion with editlog updates. This blocks the master restarting sometimes. 

For example, Client-a creates file-A, and at the same time client-b creates file-B. Then client-a get the file id as 2 and client-b gets 3 which is after file-A. However, the editlog records creating file-B before the file-A by chance. Later on, we re-boot the whole system. The master re-builds the INode by reading that editlog, then  file-B's fid is 2 and file-A's is 3, which is not consistent with original case.  If some deletion and recreation based on the previous fid, it crashes master.

This PR aims to keep the editlog's update consistent with any INode change.
