### PR TITLE
Delete all loaded completedLog during rebooting

### DIFF
--- a/src/main/java/tachyon/EditLog.java
+++ b/src/main/java/tachyon/EditLog.java
@@ -232,7 +232,21 @@ public class EditLog {
     }
   }
 
-  public static void markUpToDate() {
+  public static void markUpToDate(String path) {
+    UnderFileSystem ufs = UnderFileSystem.get(path);
+    String folder = path.substring(0, path.lastIndexOf("/")) + "/completed";
+    try {
+      //delete all loaded editlogs since mBackupLogStartNum.
+      String toDelete = folder + "/" + mBackUpLogStartNum +  ".editLog";
+      while (ufs.exists(toDelete)) {
+        LOG.info("Deleting editlog " + toDelete);
+        ufs.delete(toDelete, true);
+        mBackUpLogStartNum ++;
+        toDelete = folder + "/" + mBackUpLogStartNum +  ".editLog";
+      }
+    } catch (IOException e) {
+      CommonUtils.runtimeException(e);
+    }
     mBackUpLogStartNum = -1;
   }
 

--- a/src/main/java/tachyon/Journal.java
+++ b/src/main/java/tachyon/Journal.java
@@ -67,7 +67,7 @@ public class Journal {
   public void createImage(MasterInfo info) throws IOException {
     if (mStandbyImagePath == "") {
       Image.create(info, mImagePath);
-      EditLog.markUpToDate();
+      EditLog.markUpToDate(mEditLogPath);
     } else {
       Image.rename(mStandbyImagePath, mImagePath);
     }

--- a/src/main/java/tachyon/MasterInfo.java
+++ b/src/main/java/tachyon/MasterInfo.java
@@ -1489,4 +1489,12 @@ public class MasterInfo {
   public void stop() {
     mHeartbeatThread.shutdown();
   }
+
+  /**
+   * Get Journal instance for MasterInfo for Unit test only
+   * @return Journal instance
+   */
+  public Journal getJournal() {
+    return mJournal;
+  }
 }


### PR DESCRIPTION
Now, Tachyon system has rotated editlog into **completed/** folder which exceeds configured size limitation(i.e., 1MB).   When the master rebooting, it loads those completed logs to rebuild the image. But after it all, those loaded completedlog files under **completed/** folder are not deleted. This will influence next round of rebooting consequently. 

This PR fixes this issue, and also adds one corresponding unit test. 
