### PR TITLE
Bug fix to RemoteBlockInStream.java:seek

### DIFF
--- a/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -69,6 +69,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
     if (mCurrentBuffer == null) {
       setupStreamFromUnderFs(mBlockInfo.offset);
+      
       if (mCheckpointInputStream == null) {
         throw new IOException("Can not find the block " + FILE + " " + BLOCK_INDEX);
       }


### PR DESCRIPTION
RemoteBlockInStream seek only supported seek if the current buffer had the data; the fix allows seek to arbitrary locations in the file. The code checks to see which ByteBuffer the sought 'pos' lies in, and only fetches that ByteBuffer from remote machine, and updates the book keeping information.
