### PR TITLE
Bug fix to RemoteBlockInStream.java:seek

### DIFF
--- a/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -352,13 +352,13 @@ public class RemoteBlockInStream extends BlockInStream {
     }
     mRecache = false;
     if (mCurrentBuffer != null) {
-      long length = BUFFER_SIZE;
       mReadByte = pos;
-      if(!(pos < mBufferStartPosition + length && pos >= mBufferStartPosition)) {
-        mBufferStartPosition = ((int)pos / length) * length;
-        mCurrentBuffer = readRemoteByteBuffer(mBlockInfo, mBufferStartPosition, length);
+      if(mBufferStartPosition <= pos && pos < mBufferStartPosition + mCurrentBuffer.limit()) {
+        mCurrentBuffer.position((int) (pos - mBufferStartPosition));
+      } else {
+        mBufferStartPosition = pos;
+        updateCurrentBuffer();
       }
-      mCurrentBuffer.position((int) (pos % length));
     } else {
       if (mCheckpointInputStream != null) {
         mCheckpointInputStream.close();


### PR DESCRIPTION
RemoteBlockInStream seek only supported seek if the current buffer had the data; the fix allows seek to arbitrary locations in the file. The code checks to see which ByteBuffer the sought 'pos' lies in, and only fetches that ByteBuffer from remote machine, and updates the book keeping information.
