### PR TITLE
Fix for a null pointer exception #90

### DIFF
--- a/src/main/java/tachyon/client/FileOutStream.java
+++ b/src/main/java/tachyon/client/FileOutStream.java
@@ -134,10 +134,10 @@ public class FileOutStream extends OutStream {
         int tLen = len;
         int tOff = off;
         while (tLen > 0) {
-          if (mCurrentBlockLeftByte == 0) {
+          if (mCurrentBlockLeftByte <= 0 || mCurrentBlockOutStream == null ) {
             getNextBlock();
           }
-          if (mCurrentBlockLeftByte > tLen) {
+          if (mCurrentBlockLeftByte >= tLen) {
             mCurrentBlockOutStream.write(b, tOff, tLen);
             mCurrentBlockLeftByte -= tLen;
             mCachedBytes += tLen;


### PR DESCRIPTION
Fix for the following:  

14/01/29 15:01:35 INFO mapreduce.Job: map 100% reduce 0%
14/01/29 15:01:39 INFO mapreduce.Job: Task Id : attempt_1391014684796_0013_r_000000_0, Status : FAILED
Error: java.lang.NullPointerException
at tachyon.client.FileOutStream.write(FileOutStream.java:141)
at org.apache.hadoop.fs.FSDataOutputStream$PositionCache.write(FSDataOutputStream.java:59)
at java.io.DataOutputStream.write(DataOutputStream.java:107)
at java.io.FilterOutputStream.write(FilterOutputStream.java:97)
at org.apache.hadoop.mapred.TextOutputFormat$LineRecordWriter.write(TextOutputFormat.java:99)
at org.apache.hadoop.mapred.ReduceTask$OldTrackingRecordWriter.write(ReduceTask.java:511)
at org.apache.hadoop.mapred.ReduceTask$3.collect(ReduceTask.java:440)
at org.myorg.WordCount$Reduce.reduce(WordCount.java:83)
at org.myorg.WordCount$Reduce.reduce(WordCount.java:77)
at org.apache.hadoop.mapred.ReduceTask.runOldReducer(ReduceTask.java:462)
at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:408)
at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:162)
at java.security.AccessController.doPrivileged(Native Method)
at javax.security.auth.Subject.doAs(Subject.java:415)
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1491)
at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:157)

It's exposed by a behavior shift given the stack shift. 
