### PR TITLE
Fixed loadufs exclude

### DIFF
--- a/src/main/java/tachyon/util/UnderfsUtil.java
+++ b/src/main/java/tachyon/util/UnderfsUtil.java
@@ -72,8 +72,8 @@ public class UnderfsUtil {
         String[] files = fs.list(path);
         if (files != null) {
           for (String filePath : files) {
-            LOG.info("Get: " + path + "/" + filePath);
-            if (excludePathPrefix.outList(path + "/" + filePath)) {
+            LOG.info("Get: " + filePath);
+            if (excludePathPrefix.outList(filePath)) {
               pathQueue.add(underfsAddress + filePath);
             }
           }


### PR DESCRIPTION
We were searching the exclude path list with the underfsAddress
prepended to the path, which isn't how they were in the list.
