### PR TITLE
[RFC] Add "cacheOnRead" setting for file inodes

### DIFF
--- a/src/main/java/tachyon/client/BlockInStream.java
+++ b/src/main/java/tachyon/client/BlockInStream.java
@@ -16,6 +16,9 @@
  */
 package tachyon.client;
 
+import org.apache.log4j.Logger;
+import tachyon.Constants;
+
 import java.io.IOException;
 
 /**
@@ -24,27 +27,30 @@ import java.io.IOException;
  * the client code.
  */
 public abstract class BlockInStream extends InStream {
+  private static final Logger LOG = Logger.getLogger(Constants.LOGGER_TYPE);
+
   protected final int BLOCK_INDEX;
   protected boolean mClosed = false;
 
   /**
    * @param file
-   * @param readType
+   * @param shouldCache
    * @param blockIndex
    * @throws IOException
    */
-  BlockInStream(TachyonFile file, ReadType readType, int blockIndex) throws IOException {
-    super(file, readType);
+  BlockInStream(TachyonFile file, boolean shouldCache, int blockIndex) throws IOException {
+    super(file, shouldCache);
     BLOCK_INDEX = blockIndex;
   }
 
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex)
       throws IOException {
+    boolean shouldCache = readType.isCache(tachyonFile.CACHE_ON_READ);
     TachyonByteBuffer buf = tachyonFile.readLocalByteBuffer(blockIndex);
     if (buf != null) {
-      return new LocalBlockInStream(tachyonFile, readType, blockIndex, buf);
+      return new LocalBlockInStream(tachyonFile, shouldCache, blockIndex, buf);
     }
 
-    return new RemoteBlockInStream(tachyonFile, readType, blockIndex);
+    return new RemoteBlockInStream(tachyonFile, shouldCache, blockIndex);
   }
 }

--- a/src/main/java/tachyon/client/EmptyBlockInStream.java
+++ b/src/main/java/tachyon/client/EmptyBlockInStream.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  * <code> EmptyBlockInStream </code> is a <code> InStream </code> can not read anything.
  */
 public class EmptyBlockInStream extends InStream {
-  EmptyBlockInStream(TachyonFile file, ReadType readType) {
-    super(file, readType);
+  EmptyBlockInStream(TachyonFile file, boolean shouldCache) {
+    super(file, shouldCache);
   }
 
   @Override

--- a/src/main/java/tachyon/client/FileInStream.java
+++ b/src/main/java/tachyon/client/FileInStream.java
@@ -32,8 +32,8 @@ public class FileInStream extends InStream {
 
   private boolean mClosed = false;
 
-  public FileInStream(TachyonFile file, ReadType opType) throws IOException {
-    super(file, opType);
+  public FileInStream(TachyonFile file, boolean shouldCache) throws IOException {
+    super(file, shouldCache);
 
     FILE_LENGTH = file.length();
     BLOCK_CAPACITY = file.getBlockSizeByte();
@@ -55,7 +55,7 @@ public class FileInStream extends InStream {
       }
 
       mCurrentBlockIndex = getCurrentBlockIndex();
-      mCurrentBlockInStream = BlockInStream.get(FILE, READ_TYPE, mCurrentBlockIndex);
+      mCurrentBlockInStream = BlockInStream.get(FILE, SHOULD_CACHE ? ReadType.CACHE : ReadType.NO_CACHE, mCurrentBlockIndex);
       mCurrentBlockLeft = BLOCK_CAPACITY;
     }
   }
@@ -139,7 +139,7 @@ public class FileInStream extends InStream {
       }
 
       mCurrentBlockIndex = tBlockIndex;
-      mCurrentBlockInStream = BlockInStream.get(FILE, READ_TYPE, mCurrentBlockIndex);
+      mCurrentBlockInStream = BlockInStream.get(FILE, SHOULD_CACHE ? ReadType.CACHE : ReadType.NO_CACHE, mCurrentBlockIndex);
       long shouldSkip = mCurrentPosition % BLOCK_CAPACITY;
       long skip = mCurrentBlockInStream.skip(shouldSkip);
       mCurrentBlockLeft = BLOCK_CAPACITY - skip;
@@ -172,7 +172,7 @@ public class FileInStream extends InStream {
       if (mCurrentBlockInStream != null) {
         mCurrentBlockInStream.close();
       }
-      mCurrentBlockInStream = BlockInStream.get(FILE, READ_TYPE, mCurrentBlockIndex);
+      mCurrentBlockInStream = BlockInStream.get(FILE, SHOULD_CACHE ? ReadType.CACHE : ReadType.NO_CACHE, mCurrentBlockIndex);
     }
     mCurrentBlockInStream.seek(pos % BLOCK_CAPACITY);
     mCurrentPosition = pos;

--- a/src/main/java/tachyon/client/InStream.java
+++ b/src/main/java/tachyon/client/InStream.java
@@ -30,12 +30,12 @@ public abstract class InStream extends InputStream {
   protected final UserConf USER_CONF = UserConf.get();
   protected final TachyonFile FILE;
   protected final TachyonFS TFS;
-  protected final ReadType READ_TYPE;
+  protected final boolean SHOULD_CACHE;
 
-  InStream(TachyonFile file, ReadType readType) {
+  InStream(TachyonFile file, boolean shouldCache) {
     FILE = file;
     TFS = FILE.TFS;
-    READ_TYPE = readType;
+    SHOULD_CACHE = shouldCache;
   }
 
   @Override

--- a/src/main/java/tachyon/client/LocalBlockInStream.java
+++ b/src/main/java/tachyon/client/LocalBlockInStream.java
@@ -26,9 +26,9 @@ public class LocalBlockInStream extends BlockInStream {
   private TachyonByteBuffer mTachyonBuffer = null;
   private ByteBuffer mBuffer = null;
 
-  LocalBlockInStream(TachyonFile file, ReadType readType, int blockIndex, TachyonByteBuffer buf)
+  LocalBlockInStream(TachyonFile file, boolean shouldCache, int blockIndex, TachyonByteBuffer buf)
       throws IOException {
-    super(file, readType, blockIndex);
+    super(file, shouldCache, blockIndex);
 
     mTachyonBuffer = buf;
     mBuffer = mTachyonBuffer.DATA;

--- a/src/main/java/tachyon/client/ReadType.java
+++ b/src/main/java/tachyon/client/ReadType.java
@@ -29,7 +29,11 @@ public enum ReadType {
   /**
    * Read the file and cache it.
    */
-  CACHE(2);
+  CACHE(2),
+  /**
+   * Cache based on whether the file is set to cache on read.
+   */
+  DEFAULT(3);
 
   private final int mValue;
 
@@ -41,8 +45,8 @@ public enum ReadType {
     return mValue;
   }
 
-  public boolean isCache() {
-    return mValue == CACHE.mValue;
+  public boolean isCache(boolean cacheByDefault) {
+    return this == CACHE || (this == DEFAULT && cacheByDefault);
   }
 
   public static ReadType getOpType(String op) throws IOException {
@@ -50,6 +54,8 @@ public enum ReadType {
       return NO_CACHE;
     } else if (op.equals("CACHE")) {
       return CACHE;
+    } else if (op.equals("DEFAULT")) {
+      return DEFAULT;
     }
 
     throw new IOException("Unknown ReadType : " + op);

--- a/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -49,8 +49,8 @@ public class RemoteBlockInStream extends BlockInStream {
   private boolean mRecache = true;
   private BlockOutStream mBlockOutStream = null;
 
-  RemoteBlockInStream(TachyonFile file, ReadType readType, int blockIndex) throws IOException {
-    super(file, readType, blockIndex);
+  RemoteBlockInStream(TachyonFile file, boolean shouldCache, int blockIndex) throws IOException {
+    super(file, shouldCache, blockIndex);
 
     mBlockInfo = TFS.getClientBlockInfo(FILE.FID, BLOCK_INDEX);
     mReadByte = 0;
@@ -60,8 +60,7 @@ public class RemoteBlockInStream extends BlockInStream {
       throw new IOException("File " + FILE.getPath() + " is not ready to read");
     }
 
-    mRecache = readType.isCache();
-    if (mRecache) {
+    if (shouldCache) {
       mBlockOutStream = new BlockOutStream(file, WriteType.TRY_CACHE, blockIndex);
     }
 

--- a/src/main/java/tachyon/client/TachyonFS.java
+++ b/src/main/java/tachyon/client/TachyonFS.java
@@ -352,6 +352,12 @@ public class TachyonFS {
   }
 
   public synchronized int createFile(String path, long blockSizeByte) throws IOException {
+    return createFile(path, blockSizeByte, false);
+  }
+
+  public synchronized int createFile(String path, long blockSizeByte, boolean cacheOnRead)
+      throws IOException {
+
     if (blockSizeByte > (long) Constants.GB * 2) {
       throw new IOException("Block size must be less than 2GB: " + blockSizeByte);
     }
@@ -361,9 +367,9 @@ public class TachyonFS {
       return -1;
     }
     path = CommonUtils.cleanPath(path);
-    int fid = -1;
+    int fid;
     try {
-      fid = mMasterClient.user_createFile(path, blockSizeByte);
+      fid = mMasterClient.user_createFile(path, blockSizeByte, cacheOnRead);
     } catch (TException e) {
       mConnected = false;
       throw new IOException(e);
@@ -617,7 +623,7 @@ public class TachyonFS {
       return null;
     }
     mClientFileInfos.put(clientFileInfo.getId(), clientFileInfo);
-    return new TachyonFile(this, clientFileInfo.getId());
+    return new TachyonFile(this, clientFileInfo.getId(), clientFileInfo.isCacheOnRead());
   }
 
   /**
@@ -633,7 +639,7 @@ public class TachyonFS {
       }
       mClientFileInfos.put(fid, clientFileInfo);
     }
-    return new TachyonFile(this, fid);
+    return new TachyonFile(this, fid, mClientFileInfos.get(fid).isCacheOnRead());
   }
 
   public synchronized int getFileId(String path) throws IOException {

--- a/src/main/java/tachyon/master/EditLog.java
+++ b/src/main/java/tachyon/master/EditLog.java
@@ -145,7 +145,7 @@ public class EditLog {
         }
         case OP_CREATE_FILE: {
           info._createFile(is.readBoolean(), Utils.readString(is), is.readBoolean(), is.readInt(),
-              Utils.readByteBuffer(is), is.readLong(), is.readLong());
+              Utils.readByteBuffer(is), is.readLong(), is.readLong(), is.readBoolean());
           break;
         }
         case OP_DELETE: {
@@ -327,7 +327,8 @@ public class EditLog {
   }
 
   public synchronized void createFile(boolean recursive, String path, boolean directory,
-      int columns, ByteBuffer metadata, long blockSizeByte, long creationTimeMs) {
+      int columns, ByteBuffer metadata, long blockSizeByte, long creationTimeMs,
+      boolean cacheOnRead) {
     if (INACTIVE) {
       return;
     }
@@ -342,6 +343,7 @@ public class EditLog {
       Utils.writeByteBuffer(metadata, DOS);
       DOS.writeLong(blockSizeByte);
       DOS.writeLong(creationTimeMs);
+      DOS.writeBoolean(cacheOnRead);
     } catch (IOException e) {
       CommonUtils.runtimeException(e);
     }

--- a/src/main/java/tachyon/master/InodeFile.java
+++ b/src/main/java/tachyon/master/InodeFile.java
@@ -36,14 +36,16 @@ public class InodeFile extends Inode {
   private boolean mIsComplete = false;
   private boolean mPin = false;
   private boolean mCache = false;
+  private boolean mCacheOnRead;
   private String mCheckpointPath = "";
   private List<BlockInfo> mBlocks = new ArrayList<BlockInfo>(3);
 
   private int mDependencyId;
 
-  public InodeFile(String name, int id, int parentId, long blockSizeByte, long creationTimeMs) {
+  public InodeFile(String name, int id, int parentId, long blockSizeByte, long creationTimeMs, boolean cacheOnRead) {
     super(name, id, parentId, InodeType.File, creationTimeMs);
     BLOCK_SIZE_BYTE = blockSizeByte;
+    mCacheOnRead = cacheOnRead;
     mDependencyId = -1;
   }
 
@@ -88,6 +90,7 @@ public class InodeFile extends Inode {
     sb.append(super.toString()).append(", LENGTH: ").append(mLength);
     sb.append(", CheckpointPath: ").append(mCheckpointPath);
     sb.append(", mBlocks: ").append(mBlocks);
+    sb.append(", CacheOnRead:").append(mCacheOnRead);
     sb.append(", DependencyId:").append(mDependencyId).append(")");
     return sb.toString();
   }
@@ -252,6 +255,14 @@ public class InodeFile extends Inode {
     return ret;
   }
 
+  public synchronized boolean cacheOnRead() {
+    return mCacheOnRead;
+  }
+
+  public synchronized void setCacheOnRead(boolean cacheOnRead) {
+    mCacheOnRead = cacheOnRead;
+  }
+
   @Override
   public ClientFileInfo generateClientFileInfo(String path) {
     ClientFileInfo ret = new ClientFileInfo();
@@ -271,6 +282,7 @@ public class InodeFile extends Inode {
     ret.blockIds = getBlockIds();
     ret.dependencyId = mDependencyId;
     ret.inMemoryPercentage = getInMemoryPercentage();
+    ret.cacheOnRead = mCacheOnRead;
 
     return ret;
   }

--- a/src/main/java/tachyon/master/MasterClient.java
+++ b/src/main/java/tachyon/master/MasterClient.java
@@ -286,12 +286,12 @@ public class MasterClient {
     }
   }
 
-  public synchronized int user_createFile(String path, long blockSizeByte)
+  public synchronized int user_createFile(String path, long blockSizeByte, boolean cacheOnRead)
       throws IOException, TException {
     while (!mIsShutdown) {
       connect();
       try {
-        return mClient.user_createFile(path, blockSizeByte);
+        return mClient.user_createFile(path, blockSizeByte, cacheOnRead);
       } catch (FileAlreadyExistException e) {
         throw new IOException(e);
       } catch (InvalidPathException e) {

--- a/src/main/java/tachyon/master/MasterServiceHandler.java
+++ b/src/main/java/tachyon/master/MasterServiceHandler.java
@@ -97,10 +97,10 @@ public class MasterServiceHandler implements MasterService.Iface {
   }
 
   @Override
-  public int user_createFile(String path, long blockSizeByte)
+  public int user_createFile(String path, long blockSizeByte, boolean cacheOnRead)
       throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException,
       TException {
-    return mMasterInfo.createFile(path, blockSizeByte);
+    return mMasterInfo.createFile(path, blockSizeByte, cacheOnRead);
   }
 
   @Override
@@ -111,7 +111,7 @@ public class MasterServiceHandler implements MasterService.Iface {
     try {
       long blockSizeByte = underfs.getBlockSizeByte(checkpointPath);
       long fileSizeByte = underfs.getFileSize(checkpointPath);
-      int fileId = mMasterInfo.createFile(path, blockSizeByte);
+      int fileId = mMasterInfo.createFile(path, blockSizeByte, false);
       if (fileId != -1 && mMasterInfo.addCheckpoint(-1, fileId, fileSizeByte, checkpointPath)) {
         return fileId;
       }
@@ -329,7 +329,7 @@ public class MasterServiceHandler implements MasterService.Iface {
           BlockInfoException, TachyonException, TException {
     try {
       for (int k = 0; k < children.size(); k ++) {
-        mMasterInfo.createFile(children.get(k), childrenBlockSizeByte);
+        mMasterInfo.createFile(children.get(k), childrenBlockSizeByte, false /* TODO */);
       }
       return mMasterInfo.createDependency(parents, children, commandPrefix, 
           data, comment, framework, frameworkVersion,

--- a/src/main/java/tachyon/thrift/ClientFileInfo.java
+++ b/src/main/java/tachyon/thrift/ClientFileInfo.java
@@ -48,6 +48,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   private static final org.apache.thrift.protocol.TField BLOCK_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("blockIds", org.apache.thrift.protocol.TType.LIST, (short)13);
   private static final org.apache.thrift.protocol.TField DEPENDENCY_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("dependencyId", org.apache.thrift.protocol.TType.I32, (short)14);
   private static final org.apache.thrift.protocol.TField IN_MEMORY_PERCENTAGE_FIELD_DESC = new org.apache.thrift.protocol.TField("inMemoryPercentage", org.apache.thrift.protocol.TType.I32, (short)15);
+  private static final org.apache.thrift.protocol.TField CACHE_ON_READ_FIELD_DESC = new org.apache.thrift.protocol.TField("cacheOnRead", org.apache.thrift.protocol.TType.BOOL, (short)16);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -70,6 +71,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   public List<Long> blockIds; // required
   public int dependencyId; // required
   public int inMemoryPercentage; // required
+  public boolean cacheOnRead; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -87,7 +89,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     NEED_CACHE((short)12, "needCache"),
     BLOCK_IDS((short)13, "blockIds"),
     DEPENDENCY_ID((short)14, "dependencyId"),
-    IN_MEMORY_PERCENTAGE((short)15, "inMemoryPercentage");
+    IN_MEMORY_PERCENTAGE((short)15, "inMemoryPercentage"),
+    CACHE_ON_READ((short)16, "cacheOnRead");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -132,6 +135,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
           return DEPENDENCY_ID;
         case 15: // IN_MEMORY_PERCENTAGE
           return IN_MEMORY_PERCENTAGE;
+        case 16: // CACHE_ON_READ
+          return CACHE_ON_READ;
         default:
           return null;
       }
@@ -183,6 +188,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
   private static final int __NEEDCACHE_ISSET_ID = 8;
   private static final int __DEPENDENCYID_ISSET_ID = 9;
   private static final int __INMEMORYPERCENTAGE_ISSET_ID = 10;
+  private static final int __CACHEONREAD_ISSET_ID = 11;
   private short __isset_bitfield = 0;
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
@@ -218,6 +224,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.IN_MEMORY_PERCENTAGE, new org.apache.thrift.meta_data.FieldMetaData("inMemoryPercentage", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
+    tmpMap.put(_Fields.CACHE_ON_READ, new org.apache.thrift.meta_data.FieldMetaData("cacheOnRead", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(ClientFileInfo.class, metaDataMap);
   }
@@ -240,7 +248,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     boolean needCache,
     List<Long> blockIds,
     int dependencyId,
-    int inMemoryPercentage)
+    int inMemoryPercentage,
+    boolean cacheOnRead)
   {
     this();
     this.id = id;
@@ -269,6 +278,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     setDependencyIdIsSet(true);
     this.inMemoryPercentage = inMemoryPercentage;
     setInMemoryPercentageIsSet(true);
+    this.cacheOnRead = cacheOnRead;
+    setCacheOnReadIsSet(true);
   }
 
   /**
@@ -303,6 +314,7 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     }
     this.dependencyId = other.dependencyId;
     this.inMemoryPercentage = other.inMemoryPercentage;
+    this.cacheOnRead = other.cacheOnRead;
   }
 
   public ClientFileInfo deepCopy() {
@@ -337,6 +349,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     this.dependencyId = 0;
     setInMemoryPercentageIsSet(false);
     this.inMemoryPercentage = 0;
+    setCacheOnReadIsSet(false);
+    this.cacheOnRead = false;
   }
 
   public int getId() {
@@ -703,6 +717,29 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __INMEMORYPERCENTAGE_ISSET_ID, value);
   }
 
+  public boolean isCacheOnRead() {
+    return this.cacheOnRead;
+  }
+
+  public ClientFileInfo setCacheOnRead(boolean cacheOnRead) {
+    this.cacheOnRead = cacheOnRead;
+    setCacheOnReadIsSet(true);
+    return this;
+  }
+
+  public void unsetCacheOnRead() {
+    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __CACHEONREAD_ISSET_ID);
+  }
+
+  /** Returns true if field cacheOnRead is set (has been assigned a value) and false otherwise */
+  public boolean isSetCacheOnRead() {
+    return EncodingUtils.testBit(__isset_bitfield, __CACHEONREAD_ISSET_ID);
+  }
+
+  public void setCacheOnReadIsSet(boolean value) {
+    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __CACHEONREAD_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case ID:
@@ -825,6 +862,14 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       }
       break;
 
+    case CACHE_ON_READ:
+      if (value == null) {
+        unsetCacheOnRead();
+      } else {
+        setCacheOnRead((Boolean)value);
+      }
+      break;
+
     }
   }
 
@@ -875,6 +920,9 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     case IN_MEMORY_PERCENTAGE:
       return Integer.valueOf(getInMemoryPercentage());
 
+    case CACHE_ON_READ:
+      return Boolean.valueOf(isCacheOnRead());
+
     }
     throw new IllegalStateException();
   }
@@ -916,6 +964,8 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       return isSetDependencyId();
     case IN_MEMORY_PERCENTAGE:
       return isSetInMemoryPercentage();
+    case CACHE_ON_READ:
+      return isSetCacheOnRead();
     }
     throw new IllegalStateException();
   }
@@ -1065,6 +1115,15 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       if (!(this_present_inMemoryPercentage && that_present_inMemoryPercentage))
         return false;
       if (this.inMemoryPercentage != that.inMemoryPercentage)
+        return false;
+    }
+
+    boolean this_present_cacheOnRead = true;
+    boolean that_present_cacheOnRead = true;
+    if (this_present_cacheOnRead || that_present_cacheOnRead) {
+      if (!(this_present_cacheOnRead && that_present_cacheOnRead))
+        return false;
+      if (this.cacheOnRead != that.cacheOnRead)
         return false;
     }
 
@@ -1234,6 +1293,16 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetCacheOnRead()).compareTo(typedOther.isSetCacheOnRead());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCacheOnRead()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.cacheOnRead, typedOther.cacheOnRead);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1328,6 +1397,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
     if (!first) sb.append(", ");
     sb.append("inMemoryPercentage:");
     sb.append(this.inMemoryPercentage);
+    first = false;
+    if (!first) sb.append(", ");
+    sb.append("cacheOnRead:");
+    sb.append(this.cacheOnRead);
     first = false;
     sb.append(")");
     return sb.toString();
@@ -1504,6 +1577,14 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 16: // CACHE_ON_READ
+            if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+              struct.cacheOnRead = iprot.readBool();
+              struct.setCacheOnReadIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1579,6 +1660,9 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       oprot.writeFieldBegin(IN_MEMORY_PERCENTAGE_FIELD_DESC);
       oprot.writeI32(struct.inMemoryPercentage);
       oprot.writeFieldEnd();
+      oprot.writeFieldBegin(CACHE_ON_READ_FIELD_DESC);
+      oprot.writeBool(struct.cacheOnRead);
+      oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1642,7 +1726,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       if (struct.isSetInMemoryPercentage()) {
         optionals.set(14);
       }
-      oprot.writeBitSet(optionals, 15);
+      if (struct.isSetCacheOnRead()) {
+        optionals.set(15);
+      }
+      oprot.writeBitSet(optionals, 16);
       if (struct.isSetId()) {
         oprot.writeI32(struct.id);
       }
@@ -1694,12 +1781,15 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       if (struct.isSetInMemoryPercentage()) {
         oprot.writeI32(struct.inMemoryPercentage);
       }
+      if (struct.isSetCacheOnRead()) {
+        oprot.writeBool(struct.cacheOnRead);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, ClientFileInfo struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
-      BitSet incoming = iprot.readBitSet(15);
+      BitSet incoming = iprot.readBitSet(16);
       if (incoming.get(0)) {
         struct.id = iprot.readI32();
         struct.setIdIsSet(true);
@@ -1768,6 +1858,10 @@ public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, C
       if (incoming.get(14)) {
         struct.inMemoryPercentage = iprot.readI32();
         struct.setInMemoryPercentageIsSet(true);
+      }
+      if (incoming.get(15)) {
+        struct.cacheOnRead = iprot.readBool();
+        struct.setCacheOnReadIsSet(true);
       }
     }
   }

--- a/src/main/java/tachyon/thrift/MasterService.java
+++ b/src/main/java/tachyon/thrift/MasterService.java
@@ -35,7 +35,6 @@ public class MasterService {
   public interface Iface {
 
     public boolean addCheckpoint(long workerId, int fileId, long length, String checkpointPath) throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException, org.apache.thrift.TException;
-
     public List<ClientWorkerInfo> getWorkersInfo() throws org.apache.thrift.TException;
 
     public List<ClientFileInfo> liststatus(String path) throws InvalidPathException, FileDoesNotExistException, org.apache.thrift.TException;
@@ -67,7 +66,7 @@ public class MasterService {
 
     public void user_requestFilesInDependency(int depId) throws DependencyDoesNotExistException, org.apache.thrift.TException;
 
-    public int user_createFile(String path, long blockSizeByte) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException;
+    public int user_createFile(String path, long blockSizeByte, boolean cacheOnRead) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException;
 
     public int user_createFileOnCheckpoint(String path, String checkpointPath) throws FileAlreadyExistException, InvalidPathException, SuspectedFileSizeException, BlockInfoException, TachyonException, org.apache.thrift.TException;
 
@@ -179,7 +178,7 @@ public class MasterService {
 
     public void user_requestFilesInDependency(int depId, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_requestFilesInDependency_call> resultHandler) throws org.apache.thrift.TException;
 
-    public void user_createFile(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFile_call> resultHandler) throws org.apache.thrift.TException;
+    public void user_createFile(String path, long blockSizeByte, boolean cacheOnRead, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFile_call> resultHandler) throws org.apache.thrift.TException;
 
     public void user_createFileOnCheckpoint(String path, String checkpointPath, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.user_createFileOnCheckpoint_call> resultHandler) throws org.apache.thrift.TException;
 
@@ -596,17 +595,18 @@ public class MasterService {
       return;
     }
 
-    public int user_createFile(String path, long blockSizeByte) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException
+    public int user_createFile(String path, long blockSizeByte, boolean cacheOnRead) throws FileAlreadyExistException, InvalidPathException, BlockInfoException, TachyonException, org.apache.thrift.TException
     {
-      send_user_createFile(path, blockSizeByte);
+      send_user_createFile(path, blockSizeByte, cacheOnRead);
       return recv_user_createFile();
     }
 
-    public void send_user_createFile(String path, long blockSizeByte) throws org.apache.thrift.TException
+    public void send_user_createFile(String path, long blockSizeByte, boolean cacheOnRead) throws org.apache.thrift.TException
     {
       user_createFile_args args = new user_createFile_args();
       args.setPath(path);
       args.setBlockSizeByte(blockSizeByte);
+      args.setCacheOnRead(cacheOnRead);
       sendBase("user_createFile", args);
     }
 
@@ -1856,9 +1856,9 @@ public class MasterService {
       }
     }
 
-    public void user_createFile(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler) throws org.apache.thrift.TException {
+    public void user_createFile(String path, long blockSizeByte, boolean cacheOnRead, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler) throws org.apache.thrift.TException {
       checkReady();
-      user_createFile_call method_call = new user_createFile_call(path, blockSizeByte, resultHandler, this, ___protocolFactory, ___transport);
+      user_createFile_call method_call = new user_createFile_call(path, blockSizeByte, cacheOnRead, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
@@ -1866,10 +1866,12 @@ public class MasterService {
     public static class user_createFile_call extends org.apache.thrift.async.TAsyncMethodCall {
       private String path;
       private long blockSizeByte;
-      public user_createFile_call(String path, long blockSizeByte, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      private boolean cacheOnRead;
+      public user_createFile_call(String path, long blockSizeByte, boolean cacheOnRead, org.apache.thrift.async.AsyncMethodCallback<user_createFile_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.path = path;
         this.blockSizeByte = blockSizeByte;
+        this.cacheOnRead = cacheOnRead;
       }
 
       public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
@@ -1877,6 +1879,7 @@ public class MasterService {
         user_createFile_args args = new user_createFile_args();
         args.setPath(path);
         args.setBlockSizeByte(blockSizeByte);
+        args.setCacheOnRead(cacheOnRead);
         args.write(prot);
         prot.writeMessageEnd();
       }
@@ -3187,7 +3190,7 @@ public class MasterService {
       public user_createFile_result getResult(I iface, user_createFile_args args) throws org.apache.thrift.TException {
         user_createFile_result result = new user_createFile_result();
         try {
-          result.success = iface.user_createFile(args.path, args.blockSizeByte);
+          result.success = iface.user_createFile(args.path, args.blockSizeByte, args.cacheOnRead);
           result.setSuccessIsSet(true);
         } catch (FileAlreadyExistException eR) {
           result.eR = eR;
@@ -15955,6 +15958,7 @@ public class MasterService {
 
     private static final org.apache.thrift.protocol.TField PATH_FIELD_DESC = new org.apache.thrift.protocol.TField("path", org.apache.thrift.protocol.TType.STRING, (short)1);
     private static final org.apache.thrift.protocol.TField BLOCK_SIZE_BYTE_FIELD_DESC = new org.apache.thrift.protocol.TField("blockSizeByte", org.apache.thrift.protocol.TType.I64, (short)2);
+    private static final org.apache.thrift.protocol.TField CACHE_ON_READ_FIELD_DESC = new org.apache.thrift.protocol.TField("cacheOnRead", org.apache.thrift.protocol.TType.BOOL, (short)3);
 
     private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
     static {
@@ -15964,11 +15968,13 @@ public class MasterService {
 
     public String path; // required
     public long blockSizeByte; // required
+    public boolean cacheOnRead; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       PATH((short)1, "path"),
-      BLOCK_SIZE_BYTE((short)2, "blockSizeByte");
+      BLOCK_SIZE_BYTE((short)2, "blockSizeByte"),
+      CACHE_ON_READ((short)3, "cacheOnRead");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -15987,6 +15993,8 @@ public class MasterService {
             return PATH;
           case 2: // BLOCK_SIZE_BYTE
             return BLOCK_SIZE_BYTE;
+          case 3: // CACHE_ON_READ
+            return CACHE_ON_READ;
           default:
             return null;
         }
@@ -16028,6 +16036,7 @@ public class MasterService {
 
     // isset id assignments
     private static final int __BLOCKSIZEBYTE_ISSET_ID = 0;
+    private static final int __CACHEONREAD_ISSET_ID = 1;
     private byte __isset_bitfield = 0;
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
@@ -16036,6 +16045,8 @@ public class MasterService {
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
       tmpMap.put(_Fields.BLOCK_SIZE_BYTE, new org.apache.thrift.meta_data.FieldMetaData("blockSizeByte", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+      tmpMap.put(_Fields.CACHE_ON_READ, new org.apache.thrift.meta_data.FieldMetaData("cacheOnRead", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(user_createFile_args.class, metaDataMap);
     }
@@ -16045,12 +16056,15 @@ public class MasterService {
 
     public user_createFile_args(
       String path,
-      long blockSizeByte)
+      long blockSizeByte,
+      boolean cacheOnRead)
     {
       this();
       this.path = path;
       this.blockSizeByte = blockSizeByte;
       setBlockSizeByteIsSet(true);
+      this.cacheOnRead = cacheOnRead;
+      setCacheOnReadIsSet(true);
     }
 
     /**
@@ -16062,6 +16076,7 @@ public class MasterService {
         this.path = other.path;
       }
       this.blockSizeByte = other.blockSizeByte;
+      this.cacheOnRead = other.cacheOnRead;
     }
 
     public user_createFile_args deepCopy() {
@@ -16073,6 +16088,8 @@ public class MasterService {
       this.path = null;
       setBlockSizeByteIsSet(false);
       this.blockSizeByte = 0;
+      setCacheOnReadIsSet(false);
+      this.cacheOnRead = false;
     }
 
     public String getPath() {
@@ -16122,6 +16139,29 @@ public class MasterService {
       __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __BLOCKSIZEBYTE_ISSET_ID, value);
     }
 
+    public boolean isCacheOnRead() {
+      return this.cacheOnRead;
+    }
+
+    public user_createFile_args setCacheOnRead(boolean cacheOnRead) {
+      this.cacheOnRead = cacheOnRead;
+      setCacheOnReadIsSet(true);
+      return this;
+    }
+
+    public void unsetCacheOnRead() {
+      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __CACHEONREAD_ISSET_ID);
+    }
+
+    /** Returns true if field cacheOnRead is set (has been assigned a value) and false otherwise */
+    public boolean isSetCacheOnRead() {
+      return EncodingUtils.testBit(__isset_bitfield, __CACHEONREAD_ISSET_ID);
+    }
+
+    public void setCacheOnReadIsSet(boolean value) {
+      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __CACHEONREAD_ISSET_ID, value);
+    }
+
     public void setFieldValue(_Fields field, Object value) {
       switch (field) {
       case PATH:
@@ -16140,6 +16180,14 @@ public class MasterService {
         }
         break;
 
+      case CACHE_ON_READ:
+        if (value == null) {
+          unsetCacheOnRead();
+        } else {
+          setCacheOnRead((Boolean)value);
+        }
+        break;
+
       }
     }
 
@@ -16150,6 +16198,9 @@ public class MasterService {
 
       case BLOCK_SIZE_BYTE:
         return Long.valueOf(getBlockSizeByte());
+
+      case CACHE_ON_READ:
+        return Boolean.valueOf(isCacheOnRead());
 
       }
       throw new IllegalStateException();
@@ -16166,6 +16217,8 @@ public class MasterService {
         return isSetPath();
       case BLOCK_SIZE_BYTE:
         return isSetBlockSizeByte();
+      case CACHE_ON_READ:
+        return isSetCacheOnRead();
       }
       throw new IllegalStateException();
     }
@@ -16198,6 +16251,15 @@ public class MasterService {
         if (!(this_present_blockSizeByte && that_present_blockSizeByte))
           return false;
         if (this.blockSizeByte != that.blockSizeByte)
+          return false;
+      }
+
+      boolean this_present_cacheOnRead = true;
+      boolean that_present_cacheOnRead = true;
+      if (this_present_cacheOnRead || that_present_cacheOnRead) {
+        if (!(this_present_cacheOnRead && that_present_cacheOnRead))
+          return false;
+        if (this.cacheOnRead != that.cacheOnRead)
           return false;
       }
 
@@ -16237,6 +16299,16 @@ public class MasterService {
           return lastComparison;
         }
       }
+      lastComparison = Boolean.valueOf(isSetCacheOnRead()).compareTo(typedOther.isSetCacheOnRead());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetCacheOnRead()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.cacheOnRead, typedOther.cacheOnRead);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -16267,6 +16339,10 @@ public class MasterService {
       if (!first) sb.append(", ");
       sb.append("blockSizeByte:");
       sb.append(this.blockSizeByte);
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("cacheOnRead:");
+      sb.append(this.cacheOnRead);
       first = false;
       sb.append(")");
       return sb.toString();
@@ -16329,6 +16405,14 @@ public class MasterService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 3: // CACHE_ON_READ
+              if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+                struct.cacheOnRead = iprot.readBool();
+                struct.setCacheOnReadIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -16351,6 +16435,9 @@ public class MasterService {
         }
         oprot.writeFieldBegin(BLOCK_SIZE_BYTE_FIELD_DESC);
         oprot.writeI64(struct.blockSizeByte);
+        oprot.writeFieldEnd();
+        oprot.writeFieldBegin(CACHE_ON_READ_FIELD_DESC);
+        oprot.writeBool(struct.cacheOnRead);
         oprot.writeFieldEnd();
         oprot.writeFieldStop();
         oprot.writeStructEnd();
@@ -16376,19 +16463,25 @@ public class MasterService {
         if (struct.isSetBlockSizeByte()) {
           optionals.set(1);
         }
-        oprot.writeBitSet(optionals, 2);
+        if (struct.isSetCacheOnRead()) {
+          optionals.set(2);
+        }
+        oprot.writeBitSet(optionals, 3);
         if (struct.isSetPath()) {
           oprot.writeString(struct.path);
         }
         if (struct.isSetBlockSizeByte()) {
           oprot.writeI64(struct.blockSizeByte);
         }
+        if (struct.isSetCacheOnRead()) {
+          oprot.writeBool(struct.cacheOnRead);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, user_createFile_args struct) throws org.apache.thrift.TException {
         TTupleProtocol iprot = (TTupleProtocol) prot;
-        BitSet incoming = iprot.readBitSet(2);
+        BitSet incoming = iprot.readBitSet(3);
         if (incoming.get(0)) {
           struct.path = iprot.readString();
           struct.setPathIsSet(true);
@@ -16396,6 +16489,10 @@ public class MasterService {
         if (incoming.get(1)) {
           struct.blockSizeByte = iprot.readI64();
           struct.setBlockSizeByteIsSet(true);
+        }
+        if (incoming.get(2)) {
+          struct.cacheOnRead = iprot.readBool();
+          struct.setCacheOnReadIsSet(true);
         }
       }
     }

--- a/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/src/main/java/tachyon/worker/WorkerStorage.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/thrift/tachyon.thrift
+++ b/src/thrift/tachyon.thrift
@@ -38,6 +38,7 @@ struct ClientFileInfo {
   13: list<i64> blockIds
   14: i32 dependencyId
   15: i32 inMemoryPercentage
+  16: bool cacheOnRead
 }
 
 struct ClientDependencyInfo {
@@ -146,7 +147,7 @@ service MasterService {
   void user_requestFilesInDependency(1: i32 depId)
     throws (1: DependencyDoesNotExistException e)
 
-  i32 user_createFile(1: string path, 2: i64 blockSizeByte)
+  i32 user_createFile(1: string path, 2: i64 blockSizeByte, 3: bool cacheOnRead)
     throws (1: FileAlreadyExistException eR, 2: InvalidPathException eI, 3: BlockInfoException eB, 4: TachyonException eT)
   i32 user_createFileOnCheckpoint(1: string path, 2: string checkpointPath)
     throws (1: FileAlreadyExistException eR, 2: InvalidPathException eI, 3: SuspectedFileSizeException eS, 4: BlockInfoException eB, 5: TachyonException eT)


### PR DESCRIPTION
This setting allows a user to specify a "cacheOnRead" setting for an inode, which is respected when the file is read via ReadType.DEFAULT. The use-case here is when the writer of the file wants to declare the file to be cache-friendly or cache-avoiding, and the reader is content to accept whatever choice was made.

This approach actually adds a field to the InodeFile, which is admittedly rather invasive but does allow us to integrate easily into the WAL. The option as specified here is optional and defaults to true. I have tried to avoid removing or modifying any external APIs.

One shortcoming of this approach is that it is not currently possible to modify the property after inode creation; this would simply require a new WAL entry type and a new RPC.

(Note that this PR is in a RFC stage -- I am hoping to get feedback on the best way of accomplishing this in Tachyon. If the current approach is suitable, I will clean up the PR and submit it for real.)
