### PR TITLE
Disable instance cache in minidfscluster

### DIFF
--- a/src/test/java/tachyon/LocalMiniDFSCluster.java
+++ b/src/test/java/tachyon/LocalMiniDFSCluster.java
@@ -180,6 +180,7 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
       mDfsCluster.shutdown();
       mIsStarted = false;
     }
+    System.clearProperty("fs.hdfs.impl.disable.cache");
   }
 
   /**
@@ -210,5 +211,6 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
       mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;
     }
+    System.setProperty("fs.hdfs.impl.disable.cache", "true");
   }
 }

--- a/src/test/java/tachyon/UnderFileSystemCluster.java
+++ b/src/test/java/tachyon/UnderFileSystemCluster.java
@@ -37,7 +37,6 @@ public abstract class UnderFileSystemCluster {
           System.out.println("Failed to shutdown underfs cluster: " + e);
         }
       }
-      System.clearProperty("fs.hdfs.impl.disable.cache");
     }
   }
 
@@ -69,7 +68,6 @@ public abstract class UnderFileSystemCluster {
 
     if (mUfsClz != null && !mUfsClz.equals("")) {
       try {
-        System.setProperty("fs.hdfs.impl.disable.cache", "true");
         UnderFileSystemCluster ufsCluster =
             (UnderFileSystemCluster) Class.forName(mUfsClz).getConstructor(String.class)
                 .newInstance(baseDir);


### PR DESCRIPTION
A tiny modification to move fs.hdfs.impl.disable.cache configuration from UnderFileSystemCluster to LocalMiniDFSCluster.  If minidfscluster is not used, those configuration won't be effective. 
