### PR TITLE
Fix master cleanup for zookeeper mode

### DIFF
--- a/src/main/java/tachyon/master/Master.java
+++ b/src/main/java/tachyon/master/Master.java
@@ -236,12 +236,15 @@ public class Master {
       mWebServer.shutdownWebServer();
       mMasterInfo.stop();
       mMasterServiceServer.stop();
-
-      if (mZookeeperMode) {
+      mIsStarted = false;
+    }   
+    if (mZookeeperMode) {
+      if (mLeaderSelectorClient != null) {
         mLeaderSelectorClient.close();
       }
-
-      mIsStarted = false;
+      if (mEditLogProcessor != null) {
+        mEditLogProcessor.stop();
+      }
     }
   }
 }

--- a/src/test/java/tachyon/LocalMiniDFSCluster.java
+++ b/src/test/java/tachyon/LocalMiniDFSCluster.java
@@ -180,7 +180,6 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
       mDfsCluster.shutdown();
       mIsStarted = false;
     }
-    System.clearProperty("fs.hdfs.impl.disable.cache");
   }
 
   /**
@@ -211,6 +210,5 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
       mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;
     }
-    System.setProperty("fs.hdfs.impl.disable.cache", "true");
   }
 }

--- a/src/test/java/tachyon/master/JournalTest.java
+++ b/src/test/java/tachyon/master/JournalTest.java
@@ -127,11 +127,13 @@ public class JournalTest {
   public final void after() throws Exception {
     mLocalTachyonCluster.stop();
     System.clearProperty("tachyon.user.quota.unit.bytes");
+    System.clearProperty("fs.hdfs.impl.disable.cache");
   }
 
   @Before
   public final void before() throws IOException {
     System.setProperty("tachyon.user.quota.unit.bytes", "1000");
+    System.setProperty("fs.hdfs.impl.disable.cache", "true");
     mLocalTachyonCluster = new LocalTachyonCluster(10000);
     mLocalTachyonCluster.start();
     mTfs = mLocalTachyonCluster.getClient();

--- a/src/test/java/tachyon/master/MasterFaultToleranceTest.java
+++ b/src/test/java/tachyon/master/MasterFaultToleranceTest.java
@@ -42,12 +42,14 @@ public class MasterFaultToleranceTest {
     mLocalTachyonClusterMultiMaster.stop();
     System.clearProperty("tachyon.user.quota.unit.bytes");
     System.clearProperty("tachyon.user.default.block.size.byte");
+    System.clearProperty("fs.hdfs.impl.disable.cache");
   }
 
   @Before
   public final void before() throws IOException {
     System.setProperty("tachyon.user.quota.unit.bytes", "1000");
     System.setProperty("tachyon.user.default.block.size.byte", String.valueOf(BLOCK_SIZE));
+    System.setProperty("fs.hdfs.impl.disable.cache", "true");
     mLocalTachyonClusterMultiMaster = new LocalTachyonClusterMultiMaster(10000, 5);
     mLocalTachyonClusterMultiMaster.start();
     mTfs = mLocalTachyonClusterMultiMaster.getClient();


### PR DESCRIPTION
The value of "mIsStarted" only controls the leader master's major services' status (e.g., webservice, masterInfo, and etc.). For those standby nodes, two threads are always starting no matter "mIsStarted" is true or false. One is the leaderSelectorClient and the other is EditLogProcessor. 
Currently, the leaderSelectorClient is cleaned up only when mIsStarted == true. And EditLogProcessor won't be cleaned up. This works for leader node. However for those standby nodes, it will leave some residual threads after the master is closed. 

This issue won't affect the real-world deployment, and it only blocks other test cases which are running after the MasterFaultTolerantTest. This PR aims to close those 2 threads in zookeeper mode.
