### PR TITLE
Check if the List is null before using it

### DIFF
--- a/main/src/main/java/tachyon/client/TachyonFile.java
+++ b/main/src/main/java/tachyon/client/TachyonFile.java
@@ -120,8 +120,9 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   public List<String> getLocationHosts() throws IOException {
     List<NetAddress> locations = TFS.getClientBlockInfo(FID, 0).getLocations();
-    List<String> ret = new ArrayList<String>(locations.size());
+    List<String> ret = null;
     if (locations != null) {
+      ret = new ArrayList<String>(locations.size());
       for (int k = 0; k < locations.size(); k ++) {
         ret.add(locations.get(k).mHost);
       }


### PR DESCRIPTION
The variable "List<NetAddress> locations" might be null, so we should
check it before using its method size() in case that it throws a
NullPointerException.
