### PR TITLE
under FS prefix file:// should be treated the same as local FS

### DIFF
--- a/main/src/main/java/tachyon/UnderFileSystem.java
+++ b/main/src/main/java/tachyon/UnderFileSystem.java
@@ -44,10 +44,9 @@ public abstract class UnderFileSystem {
   }
 
   public static UnderFileSystem get(String path) {
-    if (path.startsWith("hdfs://") || path.startsWith("file://") || path.startsWith("s3://")
-        || path.startsWith("s3n://")) {
+    if (path.startsWith("hdfs://") || path.startsWith("s3://") || path.startsWith("s3n://")) {
       return UnderFileSystemHdfs.getClient(path);
-    } else if (path.startsWith(Constants.PATH_SEPARATOR)) {
+    } else if (path.startsWith(Constants.PATH_SEPARATOR) || path.startsWith("file://")) {
       return UnderFileSystemSingleLocal.getClient();
     }
     CommonUtils.illegalArgumentException("Unknown under file system scheme " + path);


### PR DESCRIPTION
When syncing local file system using command loadufs, the local path could be specified with prefix either "/" or "file://". The latter was handled currently by UnderFileSystemHdfs. It should be UnderFileSystemSingleLocal.
