### PR TITLE
Cleaned up and documented MasterInfo and related files

### DIFF
--- a/main/src/main/java/tachyon/client/TachyonFS.java
+++ b/main/src/main/java/tachyon/client/TachyonFS.java
@@ -47,6 +47,7 @@ import tachyon.thrift.ClientFileInfo;
 import tachyon.thrift.ClientRawTableInfo;
 import tachyon.thrift.ClientWorkerInfo;
 import tachyon.thrift.FileDoesNotExistException;
+import tachyon.thrift.InvalidPathException;
 import tachyon.thrift.NetAddress;
 import tachyon.thrift.NoWorkerException;
 import tachyon.thrift.TachyonException;
@@ -358,7 +359,11 @@ public class TachyonFS {
     if (!mConnected) {
       return -1;
     }
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     int fid = -1;
     try {
       fid = mMasterClient.user_createFile(path, blockSizeByte);
@@ -374,7 +379,11 @@ public class TachyonFS {
     if (!mConnected) {
       return -1;
     }
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     int fid = -1;
     try {
       fid = mMasterClient.user_createFileOnCheckpoint(path, checkpointPath);
@@ -395,7 +404,11 @@ public class TachyonFS {
     if (!mConnected) {
       return -1;
     }
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
 
     if (columns < 1 || columns > CommonConf.get().MAX_COLUMNS) {
       throw new IOException("Column count " + columns + " is smaller than 1 or " + "bigger than "
@@ -574,7 +587,11 @@ public class TachyonFS {
       return null;
     }
     ClientFileInfo ret;
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     if (useCachedMetadata && mCachedClientFileInfos.containsKey(path)) {
       return mCachedClientFileInfos.get(path);
     }
@@ -635,7 +652,11 @@ public class TachyonFS {
 
   public synchronized TachyonFile getFile(String path, boolean useCachedMetadata)
       throws IOException {
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     ClientFileInfo clientFileInfo = getClientFileInfo(path, useCachedMetadata);
     if (clientFileInfo == null) {
       return null;
@@ -699,7 +720,11 @@ public class TachyonFS {
       return -1;
     }
     int fid = -1;
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     try {
       fid = mMasterClient.user_getFileId(path);
     } catch (TException e) {
@@ -830,7 +855,11 @@ public class TachyonFS {
 
   public synchronized RawTable getRawTable(String path) throws IOException {
     connect();
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     ClientRawTableInfo clientRawTableInfo;
     try {
       clientRawTableInfo = mMasterClient.user_getClientRawTableInfoByPath(path);
@@ -982,7 +1011,11 @@ public class TachyonFS {
     if (!mConnected) {
       return false;
     }
-    path = CommonUtils.cleanPath(path);
+    try {
+      path = CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
     try {
       return mMasterClient.user_mkdir(path);
     } catch (TException e) {

--- a/main/src/main/java/tachyon/util/CommonUtils.java
+++ b/main/src/main/java/tachyon/util/CommonUtils.java
@@ -83,18 +83,15 @@ public final class CommonUtils {
 
   /**
    * Checks and normalizes the given path
-   *
+   * 
    * @param path
    *          The path to clean up
-   * @return a normalized version of the path, with single separators between path components and dot components resolved
+   * @return a normalized version of the path, with single separators between path components and
+   *         dot components resolved
    */
-  public static String cleanPath(String path) throws IOException {
-    try {
-      validatePath(path);
-    } catch (InvalidPathException e) {
-      throw new IOException(e.getMessage());
-    }
-    return FilenameUtils.normalize(path, true);
+  public static String cleanPath(String path) throws InvalidPathException {
+    validatePath(path);
+    return FilenameUtils.separatorsToUnix(FilenameUtils.normalizeNoEndSeparator(path));
   }
 
   public static ByteBuffer cloneByteBuffer(ByteBuffer buf) {
@@ -191,8 +188,8 @@ public final class CommonUtils {
    *          The path to check
    * @return true if the path is the root
    */
-  public static boolean isRoot(String path) {
-    return Constants.PATH_SEPARATOR.equals(FilenameUtils.normalize(path, true));
+  public static boolean isRoot(String path) throws InvalidPathException {
+    return Constants.PATH_SEPARATOR.equals(cleanPath(path));
   }
 
   /**
@@ -203,7 +200,7 @@ public final class CommonUtils {
    * @return the name of the file
    */
   public static String getName(String path) throws InvalidPathException {
-    return FilenameUtils.getName(FilenameUtils.normalize(path, true));
+    return FilenameUtils.getName(cleanPath(path));
   }
 
   /**
@@ -229,8 +226,7 @@ public final class CommonUtils {
    * @return the path split into components
    */
   public static String[] getPathComponents(String path) throws InvalidPathException {
-    validatePath(path);
-    path = FilenameUtils.normalize(path, true);
+    path = cleanPath(path);
     if (isRoot(path)) {
       String[] ret = new String[1];
       ret[0] = "";

--- a/main/src/main/java/tachyon/web/WebInterfaceDependencyServlet.java
+++ b/main/src/main/java/tachyon/web/WebInterfaceDependencyServlet.java
@@ -35,10 +35,10 @@ public class WebInterfaceDependencyServlet extends HttpServlet {
     try {
       ClientDependencyInfo dependencyInfo = mMasterInfo.getClientDependencyInfo(dependencyId);
       for (int pId : dependencyInfo.parents) {
-        parentFileNames.add(mMasterInfo.getFileNameById(pId));
+        parentFileNames.add(mMasterInfo.getPath(pId));
       }
       for (int cId : dependencyInfo.children) {
-        childrenFileNames.add(mMasterInfo.getFileNameById(cId));
+        childrenFileNames.add(mMasterInfo.getPath(cId));
       }
     } catch (DependencyDoesNotExistException ddnee) {
       request.setAttribute("error", ddnee.getMessage());

--- a/main/src/test/java/tachyon/master/InodeFolderTest.java
+++ b/main/src/test/java/tachyon/master/InodeFolderTest.java
@@ -31,8 +31,10 @@ public class InodeFolderTest {
   @Test
   public void addChildrenTest() {
     InodeFolder inodeFolder = new InodeFolder("testFolder1", 1, 0, System.currentTimeMillis());
-    inodeFolder.addChild(2);
-    inodeFolder.addChild(3);
+    InodeFile inodeFile1 = new InodeFile("testFile1", 2, 1, 1000, System.currentTimeMillis());
+    InodeFile inodeFile2 = new InodeFile("testFile2", 3, 1, 1000, System.currentTimeMillis());
+    inodeFolder.addChild(inodeFile1);
+    inodeFolder.addChild(inodeFile2);
     Assert.assertEquals(2, (int) inodeFolder.getChildrenIds().get(0));
     Assert.assertEquals(3, (int) inodeFolder.getChildrenIds().get(1));
   }
@@ -42,14 +44,12 @@ public class InodeFolderTest {
     InodeFolder inodeFolder = new InodeFolder("testFolder1", 1, 0, System.currentTimeMillis());
     InodeFile inodeFile1 = new InodeFile("testFile1", 2, 1, 1000, System.currentTimeMillis());
     InodeFile inodeFile2 = new InodeFile("testFile2", 3, 1, 1000, System.currentTimeMillis());
-    inodeFolder.addChild(2);
-    inodeFolder.addChild(3);
-    inodeFolder.addChild(4);
-    Map<Integer, Inode> testMap = new HashMap<Integer, Inode>(2);
-    testMap.put(2, inodeFile1);
-    testMap.put(3, inodeFile2);
+    InodeFile inodeFile3 = new InodeFile("testFile3", 4, 1, 1000, System.currentTimeMillis());
+    inodeFolder.addChild(inodeFile1);
+    inodeFolder.addChild(inodeFile2);
+    inodeFolder.addChild(inodeFile3);
     Assert.assertEquals(3, inodeFolder.getNumberOfChildren());
-    inodeFolder.removeChild("testFile1", testMap);
+    inodeFolder.removeChild("testFile1");
     Assert.assertEquals(2, inodeFolder.getNumberOfChildren());
     Assert.assertFalse(inodeFolder.getChildrenIds().contains(2));
   }
@@ -90,18 +90,21 @@ public class InodeFolderTest {
   @Test
   public void removeChildTest() {
     InodeFolder inodeFolder = new InodeFolder("testFolder1", 1, 0, System.currentTimeMillis());
-    inodeFolder.addChild(2);
+    InodeFile inodeFile1 = new InodeFile("testFile1", 2, 1, 1000, System.currentTimeMillis());
+    inodeFolder.addChild(inodeFile1);
     Assert.assertEquals(1, inodeFolder.getNumberOfChildren());
-    inodeFolder.removeChild(2);
+    inodeFolder.removeChild(inodeFile1);
     Assert.assertEquals(0, inodeFolder.getNumberOfChildren());
   }
 
   @Test
   public void removeNonExistentChildTest() {
     InodeFolder inodeFolder = new InodeFolder("testFolder1", 1, 0, System.currentTimeMillis());
-    inodeFolder.addChild(2);
+    InodeFile inodeFile1 = new InodeFile("testFile1", 2, 1, 1000, System.currentTimeMillis());
+    InodeFile inodeFile2 = new InodeFile("testFile2", 3, 1, 1000, System.currentTimeMillis());
+    inodeFolder.addChild(inodeFile1);
     Assert.assertEquals(1, inodeFolder.getNumberOfChildren());
-    inodeFolder.removeChild(3);
+    inodeFolder.removeChild(inodeFile2);
     Assert.assertEquals(1, inodeFolder.getNumberOfChildren());
   }
 
@@ -115,8 +118,9 @@ public class InodeFolderTest {
   @Test
   public void sameIdChildrenTest() {
     InodeFolder inodeFolder = new InodeFolder("testFolder1", 1, 0, System.currentTimeMillis());
-    inodeFolder.addChild(2);
-    inodeFolder.addChild(2);
+    InodeFile inodeFile1 = new InodeFile("testFile1", 2, 1, 1000, System.currentTimeMillis());
+    inodeFolder.addChild(inodeFile1);
+    inodeFolder.addChild(inodeFile1);
     Assert.assertTrue(inodeFolder.getChildrenIds().get(0) == 2);
     Assert.assertEquals(1, inodeFolder.getNumberOfChildren());
   }


### PR DESCRIPTION
Major changes:
1. InodeFolder stores its children as Inodes rather than inode ids. This
simplifies many operations
2. Writing and loading filesystem images is modified accordingly to work
with the new InodeFolder structure
