### PR TITLE
Fixed CommonUtils cleanPath

### DIFF
--- a/docs/Startup-Tasks-for-New-Contributors.md
+++ b/docs/Startup-Tasks-for-New-Contributors.md
@@ -71,6 +71,8 @@ e.g.  mvn -Dtest=TachyonFSTest#createFileTest test ;
 -   Break your work into small, single-purpose patches if possible. It’s much harder to merge in
     a large change with a lot of disjoint features.
 
+-   Make sure that any methods you add maintain the alphabetical ordering of method names in each file.
+
 -   Submit the patch as a GitHub pull request. For a tutorial, see the GitHub guides on
     [forking a repo](https://help.github.com/articles/fork-a-repo) and
     [sending a pull request](https://help.github.com/articles/using-pull-requests).

--- a/main/src/main/java/tachyon/client/TachyonFS.java
+++ b/main/src/main/java/tachyon/client/TachyonFS.java
@@ -201,6 +201,21 @@ public class TachyonFS {
     }
   }
 
+  /**
+   * Cleans the given path, throwing an IOException rather than an InvalidPathException.
+   *
+   * @param path
+   *          The path to clean
+   * @return the cleaned path
+   */
+  private synchronized String cleanPathIOException(String path) throws IOException {
+    try {
+      return CommonUtils.cleanPath(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    }
+  }
+
   public synchronized void close() throws TException {
     if (mMasterClient != null) {
       mMasterClient.cleanConnect();
@@ -353,21 +368,6 @@ public class TachyonFS {
     } catch (TException e) {
       mConnected = false;
       throw new IOException(e);
-    }
-  }
-
-  /**
-   * cleans the given path, throwing an IOException rather than an InvalidPathException.
-   *
-   * @param path
-   *          The path to clean
-   * @return the cleaned path
-   */
-  private synchronized String cleanPathIOException(String path) throws IOException {
-    try {
-      return CommonUtils.cleanPath(path);
-    } catch (InvalidPathException e) {
-      throw new IOException(e.getMessage());
     }
   }
 

--- a/main/src/main/java/tachyon/util/CommonUtils.java
+++ b/main/src/main/java/tachyon/util/CommonUtils.java
@@ -207,17 +207,6 @@ public final class CommonUtils {
   }
 
   /**
-   * Check if the given path is the root.
-   * 
-   * @param path
-   *          The path to check
-   * @return true if the path is the root
-   */
-  public static boolean isRoot(String path) throws InvalidPathException {
-    return Constants.PATH_SEPARATOR.equals(cleanPath(path));
-  }
-
-  /**
    * Get the name of the file at a path.
    * 
    * @param path
@@ -269,6 +258,17 @@ public final class CommonUtils {
 
   public static void illegalArgumentException(String msg) {
     throw new IllegalArgumentException(msg);
+  }
+
+  /**
+   * Check if the given path is the root.
+   * 
+   * @param path
+   *          The path to check
+   * @return true if the path is the root
+   */
+  public static boolean isRoot(String path) throws InvalidPathException {
+    return Constants.PATH_SEPARATOR.equals(cleanPath(path));
   }
 
   public static <T> String listToString(List<T> list) {


### PR DESCRIPTION
It throws an InvalidPathException and can be called in other code now.
