### PR TITLE
change pinlist and whitelist separator from semicolon to comma

### DIFF
--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -48,6 +48,6 @@ export TACHYON_JAVA_OPTS+="
   -Dtachyon.master.worker.timeout.ms=60000
   -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS
   -Dtachyon.master.journal.folder=$TACHYON_HOME/journal/
-  -Dtachyon.master.pinlist=/pinfiles;/pindata
+  -Dtachyon.master.pinlist=/pinfiles,/pindata
   -Dorg.apache.jasper.compiler.disablejsr199=true
 "

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -111,12 +111,12 @@ number.
 <tr>
   <td>tachyon.master.whitelist</td>
   <td>/</td>
-  <td>The list of prefixes of the paths which are cacheable, separated by semi-colons. Tachyon will try to cache the cacheable file when it is read for the first time.</td>
+  <td>The comma-separated list of prefixes of the paths which are cacheable, separated by semi-colons. Tachyon will try to cache the cacheable file when it is read for the first time.</td>
 </tr>
 <tr>
   <td>tachyon.master.pinlist</td>
   <td></td>
-  <td>The list of files that will remain in memory all the time. If the memory size is not sufficient, the exception will be raised for the last caching file's client.</td>
+  <td>The comma-separated list of files that will remain in memory all the time. If the memory size is not sufficient, the exception will be raised for the last caching file's client.</td>
 </tr>
 </table>
 

--- a/main/src/main/java/tachyon/conf/MasterConf.java
+++ b/main/src/main/java/tachyon/conf/MasterConf.java
@@ -83,10 +83,10 @@ public class MasterConf extends Utils {
     WORKER_TIMEOUT_MS = getIntProperty("tachyon.master.worker.timeout.ms", 10 * 1000);
 
     WHITELIST.addAll(Arrays.asList(getProperty("tachyon.master.whitelist",
-        Constants.PATH_SEPARATOR).split(";")));
+        Constants.PATH_SEPARATOR).split(",")));
     String tPinList = getProperty("tachyon.master.pinlist", null);
     if (tPinList != null && !tPinList.isEmpty()) {
-      PINLIST.addAll(Arrays.asList(tPinList.split(";")));
+      PINLIST.addAll(Arrays.asList(tPinList.split(",")));
     }
   }
 }


### PR DESCRIPTION
semicolon separator causes confusions while forming command line on unix. let's use comma instead.
