### PR TITLE
Create local folders if parent path doesn't exist

### DIFF
--- a/main/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/main/src/main/java/tachyon/worker/WorkerStorage.java
@@ -519,8 +519,8 @@ public class WorkerStorage {
     LOG.info("Initializing the worker storage.");
     if (!mLocalDataFolder.exists()) {
       LOG.info("Local folder " + mLocalDataFolder + " does not exist. Creating a new one.");
-      mLocalDataFolder.mkdir();
-      mLocalUserFolder.mkdir();
+      mLocalDataFolder.mkdirs();
+      mLocalUserFolder.mkdirs();
 
       CommonUtils.changeLocalFilePermission(mLocalDataFolder.getPath(), "775");
       CommonUtils.changeLocalFilePermission(mLocalUserFolder.getPath(), "775");


### PR DESCRIPTION
Previously it will fail to create the local data folder, if the parent path doesn't exist.
