### PR TITLE
Minor improvements to resilience of Heartbeat Thread

### DIFF
--- a/main/src/main/java/tachyon/HeartbeatThread.java
+++ b/main/src/main/java/tachyon/HeartbeatThread.java
@@ -18,6 +18,7 @@ import org.apache.log4j.Logger;
 
 /**
  * Thread class to execute a heartbeat periodically.
+ * This Thread is daemonic, so it will not prevent the JVM from exiting.
  */
 public class HeartbeatThread extends Thread {
   private final Logger LOG = Logger.getLogger(Constants.LOGGER_TYPE);
@@ -25,7 +26,7 @@ public class HeartbeatThread extends Thread {
   private final HeartbeatExecutor EXECUTOR;
   private final long FIXED_EXECUTION_INTERVAL_MS;
 
-  private boolean mIsShutdown = false;
+  private volatile boolean mIsShutdown = false;
 
   /**
    * @param threadName
@@ -38,28 +39,34 @@ public class HeartbeatThread extends Thread {
     THREAD_NAME = threadName;
     EXECUTOR = hbExecutor;
     FIXED_EXECUTION_INTERVAL_MS = fixedExecutionIntervalMs;
+    setDaemon(true);
   }
 
   @Override
   public void run() {
-    while (!mIsShutdown) {
-      long lastMs = System.currentTimeMillis();
-      EXECUTOR.heartbeat();
-      try {
+    try {
+      while (!mIsShutdown) {
+        long lastMs = System.currentTimeMillis();
+        EXECUTOR.heartbeat();
         long executionTimeMs = System.currentTimeMillis() - lastMs;
         if (executionTimeMs > FIXED_EXECUTION_INTERVAL_MS) {
-          LOG.error(THREAD_NAME + " last execution took " + executionTimeMs + " ms. Longer than "
+          LOG.warn(THREAD_NAME + " last execution took " + executionTimeMs + " ms. Longer than "
               + " the FIXED_EXECUTION_INTERVAL_MS " + FIXED_EXECUTION_INTERVAL_MS);
         } else {
           Thread.sleep(FIXED_EXECUTION_INTERVAL_MS - executionTimeMs);
         }
-      } catch (InterruptedException e) {
-        LOG.info(e.getMessage(), e);
       }
+    } catch (InterruptedException e) {
+      if (!mIsShutdown) {
+        LOG.error("Heartbeat Thread was interrupted ungracefully, shutting down...", e);
+      }
+    } catch (Exception e) {
+      LOG.error("Uncaught exception in heartbeat executor, Heartbeat Thread shutting down", e);
     }
   }
 
   public void shutdown() {
     mIsShutdown = true;
+    this.interrupt();
   }
 }

--- a/main/src/main/java/tachyon/worker/WorkerClient.java
+++ b/main/src/main/java/tachyon/worker/WorkerClient.java
@@ -63,7 +63,6 @@ public class WorkerClient {
     mHeartbeatThread =
         new HeartbeatThread("WorkerClientToWorkerHeartbeat", new WorkerClientHeartbeatExecutor(
             this, mUserId), UserConf.get().HEARTBEAT_INTERVAL_MS);
-    mHeartbeatThread.setDaemon(true);
   }
 
   public synchronized void accessBlock(long blockId) throws TException {


### PR DESCRIPTION
Improvements include:
- The HeartbeatThread is now always daemonic, so it will not prevent the
  Master or Worker from exiting.
- Any exceptions that propagate from the HeartbeatExecutor will be printed.
- `mIsShutdown` was made volatile, and `Thread.interrupt()` used, to ensure
  timely shutdown of the thread. Note that either one is sufficient, but
  without either of them, the JVM does not guarantee this thread ever exits.

Note that the first point should be the only actual change in behavior. If there is a reason that MasterClient and MasterInfo previously used a non-daemonic HeartbeatThread, please let me know.
