### PR TITLE
Fix buffer usage which results in data corruption in BlockOutStream

### DIFF
--- a/main/src/main/java/tachyon/client/BlockOutStream.java
+++ b/main/src/main/java/tachyon/client/BlockOutStream.java
@@ -109,7 +109,7 @@ public class BlockOutStream extends OutStream {
     }
 
     MappedByteBuffer out = mLocalFileChannel.map(MapMode.READ_WRITE, mInFileBytes, length);
-    out.put(buf, 0, length);
+    out.put(buf, offset, length);
     mInFileBytes += length;
   }
 


### PR DESCRIPTION
Prior to this, use of BlockOutStream.write() with a non-zero offset would corrupt the block data once we exceed the file limit (default 1MB).
