### PR TITLE
Canonicalize all host names

### DIFF
--- a/main/src/main/java/tachyon/master/BlockInfo.java
+++ b/main/src/main/java/tachyon/master/BlockInfo.java
@@ -15,6 +15,7 @@
 package tachyon.master;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,6 +25,7 @@ import tachyon.Pair;
 import tachyon.UnderFileSystem;
 import tachyon.thrift.ClientBlockInfo;
 import tachyon.thrift.NetAddress;
+import tachyon.util.NetworkUtils;
 
 /**
  * Block info on the master side.
@@ -107,7 +109,13 @@ public class BlockInfo {
       }
       if (locs != null) {
         for (String loc : locs) {
-          ret.add(new NetAddress(loc, -1));
+          String resolvedHost;
+          try {
+            resolvedHost = NetworkUtils.resolveHostName(loc);
+          } catch (UnknownHostException e) {
+            resolvedHost = loc;
+          }
+          ret.add(new NetAddress(resolvedHost, -1));
         }
       }
     }

--- a/main/src/main/java/tachyon/master/MasterInfo.java
+++ b/main/src/main/java/tachyon/master/MasterInfo.java
@@ -855,7 +855,7 @@ public class MasterInfo implements ImageWriter {
 
       InetSocketAddress address = tWorkerInfo.ADDRESS;
       tFile.addLocation(blockIndex, workerId,
-          new NetAddress(address.getHostName(), address.getPort()));
+          new NetAddress(address.getAddress().getCanonicalHostName(), address.getPort()));
 
       if (tFile.hasCheckpointed()) {
         return -1;

--- a/main/src/main/java/tachyon/master/MasterWorkerInfo.java
+++ b/main/src/main/java/tachyon/master/MasterWorkerInfo.java
@@ -54,7 +54,7 @@ public class MasterWorkerInfo {
   public synchronized ClientWorkerInfo generateClientWorkerInfo() {
     ClientWorkerInfo ret = new ClientWorkerInfo();
     ret.id = mId;
-    ret.address = new NetAddress(ADDRESS.getHostName(), ADDRESS.getPort());
+    ret.address = new NetAddress(ADDRESS.getAddress().getCanonicalHostName(), ADDRESS.getPort());
     ret.lastContactSec = (int) ((CommonUtils.getCurrentMs() - mLastUpdatedTimeMs) / 1000);
     ret.state = "In Service";
     ret.capacityBytes = CAPACITY_BYTES;

--- a/main/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/main/src/main/java/tachyon/worker/WorkerStorage.java
@@ -295,10 +295,11 @@ public class WorkerStorage {
     while (mWorkerId == 0) {
       try {
         mMasterClient.connect();
+        NetAddress canonicalAddress = new NetAddress(
+            mWorkerAddress.getAddress().getCanonicalHostName(), mWorkerAddress.getPort());
         mWorkerId =
-            mMasterClient.worker_register(new NetAddress(mWorkerAddress.getHostName(),
-                mWorkerAddress.getPort()), mWorkerSpaceCounter.getCapacityBytes(), 0,
-                new ArrayList<Long>());
+            mMasterClient.worker_register(canonicalAddress, mWorkerSpaceCounter.getCapacityBytes(),
+                0, new ArrayList<Long>());
       } catch (BlockInfoException e) {
         LOG.error(e.getMessage(), e);
         mWorkerId = 0;
@@ -636,10 +637,11 @@ public class WorkerStorage {
     while (id == 0) {
       try {
         mMasterClient.connect();
+        NetAddress canonicalAddress = new NetAddress(
+            mWorkerAddress.getAddress().getCanonicalHostName(), mWorkerAddress.getPort());
         id =
-            mMasterClient.worker_register(new NetAddress(mWorkerAddress.getHostName(),
-                mWorkerAddress.getPort()), mWorkerSpaceCounter.getCapacityBytes(), 0,
-                new ArrayList<Long>(mMemoryData));
+            mMasterClient.worker_register(canonicalAddress, mWorkerSpaceCounter.getCapacityBytes(),
+                0, new ArrayList<Long>(mMemoryData));
       } catch (BlockInfoException e) {
         LOG.error(e.getMessage(), e);
         id = 0;


### PR DESCRIPTION
This is motivated by the Spark/Tachyon integration, where Spark requires the host names for all block locations to match precisely with its view of the universe. Since Spark does canonicalize all of its host names, it seems reasonable for us to do so as well.
