### PR TITLE
Downgrade "Master disconnected" log message to DEBUG level

### DIFF
--- a/main/src/main/java/tachyon/master/MasterClient.java
+++ b/main/src/main/java/tachyon/master/MasterClient.java
@@ -119,7 +119,7 @@ public class MasterClient {
    */
   public synchronized void cleanConnect() {
     if (mIsConnected) {
-      LOG.info("Disconnecting from the master " + mMasterAddress);
+      LOG.debug("Disconnecting from the master " + mMasterAddress);
       mIsConnected = false;
     }
     if (mProtocol != null) {


### PR DESCRIPTION
This is particularly annoying during interactive shell sessions (e.g., spark-shell) where periods of not using Tachyon will visually interrupt user input.
