### PR TITLE
Netutil import

### DIFF
--- a/main/src/main/java/tachyon/client/TachyonFS.java
+++ b/main/src/main/java/tachyon/client/TachyonFS.java
@@ -52,6 +52,7 @@ import tachyon.thrift.NetAddress;
 import tachyon.thrift.NoWorkerException;
 import tachyon.thrift.TachyonException;
 import tachyon.util.CommonUtils;
+import tachyon.util.NetworkUtils;
 import tachyon.worker.WorkerClient;
 
 /**


### PR DESCRIPTION
I'm wondering why don't import class 'tachyon.util.NetworkUtils' , or I missed something?
