### PR TITLE
Simple cleanup to remove continue from try-catch from UnderFileSystemHdfs class

### DIFF
--- a/main/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/main/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -111,7 +111,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     throw te;
@@ -160,7 +159,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     throw te;
@@ -177,7 +175,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     CommonUtils.runtimeException(te);
@@ -231,7 +228,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       } catch (IOException e) {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
-        continue;
       }
     }
     return -1;
@@ -299,7 +295,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     CommonUtils.runtimeException(te);
@@ -317,7 +312,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     CommonUtils.runtimeException(te);
@@ -344,7 +338,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         cnt ++;
         LOG.error(cnt + " : " + e.getMessage(), e);
         te = e;
-        continue;
       }
     }
     CommonUtils.runtimeException(te);


### PR DESCRIPTION
Simple cleanup to remove continue from try-catch inside while loop in UnderFileSystemHdfs.java when it is the last line in the loop because it is not needed and also help remove warning from IDE like IntelliJ IDEA or Eclipse. 
