### PR TITLE
removed log4j prop from pom

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -347,9 +347,6 @@
         <configuration>
           <argLine>-Dufs=${ufs}</argLine>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <systemPropertyVariables>
-            <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Don't know why this was here before, but when I try to run the tests in intellij, they fail because log4j can't load src/test/resources/log4j.properties.  The reason for this is that the CWD of intellij is the root of the project, but this path is relative to core.

When I run the tests from CLI or intellij they both work.
