### PR TITLE
Use env {hadoop.version} for hadoop-client in glusterfsTest profile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
-          <version>2.3.0</version>
+          <version>${hadoop.version}</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
Change the hadoop-client version to use env {hadoop.version} instead of hardccoding 2.3.0 for glusterfsTest profile.
