### PR TITLE
Fix MapReduce with Tachyon feature by setting the TFS root path as input path

### DIFF
--- a/core/src/main/java/tachyon/hadoop/TFS.java
+++ b/core/src/main/java/tachyon/hadoop/TFS.java
@@ -182,8 +182,9 @@ public class TFS extends FileSystem {
       FileSystem fs = hdfsPath.getFileSystem(getConf());
       if (fs.exists(hdfsPath)) {
         String ufsAddrPath = CommonUtils.concat(UNDERFS_ADDRESS, path);
-        UnderfsUtils
-            .loadUnderFs(mTFS, Constants.PATH_SEPARATOR, ufsAddrPath, new PrefixList(null));
+
+        // Set the path as the TFS root path.
+        UnderfsUtils.loadUnderFs(mTFS, path, ufsAddrPath, new PrefixList(null));
       }
     }
   }


### PR DESCRIPTION
This patch is setting the TFS root path as input path to make sure the Tachyon FS has the same directory structure as the input from HDFS in

map reduce.

Currently this is what happen when I ran "bin/hadoop jar share/hadoop/mapreduce/hadoop-mapreduce-examples-3.0.0-SNAPSHOT.jar wordcount
-libjars /Users/hsaputra/open/github/tachyon/core/target/tachyon-0.5.0-SNAPSHOT-jar-with-dependencies.jar
tachyon://localhost:19998/user/hsaputra/input output2" :
1. If I have HDFS directory at /user/hsaputra/input and inside in has 10 files. So the input to the hadoop command is
   tachyon://localhost:19998/user/hsaputra/input.
2. Internally the TFS.getFileStatus will call TFS.fromHdfsToTachyon for /user/hsaputra/input and will iterate through the directory inside
   UnderfsUtil.loadUnderFs method.
3. The UnderfsUtil.loadUnderFs method takes input arguments of tfsRootPath as Constants.PATH_SEPARATOR which is "/", and the ufsAddrRootPath,
   which is the under FS root directory which is hdfs://localhost:9000/user/hsaputra/input.
4. Then, when the initial input directory /user/hsaputra/input is processed it will try to resolve the path by concat TFS root path (aka
   tfsRootPath) with substring of /user/hsaputra/input with ufsAddrRootPath length, which result to empty. So /user/hsaputra/input is not
   saved.
5. After loading all content of /user/hsaputra/input then the TFS.getFileStatus will call "TachyonFile file = mTFS.getFile(tPath);" which in
   this case path is "/user/hsaputra/input" which does not exist since we never add it.
6. So the next code execution of "mTFS.getFileId(path)" will throw FileNotFoundException.

This patch fix the flow by setting the right root path for TFS to the input path, which in this case is "/user/hsaputra/input"
