### PR TITLE
Cleanup Javadocs and comments on TachyonFS and TFS classes

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -66,7 +66,7 @@ public class TachyonFS {
    * @param tachyonPath
    *          a Tachyon path contains master address. e.g., tachyon://localhost:19998,
    *          tachyon://localhost:19998/ab/c.txt
-   * @return the corresponding TachyonFS hanlder
+   * @return the corresponding TachyonFS handler
    * @throws IOException
    */
   public static synchronized TachyonFS get(String tachyonPath) throws IOException {

--- a/core/src/main/java/tachyon/hadoop/TFS.java
+++ b/core/src/main/java/tachyon/hadoop/TFS.java
@@ -229,10 +229,10 @@ public class TFS extends FileSystem {
     return ret;
   }
 
-  @Override
   /**
    * Return the status of a single file. If the file does not exist in Tachyon, query it from HDFS.
    */
+  @Override
   public FileStatus getFileStatus(Path path) throws IOException {
     String tPath = Utils.getPathWithoutScheme(path);
     Path hdfsPath = Utils.getHDFSPath(tPath);
@@ -256,7 +256,7 @@ public class TFS extends FileSystem {
 
   /**
    * Returns an object implementing the Tachyon-specific client API.
-   * 
+   *
    * @return null if initialize() hasn't been called.
    */
   public TachyonFS getTachyonFS() {
@@ -291,9 +291,6 @@ public class TFS extends FileSystem {
   }
 
   @Override
-  /**
-   * List entries of a path
-   */
   public FileStatus[] listStatus(Path path) throws IOException {
     String tPath = Utils.getPathWithoutScheme(path);
     Path hdfsPath = Utils.getHDFSPath(tPath);
@@ -324,9 +321,6 @@ public class TFS extends FileSystem {
   }
 
   @Override
-  /**
-   * Return the FSDataInputStream of a file.
-   */
   public FSDataInputStream open(Path cPath, int bufferSize) throws IOException {
     LOG.info("open(" + cPath + ", " + bufferSize + ")");
 


### PR DESCRIPTION
Cleanup the Javadocs on TachyonFS and TFS:
1. Fix typo
2. Remove generic comment for overridden methods
3. Move the @Override after method Javadoc comment
