### PR TITLE
switched to uri get path to get hadoop path

### DIFF
--- a/core/src/main/java/tachyon/hadoop/Utils.java
+++ b/core/src/main/java/tachyon/hadoop/Utils.java
@@ -57,23 +57,7 @@ public final class Utils {
   }
 
   public static String getPathWithoutScheme(Path path) {
-    Path ori = path;
-    String ret = "";
-    while (path != null) {
-      if (ret.equals("")) {
-        ret = path.getName();
-      } else {
-        ret = CommonUtils.concat(path.getName(), ret);
-      }
-      path = path.getParent();
-    }
-    if (DEBUG) {
-      LOG.info("Utils getPathWithoutScheme(" + ori + ") result: " + ret);
-    }
-    if (ret.isEmpty()) {
-      return Constants.PATH_SEPARATOR;
-    }
-    return ret;
+    return path.toUri().getPath();
   }
 
   public static String getTachyonFileName(String path) {

--- a/core/src/test/java/tachyon/hadoop/UtilsTest.java
+++ b/core/src/test/java/tachyon/hadoop/UtilsTest.java
@@ -1,0 +1,50 @@
+package tachyon.hadoop;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+
+public final class UtilsTest {
+
+  @Test
+  public void testGetPathWithoutSchema() {
+    final Path path = new Path("/foo/bar/baz");
+
+    final String output = Utils.getPathWithoutScheme(path);
+    Assert.assertEquals("/foo/bar/baz", output);
+  }
+
+  @Test
+  public void testGetPathWithoutSchemaThatContainsSchema() {
+    final Path path = new Path("file:///foo/bar/baz");
+
+    final String output = Utils.getPathWithoutScheme(path);
+    Assert.assertEquals("/foo/bar/baz", output);
+  }
+
+  /**
+   * This test doesn't work the way you might expect.
+   *
+   * If you take the URI.create("hdfs://localhost:1234/foo/bar/baz?please=dont&show=up").getPath
+   * it will return /foo/bar/baz.  If you go through Hadoop's Path using {@link Path#Path(String)}
+   * then Hadoop injects the query params into the path, so when you call toURI it gives
+   * a different response.
+   */
+  @Test
+  public void testGetPathWithoutSchemaFromHDFS() {
+    final Path path = new Path("hdfs://localhost:1234/foo/bar/baz?please=dont&show=up");
+
+    final String output = Utils.getPathWithoutScheme(path);
+    Assert.assertFalse("/foo/bar/baz".equals(output));
+  }
+
+  @Test
+  public void testGetPathWithoutSchemaFromHDFSURI() {
+    final Path path = new Path(URI.create("hdfs://localhost:1234/foo/bar/baz?please=dont&show=up"));
+
+    final String output = Utils.getPathWithoutScheme(path);
+    Assert.assertEquals("/foo/bar/baz", output);
+  }
+}


### PR DESCRIPTION
This patch delegates getPathWithoutScheme to hadoop + uri call.  Based off the tests added, the code is backwards compatible.

There looks to be a bug in hadoop where the single arg constructor of path puts query params in the path, but thats not true when URI is used.   This can cause trouble for the get file name method.  Ill file a different PR for that.
