### PR TITLE
Reassigned path input argument to local variable when used with TachyonFS#cleanPathIOException

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -364,6 +364,7 @@ public class TachyonFS {
       LOG.error(e.getMessage());
       mLocalDataFolder = null;
       mUserTempFolder = null;
+      mWorkerClient = null;
     }
   }
 


### PR DESCRIPTION
Reassigned the path input argument to local variable to prevent accidental mutability to help reduce reassignment error by not modifying input argument to be used as local variable.

This is due call to TachyonFS#cleanPathIOException that change the path input argument.
