### PR TITLE
Doc bug

### DIFF
--- a/docs/Building-Tachyon-Master-Branch.md
+++ b/docs/Building-Tachyon-Master-Branch.md
@@ -56,4 +56,10 @@ To run all unit tests:
 
 To run all the unit tests with under filesystem other than local filesystem:
 
-    $ mvn test [ -Dhadoop.version=x.x.x ] -Dintegration [ -Dufs=tachyon.LocalMiniDFSCluster -Dtest.profile=hdfs ]
+    $ mvn test [ -Dhadoop.version=x.x.x ] [ -Dtest.profile=hdfs ]
+
+Current supported profiles:
+
+    local #default, uses local disk
+    hdfs # uses hadoop's minicluster
+    glusterfs # uses glusterfs


### PR DESCRIPTION
When running integration tests with minicluster, you need to select the hdfs test profile.  Updated the docs to reflect this.
