### PR TITLE
Distro support

### DIFF
--- a/docs/Building-Tachyon-Master-Branch.md
+++ b/docs/Building-Tachyon-Master-Branch.md
@@ -63,3 +63,43 @@ Current supported profiles:
     local #default, uses local disk
     hdfs # uses hadoop's minicluster
     glusterfs # uses glusterfs
+
+# Distro Support
+
+To build master against one of the different distros of hadoop, you only need to change the `hadoop.version`.
+
+## Apache
+
+All main builds are from Apache so all Apache releases can be used directly
+
+    -Dhadoop.version=2.2.0
+    -Dhadoop.version=2.3.0
+    -Dhadoop.version=2.4.0
+
+## Cloudera
+
+To build against Cloudera's releases, just use a version like `$apacheRelease-cdh$cdhRelease`
+
+    -Dhadoop.version=2.3.0-cdh5.1.0
+    -Dhadoop.version=2.0.0-cdh4.7.0
+
+## MapR
+
+To build against a MapR release
+
+    -Dhadoop.version=2.3.0-mapr-4.0.0-FCS
+
+## Pivotal
+
+To build against a Pivotal release, just use a version like `$apacheRelease-gphd-$pivotalRelease`
+
+    -Dhadoop.version=2.0.5-alpha-gphd-2.1.1.0
+    -Dhadoop.version=2.2.0-gphd-3.0.1.0
+
+## Hortonworks
+
+To build against a Hortonworks release, just use a version like `$apacheRelease.$hortonRelease`
+
+    -Dhadoop.version=2.1.0.2.0.5.0-67
+    -Dhadoop.version=2.2.0.2.1.0.0-92
+    -Dhadoop.version=2.4.0.2.1.3.0-563

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,22 @@
         <enabled>false</enabled>
       </snapshots>
     </repository> 
+    <repository>
+      <id>HDPReleases</id>
+      <name>HDP Releases</name>
+      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
This patch enables building tachyon against apache, cloudera, mapr, pivotal, and hortonworks. 

Updated the docs to give examples against all 5 distros
