### PR TITLE
Update UnderFileSystemHdfs class to throw IOException instead of Throwables.propagate(te)

### DIFF
--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -275,7 +275,7 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       }
       return rtn;
     } else {
-      return new String[0];
+      return null;
     }
   }
 


### PR DESCRIPTION
Per discussion in ML, update UnderFileSystemHdfs class to throw IOException as is instead of wrapping it as runtime.

This will follow the abstract method definitions that could throw IOException instead.
