### PR TITLE
Set the WorkerClient#mIsConnected to false if Thirft exception happen

### DIFF
--- a/core/src/main/java/tachyon/worker/WorkerClient.java
+++ b/core/src/main/java/tachyon/worker/WorkerClient.java
@@ -218,12 +218,12 @@ public class WorkerClient {
     if (!mIsConnected) {
       try {
         mProtocol.getTransport().open();
+        mHeartbeatThread.start();
+        mIsConnected = true;
       } catch (TTransportException e) {
         LOG.error(e.getMessage(), e);
-        return false;
+        mIsConnected = false;
       }
-      mHeartbeatThread.start();
-      mIsConnected = true;
     }
 
     return mIsConnected;


### PR DESCRIPTION
Set the WorkerClient#mIsConnected to false if Thirft exception thrown when trying to open connection.

This will allow the state to be set correctly if caller need to reuse instance of WorkerClient.
