### PR TITLE
TACHYON-48 Support backward compatible to set TACHYON_MASTER_JAVA_OPTS and TACHYON_WORKER_JAVA_OPTS

### DIFF
--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -100,6 +100,10 @@ start_master() {
     MASTER_ADDRESS=localhost
   fi
 
+  if [ -z $TACHYON_MASTER_JAVA_OPTS ] ; then
+    TACHYON_MASTER_JAVA_OPTS=$TACHYON_JAVA_OPTS
+  fi
+
   echo "Starting master @ $MASTER_ADDRESS"
   (nohup $JAVA -cp $TACHYON_JAR -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > /dev/null 2>&1) &
 }
@@ -111,11 +115,19 @@ start_worker() {
     exit 1
   fi
 
+  if [ -z $TACHYON_WORKER_JAVA_OPTS ] ; then
+    TACHYON_WORKER_JAVA_OPTS=$TACHYON_JAVA_OPTS
+  fi
+
   echo "Starting worker @ `hostname -f`"
   (nohup $JAVA -cp $TACHYON_JAR -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker `hostname -f` > /dev/null 2>&1 ) &
 }
 
 restart_worker() {
+  if [ -z $TACHYON_WORKER_JAVA_OPTS ] ; then
+    TACHYON_WORKER_JAVA_OPTS=$TACHYON_JAVA_OPTS
+  fi
+
   RUN=`ps -ef | grep "tachyon.worker.TachyonWorker" | grep "java" | wc | cut -d" " -f7`
   if [[ $RUN -eq 0 ]] ; then
     echo "Restarting worker @ `hostname -f`"


### PR DESCRIPTION
Support backward compatible to set TACHYON_MASTER_JAVA_OPTS and TACHYON_WORKER_JAVA_OPTS in tachyon-env.sh

In 0.5 we introduce new env variables to master and workers, namely TACHYON_MASTER_JAVA_OPTS
and TACHYON_WORKER_JAVA_OPTS.
However set environment script copied from older version of tachyon-env.sh.template may not
have this set so it could missing JVM arguments.

We have seen this problem in the user list where Tachyon master address is set to an
interface but when started always bind to localhost, this is because it is missing the
TACHYON_JAVA_OPTS which include "tachyon.master.hostname"
