### PR TITLE
TACHYON-63 Remove script error "[: too many arguments" in tachyon-start.sh

### DIFF
--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -100,7 +100,7 @@ start_master() {
     MASTER_ADDRESS=localhost
   fi
 
-  if [ -z $TACHYON_MASTER_JAVA_OPTS ] ; then
+  if [[ -z $TACHYON_MASTER_JAVA_OPTS ]] ; then
     TACHYON_MASTER_JAVA_OPTS=$TACHYON_JAVA_OPTS
   fi
 
@@ -115,7 +115,7 @@ start_worker() {
     exit 1
   fi
 
-  if [ -z $TACHYON_WORKER_JAVA_OPTS ] ; then
+  if [[ -z $TACHYON_WORKER_JAVA_OPTS ]] ; then
     TACHYON_WORKER_JAVA_OPTS=$TACHYON_JAVA_OPTS
   fi
 
@@ -124,7 +124,7 @@ start_worker() {
 }
 
 restart_worker() {
-  if [ -z $TACHYON_WORKER_JAVA_OPTS ] ; then
+  if [[ -z $TACHYON_WORKER_JAVA_OPTS ]] ; then
     TACHYON_WORKER_JAVA_OPTS=$TACHYON_JAVA_OPTS
   fi
 


### PR DESCRIPTION
TACHYON-63 Remove script error "[: too many arguments" in tachyon-start.sh

The fix to check for TACHYON_MASTER_JAVA_OPTS and TACHYON_WORKER_JAVA_OPTS need to be wrapped with double bracket "[[" and "]]" to prevent
error message in tachyon-start.sh when it is containing spaces or extra characters like:
export TACHYON_MASTER_JAVA_OPTS="$TACHYON_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6001"
