### PR TITLE
[TACHYON-64] Typo in INFO log messages in DataServerMessage

### DIFF
--- a/core/src/main/java/tachyon/worker/DataServerMessage.java
+++ b/core/src/main/java/tachyon/worker/DataServerMessage.java
@@ -133,7 +133,7 @@ public class DataServerMessage {
         }
 
         String filePath = CommonUtils.concat(WorkerConf.get().DATA_FOLDER, blockId);
-        ret.LOG.info("Try to response remote requst by reading from " + filePath);
+        ret.LOG.info("Try to response remote request by reading from " + filePath);
         RandomAccessFile file = new RandomAccessFile(filePath, "r");
 
         long fileLength = file.length();
@@ -165,7 +165,7 @@ public class DataServerMessage {
         file.close();
         ret.mIsMessageReady = true;
         ret.generateHeader();
-        ret.LOG.info("Response remote requst by reading from " + filePath + " preparation done.");
+        ret.LOG.info("Response remote request by reading from " + filePath + " preparation done.");
       } catch (Exception e) {
         // TODO This is a trick for now. The data may have been removed before remote retrieving.
         ret.mBlockId = -ret.mBlockId;


### PR DESCRIPTION
Typo in _DataServerMessage#createBlockResponseMessage()_ INFO message, meaning _requst_ should be **request**
