### PR TITLE
fix issue 55 in JIRA:

### DIFF
--- a/core/src/test/java/tachyon/client/TachyonFSTest.java
+++ b/core/src/test/java/tachyon/client/TachyonFSTest.java
@@ -416,9 +416,9 @@ public class TachyonFSTest {
 
   @Test
   public void toStringTest() throws IOException {
-    String tfsAddress = "tachyon://localhost:19998";
+    String tfsAddress = "tachyon://127.0.0.1:19998";
     TachyonFS tfs = TachyonFS.get(tfsAddress);
-    Assert.assertEquals(tfs.toString(), "tachyon://localhost/127.0.0.1:19998");
+    Assert.assertEquals(tfs.toString(), "tachyon:///127.0.0.1:19998");
   }
 
   @Test


### PR DESCRIPTION
InetSocketAddress may resolve "localhost" to network address like "192.168._._".
Test failed in TachyonFSTest.toStringTest:421 expected:<...achyon://localhost/1[92.168.172.43]:19998> but was:<...achyon://localhost/1[27.0.0.1]:19998>
