### PR TITLE
Include webapp dir in tar

### DIFF
--- a/assembly/src/main/assembly/tachyon-dist.xml
+++ b/assembly/src/main/assembly/tachyon-dist.xml
@@ -69,6 +69,10 @@
         <include>**/tachyon-*-jar-with-dependencies.jar</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${basedir}/../core/src/main/webapp</directory>
+      <outputDirectory>/core/src/main/webapp</outputDirectory>
+    </fileSet>
   </fileSets>
   <!-- If bundled dependencies gets supported, uncomment -->
   <!--


### PR DESCRIPTION
Assembly package was missing the webapp directory.  This patch includes it.  Testing was done locally to verify that this works.
