### PR TITLE
log stack traces on error and keep error history

### DIFF
--- a/core/src/main/java/tachyon/client/FileOutStream.java
+++ b/core/src/main/java/tachyon/client/FileOutStream.java
@@ -120,10 +120,10 @@ public class FileOutStream extends OutStream {
           }
         } catch (IOException ioe) {
           if (WRITE_TYPE.isMustCache()) {
-            LOG.error(ioe.getMessage());
-            throw new IOException("Fail to cache: " + WRITE_TYPE);
+            LOG.error(ioe);
+            throw new IOException("Fail to cache: " + WRITE_TYPE, ioe);
           } else {
-            LOG.warn("Fail to cache for: " + ioe.getMessage());
+            LOG.warn("Fail to cache for: ", ioe);
           }
         }
       }
@@ -206,9 +206,9 @@ public class FileOutStream extends OutStream {
       } catch (IOException e) {
         if (WRITE_TYPE.isMustCache()) {
           LOG.error(e.getMessage(), e);
-          throw new IOException("Fail to cache: " + WRITE_TYPE);
+          throw new IOException("Fail to cache: " + WRITE_TYPE, e);
         } else {
-          LOG.warn("Fail to cache for: " + e.getMessage());
+          LOG.warn("Fail to cache for: ", e);
         }
       }
     }
@@ -232,9 +232,9 @@ public class FileOutStream extends OutStream {
       } catch (IOException e) {
         if (WRITE_TYPE.isMustCache()) {
           LOG.error(e.getMessage(), e);
-          throw new IOException("Fail to cache: " + WRITE_TYPE);
+          throw new IOException("Fail to cache: " + WRITE_TYPE, e);
         } else {
-          LOG.warn("Fail to cache for: " + e.getMessage());
+          LOG.warn("Fail to cache for: ", e);
         }
       }
     }

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -243,12 +243,12 @@ public class RemoteBlockInStream extends BlockInStream {
             break;
           }
         } catch (IOException e) {
-          LOG.error(e.getMessage());
+          LOG.error(e);
           buf = null;
         }
       }
     } catch (IOException e) {
-      LOG.error("Failed to get read data from remote " + e.getMessage());
+      LOG.error("Failed to get read data from remote ", e);
       buf = null;
     }
 
@@ -332,8 +332,7 @@ public class RemoteBlockInStream extends BlockInStream {
           }
         }
       } catch (IOException e) {
-        LOG.error("Failed to read from checkpoint " + checkpointPath + " for File " + FILE.FID
-            + "\n" + e);
+        LOG.error("Failed to read from checkpoint " + checkpointPath + " for File " + FILE.FID, e);
         mCheckpointInputStream = null;
       }
     }

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -202,7 +202,7 @@ public class TachyonFS {
     try {
       return CommonUtils.cleanPath(path);
     } catch (InvalidPathException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e);
     }
   }
 
@@ -610,7 +610,7 @@ public class TachyonFS {
     try {
       ret = mMasterClient.user_getClientFileInfoByPath(cleanedPath);
     } catch (IOException e) {
-      LOG.info(e.getMessage() + cleanedPath);
+      LOG.warn(e.getMessage() + cleanedPath, e);
       return null;
     }
 
@@ -1165,7 +1165,7 @@ public class TachyonFS {
       } catch (FileNotFoundException e) {
         LOG.info(localFileName + " is not on local disk.");
       } catch (IOException e) {
-        LOG.info("Failed to read local file " + localFileName + " because: \n" + e.getMessage());
+        LOG.warn("Failed to read local file " + localFileName + " because:", e);
       }
     }
 

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -363,13 +363,13 @@ public class TachyonFile implements Comparable<TachyonFile> {
               break;
             }
           } catch (IOException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e);
             buf = null;
           }
         }
       }
     } catch (IOException e) {
-      LOG.error("Failed to get read data from remote " + e.getMessage());
+      LOG.error("Failed to get read data from remote ", e);
     }
 
     return buf == null ? null : new TachyonByteBuffer(TFS, buf, blockInfo.blockId, -1);
@@ -440,7 +440,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
         }
       }
     } catch (IOException e) {
-      LOG.info(e);
+      LOG.warn(e);
       return false;
     }
 


### PR DESCRIPTION
Propagate error traces when we create new exceptions.
Log stacktraces when we log exceptions.
