### PR TITLE
Changes to shell scripts

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -46,15 +46,15 @@ function runTest {
 
   if [[ "$1" == "Basic" ]]; then
     $bin/tachyon tfs rm /BasicFile_$2
-    $JAVA -cp $TACHYON_CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicOperations tachyon://$MASTER_ADDRESS:19998 /BasicFile_$2 $2
+    $JAVA -cp $CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicOperations tachyon://$MASTER_ADDRESS:19998 /BasicFile_$2 $2
     exit 0
   elif [[ "$1" == "BasicRawTable" ]]; then
     $bin/tachyon tfs rm /BasicRawTable_$2
-    $JAVA -cp $TACHYON_CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicRawTableOperations tachyon://$MASTER_ADDRESS:19998 /BasicRawTable_$2 $2
+    $JAVA -cp $CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicRawTableOperations tachyon://$MASTER_ADDRESS:19998 /BasicRawTable_$2 $2
     exit 0
   elif [[ "$1" == "BasicCheckpoint" ]]; then
     $bin/tachyon tfs rm /BasicCheckpoint
-    $JAVA -cp $TACHYON_CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicCheckpoint tachyon://$MASTER_ADDRESS:19998 /BasicCheckpoint 10
+    $JAVA -cp $CLASSPATH $TACHYON_JAVA_OPTS tachyon.examples.BasicCheckpoint tachyon://$MASTER_ADDRESS:19998 /BasicCheckpoint 10
     exit 0
   fi
 
@@ -201,4 +201,4 @@ else
   exit 1
 fi
 
-$JAVA -cp $TACHYON_CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $PARAMETER $@
+$JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $PARAMETER $@

--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -105,7 +105,7 @@ start_master() {
   fi
 
   echo "Starting master @ $MASTER_ADDRESS"
-  (nohup $JAVA -cp $TACHYON_CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > /dev/null 2>&1) &
+  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > $TACHYON_LOGS_DIR/master.out 2>&1) &
 }
 
 start_worker() {
@@ -120,7 +120,7 @@ start_worker() {
   fi
 
   echo "Starting worker @ `hostname -f`"
-  (nohup $JAVA -cp $TACHYON_CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker `hostname -f` > /dev/null 2>&1 ) &
+  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker `hostname -f` > $TACHYON_LOGS_DIR/worker.out 2>&1 ) &
 }
 
 restart_worker() {
@@ -131,7 +131,7 @@ restart_worker() {
   RUN=`ps -ef | grep "tachyon.worker.TachyonWorker" | grep "java" | wc | cut -d" " -f7`
   if [[ $RUN -eq 0 ]] ; then
     echo "Restarting worker @ `hostname -f`"
-    (nohup $JAVA -cp $TACHYON_CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker `hostname -f` > /dev/null 2>&1) &
+    (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker `hostname -f` > $TACHYON_LOGS_DIR/worker.out 2>&1) &
   fi
 }
 

--- a/bin/tachyon-stop.sh
+++ b/bin/tachyon-stop.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-usage="Usage: tachyon-stop.sh"
+Usage="Usage: tachyon-stop.sh"
 
 if [ "$#" -ne 0 ]; then
   echo $Usage

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -20,8 +20,7 @@
 # if type "hadoop" > /dev/null 2>&1; then
 #  export HADOOP_TACHYON_CLASSPATH=`hadoop classpath`
 # fi
-
-export TACHYON_CLASSPATH=$TACHYON_CONF_DIR/:$HADOOP_TACHYON_CLASSPATH:$TACHYON_JAR
+# export TACHYON_CLASSPATH=$HADOOP_TACHYON_CLASSPATH
 
 if [[ `uname -a` == Darwin* ]]; then
   # Assuming Mac OS X
@@ -31,9 +30,20 @@ if [[ `uname -a` == Darwin* ]]; then
 else
   # Assuming Linux
   if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib/jvm/java-7-oracle
+    if [ -d /usr/lib/jvm/java-7-oracle ]; then
+      export JAVA_HOME=/usr/lib/jvm/java-7-oracle
+    else
+      # openjdk will set this
+      if [ -d /usr/lib/jvm/jre-1.7.0 ]; then
+        export JAVA_HOME=/usr/lib/jvm/jre-1.7.0
+      fi
+    fi
   fi
   export TACHYON_RAM_FOLDER=/mnt/ramdisk
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  export JAVA_HOME="$(dirname $(which java))/.."
 fi
 
 export JAVA="$JAVA_HOME/bin/java"

--- a/conf/tachyon-glusterfs-env.sh.template
+++ b/conf/tachyon-glusterfs-env.sh.template
@@ -20,8 +20,7 @@
 # if type "hadoop" > /dev/null 2>&1; then
 #  export HADOOP_TACHYON_CLASSPATH=`hadoop classpath`
 # fi
-
-export TACHYON_CLASSPATH=$TACHYON_CONF_DIR/:$HADOOP_TACHYON_CLASSPATH:$TACHYON_JAR
+# export TACHYON_CLASSPATH=$HADOOP_TACHYON_CLASSPATH
 
 if [[ `uname -a` == Darwin* ]]; then
   # Assuming Mac OS X

--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -50,3 +50,5 @@ fi
 if [ -e $TACHYON_CONF_DIR/tachyon-env.sh ] ; then
   . $TACHYON_CONF_DIR/tachyon-env.sh
 fi
+
+export CLASSPATH="$TACHYON_CONF_DIR/:$TACHYON_CLASSPATH:$TACHYON_JAR"


### PR DESCRIPTION
Made a few changes to the shell scripts.

1) bug in stop script when user gave any argument
2) the addition of TACHYON_CLASSPATH wasn't compatible with older env scripts, so made it optional and moved the core logic to libexec
3) switch to openjdk if oracle not found
4) std out/error gets logged rather than piping to dev null
