### PR TITLE
TACHYON-71 Prevent Thrift exception from leaking out from MasterClient and WorkerClient classes.

### DIFF
--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.thrift.TException;
 
 import tachyon.Constants;
 import tachyon.client.InStream;
@@ -48,7 +47,7 @@ public class TFsShell {
    * @param argv
    *          [] Array of arguments given by the user's input from the terminal
    */
-  public static void main(String argv[]) throws TException {
+  public static void main(String argv[]) {
     TFsShell shell = new TFsShell();
     System.exit(shell.run(argv));
   }
@@ -442,7 +441,7 @@ public class TFsShell {
    * @param argv
    *          [] Array of arguments given by the user's input from the terminal
    * @return 0 if command is successful, -1 if an error occurred.
-   * @throws TException
+   * @throws IOException
    */
   public int rename(String argv[]) throws IOException {
     if (argv.length != 3) {
@@ -526,9 +525,8 @@ public class TFsShell {
    * @param argv
    *          [] Array of arguments given by the user's input from the terminal
    * @return 0 if command is successful, -1 if an error occurred
-   * @throws TException
    */
-  public int run(String argv[]) throws TException {
+  public int run(String argv[]) {
     if (argv.length == 0) {
       printUsage();
       return -1;
@@ -577,7 +575,6 @@ public class TFsShell {
       }
     } catch (IOException ioe) {
       System.out.println(ioe.getMessage());
-    } finally {
     }
 
     return exitCode;

--- a/core/src/main/java/tachyon/master/MasterClient.java
+++ b/core/src/main/java/tachyon/master/MasterClient.java
@@ -100,7 +100,6 @@ public class MasterClient {
    * @throws FileDoesNotExistException
    * @throws SuspectedFileSizeException
    * @throws BlockInfoException
-   * @throws TException
    */
   public synchronized boolean addCheckpoint(long workerId, int fileId, long length,
       String checkpointPath) throws FileDoesNotExistException, SuspectedFileSizeException,
@@ -610,14 +609,14 @@ public class MasterClient {
     return -1;
   }
 
-  public synchronized int user_getRawTableId(String path) throws IOException, TException {
+  public synchronized int user_getRawTableId(String path) throws IOException {
     while (!mIsShutdown) {
       connect();
       try {
         return mClient.user_getRawTableId(path);
       } catch (InvalidPathException e) {
         throw new IOException(e);
-      } catch (TTransportException e) {
+      } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
       }

--- a/core/src/main/java/tachyon/worker/WorkerClient.java
+++ b/core/src/main/java/tachyon/worker/WorkerClient.java
@@ -64,7 +64,7 @@ public class WorkerClient {
    * Create a WorkerClient, with a given MasterClient.
    * 
    * @param masterClient
-   * @throws TException
+   * @throws IOException
    */
   public WorkerClient(MasterClient masterClient) throws IOException {
     MASTER_CLIENT = masterClient;
@@ -97,7 +97,6 @@ public class WorkerClient {
    * @param fileId
    *          The id of the checkpointed file
    * @throws IOException
-   * @throws TException
    */
   public synchronized void addCheckpoint(long userId, int fileId) throws IOException {
     mustConnect();
@@ -124,8 +123,7 @@ public class WorkerClient {
    * @param fid
    *          The id of the file
    * @return true if succeed, false otherwise
-   * @throws TachyonException
-   * @throws TException
+   * @throws IOException
    */
   public synchronized boolean asyncCheckpoint(int fid) throws IOException {
     mustConnect();
@@ -148,7 +146,6 @@ public class WorkerClient {
    * @param blockId
    *          The id of the block
    * @throws IOException
-   * @throws TException
    */
   public synchronized void cacheBlock(long userId, long blockId) throws IOException {
     mustConnect();
@@ -255,7 +252,7 @@ public class WorkerClient {
 
   /**
    * @return The root local data folder of the worker
-   * @throws TException
+   * @throws IOException
    */
   public synchronized String getDataFolder() throws IOException {
     if (mDataFolder == null) {
@@ -288,9 +285,7 @@ public class WorkerClient {
 
   /**
    * Get the user temporary folder in the under file system of the specified user.
-   * 
-   * @param userId
-   *          The id of the user
+   *
    * @return The user temporary folder in the under file system
    * @throws IOException
    */
@@ -352,7 +347,6 @@ public class WorkerClient {
    * Connect to the worker.
    * 
    * @throws IOException
-   *           throw if the connection fails
    */
   public synchronized void mustConnect() throws IOException {
     int tries = 0;
@@ -372,7 +366,7 @@ public class WorkerClient {
    * @param requestBytes
    *          The requested space size, in bytes
    * @return true if succeed, false otherwise
-   * @throws TException
+   * @throws IOException
    */
   public synchronized boolean requestSpace(long userId, long requestBytes) throws IOException {
     mustConnect();
@@ -412,7 +406,7 @@ public class WorkerClient {
    *          The id of the block
    * @param userId
    *          The id of the user who wants to unlock the block
-   * @throws TException
+   * @throws IOException
    */
   public synchronized void unlockBlock(long blockId, long userId) throws IOException {
     mustConnect();
@@ -430,9 +424,13 @@ public class WorkerClient {
    * 
    * @param userId
    *          The id of the user
-   * @throws TException
+   * @throws IOException
    */
-  public synchronized void userHeartbeat(long userId) throws TException {
-    mClient.userHeartbeat(userId);
+  public synchronized void userHeartbeat(long userId) throws IOException {
+    try {
+      mClient.userHeartbeat(userId);
+    } catch (TException e) {
+      throw new IOException(e);
+    }
   }
 }

--- a/core/src/main/java/tachyon/worker/WorkerClientHeartbeatExecutor.java
+++ b/core/src/main/java/tachyon/worker/WorkerClientHeartbeatExecutor.java
@@ -14,11 +14,11 @@
  */
 package tachyon.worker;
 
-import org.apache.thrift.TException;
-
 import com.google.common.base.Throwables;
 
 import tachyon.HeartbeatExecutor;
+
+import java.io.IOException;
 
 /**
  * User client sends periodical heartbeats to the worker it is talking to. It is fails to do so,
@@ -37,7 +37,7 @@ class WorkerClientHeartbeatExecutor implements HeartbeatExecutor {
   public void heartbeat() {
     try {
       WORKER_CLIENT.userHeartbeat(USER_ID);
-    } catch (TException e) {
+    } catch (IOException e) {
       throw Throwables.propagate(e);
     }
   }

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -380,7 +380,6 @@ public class WorkerStorage {
    * @throws SuspectedFileSizeException
    * @throws FailedToCheckpointException
    * @throws BlockInfoException
-   * @throws TException
    */
   public void addCheckpoint(long userId, int fileId) throws FileDoesNotExistException,
       SuspectedFileSizeException, FailedToCheckpointException, BlockInfoException, IOException {


### PR DESCRIPTION
Remove invalid JavaDoc "@throws TException" in method declaration.
Prevent leaking of Thrift exceptions (TException and its inheritance classes) to outside of MasterClient and WorkerClient classes because no
classes outside MasterClient and WorkerClient should know about Thrift services.
Small cleanup to remove empty finally clause in TFsShell class.
