### PR TITLE
return immutable copy of children to avoid concurrent read and write

### DIFF
--- a/core/src/main/java/tachyon/master/InodeFolder.java
+++ b/core/src/main/java/tachyon/master/InodeFolder.java
@@ -20,13 +20,12 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Collections;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.ImmutableSet;
 
 import tachyon.Constants;
 import tachyon.thrift.ClientFileInfo;


### PR DESCRIPTION
Running YCSB load adding in 1m elements.
Go to the UI and try to view the dir and you get the following back

```
java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextEntry(HashMap.java:926)
    at java.util.HashMap$KeyIterator.next(HashMap.java:960)
    at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1067)
    at tachyon.master.MasterInfo.getFilesInfo(MasterInfo.java:1429)
    at tachyon.web.WebInterfaceBrowseServlet.doGet(WebInterfaceBrowseServlet.java:197)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
```

This is caused by the fact that the lock you need to have on children is on the INodeFile.  Rather than users locking on that object, when you call `getChildren`, return a immutable copy so user's don't have to worry about locking.
