### PR TITLE
[TACHYON-82] Retrieving byte buffer from remote machine can leak file handles in TachyonFile

### DIFF
--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -263,7 +263,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
       LOG.info("Connected to remote machine " + address + " sent");
       DataServerMessage sendMsg =
-                DataServerMessage.createBlockRequestMessage(blockId, offset, length);
+          DataServerMessage.createBlockRequestMessage(blockId, offset, length);
       while (!sendMsg.finishSending()) {
         sendMsg.send(socketChannel);
       }
@@ -290,7 +290,7 @@ public class RemoteBlockInStream extends BlockInStream {
       }
       return recvMsg.getReadOnlyData();
     } finally {
-        socketChannel.close();
+      socketChannel.close();
     }
   }
 

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -460,7 +460,6 @@ public class TachyonFile implements Comparable<TachyonFile> {
     return TFS.rename(FID, path);
   }
 
-
   private ByteBuffer retrieveByteBufferFromRemoteMachine(InetSocketAddress address, long blockId)
       throws IOException {
     SocketChannel socketChannel = SocketChannel.open();


### PR DESCRIPTION
If there is an IOException thrown by the retrieveByteBufferFromRemoteMachine() then file handles are leaked because of the initialization of the Socket which is never closed in finally block.

```
SocketChannel socketChannel = SocketChannel.open();
socketChannel.connect(address);
```

If there is an IOException from

```
SocketChannel#connect
DataServerMessage#send
DataServerMessage#recv
```

 then the Socket is not closed and file handles are leaked.
