### PR TITLE
stop can target a component

### DIFF
--- a/bin/tachyon-stop.sh
+++ b/bin/tachyon-stop.sh
@@ -17,16 +17,54 @@
 # limitations under the License.
 #
 
-Usage="Usage: tachyon-stop.sh"
+Usage="Usage: tachyon-stop.sh [-h] [component] 
+Where component is one of:
+  all\t\t\tStop local master/worker and remote workers. Default.
+  master\t\tStop local master.
+  worker\t\tStop local worker.
+  workers\t\tStop local worker and all remote workers.
 
-if [ "$#" -ne 0 ]; then
-  echo $Usage
-  exit 1
-fi
-
+-h  display this help."
 bin=`cd "$( dirname "$0" )"; pwd`
 
-$bin/tachyon killAll tachyon.master.TachyonMaster
-$bin/tachyon killAll tachyon.worker.TachyonWorker
+kill_master() {
+  $bin/tachyon killAll tachyon.master.TachyonMaster
+}
 
-$bin/tachyon-slaves.sh $bin/tachyon killAll tachyon.worker.TachyonWorker
+kill_worker() {
+  $bin/tachyon killAll tachyon.worker.TachyonWorker
+}
+
+kill_remote_workers() {
+  $bin/tachyon-slaves.sh $bin/tachyon killAll tachyon.worker.TachyonWorker
+}
+
+WHAT=${1:-all}
+
+case "$WHAT" in
+  master)
+    kill_master
+    ;;
+  worker)
+    kill_worker
+    ;;
+  workers)
+    kill_worker
+    kill_remote_workers
+    ;;
+  all)
+    kill_master
+    kill_worker
+    kill_remote_workers
+    ;;
+  -h)
+    echo -e "$Usage"
+    exit 0
+    ;;
+  *)
+    echo "Error: Invalid component: $WHAT"
+    echo -e "$Usage"
+    exit 1
+    ;;
+esac
+


### PR DESCRIPTION
Rather than only kill all, let you kill targeted components with the `tachyon-stop.sh`.
