### PR TITLE
[TACHYON-22] JSP compilation issue with embedded jetty in Java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <glusterfs-hadoop.version>2.3.5</glusterfs-hadoop.version>
     <libthrift.version>0.9.1</libthrift.version>
     <cxf.version>2.7.0</cxf.version>
-    <jetty.version>7.6.8.v20121106</jetty.version>
+    <jetty.version>7.6.15.v20140411</jetty.version>
     <slf4j.version>1.7.2</slf4j.version>
     <powermock.version>1.5.4</powermock.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Upgraded to Jetty version `7.6.15.v20140411`

Tested in 

```
$ java -version
java version "1.6.0_65"
Java(TM) SE Runtime Environment (build 1.6.0_65-b14-466.1-11M4716)
Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-466.1, mixed mode)
```

and 

```
java version "1.8.0"
Java(TM) SE Runtime Environment (build 1.8.0-b132)
Java HotSpot(TM) 64-Bit Server VM (build 25.0-b70, mixed mode)
```
