### PR TITLE
Exclude javassist from curator-test in test scope of pom file to prevent...

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,6 +118,12 @@
       <artifactId>curator-test</artifactId>
       <version>${apache.curator.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Exclude javassist from curator-test in test scope of pom file to prevent error in unit test of tachyon.hadoop.TFSTest.

> > mvn --version output.

Apache Maven 3.2.1 (ea8b2b07643dbb1b84b6d16e1f08391b666bc1e9; 2014-02-14T12:37:52-05:00)
Maven home: /usr/local/Cellar/maven/3.2.1/libexec
Java version: 1.8.0, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.9.4", arch: "x86_64", family: "mac"

> > mvn install, output error Message:

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.366 sec <<< FAILURE!
tachyon.hadoop.TFSTest  Time elapsed: 0.366 sec  <<< ERROR!
java.lang.IllegalStateException: Failed to transform class with name tachyon.client.TachyonFS. Reason: java.io.IOException: invalid constant type: 18
    at javassist.bytecode.ConstPool.readOne(ConstPool.java:1113)
    at javassist.bytecode.ConstPool.read(ConstPool.java:1056)
    at javassist.bytecode.ConstPool.<init>(ConstPool.java:150)
    at javassist.bytecode.ClassFile.read(ClassFile.java:765)
