### PR TITLE
throw IOException when block info is missing

### DIFF
--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -65,6 +65,10 @@ public class RemoteBlockInStream extends BlockInStream {
     super(file, readType, blockIndex);
 
     mBlockInfo = mFile.getClientBlockInfo(mBlockIndex);
+    if (mBlockInfo == null) {
+      throw new IOException("Unable to find block information for file " + file.getPath()
+          + " at block index " + blockIndex);
+    }
     mReadByte = 0;
     mBufferStartPosition = 0;
 
@@ -381,6 +385,10 @@ public class RemoteBlockInStream extends BlockInStream {
 
     if (mCurrentBuffer == null) {
       mBlockInfo = mFile.getClientBlockInfo(mBlockIndex);
+      if (mBlockInfo == null) {
+        throw new IOException("Unable to find block information for file " + mFile.getPath()
+            + " at block index " + mBlockIndex);
+      }
       mCurrentBuffer = readRemoteByteBuffer(mBlockInfo, mBufferStartPosition, length);
     }
   }


### PR DESCRIPTION
Not sure what the root cause is that made block info go missing, but the current master client will not throw the exception, but will instead return null.  Not changing this behavior, just checking for null then throwing IO.
