### PR TITLE
wrap the costly operation in debug

### DIFF
--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -550,8 +550,10 @@ public class MasterInfo extends ImageWriter {
       currentInodeFolder.addChild(ret);
       currentInodeFolder.setLastModificationTimeMs(creationTimeMs);
 
-      LOG.debug("createFile: File Created: " + ret.toString() + " parent: "
-          + currentInodeFolder.toString());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("createFile: File Created: " + ret.toString() + " parent: "
+            + currentInodeFolder.toString());
+      }
       return ret.getId();
     }
   }


### PR DESCRIPTION
Profiling the master and found that the toString is one of the most costly operations, so hiding it behind debug check
