### PR TITLE
when not local, the get worker call loops forever

### DIFF
--- a/core/src/main/java/tachyon/master/MasterClient.java
+++ b/core/src/main/java/tachyon/master/MasterClient.java
@@ -554,6 +554,8 @@ public class MasterClient implements Closeable {
 
       try {
         return mClient.user_getWorker(random, hostname);
+      } catch (NoWorkerException e) {
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;

--- a/core/src/test/java/tachyon/master/MasterClientTest.java
+++ b/core/src/test/java/tachyon/master/MasterClientTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import tachyon.Constants;
 import tachyon.thrift.FileAlreadyExistException;
 import tachyon.thrift.InvalidPathException;
+import tachyon.thrift.NoWorkerException;
 
 /**
  * Unit tests for tachyon.MasterClient
@@ -58,5 +59,14 @@ public class MasterClientTest {
     // in the cases we don't want to disconnect from master
     MasterClient masterClient = new MasterClient(mMasterInfo.getMasterAddress());
     masterClient.user_getClientBlockInfo(Long.MAX_VALUE);
+  }
+
+  @Test(timeout = 3000, expected = NoWorkerException.class)
+  public void user_getWorkerReturnsWhenNotLocal() throws TException, IOException {
+    // this test was created to show that a infi loop happens
+    // the timeout will protect against this, and the change was to throw a IOException
+    // in the cases we don't want to disconnect from master
+    MasterClient masterClient = new MasterClient(mMasterInfo.getMasterAddress());
+    masterClient.user_getWorker(false, "host.doesnotexist.fail");
   }
 }


### PR DESCRIPTION
@haoyuan this is just like the file/block not found one.  When the user is not local, the call to get the worker loops forever.  This patch just makes the HostNotFound exception propagate up.
