### PR TITLE
dont fail client module because there are no tests

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -12,6 +12,10 @@
   <description>Tachyon Project Client</description>
   <name>Tachyon Project Client</name>
 
+  <properties>
+    <failIfNoTests>false</failIfNoTests>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.tachyonproject</groupId>


### PR DESCRIPTION
if you run `mvn clean test -Dtest=tachyon.master.BlockInfoTest`, maven will fail because client module doesn't have any tests.  This patch fixes it so maven doesn't complain.
