### PR TITLE
[TACHYON-148] Fix bug in tachyon.examples.Performance

### DIFF
--- a/core/src/main/java/tachyon/examples/Performance.java
+++ b/core/src/main/java/tachyon/examples/Performance.java
@@ -52,7 +52,7 @@ public class Performance {
 
   public static void createFiles() throws IOException {
     long startTimeMs = CommonUtils.getCurrentMs();
-    for (int k = 0; k < THREADS; k ++) {
+    for (int k = 0; k < FILES; k++) {
       int fileId = MTC.createFile(FILE_NAME + (k + BASE_FILE_NUMBER));
       CommonUtils.printTimeTakenMs(startTimeMs, LOG, "user_createFiles with fileId " + fileId);
     }
@@ -109,7 +109,7 @@ public class Performance {
         for (int times = mLeft; times < mRight; times ++) {
           long startTimeMs = System.currentTimeMillis();
           if (!mMemoryOnly) {
-            file = new RandomAccessFile(FOLDER + (mWorkerId + BASE_FILE_NUMBER), "rw");
+            file = new RandomAccessFile(FOLDER + (times + BASE_FILE_NUMBER), "rw");
             dst = file.getChannel().map(MapMode.READ_WRITE, 0, FILE_BYTES);
           }
           dst.order(ByteOrder.nativeOrder());
@@ -134,7 +134,7 @@ public class Performance {
         for (int times = mLeft; times < mRight; times ++) {
           long startTimeMs = System.currentTimeMillis();
           if (!mMemoryOnly) {
-            file = new RandomAccessFile(FOLDER + (mWorkerId + BASE_FILE_NUMBER), "rw");
+            file = new RandomAccessFile(FOLDER + (times + BASE_FILE_NUMBER), "rw");
             dst = file.getChannel().map(MapMode.READ_WRITE, 0, FILE_BYTES);
           }
           dst.order(ByteOrder.nativeOrder());
@@ -180,7 +180,7 @@ public class Performance {
       mBuf.flip();
       for (int pId = mLeft; pId < mRight; pId ++) {
         long startTimeMs = System.currentTimeMillis();
-        TachyonFile file = mTC.getFile(FILE_NAME + (mWorkerId + BASE_FILE_NUMBER));
+        TachyonFile file = mTC.getFile(FILE_NAME + (pId + BASE_FILE_NUMBER));
         OutStream os = file.getOutStream(WriteType.MUST_CACHE);
         for (int k = 0; k < BLOCKS_PER_FILE; k ++) {
           mBuf.putInt(0, k + mWorkerId);
@@ -216,7 +216,7 @@ public class Performance {
         LOG.info("Verifying the reading data...");
 
         for (int pId = mLeft; pId < mRight; pId ++) {
-          TachyonFile file = mTC.getFile(FILE_NAME + mWorkerId);
+          TachyonFile file = mTC.getFile(FILE_NAME + (pId + BASE_FILE_NUMBER));
           buf = file.readByteBuffer(0);
           IntBuffer intBuf;
           intBuf = buf.DATA.order(ByteOrder.nativeOrder()).asIntBuffer();
@@ -238,7 +238,7 @@ public class Performance {
       if (TACHYON_STREAMING_READ) {
         for (int pId = mLeft; pId < mRight; pId ++) {
           long startTimeMs = System.currentTimeMillis();
-          TachyonFile file = mTC.getFile(FILE_NAME + (mWorkerId + BASE_FILE_NUMBER));
+          TachyonFile file = mTC.getFile(FILE_NAME + (pId + BASE_FILE_NUMBER));
           InputStream is = file.getInStream(ReadType.CACHE);
           long len = BLOCKS_PER_FILE * BLOCK_SIZE_BYTES;
 
@@ -253,7 +253,7 @@ public class Performance {
       } else {
         for (int pId = mLeft; pId < mRight; pId ++) {
           long startTimeMs = System.currentTimeMillis();
-          TachyonFile file = mTC.getFile(FILE_NAME + (mWorkerId + BASE_FILE_NUMBER));
+          TachyonFile file = mTC.getFile(FILE_NAME + (pId + BASE_FILE_NUMBER));
           buf = file.readByteBuffer(0);
           for (int i = 0; i < BLOCKS_PER_FILE; i ++) {
             buf.DATA.get(mBuf.array());
@@ -323,7 +323,7 @@ public class Performance {
       if (mWrite) {
         for (int times = mLeft; times < mRight; times ++) {
           long startTimeMs = System.currentTimeMillis();
-          String filePath = FILE_NAME + (mWorkerId + BASE_FILE_NUMBER);
+          String filePath = FILE_NAME + (times + BASE_FILE_NUMBER);
           OutputStream os = mHdfsFs.create(new Path(filePath));
           for (int k = 0; k < BLOCKS_PER_FILE; k ++) {
             mBuf.putInt(0, k + mWorkerId);
@@ -335,7 +335,7 @@ public class Performance {
       } else {
         for (int times = mLeft; times < mRight; times ++) {
           long startTimeMs = System.currentTimeMillis();
-          String filePath = FILE_NAME + (mWorkerId + BASE_FILE_NUMBER);
+          String filePath = FILE_NAME + (times + BASE_FILE_NUMBER);
           InputStream is = mHdfsFs.open(new Path(filePath));
           long len = BLOCKS_PER_FILE * BLOCK_SIZE_BYTES;
 


### PR DESCRIPTION
Fix the bug mentioned in [TACHYON-148]. The tachyon.examples.Performance class has two bugs:
Read test checks the data in different byte order with the write test.
In write test, it will repeatedly write the same file when one thread needs to write several files.
