### PR TITLE
Simple cleanups for Tachyon logging.

### DIFF
--- a/core/src/main/java/tachyon/client/BlockHandlerLocal.java
+++ b/core/src/main/java/tachyon/client/BlockHandlerLocal.java
@@ -21,7 +21,8 @@ import tachyon.util.CommonUtils;
  */
 public final class BlockHandlerLocal extends BlockHandler {
 
-  private final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private final RandomAccessFile mLocalFile;
   private final FileChannel mLocalFileChannel;
   private boolean mPermission = false;

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -1834,7 +1834,7 @@ public class MasterInfo extends ImageWriter {
         case Version: {
           if (ele.getInt("version") != Constants.JOURNAL_VERSION) {
             throw new IOException("Image " + path + " has journal version " + ele.getInt("version")
-                + " . The system has verion " + Constants.JOURNAL_VERSION);
+                + ". The system has version " + Constants.JOURNAL_VERSION);
           }
           break;
         }

--- a/core/src/main/java/tachyon/worker/nio/DataServerMessage.java
+++ b/core/src/main/java/tachyon/worker/nio/DataServerMessage.java
@@ -116,7 +116,7 @@ public class DataServerMessage {
         }
 
         String filePath = CommonUtils.concat(WorkerConf.get().DATA_FOLDER, blockId);
-        ret.LOG.info("Try to response remote request by reading from " + filePath);
+        LOG.info("Try to response remote request by reading from " + filePath);
         RandomAccessFile file = new RandomAccessFile(filePath, "r");
 
         long fileLength = file.length();
@@ -148,7 +148,7 @@ public class DataServerMessage {
         file.close();
         ret.mIsMessageReady = true;
         ret.generateHeader();
-        ret.LOG.info("Response remote request by reading from " + filePath + " preparation done.");
+        LOG.info("Response remote request by reading from " + filePath + " preparation done.");
       } catch (Exception e) {
         // TODO This is a trick for now. The data may have been removed before remote retrieving.
         ret.mBlockId = -ret.mBlockId;
@@ -157,7 +157,7 @@ public class DataServerMessage {
         ret.mData = ByteBuffer.allocate(0);
         ret.mIsMessageReady = true;
         ret.generateHeader();
-        ret.LOG.error("The file is not here : " + e.getMessage(), e);
+        LOG.error("The file is not here : " + e.getMessage(), e);
       }
     } else {
       ret.mHeader = ByteBuffer.allocate(HEADER_LENGTH);


### PR DESCRIPTION
Simple fixes for logging:
1. Change LOG to private final static in BlockHandlerLocal class.
2. Change access to LOG via static object instead of via instance variable.
3. Fix extra space in logging message.
