### PR TITLE
remove deprecation  in DataServerHandler

### DIFF
--- a/core/src/main/java/tachyon/worker/netty/DataServerHandler.java
+++ b/core/src/main/java/tachyon/worker/netty/DataServerHandler.java
@@ -70,7 +70,7 @@ public final class DataServerHandler extends ChannelInboundHandlerAdapter {
       ChannelFuture future = ctx.writeAndFlush(resp);
       future.addListener(ChannelFutureListener.CLOSE);
       if (file != null) {
-        Closeables.closeQuietly(file);
+        Closeables.close(file, true);
       }
     } finally {
       mLocker.unlock(blockId, lockId);


### PR DESCRIPTION
change the deprecated method Closeables.closeQuietly() to Closeables.close()
