### PR TITLE
Change from instance to class when setting mock for UserGroupInformation.getCurrentUser

### DIFF
--- a/core/src/test/java/tachyon/hadoop/TFSTest.java
+++ b/core/src/test/java/tachyon/hadoop/TFSTest.java
@@ -121,7 +121,7 @@ public class TFSTest {
     // need to mock out since FileSystem.get calls UGI, which some times has issues on some systems
     mockStatic(UserGroupInformation.class);
     final UserGroupInformation ugi = mock(UserGroupInformation.class);
-    when(ugi.getCurrentUser()).thenReturn(ugi);
+    when(UserGroupInformation.getCurrentUser()).thenReturn(ugi);
   }
 
   @Before


### PR DESCRIPTION
Change from instance to class when setting mock for UserGroupInformation.getCurrentUser.

The method UserGroupInformation.getCurrentUser is public static so use class name when setting up mockStatic for UserGroupInformation class.
