### PR TITLE
Add suppress rule for Tachyon *Conf classes

### DIFF
--- a/core/src/main/resources/tachyon_checks.xml
+++ b/core/src/main/resources/tachyon_checks.xml
@@ -164,4 +164,10 @@
                value="Static member name ''{0}'' must match pattern ''{1}''."/>
     </module>
   </module>
+  <!-- TODO: This is needed to excuse Tachyon Configuration members' name from being checked -->
+  <!-- because the members are define using all upper case. -->
+  <!-- Once the new configuration is implemented we wil remove this exception -->
+  <module name="SuppressionFilter">
+    <property name="file" value="core/src/main/resources/tachyon_checkstyle_suppressions.xml"/>
+  </module>
 </module>

--- a/core/src/main/resources/tachyon_checkstyle_suppressions.xml
+++ b/core/src/main/resources/tachyon_checkstyle_suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<!-- TODO: This is needed to excuse Tachyon Configuration members' name from being checked -->
+<!-- because the members are define using all upper case. -->
+<!-- Once the new configuration is implemented we wil remove this exception -->
+<suppressions>
+  <suppress checks="MemberNameCheck"
+            files=".*Conf.java"/>
+</suppressions>


### PR DESCRIPTION
Since PR #473 we support mvn checkstyle to check style using Google Java style.

This PR adds suppress rule for Tachyon *Conf classes to exempt the public final members as all upper cases.
We will remove the exempt file once new Configuration [1] is implemented.

Once this one is merged, I will submit PR to modify the build to break whenever checkstyle fail to integrate it as part of Jenkins CI.

[1] https://tachyon.atlassian.net/browse/TACHYON-8
