### PR TITLE
fix read(byte[] b, int off, int len)  method in FileInStream.java.

### DIFF
--- a/core/src/main/java/tachyon/client/FileInStream.java
+++ b/core/src/main/java/tachyon/client/FileInStream.java
@@ -117,6 +117,8 @@ public class FileInStream extends InStream {
       throw new IndexOutOfBoundsException();
     } else if (len == 0) {
       return 0;
+    }else if (mCurrentPosition >= FILE_LENGTH){
+        return -1;
     }
 
     int tOff = off;
@@ -135,9 +137,6 @@ public class FileInStream extends InStream {
       mCurrentBlockLeft -= tRead;
       tLen -= tRead;
       tOff += tRead;
-    }
-    if(tLen == len){
-        return -1;
     }
     return len - tLen;
   }


### PR DESCRIPTION
Method read(byte[] b, int off, int len) returns 0 when there is nothing left to read. It should return -1.
When "mCurrentPosition" is equal to "FILE_LENGTH" the while loop is skipped and "tLen" has the same value as "len", and this means that the return value will be always 0 when there is nothing left to read. This will cause an infinite loop.
The issue exists in all branches. I've made the fix and pull request here because I'm working with the release version for 5.0, but all the branches should get the fix.
