### PR TITLE
proper cleanup of resources in recompute command

### DIFF
--- a/core/src/main/java/tachyon/master/RecomputeCommand.java
+++ b/core/src/main/java/tachyon/master/RecomputeCommand.java
@@ -4,11 +4,13 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Closer;
 
 import tachyon.Constants;
 
@@ -38,21 +40,26 @@ public class RecomputeCommand implements Runnable {
       LOG.info("Exec " + mCommand + " output to " + mFilePath);
       Process p = java.lang.Runtime.getRuntime().exec(mCommand);
       String line;
-      BufferedReader bri = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      BufferedReader bre = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-      File file = new File(mFilePath);
-      FileWriter fw = new FileWriter(file.getAbsoluteFile());
-      BufferedWriter bw = new BufferedWriter(fw);
-      while ((line = bri.readLine()) != null) {
-        bw.write(line + "\n");
+      Closer closer = Closer.create();
+      try {
+        BufferedReader bri =
+            closer.register(new BufferedReader(new InputStreamReader(p.getInputStream())));
+        BufferedReader bre =
+            closer.register(new BufferedReader(new InputStreamReader(p.getErrorStream())));
+        File file = new File(mFilePath);
+        FileWriter fw = new FileWriter(file.getAbsoluteFile());
+        BufferedWriter bw = closer.register(new BufferedWriter(fw));
+        while ((line = bri.readLine()) != null) {
+          bw.write(line + "\n");
+        }
+        while ((line = bre.readLine()) != null) {
+          bw.write(line + "\n");
+        }
+        bw.flush();
+      } finally {
+        closer.close();
       }
-      bri.close();
-      while ((line = bre.readLine()) != null) {
-        bw.write(line + "\n");
-      }
-      bre.close();
-      bw.flush();
-      bw.close();
+
       p.waitFor();
       LOG.info("Exec " + mCommand + " output to " + mFilePath + " done.");
     } catch (IOException e) {


### PR DESCRIPTION
Recompute command wasn't closing the streams properly, so this patch has them all close when errors happen.
