### PR TITLE
[TACHYON-196] Set jetty thread count to 9

### DIFF
--- a/core/src/main/java/tachyon/conf/MasterConf.java
+++ b/core/src/main/java/tachyon/conf/MasterConf.java
@@ -61,7 +61,7 @@ public class MasterConf extends Utils {
         (CommonConf.get().USE_ZOOKEEPER ? Constants.HEADER_FT : Constants.HEADER) + HOSTNAME + ":"
             + PORT;
     WEB_PORT = getIntProperty("tachyon.master.web.port", Constants.DEFAULT_MASTER_WEB_PORT);
-    WEB_THREAD_COUNT = getIntProperty("tachyon.master.web.threads", 5);
+    WEB_THREAD_COUNT = getIntProperty("tachyon.master.web.threads", 9);
     TEMPORARY_FOLDER = getProperty("tachyon.master.temporary.folder", "/tmp");
 
     HEARTBEAT_INTERVAL_MS =

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -156,7 +156,7 @@ public final class LocalTachyonCluster {
     System.setProperty("tachyon.worker.selector.threads", Integer.toString(1));
     System.setProperty("tachyon.worker.server.threads", Integer.toString(2));
     System.setProperty("tachyon.worker.network.netty.worker.threads", Integer.toString(2));
-    System.setProperty("tachyon.master.web.threads", Integer.toString(1));
+    System.setProperty("tachyon.master.web.threads", Integer.toString(9));
 
     CommonConf.clear();
     MasterConf.clear();

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -144,7 +144,7 @@ number.
 </tr>
 <tr>
   <td>tachyon.master.web.threads</td>
-  <td>5</td>
+  <td>9</td>
   <td>How many threads to use for the web server.</td>
 </tr>
 </table>


### PR DESCRIPTION
Set the default jetty thread count from 5 to 9 to avoid the "insufficient threads" bug mentioned in [TACHYON-196]
