### PR TITLE
[TACHYON-199] Enable checkstyle:check on mvn install.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -401,9 +401,18 @@
           <excludes>**/tachyon/thrift/**</excludes>
           <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
-          <failsOnError>false</failsOnError>
+          <failsOnError>true</failsOnError>
           <linkXRef>false</linkXRef>
         </configuration>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>

--- a/core/src/main/resources/tachyon_checks.xml
+++ b/core/src/main/resources/tachyon_checks.xml
@@ -24,7 +24,7 @@
 <module name = "Checker">
   <property name="charset" value="UTF-8"/>
 
-  <property name="severity" value="warning"/>
+  <property name="severity" value="error"/>
 
   <!-- Checks for whitespace                               -->
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->


### PR DESCRIPTION
Enable checkstyle:check on mvn install to help contributors following code style guidelines.

When code style is violated the mvn install will barf with error:

INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Tachyon Project Parent ............................ SUCCESS [  1.184 s]
[INFO] Tachyon Project Core .............................. FAILURE [ 15.091 s]
[INFO] Tachyon Project Client ............................ SKIPPED
[INFO] Tachyon Project Assemblies ........................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16.474 s
[INFO] Finished at: 2014-10-28T13:36:19-08:00
[INFO] Final Memory: 14M/246M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.13:check (checkstyle) on project tachyon: Failed during checkstyle execution: There are 1 checkstyle errors. -> [Help 1]

  ...
