### PR TITLE
TACHYON-210 Checkstyle check fails if you run inside a core module.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -397,7 +397,13 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.13</version>
         <configuration>
-          <configLocation>src/main/resources/tachyon_checks.xml</configLocation>
+          <configLocation>${project.basedir}/src/main/resources/tachyon_checks.xml</configLocation>
+          <!-- TODO: This is needed to excuse Tachyon Configuration members' name from being -->
+          <!-- checked because the members are define using all upper case. -->
+          <!-- Once the new configuration is implemented we wil remove this exception -->
+          <suppressionsLocation>
+            ${project.basedir}/src/main/resources/tachyon_checkstyle_suppressions.xml
+          </suppressionsLocation>
           <excludes>**/tachyon/thrift/**</excludes>
           <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>

--- a/core/src/main/resources/tachyon_checks.xml
+++ b/core/src/main/resources/tachyon_checks.xml
@@ -164,10 +164,4 @@
                value="Static member name ''{0}'' must match pattern ''{1}''."/>
     </module>
   </module>
-  <!-- TODO: This is needed to excuse Tachyon Configuration members' name from being checked -->
-  <!-- because the members are define using all upper case. -->
-  <!-- Once the new configuration is implemented we wil remove this exception -->
-  <module name="SuppressionFilter">
-    <property name="file" value="core/src/main/resources/tachyon_checkstyle_suppressions.xml"/>
-  </module>
 </module>


### PR DESCRIPTION
TACHYON-210 Checkstyle check fails if you run inside a core module since location of the suppress is not relative path.

This PR update the location of the suppression XML file using relative file via maven checkstyle plugin.
