### PR TITLE
[TACHYON-207] Make the conf/slaves as a gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests.log*
 .metadata/
 .settings/
 conf/tachyon-env.sh
+conf/slaves
 core/dependency-reduced-pom.xml
 data/
 docs/_site


### PR DESCRIPTION
Make the conf/slaves as a gitignore file. It'll be handy for developers to test locally and push PRs to Tachyon.
