### PR TITLE
Simple fix for tachyon.worker.network.netty.buffer.recieve

### DIFF
--- a/core/src/main/java/tachyon/conf/WorkerConf.java
+++ b/core/src/main/java/tachyon/conf/WorkerConf.java
@@ -97,7 +97,7 @@ public class WorkerConf extends Utils {
     NETTY_SEND_BUFFER =
         Optional.fromNullable(getIntegerProperty("tachyon.worker.network.netty.buffer.send", null));
     NETTY_RECIEVE_BUFFER =
-        Optional.fromNullable(getIntegerProperty("tachyon.worker.network.netty.buffer.recieve",
+        Optional.fromNullable(getIntegerProperty("tachyon.worker.network.netty.buffer.receive",
             null));
   }
 }

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -222,7 +222,7 @@ number.
   <td>Sets SO_SNDBUF for the socket; more details can be found in the socket man page.</td>
 </tr>
 <tr>
-  <td>tachyon.worker.network.netty.buffer.recieve</td>
+  <td>tachyon.worker.network.netty.buffer.receive</td>
   <td>platform specific</td>
   <td>Sets SO_RCVBUF for the socket; more details can be found in the socket man page.</td>
 </tr>


### PR DESCRIPTION
Simple fix for typo from tachyon.worker.network.netty.buffer.recieve to tachyon.worker.network.netty.buffer.receive
