### PR TITLE
vagrant deploy: various bug fixes.

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -14,39 +14,39 @@ Addr = @cmd['Addresses']
 Init = "#{Ufs}"+"/init.sh"
 Post = "#{Ufs}"+"/post.sh"
 
-# config cluster
-(1..Total).each do |i|    
-  if i == 1
-     file = File.open("../../conf/slaves","w")
+# config cluster and create /etc/hosts 
+NameArr = Array.new
+file = File.open("../../conf/slaves","w")
+system 'mkdir', '-p', './files'
+hosts = File.open("files/hosts","w")
+for i in (1..Total)
+  if i == Total 
+    NameArr[i] = "TachyonMaster"
   else
-     file = File.open("../../conf/slaves","a")
+    NameArr[i] = "TachyonWorker#{i}"
   end
   if file != nil
-     file.write(Addr[i - 1])
-     file.write("\n")
+     file.write(NameArr[i] + ".local"  + "\n")
   end
-  file.close unless file == nil
+  if hosts != nil
+     hosts.write(Addr[i - 1] + " " + 
+                 NameArr[i] + ".local" + "\n")
+  end
 end
-  
+file.close unless file == nil
+hosts.close unless hosts == nil
+
 # Vagrantfile API/syntax version. 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.6.5"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..Total).each do |i|    
     # multi vm config
-    name = ""
-    if i == Total 
-      name = "TachyonMaster"
-    else
-      name = "TachyonWorker#{i}"
-    end
+    name = NameArr[i]
     config.vm.define "#{name}" do |n|
       # common config
       n.vm.provision "shell", path: "init.sh"
       n.vm.provision "shell", path: Init
-
-      # files shared by VMs go into shared folder
-      # system 'mkdir', '-p', './shared'
 
       # Provider specific init
       if Provider == "vb"

--- a/deploy/vagrant/hadoop2/init.sh
+++ b/deploy/vagrant/hadoop2/init.sh
@@ -10,13 +10,13 @@ if [ ! -f hadoop-${HADOOP_VERSION}.tar.gz ]
 then
     # download hadoop
     echo "Downloading hadoop ${HADOOP_VERSION} ..." 
-    wget -q http://www.us.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz  
+    wget -q http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
     tar xzf hadoop-${HADOOP_VERSION}.tar.gz  
 fi
 
-if [ ! -f /hadoop ]
+if [ ! -d /hadoop ]
 then
-    ln -fs `pwd`/hadoop-${HADOOP_VERSION} /hadoop
+    ln -s `pwd`/hadoop-${HADOOP_VERSION} /hadoop
 
     # setup hadoop
     rm -f /hadoop/etc/hadoop/slaves

--- a/deploy/vagrant/init.sh
+++ b/deploy/vagrant/init.sh
@@ -44,6 +44,12 @@ Host *
    StrictHostKeyChecking no
    UserKnownHostsFile=/dev/null
 EOF
+    # patch /etc/hosts
+    # HDFS NN binds to the first IP that resolves the hostname. 
+    # And thus make the default address to 127.0.0.1 
+    # This makes other DN unable to connect to NN
+    # Solution is to use fully qualified domain name
+    cat ${src}/hosts >> /etc/hosts
 
     chmod 600 ~/.ssh/*
     # install java


### PR DESCRIPTION
- Change Hadoop download site to archive.apache.org for better download locality.
- fix hostname resolution issue. Vagrant sets hostname in /etc/hosts, making 127.0.0.1 the default IP for given hostname. If only hostname is used in *-site.xml, when Hadoop daemons then bind their ports, they use 127.0.0.1. This makes other nodes unable to connect to NN and RM. This fix uses hostname+domain, per CDH document, to make daemons bind public IPs.

Tested on Virtualbox and AWS
