### PR TITLE
Remove logging impl from client jar

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -71,9 +71,13 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-jaxrs</artifactId>
         </exclusion>
-          <exclusion>
+        <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-xc</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Remove logging impl from client jar. This is needed when you put the jar in hadoop's classpath so it doesn't complain about multiple jars with impls.
