### PR TITLE
refact getFileStatus in TachyonFS

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -536,9 +536,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   @Override
   public ClientFileInfo getFileStatus(int fileId, TachyonURI path) throws IOException {
-    validateUri(path);
-    ClientFileInfo info = mMasterClient.getFileStatus(fileId, path.getPath());
-    return info.getId() == -1 ? null : info;
+    return getFileStatus(fileId, path, false);
   }
 
   /**
@@ -575,11 +573,11 @@ public class TachyonFS extends AbstractTachyonFS {
     if (fileId != -1) {
       info = mIdToClientFileInfo.get(fileId);
       if (!useCachedMetadata || info == null) {
-        info = getFileStatus(fileId, TachyonURI.EMPTY_URI);
+        info = mMasterClient.getFileStatus(fileId, TachyonURI.EMPTY_URI.getPath());
         updated = true;
       }
 
-      if (info == null) {
+      if (info.getId() == -1) {
         mIdToClientFileInfo.remove(fileId);
         return null;
       }
@@ -588,11 +586,11 @@ public class TachyonFS extends AbstractTachyonFS {
     } else {
       info = mPathToClientFileInfo.get(path.getPath());
       if (!useCachedMetadata || info == null) {
-        info = getFileStatus(-1, path);
+        info = mMasterClient.getFileStatus(-1, path.getPath());
         updated = true;
       }
 
-      if (info == null) {
+      if (info.getId() == -1) {
         mPathToClientFileInfo.remove(path.getPath());
         return null;
       }


### PR DESCRIPTION
make getFileStatus(int fileId, TachyonURI path,  boolean useCachedMetadata) call  RPC to get ClientFileInfo from the master.
which makes the relations of overloaded functions simpler,
and it also makes the ClientFileInfo be cached, once getting data from the master.
