### PR TITLE
FIX TACHYON-232: Add warning messages to guard against illegal input to ...

### DIFF
--- a/core/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
+++ b/core/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
@@ -233,9 +233,9 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
     }
 
     if (pos < 0) {
-      throw new IOException("Seek position is negative: " + pos);
+      throw new IllegalArgumentException("Seek position is negative: " + pos);
     } else if (pos > mTachyonFile.length()) {
-      throw new IOException("Seek position is past EOF: " + pos + ", fileSize = "
+      throw new IllegalArgumentException("Seek position is past EOF: " + pos + ", fileSize = "
           + mTachyonFile.length());
     }
 


### PR DESCRIPTION
When running Tachyon, we have seen cases that some illegal positions (such as -1) were passed to the seek function, leading to wrong blocks getting fetched. We should catch this problem early, e.g. in HdfsFileInputStream.java.
One way to handle this is to throw an exception when an illegal offset is encountered.

File touched:
https://github.com/shimingfei/tachyon/blob/7be9bb0e527a696e840b39c5e0365226a631a61d/core/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
