### PR TITLE
catch InvalidPath for getFileStatus to avoid infi loops

### DIFF
--- a/core/src/main/java/tachyon/master/MasterClient.java
+++ b/core/src/main/java/tachyon/master/MasterClient.java
@@ -251,6 +251,8 @@ public final class MasterClient implements Closeable {
         return mClient.getFileStatus(fileId, path);
       } catch (FileDoesNotExistException e) {
         throw new IOException(e);
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;


### PR DESCRIPTION
When you create a file that is not seen as valid to the rest of tachyon, then the current code does a ton of retries. This patch will throw exception rather than doing the retries.

Looks like this relates to [TACHYON-240](https://tachyon.atlassian.net/browse/TACHYON-240).
