### PR TITLE
[Docs]Update tachyon.data.folder and tachyon.workers.folder default value

### DIFF
--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -35,12 +35,12 @@ The common configuration contains constants which specify paths and the log appe
 </tr>
 <tr>
   <td>tachyon.data.folder</td>
-  <td>$tachyon.underfs.address + "/tachyon/data"</td>
+  <td>$tachyon.underfs.address + "/tmp/tachyon/data"</td>
   <td>Tachyon's data folder in the underlayer file system.</td>
 </tr>
 <tr>
   <td>tachyon.workers.folder</td>
-  <td>$tachyon.underfs.address + "/tachyon/workers"</td>
+  <td>$tachyon.underfs.address + "/tmp/tachyon/workers"</td>
   <td>Tachyon's workers folders in the underlayer file system.</td>
 </tr>
 <tr>


### PR DESCRIPTION
Configuration-Settings.html and `TACHYON_JAVA_OPTS` in tachyon-env.sh.template description is not consistent, 
update  `tachyon.data.folder` default value is `$TACHYON_UNDERFS_ADDRESS/tmp/tachyon/data` 
and `tachyon.workers.folder` default value is `$TACHYON_UNDERFS_ADDRESS/tmp/tachyon/workers` in Configuration-Settings.html.
