### PR TITLE
made master retry count configurable.

### DIFF
--- a/core/src/main/java/tachyon/conf/CommonConf.java
+++ b/core/src/main/java/tachyon/conf/CommonConf.java
@@ -81,6 +81,8 @@ public class CommonConf extends Utils {
 
   public final boolean IN_TEST_MODE;
 
+  public final int MASTER_RETRY_COUNT;
+
   private CommonConf() {
     if (System.getProperty("tachyon.home") == null) {
       LOG.warn("tachyon.home is not set. Using {} as the default value.", DEFAULT_HOME);
@@ -124,6 +126,8 @@ public class CommonConf extends Utils {
         getListProperty("tachyon.underfs.hadoop.prefixes", DEFAULT_HADOOP_UFS_PREFIX);
 
     IN_TEST_MODE = getBooleanProperty("tachyon.test.mode", false);
+
+    MASTER_RETRY_COUNT = getIntProperty("tachyon.master.retry", 45);
   }
 
   public static void assertValidPort(final int port) {

--- a/core/src/main/java/tachyon/master/MasterClient.java
+++ b/core/src/main/java/tachyon/master/MasterClient.java
@@ -78,7 +78,7 @@ import tachyon.util.NetworkUtils;
 // so all exceptions are handled poorly. This logic needs to be redone and be consistent.
 public final class MasterClient implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-  private static final int MAX_CONNECT_TRY = 5;
+  private static final int MAX_CONNECT_TRY = CommonConf.get().MASTER_RETRY_COUNT;
 
   private boolean mUseZookeeper;
   private MasterService.Client mClient = null;

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -108,6 +108,11 @@ The common configuration contains constants which specify paths and the log appe
   <td>hdfs:// s3:// s3n:// glusterfs:///</td>
   <td>Optionally specify which prefixes should run through the Apache Hadoop's implementation of UnderFileSystem.  The delimiter is any whitespace and/or ','</td>
 </tr>
+<tr>
+  <td>tachyon.master.retry</td>
+  <td>45</td>
+  <td>How many times to try to reconnect with master.</td>
+</tr>
 </table>
 
 # Master Configuration


### PR DESCRIPTION
Also upped default to 45 (matches hadoop's default). This is good to have to make tests more consistent. On our jenkins cluster, we see that tests fail often because of temporary issues with local masters.
