### PR TITLE
Remove log4j.properties from test-jar.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -372,6 +372,9 @@
               <addClasspath>true</addClasspath>
             </manifest>
           </archive>
+          <excludes>
+            <exclude>**/log4j.properties</exclude>
+          </excludes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The test-jar created by Tachyon contains a log4j.properties file. 
This automatically adds the file to the classpath, which causes unpredictable logging behavior (of testcases) in projects depending on the test-jar.
