### PR TITLE
Client doesnt depend on commons-lang, this is only provided by hadoop wh...

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Client packaging removes hadoop, and commons-lang is a transitive dependency from Hadoop. Tachyon explicitly depends  on commons-lang3, so switch to that one is required.

You will catch this when you try to use the client jar, you will get the following

```
Exception in thread "Thread-4" Exception in thread "Thread-3" java.lang.NoSuchMethodError: org.apache.commons.lang.StringUtils.isBlank(Ljava/lang/String;)Z
        at tachyon.client.TachyonFS.createAndGetUserLocalTempFolder(TachyonFS.java:239)
        at tachyon.client.LocalWritableBlockChannel.<init>(LocalWritableBlockChannel.java:35)
        at tachyon.client.Blocks.createWritableBlockImpl(Blocks.java:52)
        at tachyon.client.Blocks.createWritableBlock(Blocks.java:40)
        at tachyon.client.FileOutStream.getNextBlock(FileOutStream.java:154)
        at tachyon.client.FileOutStream.write(FileOutStream.java:173)
        at tachyon.client.FileOutStream.write(FileOutStream.java:205)
        at java.io.DataOutputStream.writeInt(DataOutputStream.java:180)
        at com.yahoo.ycsb.db.TachyonClient.writeTo(TachyonClient.java:201)
        at com.yahoo.ycsb.db.TachyonClient.write(TachyonClient.java:173)
        at com.yahoo.ycsb.db.TachyonClient.insert(TachyonClient.java:68)
        at com.yahoo.ycsb.DBWrapper.insert(DBWrapper.java:148)
        at com.yahoo.ycsb.workloads.CoreWorkload.doInsert(CoreWorkload.java:461)
        at com.yahoo.ycsb.ClientThread.run(Client.java:277)
```
