### PR TITLE
FIX ISSUE TACHYON-251: when closing RemoteBlockInStream, we should close...

### DIFF
--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -123,7 +123,7 @@ public class RemoteBlockInStream extends BlockInStream {
   public void close() throws IOException {
     if (!mClosed) {
       if (mRecache) {
-        mBlockOutStream.cancel();
+        mBlockOutStream.close();
       }
       if (mCheckpointInputStream != null) {
         mCheckpointInputStream.close();


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-251

When RemoteBlockInStream is done, it calls cancel BlockOutStream, which is writing the remote block to local disk. This would result in fetching the remote block (and failure to cache the block) later. Some perf numbers:

Before Change (simple SQL query):
Time taken: 160.786 seconds
Time taken: 131.347 seconds

After Change (simple SQL query):
Time taken: 5.9 seconds
Time taken: 5.891 seconds

remoteBlockInStream.java:
@Override
public void close() throws IOException {
if (!mClosed) {
if (mRecache)
{ mBlockOutStream.cancel(); }
if (mCheckpointInputStream != null)
{ mCheckpointInputStream.close(); }
}
mClosed = true;
}
