### PR TITLE
TACHYON-253 Add volatile modifier to EditLogProcessor.mIsStandby to guarantee visibility

### DIFF
--- a/core/src/main/java/tachyon/master/EditLogProcessor.java
+++ b/core/src/main/java/tachyon/master/EditLogProcessor.java
@@ -39,7 +39,7 @@ public class EditLogProcessor implements Runnable {
   private int mCurrentLogFileNum = 0;
   private int mLastImageFileNum = 0;
   private long mLoadedImageModTime = 0L;
-  private boolean mIsStandby = true;
+  private volatile boolean mIsStandby = true;
 
   /**
    * Create a new EditLogProcessor.
@@ -101,7 +101,7 @@ public class EditLogProcessor implements Runnable {
         throw Throwables.propagate(e);
       }
     }
-    LOG.info("Standy log processor with path " + mPath + " stopped.");
+    LOG.info("Standby log processor with path " + mPath + " stopped.");
   }
 
   /**


### PR DESCRIPTION
The EditLogProcessor.mIsStandby is being read and modify by different threads.

There could be code optimization with memory barrier that could cache the variable changes among threads.
Add volatile modifier to let JVM guarantees that every read of the variable would from main memory instead of CPU cache.

And small typo fix from "Standy" to "Standby"
