### PR TITLE
Simple typo fix of the JournalTest.CompletedEditLogDeletionTest method name

### DIFF
--- a/core/src/test/java/tachyon/master/JournalTest.java
+++ b/core/src/test/java/tachyon/master/JournalTest.java
@@ -150,7 +150,7 @@ public class JournalTest {
    * @throws Exception
    */
   @Test
-  public void CompltedEditLogDeletionTest() throws Exception {
+  public void CompletedEditLogDeletionTest() throws Exception {
     Journal journal = mLocalTachyonCluster.getMasterInfo().getJournal();
     journal.setMaxLogSize(Constants.KB);
     for (int i = 0; i < 124; i ++) {


### PR DESCRIPTION
Simple typo fix of the JournalTest.CompletedEditLogDeletionTest method name. Missing letter 'e' from "Complted" to "Completed"
