### PR TITLE
change hadoop.version to 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <test.output.redirect>true</test.output.redirect>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
-    <hadoop.version>1.0.4</hadoop.version>
+    <hadoop.version>2.4.1</hadoop.version>
     <glusterfs-hadoop.version>2.3.5</glusterfs-hadoop.version>
     <libthrift.version>0.9.1</libthrift.version>
     <cxf.version>2.7.0</cxf.version>


### PR DESCRIPTION
if hadoop.version is 1.0.4,  LocalMiniDFSCluster.java can not pass the compile since there is no "org.apache.hadoop.hdfs.MiniDFSCluster" in hadoop-1.0.4. So I think we can modify the hadoop.version to 2.4.1
