### PR TITLE
Remove blockIds from removedBlockIds after they are removed from mToRemovedBlockIds

### DIFF
--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -2342,7 +2342,9 @@ public class MasterInfo extends ImageWriter {
 
         tWorkerInfo.updateUsedBytes(usedBytes);
         tWorkerInfo.updateBlocks(false, removedBlockIds);
-        tWorkerInfo.updateToRemovedBlocks(false, removedBlockIds);
+        List<Long> updatedToRemovedBlockIds =
+            tWorkerInfo.updateToRemovedBlocks(false, removedBlockIds);
+        removedBlockIds.removeAll(updatedToRemovedBlockIds);
         tWorkerInfo.updateLastUpdatedTimeMs();
 
         for (long blockId : removedBlockIds) {

--- a/core/src/main/java/tachyon/master/MasterWorkerInfo.java
+++ b/core/src/main/java/tachyon/master/MasterWorkerInfo.java
@@ -189,13 +189,14 @@ public class MasterWorkerInfo {
    * @param add true if to add, to remove otherwise.
    * @param blockId the ID of the block to be added or removed
    */
-  public synchronized void updateToRemovedBlock(boolean add, long blockId) {
+  public synchronized boolean updateToRemovedBlock(boolean add, long blockId) {
     if (add) {
       if (mBlocks.contains(blockId)) {
-        mToRemoveBlocks.add(blockId);
+        return mToRemoveBlocks.add(blockId);
       }
+      return false;
     } else {
-      mToRemoveBlocks.remove(blockId);
+      return mToRemoveBlocks.remove(blockId);
     }
   }
 
@@ -205,10 +206,14 @@ public class MasterWorkerInfo {
    * @param add true if to add, to remove otherwise.
    * @param blockIds IDs of blocks to be added or removed
    */
-  public synchronized void updateToRemovedBlocks(boolean add, Collection<Long> blockIds) {
+  public synchronized List<Long> updateToRemovedBlocks(boolean add, Collection<Long> blockIds) {
+    List<Long> updatedBlockIds = new ArrayList<Long>();
     for (long blockId : blockIds) {
-      updateToRemovedBlock(add, blockId);
+      if (updateToRemovedBlock(add, blockId)) {
+        updatedBlockIds.add(blockId);
+      }
     }
+    return updatedBlockIds;
   }
 
   /**


### PR DESCRIPTION
Remove blockIds from removedBlockIds after they are removed from mToRemovedBlockIds, else the fileId of the blocks will not be found. and an error message will be printed.
two conditions of removing blocks:
1. client request master to delete some file by calling freePath / delete, and the block Ids of the file will added into mToRemovedBlockIds. (first delete file meta info and then delete blocks)
2. some blocks are evicted from worker, the worker will update the blocks through heartbeat with Master(removedBlockIds). those blocks are not in mToRemovedBlockIds. (delete locations of blocks only)

if removed blocks are in mToRemovedBlocks, meta info of the file which contains the block doesn't exist. an error message will be printed.
