### PR TITLE
[Tachyon 1349] Deprecate unused variables in AbstractTFS

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -68,9 +68,6 @@ import tachyon.util.CommonUtils;
  * used and {@link #getScheme()} for Hadoop's {@link java.util.ServiceLoader} support.
  */
 abstract class AbstractTFS extends FileSystem {
-  public static final String FIRST_COM_PATH = "tachyon_dep/";
-  public static final String RECOMPUTE_PATH = "tachyon_recompute/";
-
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   // Always tell Hadoop that we have 3x replication.
   private static final int BLOCK_REPLICATION_CONSTANT = 3;


### PR DESCRIPTION
The recomputation constants are no longer being used and should be deprecated this version and removed in later versions.