### PR TITLE
[DOCFIX] Change the group in Powered-By-Tachyon.md of Chinese version from "Dev Resources" to "Resources"

### DIFF
--- a/docs/cn/Powered-By-Tachyon.md
+++ b/docs/cn/Powered-By-Tachyon.md
@@ -1,7 +1,7 @@
 ---
 layout: global
 title: Powered By Tachyon
-group: Dev Resources
+group: Resources
 ---
 
 目前有许多公司和组织都在使用Tachyon，下面列出了其中一部分。如果你的组织也在使用，可以自由将你的组织[添加到这个列表中](https://github.com/amplab/tachyon/edit/master/docs/Powered-By-Tachyon.md)，或者通过邮件告诉我们(project.tachyon@gmail.com)，或者填写[调查](http://tachyon-project.org/resources/survey-users/)让我们知道。


### PR DESCRIPTION
The `group` attribute in Powered-By-Tachyon.md of Chinese version hasn't been modified to "Resources"