### PR TITLE
[DOCFIX] Improve Chinese documentation of Running-Alluxio pages

### DIFF
--- a/docs/cn/Running-Alluxio-Fault-Tolerant-on-EC2.md
+++ b/docs/cn/Running-Alluxio-Fault-Tolerant-on-EC2.md
@@ -7,7 +7,7 @@ priority: 4
 ---
 
 使用Alluxio自带的[Vagrant脚本](https://github.com/alluxio/alluxio/tree/master/deploy/vagrant)可以将带
-容错机制的Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及销毁集群，该集群自动配置了HDFS相关项。
+容错机制的Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及撤销集群，该集群自动配置了HDFS相关项。
 
 # 前期准备
 
@@ -149,10 +149,10 @@ worker进程。
 
 {% include Running-Alluxio-Fault-Tolerant-on-EC2/ssh-other-node.md %}
 
-# 销毁集群
+# 撤销集群
 
 在`deploy/vagrant`目录下运行：
 
 {% include Running-Alluxio-Fault-Tolerant-on-EC2/destroy.md %}
 
-从而销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。
+从而撤销之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。

--- a/docs/cn/Running-Alluxio-on-EC2-Mesos.md
+++ b/docs/cn/Running-Alluxio-on-EC2-Mesos.md
@@ -7,7 +7,7 @@ priority: 4
 ---
 
 使用Alluxio自带的[Vagrant脚本](https://github.com/alluxio/alluxio/tree/master/deploy/vagrant)可以通过
-Mesos将Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及销毁集群，该集群自动配置了HDFS相关项。
+Mesos将Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及撤销集群，该集群自动配置了HDFS相关项。
 
 # 前期准备
 
@@ -110,10 +110,10 @@ Hadoop Web UI的默认端口为**50070**。
 在所有测试完成后，再次访问Alluxio的web UI `http://{MASTER_IP}:19999`，在导航栏中点击
 `Browse File System`，你应该能看到测试过程中写入到Alluxio的文件。
 
-# 销毁集群
+# 撤销集群
 
 在`deploy/vagrant`目录下运行：
 
 {% include Running-Alluxio-on-EC2-Mesos/destroy.md %}
 
-从而销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。
+从而撤销之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。

--- a/docs/cn/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/cn/Running-Alluxio-on-EC2-Yarn.md
@@ -6,7 +6,7 @@ group: User Guide
 priority: 5
 ---
 
-Alluxio可以由Apache YARN启动并管理。该向导介绍如何使用Alluxio自带的
+Alluxio可以由Apache YARN启动并管理。该指南介绍如何使用Alluxio自带的
 [Vagrant脚本](https://github.com/alluxio/alluxio/tree/master/deploy/vagrant)在EC2的机器上用YARN启
 动Alluxio。
 
@@ -152,13 +152,13 @@ Alluxio作业的状态和应用ID。
 
 {% include Running-Alluxio-on-EC2-Yarn/kill-application.md %}
 
-# 销毁集群
+# 撤销集群
 
 在启动EC2机器的本地机器`deploy/vagrant`目录下运行：
 
 {% include Running-Alluxio-on-EC2-Yarn/destroy.md %}
 
-销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。
+撤销之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。
 
 # 故障排除
 

--- a/docs/cn/Running-Alluxio-on-EC2.md
+++ b/docs/cn/Running-Alluxio-on-EC2.md
@@ -7,7 +7,7 @@ priority: 3
 ---
 
 使用Alluxio自带的[Vagrant脚本](https://github.com/alluxio/alluxio/tree/master/deploy/vagrant)可以将
-Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及销毁集群。
+Alluxio部署在Amazon EC2上。该脚本允许你创建，配置以及撤销集群。
 
 # 前期准备
 
@@ -109,10 +109,10 @@ Alluxio Web UI的默认端口为**19999**。
 
 {% include Running-Alluxio-on-EC2/ssh-other-node.md %}
 
-# 销毁集群
+# 撤销集群
 
 在`deploy/vagrant`目录下运行：
 
 {% include Running-Alluxio-on-EC2/destroy.md %}
 
-从而销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。
+从而撤销之前创建的集群。一次只能创建一个集群。当该命令成功执行后，EC2实例将终止运行。

--- a/docs/cn/Running-Alluxio-on-Virtual-Box.md
+++ b/docs/cn/Running-Alluxio-on-Virtual-Box.md
@@ -6,7 +6,7 @@ group: User Guide
 priority: 2
 ---
 通过Alluxio自带的[Vagrant脚本](https://github.com/alluxio/alluxio/tree/master/deploy/vagrant)，你可以
-将Alluxio部署在本地机器上的[VirtualBox](https://www.virtualbox.org/)中。该脚本允许你创建，配置以及销毁
+将Alluxio部署在本地机器上的[VirtualBox](https://www.virtualbox.org/)中。该脚本允许你创建，配置以及撤销
 集群，该集群自动配置了HDFS相关项。
 
 # 前期准备
@@ -84,10 +84,10 @@ Hadoop Web UI的默认端口为**50070**。
 
 {% include Running-Alluxio-on-Virtual-Box/ssh-other-node.md %}
 
-# 销毁集群
+# 撤销集群
 
 在`deploy/vagrant`目录下运行：
 
 {% include Running-Alluxio-on-Virtual-Box/destroy.md %}
 
-从而销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，虚拟机将终止运行。
+从而撤销之前创建的集群。一次只能创建一个集群。当该命令成功执行后，虚拟机将终止运行。

--- a/docs/cn/Running-Flink-on-Alluxio.md
+++ b/docs/cn/Running-Flink-on-Alluxio.md
@@ -6,7 +6,7 @@ group: Frameworks
 priority: 2
 ---
 
-该向导介绍如何在Alluxio上运行[Apache Flink](http://flink.apache.org/),以便你在Flink中使用Alluxio的文件
+该指南介绍如何在Alluxio上运行[Apache Flink](http://flink.apache.org/),以便你在Flink中使用Alluxio的文件。
 
 # 前期准备
 
@@ -21,7 +21,7 @@ Apache Flink可以通过通用文件系统包装类（可用于Hadoop文件系�
 
 #### 在`core-site.xml`中设置属性
 
-如果年你安装Flink的同时安装了Hadoop，将如下属性加到`core-site.xml`配置文件：
+如果你安装Flink的同时安装了Hadoop，将如下属性加到`core-site.xml`配置文件：
 
 {% include Running-Flink-on-Alluxio/core-site-configuration.md %}
 

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -6,7 +6,7 @@ group: Frameworks
 priority: 0
 ---
 
-该向导描述了如何在Alluxio上运行[Apache Spark](http://spark-project.org/)并且使用HDFS作为Alluxio底层存储系统。Alluxio除HDFS之外也支持其它的底层存储系统，计算框架(如Spark)可以通过Alluxio从底层存储系统读写数据。
+该指南描述了如何在Alluxio上运行[Apache Spark](http://spark-project.org/)并且使用HDFS作为Alluxio底层存储系统。Alluxio除HDFS之外也支持其它的底层存储系统，计算框架(如Spark)可以通过Alluxio从底层存储系统读写数据。
 
 ## 兼容性
 
@@ -50,12 +50,12 @@ Alluxio直接兼容Spark 1.1或更新版本而无需修改.
 
 {% include Running-Spark-on-Alluxio/any-Alluxio-master.md %}
 
-## 数据局部性
+## 数据本地化
 
-如果Spark任务的局部性应该是`NODE_LOCAL`而实际是`ANY`，可能是因为Alluxio和Spark使用了不同的网络地址表示，可能其中一个使用了主机名而另一个使用了IP地址。请参考 [this jira ticket](
+如果Spark任务的定位应该是`NODE_LOCAL`而实际是`ANY`，可能是因为Alluxio和Spark使用了不同的网络地址表示，可能其中一个使用了主机名而另一个使用了IP地址。请参考 [this jira ticket](
 https://issues.apache.org/jira/browse/SPARK-10149)获取更多细节（这里可以找到Spark社区的解决方案）。
 
-提示:Alluxio使用主机名来表示网络地址，只有0.7.1版本使用了IP地址。Spark 1.5.x版本与Alluxio0.7.1做法一致，都使用了IP地址来表示网络地址，数据局部性不加修改即可使用。但是从0.8.0往后，为了与HDFS一致，Alluxio使用主机名表示网络地址。用户启动Spark时想要获取数据局部性，可以用Spark提供的如下脚本显式指定主机名。以slave-hostname启动Spark Worker:
+提示:Alluxio使用主机名来表示网络地址，只有0.7.1版本使用了IP地址。Spark 1.5.x版本与Alluxio0.7.1做法一致，都使用了IP地址来表示网络地址，数据本地化不加修改即可使用。但是从0.8.0往后，为了与HDFS一致，Alluxio使用主机名表示网络地址。用户启动Spark时想要获取数据本地化，可以用Spark提供的如下脚本显式指定主机名。以slave-hostname启动Spark Worker:
 
 {% include Running-Spark-on-Alluxio/slave-hostname.md %}
 
@@ -63,11 +63,11 @@ https://issues.apache.org/jira/browse/SPARK-10149)获取更多细节（这里可
 
 {% include Running-Spark-on-Alluxio/slave-hostname-example.md %}
 
-也可以通过设置`$SPARK_HOME/conf/spark-env.sh`里的`SPARK_LOCAL_HOSTNAME`获取数据局部性。举例而言：
+也可以通过设置`$SPARK_HOME/conf/spark-env.sh`里的`SPARK_LOCAL_HOSTNAME`获取数据本地化。举例而言：
 
 {% include Running-Spark-on-Alluxio/spark-local-hostname-example.md %}
 
-用以上任何一种方法，Spark Worker的地址变为主机名并且局部性等级变为NODE_LOCAL，如下Spark WebUI所示：
+用以上任何一种方法，Spark Worker的地址变为主机名并且定位等级变为NODE_LOCAL，如下Spark WebUI所示：
 
 ![hostname]({{site.data.img.screenshot_datalocality_sparkwebui}})
 


### PR DESCRIPTION
Improved the following Chinese docs:
Running-Alluxio-Fault-Tolerant
Running-Alluxio-Fault-Tolerant-on-EC2
Running-Alluxio-Locally
Running-Alluxio-on-a-Cluster
Running-Alluxio-on-EC2
Running-Alluxio-on-EC2-Mesos
Running-Alluxio-on-EC2-Yarn
Running-Alluxio-on-Virtual-Box
Running-Flink-on-Alluxio
Running-Hadoop-MapReduce-on-Alluxio
Running-Spark-on-Alluxio