### PR TITLE
[ALLUXIO-1718] Delete block metadata when a file is deleted.

### DIFF
--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -322,11 +322,15 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
               worker.updateToRemovedBlock(true, blockId);
             }
           }
+          // Two cases here:
+          // 1) For delete: delete the block metadata.
+          // 2) For free: keep the block metadata. mLostBlocks will be changed in
+          // processWorkerRemovedBlocks
           if (delete) {
+            // Make sure blockId is removed from mLostBlocks when the block metadata is deleted.
+            // Otherwise blockId in mLostBlock can be dangling index if the metadata is gone.
             mLostBlocks.remove(blockId);
             mBlocks.remove(blockId);
-          } else {
-            mLostBlocks.add(blockId);
           }
         }
       }

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -305,9 +305,9 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
    * Removes blocks from workers.
    *
    * @param blockIds a list of block ids to remove from Alluxio space
-   * @param deleteBlocksMetadata whether to delete blocks metadata in Master
+   * @param delete whether to delete blocks metadata in Master
    */
-  public void removeBlocks(List<Long> blockIds, boolean deleteBlocksMetadata) {
+  public void removeBlocks(List<Long> blockIds, boolean delete) {
     synchronized (mBlocks) {
       synchronized (mWorkers) {
         for (long blockId : blockIds) {
@@ -322,9 +322,10 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
               worker.updateToRemovedBlock(true, blockId);
             }
           }
-          mLostBlocks.remove(blockId);
-          if (deleteBlocksMetadata) {
+          if (delete) {
             mBlocks.remove(blockId);
+          } else {
+            mLostBlocks.add(blockId);
           }
         }
       }

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -323,6 +323,7 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
             }
           }
           if (delete) {
+            mLostBlocks.remove(blockId);
             mBlocks.remove(blockId);
           } else {
             mLostBlocks.add(blockId);

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -305,8 +305,9 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
    * Removes blocks from workers.
    *
    * @param blockIds a list of block ids to remove from Alluxio space
+   * @param deleteBlocksMetadata whether to delete blocks metadata in Master
    */
-  public void removeBlocks(List<Long> blockIds) {
+  public void removeBlocks(List<Long> blockIds, boolean deleteBlocksMetadata) {
     synchronized (mBlocks) {
       synchronized (mWorkers) {
         for (long blockId : blockIds) {
@@ -322,6 +323,9 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
             }
           }
           mLostBlocks.remove(blockId);
+          if (deleteBlocksMetadata) {
+            mBlocks.remove(blockId);
+          }
         }
       }
     }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -2215,8 +2215,7 @@ public final class FileSystemMaster extends AbstractMaster {
               inode.setPersistenceState(PersistenceState.LOST);
             }
           } catch (FileDoesNotExistException e) {
-            // TODO(calvin): Re-add this logic when we update the logic of freeing/removing blocks
-            // LOG.error("Exception trying to get inode from inode tree: {}", e.toString());
+            LOG.error("Exception trying to get inode from inode tree: {}", e.toString());
           }
         }
       }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -852,8 +852,9 @@ public final class FileSystemMaster extends AbstractMaster {
       }
 
       if (delInode.isFile()) {
-        // Remove corresponding blocks from workers.
-        mBlockMaster.removeBlocks(((InodeFile) delInode).getBlockIds());
+        // Remove corresponding blocks from workers and delete metadata in master.
+        mBlockMaster.removeBlocks(((InodeFile) delInode).getBlockIds(),
+            true /* deleteBlocksMetadata */);
       }
 
       mInodeTree.deleteInode(delInode, opTimeMs);
@@ -1353,7 +1354,8 @@ public final class FileSystemMaster extends AbstractMaster {
 
         if (freeInode.isFile()) {
           // Remove corresponding blocks from workers.
-          mBlockMaster.removeBlocks(((InodeFile) freeInode).getBlockIds());
+          mBlockMaster.removeBlocks(((InodeFile) freeInode).getBlockIds(),
+              false /* deleteBlocksMetadata */);
         }
       }
       MasterContext.getMasterSource().incFilesFreed(freeInodes.size());

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -853,8 +853,7 @@ public final class FileSystemMaster extends AbstractMaster {
 
       if (delInode.isFile()) {
         // Remove corresponding blocks from workers and delete metadata in master.
-        mBlockMaster.removeBlocks(((InodeFile) delInode).getBlockIds(),
-            true /* deleteBlocksMetadata */);
+        mBlockMaster.removeBlocks(((InodeFile) delInode).getBlockIds(), true /* delete */);
       }
 
       mInodeTree.deleteInode(delInode, opTimeMs);
@@ -1354,8 +1353,7 @@ public final class FileSystemMaster extends AbstractMaster {
 
         if (freeInode.isFile()) {
           // Remove corresponding blocks from workers.
-          mBlockMaster.removeBlocks(((InodeFile) freeInode).getBlockIds(),
-              false /* deleteBlocksMetadata */);
+          mBlockMaster.removeBlocks(((InodeFile) freeInode).getBlockIds(), false /* delete */);
         }
       }
       MasterContext.getMasterSource().incFilesFreed(freeInodes.size());

--- a/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -192,13 +192,15 @@ public class BlockMasterTest {
     mMaster.commitBlock(worker2, 1L, "MEM", 1L, 1L);
     mMaster.commitBlock(worker2, 2L, "MEM", 2L, 1L);
     mMaster.commitBlock(worker2, 3L, "MEM", 3L, 1L);
-    mMaster.removeBlocks(workerBlocks, false /* deleteBlocksMetadata */);
+    mMaster.removeBlocks(workerBlocks, false /* delete */);
     Assert.assertEquals(1L, mMaster.getBlockInfo(1L).getBlockId());
+    Assert.assertTrue(mMaster.getLostBlocks().contains(1L));
 
-    // Test removeBlocks with deleteBlocksMetadata
-    mMaster.removeBlocks(workerBlocks, true /* deleteBlocksMetadata */);
+    // Test removeBlocks with delete
+    mMaster.removeBlocks(workerBlocks, true /* delete */);
     mThrown.expect(BlockInfoException.class);
     mMaster.getBlockInfo(1L);
+    Assert.assertFalse(mMaster.getLostBlocks().contains(1L));
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -13,6 +13,7 @@ package alluxio.master.block;
 
 import alluxio.collections.IndexedSet;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.BlockInfoException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.master.block.meta.MasterBlockInfo;
@@ -34,6 +35,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.reflect.Whitebox;
 
@@ -61,6 +63,10 @@ public class BlockMasterTest {
   /** Rule to create a new temporary folder during each test. */
   @Rule
   public TemporaryFolder mTestFolder = new TemporaryFolder();
+
+  /** The exception expected to be thrown. */
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
 
   /**
    * Sets up the dependencies before a test runs.
@@ -166,7 +172,7 @@ public class BlockMasterTest {
   }
 
   /**
-   * Tests the {@link BlockMaster#removeBlocks(List)} method.
+   * Tests the {@link BlockMaster#removeBlocks(List, boolean)} method.
    *
    * @throws Exception if registering a worker fails
    */
@@ -186,7 +192,13 @@ public class BlockMasterTest {
     mMaster.commitBlock(worker2, 1L, "MEM", 1L, 1L);
     mMaster.commitBlock(worker2, 2L, "MEM", 2L, 1L);
     mMaster.commitBlock(worker2, 3L, "MEM", 3L, 1L);
-    mMaster.removeBlocks(workerBlocks);
+    mMaster.removeBlocks(workerBlocks, false /* deleteBlocksMetadata */);
+    Assert.assertEquals(1L, mMaster.getBlockInfo(1L).getBlockId());
+
+    // Test removeBlocks with deleteBlocksMetadata
+    mMaster.removeBlocks(workerBlocks, true /* deleteBlocksMetadata */);
+    mThrown.expect(BlockInfoException.class);
+    mMaster.getBlockInfo(1L);
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -194,7 +194,6 @@ public class BlockMasterTest {
     mMaster.commitBlock(worker2, 3L, "MEM", 3L, 1L);
     mMaster.removeBlocks(workerBlocks, false /* delete */);
     Assert.assertEquals(1L, mMaster.getBlockInfo(1L).getBlockId());
-    Assert.assertTrue(mMaster.getLostBlocks().contains(1L));
 
     // Test removeBlocks with delete
     mMaster.removeBlocks(workerBlocks, true /* delete */);

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -167,7 +167,7 @@ public final class FileSystemMasterTest {
         mFileSystemMaster.deleteFile(NESTED_FILE_URI, false));
 
     mThrown.expect(BlockInfoException.class);
-    mBlockMaster.getBlockInfo(blockId).getLocations().size();
+    mBlockMaster.getBlockInfo(blockId);
 
     // verify the file is deleted
     Assert.assertEquals(IdUtils.INVALID_FILE_ID, mFileSystemMaster.getFileId(NESTED_FILE_URI));

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -14,6 +14,7 @@ package alluxio.master.file;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
+import alluxio.exception.BlockInfoException;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
@@ -164,7 +165,9 @@ public final class FileSystemMasterTest {
     long blockId = createFileWithSingleBlock(NESTED_FILE_URI);
     Assert.assertTrue(
         mFileSystemMaster.deleteFile(NESTED_FILE_URI, false));
-    Assert.assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
+
+    mThrown.expect(BlockInfoException.class);
+    mBlockMaster.getBlockInfo(blockId).getLocations().size();
 
     // verify the file is deleted
     Assert.assertEquals(IdUtils.INVALID_FILE_ID, mFileSystemMaster.getFileId(NESTED_FILE_URI));

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -168,6 +168,7 @@ public final class FileSystemMasterTest {
 
     mThrown.expect(BlockInfoException.class);
     mBlockMaster.getBlockInfo(blockId);
+    Assert.assertFalse(mBlockMaster.getLostBlocks().contains(blockId));
 
     // verify the file is deleted
     Assert.assertEquals(IdUtils.INVALID_FILE_ID, mFileSystemMaster.getFileId(NESTED_FILE_URI));


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/ALLUXIO-1718

Currently the block metadata is not deleted when a file is deleted, and therefore block master regards the blocks as lost. This handling slows the system down, because the lost block will trigger lost file detection, which will in turn lead to a FileNotFound exception in inodetree look up.

Therefore, we should distinguish between freeing and deleting files in Alluxio.