### PR TITLE
[DOCFIX] Correct the group of Powered-by Chinese page

### DIFF
--- a/docs/cn/Powered-By-Alluxio.md
+++ b/docs/cn/Powered-By-Alluxio.md
@@ -1,7 +1,7 @@
 ---
 layout: global
 title: Powered By Alluxio
-group: Dev Resources
+group: Resources
 ---
 
 目前有许多公司和组织都在使用Alluxio，下面列出了其中一部分。如果你的组织也在使用，可以自由将你的组织[添加到这个列表中](https://github.com/alluxio/alluxio/edit/master/docs/cn/Powered-By-Alluxio.md)，或者通过邮件告诉我们(project.alluxio@gmail.com)，或者填写[调查](http://alluxio.org/resources/survey-users/)让我们知道。


### PR DESCRIPTION
The group of current Chinese Powered-by page should be 'Resources' but not 'Dev Resources'. Otherwise, the page would be missing when generating the webpage.