### PR TITLE
[DOCFIX]add some translation for docs/cn/Running-Spark-on-Alluxio

### DIFF
--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -15,6 +15,11 @@ Alluxio直接兼容Spark 1.1或更新版本而无需修改.
 ## 前期准备
 
 * Alluxio集群根据向导搭建完成(可以是[本地模式](Running-Alluxio-Locally.html)或者[集群模式](Running-Alluxio-on-a-Cluster.html))。
+
+* Alluxio client需要在编译时指定Spark选项。在顶层`alluxio`目录中执行如下命令构建Alluxio:
+
+{% include Running-Spark-on-Alluxio/spark-profile-build.md %}
+
 * 请添加如下代码到`spark/conf/spark-env.sh`。
 
 {% include Running-Spark-on-Alluxio/earlier-spark-version-bash.md %}


### PR DESCRIPTION
I  think these contents in en/Running-Spark-on-Alluxio needs to be translated:
![en](https://cloud.githubusercontent.com/assets/16427747/13324606/69981d72-dc19-11e5-9855-e2fc150cf8a7.png)
I add the translation in cn/Running-Spark-on-Alluxio:
![cn](https://cloud.githubusercontent.com/assets/16427747/13324753/00579710-dc1a-11e5-85c2-60486ab244f7.png)
