### PR TITLE
[ALLUXIO-1735] Using MireDot for REST API documentation

### DIFF
--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -121,6 +121,7 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
     </dependency>
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>commons-httpclient</groupId>
@@ -140,7 +141,22 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
     </dependency>
+
+    <!--- Dependency for REST annotations -->
+    <dependency>
+      <groupId>com.qmino</groupId>
+      <artifactId>miredot-annotations</artifactId>
+      <version>1.4.0</version>
+    </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>miredot</id>
+      <name>MireDot Releases</name>
+      <url>http://nexus.qmino.com/content/repositories/miredot</url>
+    </repository>
+  </repositories>
 
   <build>
     <plugins>
@@ -161,6 +177,50 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.qmino</groupId>
+        <artifactId>miredot-plugin</artifactId>
+        <version>1.6.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>restdoc</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <license>
+            UHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyfDIwMTctMDItMjV8dHJ1ZSNNQzBDRlFDUm1SMXpVb3dMOUkyNXZrcGtJOVlmOHY3M2tnSVVIa0NxSFgvdUlYZmd3SHdSa1hFYUFMRDQ3Q0E9
+          </license>
+          <restModel>
+            <httpStatusCodes>
+              <httpStatusCode>
+                <httpCode>200</httpCode>
+                <document>always</document>
+                <defaultMessage>The service call has completed successfully.</defaultMessage>
+              </httpStatusCode>
+              <httpStatusCode>
+                <httpCode>412</httpCode>
+                <document>put,post</document>
+                <defaultMessage>Invalid JSON/XML input.</defaultMessage>
+              </httpStatusCode>
+              <httpStatusCode>
+                <httpCode>500</httpCode>
+                <document>always</document>
+                <defaultMessage>The service call has not succeeded.</defaultMessage>
+                <sticky>true</sticky> <!-- Document always, even if there is an @statuscode tag -->
+              </httpStatusCode>
+            </httpStatusCodes>
+          </restModel>
+          <analysis>
+            <checks>
+              <JAVADOC_MISSING_INTERFACEDOCUMENTATION>ignore</JAVADOC_MISSING_INTERFACEDOCUMENTATION>
+              <JAVADOC_MISSING_AUTHORS>ignore</JAVADOC_MISSING_AUTHORS>
+            </checks>
+          </analysis>
+          <!-- insert other configuration here (optional) -->
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -190,6 +190,7 @@
           </execution>
         </executions>
         <configuration>
+          <!--- This following license only works for groupId org.alluxio and artifactId alluxio-core-server. -->
           <license>
             UHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyfDIwMTctMDItMjV8dHJ1ZSNNQzBDRlFDUm1SMXpVb3dMOUkyNXZrcGtJOVlmOHY3M2tnSVVIa0NxSFgvdUlYZmd3SHdSa1hFYUFMRDQ3Q0E9
           </license>

--- a/core/server/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
@@ -16,6 +16,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.master.AlluxioMaster;
 
 import com.google.common.base.Preconditions;
+import com.qmino.miredot.annotations.ReturnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ import javax.ws.rs.core.Response;
 public final class BlockMasterClientRestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  public static final String SERVICE_PREFIX = "block";
+  public static final String SERVICE_PREFIX = "master/block";
   public static final String SERVICE_NAME = "service_name";
   public static final String SERVICE_VERSION = "service_version";
   public static final String GET_BLOCK_INFO = "block_info";
@@ -48,29 +49,35 @@ public final class BlockMasterClientRestServiceHandler {
   private final BlockMaster mBlockMaster = AlluxioMaster.get().getBlockMaster();
 
   /**
-   * @return the service name
+   * @summary get the service name
+   * @return the response object
    */
   @GET
   @Path(SERVICE_NAME)
+  @ReturnType("java.lang.String")
   public Response getServiceName() {
     return Response.ok(Constants.BLOCK_MASTER_CLIENT_SERVICE_NAME).build();
   }
 
   /**
-   * @return the service version
+   * @summary get the service version
+   * @return the response object
    */
   @GET
   @Path(SERVICE_VERSION)
+  @ReturnType("java.lang.Long")
   public Response getServiceVersion() {
     return Response.ok(Constants.BLOCK_MASTER_CLIENT_SERVICE_VERSION).build();
   }
 
   /**
+   * @summary get the block descriptor for a block
    * @param blockId the block id
-   * @return the block descriptor for the given id
+   * @return the response object
    */
   @GET
   @Path(GET_BLOCK_INFO)
+  @ReturnType("alluxio.wire.BlockInfo")
   public Response getBlockInfo(@QueryParam("blockId") Long blockId) {
     try {
       Preconditions.checkNotNull(blockId, "required 'blockId' parameter is missing");
@@ -82,28 +89,34 @@ public final class BlockMasterClientRestServiceHandler {
   }
 
   /**
-   * @return the total capacity (in bytes)
+   * @summary get the total capacity
+   * @return the response object
    */
   @GET
   @Path(GET_CAPACITY_BYTES)
+  @ReturnType("java.lang.Long")
   public Response getCapacityBytes() {
     return Response.ok(mBlockMaster.getCapacityBytes()).build();
   }
 
   /**
-   * @return the used capacity (in bytes)
+   * @summary get the used capacity
+   * @return the response object
    */
   @GET
   @Path(GET_USED_BYTES)
+  @ReturnType("java.lang.Long")
   public Response getUsedBytes() {
     return Response.ok(mBlockMaster.getUsedBytes()).build();
   }
 
   /**
-   * @return a list of worker descriptors for all workers
+   * @summary get the list of worker descriptors
+   * @return the response object
    */
   @GET
   @Path(GET_WORKER_INFO_LIST)
+  @ReturnType("java.util.List<alluxio.wire.WorkerInfo>")
   public Response getWorkerInfoList() {
     return Response.ok(mBlockMaster.getWorkerInfoList()).build();
   }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
@@ -22,6 +22,7 @@ import alluxio.master.file.options.CreateFileOptions;
 import alluxio.master.file.options.SetAttributeOptions;
 
 import com.google.common.base.Preconditions;
+import com.qmino.miredot.annotations.ReturnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ import javax.ws.rs.core.Response;
 public final class FileSystemMasterClientRestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  public static final String SERVICE_PREFIX = "file";
+  public static final String SERVICE_PREFIX = "master/file";
   public static final String SERVICE_NAME = "service_name";
   public static final String SERVICE_VERSION = "service_version";
   public static final String COMPLETE_FILE = "complete_file";
@@ -70,30 +71,36 @@ public final class FileSystemMasterClientRestServiceHandler {
   private final FileSystemMaster mFileSystemMaster = AlluxioMaster.get().getFileSystemMaster();
 
   /**
-   * @return the service name
+   * @summary get the service name
+   * @return the response object
    */
   @GET
   @Path(SERVICE_NAME)
+  @ReturnType("java.lang.String")
   public Response name() {
     return Response.ok(Constants.FILE_SYSTEM_MASTER_CLIENT_SERVICE_NAME).build();
   }
 
   /**
-   * @return the service version
+   * @summary get the service version
+   * @return the response object
    */
   @GET
   @Path(SERVICE_VERSION)
+  @ReturnType("java.lang.Long")
   public Response version() {
     return Response.ok(Constants.FILE_SYSTEM_MASTER_CLIENT_SERVICE_VERSION).build();
   }
 
   /**
+   * @summary complete a file
    * @param path the file path
    * @param ufsLength the length of the file in under file system
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(COMPLETE_FILE)
+  @ReturnType("java.lang.Void")
   public Response completeFile(@QueryParam("path") String path,
       @QueryParam("ufsLength") Long ufsLength) {
     try {
@@ -112,14 +119,16 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary create a directory
    * @param path the file path
    * @param persisted whether directory should be persisted
    * @param recursive whether parent directories should be created if they do not already exist
    * @param allowExists whether the operation should succeed even if the directory already exists
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(CREATE_DIRECTORY)
+  @ReturnType("java.lang.Void")
   public Response createDirectory(@QueryParam("path") String path,
       @QueryParam("persisted") Boolean persisted, @QueryParam("recursive") Boolean recursive,
       @QueryParam("allowExists") Boolean allowExists) {
@@ -145,15 +154,17 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary create a file
    * @param path the file path
    * @param persisted whether directory should be persisted
    * @param recursive whether parent directories should be created if they do not already exist
    * @param blockSizeBytes the target block size in bytes
    * @param ttl the time-to-live (in milliseconds)
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(CREATE_FILE)
+  @ReturnType("java.lang.Void")
   public Response createFile(@QueryParam("path") String path,
       @QueryParam("persisted") Boolean persisted, @QueryParam("recursive") Boolean recursive,
       @QueryParam("blockSizeBytes") Long blockSizeBytes, @QueryParam("ttl") Long ttl) {
@@ -181,11 +192,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary get the list of file block descriptors for a file
    * @param path the file path
-   * @return a list of file block descriptors for the given path
+   * @return the response object
    */
   @GET
   @Path(GET_FILE_BLOCK_INFO_LIST)
+  @ReturnType("java.util.List<alluxio.wire.FileBlockInfo>")
   public Response getFileBlockInfoList(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -197,11 +210,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary get a new block id for a file
    * @param path the file path
-   * @return a new block id for the given path
+   * @return the response object
    */
   @POST
   @Path(GET_NEW_BLOCK_ID_FOR_FILE)
+  @ReturnType("java.lang.Long")
   public Response getNewBlockIdForFile(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -212,11 +227,13 @@ public final class FileSystemMasterClientRestServiceHandler {
     }
   }
   /**
+   * @summary get a file descriptor for a path
    * @param path the file path
-   * @return the file descriptor for the given path
+   * @return the response object
    */
   @GET
   @Path(GET_STATUS)
+  @ReturnType("alluxio.wire.FileInfo")
   public Response getStatus(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -228,11 +245,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary get a file descriptor for a file id
    * @param fileId the file id
-   * @return the file descriptor for the given file id
+   * @return the response object
    */
   @GET
   @Path(GET_STATUS_INTERNAL)
+  @ReturnType("alluxio.wire.FileInfo")
   public Response getStatusInternal(@QueryParam("fileId") Long fileId) {
     try {
       Preconditions.checkNotNull(fileId, "required 'fileId' parameter is missing");
@@ -244,21 +263,25 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary get the UFS address
    * @return the UFS address
    */
   @GET
   @Path(GET_UFS_ADDRESS)
+  @ReturnType("java.lang.String")
   public Response getUfsAddress() {
     return Response.ok(mFileSystemMaster.getUfsAddress()).build();
   }
 
   /**
+   * @summary free a path
    * @param path the path
    * @param recursive whether the path should be freed recursively
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(FREE)
+  @ReturnType("java.lang.Void")
   public Response free(@QueryParam("path") String path,
       @QueryParam("recursive") boolean recursive) {
     try {
@@ -272,11 +295,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary get the file descriptors for a path
    * @param path the file path
-   * @return a list of file descriptors for the contents of the given path
+   * @return the response object
    */
   @GET
   @Path(LIST_STATUS)
+  @ReturnType("java.util.List<alluxio.wire.FileInfo>")
   public Response listStatus(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -288,12 +313,14 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary load metadata for a path
    * @param path the alluxio path to load metadata for
    * @param recursive whether metadata should be loaded recursively
-   * @return the file id for the loaded path
+   * @return the response object
    */
   @POST
   @Path(LOAD_METADATA)
+  @ReturnType("java.lang.Long")
   public Response loadMetadata(@QueryParam("path") String path,
       @QueryParam("recursive") boolean recursive) {
     try {
@@ -306,12 +333,14 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary mount a UFS path
    * @param path the alluxio mount point
    * @param ufsPath the UFS path to mount
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(MOUNT)
+  @ReturnType("java.lang.Void")
   public Response mount(@QueryParam("path") String path, @QueryParam("ufsPath") String ufsPath) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -325,12 +354,14 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary remove a path
    * @param path the path to remove
    * @param recursive whether to remove paths recursively
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(REMOVE)
+  @ReturnType("java.lang.Void")
   public Response remove(@QueryParam("path") String path,
       @QueryParam("recursive") boolean recursive) {
     try {
@@ -344,12 +375,14 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary move a path
    * @param srcPath the source path
    * @param dstPath the destination path
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(RENAME)
+  @ReturnType("java.lang.Void")
   public Response rename(@QueryParam("srcPath") String srcPath,
       @QueryParam("dstPath") String dstPath) {
     try {
@@ -364,11 +397,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary schedule asynchronous persistence
    * @param path the file path
-   * @return the id of the worker that persistence is scheduled on
+   * @return the response object
    */
   @POST
   @Path(SCHEDULE_ASYNC_PERSIST)
+  @ReturnType("java.lang.Long")
   public Response scheduleAsyncPersist(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");
@@ -380,6 +415,7 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary set an attribute
    * @param path the file path
    * @param pinned the pinned flag value to use
    * @param ttl the time-to-live (in seconds) to use
@@ -388,9 +424,10 @@ public final class FileSystemMasterClientRestServiceHandler {
    * @param group the file group
    * @param permission the file permission bits
    * @param recursive whether the attribute should be set recursively
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
+  @ReturnType("java.lang.Void")
   @Path(SET_ATTRIBUTE)
   public Response setAttribute(@QueryParam("path") String path,
       @QueryParam("pinned") Boolean pinned, @QueryParam("ttl") Long ttl,
@@ -430,11 +467,13 @@ public final class FileSystemMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary unmount a path
    * @param path the file path
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(UNMOUNT)
+  @ReturnType("java.lang.Boolean")
   public Response unmount(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientRestServiceHandler.java
@@ -20,6 +20,7 @@ import alluxio.master.AlluxioMaster;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.qmino.miredot.annotations.ReturnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,7 @@ import javax.ws.rs.core.Response;
 public final class LineageMasterClientRestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  public static final String SERVICE_PREFIX = "lineage";
+  public static final String SERVICE_PREFIX = "master/lineage";
   public static final String SERVICE_NAME = "service_name";
   public static final String SERVICE_VERSION = "service_version";
   public static final String CREATE_LINEAGE = "create_lineage";
@@ -57,32 +58,38 @@ public final class LineageMasterClientRestServiceHandler {
   private final LineageMaster mLineageMaster = AlluxioMaster.get().getLineageMaster();
 
   /**
-   * @return the service name
+   * @summary get the service name
+   * @return the response object
    */
   @GET
   @Path(SERVICE_NAME)
+  @ReturnType("java.lang.String")
   public Response name() {
     return Response.ok(Constants.LINEAGE_MASTER_CLIENT_SERVICE_NAME).build();
   }
 
   /**
-   * @return the service version
+   * @summary get the service version
+   * @return the response object
    */
   @GET
   @Path(SERVICE_VERSION)
+  @ReturnType("java.lang.Long")
   public Response version() {
     return Response.ok(Constants.LINEAGE_MASTER_CLIENT_SERVICE_VERSION).build();
   }
 
   /**
+   * @summary create a lineage
    * @param inputFiles a colon-separated list of the lineage input files
    * @param outputFiles a colon-separated list of the lineage output files
    * @param command the job command
    * @param outputFile the job output file
-   * @return the id of the created lineage
+   * @return the response object
    */
   @POST
   @Path(CREATE_LINEAGE)
+  @ReturnType("java.lang.Long")
   public Response createLineage(@QueryParam("inputFiles") String inputFiles,
       @QueryParam("outputFiles") String outputFiles, @QueryParam("command") String command,
       @QueryParam("commandOutputFile") String outputFile) {
@@ -108,12 +115,14 @@ public final class LineageMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary delete a lineage
    * @param lineageId the lineage id
    * @param cascade whether to delete lineage recursively
-   * @return true if the lineage is deleted, false otherwise
+   * @return the response object
    */
   @POST
   @Path(DELETE_LINEAGE)
+  @ReturnType("java.lang.Boolean")
   public Response deleteLineage(@QueryParam("lineageId") Long lineageId,
       @QueryParam("cascade") boolean cascade) {
     try {
@@ -126,10 +135,12 @@ public final class LineageMasterClientRestServiceHandler {
   }
 
   /**
-   * @return a list of lineage descriptors for all lineages
+   * @summary get the list of lineage descriptors
+   * @return the response object
    */
   @GET
   @Path(GET_LINEAGE_INFO_LIST)
+  @ReturnType("java.util.List<alluxio.wire.LineageInfo>")
   public Response getLineageInfoList() {
     try {
       return Response.ok(mLineageMaster.getLineageInfoList()).build();
@@ -140,13 +151,15 @@ public final class LineageMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary reinitialize a file
    * @param path the file path
    * @param blockSizeBytes the file block size (in bytes)
    * @param ttl the file time-to-live (in seconds)
-   * @return the id of the reinitialized file when the file is lost or not completed, -1 otherwise
+   * @return the response object
    */
   @POST
   @Path(REINITIALIZE_FILE)
+  @ReturnType("java.lang.Long")
   public Response reinitializeFile(@QueryParam("path") String path,
       @QueryParam("blockSizeBytes") Long blockSizeBytes, @QueryParam("ttl") Long ttl) {
     try {
@@ -161,11 +174,13 @@ public final class LineageMasterClientRestServiceHandler {
   }
 
   /**
+   * @summary report a lost file
    * @param path the file path
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(REPORT_LOST_FILE)
+  @ReturnType("java.lang.Void")
   public Response reportLostFile(@QueryParam("path") String path) {
     try {
       Preconditions.checkNotNull(path, "required 'path' parameter is missing");

--- a/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientRestServiceHandler.java
@@ -23,6 +23,7 @@ import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 
 import com.google.common.base.Preconditions;
+import com.qmino.miredot.annotations.ReturnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ import javax.ws.rs.core.Response;
 public final class BlockWorkerClientRestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  public static final String SERVICE_PREFIX = "block";
+  public static final String SERVICE_PREFIX = "worker/block";
   public static final String SERVICE_NAME = "service_name";
   public static final String SERVICE_VERSION = "service_version";
   public static final String ACCESS_BLOCK = "access_block";
@@ -68,32 +69,38 @@ public final class BlockWorkerClientRestServiceHandler {
       new WorkerStorageTierAssoc(WorkerContext.getConf());
 
   /**
-   * @return the service name
+   * @summary get the service name
+   * @return the response object
    */
   @GET
   @Path(SERVICE_NAME)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.String")
   public Response name() {
     return Response.ok(Constants.BLOCK_WORKER_CLIENT_SERVICE_NAME).build();
   }
 
   /**
-   * @return the service version
+   * @summary get the service version
+   * @return the response object
    */
   @GET
   @Path(SERVICE_VERSION)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Long")
   public Response version() {
     return Response.ok(Constants.BLOCK_WORKER_CLIENT_SERVICE_VERSION).build();
   }
 
   /**
+   * @summary access a block
    * @param blockId the block id
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(ACCESS_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response accessBlock(@QueryParam("blockId") Long blockId) {
     try {
       Preconditions.checkNotNull(blockId, "required 'blockId' parameter is missing");
@@ -106,12 +113,14 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary asynchronously persist a file
    * @param fileId the file id
-   * @return whether the operation succeeded
+   * @return the response object
    */
   @POST
   @Path(ASYNC_CHECKPOINT)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Boolean")
   public Response asyncCheckpoint(@QueryParam("fileId") Long fileId) {
     try {
       Preconditions.checkNotNull(fileId, "required 'fileId' parameter is missing");
@@ -123,13 +132,15 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary cache a block
    * @param sessionId the session id
    * @param blockId the block id
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(CACHE_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response cacheBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId) {
     try {
@@ -144,13 +155,15 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary cancel a block
    * @param sessionId the session id
    * @param blockId the block id
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(CANCEL_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response cancelBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId) {
     try {
@@ -165,13 +178,15 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary lock a block
    * @param sessionId the session id
    * @param blockId the block id
-   * @return the lock block result
+   * @return the response object
    */
   @POST
   @Path(LOCK_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("alluxio.wire.LockBlockResult")
   public Response lockBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId) {
     try {
@@ -188,12 +203,14 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary promote a block
    * @param blockId the block id
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(PROMOTE_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response promoteBlock(@QueryParam("blockId") Long blockId) {
     try {
       Preconditions.checkNotNull(blockId, "required 'blockId' parameter is missing");
@@ -207,16 +224,18 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary read a block
    * @param sessionId the session id
    * @param blockId the block id
    * @param lockId the lock id
    * @param offset the offset to start the read at
    * @param length the number of bytes to read (the value -1 means read until EOF)
-   * @return the requested bytes
+   * @return the response object
    */
   @GET
   @Path(READ_BLOCK)
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @ReturnType("java.util.List<java.lang.Byte>")
   public Response readBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId, @QueryParam("lockId") Long lockId,
       @QueryParam("offset") Long offset, @QueryParam("length") Long length) {
@@ -260,14 +279,16 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary request a block location
    * @param sessionId the session id
    * @param blockId the block id
    * @param initialBytes the initial number of bytes to allocate
-   * @return a string representing the path to the local file
+   * @return the response object
    */
   @POST
   @Path(REQUEST_BLOCK_LOCATION)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Long")
   public Response requestBlockLocation(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId, @QueryParam("initialBytes") Long initialBytes) {
     try {
@@ -283,14 +304,16 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary request additional space for a block
    * @param sessionId the session id
    * @param blockId the block id
    * @param requestBytes the additional number of bytes to allocate
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(REQUEST_SPACE)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response requestSpace(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId, @QueryParam("requestBytes") Long requestBytes) {
     try {
@@ -306,13 +329,15 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary unlock a block
    * @param sessionId the session id
    * @param blockId the block id
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(UNLOCK_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
+  @ReturnType("java.lang.Void")
   public Response unlockBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId) {
     try {
@@ -327,17 +352,19 @@ public final class BlockWorkerClientRestServiceHandler {
   }
 
   /**
+   * @summary write a block
    * @param sessionId the session id
    * @param blockId the block id
    * @param offset the offset to start the read at
    * @param length the number of bytes to read (the value -1 means read until EOF)
    * @param data the data to write
-   * @return status 200 on success
+   * @return the response object
    */
   @POST
   @Path(WRITE_BLOCK)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  @ReturnType("java.lang.Void")
   public Response writeBlock(@QueryParam("sessionId") Long sessionId,
       @QueryParam("blockId") Long blockId, @QueryParam("offset") Long offset,
       @QueryParam("length") Long length, byte[] data) {

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
   </repositories>
 
   <pluginRepositories>
+    <pluginRepository>
+      <id>miredot</id>
+      <name>MireDot Releases</name>
+      <url>http://nexus.qmino.com/content/repositories/miredot</url>
+    </pluginRepository>
   </pluginRepositories>
 
   <properties>


### PR DESCRIPTION
Addresses: https://tachyon.atlassian.net/browse/ALLUXIO-1735

After `mvn test`, the `$ALLUXIO_HOME/core/server/target/miredot` will contain autogenerated HTML documenting the REST API. See the attached screenshots for a couple of examples.
![screen shot 2016-02-25 at 3 16 02 pm](https://cloud.githubusercontent.com/assets/1072079/13337865/c99f7b8a-dbd2-11e5-9f23-d8350a22c42f.png)
![screen shot 2016-02-25 at 3 17 26 pm](https://cloud.githubusercontent.com/assets/1072079/13337887/ec26df68-dbd2-11e5-8a57-a5579a9796be.png)

@aaudiber 