### PR TITLE
[SMALLFIX] fixing Javadoc warnings

### DIFF
--- a/core/client-internal/src/main/java/alluxio/client/block/BlockWorkerClient.java
+++ b/core/client-internal/src/main/java/alluxio/client/block/BlockWorkerClient.java
@@ -51,8 +51,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * The client talks to a block worker server. It keeps sending keep alive message to the worker
  * server.
  *
- * Since {@link BlockWorkerClientService.Client} is not thread safe, this class has to guarantee
- * thread safety.
+ * Since {@link alluxio.thrift.BlockWorkerClientService.Client} is not thread safe, this class
+ * has to guarantee thread safety.
  */
 @ThreadSafe
 public final class BlockWorkerClient extends AbstractClient {

--- a/core/client-internal/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client-internal/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -157,9 +157,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   }
 
   /**
-   * Opens an {@link FSDataOutputStream} at the indicated Path with
-   * write-progress reporting. Same as
-   * {@link #create(Path, boolean, int, short, long, Progressable)}, except fails if parent
+   * Opens an {@link FSDataOutputStream} at the indicated Path with write-progress reporting.
+   * Same as {@link #create(Path, boolean, int, short, long, Progressable)}, except fails if parent
    * directory doesn't already exist.
    *
    * TODO(hy): We need to refactor this method after having a new internal API support (ALLUXIO-46).
@@ -173,7 +172,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param progress queryable progress
    * @throws IOException if 1) overwrite is not specified and the path already exists, 2) if the
    *         path is a folder, or 3) the parent directory does not exist
-   * @see {@link #setPermission(Path, FsPermission)}
+   * @see #setPermission(Path, FsPermission)
    * @deprecated API only for 0.20-append
    */
   @Override

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -57,11 +57,11 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Alluxio (e.g., ${ALLUXIO_HOME}/conf/)
  *
  * <p>
- * Developers can create an instance of this class by {@link Configuration()}, which will load
+ * Developers can create an instance of this class by {@link #Configuration()}, which will load
  * values from any Java system properties set as well.
  *
  * <p>
- * The class only supports creation using {@link Configuration(Properties)} to override default
+ * The class only supports creation using {@link #Configuration(Properties)} to override default
  * values.
  */
 @NotThreadSafe

--- a/core/common/src/main/java/alluxio/network/protocol/RPCResponse.java
+++ b/core/common/src/main/java/alluxio/network/protocol/RPCResponse.java
@@ -24,7 +24,8 @@ public abstract class RPCResponse extends RPCMessage {
 
   /**
    * The possible types of status for RPC responses. When modifying values,
-   * {@link #statusToMessage(Status)} must be updated for the appropriate status messages.
+   * {@link #statusToMessage(RPCResponse.Status)} must be updated for the appropriate status
+   * messages.
    */
   public enum Status {
     // Success.
@@ -39,9 +40,9 @@ public abstract class RPCResponse extends RPCMessage {
     WRITE_ERROR(102);
 
     private static final String DEFAULT_ERROR_STRING = "Unknown error.";
-    /** Mapping from short id to {@link alluxio.network.protocol.RPCResponse.Status}. */
+    /** Mapping from short id to {@link Status}. */
     private static final Map<Short, Status> SHORT_TO_STATUS_MAP = new HashMap<Short, Status>();
-    /** Mapping from {@link alluxio.network.protocol.RPCResponse.Status} to status message. */
+    /** Mapping from {@link Status} to status message. */
     private static final Map<Status, String> STATUS_TO_MESSAGE_MAP = new HashMap<Status, String>();
     static {
       // Populate the mappings.
@@ -80,10 +81,10 @@ public abstract class RPCResponse extends RPCMessage {
     }
 
     /**
-     * Returns the {@link alluxio.network.protocol.RPCResponse.Status} represented by the short.
+     * Returns the {@link Status} represented by the short.
      *
-     * @param id the short representing a {@link alluxio.network.protocol.RPCResponse.Status}
-     * @return the {@link alluxio.network.protocol.RPCResponse.Status} representing the given short
+     * @param id the short representing a {@link Status}
+     * @return the {@link Status} representing the given short
      */
     public static Status fromShort(short id) {
       Status status = SHORT_TO_STATUS_MAP.get(id);
@@ -94,13 +95,12 @@ public abstract class RPCResponse extends RPCMessage {
     }
 
     /**
-     * Returns the {@link String} message for a given
-     * {@link alluxio.network.protocol.RPCResponse.Status}.
+     * Returns the {@link String} message for a given {@link Status}.
      *
      * This method must be updated when a new Status is added.
      *
-     * @param status The {@link alluxio.network.protocol.RPCResponse.Status} to get the message for
-     * @return The String message for the status
+     * @param status the {@link Status} to get the message for
+     * @return the String message for the status
      */
     private static String statusToMessage(Status status) {
       switch (status) {

--- a/core/common/src/main/java/alluxio/wire/BlockLocation.java
+++ b/core/common/src/main/java/alluxio/wire/BlockLocation.java
@@ -26,7 +26,7 @@ public final class BlockLocation {
   private String mTierAlias = "";
 
   /**
-   * Creates a new instance of {@BlockLocation}.
+   * Creates a new instance of {@link BlockLocation}.
    */
   public BlockLocation() {}
 

--- a/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -30,12 +30,12 @@ public final class WorkerNetAddress {
   private int mWebPort;
 
   /**
-   * Creates a new instance of {@WorkerNetAddress}.
+   * Creates a new instance of {@link WorkerNetAddress}.
    */
   public WorkerNetAddress() {}
 
   /**
-   * Creates a new instance of {@WorkerNetAddress} from thrift representation.
+   * Creates a new instance of {@link WorkerNetAddress} from thrift representation.
    *
    * @param workerNetAddress the thrift net address
    */

--- a/core/server/src/main/java/alluxio/web/UIFileInfo.java
+++ b/core/server/src/main/java/alluxio/web/UIFileInfo.java
@@ -60,7 +60,7 @@ public final class UIFileInfo {
     private final boolean mIsDirectory;
 
     /**
-     * Creates a new instance of {@link LocalFileInfo}.
+     * Creates a new instance of {@link UIFileInfo.LocalFileInfo}.
      *
      * @param name name
      * @param absolutePath absolute path
@@ -138,7 +138,7 @@ public final class UIFileInfo {
   /**
    * Creates a new instance of {@link UIFileInfo}.
    *
-   * @param fileInfo underlying {@link LocalFileInfo}
+   * @param fileInfo underlying {@link UIFileInfo.LocalFileInfo}
    */
   public UIFileInfo(LocalFileInfo fileInfo) {
     mId = -1;

--- a/keyvalue/client-internal/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
+++ b/keyvalue/client-internal/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
@@ -34,8 +34,8 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Client for talking to a key-value worker server.
  *
- * Since {@link KeyValueWorkerClientService.Client} is not thread safe, this class has to guarantee
- * thread safety.
+ * Since {@link alluxio.thrift.KeyValueWorkerClientService.Client} is not thread safe, this class
+ * has to guarantee thread safety.
  */
 @ThreadSafe
 public final class KeyValueWorkerClient extends AbstractClient {

--- a/keyvalue/client-internal/src/main/java/alluxio/hadoop/mapreduce/KeyValueInputFormat.java
+++ b/keyvalue/client-internal/src/main/java/alluxio/hadoop/mapreduce/KeyValueInputFormat.java
@@ -35,11 +35,11 @@ import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Implementation of {@link org.apache.hadoop.mapred.InputFormat} for MapReduce programs to access
+ * Implementation of {@code org.apache.hadoop.mapred.InputFormat} for MapReduce programs to access
  * {@link KeyValueSystem}.
  * <p>
  * It takes a {@link KeyValueSystem} URI, and emits key-value pairs stored in the KeyValueStore to
- * {@link org.apache.hadoop.mapred.Mapper}s.
+ * {@code org.apache.hadoop.mapred.Mapper}s.
  */
 @PublicApi
 @ThreadSafe


### PR DESCRIPTION
This PR contains minor Javadoc clean up. In particular, fixing warnings produced by `mvn javadoc:aggregate`.