### PR TITLE
[DOCFIX] Fix Portuguese docs navbar

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -83,7 +83,7 @@ a:hover code {
     text-decoration: underline;
 }
 .container {
-    max-width: 914px;
+    max-width: 919px;
 }
 
 /**


### PR DESCRIPTION
The Portuguese-translated categories are a bit longer than the
English versions, so they will wrap to the next line if we don't
give them 5 extra pixels in the nav bar.

Before:
![image](https://cloud.githubusercontent.com/assets/3455177/13341157/f6195b5a-dbea-11e5-8c0c-03d62e38bd46.png)

After:
![image](https://cloud.githubusercontent.com/assets/3455177/13341159/012126e0-dbeb-11e5-8dd9-19a02a157abf.png)
