### PR TITLE
[DOCFIX]Remove an extra space for docs/en/Key-Value-System-API

### DIFF
--- a/docs/en/Key-Value-System-API.md
+++ b/docs/en/Key-Value-System-API.md
@@ -73,7 +73,7 @@ Similarly, Alluxio also provides implementations of `OutputFormat` and `OutputCo
  MapReduce programs to create a key-value store by taking a key-value URI, and saving key-value
  pairs to the key-value store:
 
- {% include Key-Value-Store-API/set-output-format.md %}
+{% include Key-Value-Store-API/set-output-format.md %}
 
 
 # Configuration Parameters For Key-Value System


### PR DESCRIPTION
the page "Key-Value-System-API" cannot display correctly because of the extra space:
![former](https://cloud.githubusercontent.com/assets/16427747/13341872/4fb407a0-dc77-11e5-9a3d-9d0ff5adc850.png)
After remove the extra space:
![later](https://cloud.githubusercontent.com/assets/16427747/13341891/8e5cc10e-dc77-11e5-8265-b4151ed40f15.png)

