### PR TITLE
[SMALLFIX] Use separate user log files

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -46,7 +46,7 @@ log4j.appender.WORKER_ACCESS_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c
 
 # Appender for User
 log4j.appender.USER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.USER_LOGGER.File=${alluxio.logs.dir}/user.log
+log4j.appender.USER_LOGGER.File=${alluxio.logs.dir}/user_${user.name}.log
 log4j.appender.USER_LOGGER.MaxFileSize=10MB
 log4j.appender.USER_LOGGER.MaxBackupIndex=10
 log4j.appender.USER_LOGGER.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
The current default creates permissions issues writing to logs for client
operations with multiple users using the same cluster.
This will create a separate user_<login>.log file for all the client logging.