### PR TITLE
[ALLUXIO-1752] Issue when using deploy module with EC

### DIFF
--- a/deploy/vagrant/provision/roles/alluxio/files/alluxio_jar.sh
+++ b/deploy/vagrant/provision/roles/alluxio/files/alluxio_jar.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 alluxio_version=`grep version /alluxio/pom.xml | \
-                 head -n1 | tr -d ' '          | \
+                 head -n2 | tr -d ' '          | \
+		 sed 1d			       | \
                  sed 's/<version>//g'          | \
                  sed 's/<\/version>//g'`
 

--- a/deploy/vagrant/provision/roles/alluxio/files/alluxio_jar.sh
+++ b/deploy/vagrant/provision/roles/alluxio/files/alluxio_jar.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-alluxio_version=`grep version /alluxio/pom.xml | \
-                 head -n2 | tr -d ' '          | \
-		 sed 1d			       | \
-                 sed 's/<version>//g'          | \
-                 sed 's/<\/version>//g'`
+alluxio_version=$(sed -n -e "s/^.*<version>\(.*\)<\/version>.*$/\1/p" < /alluxio/pom.xml | head -1)
 
 grep "ALLUXIO_JAR" /alluxio/libexec/alluxio-config.sh | grep "alluxio-assemblies"
 


### PR DESCRIPTION
In recent updates, the line "The Alluxio Open Foundation licenses this work under the Apache License, version 2.0" was added to the top of pom.xml.

This caused an issue when deploy/vagrant/provision/roles/alluxio/files/alluxio_jar.sh replaced ${VERSION} of /libexec/alluxio-config.sh with the Alluxio version found in pom.xml, because the script originally grep'd for the first instance of the word "version". Since "version" appears in this new line added to the top of pom.xml, alluxio_jar.sh would now replace ${VERSION} with an incorrect parameter.

I implemented a quick fix which grabs the second instance of the word "version", which grabs the correct xml element. This should probably be revisited at some point for a more portable fix.

Addresses: https://alluxio.atlassian.net/browse/ALLUXIO-1752