### PR TITLE
[DOCFIX] Corrected link from Architecture.md doc on both languages

### DIFF
--- a/docs/cn/Architecture.md
+++ b/docs/cn/Architecture.md
@@ -21,7 +21,7 @@ Alluxio的设计使用了单Master和多Worker的架构。从高层的概念理�
 
 ### Master
 
-Alluxio有两种Master部署模式，可以用其中一种进行部署, [单Master模式](Running-Alluxio-Locally.html)或[多Master模式（一个主要的加一个备用的）](Running-Alluxio-Fault-Tolerant-on-EC2.html)。Master主要负责处理全局的系统元数据，例如，文件系统树。Client可以通过与Master的交互来读取或修改元数据。此外所有的Worker会周期性地发送心跳给Master，来确保它们还参与在Alluxio集群中。Master不会主动发起与其他组件的通信，它只是以回复请求的方式与其他组件进行通信。
+Alluxio有两种Master部署模式，可以用其中一种进行部署, [单Master模式](Running-Alluxio-Locally.html)或[多Master模式（一个主要的加一个备用的）](Running-Alluxio-Fault-Tolerant.html)。Master主要负责处理全局的系统元数据，例如，文件系统树。Client可以通过与Master的交互来读取或修改元数据。此外所有的Worker会周期性地发送心跳给Master，来确保它们还参与在Alluxio集群中。Master不会主动发起与其他组件的通信，它只是以回复请求的方式与其他组件进行通信。
 
 ### Worker
 

--- a/docs/en/Architecture.md
+++ b/docs/en/Architecture.md
@@ -39,7 +39,7 @@ client portion of Alluxio.
 ### Master
 
 Alluxio may be deployed in one of two master modes, [single master](Running-Alluxio-Locally.html) or
-[fault tolerant mode](Running-Alluxio-Fault-Tolerant-on-EC2.html). The master is primarily
+[fault tolerant mode](Running-Alluxio-Fault.html). The master is primarily
 responsible for managing the global metadata of the system, for example, the file system tree.
 Clients may interact with the master to read or modify this metadata. In addition, all workers
 periodically heartbeat to the master to maintain their participation in the cluster. The master does

--- a/docs/en/Architecture.md
+++ b/docs/en/Architecture.md
@@ -39,7 +39,7 @@ client portion of Alluxio.
 ### Master
 
 Alluxio may be deployed in one of two master modes, [single master](Running-Alluxio-Locally.html) or
-[fault tolerant mode](Running-Alluxio-Fault.html). The master is primarily
+[fault tolerant mode](Running-Alluxio-Fault-Tolerant.html). The master is primarily
 responsible for managing the global metadata of the system, for example, the file system tree.
 Clients may interact with the master to read or modify this metadata. In addition, all workers
 periodically heartbeat to the master to maintain their participation in the cluster. The master does


### PR DESCRIPTION
The link referred to Alluxio Faut Tolerant Mode on EC2 machines, so we fixed the link to Alluxio Fault Tolerant Mode site.  