### PR TITLE
[SMALLFIX] loading metadata for getFileInfo

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -383,9 +383,11 @@ public final class FileSystemMaster extends AbstractMaster {
    * @throws InvalidPathException if the file path is not valid
    */
   public FileInfo getFileInfo(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException {
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
     MasterContext.getMasterSource().incGetFileInfoOps(1);
     synchronized (mInodeTree) {
+      // getFileInfo should load from ufs if the file does not exist
+      getFileId(path);
       Inode inode = mInodeTree.getInodeByPath(path);
       return getFileInfoInternal(inode);
     }
@@ -406,7 +408,7 @@ public final class FileSystemMaster extends AbstractMaster {
   /**
    * NOTE: {@link #mInodeTree} should already be locked before calling this method.
    *
-   * @param inode the inode to get the {@linke FileInfo} for
+   * @param inode the inode to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given inode
    * @throws FileDoesNotExistException if the file does not exist
    */

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -381,6 +381,7 @@ public final class FileSystemMaster extends AbstractMaster {
    * @return the {@link FileInfo} for the given file id
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the file path is not valid
+   * @throws AccessControlException if permission checking fails
    */
   public FileInfo getFileInfo(AlluxioURI path)
       throws AccessControlException, FileDoesNotExistException, InvalidPathException {

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -465,7 +465,7 @@ public class PermissionCheckTest {
   public void setStateSuccessTest() throws Exception {
     // set unmask
     Configuration conf = MasterContext.getConf();
-    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSIONS_UMASK, "044");
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSIONS_UMASK, "000");
     MasterContext.reset(conf);
 
     String file = PathUtils.concatPath(TEST_DIR_URI, "testState1");


### PR DESCRIPTION
This PR makes sure that we load metadata from UFS for getStatus(path) arguments.