### PR TITLE
[ALLUXIO-1761] Fix the problem where ansible hangs for all script modules

### DIFF
--- a/deploy/vagrant/ansible.cfg
+++ b/deploy/vagrant/ansible.cfg
@@ -8,4 +8,4 @@ scp_if_ssh=True
 # Work around a ssh error with ansible due to ec2 name length exceeding
 # Unix socket length limit.
 # http://docs.ansible.com/ansible/intro_configuration.html#control-path
-control_path = %(directory)s/%%h-%%r
+control_path = %(directory)s/%%h-%%p-%%r

--- a/deploy/vagrant/ansible.cfg
+++ b/deploy/vagrant/ansible.cfg
@@ -8,4 +8,6 @@ scp_if_ssh=True
 # Work around a ssh error with ansible due to ec2 name length exceeding
 # Unix socket length limit.
 # http://docs.ansible.com/ansible/intro_configuration.html#control-path
+# Detailed documentation on ssh control path:
+#   http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/ssh_config.5?query=ssh_config&sec=5
 control_path = %(directory)s/%%h-%%p-%%r


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1761

The problem is that on the same host machine, all virtual machines' hosts are all 127.0.0.1, the host corresponds to the `%%h` in control path configuration, `%%r` is the remote login user name which is `vagrant`, so the control path is the same for all virtual machines, that means all machines share the same connection, which is incorrect, each machine should have a distinct connection. 

The solution is to add port `%%p` which is unique for different virtualbox machines.