### PR TITLE
[ALLUXIO-1804] Block Master shouldn't send free commands on those removed blocks.

### DIFF
--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -610,7 +610,7 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
       MasterBlockInfo masterBlockInfo = mBlocks.get(removedBlockId);
       if (masterBlockInfo == null) {
         LOG.warn("Worker {} informs the removed block {}, but block metadata does not exist"
-            + "on Master!", workerInfo.getId(), removedBlockId);
+            + " on Master!", workerInfo.getId(), removedBlockId);
         // TODO(pfxuan): [ALLUXIO-1804] should find a better way to handle the removed blocks.
         // Ideally, the delete/free I/O flow should never reach this point. Because Master may
         // update the block metadata only after receiving the acknowledgement from Workers.

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -316,10 +316,9 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
             continue;
           }
           for (long workerId : new ArrayList<Long>(masterBlockInfo.getWorkers())) {
-            masterBlockInfo.removeWorker(workerId);
-            MasterWorkerInfo worker = mWorkers.getFirstByField(mIdIndex, workerId);
-            if (worker != null) {
-              worker.updateToRemovedBlock(true, blockId);
+            MasterWorkerInfo workerInfo = mWorkers.getFirstByField(mIdIndex, workerId);
+            if (workerInfo != null) {
+              workerInfo.updateToRemovedBlock(true, blockId);
             }
           }
           // Two cases here:
@@ -611,10 +610,10 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
       MasterBlockInfo masterBlockInfo = mBlocks.get(removedBlockId);
       if (masterBlockInfo == null) {
         LOG.warn("Worker {} informs the removed block {}, but block metadata does not exist"
-            + "on Master.", workerInfo.getId(), removedBlockId);
+            + "on Master!", workerInfo.getId(), removedBlockId);
         // TODO(pfxuan): [ALLUXIO-1804] should find a better way to handle the removed blocks.
-        // Ideally, the remove I/O flow should never reach this statement. Because Master updates
-        // the block metadata only after receiving the acknowledgement from Workers.
+        // Ideally, the delete/free I/O flow should never reach this point. Because Master may
+        // update the block metadata only after receiving the acknowledgement from Workers.
         workerInfo.removeBlock(removedBlockId);
         // Continue to remove the remaining blocks.
         continue;

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -610,8 +610,10 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
     for (long removedBlockId : removedBlockIds) {
       MasterBlockInfo masterBlockInfo = mBlocks.get(removedBlockId);
       if (masterBlockInfo == null) {
-        LOG.warn("Worker {} removed block {} but block does not exist.", workerInfo.getId(),
-            removedBlockId);
+        LOG.warn("Worker {} removed block {}, block metadata has been removed.",
+            workerInfo.getId(), removedBlockId);
+        // TODO(pfxuan): [ALLUXIO-1804] should find a better way to update removed blocks.
+        workerInfo.removeBlock(removedBlockId);
         // Continue to remove the remaining blocks.
         continue;
       }

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -316,9 +316,10 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
             continue;
           }
           for (long workerId : new ArrayList<Long>(masterBlockInfo.getWorkers())) {
-            MasterWorkerInfo workerInfo = mWorkers.getFirstByField(mIdIndex, workerId);
-            if (workerInfo != null) {
-              workerInfo.removeBlock(blockId);
+            masterBlockInfo.removeWorker(workerId);
+            MasterWorkerInfo worker = mWorkers.getFirstByField(mIdIndex, workerId);
+            if (worker != null) {
+              worker.updateToRemovedBlock(true, blockId);
             }
           }
           // Two cases here:

--- a/core/server/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMaster.java
@@ -316,10 +316,9 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
             continue;
           }
           for (long workerId : new ArrayList<Long>(masterBlockInfo.getWorkers())) {
-            masterBlockInfo.removeWorker(workerId);
-            MasterWorkerInfo worker = mWorkers.getFirstByField(mIdIndex, workerId);
-            if (worker != null) {
-              worker.updateToRemovedBlock(true, blockId);
+            MasterWorkerInfo workerInfo = mWorkers.getFirstByField(mIdIndex, workerId);
+            if (workerInfo != null) {
+              workerInfo.removeBlock(blockId);
             }
           }
           // Two cases here:
@@ -610,9 +609,11 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
     for (long removedBlockId : removedBlockIds) {
       MasterBlockInfo masterBlockInfo = mBlocks.get(removedBlockId);
       if (masterBlockInfo == null) {
-        LOG.warn("Worker {} removed block {}, block metadata has been removed.",
-            workerInfo.getId(), removedBlockId);
-        // TODO(pfxuan): [ALLUXIO-1804] should find a better way to update removed blocks.
+        LOG.warn("Worker {} informs the removed block {}, but block metadata does not exist"
+            + "on Master.", workerInfo.getId(), removedBlockId);
+        // TODO(pfxuan): [ALLUXIO-1804] should find a better way to handle the removed blocks.
+        // Ideally, the remove I/O flow should never reach this statement. Because Master updates
+        // the block metadata only after receiving the acknowledgement from Workers.
         workerInfo.removeBlock(removedBlockId);
         // Continue to remove the remaining blocks.
         continue;

--- a/core/server/src/test/java/alluxio/master/MasterSourceTest.java
+++ b/core/server/src/test/java/alluxio/master/MasterSourceTest.java
@@ -28,11 +28,14 @@ import alluxio.master.file.options.MountOptions;
 import alluxio.master.file.options.SetAttributeOptions;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.ReadWriteJournal;
+import alluxio.thrift.Command;
+import alluxio.thrift.CommandType;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -384,6 +387,12 @@ public final class MasterSourceTest {
 
     // free the file
     Assert.assertTrue(mFileSystemMaster.free(NESTED_FILE_URI, false));
+    // Update the heartbeat of removedBlockId received from worker 1
+    Command heartBeat2 = mBlockMaster.workerHeartbeat(mWorkerId,
+        ImmutableMap.of("MEM", Constants.KB * 1L),
+        ImmutableList.of(blockId), ImmutableMap.<String, List<Long>>of());
+    // Verify the muted Free command on worker
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat2);
     Assert.assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
 
     Assert.assertEquals(2, mCounters.get(MasterSource.FREE_FILE_OPS).getCount());

--- a/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -180,6 +180,8 @@ public class BlockMasterTest {
   public void removeBlocksTest() throws Exception {
     long worker1 = mMaster.getWorkerId(NET_ADDRESS_1);
     long worker2 = mMaster.getWorkerId(NET_ADDRESS_1);
+    MasterWorkerInfo workerInfo1 = mPrivateAccess.getWorkerById(worker1);
+    MasterWorkerInfo workerInfo2 = mPrivateAccess.getWorkerById(worker2);
     List<Long> workerBlocks = Arrays.asList(1L, 2L, 3L);
     HashMap<String, List<Long>> noBlocksInTiers = Maps.newHashMap();
     mMaster.workerRegister(worker1, Arrays.asList("MEM"), ImmutableMap.of("MEM", 100L),
@@ -197,9 +199,34 @@ public class BlockMasterTest {
 
     // Test removeBlocks with delete
     mMaster.removeBlocks(workerBlocks, true /* delete */);
+
+    // Update the heartbeat of removedBlockIds received from worker 1
+    Command heartBeat1 = mMaster.workerHeartbeat(worker1,
+        ImmutableMap.of("MEM", 20L, "SSD", 30L, "HDD", 50L),
+        ImmutableList.of(1L, 2L, 3L), ImmutableMap.<String, List<Long>>of());
+    // Verify removedBlockIds have been removed from ToRemoveBlocks on worker 1
+    Assert.assertFalse(workerInfo1.getToRemoveBlocks().contains(1L));
+    Assert.assertFalse(workerInfo1.getToRemoveBlocks().contains(2L));
+    Assert.assertFalse(workerInfo1.getToRemoveBlocks().contains(3L));
+    // Verify the muted Free command on worker1
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat1);
+
+    // Update the heartbeat of removedBlockIds received from worker 2
+    Command heartBeat2 = mMaster.workerHeartbeat(worker2,
+        ImmutableMap.of("MEM", 30L, "SSD", 50L, "HDD", 60L),
+        ImmutableList.of(1L, 2L, 3L), ImmutableMap.<String, List<Long>>of());
+    // Verify removedBlockIds have been removed from ToRemoveBlocks on worker2
+    Assert.assertFalse(workerInfo2.getToRemoveBlocks().contains(1L));
+    Assert.assertFalse(workerInfo2.getToRemoveBlocks().contains(2L));
+    Assert.assertFalse(workerInfo2.getToRemoveBlocks().contains(3L));
+    // Verify the muted Free command on worker2
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat2);
+
     mThrown.expect(BlockInfoException.class);
     mMaster.getBlockInfo(1L);
     Assert.assertFalse(mMaster.getLostBlocks().contains(1L));
+    Assert.assertFalse(mMaster.getLostBlocks().contains(2L));
+    Assert.assertFalse(mMaster.getLostBlocks().contains(3L));
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -33,12 +33,14 @@ import alluxio.master.file.options.CreatePathOptions;
 import alluxio.master.file.options.SetAttributeOptions;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.ReadWriteJournal;
+import alluxio.thrift.Command;
 import alluxio.thrift.CommandType;
 import alluxio.thrift.FileSystemCommand;
 import alluxio.util.IdUtils;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -168,6 +170,13 @@ public final class FileSystemMasterTest {
 
     mThrown.expect(BlockInfoException.class);
     mBlockMaster.getBlockInfo(blockId);
+
+    // Update the heartbeat of removedBlockId received from worker 1
+    Command heartBeat1 = mBlockMaster.workerHeartbeat(mWorkerId1,
+        ImmutableMap.of("MEM", Constants.KB * 1L),
+        ImmutableList.of(blockId), ImmutableMap.<String, List<Long>>of());
+    // Verify the muted Free command on worker1
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat1);
     Assert.assertFalse(mBlockMaster.getLostBlocks().contains(blockId));
 
     // verify the file is deleted

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -505,6 +505,12 @@ public final class FileSystemMasterTest {
 
     // free the file
     Assert.assertTrue(mFileSystemMaster.free(NESTED_FILE_URI, false));
+    // Update the heartbeat of removedBlockId received from worker 1
+    Command heartBeat2 = mBlockMaster.workerHeartbeat(mWorkerId1,
+        ImmutableMap.of("MEM", Constants.KB * 1L),
+        ImmutableList.of(blockId), ImmutableMap.<String, List<Long>>of());
+    // Verify the muted Free command on worker1
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat2);
     Assert.assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
   }
 
@@ -520,6 +526,12 @@ public final class FileSystemMasterTest {
 
     // free the dir
     Assert.assertTrue(mFileSystemMaster.free(NESTED_FILE_URI.getParent(), true));
+    // Update the heartbeat of removedBlockId received from worker 1
+    Command heartBeat3 = mBlockMaster.workerHeartbeat(mWorkerId1,
+        ImmutableMap.of("MEM", Constants.KB * 1L),
+        ImmutableList.of(blockId), ImmutableMap.<String, List<Long>>of());
+    // Verify the muted Free command on worker1
+    Assert.assertEquals(new Command(CommandType.Nothing, ImmutableList.<Long>of()), heartBeat3);
     Assert.assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
   }
 

--- a/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
@@ -109,13 +109,20 @@ public final class FreeAndDeleteIntegrationTest {
     Assert.assertTrue(bm.getLostBlocks().isEmpty());
 
     mFileSystem.free(filePath);
-    // Execute the blocks free, which needs two heartbeats. Make sure there is some time delay
-    // between two heartbeats to make sure worker got time to generate block removal reports.
-    HeartbeatScheduler.schedule(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+    // Schedule 1st heartbeat from worker.
     Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
         TimeUnit.SECONDS));
-    CommonUtils.sleepMs(50);
     HeartbeatScheduler.schedule(HeartbeatContext.WORKER_BLOCK_SYNC);
+    // Waiting for the removal of blockMeta from worker.
+    while (bw.hasBlockMeta(blockId)) {
+      CommonUtils.sleepMs(50);
+    }
+    // Schedule 2nd heartbeat from worker.
+    Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
+        TimeUnit.SECONDS));
+    HeartbeatScheduler.schedule(HeartbeatContext.WORKER_BLOCK_SYNC);
+    // Ensure the 2nd heartbeat is finished.
     Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
         TimeUnit.SECONDS));
 

--- a/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
@@ -35,7 +35,7 @@ public class FreeCommandTest extends AbstractAlluxioShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
     mFsShell.run("free", "/testFile");
     Configuration configuration = mLocalAlluxioCluster.getMasterConf();
-    CommonUtils.sleepMs(configuration.getInt(Constants.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
+    CommonUtils.sleepMs(configuration.getInt(Constants.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2);
     Assert.assertFalse(
         mFileSystem.getStatus(new AlluxioURI("/testFile")).getInMemoryPercentage() == 100);
   }


### PR DESCRIPTION
In current `remove` I/O flow, the Block Master doesn't update the removed blocks received from worker' heartbeat when their metadata removed. This makes all works repeat sending update information after a file is deleted. Eventually, RPC communication to master server gets blocked, and client throws SocketTimeoutException: read timed out.