### PR TITLE
Refactor remote block in stream

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -138,8 +137,7 @@ public final class AlluxioBlockStore {
     }
     // No local worker/block, get the first location since it's nearest to memory tier.
     WorkerNetAddress workerNetAddress = blockInfo.getLocations().get(0).getWorkerAddress();
-    return new RemoteBlockInStream(blockId, blockInfo.getLength(),
-        new InetSocketAddress(workerNetAddress.getHost(), workerNetAddress.getDataPort()));
+    return new RemoteBlockInStream(blockId, blockInfo.getLength(), workerNetAddress);
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -15,6 +15,7 @@ import alluxio.client.ClientContext;
 import alluxio.client.RemoteBlockReader;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.exception.ExceptionMessage;
+import alluxio.wire.WorkerNetAddress;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -29,7 +30,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class RemoteBlockInStream extends BufferedBlockInStream {
   /** The address of the worker to read the data from. */
-  private final InetSocketAddress mLocation;
+  private final WorkerNetAddress mWorkerNetAddress;
+  /** mWorkerNetAddress converted to an InetSocketAddress. */
+  private final InetSocketAddress mWorkerInetSocketAddress;
   /** The returned lock id after acquiring the block lock. */
   private final Long mLockId;
 
@@ -46,13 +49,15 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
    * @param location the location
    * @throws IOException if the block is not available on the remote worker
    */
-  public RemoteBlockInStream(long blockId, long blockSize, InetSocketAddress location)
+  public RemoteBlockInStream(long blockId, long blockSize, WorkerNetAddress workerNetAddress)
       throws IOException {
     super(blockId, blockSize);
-    mLocation = location;
+    mWorkerNetAddress = workerNetAddress;
+    mWorkerInetSocketAddress =
+        new InetSocketAddress(workerNetAddress.getHost(), workerNetAddress.getDataPort());
 
     mContext = BlockStoreContext.INSTANCE;
-    mBlockWorkerClient = mContext.acquireWorkerClient(location.getHostName());
+    mBlockWorkerClient = mContext.acquireWorkerClient(mWorkerInetSocketAddress.getHostName());
 
     try {
       mLockId = mBlockWorkerClient.lockBlock(blockId).getLockId();
@@ -107,6 +112,13 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
   }
 
   /**
+   * @return the {@link WorkerNetAddress} from which this RemoteBlockInStream is reading
+   */
+  public WorkerNetAddress getWorkerNetAddress() {
+    return mWorkerNetAddress;
+  }
+
+  /**
    * Reads a portion of the block from the remote worker.
    *
    * @param b the byte array to write the data to
@@ -125,7 +137,7 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
       RemoteBlockReader reader =
           RemoteBlockReader.Factory.create(ClientContext.getConf());
       try {
-        ByteBuffer data = reader.readRemoteBlock(mLocation, mBlockId, getPosition(),
+        ByteBuffer data = reader.readRemoteBlock(mWorkerInetSocketAddress, mBlockId, getPosition(),
             bytesLeft, mLockId, mBlockWorkerClient.getSessionId());
         int bytesRead = data.remaining();
         data.get(b, off, bytesRead);

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -46,7 +46,7 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
    *
    * @param blockId the block id
    * @param blockSize the block size
-   * @param location the location
+   * @param workerNetAddress the address of the worker to read from
    * @throws IOException if the block is not available on the remote worker
    */
   public RemoteBlockInStream(long blockId, long blockSize, WorkerNetAddress workerNetAddress)

--- a/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -150,6 +150,6 @@ public final class AlluxioBlockStoreTest {
     Assert.assertEquals(Long.valueOf(BLOCK_LENGTH),
         Whitebox.getInternalState(stream, "mBlockSize"));
     Assert.assertEquals(new InetSocketAddress(WORKER_HOSTNAME_REMOTE, WORKER_DATA_PORT),
-        Whitebox.getInternalState(stream, "mLocation"));
+        Whitebox.getInternalState(stream, "mWorkerInetSocketAddress"));
   }
 }

--- a/tests/src/test/java/alluxio/client/RemoteBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/RemoteBlockInStreamIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -256,8 +255,7 @@ public class RemoteBlockInStreamIntegrationTest {
       BlockInfo info = AlluxioBlockStore.get().getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       RemoteBlockInStream is =
-          new RemoteBlockInStream(info.getBlockId(), info.getLength(), new InetSocketAddress(
-              workerAddr.getHost(), workerAddr.getDataPort()));
+          new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerAddr);
       byte[] ret = new byte[k];
       int value = is.read();
       int cnt = 0;
@@ -288,8 +286,7 @@ public class RemoteBlockInStreamIntegrationTest {
       BlockInfo info = AlluxioBlockStore.get().getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       RemoteBlockInStream is =
-          new RemoteBlockInStream(info.getBlockId(), info.getLength(), new InetSocketAddress(
-              workerAddr.getHost(), workerAddr.getDataPort()));
+          new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerAddr);
       byte[] ret = new byte[k];
       int start = 0;
       while (start < k) {
@@ -316,8 +313,7 @@ public class RemoteBlockInStreamIntegrationTest {
       BlockInfo info = AlluxioBlockStore.get().getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       RemoteBlockInStream is =
-          new RemoteBlockInStream(info.getBlockId(), info.getLength(), new InetSocketAddress(
-              workerAddr.getHost(), workerAddr.getDataPort()));
+          new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerAddr);
       byte[] ret = new byte[k / 2];
       int start = 0;
       while (start < k / 2) {
@@ -547,11 +543,8 @@ public class RemoteBlockInStreamIntegrationTest {
       BlockInfo info = AlluxioBlockStore.get().getInfo(blockId);
 
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
-      InetSocketAddress workerInetAddr =
-          new InetSocketAddress(workerAddr.getHost(), workerAddr.getDataPort());
-
       RemoteBlockInStream is =
-          new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerInetAddr);
+          new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerAddr);
       Assert.assertEquals(0, is.read());
       mFileSystem.delete(uri);
 
@@ -569,7 +562,7 @@ public class RemoteBlockInStreamIntegrationTest {
       // Try to create an in stream again, and it should fail.
       RemoteBlockInStream is2 = null;
       try {
-        is2 = new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerInetAddr);
+        is2 = new RemoteBlockInStream(info.getBlockId(), info.getLength(), workerAddr);
       } catch (IOException e) {
         Assert.assertTrue(e.getCause() instanceof BlockDoesNotExistException);
       } finally {


### PR DESCRIPTION
This makes it consistent with RemoteBlockOutStream and simplifies code.

A getter is provided for the internal WorkerNetAddress so that users of the stream can determine where the stream is reading from.