### PR TITLE
[SMALLFIX] Initialize ClientContext on two basic operations examples

### DIFF
--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -74,6 +74,7 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
     ClientContext.getConf().set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
     ClientContext.getConf().set(Constants.MASTER_RPC_PORT,
         Integer.toString(mMasterLocation.getPort()));
+    ClientContext.init();
     FileSystem alluxioClient = FileSystem.Factory.get();
     write(alluxioClient);
     return read(alluxioClient);

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -64,6 +64,7 @@ public class BasicOperations implements Callable<Boolean> {
     ClientContext.getConf().set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
     ClientContext.getConf().set(Constants.MASTER_RPC_PORT,
         Integer.toString(mMasterLocation.getPort()));
+    ClientContext.init();
     FileSystem fs = FileSystem.Factory.get();
     writeFile(fs);
     return readFile(fs);


### PR DESCRIPTION
Otherwise client will use localhost as master address if it's failed to navigate system and configuration properties.