### PR TITLE
[SMALLFIX] Updating Zeppeling documentation.

### DIFF
--- a/docs/en/Accessing-Alluxio-from-Zeppelin.md
+++ b/docs/en/Accessing-Alluxio-from-Zeppelin.md
@@ -6,7 +6,8 @@ group: Frameworks
 priority: 4
 ---
 
-[Apache Zeppelin](http://zeppelin-project.org/) is a web-based notebook that enables 
-interactive data analytics. An older version of Alluxio (Tachyon 0.8.2) has been
-[integrated](https://github.com/apache/incubator-zeppelin/blob/master/docs/interpreter/tachyon.md) 
-with Zeppelin and we will soon update the integration to work with the latest version of Alluxio.
+[Apache Zeppelin](http://zeppelin.incubator.apache.org/) is a web-based notebook that enables
+interactive data analytics. Alluxio 1.0 has been
+[integrated](https://github.com/apache/incubator-zeppelin/blob/master/docs/interpreter/alluxio.md)
+with Zeppelin and detailed instructions can be found
+[here](http://zeppelin.incubator.apache.org/docs/0.6.0-incubating-SNAPSHOT/interpreter/alluxio.html).


### PR DESCRIPTION
This PR fixes links that broke after Tachyon integration with Zeppelin was updated to Alluxio and Zeppelin main website has moved.