### PR TITLE
[SMALLFIX] Unmount on delete

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -839,15 +839,21 @@ public final class FileSystemMaster extends AbstractMaster {
       // TODO(jiri): What should the Alluxio behavior be when a UFS delete operation fails?
       // Currently, it will result in an inconsistency between Alluxio and UFS.
       if (!replayed && delInode.isPersisted()) {
-        // Delete the file in the under file system.
         try {
-          String ufsPath = mMountTable.resolve(mInodeTree.getPath(delInode)).toString();
-          UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
-          if (!ufs.exists(ufsPath)) {
-            LOG.warn("File does not exist the underfs: {}", ufsPath);
-          } else if (!ufs.delete(ufsPath, true)) {
-            LOG.error("Failed to delete {}", ufsPath);
-            return false;
+          AlluxioURI alluxioUriToDel = mInodeTree.getPath(delInode);
+          // If this is a mount point, we have deleted all the children and can unmount it
+          if (mMountTable.isMountPoint(alluxioUriToDel)) {
+            unmountInternal(alluxioUriToDel);
+          } else {
+            // Delete the file in the under file system.
+            String ufsPath = mMountTable.resolve(alluxioUriToDel).toString();
+            UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
+            if (!ufs.exists(ufsPath)) {
+              LOG.warn("File does not exist the underfs: {}", ufsPath);
+            } else if (!ufs.delete(ufsPath, true)) {
+              LOG.error("Failed to delete {}", ufsPath);
+              return false;
+            }
           }
         } catch (InvalidPathException e) {
           LOG.warn(e.getMessage());

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -842,6 +842,7 @@ public final class FileSystemMaster extends AbstractMaster {
         try {
           AlluxioURI alluxioUriToDel = mInodeTree.getPath(delInode);
           // If this is a mount point, we have deleted all the children and can unmount it
+          // TODO(calvin): Add tests (ALLUXIO-1831)
           if (mMountTable.isMountPoint(alluxioUriToDel)) {
             unmountInternal(alluxioUriToDel);
           } else {

--- a/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -132,10 +132,8 @@ public final class MountTable {
   }
 
   /**
-   * Returns in indication of whether the given path is a mount point.
-   *
    * @param uri an Alluxio path URI
-   * @return mount point the given Alluxio path is nested under
+   * @return whether the given uri is a mount point
    */
   public synchronized boolean isMountPoint(AlluxioURI uri) {
     return mMountTable.containsKey(uri.getPath());


### PR DESCRIPTION
Unmounts mount points instead of directly deleting them. This operation is not journaled and is a side effect of the delete operation which will be journaled.