### PR TITLE
[SMALLFIX] Catch the exception thrown when there is no ufs for the ufsPath

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
@@ -349,7 +349,7 @@ public final class FileSystemMasterClientRestServiceHandler {
       mFileSystemMaster
           .mount(new AlluxioURI(path), new AlluxioURI(ufsPath), MountOptions.defaults());
       return Response.ok().build();
-    } catch (AlluxioException | IOException | NullPointerException e) {
+    } catch (AlluxioException | IOException | NullPointerException | IllegalArgumentException e) {
       LOG.warn(e.getMessage());
       return Response.serverError().entity(e.getMessage()).build();
     }


### PR DESCRIPTION
Otherwise, when 
`curl -X POST "http://node1:19999/v1/api/master/file/mount?path=/sdfdsf&ufsPath=s3://dskfj"` or 

`curl -X POST "http://node1:19999/v1/api/master/file/mount?path=/sdfdsf&ufsPath=~/dskfj"`,

the response is a html like

 ```
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
<title>Error 500 Request failed.</title>
</head>
<body><h2>HTTP ERROR 500</h2>
<p>Problem accessing /v1/api/master/file/mount. Reason:
<pre>    Request failed.</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>
<br/>
</body>
</html>
```

After this PR, the result is like

```
No Under File System Factory found for: ~dksjf
```