### PR TITLE
[SMALLFIX] Set length of a directory to the number of objects it contains

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -168,7 +168,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     ret.setFileId(getId());
     ret.setName(getName());
     ret.setPath(path);
-    ret.setLength(0);
+    ret.setLength(mChildren.size());
     ret.setBlockSizeBytes(0);
     ret.setCreationTimeMs(getCreationTimeMs());
     ret.setCompleted(true);


### PR DESCRIPTION
This enables the shell or the UI to show number of objects in a directory without calling the client again to get the file infos under the directory after getting info of the directory.