### PR TITLE
[SMALLFIX] fixing address parsing in Performance.java

### DIFF
--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -24,6 +24,7 @@ import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.net.HostAndPort;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public class Performance {
   private static final String FOLDER = "/mnt/ramdisk/";
 
   private static FileSystem sFileSystem = null;
-  private static AlluxioURI sMasterAddress = null;
+  private static HostAndPort sMasterAddress = null;
   private static String sFileName = null;
   private static int sBlockSizeBytes = -1;
   private static long sBlocksPerFile = -1;
@@ -604,7 +605,7 @@ public class Performance {
       System.exit(-1);
     }
 
-    sMasterAddress = new AlluxioURI(args[0]);
+    sMasterAddress = HostAndPort.fromString(args[0]);
     sFileName = args[1];
     sBlockSizeBytes = Integer.parseInt(args[2]);
     sBlocksPerFile = Long.parseLong(args[3]);
@@ -629,7 +630,7 @@ public class Performance {
 
     CommonUtils.warmUpLoop();
 
-    configuration.set(Constants.MASTER_HOSTNAME, sMasterAddress.getHost());
+    configuration.set(Constants.MASTER_HOSTNAME, sMasterAddress.getHostText());
     configuration.set(Constants.MASTER_RPC_PORT, Integer.toString(sMasterAddress.getPort()));
 
     if (testCase == 1) {


### PR DESCRIPTION
Performance.java should not be using URI to represent the master address `<host>:<port>`. This PR fixes that.