### PR TITLE
[ALLUXIO-1783] Fix Javadoc in SetAttributeOptionsTest.defaultsTest()

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
@@ -21,7 +21,7 @@ import java.util.Random;
  */
 public class SetAttributeOptionsTest {
   /**
-   * Tests the {@link CreateDirectoryOptions#defaults()} method.
+   * Tests the {@link SetAttributeOptions#defaults()} method.
    */
   @Test
   public void defaultsTest() {


### PR DESCRIPTION
The javadoc for defaultsTest() should refer to SetAttributeOptions.