### PR TITLE
[ALLUXIO-1824] Update jets3t to latest stable version.

### DIFF
--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>net.java.dev.jets3t</groupId>
       <artifactId>jets3t</artifactId>
-      <version>0.8.1</version>
+      <version>0.9.4</version>
     </dependency>
 
     <!-- The following are jets3t dependencies


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1824

Updates jets3t to latest stable version: http://www.jets3t.org/downloads.html
Because:
- Hadoop has upgraded its jets3t dependency to 0.9
- This also paves the road for adding GCS integration.