### PR TITLE
[SMALLFIX] InvalidPathException cleanups

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -100,7 +100,7 @@ public enum ExceptionMessage {
   HDFS_FILE_NOT_FOUND("File {0} with id {1} is not found"),
 
   // file system master
-  FILE_MUST_HAVE_VALID_PARENT("{0} does not have a valid parent"),
+  PATH_MUST_HAVE_VALID_PARENT("{0} does not have a valid parent"),
   FILEID_MUST_BE_FILE("File id {0} must be a file"),
   RENAME_CANNOT_BE_ONTO_MOUNT_POINT("{0} is a mount point and cannot be renamed onto"),
   RENAME_CANNOT_BE_ACROSS_MOUNTS("Renaming {0} to {1} is a cross mount operation"),

--- a/core/common/src/main/java/alluxio/exception/InvalidPathException.java
+++ b/core/common/src/main/java/alluxio/exception/InvalidPathException.java
@@ -14,7 +14,8 @@ package alluxio.exception;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * The exception thrown when the path in Alluxio is invalid.
+ * The exception thrown when the path in Alluxio is invalid. A path could be invalid due to being
+ * malformed (e.g. /a/ /b) or due to being used in the wrong way (e.g. rename /a to /a/b).
  */
 @ThreadSafe
 public class InvalidPathException extends AlluxioException {

--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -110,7 +110,10 @@ public final class PathUtils {
   }
 
   /**
-   * Gets the path components of the given path.
+   * Gets the path components of the given path. The first component will be an empty string.
+   *
+   * "/a/b/c" => {"", "a", "b", "c"}
+   * "/" => {""}
    *
    * @param path The path to split
    * @return the path split into components
@@ -119,9 +122,7 @@ public final class PathUtils {
   public static String[] getPathComponents(String path) throws InvalidPathException {
     path = cleanPath(path);
     if (isRoot(path)) {
-      String[] ret = new String[1];
-      ret[0] = "";
-      return ret;
+      return new String[]{""};
     }
     return path.split(AlluxioURI.SEPARATOR);
   }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1210,12 +1210,12 @@ public final class FileSystemMaster extends AbstractMaster {
       Inode srcParentInode = mInodeTree.getInodeById(srcInode.getParentId());
       if (!srcParentInode.isDirectory()) {
         throw new InvalidPathException(
-            ExceptionMessage.FILE_MUST_HAVE_VALID_PARENT.getMessage(srcPath));
+            ExceptionMessage.PATH_MUST_HAVE_VALID_PARENT.getMessage(srcPath));
       }
       Inode dstParentInode = mInodeTree.getInodeByPath(dstParentURI);
       if (!dstParentInode.isDirectory()) {
         throw new InvalidPathException(
-            ExceptionMessage.FILE_MUST_HAVE_VALID_PARENT.getMessage(dstPath));
+            ExceptionMessage.PATH_MUST_HAVE_VALID_PARENT.getMessage(dstPath));
       }
 
       // Make sure destination path does not exist
@@ -2192,11 +2192,6 @@ public final class FileSystemMaster extends AbstractMaster {
     List<FileInfo> fileInfos = Lists.newArrayList();
     for (Inode inodeOnPath :  mInodeTree.collectInodes(path)) {
       fileInfos.add(inodeOnPath.generateClientFileInfo(mInodeTree.getPath(inodeOnPath).toString()));
-    }
-
-    String[] pathComponents = PathUtils.getPathComponents(path.getPath());
-    if (pathComponents.length < fileInfos.size()) {
-      throw new InvalidPathException(ExceptionMessage.PATH_INVALID.getMessage(path.getPath()));
     }
     return fileInfos;
   }


### PR DESCRIPTION
- Rename FILE_MUST_HAVE_VALID_PARENT to PATH_MUST_HAVE_VALID_PARENT since it's used for both files and directories.
- Add some javadoc
- Remove some unnecessary code