### PR TITLE
[SMALLFIX] Add generics to raw usages of Inode

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1226,7 +1226,7 @@ public final class FileSystemMaster extends AbstractMaster {
             ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(dstPath));
       }
 
-      // Now we remove srcInode<?> from it's parent and insert it into dstPath's parent
+      // Now we remove srcInode from it's parent and insert it into dstPath's parent
       long opTimeMs = System.currentTimeMillis();
       renameInternal(srcInode.getId(), dstPath, false, opTimeMs);
 

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -218,7 +218,7 @@ public final class FileSystemMaster extends AbstractMaster {
     } else if (innerEntry instanceof InodeLastModificationTimeEntry) {
       InodeLastModificationTimeEntry modTimeEntry = (InodeLastModificationTimeEntry) innerEntry;
       try {
-        Inode inode = mInodeTree.getInodeById(modTimeEntry.getId());
+        Inode<?> inode = mInodeTree.getInodeById(modTimeEntry.getId());
         inode.setLastModificationTimeMs(modTimeEntry.getLastModificationTimeMs());
       } catch (FileDoesNotExistException e) {
         throw new RuntimeException(e);
@@ -226,7 +226,7 @@ public final class FileSystemMaster extends AbstractMaster {
     } else if (innerEntry instanceof PersistDirectoryEntry) {
       PersistDirectoryEntry typedEntry = (PersistDirectoryEntry) innerEntry;
       try {
-        Inode inode = mInodeTree.getInodeById(typedEntry.getId());
+        Inode<?> inode = mInodeTree.getInodeById(typedEntry.getId());
         inode.setPersistenceState(PersistenceState.PERSISTED);
       } catch (FileDoesNotExistException e) {
         throw new RuntimeException(e);
@@ -328,7 +328,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   public boolean isDirectory(long id) {
     synchronized (mInodeTree) {
-      Inode inode;
+      Inode<?> inode;
       if (!mInodeTree.inodeIdExists(id)) {
         return false;
       }
@@ -352,7 +352,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   public long getFileId(AlluxioURI path) throws AccessControlException {
     synchronized (mInodeTree) {
-      Inode inode;
+      Inode<?> inode;
       checkPermission(FileSystemAction.READ, path, false);
       if (!mInodeTree.inodePathExists(path)) {
         try {
@@ -378,7 +378,7 @@ public final class FileSystemMaster extends AbstractMaster {
   public FileInfo getFileInfo(long fileId) throws FileDoesNotExistException {
     MasterContext.getMasterSource().incGetFileInfoOps(1);
     synchronized (mInodeTree) {
-      Inode inode = mInodeTree.getInodeById(fileId);
+      Inode<?> inode = mInodeTree.getInodeById(fileId);
       return getFileInfoInternal(inode);
     }
   }
@@ -400,7 +400,7 @@ public final class FileSystemMaster extends AbstractMaster {
       checkPermission(FileSystemAction.READ, path, false);
       // getFileInfo should load from ufs if the file does not exist
       getFileId(path);
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
       return getFileInfoInternal(inode);
     }
   }
@@ -412,7 +412,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   public PersistenceState getPersistenceState(long fileId) throws FileDoesNotExistException {
     synchronized (mInodeTree) {
-      Inode inode = mInodeTree.getInodeById(fileId);
+      Inode<?> inode = mInodeTree.getInodeById(fileId);
       return inode.getPersistenceState();
     }
   }
@@ -424,7 +424,7 @@ public final class FileSystemMaster extends AbstractMaster {
    * @return the {@link FileInfo} for the given inode
    * @throws FileDoesNotExistException if the file does not exist
    */
-  private FileInfo getFileInfoInternal(Inode inode) throws FileDoesNotExistException {
+  private FileInfo getFileInfoInternal(Inode<?> inode) throws FileDoesNotExistException {
     FileInfo fileInfo = inode.generateClientFileInfo(mInodeTree.getPath(inode).toString());
     fileInfo.setInMemoryPercentage(getInMemoryPercentage(inode));
     AlluxioURI path = mInodeTree.getPath(inode);
@@ -462,12 +462,12 @@ public final class FileSystemMaster extends AbstractMaster {
       checkPermission(FileSystemAction.READ, path, false);
       // getFileInfoList should load from ufs if the file does not exist
       getFileId(path);
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
 
       List<FileInfo> ret = new ArrayList<FileInfo>();
       if (inode.isDirectory()) {
         checkPermission(FileSystemAction.EXECUTE, path, false);
-        for (Inode child : ((InodeDirectory) inode).getChildren()) {
+        for (Inode<?> child : ((InodeDirectory) inode).getChildren()) {
           ret.add(getFileInfoInternal(child));
         }
       } else {
@@ -506,7 +506,7 @@ public final class FileSystemMaster extends AbstractMaster {
       checkPermission(FileSystemAction.WRITE, path, false);
       // Even readonly mount points should be able to complete a file, for UFS reads in CACHE mode.
       long opTimeMs = System.currentTimeMillis();
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
       long fileId = inode.getId();
       if (!inode.isFile()) {
         throw new FileDoesNotExistException(ExceptionMessage.PATH_MUST_BE_FILE.getMessage(path));
@@ -622,7 +622,7 @@ public final class FileSystemMaster extends AbstractMaster {
         mMountTable.checkUnderWritableMountPoint(path);
       }
       InodeTree.CreatePathResult createResult = createInternal(path, options);
-      List<Inode> created = createResult.getCreated();
+      List<Inode<?>> created = createResult.getCreated();
 
       writeJournalEntry(mDirectoryIdGenerator.toJournalEntry());
       journalCreatePathResult(createResult);
@@ -646,7 +646,7 @@ public final class FileSystemMaster extends AbstractMaster {
       throws InvalidPathException, FileAlreadyExistsException, BlockInfoException, IOException {
     InodeTree.CreatePathResult createResult = mInodeTree.createPath(path, options);
     // If the create succeeded, the list of created inodes will not be empty.
-    List<Inode> created = createResult.getCreated();
+    List<Inode<?>> created = createResult.getCreated();
     InodeFile inode = (InodeFile) created.get(created.size() - 1);
     if (mWhitelist.inList(path.toString())) {
       inode.setCacheable(true);
@@ -710,7 +710,7 @@ public final class FileSystemMaster extends AbstractMaster {
   public long getNewBlockIdForFile(AlluxioURI path)
       throws FileDoesNotExistException, InvalidPathException {
     MasterContext.getMasterSource().incGetNewBlockOps(1);
-    Inode inode;
+    Inode<?> inode;
     synchronized (mInodeTree) {
       inode = mInodeTree.getInodeByPath(path);
     }
@@ -760,7 +760,7 @@ public final class FileSystemMaster extends AbstractMaster {
     synchronized (mInodeTree) {
       checkPermission(FileSystemAction.WRITE, path, true);
       mMountTable.checkUnderWritableMountPoint(path);
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
       long fileId = inode.getId();
       long opTimeMs = System.currentTimeMillis();
       boolean ret = deleteFileInternal(fileId, recursive, false, opTimeMs);
@@ -835,7 +835,7 @@ public final class FileSystemMaster extends AbstractMaster {
     if (!mInodeTree.inodeIdExists(fileId)) {
       return true;
     }
-    Inode inode = mInodeTree.getInodeById(fileId);
+    Inode<?> inode = mInodeTree.getInodeById(fileId);
     if (inode == null) {
       return true;
     }
@@ -850,7 +850,7 @@ public final class FileSystemMaster extends AbstractMaster {
       return false;
     }
 
-    List<Inode> delInodes = new ArrayList<Inode>();
+    List<Inode<?>> delInodes = new ArrayList<Inode<?>>();
     delInodes.add(inode);
     if (inode.isDirectory()) {
       delInodes.addAll(mInodeTree.getInodeChildrenRecursive((InodeDirectory) inode));
@@ -859,7 +859,7 @@ public final class FileSystemMaster extends AbstractMaster {
     // We go through each inode, removing it from it's parent set and from mDelInodes. If it's a
     // file, we deal with the checkpoints and blocks as well.
     for (int i = delInodes.size() - 1; i >= 0; i--) {
-      Inode delInode = delInodes.get(i);
+      Inode<?> delInode = delInodes.get(i);
 
       // TODO(jiri): What should the Alluxio behavior be when a UFS delete operation fails?
       // Currently, it will result in an inconsistency between Alluxio and UFS.
@@ -904,7 +904,7 @@ public final class FileSystemMaster extends AbstractMaster {
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException {
     MasterContext.getMasterSource().incGetFileBlockInfoOps(1);
     synchronized (mInodeTree) {
-      Inode inode = mInodeTree.getInodeById(fileId);
+      Inode<?> inode = mInodeTree.getInodeById(fileId);
       if (inode.isDirectory()) {
         throw new FileDoesNotExistException(
             ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
@@ -933,7 +933,7 @@ public final class FileSystemMaster extends AbstractMaster {
       throws FileDoesNotExistException, InvalidPathException {
     MasterContext.getMasterSource().incGetFileBlockInfoOps(1);
     synchronized (mInodeTree) {
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
       if (inode.isDirectory()) {
         throw new FileDoesNotExistException(ExceptionMessage.PATH_MUST_BE_FILE.getMessage(path));
       }
@@ -1029,8 +1029,8 @@ public final class FileSystemMaster extends AbstractMaster {
         InodeDirectory directory = pair.getFirst();
         AlluxioURI curUri = pair.getSecond();
 
-        Set<Inode> children = directory.getChildren();
-        for (Inode inode : children) {
+        Set<Inode<?>> children = directory.getChildren();
+        for (Inode<?> inode : children) {
           AlluxioURI newUri = curUri.join(inode.getName());
           if (inode.isDirectory()) {
             nodesQueue.add(new Pair<InodeDirectory, AlluxioURI>((InodeDirectory) inode, newUri));
@@ -1050,7 +1050,7 @@ public final class FileSystemMaster extends AbstractMaster {
    * @param inode the inode
    * @return the in memory percentage
    */
-  private int getInMemoryPercentage(Inode inode) {
+  private int getInMemoryPercentage(Inode<?> inode) {
     if (!inode.isFile()) {
       return 0;
     }
@@ -1131,7 +1131,7 @@ public final class FileSystemMaster extends AbstractMaster {
    * @param createResult the {@link InodeTree.CreatePathResult} to journal
    */
   private void journalCreatePathResult(InodeTree.CreatePathResult createResult) {
-    for (Inode inode : createResult.getModified()) {
+    for (Inode<?> inode : createResult.getModified()) {
       InodeLastModificationTimeEntry inodeLastModificationTime =
           InodeLastModificationTimeEntry.newBuilder()
           .setId(inode.getId())
@@ -1140,10 +1140,10 @@ public final class FileSystemMaster extends AbstractMaster {
       writeJournalEntry(JournalEntry.newBuilder()
           .setInodeLastModificationTime(inodeLastModificationTime).build());
     }
-    for (Inode inode : createResult.getCreated()) {
+    for (Inode<?> inode : createResult.getCreated()) {
       writeJournalEntry(inode.toJournalEntry());
     }
-    for (Inode inode : createResult.getPersisted()) {
+    for (Inode<?> inode : createResult.getPersisted()) {
       PersistDirectoryEntry persistDirectory = PersistDirectoryEntry.newBuilder()
           .setId(inode.getId())
           .build();
@@ -1172,7 +1172,7 @@ public final class FileSystemMaster extends AbstractMaster {
       checkPermission(FileSystemAction.WRITE, dstPath, true);
       mMountTable.checkUnderWritableMountPoint(srcPath);
       mMountTable.checkUnderWritableMountPoint(dstPath);
-      Inode srcInode = mInodeTree.getInodeByPath(srcPath);
+      Inode<?> srcInode = mInodeTree.getInodeByPath(srcPath);
       // Renaming path to itself is a no-op.
       if (srcPath.equals(dstPath)) {
         return;
@@ -1207,12 +1207,12 @@ public final class FileSystemMaster extends AbstractMaster {
       AlluxioURI dstParentURI = dstPath.getParent();
 
       // Get the inodes of the src and dst parents.
-      Inode srcParentInode = mInodeTree.getInodeById(srcInode.getParentId());
+      Inode<?> srcParentInode = mInodeTree.getInodeById(srcInode.getParentId());
       if (!srcParentInode.isDirectory()) {
         throw new InvalidPathException(
             ExceptionMessage.FILE_MUST_HAVE_VALID_PARENT.getMessage(srcPath));
       }
-      Inode dstParentInode = mInodeTree.getInodeByPath(dstParentURI);
+      Inode<?> dstParentInode = mInodeTree.getInodeByPath(dstParentURI);
       if (!dstParentInode.isDirectory()) {
         throw new InvalidPathException(
             ExceptionMessage.FILE_MUST_HAVE_VALID_PARENT.getMessage(dstPath));
@@ -1226,7 +1226,7 @@ public final class FileSystemMaster extends AbstractMaster {
             ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(dstPath));
       }
 
-      // Now we remove srcInode from it's parent and insert it into dstPath's parent
+      // Now we remove srcInode<?> from it's parent and insert it into dstPath's parent
       long opTimeMs = System.currentTimeMillis();
       renameInternal(srcInode.getId(), dstPath, false, opTimeMs);
 
@@ -1257,7 +1257,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   void renameInternal(long fileId, AlluxioURI dstPath, boolean replayed, long opTimeMs)
       throws FileDoesNotExistException, InvalidPathException, IOException {
-    Inode srcInode = mInodeTree.getInodeById(fileId);
+    Inode<?> srcInode = mInodeTree.getInodeById(fileId);
     AlluxioURI srcPath = mInodeTree.getPath(srcInode);
     LOG.debug("Renaming {} to {}", srcPath, dstPath);
 
@@ -1279,9 +1279,9 @@ public final class FileSystemMaster extends AbstractMaster {
 
     // TODO(jiri): A crash between now and the time the rename operation is journaled will result in
     // an inconsistency between Alluxio and UFS.
-    Inode srcParentInode = mInodeTree.getInodeById(srcInode.getParentId());
+    Inode<?> srcParentInode = mInodeTree.getInodeById(srcInode.getParentId());
     AlluxioURI dstParentURI = dstPath.getParent();
-    Inode dstParentInode = mInodeTree.getInodeByPath(dstParentURI);
+    Inode<?> dstParentInode = mInodeTree.getInodeByPath(dstParentURI);
     ((InodeDirectory) srcParentInode).removeChild(srcInode);
     srcParentInode.setLastModificationTimeMs(opTimeMs);
     srcInode.setParentId(dstParentInode.getId());
@@ -1316,12 +1316,12 @@ public final class FileSystemMaster extends AbstractMaster {
    * @param replayed whether the invocation is a result of replaying the journal
    * @throws FileDoesNotExistException if a non-existent file is encountered
    */
-  private void propagatePersisted(Inode inode, boolean replayed)
+  private void propagatePersisted(Inode<?> inode, boolean replayed)
       throws FileDoesNotExistException {
     if (!inode.isPersisted()) {
       return;
     }
-    Inode handle = inode;
+    Inode<?> handle = inode;
     while (handle.getParentId() != InodeTree.NO_PARENT) {
       handle = mInodeTree.getInodeById(handle.getParentId());
       AlluxioURI path = mInodeTree.getPath(handle);
@@ -1361,7 +1361,7 @@ public final class FileSystemMaster extends AbstractMaster {
     synchronized (mInodeTree) {
       checkPermission(FileSystemAction.WRITE, path, false);
 
-      Inode inode = mInodeTree.getInodeByPath(path);
+      Inode<?> inode = mInodeTree.getInodeByPath(path);
 
       if (inode.isDirectory() && !recursive && ((InodeDirectory) inode).getNumberOfChildren() > 0) {
         // inode is nonempty, and we don't want to free a nonempty directory unless recursive is
@@ -1369,7 +1369,7 @@ public final class FileSystemMaster extends AbstractMaster {
         return false;
       }
 
-      List<Inode> freeInodes = new ArrayList<Inode>();
+      List<Inode<?>> freeInodes = new ArrayList<Inode<?>>();
       freeInodes.add(inode);
       if (inode.isDirectory()) {
         freeInodes.addAll(mInodeTree.getInodeChildrenRecursive((InodeDirectory) inode));
@@ -1377,7 +1377,7 @@ public final class FileSystemMaster extends AbstractMaster {
 
       // We go through each inode.
       for (int i = freeInodes.size() - 1; i >= 0; i--) {
-        Inode freeInode = freeInodes.get(i);
+        Inode<?> freeInode = freeInodes.get(i);
 
         if (freeInode.isFile()) {
           // Remove corresponding blocks from workers.
@@ -1449,7 +1449,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   public void reportLostFile(long fileId) throws FileDoesNotExistException {
     synchronized (mInodeTree) {
-      Inode inode = mInodeTree.getInodeById(fileId);
+      Inode<?> inode = mInodeTree.getInodeById(fileId);
       if (inode.isDirectory()) {
         LOG.warn("Reported file is a directory {}", inode);
         return;
@@ -1540,7 +1540,7 @@ public final class FileSystemMaster extends AbstractMaster {
         CreateDirectoryOptions.defaults().setMountPoint(mMountTable.isMountPoint(path))
             .setPersisted(true).setRecursive(recursive).setMetadataLoad(true);
     InodeTree.CreatePathResult result = mkdir(path, options);
-    List<Inode> inodes = null;
+    List<Inode<?>> inodes = null;
     if (result.getCreated().size() > 0) {
       inodes = result.getCreated();
     } else if (result.getPersisted().size() > 0) {
@@ -1656,7 +1656,7 @@ public final class FileSystemMaster extends AbstractMaster {
     synchronized (mInodeTree) {
       checkPermission(FileSystemAction.WRITE, alluxioPath, true);
       if (unmountInternal(alluxioPath)) {
-        Inode inode = mInodeTree.getInodeByPath(alluxioPath);
+        Inode<?> inode = mInodeTree.getInodeByPath(alluxioPath);
         // Use the internal delete API, setting {@code replayed} to false to prevent the delete
         // operations from being persisted in the UFS.
         long fileId = inode.getId();
@@ -1749,14 +1749,14 @@ public final class FileSystemMaster extends AbstractMaster {
 
       long fileId = mInodeTree.getInodeByPath(path).getId();
       long opTimeMs = System.currentTimeMillis();
-      Inode targetInode = mInodeTree.getInodeByPath(path);
+      Inode<?> targetInode = mInodeTree.getInodeByPath(path);
       if (options.isRecursive() && targetInode.isDirectory()) {
-        List<Inode> inodeChildren =
+        List<Inode<?>> inodeChildren =
             mInodeTree.getInodeChildrenRecursive((InodeDirectory) targetInode);
-        for (Inode inode : inodeChildren) {
+        for (Inode<?> inode : inodeChildren) {
           checkSetAttributePermission(mInodeTree.getPath(inode), rootRequired, ownerRequired);
         }
-        for (Inode inode : inodeChildren) {
+        for (Inode<?> inode : inodeChildren) {
           long id = inode.getId();
           setAttributeInternal(id, opTimeMs, options);
           journalSetAttribute(id, opTimeMs, options);
@@ -1842,7 +1842,7 @@ public final class FileSystemMaster extends AbstractMaster {
     }
 
     // update the state
-    Inode inode = mInodeTree.getInodeByPath(path);
+    Inode<?> inode = mInodeTree.getInodeByPath(path);
     inode.setPersistenceState(PersistenceState.IN_PROGRESS);
     long fileId = inode.getId();
 
@@ -1977,7 +1977,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   private void setAttributeInternal(long fileId, long opTimeMs, SetAttributeOptions options)
       throws FileDoesNotExistException {
-    Inode inode = mInodeTree.getInodeById(fileId);
+    Inode<?> inode = mInodeTree.getInodeById(fileId);
     if (options.getPinned() != null) {
       mInodeTree.setPinned(inode, options.getPinned(), opTimeMs);
       inode.setLastModificationTimeMs(opTimeMs);
@@ -2190,7 +2190,7 @@ public final class FileSystemMaster extends AbstractMaster {
    */
   private List<FileInfo> collectFileInfoList(AlluxioURI path) throws InvalidPathException {
     List<FileInfo> fileInfos = Lists.newArrayList();
-    for (Inode inodeOnPath :  mInodeTree.collectInodes(path)) {
+    for (Inode<?> inodeOnPath :  mInodeTree.collectInodes(path)) {
       fileInfos.add(inodeOnPath.generateClientFileInfo(mInodeTree.getPath(inodeOnPath).toString()));
     }
 
@@ -2242,7 +2242,7 @@ public final class FileSystemMaster extends AbstractMaster {
       for (long fileId : getLostFiles()) {
         // update the state
         synchronized (mInodeTree) {
-          Inode inode;
+          Inode<?> inode;
           try {
             inode = mInodeTree.getInodeById(fileId);
             if (inode.getPersistenceState() != PersistenceState.PERSISTED) {

--- a/core/server/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/Inode.java
@@ -21,6 +21,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * {@link Inode} is an abstract class, with information shared by all types of Inodes.
+ *
  * @param <T> the concrete subclass of this object
  */
 @ThreadSafe
@@ -268,10 +269,10 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Inode)) {
+    if (!(o instanceof Inode<?>)) {
       return false;
     }
-    Inode that = (Inode) o;
+    Inode<?> that = (Inode<?>) o;
     return mId == that.mId;
   }
 

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -30,22 +30,22 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class InodeDirectory extends Inode<InodeDirectory> {
-  private IndexedSet.FieldIndex<Inode> mIdIndex = new IndexedSet.FieldIndex<Inode>() {
+  private IndexedSet.FieldIndex<Inode<?>> mIdIndex = new IndexedSet.FieldIndex<Inode<?>>() {
     @Override
-    public Object getFieldValue(Inode o) {
+    public Object getFieldValue(Inode<?> o) {
       return o.getId();
     }
   };
 
-  private IndexedSet.FieldIndex<Inode> mNameIndex = new IndexedSet.FieldIndex<Inode>() {
+  private IndexedSet.FieldIndex<Inode<?>> mNameIndex = new IndexedSet.FieldIndex<Inode<?>>() {
     @Override
-    public Object getFieldValue(Inode o) {
+    public Object getFieldValue(Inode<?> o) {
       return o.getName();
     }
   };
 
   @SuppressWarnings("unchecked")
-  private IndexedSet<Inode> mChildren = new IndexedSet<Inode>(mIdIndex, mNameIndex);
+  private IndexedSet<Inode<?>> mChildren = new IndexedSet<Inode<?>>(mIdIndex, mNameIndex);
 
   private boolean mMountPoint;
 
@@ -75,7 +75,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    *
    * @param child the inode to add
    */
-  public synchronized void addChild(Inode child) {
+  public synchronized void addChild(Inode<?> child) {
     mChildren.add(child);
   }
 
@@ -83,7 +83,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @param id the inode id of the child
    * @return the inode with the given id, or null if there is no child with that id
    */
-  public synchronized Inode getChild(long id) {
+  public synchronized Inode<?> getChild(long id) {
     return mChildren.getFirstByField(mIdIndex, id);
   }
 
@@ -91,14 +91,14 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @param name the name of the child
    * @return the inode with the given name, or null if there is no child with that name
    */
-  public synchronized Inode getChild(String name) {
+  public synchronized Inode<?> getChild(String name) {
     return mChildren.getFirstByField(mNameIndex, name);
   }
 
   /**
    * @return an unmodifiable set of the children inodes
    */
-  public synchronized Set<Inode> getChildren() {
+  public synchronized Set<Inode<?>> getChildren() {
     return ImmutableSet.copyOf(mChildren.iterator());
   }
 
@@ -107,7 +107,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   public synchronized Set<Long> getChildrenIds() {
     Set<Long> ret = new HashSet<Long>(mChildren.size());
-    for (Inode child : mChildren) {
+    for (Inode<?> child : mChildren) {
       ret.add(child.getId());
     }
     return ret;
@@ -133,7 +133,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @param child the Inode to remove
    * @return true if the inode was removed, false otherwise
    */
-  public synchronized boolean removeChild(Inode child) {
+  public synchronized boolean removeChild(Inode<?> child) {
     return mChildren.remove(child);
   }
 

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -668,8 +668,8 @@ public final class InodeTree implements JournalCheckpointStreamable {
       return new TraversalResult(true, -1, inode, nonPersisted, inodes);
     }
 
-    static TraversalResult createNotFoundResult(Inode<?> inode, int index, List<Inode<?>> nonPersisted,
-        List<Inode<?>> inodes) {
+    static TraversalResult createNotFoundResult(Inode<?> inode, int index,
+        List<Inode<?>> nonPersisted, List<Inode<?>> inodes) {
       return new TraversalResult(false, index, inode, nonPersisted, inodes);
     }
 

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -150,7 +150,7 @@ public class PermissionCheckerTest {
     verifyPermissionChecker(true, TEST_PERMISSION_STATUS_SUPER.getUserName(), TEST_SUPER_GROUP);
 
     // verify initializing root twice
-    Inode root = sTree.getInodeByPath(new AlluxioURI("/"));
+    Inode<?> root = sTree.getInodeByPath(new AlluxioURI("/"));
     sTree.initializeRoot(TEST_PERMISSION_STATUS_SUPER);
     verifyPermissionChecker(true, root.getUserName(), TEST_SUPER_GROUP);
 
@@ -173,7 +173,7 @@ public class PermissionCheckerTest {
         sTree.collectInodes(new AlluxioURI(TEST_NOT_EXIST_URI)));
   }
 
-  private static void verifyInodesList(String[] expectedInodes, List<Inode> inodes) {
+  private static void verifyInodesList(String[] expectedInodes, List<Inode<?>> inodes) {
     String[] inodesName = new String[inodes.size()];
     for (int i = 0; i < inodes.size(); i++) {
       inodesName[i] = inodes.get(i).getName();
@@ -304,9 +304,9 @@ public class PermissionCheckerTest {
   }
 
   private List<FileInfo> collectFileInfos(AlluxioURI path) throws Exception {
-    List<Inode> inodes = sTree.collectInodes(path);
+    List<Inode<?>> inodes = sTree.collectInodes(path);
     List<FileInfo> fileInfos = new ArrayList<FileInfo>();
-    for (Inode inode : inodes) {
+    for (Inode<?> inode : inodes) {
       fileInfos.add(inode.generateClientFileInfo(sTree.getPath(inode).toString()));
     }
     return fileInfos;

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -200,7 +200,7 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
     // large number of small files
     InodeDirectory inodeDirectory = createInodeDirectory();
     int nFiles = (int) 1E5;
-    Inode[] inodes = new Inode[nFiles];
+    Inode<?>[] inodes = new Inode[nFiles];
     for (int i = 0; i < nFiles; i++) {
       inodes[i] = createInodeFile(i + 1);
       inodeDirectory.addChild(inodes[i]);

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -117,11 +117,11 @@ public final class InodeTreeTest {
    */
   @Test
   public void initializeRootTwiceTest() throws Exception {
-    Inode root = mTree.getInodeByPath(new AlluxioURI("/"));
+    Inode<?> root = mTree.getInodeByPath(new AlluxioURI("/"));
     // initializeRoot call does nothing
     mTree.initializeRoot(TEST_PERMISSION_STATUS);
     verifyPermissionChecker(true, root.getUserName(), "test-supergroup");
-    Inode newRoot = mTree.getInodeByPath(new AlluxioURI("/"));
+    Inode<?> newRoot = mTree.getInodeByPath(new AlluxioURI("/"));
     Assert.assertEquals(root, newRoot);
   }
 
@@ -136,7 +136,7 @@ public final class InodeTreeTest {
     // create directory
     mTree.createPath(TEST_URI, sDirectoryOptions);
     Assert.assertTrue(mTree.inodePathExists(TEST_URI));
-    Inode test = mTree.getInodeByPath(TEST_URI);
+    Inode<?> test = mTree.getInodeByPath(TEST_URI);
     Assert.assertEquals(TEST_PATH, test.getName());
     Assert.assertTrue(test.isDirectory());
     Assert.assertEquals("user1", test.getUserName());
@@ -146,7 +146,7 @@ public final class InodeTreeTest {
     // create nested directory
     mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
     Assert.assertTrue(mTree.inodePathExists(NESTED_URI));
-    Inode nested = mTree.getInodeByPath(NESTED_URI);
+    Inode<?> nested = mTree.getInodeByPath(NESTED_URI);
     Assert.assertEquals(TEST_PATH, nested.getName());
     Assert.assertEquals(2, nested.getParentId());
     Assert.assertTrue(test.isDirectory());
@@ -184,8 +184,8 @@ public final class InodeTreeTest {
   public void createFileUnderPinnedDirectoryTest() throws Exception {
     // create nested directory
     InodeTree.CreatePathResult createResult = mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
-    List<Inode> created = createResult.getCreated();
-    Inode nested = created.get(created.size() - 1);
+    List<Inode<?>> created = createResult.getCreated();
+    Inode<?> nested = created.get(created.size() - 1);
 
     // pin nested folder
     mTree.setPinned(nested, true);
@@ -207,7 +207,7 @@ public final class InodeTreeTest {
   public void createFileTest() throws Exception {
     // created nested file
     mTree.createPath(NESTED_FILE_URI, sNestedFileOptions);
-    Inode nestedFile = mTree.getInodeByPath(NESTED_FILE_URI);
+    Inode<?> nestedFile = mTree.getInodeByPath(NESTED_FILE_URI);
     Assert.assertEquals("file", nestedFile.getName());
     Assert.assertEquals(2, nestedFile.getParentId());
     Assert.assertTrue(nestedFile.isFile());
@@ -231,8 +231,8 @@ public final class InodeTreeTest {
     // create nested directory
     InodeTree.CreatePathResult createResult =
         mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
-    List<Inode> modified = createResult.getModified();
-    List<Inode> created = createResult.getCreated();
+    List<Inode<?>> modified = createResult.getModified();
+    List<Inode<?>> created = createResult.getCreated();
     // 1 modified directory
     Assert.assertEquals(1, modified.size());
     Assert.assertEquals("", modified.get(0).getName());
@@ -362,7 +362,7 @@ public final class InodeTreeTest {
     Assert.assertFalse(mTree.inodeIdExists(1));
 
     mTree.createPath(TEST_URI, sFileOptions);
-    Inode inode = mTree.getInodeByPath(TEST_URI);
+    Inode<?> inode = mTree.getInodeByPath(TEST_URI);
     Assert.assertTrue(mTree.inodeIdExists(inode.getId()));
 
     mTree.deleteInode(inode);
@@ -442,13 +442,13 @@ public final class InodeTreeTest {
    */
   @Test
   public void getPathTest() throws Exception {
-    Inode root = mTree.getInodeById(0);
+    Inode<?> root = mTree.getInodeById(0);
     // test root path
     Assert.assertEquals(new AlluxioURI("/"), mTree.getPath(root));
 
     // test one level
     InodeTree.CreatePathResult createResult = mTree.createPath(TEST_URI, sDirectoryOptions);
-    List<Inode> created = createResult.getCreated();
+    List<Inode<?>> created = createResult.getCreated();
     Assert.assertEquals(new AlluxioURI("/test"), mTree.getPath(created.get(created.size() - 1)));
 
     // test nesting
@@ -471,7 +471,7 @@ public final class InodeTreeTest {
     mTree.createPath(NESTED_FILE_URI, sNestedFileOptions);
 
     // all inodes under root
-    List<Inode> inodes = mTree.getInodeChildrenRecursive((InodeDirectory) mTree.getInodeById(0));
+    List<Inode<?>> inodes = mTree.getInodeChildrenRecursive((InodeDirectory) mTree.getInodeById(0));
     // /test, /nested, /nested/test, /nested/test/file
     Assert.assertEquals(4, inodes.size());
   }
@@ -485,10 +485,10 @@ public final class InodeTreeTest {
   public void deleteInodeTest() throws Exception {
     InodeTree.CreatePathResult createResult =
         mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
-    List<Inode> created = createResult.getCreated();
+    List<Inode<?>> created = createResult.getCreated();
 
     // all inodes under root
-    List<Inode> inodes = mTree.getInodeChildrenRecursive((InodeDirectory) mTree.getInodeById(0));
+    List<Inode<?>> inodes = mTree.getInodeChildrenRecursive((InodeDirectory) mTree.getInodeById(0));
     // /nested, /nested/test
     Assert.assertEquals(2, inodes.size());
     // delete the nested inode
@@ -508,7 +508,7 @@ public final class InodeTreeTest {
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage("Inode id 1 does not exist");
 
-    Inode testFile = new InodeFile(1).setName("testFile1").setParentId(1)
+    Inode<?> testFile = new InodeFile(1).setName("testFile1").setParentId(1)
         .setPermissionStatus(TEST_PERMISSION_STATUS);
     mTree.deleteInode(testFile);
   }
@@ -522,8 +522,8 @@ public final class InodeTreeTest {
   public void setPinnedTest() throws Exception {
     InodeTree.CreatePathResult createResult =
         mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
-    List<Inode> created = createResult.getCreated();
-    Inode nested = created.get(created.size() - 1);
+    List<Inode<?>> created = createResult.getCreated();
+    Inode<?> nested = created.get(created.size() - 1);
     mTree.createPath(NESTED_FILE_URI, sNestedFileOptions);
 
     // no inodes pinned
@@ -549,20 +549,20 @@ public final class InodeTreeTest {
     InodeDirectory root = mTree.getRoot();
 
     // test root
-    verifyJournal(mTree, Lists.<Inode>newArrayList(root));
+    verifyJournal(mTree, Lists.<Inode<?>>newArrayList(root));
 
     // test nested URI
     mTree.createPath(NESTED_FILE_URI, sNestedFileOptions);
     InodeDirectory nested = (InodeDirectory) root.getChild("nested");
     InodeDirectory test = (InodeDirectory) nested.getChild("test");
-    Inode file = test.getChild("file");
-    verifyJournal(mTree, Lists.newArrayList(root, nested, test, file));
+    Inode<?> file = test.getChild("file");
+    verifyJournal(mTree, Lists.<Inode<?>>newArrayList(root, nested, test, file));
 
     // add a sibling of test and verify journaling is in correct order (breadth first)
     mTree.createPath(new AlluxioURI("/nested/test1/file1"), sNestedFileOptions);
     InodeDirectory test1 = (InodeDirectory) nested.getChild("test1");
-    Inode file1 = test1.getChild("file1");
-    verifyJournal(mTree, Lists.newArrayList(root, nested, test, test1, file, file1));
+    Inode<?> file1 = test1.getChild("file1");
+    verifyJournal(mTree, Lists.<Inode<?>>newArrayList(root, nested, test, test1, file, file1));
   }
 
   /**
@@ -578,9 +578,9 @@ public final class InodeTreeTest {
     InodeDirectory root = mTree.getRoot();
     InodeDirectory nested = (InodeDirectory) root.getChild("nested");
     InodeDirectory test = (InodeDirectory) nested.getChild("test");
-    Inode file = test.getChild("file");
+    Inode<?> file = test.getChild("file");
     InodeDirectory test1 = (InodeDirectory) nested.getChild("test1");
-    Inode file1 = test1.getChild("file1");
+    Inode<?> file1 = test1.getChild("file1");
 
     // reset the tree
     mTree.addInodeFromJournal(root.toJournalEntry());
@@ -606,10 +606,10 @@ public final class InodeTreeTest {
   }
 
   // helper for verifying that correct objects were journaled to the output stream
-  private static void verifyJournal(InodeTree root, List<Inode> journaled) throws Exception {
+  private static void verifyJournal(InodeTree root, List<Inode<?>> journaled) throws Exception {
     JournalOutputStream mockOutputStream = Mockito.mock(JournalOutputStream.class);
     root.streamToJournalCheckpoint(mockOutputStream);
-    for (Inode node : journaled) {
+    for (Inode<?> node : journaled) {
       Mockito.verify(mockOutputStream).writeEntry(node.toJournalEntry());
     }
     Mockito.verifyNoMoreInteractions(mockOutputStream);
@@ -618,9 +618,9 @@ public final class InodeTreeTest {
   // verify that the tree has the given children
   private static void verifyChildrenNames(InodeTree tree, InodeDirectory root,
       Set<String> childNames) throws Exception {
-    List<Inode> children = tree.getInodeChildrenRecursive(root);
+    List<Inode<?>> children = tree.getInodeChildrenRecursive(root);
     Assert.assertEquals(childNames.size(), children.size());
-    for (Inode child : children) {
+    for (Inode<?> child : children) {
       Assert.assertTrue(childNames.contains(child.getName()));
     }
   }


### PR DESCRIPTION
Followup to https://github.com/Alluxio/alluxio/pull/2771 - if we aren't hiding extendible-fluent-builder generics inside an `Inode.Builder` class, `Inode` needs to be referred to by `Inode<?>` to avoid raw type warnings.