### PR TITLE
[SMALLFIX] Improve handling of FileDoesNotExistException

### DIFF
--- a/core/common/src/main/java/alluxio/exception/FileDoesNotExistException.java
+++ b/core/common/src/main/java/alluxio/exception/FileDoesNotExistException.java
@@ -14,7 +14,7 @@ package alluxio.exception;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * The exception thrown when a file does not exist in Alluxio.
+ * The exception thrown when a path does not exist in Alluxio.
  */
 @ThreadSafe
 public class FileDoesNotExistException extends AlluxioException {

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -601,8 +601,8 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * Creates a file (not a directory) for a given path.
-   * Needs {@link FileSystemAction#WRITE} permission on the parent of the path.
+   * Creates a file (not a directory) for a given path. Needs {@link FileSystemAction#WRITE}
+   * permission on the parent of the path.
    *
    * @param path the file to create
    * @param options method options
@@ -612,7 +612,8 @@ public final class FileSystemMaster extends AbstractMaster {
    * @throws BlockInfoException if an invalid block information in encountered
    * @throws IOException if the creation fails
    * @throws AccessControlException if permission checking fails
-   * @throws FileDoesNotExistException if the path does not exist
+   * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
+   *         option is false
    */
   public long create(AlluxioURI path, CreateFileOptions options)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
@@ -643,7 +644,8 @@ public final class FileSystemMaster extends AbstractMaster {
    * @throws FileAlreadyExistsException if the file already exists
    * @throws BlockInfoException if invalid block information is encountered
    * @throws IOException if an I/O error occurs
-   * @throws FileDoesNotExistException if the path does not exist
+   * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
+   *         option is false
    */
   InodeTree.CreatePathResult createInternal(AlluxioURI path, CreateFileOptions options)
       throws InvalidPathException, FileAlreadyExistsException, BlockInfoException, IOException,

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -186,12 +186,14 @@ public final class InodeTree implements JournalCheckpointStreamable {
    * @param path the path to get the inode for
    * @return the inode with the given path
    * @throws InvalidPathException if the path is invalid
+   * @throws FileDoesNotExistException if the path does not exist
    */
-  public Inode getInodeByPath(AlluxioURI path) throws InvalidPathException {
+  public Inode getInodeByPath(AlluxioURI path)
+      throws InvalidPathException, FileDoesNotExistException {
     TraversalResult traversalResult =
         traverseToInode(PathUtils.getPathComponents(path.toString()), false);
     if (!traversalResult.isFound()) {
-      throw new InvalidPathException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
+      throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
     }
     return traversalResult.getInode();
   }
@@ -242,9 +244,12 @@ public final class InodeTree implements JournalCheckpointStreamable {
    *         necessary parent directories and recursive is false, (2) when one of the necessary
    *         parent directories is actually a file
    * @throws IOException if creating the path fails
+   * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
+   *         option is false
    */
   public CreatePathResult createPath(AlluxioURI path, CreatePathOptions options)
-      throws FileAlreadyExistsException, BlockInfoException, InvalidPathException, IOException {
+      throws FileAlreadyExistsException, BlockInfoException, InvalidPathException, IOException,
+      FileDoesNotExistException {
     if (path.isRoot()) {
       LOG.info(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
       throw new FileAlreadyExistsException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
@@ -277,8 +282,8 @@ public final class InodeTree implements JournalCheckpointStreamable {
             .append(traversalResult.getNonexistentPathIndex()).append("(")
             .append(parentPath[traversalResult.getNonexistentPathIndex()])
             .append(") does not exist").toString();
-        LOG.info("InvalidPathException: {}", msg);
-        throw new InvalidPathException(msg);
+        LOG.info("FileDoesNotExistException: {}", msg);
+        throw new FileDoesNotExistException(msg);
       } else {
         // We will start filling at the index of the non-existing step found by the traversal.
         pathIndex = traversalResult.getNonexistentPathIndex();
@@ -393,9 +398,10 @@ public final class InodeTree implements JournalCheckpointStreamable {
    * @param ttl the ttl
    * @return the file id
    * @throws InvalidPathException if the path is invalid
+   * @throws FileDoesNotExistException if the path does not exist
    */
   public long reinitializeFile(AlluxioURI path, long blockSizeBytes, long ttl)
-      throws InvalidPathException {
+      throws InvalidPathException, FileDoesNotExistException {
     InodeFile file = (InodeFile) getInodeByPath(path);
     file.setBlockSizeBytes(blockSizeBytes);
     file.setTtl(ttl);

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -184,16 +184,17 @@ public final class LineageMaster extends AbstractMaster {
    * @throws BlockInfoException if fails to create the output file
    * @throws IOException if the creation of a file fails
    * @throws AccessControlException if the permission check fails
+   * @throws FileDoesNotExistException if any of the input files do not exist
    */
   public synchronized long createLineage(List<AlluxioURI> inputFiles, List<AlluxioURI> outputFiles,
       Job job) throws InvalidPathException, FileAlreadyExistsException, BlockInfoException,
-      IOException, AccessControlException {
+      IOException, AccessControlException, FileDoesNotExistException {
     List<Long> inputAlluxioFiles = Lists.newArrayList();
     for (AlluxioURI inputFile : inputFiles) {
       long fileId;
       fileId = mFileSystemMaster.getFileId(inputFile);
       if (fileId == IdUtils.INVALID_FILE_ID) {
-        throw new InvalidPathException(
+        throw new FileDoesNotExistException(
             ExceptionMessage.LINEAGE_INPUT_FILE_NOT_EXIST.getMessage(inputFile));
       }
       inputAlluxioFiles.add(fileId);
@@ -278,9 +279,11 @@ public final class LineageMaster extends AbstractMaster {
    * @throws InvalidPathException the file path is invalid
    * @throws LineageDoesNotExistException when the file does not exist
    * @throws AccessControlException if permission checking fails
+   * @throws FileDoesNotExistException if the path does not exist
    */
   public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl)
-      throws InvalidPathException, LineageDoesNotExistException, AccessControlException {
+      throws InvalidPathException, LineageDoesNotExistException, AccessControlException,
+      FileDoesNotExistException {
     long fileId = mFileSystemMaster.getFileId(new AlluxioURI(path));
     FileInfo fileInfo;
     try {

--- a/core/server/src/test/java/alluxio/master/MasterSourceTest.java
+++ b/core/server/src/test/java/alluxio/master/MasterSourceTest.java
@@ -17,7 +17,6 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyCompletedException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
-import alluxio.exception.InvalidPathException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.FileSystemMaster;
@@ -232,7 +231,7 @@ public final class MasterSourceTest {
     try {
       mFileSystemMaster.getFileBlockInfoList(new AlluxioURI("/doesNotExist"));
       Assert.fail("get file block info for a non existing file must throw an exception");
-    } catch (InvalidPathException e) {
+    } catch (FileDoesNotExistException e) {
       Assert.assertEquals(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("/doesNotExist"),
           e.getMessage());
     }

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -456,7 +456,7 @@ public final class FileSystemMasterTest {
    */
   @Test
   public void renameUnderNonexistingDir() throws Exception {
-    mThrown.expect(InvalidPathException.class);
+    mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("/nested/test"));
 
     CreateFileOptions options = CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB);

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -16,7 +16,7 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
-import alluxio.exception.InvalidPathException;
+import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.MasterContext;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.options.CompleteFileOptions;
@@ -301,7 +301,7 @@ public class PermissionCheckTest {
 
   @Test
   public void renameFailNotByPermissionTest() throws Exception {
-    mThrown.expect(InvalidPathException.class);
+    mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("/testDir/notExistDir"));
 
     // rename "/testDir/file" to "/testDir/notExistDir/fileRenamed" for user1

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -318,7 +318,7 @@ public final class InodeTreeTest {
    */
   @Test
   public void createFileUnderNonexistingDirTest() throws Exception {
-    mThrown.expect(InvalidPathException.class);
+    mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage("File /nested/test creation failed. Component 1(nested) does not exist");
 
     mTree.createPath(NESTED_URI, sFileOptions);
@@ -390,7 +390,7 @@ public final class InodeTreeTest {
    */
   @Test
   public void getInodeByNonexistingPathTest() throws Exception {
-    mThrown.expect(InvalidPathException.class);
+    mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage("Path /test does not exist");
 
     Assert.assertFalse(mTree.inodePathExists(TEST_URI));
@@ -404,7 +404,7 @@ public final class InodeTreeTest {
    */
   @Test
   public void getInodeByNonexistingNestedPathTest() throws Exception {
-    mThrown.expect(InvalidPathException.class);
+    mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage("Path /nested/test/file does not exist");
 
     mTree.createPath(NESTED_URI, sNestedDirectoryOptions);

--- a/core/server/src/test/java/alluxio/master/lineage/LineageMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/lineage/LineageMasterTest.java
@@ -13,7 +13,7 @@ package alluxio.master.lineage;
 
 import alluxio.AlluxioURI;
 import alluxio.exception.ExceptionMessage;
-import alluxio.exception.InvalidPathException;
+import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.LineageDeletionException;
 import alluxio.exception.LineageDoesNotExistException;
 import alluxio.job.CommandLineJob;
@@ -101,7 +101,7 @@ public final class LineageMasterTest {
       mLineageMaster.createLineage(Lists.newArrayList(missingInput),
           Lists.newArrayList(new AlluxioURI("/test2")), mJob);
       Assert.fail();
-    } catch (InvalidPathException e) {
+    } catch (FileDoesNotExistException e) {
       Assert.assertEquals(ExceptionMessage.LINEAGE_INPUT_FILE_NOT_EXIST.getMessage("/test1"),
           e.getMessage());
     }

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import jersey.repackaged.com.google.common.base.Throwables;
 import org.apache.thrift.TProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,8 +250,17 @@ public final class KeyValueMaster extends AbstractMaster {
       // TODO(binfan): Investigate why mFileSystemMaster.mkdir throws IOException
       throw new InvalidPathException(
           String.format("Failed to createStore: can not create path %s", path), e);
+    } catch (FileDoesNotExistException e) {
+      // This should be impossible since we pass the recursive option into mkdir
+      throw Throwables.propagate(e);
     }
-    final long fileId = mFileSystemMaster.getFileId(path);
+    long fileId;
+    try {
+      fileId = mFileSystemMaster.getFileId(path);
+    } catch (FileDoesNotExistException e) {
+      // This is unexpected since we just successfully created this directory
+      throw Throwables.propagate(e);
+    }
     Preconditions.checkState(fileId != IdUtils.INVALID_FILE_ID);
 
     createStoreInternal(fileId);

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -38,11 +38,11 @@ import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
-import jersey.repackaged.com.google.common.base.Throwables;
 import org.apache.thrift.TProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
There were many places where we would throw InvalidPathException due to a file not existing. This PR throws FileDoesNotExistException in those places instead.

As a next step, I would like to rename FileDoesNotExistException to PathDoesNotExistException since that is already what it represents.