### PR TITLE
[ALLUXIO-1855] Add central handling for server-side exceptions

### DIFF
--- a/core/common/src/main/java/alluxio/exception/AlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/AlluxioException.java
@@ -20,7 +20,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * the RPC framework and convert back without losing any necessary information.
  */
 @ThreadSafe
-public class AlluxioException extends Exception {
+public abstract class AlluxioException extends Exception {
   private static final long serialVersionUID = 2243833925609642384L;
 
   /**
@@ -28,7 +28,7 @@ public class AlluxioException extends Exception {
    *
    * @param te the type of the exception
    */
-  public AlluxioException(AlluxioTException te) {
+  protected AlluxioException(AlluxioTException te) {
     super(te.getMessage());
   }
 
@@ -37,7 +37,7 @@ public class AlluxioException extends Exception {
    *
    * @param cause the cause
    */
-  public AlluxioException(Throwable cause) {
+  protected AlluxioException(Throwable cause) {
     super(cause);
   }
 
@@ -46,7 +46,7 @@ public class AlluxioException extends Exception {
    *
    * @param message the message
    */
-  public AlluxioException(String message) {
+  protected AlluxioException(String message) {
     super(message);
   }
 
@@ -56,7 +56,7 @@ public class AlluxioException extends Exception {
    * @param message the message
    * @param cause the cause
    */
-  public AlluxioException(String message, Throwable cause) {
+  protected AlluxioException(String message, Throwable cause) {
     super(message, cause);
   }
 

--- a/core/common/src/main/java/alluxio/exception/AlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/AlluxioException.java
@@ -20,7 +20,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * the RPC framework and convert back without losing any necessary information.
  */
 @ThreadSafe
-public abstract class AlluxioException extends Exception {
+public class AlluxioException extends Exception {
   private static final long serialVersionUID = 2243833925609642384L;
 
   /**
@@ -32,15 +32,15 @@ public abstract class AlluxioException extends Exception {
     super(te.getMessage());
   }
 
-  protected AlluxioException(Throwable cause) {
+  public AlluxioException(Throwable cause) {
     super(cause);
   }
 
-  protected AlluxioException(String message) {
+  public AlluxioException(String message) {
     super(message);
   }
 
-  protected AlluxioException(String message, Throwable cause) {
+  public AlluxioException(String message, Throwable cause) {
     super(message, cause);
   }
 

--- a/core/common/src/main/java/alluxio/exception/AlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/AlluxioException.java
@@ -32,14 +32,30 @@ public class AlluxioException extends Exception {
     super(te.getMessage());
   }
 
+  /**
+   * Constructs an {@link AlluxioException} with the given cause.
+   *
+   * @param cause the cause
+   */
   public AlluxioException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Constructs an {@link AlluxioException} with the given message.
+   *
+   * @param message the message
+   */
   public AlluxioException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs an {@link AlluxioException} with the given message and cause.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public AlluxioException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
@@ -18,6 +18,15 @@ public final class UnexpectedAlluxioException extends AlluxioException {
   private static final long serialVersionUID = -1029072354884843903L;
 
   /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public UnexpectedAlluxioException(String message) {
+    super(message);
+  }
+
+  /**
    * @param e an exception to wrap
    */
   public UnexpectedAlluxioException(RuntimeException e) {

--- a/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
@@ -8,6 +8,7 @@
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
+
 package alluxio.exception;
 
 /**
@@ -17,7 +18,7 @@ public final class UnexpectedAlluxioException extends AlluxioException {
   private static final long serialVersionUID = -1029072354884843903L;
 
   /**
-   * @param e an exception to wrap.
+   * @param e an exception to wrap
    */
   public UnexpectedAlluxioException(RuntimeException e) {
     super(e);

--- a/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
+++ b/core/common/src/main/java/alluxio/exception/UnexpectedAlluxioException.java
@@ -1,0 +1,25 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the “License”). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+package alluxio.exception;
+
+/**
+ * The exception thrown when an unexpected error occurs within the Alluxio system.
+ */
+public final class UnexpectedAlluxioException extends AlluxioException {
+  private static final long serialVersionUID = -1029072354884843903L;
+
+  /**
+   * @param e an exception to wrap.
+   */
+  public UnexpectedAlluxioException(RuntimeException e) {
+    super(e);
+  }
+}

--- a/core/server/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/src/main/java/alluxio/RpcUtils.java
@@ -12,10 +12,10 @@
 package alluxio;
 
 import alluxio.exception.AlluxioException;
+import alluxio.exception.UnexpectedAlluxioException;
 import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.ThriftIOException;
 
-import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,7 @@ public final class RpcUtils {
       throw e.toAlluxioTException();
     } catch (RuntimeException e) {
       LOG.error("Unexpected error running rpc", e);
-      throw new AlluxioException(Throwables.getRootCause(e)).toAlluxioTException();
+      throw new UnexpectedAlluxioException(e).toAlluxioTException();
     }
   }
 
@@ -65,7 +65,7 @@ public final class RpcUtils {
       throw new ThriftIOException(e.getMessage());
     } catch (RuntimeException e) {
       LOG.error("Unexpected error running rpc", e);
-      throw new AlluxioException(Throwables.getRootCause(e)).toAlluxioTException();
+      throw new UnexpectedAlluxioException(e).toAlluxioTException();
     }
   }
 

--- a/core/server/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/src/main/java/alluxio/RpcUtils.java
@@ -8,6 +8,7 @@
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
+
 package alluxio;
 
 import alluxio.exception.AlluxioException;
@@ -30,6 +31,7 @@ public final class RpcUtils {
    * Calls the given {@link RpcCallable} and handles any exceptions thrown.
    *
    * @param callable the callable to call
+   * @param <T> the return type of the callable
    * @return the return value from calling the callable
    * @throws AlluxioTException if the callable throws an Alluxio or runtime exception
    */
@@ -48,6 +50,7 @@ public final class RpcUtils {
    * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown.
    *
    * @param callable the callable to call
+   * @param <T> the return type of the callable
    * @return the return value from calling the callable
    * @throws AlluxioTException if the callable throws an Alluxio or runtime exception
    * @throws ThriftIOException if the callable throws an IOException
@@ -72,6 +75,12 @@ public final class RpcUtils {
    * @param <T> the return type of the callable
    */
   public interface RpcCallable<T> {
+    /**
+     * The RPC implementation.
+     *
+     * @return the return value from the RPC
+     * @throws AlluxioException if an expected exception occurs in the Alluxio system
+     */
     T call() throws AlluxioException;
   }
 
@@ -81,6 +90,13 @@ public final class RpcUtils {
    * @param <T> the return type of the callable
    */
   public interface RpcCallableThrowsIOException<T> {
+    /**
+     * The RPC implementation.
+     *
+     * @return the return value from the RPC
+     * @throws AlluxioException if an expected exception occurs in the Alluxio system
+     * @throws IOException if an exception is thrown when interacting with the underlying system
+     */
     T call() throws AlluxioException, IOException;
   }
 }

--- a/core/server/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/src/main/java/alluxio/RpcUtils.java
@@ -1,0 +1,86 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the “License”). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+package alluxio;
+
+import alluxio.exception.AlluxioException;
+import alluxio.thrift.AlluxioTException;
+import alluxio.thrift.ThriftIOException;
+
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Utilities for handling rpc calls.
+ */
+public final class RpcUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  /**
+   * Calls the given {@link RpcCallable} and handles any exceptions thrown.
+   *
+   * @param callable the callable to call
+   * @return the return value from calling the callable
+   * @throws AlluxioTException if the callable throws an Alluxio or runtime exception
+   */
+  public static <T> T call(RpcCallable<T> callable) throws AlluxioTException {
+    try {
+      return callable.call();
+    } catch (AlluxioException e) {
+      throw e.toAlluxioTException();
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error running rpc", e);
+      throw new AlluxioException(Throwables.getRootCause(e)).toAlluxioTException();
+    }
+  }
+
+  /**
+   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown.
+   *
+   * @param callable the callable to call
+   * @return the return value from calling the callable
+   * @throws AlluxioTException if the callable throws an Alluxio or runtime exception
+   * @throws ThriftIOException if the callable throws an IOException
+   */
+  public static <T> T call(RpcCallableThrowsIOException<T> callable)
+      throws AlluxioTException, ThriftIOException {
+    try {
+      return callable.call();
+    } catch (AlluxioException e) {
+      throw e.toAlluxioTException();
+    } catch (IOException e) {
+      throw new ThriftIOException(e.getMessage());
+    } catch (RuntimeException e) {
+      LOG.error("Unexpected error running rpc", e);
+      throw new AlluxioException(Throwables.getRootCause(e)).toAlluxioTException();
+    }
+  }
+
+  /**
+   * An interface representing a callable which can only throw Alluxio exceptions.
+   *
+   * @param <T> the return type of the callable
+   */
+  public interface RpcCallable<T> {
+    T call() throws AlluxioException;
+  }
+
+  /**
+   * An interface representing a callable which can only throw Alluxio or IO exceptions.
+   *
+   * @param <T> the return type of the callable
+   */
+  public interface RpcCallableThrowsIOException<T> {
+    T call() throws AlluxioException, IOException;
+  }
+}

--- a/core/server/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
@@ -12,6 +12,8 @@
 package alluxio.master.block;
 
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallable;
 import alluxio.exception.AlluxioException;
 import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.BlockInfo;
@@ -68,11 +70,12 @@ public class BlockMasterClientServiceHandler implements BlockMasterClientService
   }
 
   @Override
-  public BlockInfo getBlockInfo(long blockId) throws AlluxioTException {
-    try {
-      return ThriftUtils.toThrift(mBlockMaster.getBlockInfo(blockId));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public BlockInfo getBlockInfo(final long blockId) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<BlockInfo>() {
+      @Override
+      public BlockInfo call() throws AlluxioException {
+        return ThriftUtils.toThrift(mBlockMaster.getBlockInfo(blockId));
+      }
+    });
   }
 }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -13,10 +13,10 @@ package alluxio.master.file;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallable;
+import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
-import alluxio.master.RpcUtils;
-import alluxio.master.RpcUtils.RpcCallable;
-import alluxio.master.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -14,8 +14,9 @@ package alluxio.master.file;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.FileDoesNotExistException;
-import alluxio.exception.InvalidPathException;
+import alluxio.master.RpcUtils;
+import alluxio.master.RpcUtils.RpcCallable;
+import alluxio.master.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
@@ -65,86 +66,95 @@ public final class FileSystemMasterClientServiceHandler implements
   }
 
   @Override
-  public void completeFile(String path, CompleteFileTOptions options) throws AlluxioTException {
-    try {
-      mFileSystemMaster.completeFile(new AlluxioURI(path), new CompleteFileOptions(options));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
-  }
-
-  @Override
-  public void createDirectory(String path, CreateDirectoryTOptions options)
-      throws AlluxioTException, ThriftIOException {
-    try {
-      mFileSystemMaster.mkdir(new AlluxioURI(path), new CreateDirectoryOptions(options));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
-  }
-
-  @Override
-  public void createFile(String path, CreateFileTOptions options) throws AlluxioTException,
-      ThriftIOException {
-    try {
-      mFileSystemMaster.create(new AlluxioURI(path), new CreateFileOptions(options));
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
-  }
-
-  @Override
-  public void free(String path, boolean recursive) throws AlluxioTException {
-    try {
-      mFileSystemMaster.free(new AlluxioURI(path), recursive);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
-  }
-
-  @Override
-  public List<FileBlockInfo> getFileBlockInfoList(String path) throws AlluxioTException {
-    try {
-      List<FileBlockInfo> result = new ArrayList<FileBlockInfo>();
-      for (alluxio.wire.FileBlockInfo fileBlockInfo :
-          mFileSystemMaster.getFileBlockInfoList(new AlluxioURI(path))) {
-        result.add(ThriftUtils.toThrift(fileBlockInfo));
+  public void completeFile(final String path, final CompleteFileTOptions options)
+      throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mFileSystemMaster.completeFile(new AlluxioURI(path), new CompleteFileOptions(options));
+        return null;
       }
-      return result;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+    });
   }
 
   @Override
-  public long getNewBlockIdForFile(String path) throws AlluxioTException {
-    try {
-      return mFileSystemMaster.getNewBlockIdForFile(new AlluxioURI(path));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void createDirectory(final String path, final CreateDirectoryTOptions options)
+      throws AlluxioTException, ThriftIOException {
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.mkdir(new AlluxioURI(path), new CreateDirectoryOptions(options));
+        return null;
+      }
+    });
   }
 
   @Override
-  public FileInfo getStatus(String path) throws AlluxioTException {
-    try {
-      return ThriftUtils.toThrift(mFileSystemMaster.getFileInfo(new AlluxioURI(path)));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void createFile(final String path, final CreateFileTOptions options)
+      throws AlluxioTException, ThriftIOException {
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.create(new AlluxioURI(path), new CreateFileOptions(options));
+        return null;
+      }
+    });
   }
 
   @Override
-  public FileInfo getStatusInternal(long fileId) throws AlluxioTException {
-    try {
-      return ThriftUtils.toThrift(mFileSystemMaster.getFileInfo(fileId));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void free(final String path, final boolean recursive) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mFileSystemMaster.free(new AlluxioURI(path), recursive);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public List<FileBlockInfo> getFileBlockInfoList(final String path) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<List<FileBlockInfo>>() {
+      @Override
+      public List<FileBlockInfo> call() throws AlluxioException {
+        List<FileBlockInfo> result = new ArrayList<FileBlockInfo>();
+        for (alluxio.wire.FileBlockInfo fileBlockInfo :
+            mFileSystemMaster.getFileBlockInfoList(new AlluxioURI(path))) {
+          result.add(ThriftUtils.toThrift(fileBlockInfo));
+        }
+        return result;
+      }
+    });
+  }
+
+  @Override
+  public long getNewBlockIdForFile(final String path) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<Long>() {
+      @Override
+      public Long call() throws AlluxioException {
+        return mFileSystemMaster.getNewBlockIdForFile(new AlluxioURI(path));
+      }
+    });
+  }
+
+  @Override
+  public FileInfo getStatus(final String path) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<FileInfo>() {
+      @Override
+      public FileInfo call() throws AlluxioException {
+        return ThriftUtils.toThrift(mFileSystemMaster.getFileInfo(new AlluxioURI(path)));
+      }
+    });
+  }
+
+  @Override
+  public FileInfo getStatusInternal(final long fileId) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<FileInfo>() {
+      @Override
+      public FileInfo call() throws AlluxioException {
+        return ThriftUtils.toThrift(mFileSystemMaster.getFileInfo(fileId));
+      }
+    });
   }
 
   /**
@@ -159,97 +169,100 @@ public final class FileSystemMasterClientServiceHandler implements
   }
 
   @Override
-  public List<FileInfo> listStatus(String path) throws AlluxioTException {
-    try {
-      List<FileInfo> result = new ArrayList<FileInfo>();
-      for (alluxio.wire.FileInfo fileInfo :
-          mFileSystemMaster.getFileInfoList(new AlluxioURI(path))) {
-        result.add(ThriftUtils.toThrift(fileInfo));
+  public List<FileInfo> listStatus(final String path) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<List<FileInfo>>() {
+      @Override
+      public List<FileInfo> call() throws AlluxioException {
+        List<FileInfo> result = new ArrayList<FileInfo>();
+        for (alluxio.wire.FileInfo fileInfo :
+            mFileSystemMaster.getFileInfoList(new AlluxioURI(path))) {
+          result.add(ThriftUtils.toThrift(fileInfo));
+        }
+        return result;
       }
-      return result;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+    });
   }
 
   @Override
-  public long loadMetadata(String alluxioPath, boolean recursive)
+  public long loadMetadata(final String alluxioPath, final boolean recursive)
       throws AlluxioTException, ThriftIOException {
-    try {
-      return mFileSystemMaster.loadMetadata(new AlluxioURI(alluxioPath), recursive);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    return RpcUtils.call(new RpcCallableThrowsIOException<Long>() {
+      @Override
+      public Long call() throws AlluxioException, IOException {
+        return mFileSystemMaster.loadMetadata(new AlluxioURI(alluxioPath), recursive);
+      }
+    });
   }
 
   @Override
-  public void mount(String alluxioPath, String ufsPath, MountTOptions options)
+  public void mount(final String alluxioPath, final String ufsPath, final MountTOptions options)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mFileSystemMaster
-          .mount(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath), new MountOptions(options));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.mount(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath),
+            new MountOptions(options));
+        return null;
+      }
+    });
   }
 
   @Override
-  public void remove(String path, boolean recursive)
+  public void remove(final String path, final boolean recursive)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mFileSystemMaster.deleteFile(new AlluxioURI(path), recursive);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.deleteFile(new AlluxioURI(path), recursive);
+        return null;
+      }
+    });
   }
 
   @Override
-  public void rename(String srcPath, String dstPath)
+  public void rename(final String srcPath, final String dstPath)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mFileSystemMaster.rename(new AlluxioURI(srcPath), new AlluxioURI(dstPath));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.rename(new AlluxioURI(srcPath), new AlluxioURI(dstPath));
+        return null;
+      }
+    });
   }
 
   @Override
-  public void scheduleAsyncPersist(String path) throws AlluxioTException {
-    try {
-      mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
-    } catch (FileDoesNotExistException e) {
-      throw e.toAlluxioTException();
-    } catch (InvalidPathException e) {
-      throw e.toAlluxioTException();
-    }
+  public void scheduleAsyncPersist(final String path) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
+        return null;
+      }
+    });
   }
 
   // TODO(calvin): Do not rely on client side options
   @Override
-  public void setAttribute(String path, SetAttributeTOptions options) throws AlluxioTException {
-    try {
-      mFileSystemMaster.setAttribute(new AlluxioURI(path), new SetAttributeOptions(options));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void setAttribute(final String path, final SetAttributeTOptions options)
+      throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+          mFileSystemMaster.setAttribute(new AlluxioURI(path), new SetAttributeOptions(options));
+          return null;
+      }
+    });
   }
 
   @Override
-  public void unmount(String alluxioPath) throws AlluxioTException, ThriftIOException {
-    try {
-      mFileSystemMaster.unmount(new AlluxioURI(alluxioPath));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+  public void unmount(final String alluxioPath) throws AlluxioTException, ThriftIOException {
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mFileSystemMaster.unmount(new AlluxioURI(alluxioPath));
+        return null;
+      }
+    });
   }
 }

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
@@ -13,6 +13,9 @@ package alluxio.master.lineage;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallable;
+import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.job.CommandLineJob;
 import alluxio.job.JobConf;
@@ -58,64 +61,68 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
   public long createLineage(List<String> inputFiles, List<String> outputFiles,
       CommandLineJobInfo jobInfo) throws AlluxioTException, ThriftIOException {
     // deserialization
-    List<AlluxioURI> inputFilesUri = Lists.newArrayList();
+    final List<AlluxioURI> inputFilesUri = Lists.newArrayList();
     for (String inputFile : inputFiles) {
       inputFilesUri.add(new AlluxioURI(inputFile));
     }
-    List<AlluxioURI> outputFilesUri = Lists.newArrayList();
+    final List<AlluxioURI> outputFilesUri = Lists.newArrayList();
     for (String outputFile : outputFiles) {
       outputFilesUri.add(new AlluxioURI(outputFile));
     }
 
-    CommandLineJob job =
+    final CommandLineJob job =
         new CommandLineJob(jobInfo.getCommand(), new JobConf(jobInfo.getConf().getOutputFile()));
-    try {
-      return mLineageMaster.createLineage(inputFilesUri, outputFilesUri, job);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    return RpcUtils.call(new RpcCallableThrowsIOException<Long>() {
+      @Override
+      public Long call() throws AlluxioException, IOException {
+        return mLineageMaster.createLineage(inputFilesUri, outputFilesUri, job);
+      }
+    });
   }
 
   @Override
-  public boolean deleteLineage(long lineageId, boolean cascade) throws AlluxioTException {
-    try {
-      return mLineageMaster.deleteLineage(lineageId, cascade);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public boolean deleteLineage(final long lineageId, final boolean cascade) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<Boolean>() {
+      @Override
+      public Boolean call() throws AlluxioException {
+        return mLineageMaster.deleteLineage(lineageId, cascade);
+      }
+    });
   }
 
   @Override
-  public long reinitializeFile(String path, long blockSizeBytes, long ttl)
+  public long reinitializeFile(final String path, final long blockSizeBytes, final long ttl)
       throws AlluxioTException {
-    try {
-      return mLineageMaster.reinitializeFile(path, blockSizeBytes, ttl);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+    return RpcUtils.call(new RpcCallable<Long>() {
+      @Override
+      public Long call() throws AlluxioException {
+        return mLineageMaster.reinitializeFile(path, blockSizeBytes, ttl);
+      }
+    });
   }
 
   @Override
-  public void reportLostFile(String path) throws AlluxioTException, ThriftIOException {
-    try {
-      mLineageMaster.reportLostFile(path);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void reportLostFile(final String path) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mLineageMaster.reportLostFile(path);
+        return null;
+      }
+    });
   }
 
   @Override
   public List<LineageInfo> getLineageInfoList() throws AlluxioTException {
-    try {
-      List<LineageInfo> result = new ArrayList<LineageInfo>();
-      for (alluxio.wire.LineageInfo lineageInfo : mLineageMaster.getLineageInfoList()) {
-        result.add(ThriftUtils.toThrift(lineageInfo));
+    return RpcUtils.call(new RpcCallable<List<LineageInfo>>() {
+      @Override
+      public List<LineageInfo> call() throws AlluxioException {
+        List<LineageInfo> result = new ArrayList<LineageInfo>();
+        for (alluxio.wire.LineageInfo lineageInfo : mLineageMaster.getLineageInfoList()) {
+          result.add(ThriftUtils.toThrift(lineageInfo));
+        }
+        return result;
       }
-      return result;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+    });
   }
 }

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
@@ -81,7 +81,8 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
   }
 
   @Override
-  public boolean deleteLineage(final long lineageId, final boolean cascade) throws AlluxioTException {
+  public boolean deleteLineage(final long lineageId, final boolean cascade)
+      throws AlluxioTException {
     return RpcUtils.call(new RpcCallable<Boolean>() {
       @Override
       public Boolean call() throws AlluxioException {

--- a/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
@@ -12,6 +12,9 @@
 package alluxio.worker.block;
 
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallable;
+import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.Sessions;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;
@@ -65,12 +68,14 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws AlluxioTException if an Alluxio error occurs
    */
   @Override
-  public void accessBlock(long blockId) throws AlluxioTException {
-    try {
-      mWorker.accessBlock(Sessions.ACCESS_BLOCK_SESSION_ID, blockId);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void accessBlock(final long blockId) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mWorker.accessBlock(Sessions.ACCESS_BLOCK_SESSION_ID, blockId);
+        return null;
+      }
+    });
   }
 
   // TODO(calvin): Make this supported again.
@@ -90,14 +95,14 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws ThriftIOException if an I/O error occurs
    */
   @Override
-  public void cacheBlock(long sessionId, long blockId) throws AlluxioTException, ThriftIOException {
-    try {
-      mWorker.commitBlock(sessionId, blockId);
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void cacheBlock(final long sessionId, final long blockId) throws AlluxioTException, ThriftIOException {
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mWorker.commitBlock(sessionId, blockId);
+        return null;
+      }
+    });
   }
 
   /**
@@ -110,15 +115,15 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws ThriftIOException if an I/O error occurs
    */
   @Override
-  public void cancelBlock(long sessionId, long blockId)
+  public void cancelBlock(final long sessionId, final long blockId)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mWorker.abortBlock(sessionId, blockId);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mWorker.abortBlock(sessionId, blockId);
+        return null;
+      }
+    });
   }
 
   /**
@@ -130,13 +135,15 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws AlluxioTException if an Alluxio error occurs
    */
   @Override
-  public LockBlockResult lockBlock(long blockId, long sessionId) throws AlluxioTException {
-    try {
-      long lockId = mWorker.lockBlock(sessionId, blockId);
-      return new LockBlockResult(lockId, mWorker.readBlock(sessionId, blockId, lockId));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public LockBlockResult lockBlock(final long blockId, final long sessionId)
+      throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<LockBlockResult>() {
+      @Override
+      public LockBlockResult call() throws AlluxioException {
+        long lockId = mWorker.lockBlock(sessionId, blockId);
+        return new LockBlockResult(lockId, mWorker.readBlock(sessionId, blockId, lockId));
+      }
+    });
   }
 
   /**
@@ -151,16 +158,14 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    */
   // TODO(calvin): This may be better as void.
   @Override
-  public boolean promoteBlock(long blockId) throws AlluxioTException, ThriftIOException {
-    try {
-      // TODO(calvin): Make the top level configurable.
-      mWorker.moveBlock(Sessions.MIGRATE_DATA_SESSION_ID, blockId, mStorageTierAssoc.getAlias(0));
-      return true;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+  public boolean promoteBlock(final long blockId) throws AlluxioTException, ThriftIOException {
+    return RpcUtils.call(new RpcCallableThrowsIOException<Boolean>() {
+      @Override
+      public Boolean call() throws AlluxioException, IOException {
+        mWorker.moveBlock(Sessions.MIGRATE_DATA_SESSION_ID, blockId, mStorageTierAssoc.getAlias(0));
+        return true;
+      }
+    });
   }
 
   /**
@@ -178,16 +183,14 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws ThriftIOException if an I/O error occurs
    */
   @Override
-  public String requestBlockLocation(long sessionId, long blockId, long initialBytes)
-      throws AlluxioTException, ThriftIOException {
-    try {
-      // NOTE: right now, we ask allocator to allocate new blocks in top tier
-      return mWorker.createBlock(sessionId, blockId, mStorageTierAssoc.getAlias(0), initialBytes);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+  public String requestBlockLocation(final long sessionId, final long blockId,
+      final long initialBytes) throws AlluxioTException, ThriftIOException {
+    return RpcUtils.call(new RpcCallableThrowsIOException<String>() {
+      @Override
+      public String call() throws AlluxioException, IOException {
+        return mWorker.createBlock(sessionId, blockId, mStorageTierAssoc.getAlias(0), initialBytes);
+      }
+    });
   }
 
   /**
@@ -220,14 +223,16 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * found or failed to delete the block
    * @throws AlluxioTException if an Alluxio error occurs
    */
+  // TODO(andrew): this should return void
   @Override
-  public boolean unlockBlock(long blockId, long sessionId) throws AlluxioTException {
-    try {
-      mWorker.unlockBlock(sessionId, blockId);
-      return true;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public boolean unlockBlock(final long blockId, final long sessionId) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<Boolean>() {
+      @Override
+      public Boolean call() throws AlluxioException {
+        mWorker.unlockBlock(sessionId, blockId);
+        return true;
+      }
+    });
   }
 
   /**

--- a/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
@@ -95,7 +95,8 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * @throws ThriftIOException if an I/O error occurs
    */
   @Override
-  public void cacheBlock(final long sessionId, final long blockId) throws AlluxioTException, ThriftIOException {
+  public void cacheBlock(final long sessionId, final long blockId)
+      throws AlluxioTException, ThriftIOException {
     RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
       @Override
       public Void call() throws AlluxioException, IOException {
@@ -162,6 +163,7 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
     return RpcUtils.call(new RpcCallableThrowsIOException<Boolean>() {
       @Override
       public Boolean call() throws AlluxioException, IOException {
+        // TODO(calvin): Make the top level configurable.
         mWorker.moveBlock(Sessions.MIGRATE_DATA_SESSION_ID, blockId, mStorageTierAssoc.getAlias(0));
         return true;
       }
@@ -188,6 +190,7 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
     return RpcUtils.call(new RpcCallableThrowsIOException<String>() {
       @Override
       public String call() throws AlluxioException, IOException {
+        // NOTE: right now, we ask allocator to allocate new blocks in top tier
         return mWorker.createBlock(sessionId, blockId, mStorageTierAssoc.getAlias(0), initialBytes);
       }
     });
@@ -223,7 +226,7 @@ public final class BlockWorkerClientServiceHandler implements BlockWorkerClientS
    * found or failed to delete the block
    * @throws AlluxioTException if an Alluxio error occurs
    */
-  // TODO(andrew): this should return void
+  // TODO(andrew): This should return void
   @Override
   public boolean unlockBlock(final long blockId, final long sessionId) throws AlluxioTException {
     return RpcUtils.call(new RpcCallable<Boolean>() {

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
@@ -13,6 +13,9 @@ package alluxio.master.keyvalue;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallable;
+import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.KeyValueMasterClientService;
@@ -46,73 +49,81 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   }
 
   @Override
-  public void completePartition(String path, PartitionInfo info) throws AlluxioTException {
-    try {
-      mKeyValueMaster.completePartition(new AlluxioURI(path), info);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void completePartition(final String path, final PartitionInfo info)
+      throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mKeyValueMaster.completePartition(new AlluxioURI(path), info);
+        return null;
+      }
+    });
   }
 
   @Override
-  public void createStore(String path) throws AlluxioTException {
-    try {
-      mKeyValueMaster.createStore(new AlluxioURI(path));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void createStore(final String path) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mKeyValueMaster.createStore(new AlluxioURI(path));
+        return null;
+      }
+    });
   }
 
   @Override
-  public void completeStore(String path) throws AlluxioTException {
-    try {
-      mKeyValueMaster.completeStore(new AlluxioURI(path));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public void completeStore(final String path) throws AlluxioTException {
+    RpcUtils.call(new RpcCallable<Void>() {
+      @Override
+      public Void call() throws AlluxioException {
+        mKeyValueMaster.completeStore(new AlluxioURI(path));
+        return null;
+      }
+    });
   }
 
   @Override
-  public List<PartitionInfo> getPartitionInfo(String path) throws AlluxioTException {
-    try {
-      return mKeyValueMaster.getPartitionInfo(new AlluxioURI(path));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    }
+  public List<PartitionInfo> getPartitionInfo(final String path) throws AlluxioTException {
+    return RpcUtils.call(new RpcCallable<List<PartitionInfo>>() {
+      @Override
+      public List<PartitionInfo> call() throws AlluxioException {
+        return mKeyValueMaster.getPartitionInfo(new AlluxioURI(path));
+      }
+    });
   }
 
   @Override
-  public void deleteStore(String path) throws AlluxioTException, ThriftIOException {
-    try {
-      mKeyValueMaster.deleteStore(new AlluxioURI(path));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+  public void deleteStore(final String path) throws AlluxioTException, ThriftIOException {
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mKeyValueMaster.deleteStore(new AlluxioURI(path));
+        return null;
+      }
+    });
   }
 
   @Override
-  public void renameStore(String oldPath, String newPath)
+  public void renameStore(final String oldPath, final String newPath)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mKeyValueMaster.renameStore(new AlluxioURI(oldPath), new AlluxioURI(newPath));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mKeyValueMaster.renameStore(new AlluxioURI(oldPath), new AlluxioURI(newPath));
+        return null;
+      }
+    });
   }
 
   @Override
-  public void mergeStore(String fromPath, String toPath)
+  public void mergeStore(final String fromPath, final String toPath)
       throws AlluxioTException, ThriftIOException {
-    try {
-      mKeyValueMaster.mergeStore(new AlluxioURI(fromPath), new AlluxioURI(toPath));
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    RpcUtils.call(new RpcCallableThrowsIOException<Void>() {
+      @Override
+      public Void call() throws AlluxioException, IOException {
+        mKeyValueMaster.mergeStore(new AlluxioURI(fromPath), new AlluxioURI(toPath));
+        return null;
+      }
+    });
   }
 }

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
@@ -12,6 +12,8 @@
 package alluxio.worker.keyvalue;
 
 import alluxio.Constants;
+import alluxio.RpcUtils;
+import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.Sessions;
 import alluxio.client.keyvalue.ByteBufferKeyValuePartitionReader;
 import alluxio.client.keyvalue.Index;
@@ -71,18 +73,18 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
    * @throws ThriftIOException if a non-Alluxio related exception occurs
    */
   @Override
-  public ByteBuffer get(long blockId, ByteBuffer key) throws AlluxioTException, ThriftIOException {
-    try {
-      ByteBuffer value = getInternal(blockId, key);
-      if (value == null) {
-        return ByteBuffer.allocate(0);
+  public ByteBuffer get(final long blockId, final ByteBuffer key)
+      throws AlluxioTException, ThriftIOException {
+    return RpcUtils.call(new RpcCallableThrowsIOException<ByteBuffer>() {
+      @Override
+      public ByteBuffer call() throws AlluxioException, IOException {
+        ByteBuffer value = getInternal(blockId, key);
+        if (value == null) {
+          return ByteBuffer.allocate(0);
+        }
+        return copyAsNonDirectBuffer(value);
       }
-      return copyAsNonDirectBuffer(value);
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    });
   }
 
   private ByteBuffer copyAsNonDirectBuffer(ByteBuffer directBuffer) {
@@ -125,59 +127,58 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
   }
 
   @Override
-  public List<ByteBuffer> getNextKeys(long blockId, ByteBuffer currentKey, int numKeys)
+  public List<ByteBuffer> getNextKeys(final long blockId, final ByteBuffer key, final int numKeys)
       throws AlluxioTException, ThriftIOException {
-    try {
-      final long sessionId = Sessions.KEYVALUE_SESSION_ID;
-      final long lockId = mBlockWorker.lockBlock(sessionId, blockId);
-      try {
-        ByteBufferKeyValuePartitionReader reader = getReader(sessionId, lockId, blockId);
-        Index index = reader.getIndex();
-        PayloadReader payloadReader = reader.getPayloadReader();
+    return RpcUtils.call(new RpcCallableThrowsIOException<List<ByteBuffer>>() {
+      @Override
+      public List<ByteBuffer> call() throws AlluxioException, IOException {
+        final long sessionId = Sessions.KEYVALUE_SESSION_ID;
+        final long lockId = mBlockWorker.lockBlock(sessionId, blockId);
+        try {
+          ByteBufferKeyValuePartitionReader reader = getReader(sessionId, lockId, blockId);
+          Index index = reader.getIndex();
+          PayloadReader payloadReader = reader.getPayloadReader();
 
-        List<ByteBuffer> ret = Lists.newArrayListWithExpectedSize(numKeys);
-        for (int i = 0; i < numKeys; i++) {
-          ByteBuffer nextKey = index.nextKey(currentKey, payloadReader);
-          if (nextKey == null) {
-            break;
+          List<ByteBuffer> ret = Lists.newArrayListWithExpectedSize(numKeys);
+          ByteBuffer currentKey = key;
+          for (int i = 0; i < numKeys; i++) {
+            ByteBuffer nextKey = index.nextKey(currentKey, payloadReader);
+            if (nextKey == null) {
+              break;
+            }
+            ret.add(copyAsNonDirectBuffer(nextKey));
+            currentKey = nextKey;
           }
-          ret.add(copyAsNonDirectBuffer(nextKey));
-          currentKey = nextKey;
+          return ret;
+        } catch (InvalidWorkerStateException e) {
+          // We shall never reach here
+          LOG.error("Reaching invalid state to get all keys", e);
+        } finally {
+          mBlockWorker.unlockBlock(lockId);
         }
-        return ret;
-      } catch (InvalidWorkerStateException e) {
-        // We shall never reach here
-        LOG.error("Reaching invalid state to get all keys", e);
-      } finally {
-        mBlockWorker.unlockBlock(lockId);
+        return Collections.emptyList();
       }
-      return Collections.emptyList();
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    });
   }
 
   // TODO(cc): Try to remove the duplicated try-catch logic in other methods like getNextKeys.
   @Override
-  public int getSize(long blockId) throws AlluxioTException, ThriftIOException {
-    try {
-      final long sessionId = Sessions.KEYVALUE_SESSION_ID;
-      final long lockId = mBlockWorker.lockBlock(sessionId, blockId);
-      try {
-        return getReader(sessionId, lockId, blockId).size();
-      } catch (InvalidWorkerStateException e) {
-        // We shall never reach here
-        LOG.error("Reaching invalid state to get size", e);
-      } finally {
-        mBlockWorker.unlockBlock(lockId);
+  public int getSize(final long blockId) throws AlluxioTException, ThriftIOException {
+    return RpcUtils.call(new RpcCallableThrowsIOException<Integer>() {
+      @Override
+      public Integer call() throws AlluxioException, IOException {
+        final long sessionId = Sessions.KEYVALUE_SESSION_ID;
+        final long lockId = mBlockWorker.lockBlock(sessionId, blockId);
+        try {
+          return getReader(sessionId, lockId, blockId).size();
+        } catch (InvalidWorkerStateException e) {
+          // We shall never reach here
+          LOG.error("Reaching invalid state to get size", e);
+        } finally {
+          mBlockWorker.unlockBlock(lockId);
+        }
+        return 0;
       }
-      return 0;
-    } catch (AlluxioException e) {
-      throw e.toAlluxioTException();
-    } catch (IOException e) {
-      throw new ThriftIOException(e.getMessage());
-    }
+    });
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1855

With server-side exceptions centralized, this PR also changes the handling so that runtime exceptions are converted to AlluxioExceptions. This is necessary because allowing these exceptions to propagate will cause the client to receive a Thrift exception and retry.