### PR TITLE
[SMALLFIX] Fix outdated configuration parameter in doc

### DIFF
--- a/docs/_data/table/cn/master-configuration.yml
+++ b/docs/_data/table/cn/master-configuration.yml
@@ -28,7 +28,7 @@ alluxio.master.port:
   Alluxio master的运行端口。
 alluxio.master.retry:
   client尝试与master相连的最大重试次数。
-alluxio.master.ttlchecker.interval.ms:
+alluxio.master.ttl.checker.interval.ms:
   清除过期ttl值的文件任务的时间间隔（单位：毫秒）。
 alluxio.master.web.bind.host:
   Alluxio master web UI绑定的主机名。参考<a href="#configure-multihomed-networks">多宿主网络</a>

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -35,7 +35,7 @@ alluxio.master.port:
   The port that Alluxio master node runs on.
 alluxio.master.retry:
   The number of retries that the client connects to master
-alluxio.master.ttlchecker.interval.ms:
+alluxio.master.ttl.checker.interval.ms:
   Time interval (in milliseconds) to periodically delete the files with expired ttl value.
 alluxio.master.web.bind.host:
   The hostname Alluxio master web UI binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>

--- a/docs/_data/table/master-configuration.csv
+++ b/docs/_data/table/master-configuration.csv
@@ -14,7 +14,7 @@ alluxio.master.lineage.recompute.interval.ms,600000
 alluxio.master.lineage.recompute.log.path,${alluxio.home}/logs/recompute.log
 alluxio.master.port,19998
 alluxio.master.retry,29
-alluxio.master.ttlchecker.interval.ms,3600000
+alluxio.master.ttl.checker.interval.ms,3600000
 alluxio.master.web.bind.host,0.0.0.0
 alluxio.master.web.hostname,localhost
 alluxio.master.web.port,19999


### PR DESCRIPTION
`alluxio.master.ttlchecker.interval.ms` has been renamed to `alluxio.master.ttl.checker.interval.ms`, but documentation is not updated.