### PR TITLE
[ALLUXIO-1856] When authorization is not turned on, changed the default permission to full permission

### DIFF
--- a/core/common/src/main/java/alluxio/security/authorization/FileSystemPermission.java
+++ b/core/common/src/main/java/alluxio/security/authorization/FileSystemPermission.java
@@ -190,6 +190,16 @@ public final class FileSystemPermission {
   }
 
   /**
+   * Gets the full permission for NOSASL authentication mode.
+   *
+   * @return the none {@link FileSystemPermission}
+   */
+  public static FileSystemPermission getFullFsPermission() {
+    return new FileSystemPermission(FileSystemAction.ALL, FileSystemAction.ALL,
+        FileSystemAction.ALL);
+  }
+
+  /**
    * Gets the file/directory creation umask.
    *
    * @param conf the runtime configuration of Alluxio

--- a/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
+++ b/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
@@ -90,7 +90,7 @@ public final class PermissionStatus {
    * @see FileSystemPermission#applyUMask(FileSystemPermission)
    */
   public PermissionStatus applyUMask(FileSystemPermission umask, Configuration configuration) {
-    if (!SecurityUtils.isSecurityEnabled(configuration)) {
+    if (!SecurityUtils.isAuthorizationEnabled(configuration)) {
       return new PermissionStatus(mUserName, mGroupName, mPermission);
     }
     FileSystemPermission newFileSystemPermission = mPermission.applyUMask(umask);

--- a/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
+++ b/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
@@ -85,10 +85,14 @@ public final class PermissionStatus {
    * Applies umask.
    *
    * @param umask the umask to apply
+   * @param Configuration the configuration
    * @return a new {@link PermissionStatus}
    * @see FileSystemPermission#applyUMask(FileSystemPermission)
    */
-  public PermissionStatus applyUMask(FileSystemPermission umask) {
+  public PermissionStatus applyUMask(FileSystemPermission umask, Configuration configuration) {
+    if (!SecurityUtils.isSecurityEnabled(configuration)) {
+      return new PermissionStatus(mUserName, mGroupName, mPermission);
+    }
     FileSystemPermission newFileSystemPermission = mPermission.applyUMask(umask);
     return new PermissionStatus(mUserName, mGroupName, newFileSystemPermission);
   }
@@ -117,7 +121,7 @@ public final class PermissionStatus {
    * @throws java.io.IOException when getting login user fails
    */
   public static PermissionStatus get(Configuration conf, boolean remote) throws IOException {
-    if (!SecurityUtils.isAuthenticationEnabled(conf)) {
+    if (!SecurityUtils.isSecurityEnabled(conf)) {
       // no authentication, every action is permitted
       return new PermissionStatus("", "", FileSystemPermission.getFullFsPermission());
     }

--- a/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
+++ b/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
@@ -85,7 +85,7 @@ public final class PermissionStatus {
    * Applies umask.
    *
    * @param umask the umask to apply
-   * @param Configuration the configuration
+   * @param configuration the configuration
    * @return a new {@link PermissionStatus}
    * @see FileSystemPermission#applyUMask(FileSystemPermission)
    */

--- a/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
+++ b/core/common/src/main/java/alluxio/security/authorization/PermissionStatus.java
@@ -118,8 +118,8 @@ public final class PermissionStatus {
    */
   public static PermissionStatus get(Configuration conf, boolean remote) throws IOException {
     if (!SecurityUtils.isAuthenticationEnabled(conf)) {
-      // no authentication
-      return new PermissionStatus("", "", FileSystemPermission.getNoneFsPermission());
+      // no authentication, every action is permitted
+      return new PermissionStatus("", "", FileSystemPermission.getFullFsPermission());
     }
     if (remote) {
       // get the username through the authentication mechanism

--- a/core/common/src/test/java/alluxio/security/authorization/PermissionStatusTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/PermissionStatusTest.java
@@ -67,7 +67,10 @@ public final class PermissionStatusTest {
     FileSystemPermission umaskPermission = new FileSystemPermission((short) 0022);
     PermissionStatus permissionStatus =
         new PermissionStatus("user1", "group1", FileSystemPermission.getDefault());
-    permissionStatus = permissionStatus.applyUMask(umaskPermission);
+    Configuration conf = new Configuration();
+    conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
+    permissionStatus = permissionStatus.applyUMask(umaskPermission, conf);
 
     Assert.assertEquals(FileSystemAction.ALL, permissionStatus.getPermission().getUserAction());
     Assert.assertEquals(FileSystemAction.READ_EXECUTE,
@@ -87,11 +90,13 @@ public final class PermissionStatusTest {
 
     // no authentication
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false");
     permissionStatus = PermissionStatus.get(conf, true);
-    verifyPermissionStatus("", "", (short) 0000, permissionStatus);
+    verifyPermissionStatus("", "", (short) 0777, permissionStatus);
 
     // authentication is enabled, and remote is true
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     AuthenticatedClientUser.set("test_client_user");
     conf.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
     permissionStatus = PermissionStatus.get(conf, true);
@@ -124,10 +129,11 @@ public final class PermissionStatusTest {
     // no authentication
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
     permissionStatus = PermissionStatus.get(conf, true);
-    verifyPermissionStatus("", "", (short) 0000, permissionStatus);
+    verifyPermissionStatus("", "", (short) 0777, permissionStatus);
 
     // authentication is enabled, and remote is true
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     AuthenticatedClientUser.set("test_client_user");
     permissionStatus = PermissionStatus.get(conf, true);
     verifyPermissionStatus("test_client_user", "group1", (short) 0755, permissionStatus);
@@ -159,10 +165,11 @@ public final class PermissionStatusTest {
     // no authentication
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
     permissionStatus = PermissionStatus.get(conf, true);
-    verifyPermissionStatus("", "", (short) 0000, permissionStatus);
+    verifyPermissionStatus("", "", (short) 0777, permissionStatus);
 
     // authentication is enabled, and remote is true
     conf.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+    conf.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     AuthenticatedClientUser.set("test_client_user");
     permissionStatus = PermissionStatus.get(conf, true);
     verifyPermissionStatus("test_client_user", "", (short) 0755, permissionStatus);

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.FileAlreadyCompletedException;
 import alluxio.exception.InvalidFileSizeException;
+import alluxio.master.MasterContext;
 import alluxio.master.block.BlockId;
 import alluxio.proto.journal.File.InodeFileEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
@@ -225,7 +226,7 @@ public final class InodeFile extends Inode<InodeFile> {
   @Override
   public InodeFile setPermissionStatus(PermissionStatus permissionStatus) {
     Preconditions.checkNotNull(permissionStatus, "Permission status is not set");
-    return super.setPermissionStatus(permissionStatus.applyUMask(UMASK));
+    return super.setPermissionStatus(permissionStatus.applyUMask(UMASK, MasterContext.getConf()));
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -36,6 +36,7 @@ import alluxio.master.journal.ReadWriteJournal;
 import alluxio.thrift.CommandType;
 import alluxio.thrift.FileSystemCommand;
 import alluxio.util.IdUtils;
+import alluxio.util.SecurityUtils;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -386,6 +387,18 @@ public final class FileSystemMasterTest {
     long fileId = mFileSystemMaster.create(NESTED_FILE_URI, sNestedFileOptions);
     Assert.assertFalse(mFileSystemMaster.isDirectory(fileId));
     Assert.assertTrue(mFileSystemMaster.isDirectory(mFileSystemMaster.getFileId(NESTED_URI)));
+  }
+
+  /**
+   * Tests both directories and files have full permissions when the security is not turned on.
+   */
+  @Test
+  public void permissionTest() throws Exception {
+    Assert.assertFalse(SecurityUtils.isAuthenticationEnabled(new Configuration()));
+    mFileSystemMaster.create(NESTED_URI, sNestedFileOptions);
+    Assert.assertEquals(0777, mFileSystemMaster.getFileInfo(NESTED_URI).getPermission());
+    mFileSystemMaster.create(NESTED_FILE_URI, sNestedFileOptions);
+    Assert.assertEquals(0666, mFileSystemMaster.getFileInfo(NESTED_FILE_URI).getPermission());
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -394,11 +394,10 @@ public final class FileSystemMasterTest {
    */
   @Test
   public void permissionTest() throws Exception {
-    Assert.assertFalse(SecurityUtils.isAuthenticationEnabled(new Configuration()));
-    mFileSystemMaster.create(NESTED_URI, sNestedFileOptions);
-    Assert.assertEquals(0777, mFileSystemMaster.getFileInfo(NESTED_URI).getPermission());
+    Assert.assertFalse(SecurityUtils.isSecurityEnabled(new Configuration()));
     mFileSystemMaster.create(NESTED_FILE_URI, sNestedFileOptions);
-    Assert.assertEquals(0666, mFileSystemMaster.getFileInfo(NESTED_FILE_URI).getPermission());
+    Assert.assertEquals(0777, mFileSystemMaster.getFileInfo(NESTED_URI).getPermission());
+    Assert.assertEquals(0777, mFileSystemMaster.getFileInfo(NESTED_FILE_URI).getPermission());
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
@@ -26,7 +26,7 @@ public abstract class AbstractInodeTest {
   public static final String TEST_GROUP_NAME = "group1";
 
   private static PermissionStatus sPermissionStatus =
-      new PermissionStatus(TEST_USER_NAME, TEST_GROUP_NAME, (short) 0755);
+      new PermissionStatus(TEST_USER_NAME, TEST_GROUP_NAME, (short) 0777);
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -233,7 +233,7 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
     InodeDirectory inode2 = createInodeDirectory();
     Assert.assertEquals(AbstractInodeTest.TEST_USER_NAME, inode2.getUserName());
     Assert.assertEquals(AbstractInodeTest.TEST_GROUP_NAME, inode2.getGroupName());
-    Assert.assertEquals((short) 0755, inode2.getPermission());
+    Assert.assertEquals((short) 0777, inode2.getPermission());
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeFileTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeFileTest.java
@@ -150,6 +150,6 @@ public final class InodeFileTest extends AbstractInodeTest {
     InodeFile inode1 = createInodeFile(1);
     Assert.assertEquals(AbstractInodeTest.TEST_USER_NAME, inode1.getUserName());
     Assert.assertEquals(AbstractInodeTest.TEST_GROUP_NAME, inode1.getGroupName());
-    Assert.assertEquals((short) 0644, inode1.getPermission());
+    Assert.assertEquals((short) 0777, inode1.getPermission());
   }
 }

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -324,7 +324,8 @@ public class FileSystemMasterIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource(1000, Constants.GB,
-          Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+          Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName(),
+          Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
   private Configuration mMasterConfiguration;
   private FileSystemMaster mFsMaster;
 

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -134,6 +134,7 @@ public class FileSystemMasterIntegrationTest {
 
     @Override
     public Void call() throws Exception {
+      AuthenticatedClientUser.set(TEST_AUTHENTICATE_USER);
       exec(mDepth, mConcurrencyDepth, mInitPath);
       return null;
     }
@@ -191,6 +192,7 @@ public class FileSystemMasterIntegrationTest {
 
     @Override
     public Void call() throws Exception {
+      AuthenticatedClientUser.set(TEST_AUTHENTICATE_USER);
       exec(mDepth, mConcurrencyDepth, mInitPath);
       return null;
     }
@@ -759,6 +761,8 @@ public class FileSystemMasterIntegrationTest {
     Assert.assertEquals(ttl, folderInfo.getTtl());
   }
 
+  @LocalAlluxioClusterResource.Config(
+      confParams = {Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false"})
   @Test
   public void ttlExpiredCreateFileTest() throws Exception {
     mFsMaster.mkdir(new AlluxioURI("/testFolder"), CreateDirectoryOptions.defaults());


### PR DESCRIPTION
By default the security and authorization is not turned on. However, the permission on inodes by default was set to no permission. This is problematic when permission info is fetched by listStatus. The default permission should be full permission.