### PR TITLE
 [ALLUXIO-1857] Fixes to the dependencies in the pom.xml of underfs swift

### DIFF
--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -30,8 +30,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
@@ -39,36 +39,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-openstack</artifactId>
-      <version>${hadoop-openstack.version}</version>
-
-      <!-- Exclude the jsp/servlet related dependencies to avoid troubles in web test -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jsp-2.1</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>tomcat</groupId>
-          <artifactId>jasper-runtime</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>tomcat</groupId>
-          <artifactId>jasper-compiler</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet.jsp</groupId>
-          <artifactId>jsp-api</artifactId>
-        </exclusion>
-      </exclusions>
-
-    </dependency>
-     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
@@ -81,7 +51,13 @@
     <dependency>
       <groupId>org.javaswift</groupId>
       <artifactId>joss</artifactId>
-      <version>0.9.8</version>
+      <version>0.9.10</version>
+      <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
Swift underfs contains wrong entries in the pom.xml.
It still points to hadoop modules, which are not needed anymore.
In addition joss updated to recent version.