### PR TITLE
[ALLUXIO-1859] temporary file name may contain space. It should be UR…

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -21,6 +21,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FilenameUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -187,7 +189,12 @@ public final class PathUtils {
    * @return a deterministic temporary file name
    */
   public static String temporaryFileName(long nonce, String path) {
-    return path + ".alluxio." + String.format("0x%16X", nonce) + ".tmp";
+    try {
+      return path + ".alluxio." + URLEncoder.encode(String.format("0x%16X", nonce),
+          "UTF-8") + ".tmp";
+    } catch (UnsupportedEncodingException e) {
+      return path + ".alluxio." + String.format("0x%16X", nonce) + ".tmp";
+    }
   }
 
   /**


### PR DESCRIPTION
Object temp name may contain spaces. It might be an issue in the object store.
I think this name should be url encoded.
