### PR TITLE
[SMALLFIX] Use Files.delete instead of writing our own util method

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -117,22 +117,6 @@ public final class FileUtils {
   }
 
   /**
-   * Deletes the file or directory.
-   *
-   * Current implementation uses {@link java.io.File#delete()}, may change if there is a better
-   * solution.
-   *
-   * @param path pathname string of file or directory
-   * @throws IOException when fails to delete
-   */
-  public static void delete(String path) throws IOException {
-    File file = new File(path);
-    if (!file.delete()) {
-      throw new IOException("Failed to delete " + path);
-    }
-  }
-
-  /**
    * Creates the storage directory path, including any necessary but nonexistent parent directories.
    * If the directory already exists, do nothing.
    *

--- a/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
@@ -130,37 +130,6 @@ public class FileUtilsTest {
   }
 
   /**
-   * Tests the {@link FileUtils#delete(String)} method when trying to delete a file and a directory.
-   *
-   * @throws IOException thrown if a non-Alluxio related exception occurs
-   */
-  @Test
-  public void deleteFileTest() throws IOException {
-    File tempFile = mTestFolder.newFile("fileToDelete");
-    File tempFolder = mTestFolder.newFolder("dirToDelete");
-    // Delete a file and a directory
-    FileUtils.delete(tempFile.getAbsolutePath());
-    FileUtils.delete(tempFolder.getAbsolutePath());
-    Assert.assertFalse(tempFile.exists());
-    Assert.assertFalse(tempFolder.exists());
-  }
-
-  /**
-   * Tests the {@link FileUtils#delete(String)} method to throw an exception when trying to delete a
-   * non-existent file.
-   *
-   * @throws IOException thrown if a non-Alluxio related exception occurs
-   */
-  @Test
-  public void deleteNonExistentFileTest() throws IOException {
-    // ghostFile is never created, so deleting should fail
-    File ghostFile = new File(mTestFolder.getRoot(), "ghost.txt");
-    mException.expect(IOException.class);
-    FileUtils.delete(ghostFile.getAbsolutePath());
-    Assert.fail("deleting a non-existent file should have failed");
-  }
-
-  /**
    * Tests the {@link FileUtils#setLocalDirStickyBit(String)} method.
    *
    * @throws IOException thrown if a non-Alluxio related exception occurs

--- a/core/server/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -45,6 +45,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -372,7 +374,7 @@ public final class TieredBlockStore implements BlockStore {
         String sessionFolderPath = PathUtils.concatPath(dir.getDirPath(), sessionId);
         try {
           if (new File(sessionFolderPath).exists()) {
-            FileUtils.delete(sessionFolderPath);
+            Files.delete(Paths.get(sessionFolderPath));
           }
         } catch (IOException e) {
           // This error means we could not delete the directory but should not affect the
@@ -473,7 +475,7 @@ public final class TieredBlockStore implements BlockStore {
       }
 
       // Heavy IO is guarded by block lock but not metadata lock. This may throw IOException.
-      FileUtils.delete(path);
+      Files.delete(Paths.get(path));
 
       mMetadataWriteLock.lock();
       try {
@@ -853,7 +855,7 @@ public final class TieredBlockStore implements BlockStore {
             location);
       }
       // Heavy IO is guarded by block lock but not metadata lock. This may throw IOException.
-      FileUtils.delete(filePath);
+      Files.delete(Paths.get(filePath));
 
       mMetadataWriteLock.lock();
       try {


### PR DESCRIPTION
One particular advantage of doing this is that we will now get more descriptive delete error messages instead of just "Failed to delete blah".