### PR TITLE
[SMALLFIX] fixing encoding of strings in REST API endpoints

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -196,8 +196,6 @@ public final class CommonUtils {
     return ctor.newInstance(ctorArgs);
   }
 
-  private CommonUtils() {} // prevent instantiation
-
   /**
    * Gets the current user's group list from Unix by running the command 'groups' NOTE. For
    * non-existing user it will return EMPTY list. This method may return duplicate groups.
@@ -238,4 +236,6 @@ public final class CommonUtils {
     List<String> groups = groupMappingService.getGroups(userName);
     return (groups != null && groups.size() > 0) ? groups.get(0) : "";
   }
+
+  private CommonUtils() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/util/FormatUtils.java
+++ b/core/common/src/main/java/alluxio/util/FormatUtils.java
@@ -14,6 +14,8 @@ package alluxio.util;
 import alluxio.Constants;
 import alluxio.security.authorization.FileSystemPermission;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Locale;
@@ -200,6 +202,16 @@ public final class FormatUtils {
     }
     permissionStr.append(new FileSystemPermission(permission).toString());
     return permissionStr.toString();
+  }
+
+  /**
+   * Encodes the given string as a JSON object.
+   *
+   * @param input the string to encode
+   * @return the JSON-encoded version of the input string
+   */
+  public static String encodeJson(String input) {
+    return "\"" + StringEscapeUtils.escapeJson(input) + "\"";
   }
 
   private FormatUtils() {} // prevent instantiation

--- a/core/server/src/main/java/alluxio/master/AlluxioMasterRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/AlluxioMasterRestServiceHandler.java
@@ -18,6 +18,7 @@ import alluxio.Version;
 import alluxio.master.block.BlockMaster;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
+import alluxio.util.FormatUtils;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -101,7 +102,8 @@ public final class AlluxioMasterRestServiceHandler {
   @Path(GET_RPC_ADDRESS)
   @ReturnType("java.lang.String")
   public Response getRpcAddress() {
-    return Response.ok(mMaster.getMasterAddress().toString()).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(mMaster.getMasterAddress().toString())).build();
   }
 
   /**
@@ -165,7 +167,8 @@ public final class AlluxioMasterRestServiceHandler {
   @Path(GET_VERSION)
   @ReturnType("java.lang.String")
   public Response getVersion() {
-    return Response.ok(Version.VERSION).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Version.VERSION)).build();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
@@ -14,6 +14,7 @@ package alluxio.master.block;
 import alluxio.Constants;
 import alluxio.exception.AlluxioException;
 import alluxio.master.AlluxioMaster;
+import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
 import com.qmino.miredot.annotations.ReturnType;
@@ -52,7 +53,8 @@ public final class BlockMasterClientRestServiceHandler {
   @Path(SERVICE_NAME)
   @ReturnType("java.lang.String")
   public Response getServiceName() {
-    return Response.ok(Constants.BLOCK_MASTER_CLIENT_SERVICE_NAME).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Constants.BLOCK_MASTER_CLIENT_SERVICE_NAME)).build();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
@@ -20,6 +20,7 @@ import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
 import alluxio.master.file.options.MountOptions;
 import alluxio.master.file.options.SetAttributeOptions;
+import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
 import com.qmino.miredot.annotations.ReturnType;
@@ -77,8 +78,10 @@ public final class FileSystemMasterClientRestServiceHandler {
   @GET
   @Path(SERVICE_NAME)
   @ReturnType("java.lang.String")
-  public Response name() {
-    return Response.ok(Constants.FILE_SYSTEM_MASTER_CLIENT_SERVICE_NAME).build();
+  public Response getServiceName() {
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Constants.FILE_SYSTEM_MASTER_CLIENT_SERVICE_NAME))
+        .build();
   }
 
   /**
@@ -88,7 +91,7 @@ public final class FileSystemMasterClientRestServiceHandler {
   @GET
   @Path(SERVICE_VERSION)
   @ReturnType("java.lang.Long")
-  public Response version() {
+  public Response getServiceVersion() {
     return Response.ok(Constants.FILE_SYSTEM_MASTER_CLIENT_SERVICE_VERSION).build();
   }
 
@@ -270,7 +273,8 @@ public final class FileSystemMasterClientRestServiceHandler {
   @Path(GET_UFS_ADDRESS)
   @ReturnType("java.lang.String")
   public Response getUfsAddress() {
-    return Response.ok(mFileSystemMaster.getUfsAddress()).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(mFileSystemMaster.getUfsAddress())).build();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMasterClientRestServiceHandler.java
@@ -17,6 +17,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.job.CommandLineJob;
 import alluxio.job.JobConf;
 import alluxio.master.AlluxioMaster;
+import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -63,8 +64,10 @@ public final class LineageMasterClientRestServiceHandler {
   @GET
   @Path(SERVICE_NAME)
   @ReturnType("java.lang.String")
-  public Response name() {
-    return Response.ok(Constants.LINEAGE_MASTER_CLIENT_SERVICE_NAME).build();
+  public Response getServiceName() {
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Constants.LINEAGE_MASTER_CLIENT_SERVICE_NAME))
+        .build();
   }
 
   /**
@@ -74,7 +77,7 @@ public final class LineageMasterClientRestServiceHandler {
   @GET
   @Path(SERVICE_VERSION)
   @ReturnType("java.lang.Long")
-  public Response version() {
+  public Response getServiceVersion() {
     return Response.ok(Constants.LINEAGE_MASTER_CLIENT_SERVICE_VERSION).build();
   }
 

--- a/core/server/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -14,6 +14,7 @@ package alluxio.worker;
 import alluxio.Version;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.util.CommonUtils;
+import alluxio.util.FormatUtils;
 import alluxio.worker.block.BlockStoreMeta;
 
 import com.codahale.metrics.Counter;
@@ -64,7 +65,8 @@ public final class AlluxioWorkerRestServiceHandler {
   @Path(GET_RPC_ADDRESS)
   @ReturnType("java.lang.String")
   public Response getRpcAddress() {
-    return Response.ok(mWorker.getWorkerAddress().toString()).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(mWorker.getWorkerAddress().toString())).build();
   }
 
   /**
@@ -162,7 +164,8 @@ public final class AlluxioWorkerRestServiceHandler {
   @Path(GET_VERSION)
   @ReturnType("java.lang.String")
   public Response getVersion() {
-    return Response.ok(Version.VERSION).build();
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Version.VERSION)).build();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientRestServiceHandler.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockWorkerClientRestServiceHandler.java
@@ -16,6 +16,7 @@ import alluxio.Sessions;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.exception.AlluxioException;
+import alluxio.util.FormatUtils;
 import alluxio.wire.LockBlockResult;
 import alluxio.worker.AlluxioWorker;
 import alluxio.worker.WorkerContext;
@@ -75,8 +76,9 @@ public final class BlockWorkerClientRestServiceHandler {
   @Path(SERVICE_NAME)
   @Produces(MediaType.APPLICATION_JSON)
   @ReturnType("java.lang.String")
-  public Response name() {
-    return Response.ok(Constants.BLOCK_WORKER_CLIENT_SERVICE_NAME).build();
+  public Response getServiceName() {
+    // Need to encode the string as JSON because Jackson will not do it automatically.
+    return Response.ok(FormatUtils.encodeJson(Constants.BLOCK_WORKER_CLIENT_SERVICE_NAME)).build();
   }
 
   /**
@@ -87,7 +89,7 @@ public final class BlockWorkerClientRestServiceHandler {
   @Path(SERVICE_VERSION)
   @Produces(MediaType.APPLICATION_JSON)
   @ReturnType("java.lang.Long")
-  public Response version() {
+  public Response getServiceVersion() {
     return Response.ok(Constants.BLOCK_WORKER_CLIENT_SERVICE_VERSION).build();
   }
 
@@ -294,8 +296,9 @@ public final class BlockWorkerClientRestServiceHandler {
       Preconditions.checkNotNull(blockId, "required 'blockId' parameter is missing");
       Preconditions.checkNotNull(sessionId, "required 'sessionId' parameter is missing");
       Preconditions.checkNotNull(initialBytes, "required 'initialBytes' parameter is missing");
-      return Response.ok(mBlockWorker
-          .createBlock(sessionId, blockId, mStorageTierAssoc.getAlias(0), initialBytes)).build();
+      // Need to encode the string as JSON because Jackson will not do it automatically.
+      return Response.ok(FormatUtils.encodeJson(mBlockWorker
+          .createBlock(sessionId, blockId, mStorageTierAssoc.getAlias(0), initialBytes))).build();
     } catch (AlluxioException | IOException | NullPointerException e) {
       LOG.warn(e.getMessage());
       return Response.serverError().entity(e.getMessage()).build();

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.0</version>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.mesos</groupId>

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterClientRestApiTest.java
@@ -91,7 +91,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.COMPLETE_FILE),
-            params, "POST", "", mResource).run();
+            params, "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster)
         .completeFile(Mockito.<AlluxioURI>any(), Mockito.<CompleteFileOptions>any());
@@ -107,7 +107,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.CREATE_DIRECTORY),
-            params, "POST", "", mResource).run();
+            params, "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster)
         .mkdir(Mockito.<AlluxioURI>any(), Mockito.<CreateDirectoryOptions>any());
@@ -124,7 +124,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.CREATE_FILE),
-            params, "POST", "", mResource).run();
+            params, "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster)
         .create(Mockito.<AlluxioURI>any(), Mockito.<CreateFileOptions>any());
@@ -218,7 +218,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.FREE), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster).free(Mockito.<AlluxioURI>any(), Mockito.anyBoolean());
   }
@@ -269,7 +269,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.MOUNT), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster)
         .mount(Mockito.<AlluxioURI>any(), Mockito.<AlluxioURI>any(), Mockito.<MountOptions>any());
@@ -283,7 +283,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.REMOVE), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster).deleteFile(Mockito.<AlluxioURI>any(), Mockito.anyBoolean());
   }
@@ -296,7 +296,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.RENAME), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster).rename(Mockito.<AlluxioURI>any(), Mockito.<AlluxioURI>any());
   }
@@ -332,7 +332,7 @@ public class FileSystemMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(FileSystemMasterClientRestServiceHandler.SET_ATTRIBUTE),
-            params, "POST", "", mResource).run();
+            params, "POST", null, mResource).run();
 
     Mockito.verify(sFileSystemMaster)
         .setAttribute(Mockito.<AlluxioURI>any(), Mockito.<SetAttributeOptions>any());

--- a/tests/src/test/java/alluxio/master/lineage/LineageMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/lineage/LineageMasterClientRestApiTest.java
@@ -161,7 +161,7 @@ public class LineageMasterClientRestApiTest {
 
     TestCaseFactory
         .newMasterTestCase(getEndpoint(LineageMasterClientRestServiceHandler.REPORT_LOST_FILE),
-            params, "POST", "", mResource).run();
+            params, "POST", null, mResource).run();
 
     Mockito.verify(sLineageMaster).reportLostFile(Mockito.anyString());
   }

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -114,9 +114,11 @@ public class TestCase {
     connection.connect();
     Assert
         .assertEquals(mEndpoint, Response.Status.OK.getStatusCode(), connection.getResponseCode());
-    ObjectMapper mapper = new ObjectMapper();
-    String expected = mapper.writeValueAsString(mExpectedResult);
-    expected = expected.replaceAll("^\"|\"$", ""); // needed to handle string return values
+    String expected = "";
+    if (mExpectedResult != null) {
+      ObjectMapper mapper = new ObjectMapper();
+      expected = mapper.writeValueAsString(mExpectedResult);
+    }
     Assert.assertEquals(mEndpoint, expected, getResponse(connection));
   }
 }

--- a/tests/src/test/java/alluxio/rest/TestCaseFactory.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseFactory.java
@@ -28,7 +28,7 @@ public class TestCaseFactory {
    * @param suffix the suffix to use
    * @param parameters the parameters to use
    * @param method the method to use
-   * @param expectedResult the expected result to use
+   * @param expectedResult the expected result to use; null implies empty response
    * @param resource the local Alluxio cluster resource
    * @return a REST API test case
    */
@@ -44,7 +44,7 @@ public class TestCaseFactory {
    * @param suffix the suffix to use
    * @param parameters the parameters to use
    * @param method the method to use
-   * @param expectedResult the expected result to use
+   * @param expectedResult the expected result to use; null implies empty response
    * @param resource the local Alluxio cluster resource
    * @return a REST API test case
    */

--- a/tests/src/test/java/alluxio/worker/block/BlockWorkerClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/worker/block/BlockWorkerClientRestApiTest.java
@@ -89,7 +89,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.ACCESS_BLOCK), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker).accessBlock(Mockito.anyLong(), Mockito.anyLong());
   }
@@ -101,7 +101,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.ASYNC_CHECKPOINT),
-            params, "POST", "false", mResource).run();
+            params, "POST", false, mResource).run();
   }
 
   @Test
@@ -112,7 +112,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.CACHE_BLOCK), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker).commitBlock(Mockito.anyLong(), Mockito.anyLong());
   }
@@ -125,7 +125,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.CANCEL_BLOCK), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker).abortBlock(Mockito.anyLong(), Mockito.anyLong());
   }
@@ -157,7 +157,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.PROMOTE_BLOCK), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker)
         .moveBlock(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString());
@@ -226,7 +226,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.REQUEST_SPACE), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker)
         .requestSpace(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
@@ -240,7 +240,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.UNLOCK_BLOCK), params,
-            "POST", "", mResource).run();
+            "POST", null, mResource).run();
 
     Mockito.verify(sBlockWorker).unlockBlock(Mockito.anyLong(), Mockito.anyLong());
 
@@ -263,7 +263,7 @@ public class BlockWorkerClientRestApiTest {
 
     TestCase testCase = TestCaseFactory
         .newWorkerTestCase(getEndpoint(BlockWorkerClientRestServiceHandler.WRITE_BLOCK), params,
-            "POST", "", mResource);
+            "POST", null, mResource);
 
     HttpURLConnection connection = (HttpURLConnection) testCase.createURL().openConnection();
     connection.setRequestProperty("Content-Type", MediaType.APPLICATION_OCTET_STREAM);


### PR DESCRIPTION
This PR works around a limitation in the Jackson framework, which fails to properly encode String return values as JSON.