### PR TITLE
[ALLUXIO-1871] Improve Alluxio scripts for non-sudo deployment

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -208,9 +208,6 @@ function mount_local() {
 }
 
 case "${1}" in
-  NoMount)
-    if [[ $(uname -a) == Darwin* ]]; then
-      # Assuming Max OS X
   Mount|SudoMount)
     case "${2}" in
       ""|local)

--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -208,6 +208,9 @@ function mount_local() {
 }
 
 case "${1}" in
+  NoMount)
+    if [[ $(uname -a) == Darwin* ]]; then
+      # Assuming Max OS X
   Mount|SudoMount)
     case "${2}" in
       ""|local)

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -79,6 +79,22 @@ do_mount() {
   esac
 }
 
+check_local_mode() {
+  if [[ "$1" = "NoMount" ]]; then
+    if [[ $(uname -s) == Darwin ]]; then
+      echo "Local mode without mounting is only supported in Linux now."
+      echo -e "${USAGE}"
+      exit 1
+    fi
+    if [[ ${ALLUXIO_RAM_FOLDER} != "/dev/shm" || ${ALLUXIO_RAM_FOLDER} != "/dev/shm/" ]]; then
+      echo "WARNING: ALLUXIO_RAM_FOLDER is not set to /dev/shm in NoMount local mode."
+      echo "Use Mount mode if use ramfs."
+      echo -e "${USAGE}"
+      exit 1
+    fi
+  fi
+}
+
 stop() {
   ${BIN}/alluxio-stop.sh all
 }
@@ -208,6 +224,7 @@ case "${WHAT}" in
     ${LAUNCHER} ${BIN}/alluxio-workers.sh ${BIN}/alluxio-start.sh worker $2
     ;;
   local)
+    check_local_mode $2
     if [[ "${killonstart}" != "no" ]]; then
       stop ${BIN}
       sleep 1

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -215,7 +215,7 @@ case "${WHAT}" in
     if [[ $2 != "NoMount" ]]; then
       ${LAUNCHER} ${BIN}/alluxio-mount.sh SudoMount
       stat=$?
-      if [[ ${stat} -ne 0 ]]; the
+      if [[ ${stat} -ne 0 ]]; then
         echo "Mount failed, not starting"
         exit 1
       fi

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -56,6 +56,7 @@ check_mount_mode() {
         if [[ $( uname -a) == Darwin* ]]; then
           # Assuming Max OS X
           echo "ERROR: tmpFS is only enabled in Linux."
+          echo -e "${USAGE}"
           exit 1
         fi
         echo "Warning: Alluxio is running on tmpfs that supports swapping."

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -60,7 +60,7 @@ check_mount_mode() {
           exit 1
         else
           echo "WARNING: Overriding ALLUXIO_RAM_FOLDER to /dev/shm to use tmpFS now."
-          ALLUXIO_RAM_FOLDER="dev/shm"
+          export ALLUXIO_RAM_FOLDER="/dev/shm"
         fi
       fi
       if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -23,8 +23,8 @@ Where WHAT is one of:
 MOPT is one of:
   Mount\t\t\tMount the configured RamFS. Notice: this will format the existing RamFS.
   SudoMount\t\tMount the configured RamFS using sudo. Notice: this will format the existing RamFS.
-  NoMount\t\tDo not mount the configured RamFS. Notice: Use NoMount and set ALLUXIO_RAM_FOLDER to
-  /dev/shm to use tmpFS to avoid sudo requirement.
+  NoMount\t\tDo not mount the configured RamFS. Notice: Use NoMount (Linux only) to use tmpFS
+  to avoid sudo requirement.
 
 -f  format Journal, UnderFS Data and Workers Folder on master
 

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -53,13 +53,13 @@ check_mount_mode() {
     SudoMount);;
     NoMount)
       if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
-        echo "Warning: Alluxio is running on tmpfs that supports swapping."
-        echo "Warning: Check vmstat if Alluxio is slow."
         if [[ $( uname -a) == Darwin* ]]; then
           # Assuming Max OS X
           echo "ERROR: tmpFS is only enabled in Linux."
           exit 1
         fi
+        echo "Warning: Alluxio is running on tmpfs that supports swapping."
+        echo "Warning: Check vmstat if Alluxio is slow."
       else
         echo "WARNING: using NoMount but ALLUXIO_RAM_FOLDER is not set to /dev/shm."
       fi

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -65,7 +65,7 @@ check_mount_mode() {
       fi
       if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
         echo "WARNING: Using tmpFS which is not guaranteed to be in memory."
-        echo "WARNING: Check vimstat for memory statistics (e.g. swapping)."
+        echo "WARNING: Check vmstat for memory statistics (e.g. swapping)."
       fi
     ;;
     *)

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -47,6 +47,7 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 }
 
+# Called when ${MOPT}=NoMount
 check_tmpfs_mode() {
   if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
     echo "Warning: Alluxio is running on tmpfs that supports swapping."
@@ -66,7 +67,7 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-    check_tmpfs_mode
+      check_tmpfs_mode
     ;;
     *)
       if [[ -z $1 ]]; then

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -64,7 +64,7 @@ check_mount_mode() {
         fi
       fi
       if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
-        echo "WARNING: using tmpFS which is not guaranteed to be in memory."
+        echo "WARNING: Using tmpFS which is not guaranteed to be in memory."
         echo "WARNING: Check vimstat for memory statistics (e.g. swapping)."
       fi
     ;;

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -212,12 +212,6 @@ case "${WHAT}" in
       stop ${BIN}
       sleep 1
     fi
-    ${LAUNCHER} ${BIN}/alluxio-mount.sh SudoMount
-    stat=$?
-    if [[ ${stat} -ne 0 ]]; then
-      echo "Mount failed, not starting"
-      exit 1
-    fi
     if [ ! -z $2 ] && [ $2 != "-f" ]; then
       echo -e "${USAGE}"
       exit 1

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -47,27 +47,22 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 }
 
-# Called when ${MOPT}=NoMount
-check_nomount_mode() {
-  if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
-    echo "Warning: Alluxio is running on tmpfs that supports swapping."
-    echo "Warning: Check vmstat if Alluxio is slow."
-    if [[ $( uname -a) == Darwin* ]]; then
-      # Assuming Max OS X
-      echo "ERROR: tmpFS is only enabled in Linux."
-      exit 1
-    fi
-  else
-    echo "WARNING: using NoMount but ALLUXIO_RAM_FOLDER is not set to /dev/shm."
-  fi
-}
-
 check_mount_mode() {
   case "$1" in
     Mount);;
     SudoMount);;
     NoMount)
-      check_nomount_mode
+      if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
+        echo "Warning: Alluxio is running on tmpfs that supports swapping."
+        echo "Warning: Check vmstat if Alluxio is slow."
+        if [[ $( uname -a) == Darwin* ]]; then
+          # Assuming Max OS X
+          echo "ERROR: tmpFS is only enabled in Linux."
+          exit 1
+        fi
+      else
+        echo "WARNING: using NoMount but ALLUXIO_RAM_FOLDER is not set to /dev/shm."
+      fi
     ;;
     *)
       if [[ -z $1 ]]; then

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -87,11 +87,12 @@ check_local_mode() {
       exit 1
     fi
     if [[ ${ALLUXIO_RAM_FOLDER} != "/dev/shm" || ${ALLUXIO_RAM_FOLDER} != "/dev/shm/" ]]; then
-      echo "WARNING: ALLUXIO_RAM_FOLDER is not set to /dev/shm in NoMount local mode."
-      echo "Use Mount mode if use ramfs."
+      echo "ERROR: ALLUXIO_RAM_FOLDER is not set to /dev/shm in NoMount local mode."
       echo -e "${USAGE}"
       exit 1
     fi
+    echo "Warning: Alluxio is running on tmpfs that supports swapping."
+    echo "Check swap stats via vmstat first if Alluxio is slow."
   fi
 }
 

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -55,7 +55,7 @@ check_mount_mode() {
       if ! mount | grep ${ALLUXIO_RAM_FOLDER} > /dev/null; then
         if [[ $( uname -a) == Darwin* ]]; then
           # Assuming Mac OS X
-          echo "ERROR: mount mode is required."
+          echo "ERROR: NoMount is not supported in Mac OS X."
           echo -e "${USAGE}"
           exit 1
         else

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -212,6 +212,16 @@ case "${WHAT}" in
       stop ${BIN}
       sleep 1
     fi
+    if [[ $2 != "NoMount" ]]; then
+      ${LAUNCHER} ${BIN}/alluxio-mount.sh SudoMount
+      stat=$?
+      if [[ ${stat} -ne 0 ]]; the
+        echo "Mount failed, not starting"
+        exit 1
+      fi
+    else
+      shift
+    fi
     if [ ! -z $2 ] && [ $2 != "-f" ]; then
       echo -e "${USAGE}"
       exit 1

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,7 +52,7 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      if ! mount | grep ${ALLUXIO_RAM_FOLDER} > /dev/null; then
+      if ! mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null; then
         if [[ $( uname -s) == Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported in Mac OS X."

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -66,11 +66,9 @@ check_mount_mode() {
 do_mount() {
   MOUNT_FAILED=0
   case "$1" in
-    Mount|SudoMount)
+    Mount|SudoMount|NoMount)
       ${LAUNCHER} ${BIN}/alluxio-mount.sh $1
       MOUNT_FAILED=$?
-      ;;
-    NoMount)
       ;;
     *)
       echo "This command requires a mount mode be specified"

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -48,7 +48,7 @@ get_env() {
 }
 
 # Called when ${MOPT}=NoMount
-check_tmpfs_mode() {
+check_nomount_mode() {
   if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
     echo "Warning: Alluxio is running on tmpfs that supports swapping."
     echo "Warning: Check vmstat if Alluxio is slow."
@@ -67,7 +67,7 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      check_tmpfs_mode
+      check_nomount_mode
     ;;
     *)
       if [[ -z $1 ]]; then

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -87,7 +87,7 @@ check_local_mode() {
       exit 1
     fi
     if [[ ${ALLUXIO_RAM_FOLDER} != "/dev/shm" || ${ALLUXIO_RAM_FOLDER} != "/dev/shm/" ]]; then
-      echo "Warning: ALLUXIO_RAM_FOLDER is not set to /dev/shm in NoMount local mode."
+      echo "Warning: ALLUXIO_RAM_FOLDER is not set to /dev/shm in local NoMount mode."
       echo "Warning: Overriding ALLUXIO_RAM_FOLDER to /dev/shm."
       export ALLUXIO_RAM_FOLDER="/dev/shm/"
     fi

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -53,7 +53,7 @@ check_mount_mode() {
     SudoMount);;
     NoMount)
       if ! mount | grep ${ALLUXIO_RAM_FOLDER} > /dev/null; then
-        if [[ $( uname -a) == Darwin* ]]; then
+        if [[ $( uname -s) == Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported in Mac OS X."
           echo -e "${USAGE}"
@@ -208,7 +208,6 @@ if [[ -z "${WHAT}" ]]; then
 fi
 shift
 
-
 MOPT=$1
 # Set MOPT.
 case "${WHAT}" in
@@ -229,24 +228,26 @@ case "${WHAT}" in
     ;;
 esac
 
+FORMAT=$1
+if [ ! -z ${FORMAT} ] && [ ${FORMAT} != "-f" ]; then
+  echo -e "${USAGE}"
+  exit 1
+fi
+
 # get environment
 get_env
 
 # ensure log/data dirs
 ensure_dirs
 
-if [ ! -z $1 ] && [ $1 != "-f" ]; then
-  echo -e "${USAGE}"
-  exit 1
-fi
-
 case "${WHAT}" in
   all)
     if [[ "${killonstart}" != "no" ]]; then
       stop ${BIN}
     fi
-    start_master $1
+    start_master ${FORMAT}
     sleep 2
+
     ${LAUNCHER} ${BIN}/alluxio-workers.sh ${BIN}/alluxio-start.sh worker ${MOPT}
     ;;
   local)
@@ -254,15 +255,15 @@ case "${WHAT}" in
       stop ${BIN}
       sleep 1
     fi
-    start_master $1
+    start_master ${FORMAT}
     sleep 2
     start_worker ${MOPT}
     ;;
   master)
-    start_master $1
+    start_master ${FORMAT}
     ;;
   worker)
-    start_worker $1
+    start_worker ${MOPT}
     ;;
   safe)
     run_safe

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -23,7 +23,8 @@ Where WHAT is one of:
 MOPT is one of:
   Mount\t\t\tMount the configured RamFS. Notice: this will format the existing RamFS.
   SudoMount\t\tMount the configured RamFS using sudo. Notice: this will format the existing RamFS.
-  NoMount\t\tDo not mount the configured RamFS
+  NoMount\t\tDo not mount the configured RamFS. Notice: Use NoMount and set ALLUXIO_RAM_FOLDER to
+  /dev/shm to use tmpFS to avoid sudo requirement.
 
 -f  format Journal, UnderFS Data and Workers Folder on master
 
@@ -46,11 +47,25 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 }
 
+check_tmpfs_mode() {
+  if [[ "${ALLUXIO_RAM_FOLDER}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
+    echo "tmpFS is enabled."
+    if [[ $( uname -a) == Darwin* ]]; then
+      # Assuming Max OS X
+      echo "ERROR: tmpFS is only enabled in Linux."
+      exit 1
+    fi
+  fi
+}
+
 check_mount_mode() {
   case "$1" in
     Mount);;
     SudoMount);;
-    NoMount);;
+    NoMount)
+
+
+    ;;
     *)
       if [[ -z $1 ]]; then
         echo "This command requires a mount mode be specified"

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -52,7 +52,6 @@
 # fi
 # export ALLUXIO_CLASSPATH=${ALLUXIO_CLASSPATH:-${HADOOP_ALLUXIO_CLASSPATH}}
 
-export ALLUXIO_RAM_FOLDER="/dev/shm/"
 if [[ $(uname -s) == Darwin ]]; then
   # Assuming Mac OS X
   export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -52,6 +52,7 @@
 # fi
 # export ALLUXIO_CLASSPATH=${ALLUXIO_CLASSPATH:-${HADOOP_ALLUXIO_CLASSPATH}}
 
+export ALLUXIO_RAM_FOLDER="/dev/shm/"
 if [[ $(uname -s) == Darwin ]]; then
   # Assuming Mac OS X
   export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -8,7 +8,8 @@
 # - ALLUXIO_MASTER_ADDRESS, to bind the master to a different IP address or hostname
 # - ALLUXIO_UNDERFS_ADDRESS, to set the under filesystem address.
 # - ALLUXIO_WORKER_MEMORY_SIZE, to set how much memory to use (e.g. 1000mb, 2gb) per worker
-# - ALLUXIO_RAM_FOLDER, to set where worker stores in memory data
+# - ALLUXIO_RAM_FOLDER, to set where worker stores in memory data. Consider setting it to
+#   /dev/shm if tmpFS is used.
 
 
 # Support for Multihomed Networks.


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1871
Right now sudo access is required to start Alluxio because of ramfs. This issue is to track tasks to make it easier to start alluxio for people without sudo access.

Summary:
1.  Use tmmFS (pre-mounted on /dev/shm) in linux machines. 
2. Mac OS-X is not supported.

How to use: (Linux only)
./bin/alluxio-start.sh local NoMount 
