### PR TITLE
[SMALLFIX] Add block lock manager test

### DIFF
--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -66,7 +66,7 @@ public abstract class ResourcePool<T> {
    * {@link #release(Object)}} after the use of this resource completes to return this resource to
    * the pool.
    *
-   * @return a resource taken from the pool, or null if the operation times out
+   * @return a resource taken from the pool
    */
   public T acquire() {
     return acquire(null, null);
@@ -77,8 +77,8 @@ public abstract class ResourcePool<T> {
    * This method is like {@link #acquire()}, but it will time out if an object cannot be
    * acquired before the specified amount of time.
    *
-   * @param an amount of time to wait, null to wait indefinitely
-   * @param the unit to use for time, null to wait indefinitely
+   * @param time an amount of time to wait, null to wait indefinitely
+   * @param unit the unit to use for time, null to wait indefinitely
    * @return a resource taken from the pool, or null if the operation times out
    */
   public T acquire(Integer time, TimeUnit unit) {

--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -87,7 +87,7 @@ public abstract class ResourcePool<T> {
     Preconditions.checkState((time == null) == (unit == null));
     long endTimeMs = 0;
     if (time != null) {
-       endTimeMs = System.currentTimeMillis() + unit.toMillis(time);
+      endTimeMs = System.currentTimeMillis() + unit.toMillis(time);
     }
 
     // Try to take a resource without blocking

--- a/core/server/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -143,7 +143,7 @@ public final class BlockLockManager {
       // allocated to another thread, in which case we could just use that lock.
       if (blockLock == null) {
         blockLock = mLockPool.acquire(1, TimeUnit.SECONDS);
-        acquiredNewLock = true;
+        acquiredNewLock = (blockLock != null);
       }
     }
     // If we acquired a new block lock, we need to add it to the mLocks map.

--- a/core/server/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -201,8 +201,8 @@ public final class BlockLockManager {
     synchronized (mSharedMapsLock) {
       Set<Long> sessionLockIds = mSessionIdToLockIdsMap.get(sessionId);
       if (sessionLockIds == null) {
-        LOG.warn("Attempted to unlock block {} with session {}, but the session has not taken" +
-            " any block locks", blockId, sessionId);
+        LOG.warn("Attempted to unlock block {} with session {}, but the session has not taken"
+            + " any block locks", blockId, sessionId);
         return;
       }
       for (long lockId : sessionLockIds) {
@@ -333,9 +333,9 @@ public final class BlockLockManager {
    * Checks the internal state of the manager to make sure invariants hold.
    *
    * This method is intended for testing purposes. A runtime exception will be thrown if invalid
-   * state is encountered.   *
+   * state is encountered.
    */
-  public void validate() throws Exception {
+  public void validate() {
     synchronized (mSharedMapsLock) {
       // Compute block lock reference counts based off of lock records
       ConcurrentMap<Long, AtomicInteger> blockLockReferenceCounts = Maps.newConcurrentMap();

--- a/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -48,7 +48,7 @@ public final class ClientRWLock implements ReadWriteLock {
   /**
    * @return the reference count
    */
-  public Integer getReferenceCount() {
+  public int getReferenceCount() {
     return mReferences.get();
   }
 
@@ -64,7 +64,7 @@ public final class ClientRWLock implements ReadWriteLock {
    *
    * @return the new reference count
    */
-  public Integer dropReference() {
+  public int dropReference() {
     return mReferences.decrementAndGet();
   }
 

--- a/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ClientRWLock implements ReadWriteLock {
   // TODO(bin): Make this const a configurable.
   /** Total number of permits. This value decides the max number of concurrent readers. */
-  private static final int MAX_AVAILABLE = 100;
+  private static final int MAX_AVAILABLE = 1000;
   /** Underlying Semaphore. */
   private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, true);
   /** Reference count. */
@@ -43,6 +43,13 @@ public final class ClientRWLock implements ReadWriteLock {
   @Override
   public Lock writeLock() {
     return new SessionLock(MAX_AVAILABLE);
+  }
+
+  /**
+   * Reports the reference count.
+   */
+  public Integer getReferenceCount() {
+    return mReferences.get();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -46,7 +46,7 @@ public final class ClientRWLock implements ReadWriteLock {
   }
 
   /**
-   * Reports the reference count.
+   * @return the reference count
    */
   public Integer getReferenceCount() {
     return mReferences.get();

--- a/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -250,8 +250,9 @@ public class BlockLockManagerTest {
   /**
    * Tests that taking and releasing many block locks concurrently won't cause a failure.
    *
-   * This is done by creating 1500 threads, 500 for each of 3 different block ids. Each thread locks
-   * and then unlocks its block 100 times.
+   * This is done by creating 1500 threads, 300 for each of 5 different block ids. Each thread locks
+   * and then unlocks its block 100 times. After this, it takes a final lock on its block before
+   * returning. At the end of the test, the internal state of the lock manager is validated.
    */
   @Test(timeout = 10000)
   public void stressTest() throws Throwable {

--- a/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -17,6 +17,9 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.worker.WorkerContext;
 
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,6 +30,11 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Unit tests for {@link BlockLockManager}.
@@ -57,6 +65,11 @@ public class BlockLockManagerTest {
     BlockMetadataManager mockMetaManager = PowerMockito.mock(BlockMetadataManager.class);
     PowerMockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
     mLockManager = new BlockLockManager();
+  }
+
+  @After
+  public void after() throws Exception {
+    WorkerContext.reset();
   }
 
   /**
@@ -232,6 +245,68 @@ public class BlockLockManagerTest {
     thread.join(200);
     // Locking should not take 200ms unless there is a hang.
     Assert.assertTrue(thread.isAlive());
+  }
+
+  /**
+   * Tests that taking and releasing many block locks concurrently won't cause a failure.
+   *
+   * This is done by creating 1500 threads, 500 for each of 3 different block ids. Each thread locks
+   * and then unlocks its block 100 times.
+   */
+  @Test(timeout = 10000)
+  public void stressTest() throws Throwable {
+    int numBlocks = 5;
+    int threadsPerBlock = 300;
+    setMaxLocks(numBlocks);
+    final BlockLockManager manager = new BlockLockManager();
+    final List<Thread> threads = Lists.newArrayList();
+    final CyclicBarrier barrier = new CyclicBarrier(numBlocks * threadsPerBlock);
+    // If there is an exception, we will store it here.
+    final AtomicReference<Throwable> failedThreadThrowable = new AtomicReference<Throwable>();
+    Thread.UncaughtExceptionHandler exceptionHandler = new Thread.UncaughtExceptionHandler() {
+      public void uncaughtException(Thread th, Throwable ex) {
+        failedThreadThrowable.set(ex);
+      }
+    };
+    for (int blockId = 0; blockId < numBlocks; blockId++) {
+      final int finalBlockId = blockId;
+      for (int i = 0; i < threadsPerBlock; i++) {
+        Thread t = new Thread(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              barrier.await();
+            } catch (Exception e) {
+              throw Throwables.propagate(e);
+            }
+            // Lock and unlock the block 100 times.
+            for (int j = 0; j < 100; j++) {
+              long lockId = manager.lockBlock(TEST_SESSION_ID, finalBlockId, BlockLockType.READ);
+              try {
+                manager.unlockBlock(lockId);
+              } catch (BlockDoesNotExistException e) {
+                throw Throwables.propagate(e);
+              }
+            }
+            // Lock the block one last time.
+            manager.lockBlock(TEST_SESSION_ID, finalBlockId, BlockLockType.READ);
+          }
+        });
+        t.setUncaughtExceptionHandler(exceptionHandler);
+        threads.add(t);
+      }
+    }
+    Collections.shuffle(threads);
+    for (Thread t : threads) {
+      t.start();
+    }
+    for (Thread t : threads) {
+      t.join();
+    }
+    if (failedThreadThrowable.get() != null) {
+      throw failedThreadThrowable.get();
+    }
+    manager.validate();
   }
 
   private void setMaxLocks(int maxLocks) {

--- a/core/server/src/test/java/alluxio/worker/block/ClientRWLockTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/ClientRWLockTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.Lock;
  */
 public final class ClientRWLockTest {
 
+  private ClientRWLock mClientRWLock;
   private Lock mReadLock;
   private Lock mWriteLock;
 
@@ -30,8 +31,9 @@ public final class ClientRWLockTest {
    */
   @Before
   public void before() {
-    mReadLock = new ClientRWLock().readLock();
-    mWriteLock = new ClientRWLock().writeLock();
+    mClientRWLock = new ClientRWLock();
+    mReadLock = mClientRWLock.readLock();
+    mWriteLock = mClientRWLock.writeLock();
   }
 
   /**
@@ -67,5 +69,24 @@ public final class ClientRWLockTest {
   public void lockInterruptiblyTest() throws Exception {
     mReadLock.lockInterruptibly();
     Assert.assertTrue(true);
+  }
+
+
+  /**
+   * Tests reference counting.
+   */
+  @Test
+  public void referenceCountingTest() throws Exception {
+    Assert.assertEquals(0, mClientRWLock.getReferenceCount());
+    mClientRWLock.addReference();
+    mClientRWLock.addReference();
+    Assert.assertEquals(2, mClientRWLock.getReferenceCount());
+    Assert.assertEquals(1, mClientRWLock.dropReference());
+    for (int i = 0; i < 10; i++) {
+      mClientRWLock.addReference();
+    }
+    Assert.assertEquals(11, mClientRWLock.getReferenceCount());
+    Assert.assertEquals(10, mClientRWLock.dropReference());
+    Assert.assertEquals(10, mClientRWLock.getReferenceCount());
   }
 }

--- a/core/server/src/test/java/alluxio/worker/block/ClientRWLockTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/ClientRWLockTest.java
@@ -71,7 +71,6 @@ public final class ClientRWLockTest {
     Assert.assertTrue(true);
   }
 
-
   /**
    * Tests reference counting.
    */


### PR DESCRIPTION
This commit also fixes an issue which could occur when the lock pool is empty. If two threads tried to  acquire the last lock in the rwlock pool for the same block id, the second acquire would hang until a rwlock was returned to the pool. It should instead share the block lock acquired by the first thread. As a result, you could have n blocks and n locks, but not be able to lock all the blocks at once.