### PR TITLE
[ALLUXIO-1871 ] Load env variables again after overriding ALLUXIO_RAM_FOLDER

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,7 +52,7 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null; then
+      mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null
       if [[ $? -ne 0 || -z ${ALLUXIO_RAM_FOLDER} ]]; then
         if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,7 +52,8 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      if ! mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null; then
+      mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null; then
+      if [[ $? -ne 0 || -z ${ALLUXIO_RAM_FOLDER} ]]; then
         if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported on Mac OS X."


### PR DESCRIPTION
Small style fix in alluxio-start.sh