### PR TITLE
[ALLUXIO-1876] Improve copyToLocal shell efficiency by getting rid of tempFile

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
@@ -171,23 +171,16 @@ public final class CopyToLocalCommand extends AbstractShellCommand {
    */
   private void copyFileToLocal(AlluxioURI srcPath, File dstFile) throws IOException {
     try {
-      File tmpDst = File.createTempFile("copyToLocal", null);
-      tmpDst.deleteOnExit();
-
       Closer closer = Closer.create();
       try {
         OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
         FileInStream is = closer.register(mFileSystem.openFile(srcPath, options));
-        FileOutputStream out = closer.register(new FileOutputStream(tmpDst));
+        FileOutputStream out = closer.register(new FileOutputStream(dstFile));
         byte[] buf = new byte[64 * Constants.MB];
         int t = is.read(buf);
         while (t != -1) {
           out.write(buf, 0, t);
           t = is.read(buf);
-        }
-        if (!tmpDst.renameTo(dstFile)) {
-          throw new IOException(
-              "Failed to rename " + tmpDst.getPath() + " to destination " + dstFile.getPath());
         }
         System.out.println("Copied " + srcPath + " to " + dstFile.getPath());
       } finally {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1876

Simply copyToLocal from a 1GB remote file comparison:

With TempFile:
```
[ec2-user@AlluxioWorker1 alluxio]$ time ./bin/alluxio fs copyToLocal /file.txt file.txt
AlluxioShell milliseconds: 452
Copied /file.txt to file.txt
copyFileToLocal milliseconds: 16974
shell.run milliseconds: 16981
shell.close() milliseconds: 0
It takes 18 seconds to complete the shell...
real	0m17.780s
user	0m6.576s
sys	0m2.320s
```

Without tempFile:
```
[ec2-user@AlluxioWorker1 alluxio]$ time ./bin/alluxio fs copyToLocal /file.txt file.txt
AlluxioShell milliseconds: 446
Copied /file.txt to file.txt
copyFileToLocal milliseconds: 8887
shell.run milliseconds: 8893
shell.close() milliseconds: 0
It takes 9 seconds to complete the shell...
real	0m9.663s
user	0m6.524s
sys	0m2.304s
```


