### PR TITLE
[SMALLFIX] Remove unused configuration

### DIFF
--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -65,11 +65,11 @@ public abstract class AbstractFileOutStreamIntegrationTest {
   @Before
   public void before() throws Exception {
     mTestConf = mLocalAlluxioClusterResource.get().getWorkerConf();
-    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(mTestConf);
-    mWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(mTestConf);
-    mWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough(mTestConf);
-    mWriteLocal = StreamOptionUtils.getCreateFileOptionsWriteLocal(mTestConf);
-    mWriteAsync = StreamOptionUtils.getCreateFileOptionsAsync(mTestConf);
+    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
+    mWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
+    mWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough();
+    mWriteLocal = StreamOptionUtils.getCreateFileOptionsWriteLocal();
+    mWriteAsync = StreamOptionUtils.getCreateFileOptionsAsync();
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }
 

--- a/tests/src/test/java/alluxio/client/BufferedBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/BufferedBlockInStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
@@ -42,7 +41,6 @@ public final class BufferedBlockInStreamIntegrationTest {
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource();
   private static FileSystem sFileSystem;
-  private static Configuration sConfiguration;
   private static CreateFileOptions sWriteBoth;
   private static CreateFileOptions sWriteAlluxio;
   private static CreateFileOptions sWriteUnderStore;
@@ -51,10 +49,9 @@ public final class BufferedBlockInStreamIntegrationTest {
   @BeforeClass
   public static final void beforeClass() throws Exception {
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
-    sConfiguration = sLocalAlluxioClusterResource.get().getMasterConf();
-    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(sConfiguration);
-    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(sConfiguration);
-    sWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough(sConfiguration);
+    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
+    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
+    sWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough();
     sTestPath = PathUtils.uniqPath();
 
     // Create files of varying size and write type to later read from

--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileInStream;
@@ -47,7 +46,6 @@ public class FileInStreamIntegrationTest {
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource(Constants.GB, BLOCK_SIZE);
   private static FileSystem sFileSystem = null;
-  private static Configuration sConfiguration;
   private static CreateFileOptions sWriteBoth;
   private static CreateFileOptions sWriteAlluxio;
   private static CreateFileOptions sWriteUnderStore;
@@ -62,10 +60,9 @@ public class FileInStreamIntegrationTest {
   @BeforeClass
   public static final void beforeClass() throws Exception {
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
-    sConfiguration = sLocalAlluxioClusterResource.get().getMasterConf();
-    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(sConfiguration);
-    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(sConfiguration);
-    sWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough(sConfiguration);
+    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
+    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
+    sWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough();
     sTestPath = PathUtils.uniqPath();
 
     // Create files of varying size and write type to later read from

--- a/tests/src/test/java/alluxio/client/FileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileSystemIntegrationTest.java
@@ -55,8 +55,7 @@ public class FileSystemIntegrationTest {
   @Before
   public void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
-    Configuration conf = mLocalAlluxioClusterResource.get().getMasterConf();
-    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(conf);
+    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/FileSystemUtilsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileSystemUtilsIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileOutStream;
@@ -53,8 +52,7 @@ public class FileSystemUtilsIntegrationTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
-    Configuration conf = sLocalAlluxioClusterResource.get().getMasterConf();
-    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(conf);
+    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileOutStream;
@@ -61,8 +60,7 @@ public final class FreeAndDeleteIntegrationTest {
   @Before
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
-    Configuration workerConfiguration = mLocalAlluxioClusterResource.get().getWorkerConf();
-    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(workerConfiguration);
+    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
   }
 
   @BeforeClass

--- a/tests/src/test/java/alluxio/client/IsolatedFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/IsolatedFileSystemIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileInStream;
@@ -57,9 +56,7 @@ public class IsolatedFileSystemIntegrationTest {
   @Before
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
-
-    Configuration workerConfiguration = mLocalAlluxioClusterResource.get().getWorkerConf();
-    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(workerConfiguration);
+    mWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/LocalBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/LocalBlockInStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
@@ -50,7 +49,6 @@ public final class LocalBlockInStreamIntegrationTest {
   private static CreateFileOptions sWriteAlluxio;
   private static OpenFileOptions sReadNoCache;
   private static OpenFileOptions sReadCache;
-  private static Configuration sConfiguration;
   private static String sTestPath;
 
   @Rule
@@ -59,11 +57,10 @@ public final class LocalBlockInStreamIntegrationTest {
   @BeforeClass
   public static final void beforeClass() throws Exception {
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
-    sConfiguration = sLocalAlluxioClusterResource.get().getMasterConf();
-    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(sConfiguration);
-    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(sConfiguration);
-    sReadCache = StreamOptionUtils.getOpenFileOptionsCache(sConfiguration);
-    sReadNoCache = StreamOptionUtils.getOpenFileOptionsNoCache(sConfiguration);
+    sWriteBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
+    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
+    sReadCache = StreamOptionUtils.getOpenFileOptionsCache();
+    sReadNoCache = StreamOptionUtils.getOpenFileOptionsNoCache();
     sTestPath = PathUtils.uniqPath();
 
     // Create files of varying size and write type to later read from

--- a/tests/src/test/java/alluxio/client/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/ReadOnlyMountIntegrationTest.java
@@ -76,8 +76,7 @@ public class ReadOnlyMountIntegrationTest {
 
   @Test
   public void createFileTest() throws IOException, AlluxioException {
-    Configuration testConf = mLocalAlluxioClusterResource.getTestConf();
-    CreateFileOptions writeBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough(testConf);
+    CreateFileOptions writeBoth = StreamOptionUtils.getCreateFileOptionsCacheThrough();
 
     AlluxioURI uri = new AlluxioURI(FILE_PATH + "_create");
     try {

--- a/tests/src/test/java/alluxio/client/RemoteBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/RemoteBlockInStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.IntegrationTestConstants;
 import alluxio.LocalAlluxioClusterResource;
@@ -96,12 +95,11 @@ public class RemoteBlockInStreamIntegrationTest {
 
   @Before
   public final void before() throws Exception {
-    Configuration configuration = mLocalAlluxioClusterResource.get().getMasterConf();
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
-    mWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(configuration);
-    mWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough(configuration);
-    mReadCache = StreamOptionUtils.getOpenFileOptionsCache(configuration);
-    mReadNoCache = StreamOptionUtils.getOpenFileOptionsNoCache(configuration);
+    mWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
+    mWriteUnderStore = StreamOptionUtils.getCreateFileOptionsThrough();
+    mReadCache = StreamOptionUtils.getOpenFileOptionsCache();
+    mReadNoCache = StreamOptionUtils.getOpenFileOptionsNoCache();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/StreamOptionUtils.java
+++ b/tests/src/test/java/alluxio/client/StreamOptionUtils.java
@@ -11,7 +11,6 @@
 
 package alluxio.client;
 
-import alluxio.Configuration;
 import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.options.OpenFileOptions;
 import alluxio.client.file.policy.LocalFirstPolicy;
@@ -31,7 +30,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link CreateFileOptions}
    */
-  public static CreateFileOptions getCreateFileOptionsCacheThrough(Configuration conf) {
+  public static CreateFileOptions getCreateFileOptionsCacheThrough() {
     return CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH);
   }
 
@@ -41,7 +40,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link CreateFileOptions}
    */
-  public static CreateFileOptions getCreateFileOptionsMustCache(Configuration conf) {
+  public static CreateFileOptions getCreateFileOptionsMustCache() {
     return CreateFileOptions.defaults().setWriteType(WriteType.MUST_CACHE);
   }
 
@@ -51,7 +50,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link CreateFileOptions}
    */
-  public static CreateFileOptions getCreateFileOptionsThrough(Configuration conf) {
+  public static CreateFileOptions getCreateFileOptionsThrough() {
     return CreateFileOptions.defaults().setWriteType(WriteType.THROUGH);
   }
 
@@ -61,7 +60,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link CreateFileOptions}
    */
-  public static CreateFileOptions getCreateFileOptionsWriteLocal(Configuration conf) {
+  public static CreateFileOptions getCreateFileOptionsWriteLocal() {
     return CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH)
         .setLocationPolicy(new LocalFirstPolicy());
   }
@@ -72,7 +71,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link OpenFileOptions}
    */
-  public static OpenFileOptions getOpenFileOptionsCache(Configuration conf) {
+  public static OpenFileOptions getOpenFileOptionsCache() {
     return OpenFileOptions.defaults().setReadType(ReadType.CACHE_PROMOTE);
   }
 
@@ -82,7 +81,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link OpenFileOptions}
    */
-  public static OpenFileOptions getOpenFileOptionsNoCache(Configuration conf) {
+  public static OpenFileOptions getOpenFileOptionsNoCache() {
     return OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
   }
 
@@ -92,7 +91,7 @@ public final class StreamOptionUtils {
    * @param conf the Alluxio config
    * @return the {@link CreateFileOptions}
    */
-  public static CreateFileOptions getCreateFileOptionsAsync(Configuration conf) {
+  public static CreateFileOptions getCreateFileOptionsAsync() {
     return CreateFileOptions.defaults().setWriteType(WriteType.ASYNC_THROUGH);
   }
 }

--- a/tests/src/test/java/alluxio/client/concurrent/FileInStreamConcurrencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/concurrent/FileInStreamConcurrencyIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client.concurrent;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.ClientContext;
@@ -43,14 +42,12 @@ public final class FileInStreamConcurrencyIntegrationTest {
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource(Constants.GB, BLOCK_SIZE);
   private static FileSystem sFileSystem = null;
-  private static Configuration sConfiguration;
   private static CreateFileOptions sWriteAlluxio;
 
   @BeforeClass
   public static final void beforeClass() throws Exception {
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
-    sConfiguration = sLocalAlluxioClusterResource.get().getMasterConf();
-    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache(sConfiguration);
+    sWriteAlluxio = StreamOptionUtils.getCreateFileOptionsMustCache();
   }
 
   /**


### PR DESCRIPTION
The methods in StreamOptionUtils took a config but didn't use it. This PR removes the parameter and cleans up call sites.