### PR TITLE
[ALLUXIO-1871] Follow-up fix on non-sudo deployment

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,8 +52,7 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null
-      if [[ $? -ne 0 || -z ${ALLUXIO_RAM_FOLDER} ]]; then
+      if [[ $(mount | grep -c ${ALLUXIO_RAM_FOLDER}) != 0 ]]; then
         if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported on Mac OS X."


### PR DESCRIPTION
This is a follow-up PR for https://github.com/Alluxio/alluxio/pull/2999. It can fix the bug of overriding on user-specified ALLUXIO_RAM_FOLDER. The original PR always uses `/dev/shm` as RAM storage folder no matter whether `ALLUXIO_RAM_FOLDER` is defined. 
cc @peisun1115, @yupeng9 