### PR TITLE
[ALLUXIO-1885] Improve concurrency of IndexedSet

### DIFF
--- a/core/common/src/main/java/alluxio/collections/IndexedSet.java
+++ b/core/common/src/main/java/alluxio/collections/IndexedSet.java
@@ -251,19 +251,6 @@ public class IndexedSet<T> implements Iterable<T> {
   }
 
   /**
-   * Whether there is an object with the specified field value in the set.
-   *
-   * @param index the field index
-   * @param value the field value
-   * @return true if there is one such object, otherwise false
-   */
-  public boolean contains(FieldIndex<T> index, Object value) {
-    synchronized (mLock) {
-      return getByFieldInternal(index, value) != null;
-    }
-  }
-
-  /**
    * Gets a subset of objects with the specified field value. If there is no object with the
    * specified field value, a newly created empty set is returned. Otherwise, the returned set is
    * backed up by an internal set, so changes in internal set will be reflected in returned set and

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -24,9 +24,12 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -235,6 +238,14 @@ public final class CommonUtils {
         GroupMappingService.Factory.getUserToGroupsMappingService(conf);
     List<String> groups = groupMappingService.getGroups(userName);
     return (groups != null && groups.size() > 0) ? groups.get(0) : "";
+  }
+
+  /**
+   * @param <T> class type of elements in the set
+   * @return a set backed by a {@link java.util.concurrent.ConcurrentHashMap}
+   */
+  public static <T> Set<T> newConcurrentHashSet() {
+    return Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>());
   }
 
   private CommonUtils() {} // prevent instantiation

--- a/core/common/src/test/java/alluxio/collections/IndexedSetTest.java
+++ b/core/common/src/test/java/alluxio/collections/IndexedSetTest.java
@@ -74,21 +74,6 @@ public class IndexedSetTest {
   }
 
   /**
-   * Tests the {@link IndexedSet#contains(IndexedSet.FieldIndex, Object)} method.
-   */
-  @Test
-  public void containsTest() {
-    for (int i = 0; i < 3; i++) {
-      Assert.assertTrue(mSet.contains(mIntIndex, i));
-    }
-    Assert.assertFalse(mSet.contains(mIntIndex, 4));
-    for (long l = 0; l < 3; l++) {
-      Assert.assertTrue(mSet.contains(mLongIndex, l));
-    }
-    Assert.assertFalse(mSet.contains(mLongIndex, 4L));
-  }
-
-  /**
    * Tests the {@link IndexedSet#getByField(IndexedSet.FieldIndex, Object)} method.
    */
   @Test


### PR DESCRIPTION
IndexedSet uses a global lock which is not scalable.

This PR improves concurrency by using concurrent hash map and set, and synchronizing on inserted/deleted object itself, so that the global lock is removed.