### PR TITLE
[ALLUXIO-1852] Fixing wrong authentication header. Adapt configuration key

### DIFF
--- a/conf/alluxio-swift-env.sh.template
+++ b/conf/alluxio-swift-env.sh.template
@@ -78,7 +78,7 @@ fi
 
 export JAVA="${JAVA_HOME}/bin/java"
 export ALLUXIO_MASTER_ADDRESS=${ALLUXIO_MASTER_ADDRESS:-localhost}
-export ALLUXIO_UNDERFS_ADDRESS=${ALLUXIO_UNDERFS_ADDRESS:-swift://alluxiotestcont}
+export ALLUXIO_UNDERFS_ADDRESS=${ALLUXIO_UNDERFS_ADDRESS:-swift://alluxiocontainer}
 export ALLUXIO_WORKER_MEMORY_SIZE=${ALLUXIO_WORKER_MEMORY_SIZE:-1GB}
 
 export ALLUXIO_SSH_FOREGROUND=${ALLUXIO_SSH_FOREGROUND:-"yes"}
@@ -106,7 +106,7 @@ export ALLUXIO_JAVA_OPTS+="
   -Djava.net.preferIPv4Stack=true
   -Dfs.swift.user=<swift-user>
   -Dfs.swift.tenant=<swift-tenant>
-  -Dfs.swift.apikey=<swift-user-password>
+  -Dfs.swift.password=<swift-user-password>
   -Dfs.swift.auth.url=<swift-auth-url>
   -Dfs.swift.auth.port=<swift-auth-url-port>
   -Dfs.swift.use.public.url=<swift-use-public: true, false>

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -379,6 +379,7 @@ public final class Constants {
   public static final String SWIFT_USER_KEY = "fs.swift.user";
   public static final String SWIFT_TENANT_KEY = "fs.swift.tenant";
   public static final String SWIFT_API_KEY = "fs.swift.apikey";
+  public static final String SWIFT_PASSWORD_KEY = "fs.swift.password";
   public static final String SWIFT_AUTH_URL_KEY = "fs.swift.auth.url";
   public static final String SWIFT_AUTH_PORT_KEY = "fs.swift.auth.port";
   public static final String SWIFT_AUTH_METHOD_KEY = "fs.swift.auth.method";

--- a/docs/_includes/Configuring-Alluxio-with-Swift/several-configurations.md
+++ b/docs/_includes/Configuring-Alluxio-with-Swift/several-configurations.md
@@ -1,6 +1,6 @@
     -Dfs.swift.user=<swift-user>
     -Dfs.swift.tenant=<swift-tenant>
-    -Dfs.swift.apikey=<swift-user-password>
+    -Dfs.swift.password=<swift-user-password>
     -Dfs.swift.auth.url=<swift-auth-url>
     -Dfs.swift.auth.port=<swift-auth-url-port>
     -Dfs.swift.use.public.url=<swift-use-public>

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -79,15 +79,21 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     super(configuration);
     LOG.debug("Constructor init: {}", containerName);
     AccountConfig config = new AccountConfig();
-    config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
-    config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
-    config.setPassword(configuration.get(Constants.SWIFT_API_KEY));
+    if (configuration.containsKey(Constants.SWIFT_API_KEY)) {
+      config.setPassword(configuration.get(Constants.SWIFT_API_KEY));
+    } else if (configuration.containsKey(Constants.SWIFT_PASSWORD_KEY)) {
+      config.setPassword(configuration.get(Constants.SWIFT_PASSWORD_KEY));
+    }
     config.setAuthUrl(configuration.get(Constants.SWIFT_AUTH_URL_KEY));
     String authMethod = configuration.get(Constants.SWIFT_AUTH_METHOD_KEY);
     if (authMethod != null && authMethod.equals("keystone")) {
       config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
+      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
     } else {
       config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
+      config.setTenantName(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setUsername(configuration.get(Constants.SWIFT_TENANT_KEY));
     }
 
     ObjectMapper mapper = new ObjectMapper();

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
@@ -96,8 +96,17 @@ public class SwiftUnderFileSystemFactory implements UnderFileSystemFactory {
             && configuration.get(authMethodKeyConf) == null)) {
       configuration.set(authMethodKeyConf, System.getProperty(authMethodKeyConf));
     }
+    String passwordKeyConf = Constants.SWIFT_PASSWORD_KEY;
+    if (System.getProperty(passwordKeyConf) != null
+        || (configuration.containsKey(passwordKeyConf)
+            && configuration.get(passwordKeyConf) == null)) {
+      configuration.set(passwordKeyConf, System.getProperty(passwordKeyConf));
+    }
 
-    return configuration.get(tenantApiKeyConf) != null
+    return ((configuration.containsKey(tenantApiKeyConf)
+        && configuration.get(tenantApiKeyConf) != null)
+        || (configuration.containsKey(passwordKeyConf)
+        && configuration.get(passwordKeyConf) != null))
         && configuration.get(tenantKeyConf) != null
         && configuration.get(tenantAuthURLKeyConf) != null
         && configuration.get(tenantUserConf) != null;


### PR DESCRIPTION
- Fixing wrong authentication header for SoftLayer object store.

- Adding "password" configuration key and removing "apikey". Contains support for "apikey" to be backward compatible.