### PR TITLE
[ALLUXIO-1852] Fixing wrong authentication header when connecting to …

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -387,6 +387,7 @@ public final class Constants {
   public static final String SWIFT_USER_KEY = "fs.swift.user";
   public static final String SWIFT_TENANT_KEY = "fs.swift.tenant";
   public static final String SWIFT_API_KEY = "fs.swift.apikey";
+  public static final String SWIFT_PASSWORD_KEY = "fs.swift.password";
   public static final String SWIFT_AUTH_URL_KEY = "fs.swift.auth.url";
   public static final String SWIFT_AUTH_PORT_KEY = "fs.swift.auth.port";
   public static final String SWIFT_AUTH_METHOD_KEY = "fs.swift.auth.method";

--- a/docs/_includes/Configuring-Alluxio-with-Swift/several-configurations.md
+++ b/docs/_includes/Configuring-Alluxio-with-Swift/several-configurations.md
@@ -1,6 +1,6 @@
     -Dfs.swift.user=<swift-user>
     -Dfs.swift.tenant=<swift-tenant>
-    -Dfs.swift.apikey=<swift-user-password>
+    -Dfs.swift.password=<swift-user-password>
     -Dfs.swift.auth.url=<swift-auth-url>
     -Dfs.swift.auth.port=<swift-auth-url-port>
     -Dfs.swift.use.public.url=<swift-use-public>

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -93,6 +93,9 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
     } else {
       config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
+      // tempauth requires authentication header to be of the form tenant:user.
+      // JOSS however generates header of the form user:tenant.
+      // To resolve this, we switch user with tenant
       config.setTenantName(configuration.get(Constants.SWIFT_USER_KEY));
       config.setUsername(configuration.get(Constants.SWIFT_TENANT_KEY));
     }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -80,15 +80,21 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     String containerName = uri.getHost();
     LOG.debug("Constructor init: {}", containerName);
     AccountConfig config = new AccountConfig();
-    config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
-    config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
-    config.setPassword(configuration.get(Constants.SWIFT_API_KEY));
+    if (configuration.containsKey(Constants.SWIFT_API_KEY)) {
+      config.setPassword(configuration.get(Constants.SWIFT_API_KEY));
+    } else if (configuration.containsKey(Constants.SWIFT_PASSWORD_KEY)) {
+      config.setPassword(configuration.get(Constants.SWIFT_PASSWORD_KEY));
+    }
     config.setAuthUrl(configuration.get(Constants.SWIFT_AUTH_URL_KEY));
     String authMethod = configuration.get(Constants.SWIFT_AUTH_METHOD_KEY);
     if (authMethod != null && authMethod.equals("keystone")) {
       config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
+      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
     } else {
       config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
+      config.setTenantName(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setUsername(configuration.get(Constants.SWIFT_TENANT_KEY));
     }
 
     ObjectMapper mapper = new ObjectMapper();

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
@@ -95,8 +95,17 @@ public class SwiftUnderFileSystemFactory implements UnderFileSystemFactory {
             && configuration.get(authMethodKeyConf) == null)) {
       configuration.set(authMethodKeyConf, System.getProperty(authMethodKeyConf));
     }
+    String passwordKeyConf = Constants.SWIFT_PASSWORD_KEY;
+    if (System.getProperty(passwordKeyConf) != null
+        || (configuration.containsKey(passwordKeyConf)
+            && configuration.get(passwordKeyConf) == null)) {
+      configuration.set(passwordKeyConf, System.getProperty(passwordKeyConf));
+    }
 
-    return configuration.get(tenantApiKeyConf) != null
+    return ((configuration.containsKey(tenantApiKeyConf)
+        && configuration.get(tenantApiKeyConf) != null)
+        || (configuration.containsKey(passwordKeyConf)
+        && configuration.get(passwordKeyConf) != null))
         && configuration.get(tenantKeyConf) != null
         && configuration.get(tenantAuthURLKeyConf) != null
         && configuration.get(tenantUserConf) != null;


### PR DESCRIPTION
This PR covers:
1. Fix for the bug, that wrong header is sent to SoftLayer object store. This was caused authentication issues.
2. Replace wrong "apikey" with "password". New change is backward compatible and still supports "apikey".