### PR TITLE
[ALLUXIO-1871] Support NoMount when ALLUXIO_RAM_FOLDER is set to a subdir in a mount point.

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -47,7 +47,7 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 }
 
-# The eixt status is 0 if ALLUXIO_RAM_FOLDER is mounted as tmpfs or ramfs.
+# The exit status is 0 if ALLUXIO_RAM_FOLDER is mounted as tmpfs or ramfs.
 is_ram_folder_mounted() {
   if [[ -z ${ALLUXIO_RAM_FOLDER} ]]; then
     return 1

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -47,14 +47,36 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 }
 
+# The eixt status is 0 if ALLUXIO_RAM_FOLDER is mounted as tmpfs or ramfs.
+is_ram_folder_mounted() {
+  if [[ -z ${ALLUXIO_RAM_FOLDER} ]]; then
+    return 1
+  fi
+  local mounted_fs=""
+  if [[ $(uname -s) = Darwin ]]; then
+    mounted_fs=$(mount -t "hfs" | grep '/Volumes/' | cut -d " " -f 3)
+  else
+    mounted_fs=$(mount -t "tmpfs,ramfs" | cut -d " " -f 3)
+  fi
+
+  for fs in ${mounted_fs}; do
+    if [[ "${ALLUXIO_RAM_FOLDER}" = "${fs}" || \
+     "${ALLUXIO_RAM_FOLDER}" =~ ^"${fs}"\/.* ]]; then
+      return
+    fi
+  done
+
+  return 1
+}
+
 check_mount_mode() {
   case "$1" in
     Mount);;
     SudoMount);;
     NoMount)
-      mount | grep "${ALLUXIO_RAM_FOLDER}" > /dev/null
-      if [[ $? -ne 0 || -z ${ALLUXIO_RAM_FOLDER} ]]; then
-        if [[ $(uname -s) == Darwin ]]; then
+      is_ram_folder_mounted
+      if [[ $? -ne 0 ]]; then
+        if [[ $(uname -s) = Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported on Mac OS X."
           echo -e "${USAGE}"

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -76,7 +76,7 @@ check_mount_mode() {
     NoMount)
       is_ram_folder_mounted
       if [[ $? -ne 0 ]]; then
-        if [[ $(uname -s) = Darwin ]]; then
+        if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X
           echo "ERROR: NoMount is not supported on Mac OS X."
           echo -e "${USAGE}"

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -62,7 +62,7 @@ is_ram_folder_mounted() {
   for fs in ${mounted_fs}; do
     if [[ "${ALLUXIO_RAM_FOLDER}" = "${fs}" || \
      "${ALLUXIO_RAM_FOLDER}" =~ ^"${fs}"\/.* ]]; then
-      return
+      return 0
     fi
   done
 


### PR DESCRIPTION
Support NoMount when ALLUXIO_RAM_FOLDER is set to a subdir in a mount point.

Usecase:
/mnt/ramdisk is mounted by a sudo user.

A non-sudo user can do this:
export ALLUXIO_RAM_FOLDER="/mnt/ramdisk/myfolder"
./bin/alluxio-start.sh local NoMount

https://alluxio.atlassian.net/browse/ALLUXIO-1871