### PR TITLE
[ALLUXIO-1739] Use Alluxio Worker for DataServerHandler

### DIFF
--- a/core/server/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -187,9 +187,10 @@ public final class AlluxioWorker {
       mThriftServer = createThriftServer();
 
       // Setup Data server
-      mDataServer = DataServer.Factory.create(
-          NetworkAddressUtils.getBindAddress(ServiceType.WORKER_DATA, mConfiguration),
-          mBlockWorker, mConfiguration);
+      mDataServer =
+          DataServer.Factory.create(
+              NetworkAddressUtils.getBindAddress(ServiceType.WORKER_DATA, mConfiguration), this,
+              mConfiguration);
       // Reset data server port
       mConfiguration.set(Constants.WORKER_DATA_PORT, Integer.toString(mDataServer.getPort()));
 

--- a/core/server/src/main/java/alluxio/worker/DataServer.java
+++ b/core/server/src/main/java/alluxio/worker/DataServer.java
@@ -14,7 +14,6 @@ package alluxio.worker;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.util.CommonUtils;
-import alluxio.worker.block.BlockWorker;
 
 import com.google.common.base.Throwables;
 
@@ -37,17 +36,17 @@ public interface DataServer extends Closeable {
      * Factory for {@link DataServer}.
      *
      * @param dataAddress the address of the data server
-     * @param blockWorker block worker handle
+     * @param worker the Alluxio worker handle
      * @param conf Alluxio configuration
      * @return the generated {@link DataServer}
      */
     public static DataServer create(final InetSocketAddress dataAddress,
-        final BlockWorker blockWorker, Configuration conf) {
+        final AlluxioWorker worker, final Configuration conf) {
       try {
         return CommonUtils.createNewClassInstance(
             conf.<DataServer>getClass(Constants.WORKER_DATA_SERVER),
-            new Class[] { InetSocketAddress.class, BlockWorker.class, Configuration.class },
-            new Object[] { dataAddress, blockWorker, conf });
+            new Class[] { InetSocketAddress.class, AlluxioWorker.class, Configuration.class },
+            new Object[] { dataAddress, worker, conf });
       } catch (Exception e) {
         throw Throwables.propagate(e);
       }

--- a/core/server/src/main/java/alluxio/worker/netty/DataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/DataServerHandler.java
@@ -19,7 +19,7 @@ import alluxio.network.protocol.RPCErrorResponse;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCRequest;
 import alluxio.network.protocol.RPCResponse;
-import alluxio.worker.block.BlockWorker;
+import alluxio.worker.AlluxioWorker;
 
 import com.google.common.base.Preconditions;
 import io.netty.channel.ChannelHandler;
@@ -46,13 +46,13 @@ public final class DataServerHandler extends SimpleChannelInboundHandler<RPCMess
   /**
    * Creates a new instance of {@link DataServerHandler}.
    *
-   * @param blockWorker the block worker handle
+   * @param worker the block worker handle
    * @param configuration Alluxio configuration
    */
-  public DataServerHandler(final BlockWorker blockWorker, Configuration configuration) {
-    Preconditions.checkNotNull(blockWorker);
+  public DataServerHandler(final AlluxioWorker worker, Configuration configuration) {
+    Preconditions.checkNotNull(worker);
     Preconditions.checkNotNull(configuration);
-    mBlockHandler = new BlockDataServerHandler(blockWorker, configuration);
+    mBlockHandler = new BlockDataServerHandler(worker.getBlockWorker(), configuration);
   }
 
   @Override

--- a/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -15,8 +15,8 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.network.ChannelType;
 import alluxio.util.network.NettyUtils;
+import alluxio.worker.AlluxioWorker;
 import alluxio.worker.DataServer;
-import alluxio.worker.block.BlockWorker;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -48,14 +48,15 @@ public final class NettyDataServer implements DataServer {
    * Creates a new instance of {@link NettyDataServer}.
    *
    * @param address the server address
-   * @param blockWorker the block worker to use for data operations
+   * @param worker the Alluxio worker which contains the appropriate components to handle data
+   *               operations
    * @param configuration Alluxio configuration
    */
-  public NettyDataServer(final InetSocketAddress address, final BlockWorker blockWorker,
+  public NettyDataServer(final InetSocketAddress address, final AlluxioWorker worker,
       final Configuration configuration) {
     mConf = Preconditions.checkNotNull(configuration);
     mDataServerHandler =
-        new DataServerHandler(Preconditions.checkNotNull(blockWorker), mConf);
+        new DataServerHandler(Preconditions.checkNotNull(worker), mConf);
     mBootstrap = createBootstrap().childHandler(new PipelineHandler(mDataServerHandler));
 
     try {

--- a/core/server/src/test/java/alluxio/worker/block/SpaceReserverTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/SpaceReserverTest.java
@@ -13,6 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.Configuration;
 import alluxio.Constants;
+import alluxio.worker.AlluxioWorker;
 import alluxio.worker.DataServer;
 import alluxio.worker.WorkerContext;
 
@@ -78,7 +79,7 @@ public class SpaceReserverTest {
     PowerMockito.mockStatic(DataServer.Factory.class);
     PowerMockito
         .when(DataServer.Factory.create(Mockito.<InetSocketAddress>any(),
-            Mockito.<BlockWorker>any(), Mockito.<Configuration>any()))
+            Mockito.<AlluxioWorker>any(), Mockito.<Configuration>any()))
         .thenReturn(Mockito.mock(DataServer.class));
 
     BlockWorker blockWorker = new BlockWorker();


### PR DESCRIPTION
Since we've moved the dataserver to be at the Alluxio Worker level, we should pass the Alluxio worker instead of the block worker.