### PR TITLE
[SMALLFIX] Fix typos in rpc messages.

### DIFF
--- a/core/common/src/main/java/alluxio/network/protocol/RPCBlockReadRequest.java
+++ b/core/common/src/main/java/alluxio/network/protocol/RPCBlockReadRequest.java
@@ -91,7 +91,7 @@ public final class RPCBlockReadRequest extends RPCRequest {
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("blockId", mBlockId).add("offset", mOffset)
-        .add("lenght", mLength).add("lockId", mLockId).add("sessionId", mSessionId).toString();
+        .add("length", mLength).add("lockId", mLockId).add("sessionId", mSessionId).toString();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/network/protocol/RPCBlockWriteRequest.java
+++ b/core/common/src/main/java/alluxio/network/protocol/RPCBlockWriteRequest.java
@@ -102,7 +102,7 @@ public final class RPCBlockWriteRequest extends RPCRequest {
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("blockId", mBlockId).add("offset", mOffset)
-        .add("lenght", mLength).add("sessionId", mSessionId).toString();
+        .add("length", mLength).add("sessionId", mSessionId).toString();
   }
 
   /**


### PR DESCRIPTION
`lenght`->`length`