### PR TITLE
[ALLUXIO-1895] Fix failing unit tests InodeDirectoryTest.permissionSt…

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -12,7 +12,9 @@
 package alluxio.master.file.meta;
 
 import alluxio.Constants;
+import alluxio.master.MasterContext;
 import alluxio.master.file.options.CreateDirectoryOptions;
+import alluxio.security.authorization.PermissionStatus;
 import alluxio.wire.FileInfo;
 
 import com.google.common.collect.Sets;
@@ -228,9 +230,11 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
   @Test
   public void permissionStatusTest() {
     InodeDirectory inode2 = createInodeDirectory();
-    Assert.assertEquals(AbstractInodeTest.TEST_USER_NAME, inode2.getUserName());
-    Assert.assertEquals(AbstractInodeTest.TEST_GROUP_NAME, inode2.getGroupName());
-    Assert.assertEquals((short) 0755, inode2.getPermission());
+    Assert.assertEquals(TEST_USER_NAME, inode2.getUserName());
+    Assert.assertEquals(TEST_GROUP_NAME, inode2.getGroupName());
+    Assert.assertEquals(
+        new PermissionStatus(TEST_PERMISSION_STATUS).applyDirectoryUMask(MasterContext.getConf())
+            .getPermission().toShort(), inode2.getPermission());
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeFileTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeFileTest.java
@@ -16,6 +16,7 @@ import alluxio.exception.BlockInfoException;
 import alluxio.exception.FileAlreadyCompletedException;
 import alluxio.exception.InvalidFileSizeException;
 import alluxio.master.MasterContext;
+import alluxio.security.authorization.PermissionStatus;
 
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -151,7 +152,8 @@ public final class InodeFileTest extends AbstractInodeTest {
     InodeFile inode1 = createInodeFile(1);
     Assert.assertEquals(TEST_USER_NAME, inode1.getUserName());
     Assert.assertEquals(TEST_GROUP_NAME, inode1.getGroupName());
-    Assert.assertEquals(TEST_PERMISSION_STATUS.applyFileUMask(MasterContext.getConf())
-        .getPermission().toShort(), inode1.getPermission());
+    Assert.assertEquals(
+        new PermissionStatus(TEST_PERMISSION_STATUS).applyFileUMask(MasterContext.getConf())
+            .getPermission().toShort(), inode1.getPermission());
   }
 }


### PR DESCRIPTION
Original test failed due to 
`TEST_PERMISSION_STATUS.applyFileUMask(MasterContext.getConf())` in `InodeFileTest.java` modifies `TEST_PERMISSION_STATUS`, affecting the test in `InodeDirectoryTest.java` which creates dir using `TEST_PERMISSION_STATUS` as permission