### PR TITLE
[SMALLFIX] Fix the broken master link in worker web UI for master fault tolerance mode

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -13,12 +13,9 @@ package alluxio;
 
 import alluxio.util.network.NetworkAddressUtils;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -57,18 +54,6 @@ public abstract class AbstractMasterClient extends AbstractClient {
     if (!mUseZookeeper) {
       return super.getAddress();
     }
-
-    Preconditions.checkState(mConfiguration.containsKey(Constants.ZOOKEEPER_ADDRESS));
-    Preconditions.checkState(mConfiguration.containsKey(Constants.ZOOKEEPER_LEADER_PATH));
-    LeaderInquireClient leaderInquireClient =
-        LeaderInquireClient.getClient(mConfiguration.get(Constants.ZOOKEEPER_ADDRESS),
-            mConfiguration.get(Constants.ZOOKEEPER_LEADER_PATH), mConfiguration);
-    try {
-      String temp = leaderInquireClient.getMasterAddress();
-      return NetworkAddressUtils.parseInetSocketAddress(temp);
-    } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
-      throw Throwables.propagate(e);
-    }
+    return NetworkAddressUtils.getMasterAddressFormZK(mConfiguration);
   }
 }

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -54,6 +54,6 @@ public abstract class AbstractMasterClient extends AbstractClient {
     if (!mUseZookeeper) {
       return super.getAddress();
     }
-    return NetworkAddressUtils.getMasterAddressFormZK(mConfiguration);
+    return NetworkAddressUtils.getMasterAddressFromZK(mConfiguration);
   }
 }

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -585,12 +585,13 @@ public final class NetworkAddressUtils {
   }
 
   /**
-   * Get master address from zookeeper for the fault tolerant Alluxio masters.
+   * Get the active master address from zookeeper for the fault tolerant Alluxio masters.
+   * The zookeeper path is specified by the config: {@link Constants.ZOOKEEPER_LEADER_PATH}.
    *
-   * @param conf the Alluxio Configuration
-   * @return InetSocketAddress
+   * @param conf the Alluxio configuration
+   * @return InetSocketAddress the active master address retrieved from zookeeper
    */
-  public static InetSocketAddress getMasterAddressFormZK(Configuration conf) {
+  public static InetSocketAddress getMasterAddressFromZK(Configuration conf) {
     Preconditions.checkState(conf.containsKey(Constants.ZOOKEEPER_ADDRESS));
     Preconditions.checkState(conf.containsKey(Constants.ZOOKEEPER_LEADER_PATH));
     LeaderInquireClient leaderInquireClient =

--- a/core/server/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
@@ -55,8 +55,12 @@ public final class WebInterfaceHeaderServlet extends HttpServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     int masterWebPort = mConfiguration.getInt(Constants.MASTER_WEB_PORT);
-    String masterHostName =
-        NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, mConfiguration);
+    String masterHostName;
+    if (!mConfiguration.getBoolean(Constants.ZOOKEEPER_ENABLED)) {
+      masterHostName = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, mConfiguration);
+    } else {
+      masterHostName = NetworkAddressUtils.getMasterAddressFormZK(mConfiguration).getHostName();
+    }
     request.setAttribute("masterHost", masterHostName);
     request.setAttribute("masterPort", masterWebPort);
     getServletContext().getRequestDispatcher("/header.jsp").include(request, response);

--- a/core/server/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
@@ -59,7 +59,7 @@ public final class WebInterfaceHeaderServlet extends HttpServlet {
     if (!mConfiguration.getBoolean(Constants.ZOOKEEPER_ENABLED)) {
       masterHostName = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, mConfiguration);
     } else {
-      masterHostName = NetworkAddressUtils.getMasterAddressFormZK(mConfiguration).getHostName();
+      masterHostName = NetworkAddressUtils.getMasterAddressFromZK(mConfiguration).getHostName();
     }
     request.setAttribute("masterHost", masterHostName);
     request.setAttribute("masterPort", masterWebPort);


### PR DESCRIPTION
In master fault tolerance mode, the link of " return to master " in work web UI is borken.
Because we should get the master address from zookeeper, rather than from the configuration.

Suggestions and reviews are welcomed~