### PR TITLE
[ALLUXIO-1852] Fixing Swift underfs issues when working with Spark

### DIFF
--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -132,6 +132,9 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     LOG.debug("Create method: {}", path);
     String newPath = path.substring(Constants.HEADER_SWIFT.length());
     if (newPath.endsWith("_SUCCESS")) {
+      // when path/_SUCCESS is created, there is need to create path as
+      // an empty object. This is required by Spark in case Spark
+      // accesses path directly, bypassing Alluxio
       String plainName = newPath.substring(0, newPath.indexOf("_SUCCESS"));
       LOG.debug("Plain name: {}", plainName);
       SwiftOutputStream out = SwiftDirectClient.put(mAccess, plainName);
@@ -192,6 +195,10 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
   public boolean exists(String path) throws IOException {
     String newPath = stripPrefixIfPresent(path);
     if (newPath.endsWith("_temporary")) {
+      // To get better performance Swift driver does not
+      // creates _temporary folder
+      // This optimization should be hidden from Spark, therefore
+      // exists _teporary will return true
       return true;
     }
     return isObjectExists(newPath);

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -131,6 +131,12 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
   public OutputStream create(String path) throws IOException {
     LOG.debug("Create method: {}", path);
     String newPath = path.substring(Constants.HEADER_SWIFT.length());
+    if (newPath.endsWith("_SUCCESS")) {
+      String plainName = newPath.substring(0, newPath.indexOf("_SUCCESS"));
+      LOG.debug("Plain name: {}", plainName);
+      SwiftOutputStream out = SwiftDirectClient.put(mAccess, plainName);
+      out.close();
+    }
     SwiftOutputStream out = SwiftDirectClient.put(mAccess, newPath);
     return out;
   }
@@ -185,6 +191,9 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
   @Override
   public boolean exists(String path) throws IOException {
     String newPath = stripPrefixIfPresent(path);
+    if (newPath.endsWith("_temporary")) {
+      return true;
+    }
     return isObjectExists(newPath);
   }
 
@@ -349,10 +358,12 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
    */
   private boolean copy(String src, String dst) {
     LOG.debug("copy from {} to {}", src, dst);
+    String strippedSrcPath = stripPrefixIfPresent(src);
+    String strippedDstPath = stripPrefixIfPresent(dst);
     try {
       Container container = mAccount.getContainer(mContainerName);
-      container.getObject(src).copyObject(container,
-          container.getObject(dst));
+      container.getObject(strippedSrcPath).copyObject(container,
+          container.getObject(strippedDstPath));
       return true;
     } catch (Exception e) {
       LOG.error(e.getMessage());


### PR DESCRIPTION
Those are critical issues for Spark-Alluxio-Swift
1. When objectname/_SUCCESS is created, there is need to create also 0 byte size objectname. Otherwise it's not possible to read data back from Swift ( directly with Spark)
2. Fixing bug in copy
3. Swift driver doesn't create _temporary directory, however exists method for _temporary should return true. This is important for Spark