### PR TITLE
[ALLUXIO-1898] Check LockBlockResult to be not null in RemoteBlockInStream#constructor

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -15,6 +15,7 @@ import alluxio.client.ClientContext;
 import alluxio.client.RemoteBlockReader;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.exception.ExceptionMessage;
+import alluxio.wire.LockBlockResult;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.ClientMetrics;
 
@@ -62,10 +63,11 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
     mBlockWorkerClient = mContext.acquireWorkerClient(workerNetAddress);
 
     try {
-      mLockId = mBlockWorkerClient.lockBlock(blockId).getLockId();
-      if (mLockId == null) {
+      LockBlockResult result = mBlockWorkerClient.lockBlock(blockId);
+      if (result == null) {
         throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId));
       }
+      mLockId = result.getLockId();
       mMetrics = mBlockWorkerClient.getClientMetrics();
     } catch (IOException e) {
       mContext.releaseWorkerClient(mBlockWorkerClient);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1898