### PR TITLE
[ALLUXIO-1735] Upgrades free Miredot license to open-source license.

### DIFF
--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -205,9 +205,9 @@
           </execution>
         </executions>
         <configuration>
-          <!--- This following license only works for groupId org.alluxio and artifactId alluxio-core-server. -->
+          <!--- This following license only works for groupId org.alluxio and artifactId alluxio-core-server, it expires on 2018/04/24 -->
           <license>
-            UHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyfDIwMTctMDItMjV8dHJ1ZSNNQzBDRlFDUm1SMXpVb3dMOUkyNXZrcGtJOVlmOHY3M2tnSVVIa0NxSFgvdUlYZmd3SHdSa1hFYUFMRDQ3Q0E9
+            cHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyfDIwMTgtMDQtMjh8dHJ1ZXwtMSNNQ3dDRkFFM0JGSnAwZ1FRNFFaNDd5SnlRd0x3ZGhmQUFoUU1ZMkJpWWVOamhOZndvQmU3UldMRVFzZnNGUT09
           </license>
           <restModel>
             <httpStatusCodes>


### PR DESCRIPTION
Dear maintainers of Alluxio,

We noticed you were using a free Miredot license for Alluxio. We thought we'd help you out and upgrade that license to an open-source license.

With this license you get access to all the paying features, free of charge. 

I tried building the project myself in order to fully test the license, but was not able to do that on my windows machine. It should be fine though. If you have any questions, problems or feedback, please let us know!

Kind Regards,
Ewout & The Miredot team.

P.S.: It will expire on 28/04/2018, we will send you another pull request with a license update before that happens.

Edit: added what I think was the original JIRA ticket for adding rest docs. 
Link: https://alluxio.atlassian.net/browse/ALLUXIO-1735