### PR TITLE
[ALLUXIO-1914] Fix flaky test

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -258,7 +258,7 @@ public final class FileSystemMasterTest {
   @Test
   public void createFileWithTtlTest() throws Exception {
     CreateFileOptions options =
-        CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setRecursive(true).setTtl(1);
+        CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setRecursive(true).setTtl(0);
     long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, options);
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
     Assert.assertEquals(fileInfo.getFileId(), fileId);
@@ -280,7 +280,7 @@ public final class FileSystemMasterTest {
         CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setRecursive(true);
     long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, options);
     executeTtlCheckOnce();
-    // Since no valid TTL is set, the file should not be deleted.
+    // Since no TTL is set, the file should not be deleted.
     Assert.assertEquals(fileId, mFileSystemMaster.getFileInfo(NESTED_FILE_URI).getFileId());
 
     mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeOptions.defaults().setTtl(0));


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1914

The TTL needs to be 0 to guarantee that the file will be expired at the time of the TTL check.