### PR TITLE
[SMALLFIX] Improve missing file exception handling

### DIFF
--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -160,11 +160,12 @@ public final class KeyValueMaster extends AbstractMaster {
    *
    * @param path URI of the key-value store
    * @param info information of this completed parition
-   * @throws FileDoesNotExistException if the key-value store URI does not exists
    * @throws AccessControlException if permission checking fails
+   * @throws FileDoesNotExistException if the key-value store URI does not exists
+   * @throws InvalidPathException if the path is invalid
    */
   public synchronized void completePartition(AlluxioURI path, PartitionInfo info)
-      throws FileDoesNotExistException, AccessControlException {
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -202,10 +203,11 @@ public final class KeyValueMaster extends AbstractMaster {
    *
    * @param path URI of the key-value store
    * @throws FileDoesNotExistException if the key-value store URI does not exists
+   * @throws InvalidPathException if the path is not valid
    * @throws AccessControlException if permission checking fails
    */
-  public synchronized void completeStore(AlluxioURI path) throws FileDoesNotExistException,
-      AccessControlException {
+  public synchronized void completeStore(AlluxioURI path)
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -311,7 +313,8 @@ public final class KeyValueMaster extends AbstractMaster {
     mCompleteStoreToPartitions.remove(fileId);
   }
 
-  private long getFileId(AlluxioURI uri) throws AccessControlException, FileDoesNotExistException {
+  private long getFileId(AlluxioURI uri)
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
     long fileId = mFileSystemMaster.getFileId(uri);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
@@ -408,9 +411,10 @@ public final class KeyValueMaster extends AbstractMaster {
    * @return a list of partition information
    * @throws FileDoesNotExistException if the key-value store URI does not exists
    * @throws AccessControlException if permission checking fails
+   * @throws InvalidPathException if the path is invalid
    */
   public synchronized List<PartitionInfo> getPartitionInfo(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException {
     long fileId = getFileId(path);
     List<PartitionInfo> partitions = mCompleteStoreToPartitions.get(fileId);
     if (partitions == null) {


### PR DESCRIPTION
We should use FileDoesNotExistException when a file doesn't exist, and InvalidPathException for other path-related errors.