### PR TITLE
[SMALLFIX] Removed explicit type argument in DataServerIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
@@ -61,7 +61,7 @@ public class DataServerIntegrationTest {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     // Creates a new instance of DataServerIntegrationTest for different combinations of parameters.
-    List<Object[]> list = new ArrayList<Object[]>();
+    List<Object[]> list = new ArrayList<>();
     list.add(new Object[] {IntegrationTestConstants.NETTY_DATA_SERVER,
         IntegrationTestConstants.MAPPED_TRANSFER, IntegrationTestConstants.NETTY_BLOCK_READER});
     list.add(new Object[] {IntegrationTestConstants.NETTY_DATA_SERVER,


### PR DESCRIPTION
Removed an unneeded explicit type argument in ```DataServerIntegrationTest```.