### PR TITLE
[SMALLFIX] Simplified equals implementation of ExistsOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/ExistsOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/ExistsOptions.java
@@ -36,13 +36,7 @@ public final class ExistsOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof ExistsOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof ExistsOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` of the *ExistsOptions* class.