### PR TITLE
[SMALLFIX] Simplified equals implementation of GetStatusOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/GetStatusOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/GetStatusOptions.java
@@ -36,13 +36,7 @@ public final class GetStatusOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof GetStatusOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof GetStatusOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` of the *GetStatusOptions* class.