### PR TITLE
[SMALLFIX] Simplified equals implementation of ListStatusOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/ListStatusOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/ListStatusOptions.java
@@ -36,13 +36,7 @@ public final class ListStatusOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof ListStatusOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof ListStatusOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` of the *ListStatusOptions* class.