### PR TITLE
[ALLUXIO-1918]: Change name testEquals to equalsTest

### DIFF
--- a/core/client/src/test/java/alluxio/client/file/options/CompleteFileOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/CompleteFileOptionsTest.java
@@ -57,7 +57,7 @@ public class CompleteFileOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CompleteFileOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/CreateDirectoryOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/CreateDirectoryOptionsTest.java
@@ -80,7 +80,7 @@ public class CreateDirectoryOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CreateDirectoryOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/CreateFileOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/CreateFileOptionsTest.java
@@ -87,7 +87,7 @@ public class CreateFileOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CreateFileOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/DeleteOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/DeleteOptionsTest.java
@@ -47,7 +47,7 @@ public class DeleteOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(DeleteOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/FreeOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/FreeOptionsTest.java
@@ -47,7 +47,7 @@ public class FreeOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(FreeOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/InStreamOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/InStreamOptionsTest.java
@@ -69,7 +69,7 @@ public class InStreamOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(InStreamOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/LoadMetadataOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/LoadMetadataOptionsTest.java
@@ -47,7 +47,7 @@ public class LoadMetadataOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(LoadMetadataOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/MountOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/MountOptionsTest.java
@@ -57,7 +57,7 @@ public class MountOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(MountOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/OpenFileOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/OpenFileOptionsTest.java
@@ -63,7 +63,7 @@ public class OpenFileOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(OpenFileOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
@@ -77,7 +77,7 @@ public class OutStreamOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(OutStreamOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
@@ -101,7 +101,7 @@ public class SetAttributeOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(SetAttributeOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/lineage/options/CreateLineageOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/lineage/options/CreateLineageOptionsTest.java
@@ -31,7 +31,7 @@ public final class CreateLineageOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CreateLineageOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/lineage/options/DeleteLineageOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/lineage/options/DeleteLineageOptionsTest.java
@@ -40,7 +40,7 @@ public final class DeleteLineageOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(DeleteLineageOptions.class);
   }
 }

--- a/core/client/src/test/java/alluxio/client/lineage/options/GetLineageInfoListOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/lineage/options/GetLineageInfoListOptionsTest.java
@@ -30,7 +30,7 @@ public class GetLineageInfoListOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(GetLineageInfoListOptions.class);
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/CompleteFileOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/CompleteFileOptionsTest.java
@@ -49,7 +49,7 @@ public class CompleteFileOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CompleteFileOptions.class, "mOperationTimeMs");
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/CreateDirectoryOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/CreateDirectoryOptionsTest.java
@@ -79,7 +79,7 @@ public class CreateDirectoryOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CreateDirectoryOptions.class, "mOperationTimeMs");
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/CreateFileOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/CreateFileOptionsTest.java
@@ -83,7 +83,7 @@ public class CreateFileOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(CreateFileOptions.class, "mOperationTimeMs");
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/MountOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/MountOptionsTest.java
@@ -116,7 +116,7 @@ public class MountOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(MountOptions.class, "mOperationTimeMs");
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
@@ -55,7 +55,7 @@ public class SetAttributeOptionsTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void equalsTest() throws Exception {
     CommonTestUtils.testEquals(SetAttributeOptions.class, "mOperationTimeMs");
   }
 }


### PR DESCRIPTION
Changed all tests in the form on `testEquals` to `equalsTest`. In the one case where there is a test against the `CommonTestUtils` titled `testEqualsTest` I figured that:
1. since it ends with `Test` it conforms to the Alluxio naming conventions
2. it is accurately testing a function (not a test) called `testEquals` 

[ALLUXIO-1918 here](https://alluxio.atlassian.net/browse/ALLUXIO-1918)