### PR TITLE
[ALLUXIO-1917]: Improve name consistency in alluxio.hadoop.fs.DFSIOIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -235,7 +235,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.cleanup(fs);
   }
 
-  public static void testWrite() throws Exception {
+  public static void writeTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -245,7 +245,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   @Test(timeout = 25000)
-  public void testRead() throws Exception {
+  public void readTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -255,7 +255,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   @Test(timeout = 25000)
-  public void testReadRandom() throws Exception {
+  public void readRandomTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -266,7 +266,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   @Test(timeout = 25000)
-  public void testReadBackward() throws Exception {
+  public void readBackwardTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -277,7 +277,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   @Test(timeout = 25000)
-  public void testReadSkip() throws Exception {
+  public void readSkipTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -288,7 +288,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   @Test(timeout = 25000)
-  public void testReadLargeSkip() throws Exception {
+  public void readLargeSkipTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -300,7 +300,7 @@ public class DFSIOIntegrationTest implements Tool {
 
   // TODO(hy): Should active this unit test after ALLUXIO-25 has been solved
   // @Test (timeout = 25000)
-  public void testAppend() throws Exception {
+  public void appendTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -239,7 +239,7 @@ public class DFSIOIntegrationTest implements Tool {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
-    sBench.writeTest(fs);
+    sBench.mapperWriteTest(fs);
     long execTime = System.currentTimeMillis() - tStart;
     sBench.analyzeResult(fs, TestType.TEST_TYPE_WRITE, execTime);
   }
@@ -249,7 +249,7 @@ public class DFSIOIntegrationTest implements Tool {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
-    sBench.readTest(fs);
+    sBench.mapperReadTest(fs);
     long execTime = System.currentTimeMillis() - tStart;
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ, execTime);
   }
@@ -304,7 +304,7 @@ public class DFSIOIntegrationTest implements Tool {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
-    sBench.appendTest(fs);
+    sBench.mapperAppendTest(fs);
     long execTime = System.currentTimeMillis() - tStart;
     sBench.analyzeResult(fs, TestType.TEST_TYPE_APPEND, execTime);
   }
@@ -448,7 +448,7 @@ public class DFSIOIntegrationTest implements Tool {
     }
   }
 
-  private void writeTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
+  private void mapperWriteTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
     Path writeDir = getWriteDir(mConfig);
     fs.delete(getDataDir(mConfig), true);
     fs.delete(writeDir, true);
@@ -512,7 +512,7 @@ public class DFSIOIntegrationTest implements Tool {
     }
   }
 
-  private void appendTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
+  private void mapperAppendTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
     Path appendDir = getAppendDir(mConfig);
     fs.delete(appendDir, true);
     runIOTest(AppendMapper.class, appendDir);
@@ -555,7 +555,7 @@ public class DFSIOIntegrationTest implements Tool {
     }
   }
 
-  private void readTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
+  private void mapperReadTest(org.apache.hadoop.fs.FileSystem fs) throws IOException {
     Path readDir = getReadDir(mConfig);
     fs.delete(readDir, true);
     runIOTest(ReadMapper.class, readDir);
@@ -792,13 +792,13 @@ public class DFSIOIntegrationTest implements Tool {
     long tStart = System.currentTimeMillis();
     switch (testType) {
       case TEST_TYPE_WRITE:
-        writeTest(fs);
+        mapperWriteTest(fs);
         break;
       case TEST_TYPE_READ:
-        readTest(fs);
+        mapperReadTest(fs);
         break;
       case TEST_TYPE_APPEND:
-        appendTest(fs);
+        mapperAppendTest(fs);
         break;
       case TEST_TYPE_READ_RANDOM:
       case TEST_TYPE_READ_BACKWARD:

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -224,7 +224,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.createControlFile(fs, DEFAULT_NR_BYTES, DEFAULT_NR_FILES);
 
     /** Check write here, as it is required for other tests */
-    testWrite();
+    writeTest();
   }
 
   @AfterClass


### PR DESCRIPTION
Updated all tests to be in the naming convention of `*Test` rather then `test*`.

[ALLUXIO-1917 here](https://alluxio.atlassian.net/browse/ALLUXIO-1917)