### PR TITLE
[SMALLFIX] Avoid retrying unrecoverable alluxio exceptions

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -22,6 +22,7 @@ import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.ThriftIOException;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TMultiplexedProtocol;
@@ -297,6 +298,8 @@ public abstract class AbstractClient implements Closeable {
         return rpc.call();
       } catch (ThriftIOException e) {
         throw new IOException(e);
+      } catch (AlluxioTException e) {
+        throw Throwables.propagate(AlluxioException.from(e));
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -278,9 +278,10 @@ public abstract class AbstractClient implements Closeable {
   }
 
   /**
-   * Tries to execute an RPC defined as a {@link RpcCallable}, if error
-   * happens in one execution, a reconnection will be tried through {@link #connect()} and the
-   * action will be re-executed.
+   * Tries to execute an RPC defined as a {@link RpcCallable}.
+   *
+   * If a non-Alluxio thrift exception occurs, a reconnection will be tried through
+   * {@link #connect()} and the action will be re-executed.
    *
    * @param rpc the RPC call to be executed
    * @param <V> type of return value of the RPC call


### PR DESCRIPTION
All RPCs can potentially throw runtime exceptions which get converted to AlluxioTExceptions. We should handle this by propagation instead of retrying.