### PR TITLE
[SMALLFIX] Removed unnecessary return statement in LineageFileOutStream

### DIFF
--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
@@ -52,6 +52,5 @@ public class LineageFileOutStream extends FileOutStream {
   @Override
   protected void scheduleAsyncPersist() throws IOException {
     // do nothing, the scheduling is handled by the lineage master
-    return;
   }
 }


### PR DESCRIPTION
Removed an unnecessary return statement in the *LineageFileOutStream* class.