### PR TITLE
[SMALLFIX] Removed explicit type argument in LineageMasterClient

### DIFF
--- a/core/client/src/main/java/alluxio/client/lineage/LineageMasterClient.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageMasterClient.java
@@ -147,7 +147,7 @@ public final class LineageMasterClient extends AbstractMasterClient {
     return retryRPC(new RpcCallable<List<LineageInfo>>() {
       @Override
       public List<LineageInfo> call() throws TException {
-        List<LineageInfo> result = new ArrayList<LineageInfo>();
+        List<LineageInfo> result = new ArrayList<>();
         for (alluxio.thrift.LineageInfo lineageInfo : mClient.getLineageInfoList()) {
           result.add(ThriftUtils.fromThrift(lineageInfo));
         }


### PR DESCRIPTION
Removed an explicit argument type in the *LineageMasterClient* class.