### PR TITLE
[SMALLFIX] Simplified equals implementation of GetLineageInfoListOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/lineage/options/GetLineageInfoListOptions.java
+++ b/core/client/src/main/java/alluxio/client/lineage/options/GetLineageInfoListOptions.java
@@ -36,13 +36,7 @@ public final class GetLineageInfoListOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof GetLineageInfoListOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof GetLineageInfoListOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` implementation of the *GetLineageInfoListOptions* class.