### PR TITLE
[SMALLFIX] Simplified equals implementation of CreateLineageOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/lineage/options/CreateLineageOptions.java
+++ b/core/client/src/main/java/alluxio/client/lineage/options/CreateLineageOptions.java
@@ -36,13 +36,7 @@ public final class CreateLineageOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof CreateLineageOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof CreateLineageOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` implementation of the *CreateLineageOptions* class.