### PR TITLE
[SMALLFIX] Simplified equals implementation of UnmountOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/UnmountOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/UnmountOptions.java
@@ -36,13 +36,7 @@ public final class UnmountOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof UnmountOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof UnmountOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` implementation of the *UnmountOptions* class.