### PR TITLE
[SMALLFIX] Simplified equals implementation of MostAvailableFirstPolicy

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/policy/MostAvailableFirstPolicy.java
+++ b/core/client/src/main/java/alluxio/client/file/policy/MostAvailableFirstPolicy.java
@@ -45,13 +45,7 @@ public final class MostAvailableFirstPolicy implements FileWriteLocationPolicy {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof MostAvailableFirstPolicy)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof MostAvailableFirstPolicy;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` implementation of the *MostAvailableFirstPolicy* class.