### PR TITLE
[SMALLFIX] Simplified equals implementation of RenameOptions

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/RenameOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/RenameOptions.java
@@ -36,13 +36,7 @@ public final class RenameOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof RenameOptions)) {
-      return false;
-    }
-    return true;
+    return this == o || o instanceof RenameOptions;
   }
 
   @Override


### PR DESCRIPTION
Simplified the ```equals``` implementation of the *RenameOptions* class.