### PR TITLE
[SMALLFIX] Removed explicit type argument in ClientHandler

### DIFF
--- a/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
+++ b/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
@@ -55,7 +55,7 @@ public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage>
    * Creates a new {@link ClientHandler}.
    */
   public ClientHandler() {
-    mListeners = new HashSet<ResponseListener>(4);
+    mListeners = new HashSet<>(4);
   }
 
   /**


### PR DESCRIPTION
Removed an explicit argument type in the *ClientHandler* class.