### PR TITLE
[SMALLFIX] Removed explicit type argument in FileSystemTestUtils

### DIFF
--- a/core/client/src/main/java/alluxio/client/FileSystemTestUtils.java
+++ b/core/client/src/main/java/alluxio/client/FileSystemTestUtils.java
@@ -126,7 +126,7 @@ public final class FileSystemTestUtils {
   public static List<String> listFiles(FileSystem fs, String path) throws IOException {
     try {
       List<URIStatus> statuses = fs.listStatus(new AlluxioURI(path));
-      List<String> res = new ArrayList<String>();
+      List<String> res = new ArrayList<>();
       for (URIStatus status : statuses) {
         res.add(status.getPath());
         if (status.isFolder()) {


### PR DESCRIPTION
Removed an explicit type argument in the *FileSystemTestUtils* class.