### PR TITLE
[SMALLFIX] Removed redundant variable in AbstractFileSystem

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -291,11 +291,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       throw new IOException(e);
     }
 
-    FileStatus ret = new FileStatus(fileStatus.getLength(), fileStatus.isFolder(),
+    return new FileStatus(fileStatus.getLength(), fileStatus.isFolder(),
         BLOCK_REPLICATION_CONSTANT, fileStatus.getBlockSizeBytes(), fileStatus.getCreationTimeMs(),
             fileStatus.getCreationTimeMs(), new FsPermission((short) fileStatus.getPermission()),
             fileStatus.getUserName(), fileStatus.getGroupName(), new Path(mAlluxioHeader + uri));
-    return ret;
   }
 
   /**


### PR DESCRIPTION
Merged variable and return statement in the *AbstractFileSystem* class.