### PR TITLE
[SMALLFIX] Removed redundant intializer in HdfsFileInputStream

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -160,9 +160,8 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
       throw new IOException("Cannot read from a closed stream.");
     }
     if (mAlluxioFileInputStream != null) {
-      int ret;
       try {
-        ret = mAlluxioFileInputStream.read();
+        int ret = mAlluxioFileInputStream.read();
         if (mStatistics != null && ret != -1) {
           mStatistics.incrementBytesRead(1);
         }

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -160,7 +160,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
       throw new IOException("Cannot read from a closed stream.");
     }
     if (mAlluxioFileInputStream != null) {
-      int ret = 0;
+      int ret;
       try {
         ret = mAlluxioFileInputStream.read();
         if (mStatistics != null && ret != -1) {


### PR DESCRIPTION
Removed redundant initializer in the *HdfsFileInputStream* class.