### PR TITLE
[SMALLFIX] reducing heap overhead

### DIFF
--- a/core/common/src/main/java/alluxio/collections/ConcurrentHashSet.java
+++ b/core/common/src/main/java/alluxio/collections/ConcurrentHashSet.java
@@ -34,7 +34,7 @@ public class ConcurrentHashSet<T> extends AbstractSet<T> {
    * Creates a new {@link ConcurrentHashSet}.
    */
   public ConcurrentHashSet() {
-    this(1024, 0.75f, 32);
+    this(8, 0.75f, 32);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14</version>
           <configuration>
-            <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M  -Xmx768M -XX:-UseGCOverheadLimit</argLine>
+            <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M -Xmx768M -XX:-UseGCOverheadLimit</argLine>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>


### PR DESCRIPTION
this PR reduces the InodeDirectory overhead of adding a child from 16kB to 64B