### PR TITLE
[SMALLFIX] Removed explicit parameter types in PrefixList

### DIFF
--- a/core/common/src/main/java/alluxio/collections/PrefixList.java
+++ b/core/common/src/main/java/alluxio/collections/PrefixList.java
@@ -33,7 +33,7 @@ public final class PrefixList {
    */
   public PrefixList(List<String> prefixList) {
     if (prefixList == null) {
-      mInnerList = new ArrayList<String>(0);
+      mInnerList = new ArrayList<>(0);
     } else {
       mInnerList = prefixList;
     }
@@ -47,7 +47,7 @@ public final class PrefixList {
    */
   public PrefixList(String prefixes, String separator) {
     Validate.notNull(separator);
-    mInnerList = new ArrayList<String>(0);
+    mInnerList = new ArrayList<>(0);
     if (prefixes != null && !prefixes.trim().isEmpty()) {
       String[] candidates = prefixes.trim().split(separator);
       for (String prefix : candidates) {


### PR DESCRIPTION
Removed explicit parameter types in the *PrefixList* class.