### PR TITLE
[SMALLFIX] Removed redundant initializer in DataFileChannel

### DIFF
--- a/core/common/src/main/java/alluxio/network/protocol/databuffer/DataFileChannel.java
+++ b/core/common/src/main/java/alluxio/network/protocol/databuffer/DataFileChannel.java
@@ -53,7 +53,7 @@ public final class DataFileChannel implements DataBuffer {
     ByteBuffer buffer = ByteBuffer.allocate((int) mLength);
     try {
       mFileChannel.position(mOffset);
-      int bytesRead = 0;
+      int bytesRead;
       long bytesRemaining = mLength;
       while (bytesRemaining > 0 && (bytesRead = mFileChannel.read(buffer)) >= 0) {
         bytesRemaining -= bytesRead;


### PR DESCRIPTION
Removed a redundant initializer in the *DataFileChannel* class.