### PR TITLE
[SMALLFIX] Removed explicit parameter types in ShellBasedUnixGroupsMapping

### DIFF
--- a/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
@@ -37,7 +37,7 @@ public final class ShellBasedUnixGroupsMapping implements GroupMappingService {
   public List<String> getGroups(String user) throws IOException {
     List<String> groups = CommonUtils.getUnixGroups(user);
     // remove duplicated primary group
-    return new ArrayList<String>(new LinkedHashSet<String>(groups));
+    return new ArrayList<>(new LinkedHashSet<>(groups));
   }
 
   @Override


### PR DESCRIPTION
Removed an explicit parameter type in the *ShellBasedUnixGroupsMapping* class.