### PR TITLE
[SMALLFIX] Removed explicit parameter type in LoginModuleConfiguration

### DIFF
--- a/core/common/src/main/java/alluxio/security/login/LoginModuleConfiguration.java
+++ b/core/common/src/main/java/alluxio/security/login/LoginModuleConfiguration.java
@@ -34,7 +34,7 @@ import javax.security.auth.login.Configuration;
 @ThreadSafe
 public final class LoginModuleConfiguration extends Configuration {
 
-  private static final Map<String, String> EMPTY_JAAS_OPTIONS = new HashMap<String, String>();
+  private static final Map<String, String> EMPTY_JAAS_OPTIONS = new HashMap<>();
 
   /** Login module that allows a user name provided by OS. */
   private static final AppConfigurationEntry OS_SPECIFIC_LOGIN =


### PR DESCRIPTION
Removed an explicit parameter type in the *LoginModuleConfiguration* class.