### PR TITLE
[SMALLFIX]improve the javadoc of "PrefixList#toString()"

### DIFF
--- a/core/common/src/main/java/alluxio/collections/PrefixList.java
+++ b/core/common/src/main/java/alluxio/collections/PrefixList.java
@@ -101,7 +101,7 @@ public final class PrefixList {
   /**
    * Print out all prefixes separated by ";".
    *
-   * @return the string representation like "a;b/c"
+   * @return the string representation like "a;b/c;"
    */
   @Override
   public String toString() {


### PR DESCRIPTION
the following code of "toString()" indicates that there must be a ";" at the end of the string representation, so I think we should add a ";" in the example of the string representation. 