### PR TITLE
[SMALLFIX]change "{@code Runnable}" to "{@link Runnable}" in HeartbeatThread javadoc

### DIFF
--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -33,7 +33,7 @@ public final class HeartbeatThread implements Runnable {
   private HeartbeatTimer mTimer;
 
   /**
-   * Creates a {@code Runnable} to execute heartbeats for the given {@link HeartbeatExecutor}.
+   * Creates a {@link Runnable} to execute heartbeats for the given {@link HeartbeatExecutor}.
    *
    * This class is responsible for closing the given {@link HeartbeatExecutor} when it finishes.
    *


### PR DESCRIPTION
I think {@link Runnable} is more suitable because Runnable is a class name.