### PR TITLE
[SMALLFIX]remove the extra "synchronized" keyword in ScheduledTimer

### DIFF
--- a/core/common/src/main/java/alluxio/heartbeat/ScheduledTimer.java
+++ b/core/common/src/main/java/alluxio/heartbeat/ScheduledTimer.java
@@ -79,7 +79,7 @@ public final class ScheduledTimer implements HeartbeatTimer {
    *
    * @throws InterruptedException if the thread is interrupted while waiting
    */
-  public synchronized void tick() throws InterruptedException {
+  public void tick() throws InterruptedException {
     mLock.lock();
     try {
       HeartbeatScheduler.addTimer(this);


### PR DESCRIPTION
the method "#tick()" uses an explicit lock "mLock", I think there is no need to use "synchronized".