### PR TITLE
[SMALLFIX] Removed unused import in Format class

### DIFF
--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -13,7 +13,6 @@ package alluxio.cli;
 
 import alluxio.Configuration;
 import alluxio.Constants;
-import alluxio.cli.Version;
 import alluxio.master.AlluxioMaster;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.UnderFileSystemUtils;


### PR DESCRIPTION
Removed an unused import in the *Format* class.