### PR TITLE
[SMALL FIX] Fix a bug in FileSystemMaster

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1630,7 +1630,11 @@ public final class FileSystemMaster extends AbstractMaster {
       throws IOException, InvalidPathException, AccessControlException, FileDoesNotExistException {
     if (mInodeTree.inodePathExists(path)) {
       Inode inode = mInodeTree.getInodeByPath(path);
-      if (inode.isPersisted() || path.isRoot()) {
+      if (path.isRoot()) {
+        // Root is always persisted.
+        inode.setPersistenceState(PersistenceState.PERSISTED);
+      }
+      if (inode.isPersisted()) {
         return inode.getId();
       }
     }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1630,7 +1630,7 @@ public final class FileSystemMaster extends AbstractMaster {
       throws IOException, InvalidPathException, AccessControlException, FileDoesNotExistException {
     if (mInodeTree.inodePathExists(path)) {
       Inode inode = mInodeTree.getInodeByPath(path);
-      if (inode.isPersisted()) {
+      if (inode.isPersisted() || path.isRoot()) {
         return inode.getId();
       }
     }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1630,10 +1630,6 @@ public final class FileSystemMaster extends AbstractMaster {
       throws IOException, InvalidPathException, AccessControlException, FileDoesNotExistException {
     if (mInodeTree.inodePathExists(path)) {
       Inode inode = mInodeTree.getInodeByPath(path);
-      if (path.isRoot()) {
-        // Root is always persisted.
-        inode.setPersistenceState(PersistenceState.PERSISTED);
-      }
       if (inode.isPersisted()) {
         return inode.getId();
       }

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -124,6 +124,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
       mRoot = InodeDirectory
           .create(mDirectoryIdGenerator.getNewDirectoryId(), NO_PARENT, ROOT_INODE_NAME,
               CreateDirectoryOptions.defaults().setPermissionStatus(rootPermissionStatus));
+      mRoot.setPersistenceState(PersistenceState.PERSISTED);
       mInodes.add(mRoot);
       mCachedInode = mRoot;
     }

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -733,6 +733,7 @@ public final class FileSystemMasterTest {
   @Test
   public void testLoadMetadataTest() throws Exception {
     FileUtils.createDir(Paths.get(mUnderFS).resolve("a").toString());
+    mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/"), LoadMetadataOptions.defaults());
     mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/a"),
         LoadMetadataOptions.defaults().setCreateAncestors(true));
     mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/a"),

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -733,7 +733,6 @@ public final class FileSystemMasterTest {
   @Test
   public void testLoadMetadataTest() throws Exception {
     FileUtils.createDir(Paths.get(mUnderFS).resolve("a").toString());
-    mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/"), LoadMetadataOptions.defaults());
     mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/a"),
         LoadMetadataOptions.defaults().setCreateAncestors(true));
     mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/a"),
@@ -751,6 +750,16 @@ public final class FileSystemMasterTest {
     // TODO(peis): Avoid this hack by adding an option in getFileInfo to skip loading metadata.
     mThrown.expect(FileAlreadyExistsException.class);
     mFileSystemMaster.createFile(new AlluxioURI("alluxio:/a/f"), CreateFileOptions.defaults());
+  }
+
+  /**
+   * Tests load root metadata. It should not fail.
+   *
+    * @throws Exception if a {@link FileSystemMaster} operation fails
+   */
+  @Test
+  public void testLoadRoot() throws Exception {
+    mFileSystemMaster.loadMetadata(new AlluxioURI("alluxio:/"), LoadMetadataOptions.defaults());
   }
 
   private long createFileWithSingleBlock(AlluxioURI uri) throws Exception {


### PR DESCRIPTION
InodeTree.java, line 284. It checks whether the path is root. If it root, it throws "FileAlreadyExistsException". I have changed loadMetadata function so that it throws a runtime exception if it catches FileAlreadyExistsException .