### PR TITLE
[DOCFIX]change "KeyValueSystem.Factory()" to "KeyValueSystem.Factory"

### DIFF
--- a/docs/_includes/Key-Value-Store-API/get-key-value-system.md
+++ b/docs/_includes/Key-Value-Store-API/get-key-value-system.md
@@ -1,3 +1,3 @@
 ```java
-KeyValueSystem kvs = KeyValueSystem.Factory().create();
+KeyValueSystem kvs = KeyValueSystem.Factory.create();
 ```


### PR DESCRIPTION
the "create()" is a static method, and I can only use the "KeyValueSystem.Factory.create()" when I use KeyValue API.