### PR TITLE
[SMALLFIX] Removed explicit type argument in StorageTier

### DIFF
--- a/core/server/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -70,7 +70,7 @@ public final class StorageTier {
         String.format(Constants.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA_FORMAT, mTierOrdinal);
     String[] dirQuotas = WorkerContext.getConf().get(tierDirCapacityConf).split(",");
 
-    mDirs = new ArrayList<StorageDir>(dirPaths.length);
+    mDirs = new ArrayList<>(dirPaths.length);
 
     long totalCapacity = 0;
     for (int i = 0; i < dirPaths.length; i++) {


### PR DESCRIPTION
Removed an explicit type argument in the *StorageTier* class.