### PR TITLE
[SMALLFIX]improve the javadoc of "BufferUtils"

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -181,8 +181,8 @@ public final class BufferUtils {
    * @param value the value to check for
    * @param len the target length of the sequence
    * @param arr the byte array to check
-   * @return true if the byte array has a prefix of length {@code len} that is an increasing
-   *         sequence of bytes starting at zero
+   * @return true if the byte array has a prefix of length {@code len} that is a constant
+   *         sequence of bytes of the given value
    */
   public static boolean equalConstantByteArray(byte value, int len, byte[] arr) {
     if (arr == null || arr.length != len) {
@@ -213,18 +213,18 @@ public final class BufferUtils {
    * Checks if the given byte array starts with an increasing sequence of bytes of the given
    * length, starting from the given value.
    *
-   * @param value the starting value to use
+   * @param start the starting value to use
    * @param len the target length of the sequence
    * @param arr the byte array to check
    * @return true if the byte array has a prefix of length {@code len} that is an increasing
    *         sequence of bytes starting at {@code start}
    */
-  public static boolean equalIncreasingByteArray(int value, int len, byte[] arr) {
+  public static boolean equalIncreasingByteArray(int start, int len, byte[] arr) {
     if (arr == null || arr.length != len) {
       return false;
     }
     for (int k = 0; k < len; k++) {
-      if (arr[k] != (byte) (value + k)) {
+      if (arr[k] != (byte) (start + k)) {
         return false;
       }
     }


### PR DESCRIPTION
the "#equalConstantByteArray()" @return is not consistent with the code.

the "#equalIncreasingByteArray()" @return uses "{@code start}", but uses "value" at other places, but many methods in BufferUtils uses "start" such as ""#equalIncreasingByteBuffer()" ":
![lmgcxc g2 46o ex2 z8 w6](https://cloud.githubusercontent.com/assets/16427747/15312180/7dca07c8-1c34-11e6-9407-e24a0eb6fdf1.png)
