### PR TITLE
[SMALLFIX] Removed explicit type argument in FileSystemWorker

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
@@ -73,7 +73,7 @@ public final class FileSystemWorker extends AbstractWorker {
    */
   @Override
   public Map<String, TProcessor> getServices() {
-    return new HashMap<String, TProcessor>();
+    return new HashMap<>();
   }
 
   /**


### PR DESCRIPTION
Removed an explicit type argument in the *FileSystemWorker* class.