### PR TITLE
[SMALLFIX] Removed redundant initializer in FileWorkerMasterSyncExecutor

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -78,7 +78,7 @@ final class FileWorkerMasterSyncExecutor implements HeartbeatExecutor {
       LOG.info("files {} persisted", persistedFiles);
     }
 
-    FileSystemCommand command = null;
+    FileSystemCommand command;
     try {
       command = mMasterClient.heartbeat(WorkerIdRegistry.getWorkerId(), persistedFiles);
     } catch (IOException e) {


### PR DESCRIPTION
Removed a redundant initializer in the *FileWorkerMasterSyncExecutor* class.