### PR TITLE
[SMALLFIX] Removed explicit type arguments in InodeTreeTest

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -553,13 +553,13 @@ public final class InodeTreeTest {
     InodeDirectory nested = (InodeDirectory) root.getChild("nested");
     InodeDirectory test = (InodeDirectory) nested.getChild("test");
     Inode<?> file = test.getChild("file");
-    verifyJournal(mTree, Lists.<Inode<?>>newArrayList(root, nested, test, file));
+    verifyJournal(mTree, Lists.newArrayList(root, nested, test, file));
 
     // add a sibling of test and verify journaling is in correct order (breadth first)
     mTree.createPath(new AlluxioURI("/nested/test1/file1"), sNestedFileOptions);
     InodeDirectory test1 = (InodeDirectory) nested.getChild("test1");
     Inode<?> file1 = test1.getChild("file1");
-    verifyJournal(mTree, Lists.<Inode<?>>newArrayList(root, nested, test, test1, file, file1));
+    verifyJournal(mTree, Lists.newArrayList(root, nested, test, test1, file, file1));
   }
 
   /**


### PR DESCRIPTION
Removed some explicit type arguments in the *InodeTreeTest* class.