### PR TITLE
[SMALLFIX] Removed explicit type argument in PermissionCheckerTest

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -128,7 +128,7 @@ public final class PermissionCheckerTest {
   }
 
   public static class FakeUserGroupsMapping implements GroupMappingService {
-    private HashMap<String, String> mUserGroups = new HashMap<String, String>();
+    private HashMap<String, String> mUserGroups = new HashMap<>();
 
     public FakeUserGroupsMapping() {
       mUserGroups.put(TEST_USER_ADMIN.getUser(), TEST_USER_ADMIN.getGroups());


### PR DESCRIPTION
Removed an explicit type argument in the *PermissionCheckerTest* class.