### PR TITLE
[SMALLFIX]improve javadoc and change the code of "#replaceHostName(URI)"

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -228,7 +228,7 @@ public final class PathUtils {
   }
 
   /**
-   * Adds a trailing separator if it does not exists in path.
+   * Adds a trailing separator if it does not exist in path.
    *
    * @param path the file name
    * @param separator trailing separator to add

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -140,7 +140,7 @@ public final class NetworkAddressUtils {
     /**
      * Gets the key of bind hostname.
      *
-     * @return key of bindhostname
+     * @return key of bind hostname
      */
     public String getBindHostKey() {
       return mBindHostKey;
@@ -451,7 +451,7 @@ public final class NetworkAddressUtils {
       return null;
     }
 
-    if (path.hasAuthority() && path.getPort() != -1) {
+    if (path.hasAuthority()) {
       String authority = resolveHostName(path.getHost());
       if (path.getPort() != -1) {
         authority += ":" + path.getPort();


### PR DESCRIPTION
the method "#replaceHostName()"  checks the condition "path.getPort() != -1" repeatedly, I think we can remove the outer one.(this is because an AlluxioURI doesn't ensure an authority has a port)
Or remove the inner one?