### PR TITLE
[SMALLFIX] Removed explicit type arguments in StorageDirTest

### DIFF
--- a/core/server/src/test/java/alluxio/worker/block/meta/StorageDirTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/meta/StorageDirTest.java
@@ -279,7 +279,7 @@ public final class StorageDirTest {
     mDir.addBlockMeta(blockMeta2);
 
     List<Long> actual = mDir.getBlockIds();
-    Assert.assertEquals(Sets.newHashSet(blockId1, blockId2), new HashSet<Long>(actual));
+    Assert.assertEquals(Sets.newHashSet(blockId1, blockId2), new HashSet<>(actual));
   }
 
   /**
@@ -298,7 +298,7 @@ public final class StorageDirTest {
     mDir.addBlockMeta(blockMeta2);
 
     List<BlockMeta> actual = mDir.getBlocks();
-    Assert.assertEquals(Sets.newHashSet(blockMeta1, blockMeta2), new HashSet<BlockMeta>(actual));
+    Assert.assertEquals(Sets.newHashSet(blockMeta1, blockMeta2), new HashSet<>(actual));
   }
 
   /**
@@ -560,12 +560,12 @@ public final class StorageDirTest {
 
     // Check the temporary blocks belonging to TEST_SESSION_ID
     List<TempBlockMeta> actual = mDir.getSessionTempBlocks(TEST_SESSION_ID);
-    List<Long> actualBlockIds = new ArrayList<Long>(actual.size());
+    List<Long> actualBlockIds = new ArrayList<>(actual.size());
     for (TempBlockMeta tempBlockMeta : actual) {
       actualBlockIds.add(tempBlockMeta.getBlockId());
     }
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta1, tempBlockMeta2),
-        new HashSet<TempBlockMeta>(actual));
+        new HashSet<>(actual));
     Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId1));
     Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId2));
 


### PR DESCRIPTION
Removed some explicit type arguments in the *StorageDirTest* class.