### PR TITLE
[SMALLFIX] Fix some bugs in ufsdataserver logic

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -118,6 +118,8 @@ public final class UnderFileSystemFileInStream extends InputStream {
       int bytesRead = directRead(b, off, len);
       if (bytesRead != -1) {
         mPos += bytesRead;
+      } else { // Hit end of file, set flag
+        mEOF = true;
       }
       return bytesRead;
     }
@@ -164,9 +166,10 @@ public final class UnderFileSystemFileInStream extends InputStream {
   private void bufferedRead(int len) throws IOException {
     mBuffer.clear();
     int bytesRead = directRead(mBuffer.array(), 0, len);
-    if (bytesRead >= 0) {
+    if (bytesRead != -1) {
       mBuffer.limit(bytesRead);
-      mBuffer.position(0);
+    } else {
+      mEOF = true;
     }
   }
 
@@ -198,7 +201,6 @@ public final class UnderFileSystemFileInStream extends InputStream {
       ByteBuffer data = mReader.read(mAddress, mUfsFileId, currentPosition, bytesLeft);
       if (data == null) { // No more data
         if (bytesRead == 0) { // Did not read any bytes, at EOF
-          mEOF = true;
           return -1;
         }
         break;

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -157,23 +157,6 @@ public final class UnderFileSystemFileInStream extends InputStream {
   }
 
   /**
-   * Reads from the data source into the buffer. The buffer's position will be at 0 and have an
-   * appropriate limit set.
-   *
-   * @param len length of data to fill in the buffer, must always be <= buffer size
-   * @throws IOException if the read failed to buffer the requested number of bytes
-   */
-  private void bufferedRead(int len) throws IOException {
-    mBuffer.clear();
-    int bytesRead = directRead(mBuffer.array(), 0, len);
-    if (bytesRead != -1) {
-      mBuffer.limit(bytesRead);
-    } else {
-      mEOF = true;
-    }
-  }
-
-  /**
    * Convenience method to ensure the stream is not closed.
    */
   private void checkIfClosed() {
@@ -221,7 +204,13 @@ public final class UnderFileSystemFileInStream extends InputStream {
    * @throws IOException if an error occurs reading the data
    */
   private void updateBuffer() throws IOException {
-    bufferedRead(mBuffer.capacity());
-    mIsBufferValid = true;
+    mBuffer.clear();
+    int bytesRead = directRead(mBuffer.array(), 0, mBuffer.capacity());
+    if (bytesRead != -1) {
+      mBuffer.limit(bytesRead);
+      mIsBufferValid = true;
+    } else {
+      mEOF = true;
+    }
   }
 }

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -173,6 +173,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
    * @return the number of bytes successfully read, -1 if at EOF before reading
    * @throws IOException if an error occurs reading the data
    */
+  // TODO(calvin): This may be better implemented with a Bytebuffer instead of byte array parameter
   private int directRead(byte[] b, int off, int len) throws IOException {
     int bytesLeft = len;
     int bytesRead = 0;

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -86,16 +86,15 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
         case RPC_FILE_READ_RESPONSE:
           RPCFileReadResponse resp = (RPCFileReadResponse) response;
           LOG.debug("Data for ufs file id {} from machine {} received", ufsFileId, address);
-
           RPCResponse.Status status = resp.getStatus();
           if (status == RPCResponse.Status.SUCCESS) {
             // always clear the previous response before reading another one
             cleanup();
-            mReadResponse = resp;
             // End of file reached
             if (resp.getLength() == -1) {
               return null;
             }
+            mReadResponse = resp;
             return resp.getPayloadDataBuffer().getReadOnlyByteBuffer();
           }
           throw new IOException(status.getMessage() + " response: " + resp);

--- a/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
@@ -13,6 +13,7 @@ package alluxio.client.file;
 
 import alluxio.client.netty.NettyUnderFileSystemFileReader;
 import alluxio.util.io.BufferUtils;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,8 +35,8 @@ import java.nio.ByteBuffer;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(NettyUnderFileSystemFileReader.class)
 public class UnderFileSystemFileInStreamTest {
-  private static long FILE_ID = 1L;
-  private static int FILE_SIZE = 1000;
+  private static final long FILE_ID = 1L;
+  private static final int FILE_SIZE = 1000;
 
   private byte[] mData;
   private NettyUnderFileSystemFileReader mMockReader;
@@ -47,8 +48,7 @@ public class UnderFileSystemFileInStreamTest {
     mMockReader = PowerMockito.mock(NettyUnderFileSystemFileReader.class);
     InetSocketAddress mockAddr = Mockito.mock(InetSocketAddress.class);
     Mockito.when(mMockReader.read(Mockito.any(InetSocketAddress.class), Mockito.anyLong(),
-        Mockito.anyLong(), Mockito.anyLong())).thenAnswer(
-        new Answer<ByteBuffer>() {
+        Mockito.anyLong(), Mockito.anyLong())).thenAnswer(new Answer<ByteBuffer>() {
           @Override
           public ByteBuffer answer(InvocationOnMock invocation) throws Throwable {
             Object[] args = invocation.getArguments();

--- a/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
@@ -1,0 +1,128 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the “License”). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.client.netty.NettyUnderFileSystemFileReader;
+import alluxio.util.io.BufferUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+/**
+* Tests {@link alluxio.client.file.UnderFileSystemFileInStream}.
+*/
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NettyUnderFileSystemFileReader.class)
+public class UnderFileSystemFileInStreamTest {
+  private static long FILE_ID = 1L;
+  private static int FILE_SIZE = 1000;
+
+  private byte[] mData;
+  private NettyUnderFileSystemFileReader mMockReader;
+  private UnderFileSystemFileInStream mTestStream;
+
+  @Before
+  public final void before() throws Exception {
+    mData = BufferUtils.getIncreasingByteArray(FILE_SIZE);
+    mMockReader = PowerMockito.mock(NettyUnderFileSystemFileReader.class);
+    InetSocketAddress mockAddr = Mockito.mock(InetSocketAddress.class);
+    Mockito.when(mMockReader.read(Mockito.any(InetSocketAddress.class), Mockito.anyLong(),
+        Mockito.anyLong(), Mockito.anyLong())).thenAnswer(
+        new Answer<ByteBuffer>() {
+          @Override
+          public ByteBuffer answer(InvocationOnMock invocation) throws Throwable {
+            Object[] args = invocation.getArguments();
+            long offset = (long) args[2];
+            long length = (long) args[3];
+            if (offset == mData.length) {
+              return null;
+            }
+            int len = (int) Math.min(mData.length - offset, length);
+            return ByteBuffer.wrap(mData, (int) offset, len);
+          }
+        });
+    mTestStream = new UnderFileSystemFileInStream(mockAddr, FILE_ID);
+    Whitebox.setInternalState(mTestStream, "mReader", mMockReader);
+  }
+
+  /**
+   * Tests the read() method.
+   */
+  @Test
+  public void readByteTest() throws Exception {
+    for (int i = 0; i < FILE_SIZE; i++) {
+      Assert.assertEquals((byte) mTestStream.read(), mData[i]);
+    }
+  }
+
+  /**
+   * Tests the internal buffering of the class.
+   */
+  @Test
+  public void readByteBufferedTest() throws Exception {
+    for (int i = 0; i < FILE_SIZE; i++) {
+      Assert.assertEquals((byte) mTestStream.read(), mData[i]);
+    }
+    // One call to get the data, second call to verify end of file
+    Mockito.verify(mMockReader, Mockito.times(2)).read(Mockito.any(InetSocketAddress.class),
+        Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+  }
+
+  /**
+   * Tests the read(byte[]) method.
+   */
+  @Test
+  public void readByteArrayTest() throws Exception {
+    byte[] b = new byte[FILE_SIZE];
+    Assert.assertEquals(FILE_SIZE, mTestStream.read(b));
+    BufferUtils.equalIncreasingByteArray(FILE_SIZE, b);
+  }
+
+  /**
+   * Tests the read(byte[], int, int) method.
+   */
+  @Test
+  public void readByteArrayOffsetTest() throws Exception {
+    byte[] b = new byte[FILE_SIZE];
+    Assert.assertEquals(FILE_SIZE / 2, mTestStream.read(b, FILE_SIZE / 2, FILE_SIZE / 2));
+    for (int i = 0; i < FILE_SIZE; i++) {
+      Assert.assertEquals((byte) Math.max(0, i - FILE_SIZE / 2), b[i]);
+    }
+  }
+
+  /**
+   * Tests that the stream stops at EOF when reading more than available data and sets the flag
+   * appropriately after detecting EOF.
+   */
+  @Test
+  public void readToEOFTest() throws Exception {
+    byte[] b = new byte[FILE_SIZE * 100];
+    Assert.assertEquals(FILE_SIZE, mTestStream.read(b));
+    for (int i = 0; i < FILE_SIZE; i++) {
+      Assert.assertEquals((byte) i, b[i]);
+    }
+    Assert.assertEquals(-1, mTestStream.read());
+    boolean eof = Whitebox.getInternalState(mTestStream, "mEOF");
+    Assert.assertTrue(eof);
+  }
+}

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -250,7 +250,7 @@ public final class UnderFileSystemManager {
             ufs.setOwner(mUri, user, group);
           } catch (Exception e) {
             LOG.warn("Failed to update the ufs user, Alluxio system defaults will be used. Error: "
-                + e.getMessage());
+                + e);
           }
         }
       } else {

--- a/core/server/src/main/java/alluxio/worker/netty/DataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/DataServerHandler.java
@@ -82,6 +82,10 @@ public final class DataServerHandler extends SimpleChannelInboundHandler<RPCMess
         assert msg instanceof RPCFileWriteRequest;
         mUnderFileSystemHandler.handleFileWriteRequest(ctx, (RPCFileWriteRequest) msg);
         break;
+      case RPC_ERROR_RESPONSE:
+        assert msg instanceof RPCErrorResponse;
+        LOG.error("Received an error response from the client: " + msg.toString());
+        break;
       default:
         RPCErrorResponse resp = new RPCErrorResponse(RPCResponse.Status.UNKNOWN_MESSAGE_ERROR);
         ctx.writeAndFlush(resp);

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -77,9 +77,9 @@ public class UnderFileSystemDataServerHandler {
     // TODO(calvin): This can be more efficient for sequential reads if we keep state
     try (InputStream in = mWorker.getUfsInputStream(ufsFileId, offset)) {
       int read = in.read(data);
+      DataBuffer buf = read != -1 ? new DataByteBuffer(ByteBuffer.wrap(data), read) : null;
       RPCFileReadResponse resp =
-          new RPCFileReadResponse(ufsFileId, offset, read, new DataByteBuffer(
-              ByteBuffer.wrap(data), read), RPCResponse.Status.SUCCESS);
+          new RPCFileReadResponse(ufsFileId, offset, read, buf, RPCResponse.Status.SUCCESS);
       ChannelFuture future = ctx.writeAndFlush(resp);
       future.addListener(ChannelFutureListener.CLOSE);
     } catch (Exception e) {
@@ -111,7 +111,7 @@ public class UnderFileSystemDataServerHandler {
     try {
       OutputStream out = mWorker.getUfsOutputStream(ufsFileId);
       // This channel will not be closed because the underlying stream should not be closed, the
-      // channel will be cleaned up when the underyling stream is closed.
+      // channel will be cleaned up when the underlying stream is closed.
       WritableByteChannel channel = Channels.newChannel(out);
       channel.write(data.getReadOnlyByteBuffer());
       RPCFileWriteResponse resp =

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -77,7 +77,7 @@ public class UnderFileSystemDataServerHandler {
     // TODO(calvin): This can be more efficient for sequential reads if we keep state
     try (InputStream in = mWorker.getUfsInputStream(ufsFileId, offset)) {
       int read = in.read(data);
-      DataBuffer buf = read != -1 ? new DataByteBuffer(ByteBuffer.wrap(data), read) : null;
+      DataBuffer buf = read != -1 ? new DataByteBuffer(ByteBuffer.wrap(data, 0, read), read) : null;
       RPCFileReadResponse resp =
           new RPCFileReadResponse(ufsFileId, offset, read, buf, RPCResponse.Status.SUCCESS);
       ChannelFuture future = ctx.writeAndFlush(resp);


### PR DESCRIPTION
Wrap the correct portion of the byte array and consume the data on the client side properly. Also a cosmetic fix in the server exception logging.