### PR TITLE
[SMALLFIX] Fixed Javadoc in BlockLockManagerTest

### DIFF
--- a/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -231,7 +231,8 @@ public class BlockLockManagerTest {
    * Calls {@link BlockLockManager#lockBlock(long, long, BlockLockType)} and fails if it doesn't
    * hang.
    *
-   * @param the block id to try locking
+   * @param manager the manager to used to lock
+   * @param blockId block id to try locking
    */
   private void lockExpectingHang(final BlockLockManager manager, final long blockId)
       throws Exception {

--- a/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -231,7 +231,7 @@ public class BlockLockManagerTest {
    * Calls {@link BlockLockManager#lockBlock(long, long, BlockLockType)} and fails if it doesn't
    * hang.
    *
-   * @param manager the manager to used to lock
+   * @param manager the manager to call lock on
    * @param blockId block id to try locking
    */
   private void lockExpectingHang(final BlockLockManager manager, final long blockId)


### PR DESCRIPTION
Fixed Javadoc in the *BlockLockManagerTest* class.