### PR TITLE
[SMALLFIX] reducing the default max size of the block worker Thrift client pool

### DIFF
--- a/conf/alluxio-site.properties.template
+++ b/conf/alluxio-site.properties.template
@@ -68,7 +68,7 @@ alluxio.worker.web.port=30000
 
 # User properties
 alluxio.user.block.master.client.threads=10
-alluxio.user.block.worker.client.threads=10000
+alluxio.user.block.worker.client.threads=128
 alluxio.user.block.remote.read.buffer.size.bytes=8MB
 alluxio.user.block.size.bytes.default=512MB
 alluxio.user.failed.space.request.limits=3

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -141,7 +141,7 @@ alluxio.worker.web.port=30000
 
 # User properties
 alluxio.user.block.master.client.threads=10
-alluxio.user.block.worker.client.threads=10000
+alluxio.user.block.worker.client.threads=128
 alluxio.user.block.remote.read.buffer.size.bytes=8MB
 alluxio.user.block.remote.reader.class=alluxio.client.netty.NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class=alluxio.client.netty.NettyRemoteBlockWriter
@@ -170,4 +170,3 @@ alluxio.fuse.cached.paths.max=500
 alluxio.fuse.mount.default=/mnt/alluxio
 alluxio.fuse.fs.root=/
 alluxio.fuse.fs.name=alluxio-fuse
-

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -1,7 +1,9 @@
 alluxio.user.block.master.client.threads:
-  The number of threads used by a block master client to talk to the block master.
+  The number of threads used by a block master client pool to talk to the block master.
 alluxio.user.block.worker.client.threads:
-  How many threads to use for block worker client pool to read from a local block worker.
+  The number of threads used by a block worker client pool to talk to a remote block worker. It
+  determines the maximum number of Thrift connections between an Alluxio client and an Alluxio
+  worker.
 alluxio.user.block.remote.read.buffer.size.bytes:
   The size of the file buffer to read data from remote Alluxio worker.
 alluxio.user.block.remote.reader.class:

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -12,6 +12,9 @@ alluxio.worker.block.heartbeat.timeout.ms:
 alluxio.worker.block.threads.max:
   The maximum number of incoming RPC requests to block worker that can be handled.
   This value is used to configure maximum number of threads in Thrift thread pool with block worker.
+  This value should be greater than the sum of `alluxio.user.block.worker.client.threads` across
+  concurrent Alluxio clients. Otherwise, the worker connection pool can be drained, preventing new
+  connections from being established.
 alluxio.worker.block.threads.min:
   The minimum number of threads used to handle incoming RPC requests to block worker.
   This value is used to configure minimum number of threads in Thrift thread pool with block worker.

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -1,6 +1,6 @@
 propertyName,defaultValue
 alluxio.user.block.master.client.threads,10
-alluxio.user.block.worker.client.threads,10000
+alluxio.user.block.worker.client.threads,128
 alluxio.user.block.remote.read.buffer.size.bytes,8 MB
 alluxio.user.block.remote.reader.class,alluxio.client.netty.&#8203;NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class,alluxio.client.netty.&#8203;NettyRemoteBlockWriter


### PR DESCRIPTION
This changes prevents a highly concurrent Alluxio client from depleting the Alluxio worker connection pool.