### PR TITLE
[SMALLFIX] Hadoop fs init fix

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -36,6 +36,7 @@ import alluxio.wire.FileBlockInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -73,7 +74,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
   /** Flag for if the contexts have been initialized. */
   @GuardedBy("INIT_LOCK")
-  private static boolean sInitialized = false;
+  private static volatile boolean sInitialized = false;
 
   private URI mUri = null;
   private Path mWorkingDir = new Path(AlluxioURI.SEPARATOR);
@@ -389,6 +390,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    *
    * Initialize is guaranteed to only be called once per process.
    */
+  @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Override
   public void initialize(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
     Preconditions.checkNotNull(uri.getHost(), PreconditionMessage.URI_HOST_NULL);

--- a/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -16,8 +16,8 @@ import alluxio.client.ClientContext;
 import alluxio.client.block.BlockStoreContext;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.lineage.LineageContext;
-
 import alluxio.hadoop.HadoopClientTestUtils;
+
 import com.google.common.base.Throwables;
 import org.powermock.reflect.Whitebox;
 

--- a/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -17,6 +17,7 @@ import alluxio.client.block.BlockStoreContext;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.lineage.LineageContext;
 
+import alluxio.hadoop.HadoopClientTestUtils;
 import com.google.common.base.Throwables;
 import org.powermock.reflect.Whitebox;
 
@@ -35,13 +36,14 @@ public final class ClientTestUtils {
 
   /**
    * Reverts the client context configuration to the default value, and reinitializes all contexts
-   * while rely on this configuration.
+   * while rely on this configuration. Resets the initialization flag in AbstractFileSystem.
    *
    * This method should only be used as a cleanup mechanism between tests. It should not be used
    * while any object may be using the {@link ClientContext}.
    */
   public static void resetClientContext() {
     try {
+      HadoopClientTestUtils.resetHadoopClientContext();
       Whitebox.invokeMethod(ClientContext.class, "reset");
       resetContexts();
     } catch (Exception e) {

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -185,6 +185,10 @@ public class AbstractFileSystemTest {
         "mLineageMasterClientPool", "mMasterAddress"));
   }
 
+  /**
+   * Verifies that the initialize method is only called once even when there are many concurrent
+   * initializers during the initialization phase.
+   */
   @Test
   public void concurrentInitializeTest() throws Exception {
     final List<Thread> threads = new ArrayList<Thread>();

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -167,22 +167,18 @@ public class AbstractFileSystemTest {
    */
   @Test
   public void resetContextTest() throws Exception {
-    // Create system with master at localhost:19998
-    URI uri = URI.create(Constants.HEADER + "localhost:19998/");
-    Configuration conf = getConf();
-    org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
 
     // Change to otherhost:410
-    URI newUri = URI.create(Constants.HEADER + "otherhost:410/");
-    fs.initialize(newUri, conf);
+    URI uri = URI.create(Constants.HEADER + "otherhost:410/");
+    org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, getConf());
 
     // Make sure all contexts are using the new address
     InetSocketAddress newAddress = new InetSocketAddress("otherhost", 410);
     Assert.assertEquals(newAddress, ClientContext.getMasterAddress());
     Assert.assertEquals(newAddress, CommonTestUtils.getInternalState(BlockStoreContext.INSTANCE,
         "mBlockMasterClientPool", "mMasterAddress"));
-    // Once from calling FileSystem.get, once from calling initialize.
-    Mockito.verify(mMockFileSystemContext, Mockito.times(2)).reset();
+    // Once from calling FileSystem.get
+    Mockito.verify(mMockFileSystemContext).reset();
     Assert.assertEquals(newAddress, CommonTestUtils.getInternalState(LineageContext.INSTANCE,
         "mLineageMasterClientPool", "mMasterAddress"));
   }

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -70,6 +70,7 @@ public class AbstractFileSystemTest {
    */
   @Before
   public void setup() throws Exception {
+    ClientTestUtils.resetClientContext();
     mockUserGroupInformation();
     mockMasterClient();
 

--- a/core/client/src/test/java/alluxio/hadoop/HadoopClientTestUtils.java
+++ b/core/client/src/test/java/alluxio/hadoop/HadoopClientTestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the “License”). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import com.google.common.base.Throwables;
+import org.powermock.reflect.Whitebox;
+
+/**
+ * Utility methods for the Hadoop client tests.
+ */
+public final class HadoopClientTestUtils {
+  /**
+   * Resets the initialized flag in {@link AbstractFileSystem} allowing FileSystems with
+   * different URIs to be initialized.
+   */
+  public static void resetHadoopClientContext() {
+    try {
+      Whitebox.setInternalState(AbstractFileSystem.class, "sInitialized", false);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}


### PR DESCRIPTION
Enforces the assumption we only init the hadoop client once.