### PR TITLE
[SMALLFIX] improve javadoc and chenge code in "Sessions"

### DIFF
--- a/core/server/src/main/java/alluxio/SessionInfo.java
+++ b/core/server/src/main/java/alluxio/SessionInfo.java
@@ -17,7 +17,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Represent one session in the worker daemon.
+ * Represents one session in the worker daemon.
  */
 @ThreadSafe
 public class SessionInfo {

--- a/core/server/src/main/java/alluxio/Sessions.java
+++ b/core/server/src/main/java/alluxio/Sessions.java
@@ -71,7 +71,7 @@ public class Sessions {
    *
    * @param sessionId the id of the session to be removed
    */
-  public synchronized void removeSession(long sessionId) {
+  public void removeSession(long sessionId) {
     LOG.info("Cleaning up session {}", sessionId);
     synchronized (mSessions) {
       mSessions.remove(sessionId);


### PR DESCRIPTION
Any other methods in "Sessions" synchronize on "mSessions", only "#removeSessions(sessionid)" uses
synchronize on the method and "mSessions" both, I think we can remove the "synchronize" which on the method