### PR TITLE
[SMALLFIX] Removed explicit parameter type in BufferUtils

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -117,7 +117,7 @@ public final class BufferUtils {
    * @return the new list of ByteBuffers
    */
   public static List<ByteBuffer> cloneByteBufferList(List<ByteBuffer> source) {
-    List<ByteBuffer> ret = new ArrayList<ByteBuffer>(source.size());
+    List<ByteBuffer> ret = new ArrayList<>(source.size());
     for (ByteBuffer b : source) {
       ret.add(cloneByteBuffer(b));
     }


### PR DESCRIPTION
Removed an explicit parameter type in the *BufferUtils* class.