### PR TITLE
[SMALLFIX] Cleanup netty listeners on read path

### DIFF
--- a/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
@@ -58,13 +58,11 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
   @Override
   public ByteBuffer readRemoteBlock(InetSocketAddress address, long blockId, long offset,
       long length, long lockId, long sessionId) throws IOException {
-
+    SingleResponseListener listener = new SingleResponseListener();
     try {
       ChannelFuture f = mClientBootstrap.connect(address).sync();
-
       LOG.info("Connected to remote machine {}", address);
       Channel channel = f.channel();
-      SingleResponseListener listener = new SingleResponseListener();
       mHandler.addListener(listener);
       channel.writeAndFlush(new RPCBlockReadRequest(blockId, offset, length, lockId, sessionId));
 
@@ -93,6 +91,8 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
       }
     } catch (Exception e) {
       throw new IOException(e);
+    } finally {
+      mHandler.removeListener(listener);
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -70,12 +70,12 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
    */
   public ByteBuffer read(InetSocketAddress address, long ufsFileId, long offset, long length)
       throws IOException {
+    SingleResponseListener listener = new SingleResponseListener();
     try {
       ChannelFuture f = mClientBootstrap.connect(address).sync();
 
       LOG.debug("Connected to remote machine {}", address);
       Channel channel = f.channel();
-      SingleResponseListener listener = new SingleResponseListener();
       mHandler.addListener(listener);
       channel.writeAndFlush(new RPCFileReadRequest(ufsFileId, offset, length));
 
@@ -107,6 +107,8 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
       }
     } catch (Exception e) {
       throw new IOException(e);
+    } finally {
+      mHandler.removeListener(listener);
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -70,12 +70,13 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
    */
   public ByteBuffer read(InetSocketAddress address, long ufsFileId, long offset, long length)
       throws IOException {
-    SingleResponseListener listener = new SingleResponseListener();
+    SingleResponseListener listener = null;
     try {
       ChannelFuture f = mClientBootstrap.connect(address).sync();
 
       LOG.debug("Connected to remote machine {}", address);
       Channel channel = f.channel();
+      listener = new SingleResponseListener();
       mHandler.addListener(listener);
       channel.writeAndFlush(new RPCFileReadRequest(ufsFileId, offset, length));
 
@@ -108,7 +109,9 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
     } catch (Exception e) {
       throw new IOException(e);
     } finally {
-      mHandler.removeListener(listener);
+      if (listener != null) {
+        mHandler.removeListener(listener);
+      }
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
@@ -67,12 +67,13 @@ public final class NettyUnderFileSystemFileWriter {
    */
   public void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
       int offset, int length) throws IOException {
-    SingleResponseListener listener = new SingleResponseListener();
+    SingleResponseListener listener = null;
     try {
       ChannelFuture f = mClientBootstrap.connect(address).sync();
 
       LOG.debug("Connected to remote machine {}", address);
       Channel channel = f.channel();
+      listener = new SingleResponseListener();
       mHandler.addListener(listener);
       channel.writeAndFlush(new RPCFileWriteRequest(ufsFileId, fileOffset, length,
           new DataByteArrayChannel(bytes, offset, length)));
@@ -101,7 +102,9 @@ public final class NettyUnderFileSystemFileWriter {
     } catch (Exception e) {
       throw new IOException(e);
     } finally {
-      mHandler.removeListener(listener);
+      if (listener != null) {
+        mHandler.removeListener(listener);
+      }
     }
   }
 }


### PR DESCRIPTION
Cleans up the listener so long living Netty readers do not have an infinitely growing set of listeners.