### PR TITLE
[SMALLFIX]remove "synchronized" in "BlockContainerIdGenerator"

### DIFF
--- a/core/server/src/main/java/alluxio/master/block/BlockContainerIdGenerator.java
+++ b/core/server/src/main/java/alluxio/master/block/BlockContainerIdGenerator.java
@@ -31,14 +31,14 @@ public final class BlockContainerIdGenerator implements ContainerIdGenerable {
   }
 
   @Override
-  public synchronized long getNewContainerId() {
+  public long getNewContainerId() {
     return mNextContainerId.getAndIncrement();
   }
 
   /**
    * @param id the next container id to use
    */
-  public synchronized void setNextContainerId(long id) {
+  public void setNextContainerId(long id) {
     mNextContainerId.set(id);
   }
 }


### PR DESCRIPTION
This class has only one single variable "mNextContainerId" which type is AtomicLong, Atomic variables supports lock-free thread-safe programming on single variables. I think we can delegate the thread-safety to this atomic variable and don't need to use intrinsic lock.