### PR TITLE
[SMALLFIX] Faster return on EOF in under storage read path.

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
@@ -182,7 +182,8 @@ public final class FileSystemWorker extends AbstractWorker {
    *
    * @param tempUfsFileId the worker specific temporary file id for the file in the under storage
    * @param position the absolute position in the file to position the stream at before returning
-   * @return an input stream to the ufs file positioned at the given position
+   * @return an input stream to the ufs file positioned at the given position, null if the
+   *         position is past the end of the file.
    * @throws FileDoesNotExistException if the worker file id is invalid
    * @throws IOException if an error occurs interacting with the under file system
    */

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -116,6 +116,8 @@ public final class UnderFileSystemManager {
     private final long mSessionId;
     /** Id referencing this agent, used as an index. */
     private final long mAgentId;
+    /** The length of the file in the under storage. */
+    private final long mLength;
     /** Configuration to use for this stream. */
     private final Configuration mConfiguration;
     /** The string form of the uri to the file in the under file system. */
@@ -145,6 +147,7 @@ public final class UnderFileSystemManager {
         throw new FileDoesNotExistException(
             ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(mUri));
       }
+      mLength = ufs.getFileSize(mUri);
     }
 
     /**
@@ -153,10 +156,14 @@ public final class UnderFileSystemManager {
      * closing the stream.
      *
      * @param position the absolute position in the file to start the stream at
-     * @return an input stream to the file starting at the specified position
+     * @return an input stream to the file starting at the specified position, null if the position
+     *         is past the end of the file
      * @throws IOException if an error occurs when interacting with the UFS
      */
     private InputStream openAtPosition(long position) throws IOException {
+      if (position >= mLength) {
+        return null;
+      }
       UnderFileSystem ufs = UnderFileSystem.get(mUri, mConfiguration);
       InputStream stream = ufs.open(mUri);
       if (position != stream.skip(position)) {
@@ -385,7 +392,8 @@ public final class UnderFileSystemManager {
   /**
    * @param tempUfsFileId the temporary ufs file id
    * @param position the absolute position in the file to start the stream at
-   * @return the input stream to read from this file
+   * @return the input stream to read from this file, null if the position is past the end of the
+   *         file
    * @throws FileDoesNotExistException if the worker file id not valid
    * @throws IOException if an error occurs when operating on the under file system
    */

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -77,12 +77,14 @@ public class UnderFileSystemDataServerHandler {
     // TODO(calvin): This can be more efficient for sequential reads if we keep state
     try (InputStream in = mWorker.getUfsInputStream(ufsFileId, offset)) {
       int bytesRead = 0;
-      while (bytesRead < length) {
-        int read = in.read(data, bytesRead, (int) length - bytesRead);
-        if (read == -1) {
-          break;
+      if (in != null) { // if we have not reached the end of the file
+        while (bytesRead < length) {
+          int read = in.read(data, bytesRead, (int) length - bytesRead);
+          if (read == -1) {
+            break;
+          }
+          bytesRead += read;
         }
-        bytesRead += read;
       }
       DataBuffer buf =
           bytesRead != 0 ? new DataByteBuffer(ByteBuffer.wrap(data, 0, bytesRead), bytesRead)


### PR DESCRIPTION
It isn't guaranteed the underlying under storage stream will support skip to or past end of file. Also reduces one communication to the under storage.