### PR TITLE
Add missing super calls to hadoop FileSystem client

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/FaultTolerantFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/FaultTolerantFileSystem.java
@@ -32,7 +32,9 @@ public final class FaultTolerantFileSystem extends AbstractFileSystem {
   /**
    * Constructs a new {@link FaultTolerantFileSystem}.
    */
-  public FaultTolerantFileSystem() {}
+  public FaultTolerantFileSystem() {
+    super();
+  }
 
   @Override
   public String getScheme() {

--- a/core/client/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/FileSystem.java
@@ -29,7 +29,9 @@ public final class FileSystem extends AbstractFileSystem {
   /**
    * Constructs a new {@link FileSystem}.
    */
-  public FileSystem() {}
+  public FileSystem() {
+    super();
+  }
 
   @Override
   public String getScheme() {


### PR DESCRIPTION
When we added the "default" constructor we forgot to call the super constructor