### PR TITLE
[SMALLFIX] Removed explicit argument types in KeyValueWorker

### DIFF
--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorker.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorker.java
@@ -57,11 +57,10 @@ public final class KeyValueWorker extends AbstractWorker {
 
   @Override
   public Map<String, TProcessor> getServices() {
-    Map<String, TProcessor> services = new HashMap<String, TProcessor>();
+    Map<String, TProcessor> services = new HashMap<>();
     services.put(
         Constants.KEY_VALUE_WORKER_CLIENT_SERVICE_NAME,
-        new KeyValueWorkerClientService.Processor<KeyValueWorkerClientServiceHandler>(
-            mKeyValueServiceHandler));
+        new KeyValueWorkerClientService.Processor<>(mKeyValueServiceHandler));
     return services;
   }
 


### PR DESCRIPTION
Removed some explicit parameter types in the *KeyValueWorker* class.