### PR TITLE
[SMALLFIX] Removed explicit argument type in AbstractLocalAlluxioCluster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -386,7 +386,7 @@ public abstract class AbstractLocalAlluxioCluster {
       String tierLevelDirPath =
           String.format(Constants.WORKER_TIERED_STORE_LEVEL_DIRS_PATH_FORMAT, level);
       String[] dirPaths = testConf.get(tierLevelDirPath).split(",");
-      List<String> newPaths = new ArrayList<String>();
+      List<String> newPaths = new ArrayList<>();
       for (String dirPath : dirPaths) {
         String newPath = mHome + dirPath;
         newPaths.add(newPath);


### PR DESCRIPTION
Removed an explicit argument type in the *AbstractLocalAlluxioCluster* class.