### PR TITLE
[SMALLFIX] Implement isDirectory in Swift UFS

### DIFF
--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -366,7 +366,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
   }
 
   /**
-   * Check if the path is a prefix of at least one object in Swift.
+   * Checks if the path is a prefix of at least one object in Swift.
    *
    * @param path the path to check
    * @return boolean indicating if the path is a directory

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -249,11 +249,11 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean isFile(String path) throws IOException {
-    String normalizedPath = stripPrefixIfPresent(path);
+    String strippedPath = stripPrefixIfPresent(path);
     // To get better performance Swift driver does not create a _temporary folder.
     // This optimization should be hidden from Spark, therefore exists _temporary will return true.
-    return normalizedPath.endsWith("_temporary")
-        || mAccount.getContainer(mContainerName).getObject(normalizedPath).exists();
+    return strippedPath.endsWith("_temporary")
+        || mAccount.getContainer(mContainerName).getObject(strippedPath).exists();
   }
 
   @Override
@@ -375,6 +375,11 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
    */
   private boolean isDirectory(String path) throws IOException {
     String strippedPath = stripPrefixIfPresent(path);
+    // To get better performance Swift driver does not create a _temporary folder.
+    // This optimization should be hidden from Spark, therefore exists _temporary will return true.
+    if (strippedPath.endsWith("_temporary")) {
+      return true;
+    }
     String[] children = listInternal(strippedPath, true);
     return children != null && children.length > 0;
   }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -45,8 +45,12 @@ import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * OpenStack Swift {@link UnderFileSystem} implementation based on the JOSS library.
+ * OpenStack Swift {@link UnderFileSystem} implementation based on the JOSS library. This
+ * implementation does not support the concept of directories due to Swift being an object store.
+ * All mkdir operations will no-op and return true and empty directories will not exist.
+ * Directories with objects inside will be inferred through the prefix.
  */
+//TODO(calvin): Reconsider the directory limitations of this class.
 @ThreadSafe
 public class SwiftUnderFileSystem extends UnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);


### PR DESCRIPTION
Valid prefixes ending in a path separator will be counted as "existing" paths.