### PR TITLE
[SMALLFIX] Removed explicit argument type in MultiMasterLocalAlluxioCluster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -38,7 +38,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
   private TestingServer mCuratorServer = null;
   private int mNumOfMasters = 0;
 
-  private final List<LocalAlluxioMaster> mMasters = new ArrayList<LocalAlluxioMaster>();
+  private final List<LocalAlluxioMaster> mMasters = new ArrayList<>();
 
   /**
    * @param workerCapacityBytes the capacity of the worker in bytes


### PR DESCRIPTION
Removed an explicit argument type in the *MultiMasterLocalAlluxioCluster* class.