### PR TITLE
[SMALLFIX] Removed explicit argument type in AbstractFileOutStreamIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractFileOutStreamIntegrationTest {
   }
 
   protected List<CreateFileOptions> getOptionSet() {
-    List<CreateFileOptions> ret = new ArrayList<CreateFileOptions>(3);
+    List<CreateFileOptions> ret = new ArrayList<>(3);
     ret.add(mWriteBoth);
     ret.add(mWriteAlluxio);
     ret.add(mWriteUnderStore);


### PR DESCRIPTION
Removed an explicit argument type in the *AbstractFileOutStreamIntegrationTest* class.