### PR TITLE
[SMALLFIX] Removed explicit argument type in S3UnderFileSystem

### DIFF
--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -541,7 +541,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
         return ret.toArray(new String[ret.size()]);
       }
       // Non recursive list
-      Set<String> children = new HashSet<String>();
+      Set<String> children = new HashSet<>();
       for (S3Object obj : objs) {
         // Remove parent portion of the key
         String child = getChildName(obj.getKey(), path);


### PR DESCRIPTION
Removed an explicit argument type in the *S3UnderFileSystem* class.