### PR TITLE
[SMALLFIX] Inlined variable in SwiftDirectClient

### DIFF
--- a/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
@@ -66,9 +66,7 @@ public class SwiftDirectClient {
         httpCon.setDoOutput(true);
         httpCon.setChunkedStreamingMode(HTTP_CHUNK_STREAMING);
         httpCon.connect();
-        SwiftOutputStream outStream = new SwiftOutputStream(
-            httpCon);
-        return outStream;
+        return new SwiftOutputStream(httpCon);
       }
       LOG.debug("Not an instance of HTTP URL Connection");
     } catch (MalformedURLException e) {


### PR DESCRIPTION
Simplified the return statement in the *SwiftDirectClient* class.