### PR TITLE
[SMALLFIX] Removed explicit argument type in BufferedBlockInStreamIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/BufferedBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/BufferedBlockInStreamIntegrationTest.java
@@ -64,7 +64,7 @@ public final class BufferedBlockInStreamIntegrationTest {
   }
 
   private static List<CreateFileOptions> getOptionSet() {
-    List<CreateFileOptions> ret = new ArrayList<CreateFileOptions>(3);
+    List<CreateFileOptions> ret = new ArrayList<>(3);
     ret.add(sWriteBoth);
     ret.add(sWriteAlluxio);
     ret.add(sWriteUnderStore);


### PR DESCRIPTION
Removed an explicit argument type in the *BufferedBlockInStreamIntegrationTest* class.