### PR TITLE
[SMALLFIX] Fix spurious delete failure message

### DIFF
--- a/core/server/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -84,7 +84,9 @@ public final class StorageTier {
       try {
         FileUtils.deletePathRecursively(tmpDirPath);
       } catch (IOException e) {
-        LOG.error("Failed to clean up temporary directory: {}.", tmpDirPath);
+        if (FileUtils.exists(tmpDirPath)) {
+          LOG.error("Failed to clean up temporary directory: {}.", tmpDirPath);
+        }
       }
     }
     mCapacityBytes = totalCapacity;


### PR DESCRIPTION
This error would appear the first time the worker is started because there is no previous directory to delete.