### PR TITLE
[SMALLFIX] Ufs delegation constants.

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/UnderStoreBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/UnderStoreBlockInStream.java
@@ -88,7 +88,7 @@ public abstract class UnderStoreBlockInStream extends BlockInStream {
     public static UnderStoreBlockInStream create(long blockStart, long length, long blockSize,
         String path) throws IOException {
       UnderStoreBlockInStream stream;
-      if (ClientContext.getConf().getBoolean(Constants.USER_UFS_OPERATION_DELEGATION)) {
+      if (ClientContext.getConf().getBoolean(Constants.USER_UFS_DELEGATION_ENABLED)) {
         stream = new DelegatedUnderStoreBlockInStream(blockStart, length, blockSize, path);
       } else {
         stream = new DirectUnderStoreBlockInStream(blockStart, length, blockSize, path);

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -95,7 +95,7 @@ public class FileOutStream extends AbstractOutStream {
     mUnderStorageType = options.getUnderStorageType();
     mContext = FileSystemContext.INSTANCE;
     mPreviousBlockOutStreams = new LinkedList<BufferedBlockOutStream>();
-    mUfsDelegation = ClientContext.getConf().getBoolean(Constants.USER_UFS_OPERATION_DELEGATION);
+    mUfsDelegation = ClientContext.getConf().getBoolean(Constants.USER_UFS_DELEGATION_ENABLED);
     if (mUnderStorageType.isSyncPersist()) {
       if (mUfsDelegation) {
         updateUfsPath();

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -152,7 +152,8 @@ public final class UnderFileSystemFileInStream extends InputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_READ_BUFFER_SIZE));
+    return ByteBuffer.allocate(
+        (int) conf.getBytes(Constants.USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES));
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -152,8 +152,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer.allocate(
-        (int) conf.getBytes(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES));
+    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_READ_BUFFER_SIZE));
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -152,7 +152,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_READ_BUFFER_SIZE));
+    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_READ_BUFFER_SIZE));
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
@@ -167,6 +167,6 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_FILE_BUFFER_BYTES));
+    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_WRITE_BUFFER_SIZE));
   }
 }

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
@@ -167,6 +167,7 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_WRITE_BUFFER_SIZE));
+    return ByteBuffer
+        .allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE));
   }
 }

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
@@ -167,7 +167,7 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return ByteBuffer
-        .allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE));
+    return
+        ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE));
   }
 }

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
@@ -167,7 +167,7 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
    */
   private ByteBuffer allocateBuffer() {
     Configuration conf = ClientContext.getConf();
-    return
-        ByteBuffer.allocate((int) conf.getBytes(Constants.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE));
+    return ByteBuffer.allocate(
+        (int) conf.getBytes(Constants.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES));
   }
 }

--- a/core/client/src/test/java/alluxio/client/block/DelegatedUnderStoreBlockInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/block/DelegatedUnderStoreBlockInStreamTest.java
@@ -65,7 +65,7 @@ public class DelegatedUnderStoreBlockInStreamTest {
    */
   @Before
   public void before() throws Exception {
-    ClientContext.getConf().set(Constants.USER_UFS_OPERATION_DELEGATION, "true");
+    ClientContext.getConf().set(Constants.USER_UFS_DELEGATION_ENABLED, "true");
     mFile = mFolder.newFile(TEST_FILENAME);
     FileOutputStream os = new FileOutputStream(mFile);
     // Create a file of 2 block sizes.

--- a/core/client/src/test/java/alluxio/client/block/DirectUnderStoreBlockInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/block/DirectUnderStoreBlockInStreamTest.java
@@ -48,7 +48,7 @@ public class DirectUnderStoreBlockInStreamTest {
    */
   @Before
   public void before() throws IOException {
-    ClientContext.getConf().set(Constants.USER_UFS_OPERATION_DELEGATION, "false");
+    ClientContext.getConf().set(Constants.USER_UFS_DELEGATION_ENABLED, "false");
 
     File file = mFolder.newFile(TEST_FILENAME);
     FileOutputStream os = new FileOutputStream(file);

--- a/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -88,7 +88,7 @@ public class FileInStreamTest {
   @Before
   public void before() throws AlluxioException, IOException {
     mInfo = new FileInfo().setBlockSizeBytes(BLOCK_LENGTH).setLength(FILE_LENGTH);
-    mDelegateUfsOps = ClientContext.getConf().getBoolean(Constants.USER_UFS_OPERATION_DELEGATION);
+    mDelegateUfsOps = ClientContext.getConf().getBoolean(Constants.USER_UFS_DELEGATION_ENABLED);
 
     ClientTestUtils.setSmallBufferSizes();
 

--- a/core/client/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -92,7 +92,7 @@ public class FileOutStreamTest {
   @Before
   public void before() throws Exception {
     ClientTestUtils.setSmallBufferSizes();
-    mDelegateUfsOps = ClientContext.getConf().getBoolean(Constants.USER_UFS_OPERATION_DELEGATION);
+    mDelegateUfsOps = ClientContext.getConf().getBoolean(Constants.USER_UFS_DELEGATION_ENABLED);
 
     // PowerMock enums and final classes
     mFileSystemContext = PowerMockito.mock(FileSystemContext.class);

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -380,6 +380,10 @@ public final class Constants {
       "alluxio.user.file.waitcompleted.poll.ms";
   public static final String USER_UFS_OPERATION_DELEGATION =
       "alluxio.user.ufs.operation.delegation";
+  public static final String USER_UFS_READ_BUFFER_SIZE =
+      "alluxio.user.ufs.read.buffer.size";
+  public static final String USER_UFS_WRITE_BUFFER_SIZE =
+      "alluxio.user.ufs.write.buffer.size";
 
   /** alluxio-fuse related conf keys */
 

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -378,12 +378,12 @@ public final class Constants {
   public static final String USER_LINEAGE_ENABLED = "alluxio.user.lineage.enabled";
   public static final String USER_FILE_WAITCOMPLETED_POLL_MS =
       "alluxio.user.file.waitcompleted.poll.ms";
-  public static final String USER_UFS_OPERATION_DELEGATION =
+  public static final String USER_UFS_DELEGATION_ENABLED =
       "alluxio.user.ufs.delegation.enabled";
-  public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE =
-      "alluxio.user.ufs.delegation.read.buffer.size";
-  public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE =
-      "alluxio.user.ufs.delegation.write.buffer.size";
+  public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
+      "alluxio.user.ufs.delegation.read.buffer.size.bytes";
+  public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES =
+      "alluxio.user.ufs.delegation.write.buffer.size.bytes";
 
   /** alluxio-fuse related conf keys */
 

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -379,7 +379,7 @@ public final class Constants {
   public static final String USER_FILE_WAITCOMPLETED_POLL_MS =
       "alluxio.user.file.waitcompleted.poll.ms";
   public static final String USER_UFS_OPERATION_DELEGATION =
-      "alluxio.user.ufs.operation.delegation";
+      "alluxio.user.ufs.delegation.enabled";
   public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE =
       "alluxio.user.ufs.delegation.read.buffer.size";
   public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE =

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -380,10 +380,10 @@ public final class Constants {
       "alluxio.user.file.waitcompleted.poll.ms";
   public static final String USER_UFS_OPERATION_DELEGATION =
       "alluxio.user.ufs.operation.delegation";
-  public static final String USER_UFS_READ_BUFFER_SIZE =
-      "alluxio.user.ufs.read.buffer.size";
-  public static final String USER_UFS_WRITE_BUFFER_SIZE =
-      "alluxio.user.ufs.write.buffer.size";
+  public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE =
+      "alluxio.user.ufs.delegation.read.buffer.size";
+  public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE =
+      "alluxio.user.ufs.delegation.write.buffer.size";
 
   /** alluxio-fuse related conf keys */
 

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -162,6 +162,8 @@ alluxio.user.lineage.master.client.threads=10
 alluxio.user.network.netty.timeout.ms=30000
 alluxio.user.network.netty.worker.threads=0
 alluxio.user.ufs.operation.delegation=true
+alluxio.user.ufs.read.buffer.size=2MB
+alluxio.user.ufs.write.buffer.size=2MB
 
 # Fuse properties
 alluxio.fuse.maxwrite.bytes=131072

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -162,8 +162,8 @@ alluxio.user.lineage.master.client.threads=10
 alluxio.user.network.netty.timeout.ms=30000
 alluxio.user.network.netty.worker.threads=0
 alluxio.user.ufs.delegation.enabled=true
-alluxio.user.ufs.delegation.read.buffer.size=2MB
-alluxio.user.ufs.delegation.write.buffer.size=2MB
+alluxio.user.ufs.delegation.read.buffer.size.bytes=2MB
+alluxio.user.ufs.delegation.write.buffer.size.bytes=2MB
 
 # Fuse properties
 alluxio.fuse.maxwrite.bytes=131072

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -161,7 +161,7 @@ alluxio.user.lineage.enabled=false
 alluxio.user.lineage.master.client.threads=10
 alluxio.user.network.netty.timeout.ms=30000
 alluxio.user.network.netty.worker.threads=0
-alluxio.user.ufs.operation.delegation=true
+alluxio.user.ufs.delegation.enabled=true
 alluxio.user.ufs.delegation.read.buffer.size=2MB
 alluxio.user.ufs.delegation.write.buffer.size=2MB
 

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -162,8 +162,8 @@ alluxio.user.lineage.master.client.threads=10
 alluxio.user.network.netty.timeout.ms=30000
 alluxio.user.network.netty.worker.threads=0
 alluxio.user.ufs.operation.delegation=true
-alluxio.user.ufs.read.buffer.size=2MB
-alluxio.user.ufs.write.buffer.size=2MB
+alluxio.user.ufs.delegation.read.buffer.size=2MB
+alluxio.user.ufs.delegation.write.buffer.size=2MB
 
 # Fuse properties
 alluxio.fuse.maxwrite.bytes=131072

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -56,3 +56,11 @@ alluxio.user.network.netty.worker.threads:
 alluxio.user.ufs.operation.delegation:
   Flag for delegating ufs data operations to the worker. Set this to false to use client to directly
   communicate with the ufs. Setting this to true is currently experimental.
+alluxio.user.ufs.delegation.read.buffer.size:
+  Size of the read buffer when reading from the ufs through the Alluxio worker. Each read request
+  will fetch at least this many bytes. This property has no effect if the delegation flag is turned
+  off.
+alluxio.user.ufs.delegation.write.buffer.size:
+  Size of the write buffer when writing to the ufs through the Alluxio worker. Each write request
+  will write at least this many bytes, unless the write is at the end of the file. This property
+  has no effect if the delegation flag is turned off.

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -53,9 +53,10 @@ alluxio.user.network.netty.timeout.ms:
   wait for a response from the data server.
 alluxio.user.network.netty.worker.threads:
   How many threads to use for remote block worker client to read from remote block workers.
-alluxio.user.ufs.operation.delegation:
+alluxio.user.ufs.delegation.enabled:
   Flag for delegating ufs data operations to the worker. Set this to false to use client to directly
-  communicate with the ufs. Setting this to true is currently experimental.
+  communicate with the ufs. Setting this to true is currently experimental and may have an impact
+  on performance for certain workloads.
 alluxio.user.ufs.delegation.read.buffer.size:
   Size of the read buffer when reading from the ufs through the Alluxio worker. Each read request
   will fetch at least this many bytes. This property has no effect if the delegation flag is turned

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -57,11 +57,11 @@ alluxio.user.ufs.delegation.enabled:
   Flag for delegating ufs data operations to the worker. Set this to false to use client to directly
   communicate with the ufs. Setting this to true is currently experimental and may have an impact
   on performance for certain workloads.
-alluxio.user.ufs.delegation.read.buffer.size:
+alluxio.user.ufs.delegation.read.buffer.size.bytes:
   Size of the read buffer when reading from the ufs through the Alluxio worker. Each read request
   will fetch at least this many bytes. This property has no effect if the delegation flag is turned
   off.
-alluxio.user.ufs.delegation.write.buffer.size:
+alluxio.user.ufs.delegation.write.buffer.size.bytes:
   Size of the write buffer when writing to the ufs through the Alluxio worker. Each write request
   will write at least this many bytes, unless the write is at the end of the file. This property
   has no effect if the delegation flag is turned off.

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -20,5 +20,5 @@ alluxio.user.lineage.master.client.threads,10
 alluxio.user.network.netty.timeout.ms,3000
 alluxio.user.network.netty.worker.threads,0
 alluxio.user.ufs.delegation.enabled,true
-alluxio.user.ufs.delegation.read.buffer.size,2MB
-alluxio.user.ufs.delegation.write.buffer.size,2MB
+alluxio.user.ufs.delegation.read.buffer.size.bytes,2MB
+alluxio.user.ufs.delegation.write.buffer.size.bytes,2MB

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -20,3 +20,5 @@ alluxio.user.lineage.master.client.threads,10
 alluxio.user.network.netty.timeout.ms,3000
 alluxio.user.network.netty.worker.threads,0
 alluxio.user.ufs.operation.delegation,true
+alluxio.user.ufs.delegation.read.buffer.size,2MB
+alluxio.user.ufs.delegation.write.buffer.size,2MB

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -19,6 +19,6 @@ alluxio.user.lineage.enabled,false
 alluxio.user.lineage.master.client.threads,10
 alluxio.user.network.netty.timeout.ms,3000
 alluxio.user.network.netty.worker.threads,0
-alluxio.user.ufs.operation.delegation,true
+alluxio.user.ufs.delegation.enabled,true
 alluxio.user.ufs.delegation.read.buffer.size,2MB
 alluxio.user.ufs.delegation.write.buffer.size,2MB


### PR DESCRIPTION
Makes specific constants for ufs ops through the worker instead of using constants intended for other purposes.