### PR TITLE
[SMALLFIX] Removed explicit argument type in FileInStreamIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -75,7 +75,7 @@ public class FileInStreamIntegrationTest {
   }
 
   private static List<CreateFileOptions> getOptionSet() {
-    List<CreateFileOptions> ret = new ArrayList<CreateFileOptions>(3);
+    List<CreateFileOptions> ret = new ArrayList<>(3);
     ret.add(sWriteBoth);
     ret.add(sWriteAlluxio);
     ret.add(sWriteUnderStore);


### PR DESCRIPTION
Removed an explicit argument type in the *FileInStreamIntegrationTest* class.