### PR TITLE
[ALLUXIO-1907] second attempt to deflake free tests

### DIFF
--- a/tests/src/test/java/alluxio/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/IntegrationTestUtils.java
@@ -90,8 +90,8 @@ public final class IntegrationTestUtils {
    * worker.
    * Blocks until the master and block are in sync with the state of the blocks.
    *
-   * @param bw the block worker that will remove the blocks.
-   * @param blockIds a list of blockIds to be removed.
+   * @param bw the block worker that will remove the blocks
+   * @param blockIds a list of blockIds to be removed
    */
   public static void waitForBlocksToBeRemoved(final BlockWorker bw, long... blockIds) {
     try {

--- a/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
@@ -12,8 +12,8 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.CommonTestUtils;
 import alluxio.Constants;
+import alluxio.IntegrationTestUtils;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
@@ -29,7 +29,6 @@ import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.worker.block.BlockWorker;
 
-import com.google.common.base.Function;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -94,26 +93,7 @@ public final class FreeAndDeleteIntegrationTest {
 
     mFileSystem.free(filePath);
 
-    // Schedule 1st heartbeat from worker.
-    Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
-        TimeUnit.SECONDS));
-    HeartbeatScheduler.schedule(HeartbeatContext.WORKER_BLOCK_SYNC);
-
-    // Waiting for the removal of blockMeta from worker.
-    CommonTestUtils.waitFor(new Function<Void, Boolean>() {
-      @Override
-      public Boolean apply(Void input) {
-        return !bw.hasBlockMeta(blockId);
-      }
-    }, 100 * Constants.SECOND_MS);
-
-    // Schedule 2nd heartbeat from worker.
-    Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
-        TimeUnit.SECONDS));
-    HeartbeatScheduler.schedule(HeartbeatContext.WORKER_BLOCK_SYNC);
-    // Ensure the 2nd heartbeat is finished.
-    Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.WORKER_BLOCK_SYNC, 5,
-        TimeUnit.SECONDS));
+    IntegrationTestUtils.waitForBlocksToBeRemoved(bw, blockId);
 
     status = mFileSystem.getStatus(filePath);
     // Verify block metadata in master is still present after block freed.

--- a/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FreeAndDeleteIntegrationTest.java
@@ -93,7 +93,7 @@ public final class FreeAndDeleteIntegrationTest {
 
     mFileSystem.free(filePath);
 
-    IntegrationTestUtils.waitForBlocksToBeRemoved(bw, blockId);
+    IntegrationTestUtils.waitForBlocksToBeFreed(bw, blockId);
 
     status = mFileSystem.getStatus(filePath);
     // Verify block metadata in master is still present after block freed.

--- a/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
@@ -42,7 +42,7 @@ public class FreeCommandTest extends AbstractAlluxioShellTest {
     long blockId = mFileSystem.getStatus(new AlluxioURI(fileName)).getBlockIds().get(0);
 
     mFsShell.run("free", fileName);
-    IntegrationTestUtils.waitForBlocksToBeRemoved(
+    IntegrationTestUtils.waitForBlocksToBeFreed(
         mLocalAlluxioCluster.getWorker().getBlockWorker(), blockId);
     Assert.assertFalse(isInMemoryTest(fileName));
   }
@@ -57,7 +57,7 @@ public class FreeCommandTest extends AbstractAlluxioShellTest {
 
     int ret = mFsShell.run("free", "/testWild*/foo/*");
 
-    IntegrationTestUtils.waitForBlocksToBeRemoved(
+    IntegrationTestUtils.waitForBlocksToBeFreed(
         mLocalAlluxioCluster.getWorker().getBlockWorker(), blockId1, blockId2);
     Assert.assertEquals(0, ret);
     Assert.assertFalse(isInMemoryTest("/testWildCards/foo/foobar1"));
@@ -71,7 +71,7 @@ public class FreeCommandTest extends AbstractAlluxioShellTest {
         mFileSystem.getStatus(new AlluxioURI("/testWildCards/foobar4")).getBlockIds().get(0);
 
     ret = mFsShell.run("free", "/testWild*/*/");
-    IntegrationTestUtils.waitForBlocksToBeRemoved(
+    IntegrationTestUtils.waitForBlocksToBeFreed(
         mLocalAlluxioCluster.getWorker().getBlockWorker(), blockId1, blockId2);
     Assert.assertEquals(0, ret);
     Assert.assertFalse(isInMemoryTest("/testWildCards/bar/foobar3"));


### PR DESCRIPTION
The reason for flakiness seems to be that the test is only waiting for https://github.com/Alluxio/alluxio/blob/master/core/server/src/main/java/alluxio/worker/block/TieredBlockStore.java#L302 finishes, where it removes the block metadata. There's a slight chance that the test issues the second heartbeat while the listener has not been fired in line 305, thus the removed blocks are not sent to the master in the second heartbeat.

@aaudiber 