### PR TITLE
[ALLUXIO-1972] Update key-value mapreduce interface

### DIFF
--- a/docs/_includes/Key-Value-Store-API/set-output-format.md
+++ b/docs/_includes/Key-Value-Store-API/set-output-format.md
@@ -2,6 +2,5 @@
 conf.setOutputKeyClass(BytesWritable.class);
 conf.setOutputValueClass(BytesWritable.class);
 conf.setOutputFormat(KeyValueOutputFormat.class);
-conf.setOutputCommitter(KeyValueOutputCommitter.class);
 FileOutputFormat.setOutputPath(conf, new Path("alluxio://output-store"));
 ```


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1972

Originally, the key-value mapreduce interface uses hadoop1.x API, after upgrading to hadoop2.x API, the original implementation is not quite correct, the problem is caused by the different handling of task output directory and job output directory by output committer in different API versions.

This PR is tested against hadoop1.2.1 and hadoop2.4.1 with Alluxio tag v1.1.0-RC4, on a local deployment.