### PR TITLE
[SMALLFIX] Removed explicit argument type in LocalBlockInStreamIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/LocalBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/LocalBlockInStreamIntegrationTest.java
@@ -73,7 +73,7 @@ public final class LocalBlockInStreamIntegrationTest {
   }
 
   private static List<CreateFileOptions> getOptionSet() {
-    List<CreateFileOptions> ret = new ArrayList<CreateFileOptions>(2);
+    List<CreateFileOptions> ret = new ArrayList<>(2);
     ret.add(sWriteBoth);
     ret.add(sWriteAlluxio);
     return ret;


### PR DESCRIPTION
Removed an explicit argument type in the *LocalBlockInStreamIntegrationTest* class.