### PR TITLE
[SMALLFIX] Removed redundant intializers in FileSystemBlockLocationIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/hadoop/FileSystemBlockLocationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemBlockLocationIntegrationTest.java
@@ -56,13 +56,11 @@ public class FileSystemBlockLocationIntegrationTest {
    */
   @Test
   public void basicBlockLocationTest() throws Exception {
-    long start = 0;
-    long len = 0;
     FileStatus fStatus = sTFS.getFileStatus(new Path("/testFile1"));
 
     // block0.offset = start < start+len < block1.offset
-    start = 0;
-    len = BLOCK_SIZE - 1;
+    long start = 0;
+    long len = BLOCK_SIZE - 1;
     Assert.assertEquals(1, sTFS.getFileBlockLocations(fStatus, start, len).length);
 
     // block0.offset < start < start+len < block1.offset


### PR DESCRIPTION
Removed some redundant initializers in the *FileSystemBlockLocationIntegrationTest* class.