### PR TITLE
[SMALL FIX] Do not load metadata for non-persisted directory

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1784,8 +1784,7 @@ public final class FileSystemMaster extends AbstractMaster {
     UnderFileSystem ufs = resolution.getUfs();
     try {
       if (!ufs.exists(ufsUri.toString())) {
-        throw new FileDoesNotExistException(
-            ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path.getPath()));
+        return AsyncJournalWriter.INVALID_FLUSH_COUNTER;
       }
       if (ufs.isFile(ufsUri.toString())) {
         return loadFileMetadataAndJournal(inodePath, resolution, options);

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1784,7 +1784,8 @@ public final class FileSystemMaster extends AbstractMaster {
     UnderFileSystem ufs = resolution.getUfs();
     try {
       if (!ufs.exists(ufsUri.toString())) {
-        return AsyncJournalWriter.INVALID_FLUSH_COUNTER;
+        throw new FileDoesNotExistException(
+            ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path.getPath()));
       }
       if (ufs.isFile(ufsUri.toString())) {
         return loadFileMetadataAndJournal(inodePath, resolution, options);
@@ -1905,7 +1906,9 @@ public final class FileSystemMaster extends AbstractMaster {
     boolean loadDirectChildren = false;
     if (inodeExists) {
       try {
-        loadDirectChildren = inodePath.getInode().isDirectory() && options.isLoadDirectChildren();
+        Inode inode = inodePath.getInode();
+        loadDirectChildren =
+            inode.isDirectory() && inode.isPersisted() && options.isLoadDirectChildren();
       } catch (FileDoesNotExistException e) {
         // This should never happen.
         throw new RuntimeException(e);

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1895,11 +1895,13 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * Loads the metadata for the path, if it doesn't exist or we need to load the direct children.
+   * Loads metadata for the path if it is (non-existing || (persisted && load direct children is
+   * set).
    *
    * @param inodePath the {@link LockedInodePath} to load the metadata for
    * @param options the load metadata options
    */
+  // TODO(peis): Add a unit test for this function.
   private long loadMetadataIfNotExistAndJournal(LockedInodePath inodePath,
       LoadMetadataOptions options) {
     boolean inodeExists = inodePath.fullPathExists();


### PR DESCRIPTION
Do not throw exception when loading metadata on a non-existing file/dir. 