### PR TITLE
[SMALLFIX] Removed explicit argument type in JournalIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -581,7 +581,7 @@ public class JournalIntegrationTest {
     public static final String FULL_CLASS_NAME =
         "alluxio.master.JournalIntegrationTest$FakeUserGroupsMapping";
 
-    private HashMap<String, String> mUserGroups = new HashMap<String, String>();
+    private HashMap<String, String> mUserGroups = new HashMap<>();
 
     public FakeUserGroupsMapping() {
       mUserGroups.put("alluxio", "supergroup");


### PR DESCRIPTION
Removed an explicit argument type in the *JournalIntegrationTest* class.