### PR TITLE
[SMALLFIX] Change the default remote buffer size to 4KB.

### DIFF
--- a/conf/alluxio-site.properties.template
+++ b/conf/alluxio-site.properties.template
@@ -68,7 +68,7 @@ alluxio.worker.web.port=30000
 # User properties
 alluxio.user.block.master.client.threads=10
 alluxio.user.block.worker.client.threads=128
-alluxio.user.block.remote.read.buffer.size.bytes=8MB
+alluxio.user.block.remote.read.buffer.size.bytes=4KB
 alluxio.user.block.size.bytes.default=512MB
 alluxio.user.failed.space.request.limits=3
 alluxio.user.file.buffer.bytes=1MB

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -145,7 +145,7 @@ alluxio.worker.web.port=30000
 # User properties
 alluxio.user.block.master.client.threads=10
 alluxio.user.block.worker.client.threads=128
-alluxio.user.block.remote.read.buffer.size.bytes=8MB
+alluxio.user.block.remote.read.buffer.size.bytes=4KB
 alluxio.user.block.remote.reader.class=alluxio.client.netty.NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class=alluxio.client.netty.NettyRemoteBlockWriter
 alluxio.user.block.size.bytes.default=512MB

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -1,7 +1,7 @@
 propertyName,defaultValue
 alluxio.user.block.master.client.threads,10
 alluxio.user.block.worker.client.threads,128
-alluxio.user.block.remote.read.buffer.size.bytes,8 MB
+alluxio.user.block.remote.read.buffer.size.bytes,4KB
 alluxio.user.block.remote.reader.class,alluxio.client.netty.&#8203;NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class,alluxio.client.netty.&#8203;NettyRemoteBlockWriter
 alluxio.user.block.size.bytes.default,512MB


### PR DESCRIPTION
Remote read microbench result shows that 4KB remote buffer size performs better than 4MB/8MB.
