### PR TITLE
[SMALLFIX] Removed explicit argument type in WithWildCardPathCommand

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
@@ -65,7 +65,7 @@ public abstract class WithWildCardPathCommand extends AbstractShellCommand {
     }
     Collections.sort(paths, createAlluxioURIComparator());
 
-    List<String> errorMessages = new ArrayList<String>();
+    List<String> errorMessages = new ArrayList<>();
     for (AlluxioURI path : paths) {
       try {
         runCommand(path, cl);


### PR DESCRIPTION
Removed an explicit argument type in the *WithWildCardPathCommand* class.