### PR TITLE
[SMALLFIX] Clean up in underfs package

### DIFF
--- a/underfs/glusterfs/src/test/java/alluxio/underfs/glusterfs/GlusterFSUnderFileSystemFactoryTest.java
+++ b/underfs/glusterfs/src/test/java/alluxio/underfs/glusterfs/GlusterFSUnderFileSystemFactoryTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
  * Unit tests for {@link GlusterFSUnderFileSystem}.
  */
 public class GlusterFSUnderFileSystemFactoryTest {
-  private UnderFileSystem mGfs = null;
   private String mMount = null;
   private String mVolume = null;
   private Configuration mConfiguration;
@@ -58,8 +57,8 @@ public class GlusterFSUnderFileSystemFactoryTest {
     Assume.assumeTrue(!StringUtils.isEmpty(mMount));
     Assume.assumeTrue(!StringUtils.isEmpty(mVolume));
 
-    mGfs = UnderFileSystem.get("glusterfs:///", mConfiguration);
-    Assert.assertNotNull(mGfs.create("alluxio_test"));
+    UnderFileSystem gfs = UnderFileSystem.get("glusterfs:///", mConfiguration);
+    Assert.assertNotNull(gfs.create("alluxio_test"));
   }
 
   /**

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -236,7 +236,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public List<String> getFileLocations(String path, long offset) throws IOException {
-    List<String> ret = new ArrayList<String>();
+    List<String> ret = new ArrayList<>();
     try {
       FileStatus fStatus = mFileSystem.getFileStatus(new Path(path));
       BlockLocation[] bLocations = mFileSystem.getFileBlockLocations(fStatus, offset, 1);
@@ -368,7 +368,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
         }
         // Create directories one by one with explicit permissions to ensure no umask is applied,
         // using mkdirs will apply the permission only to the last directory
-        Stack<Path> dirsToMake = new Stack<Path>();
+        Stack<Path> dirsToMake = new Stack<>();
         dirsToMake.push(hdfsPath);
         Path parent = hdfsPath.getParent();
         while (!mFileSystem.exists(parent)) {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -131,7 +131,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
 
   @Override
   public List<String> getFileLocations(String path) throws IOException {
-    List<String> ret = new ArrayList<String>();
+    List<String> ret = new ArrayList<>();
     ret.add(NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, mConfiguration));
     return ret;
   }
@@ -208,7 +208,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
       return false;
     }
     // Create parent directories one by one and set their permissions to rwxrwxrwx.
-    Stack<File> dirsToMake = new Stack<File>();
+    Stack<File> dirsToMake = new Stack<>();
     dirsToMake.push(file);
     File parent = file.getParentFile();
     while (!parent.exists()) {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -65,14 +65,12 @@ public class OSSInputStream extends InputStream {
 
   @Override
   public int read() throws IOException {
-    int ret = mInputStream.read();
-    return ret;
+    return mInputStream.read();
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    int ret = mInputStream.read(b, off, len);
-    return ret;
+    return mInputStream.read(b, off, len);
   }
 
   @Override

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -496,7 +496,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
 
       // Non recursive, so set the delimiter, let the listObjects only get the files in the folder
       listObjectsRequest.setDelimiter(PATH_SEPARATOR);
-      Set<String> children = new HashSet<String>();
+      Set<String> children = new HashSet<>();
       ObjectListing listing = mOssClient.listObjects(listObjectsRequest);
       for (OSSObjectSummary objectSummary : listing.getObjectSummaries()) {
         // Remove parent portion of the key


### PR DESCRIPTION
Small clean up of some classes in the *underfs* package

GlusterFSUnderFileSystemFactoryTest:
- Made a field a local variable

HdfsUnderFileSystem:
- Removed explicit argument types

LocalUnderFileSystem:
- Removed explicit argument types

OSSInputStream:
- Simplified return statement

OSSUnderFileSystem:
- Removed explicit argument type