### PR TITLE
[SMALLFIX] Clean up in underfs and test module

### DIFF
--- a/tests/src/test/java/alluxio/network/protocol/RPCMessageIntegrationTest.java
+++ b/tests/src/test/java/alluxio/network/protocol/RPCMessageIntegrationTest.java
@@ -211,8 +211,7 @@ public class RPCMessageIntegrationTest {
     // Write the message to the outgoing channel.
     mOutgoingChannel.writeAndFlush(msg);
     // Read the decoded message from the incoming side.
-    RPCMessage outputMessage = sIncomingHandler.getMessage();
-    return outputMessage;
+    return sIncomingHandler.getMessage();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
@@ -130,13 +130,13 @@ public final class AlluxioShellUtilsTest {
     List<String> ret = null;
     if (fsType == FsType.TFS) {
       List<AlluxioURI> tPaths = AlluxioShellUtils.getAlluxioURIs(mFileSystem, new AlluxioURI(path));
-      ret = new ArrayList<String>(tPaths.size());
+      ret = new ArrayList<>(tPaths.size());
       for (AlluxioURI tPath : tPaths) {
         ret.add(tPath.getPath());
       }
     } else if (fsType == FsType.LOCAL) {
       List<File> tPaths = AlluxioShellUtils.getFiles(path);
-      ret = new ArrayList<String>(tPaths.size());
+      ret = new ArrayList<>(tPaths.size());
       for (File tPath : tPaths) {
         ret.add(tPath.getPath());
       }

--- a/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
@@ -232,7 +232,7 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
 
       // For HDFS of earlier versions, getFileSystem() returns an instance of type
       // {@link org.apache.hadoop.fs.FileSystem} rather than {@link DistributedFileSystem}
-      mDfsClient = mDfsCluster.getFileSystem();
+      mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;
     }
   }

--- a/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
@@ -232,7 +232,7 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
 
       // For HDFS of earlier versions, getFileSystem() returns an instance of type
       // {@link org.apache.hadoop.fs.FileSystem} rather than {@link DistributedFileSystem}
-      mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
+      mDfsClient = mDfsCluster.getFileSystem();
       mIsStarted = true;
     }
   }

--- a/tests/src/test/java/alluxio/worker/BlockServiceHandlerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/BlockServiceHandlerIntegrationTest.java
@@ -66,21 +66,20 @@ public class BlockServiceHandlerIntegrationTest {
   private BlockWorkerClientServiceHandler mBlockWorkerServiceHandler = null;
   private FileSystem mFileSystem = null;
   private Configuration mMasterConfiguration;
-  private Configuration mWorkerConfiguration;
   private BlockMasterClient mBlockMasterClient;
 
   @Before
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
     mMasterConfiguration = mLocalAlluxioClusterResource.get().getMasterConf();
-    mWorkerConfiguration = mLocalAlluxioClusterResource.get().getWorkerConf();
+    Configuration workerConfiguration = mLocalAlluxioClusterResource.get().getWorkerConf();
     mBlockWorkerServiceHandler =
         mLocalAlluxioClusterResource.get().getWorker().getBlockWorker().getWorkerServiceHandler();
 
     mBlockMasterClient = new BlockMasterClient(
         new InetSocketAddress(mLocalAlluxioClusterResource.get().getHostname(),
             mLocalAlluxioClusterResource.get().getMasterPort()),
-        mWorkerConfiguration);
+            workerConfiguration);
   }
 
   @After

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -503,7 +503,7 @@ public class GCSUnderFileSystem extends UnderFileSystem {
         return ret;
       }
       // Non recursive list
-      Set<String> children = new HashSet<String>();
+      Set<String> children = new HashSet<>();
       for (GSObject obj : objs) {
         // Remove parent portion of the key
         String child = getChildName(obj.getKey(), path);


### PR DESCRIPTION
Small clean up of some classes in the *underfs* and *test* package.

RPCMessageIntegrationTest:
- Simplified return statement

AlluxioShellUtilsTest:
- Removed explicit argument types

LocalMiniDFSCluster:
- Removed unnecessary cast

BlockServiceHandlerIntegrationTest:
- Made a field a local variable

GCSUnderFileSystem:
- Removed explicit argument type