### PR TITLE
[SMALLFIX] Improvement to openAtPosition when delegation is turned on, for S3/GCS.

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -20,6 +20,7 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.gcs.GCSUnderFileSystem;
 import alluxio.underfs.s3.S3UnderFileSystem;
 import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
@@ -169,6 +170,9 @@ public final class UnderFileSystemManager {
       // Special handing for S3 and GCS to save redundant ufs open and close in S3/GCS skip.
       if (ufs instanceof S3UnderFileSystem) {
         return ((S3UnderFileSystem) ufs).openAtPosition(mUri, position);
+      }
+      if (ufs instanceof GCSUnderFileSystem) {
+        return ((GCSUnderFileSystem) ufs).openAtPosition(mUri, position);
       }
       InputStream stream = ufs.open(mUri);
       if (position != stream.skip(position)) {

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -167,7 +167,8 @@ public final class UnderFileSystemManager {
         return null;
       }
       UnderFileSystem ufs = UnderFileSystem.get(mUri, mConfiguration);
-      // Special handing for S3 and GCS to save redundant ufs open and close in S3/GCS skip.
+      // Special handling for S3/GCS with open object at position to save redundant ufs stream
+      // close and reopen in S3InputStream/GCSInputStream skip.
       if (ufs instanceof S3UnderFileSystem) {
         return ((S3UnderFileSystem) ufs).openAtPosition(mUri, position);
       }

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -20,6 +20,7 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.s3.S3UnderFileSystem;
 import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -165,6 +166,10 @@ public final class UnderFileSystemManager {
         return null;
       }
       UnderFileSystem ufs = UnderFileSystem.get(mUri, mConfiguration);
+      // Special handing for S3 and GCS to save redundant ufs open and close in S3/GCS skip.
+      if (ufs instanceof S3UnderFileSystem) {
+        return ((S3UnderFileSystem) ufs).openAtPosition(mUri, position);
+      }
       InputStream stream = ufs.open(mUri);
       if (position != stream.skip(position)) {
         throw new IOException(ExceptionMessage.FAILED_SKIP.getMessage(position));

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
@@ -63,6 +63,25 @@ public final class GCSInputStream extends InputStream {
     mInputStream = new BufferedInputStream(mObject.getDataInputStream());
   }
 
+  /**
+   * Creates a new instance of {@link GCSInputStream}, at a specific position.
+   *
+   * @param bucketName the name of the bucket
+   * @param key the key of the file
+   * @param client the client for GCS
+   * @param pos the position to start
+   * @throws ServiceException if a service exception occurs
+   */
+  GCSInputStream(String bucketName, String key, GoogleStorageService client, long pos)
+      throws ServiceException {
+    mBucketName = bucketName;
+    mKey = key;
+    mClient = client;
+    mPos = pos;
+    mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
+    mInputStream = new BufferedInputStream(mObject.getDataInputStream());
+  }
+
   @Override
   public void close() throws IOException {
     mInputStream.close();

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -286,7 +286,7 @@ public class GCSUnderFileSystem extends UnderFileSystem {
   }
 
   /**
-   * Opens a GCS object at position and returns the input stream.
+   * Opens a GCS object at given position and returns the opened input stream.
    *
    * @param path the GCS object path
    * @param pos the position to open at

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -295,6 +295,7 @@ public class GCSUnderFileSystem extends UnderFileSystem {
    */
   public InputStream openAtPosition(String path, long pos) throws IOException {
     try {
+      path = stripPrefixIfPresent(path);
       GSObject obj = mClient.getObject(mBucketName, path, null, null, null, null, pos, null);
       return obj.getDataInputStream();
     } catch (ServiceException e) {

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -285,6 +285,24 @@ public class GCSUnderFileSystem extends UnderFileSystem {
     }
   }
 
+  /**
+   * Opens a GCS object at position and returns the input stream.
+   *
+   * @param path the GCS object path
+   * @param pos the position to open at
+   * @return the opened input stream
+   * @throws IOException if failed to open file at position
+   */
+  public InputStream openAtPosition(String path, long pos) throws IOException {
+    try {
+      GSObject obj = mClient.getObject(mBucketName, path, null, null, null, null, pos, null);
+      return obj.getDataInputStream();
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file {} at position {}:", path, pos, e);
+      return null;
+    }
+  }
+
   @Override
   public boolean rename(String src, String dst) throws IOException {
     if (!exists(src)) {

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -296,8 +296,7 @@ public class GCSUnderFileSystem extends UnderFileSystem {
   public InputStream openAtPosition(String path, long pos) throws IOException {
     try {
       path = stripPrefixIfPresent(path);
-      GSObject obj = mClient.getObject(mBucketName, path, null, null, null, null, pos, null);
-      return obj.getDataInputStream();
+      return new GCSInputStream(mBucketName, path, mClient, pos);
     } catch (ServiceException e) {
       LOG.error("Failed to open file {} at position {}:", path, pos, e);
       return null;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3InputStream.java
@@ -63,6 +63,24 @@ public class S3InputStream extends InputStream {
     mInputStream = new BufferedInputStream(mObject.getDataInputStream());
   }
 
+  /**
+   * Creates a new instance of {@link S3InputStream}, at a specific position.
+   *
+   * @param bucketName the name of the bucket
+   * @param key the key of the file
+   * @param client the client for S3
+   * @param pos the position to start
+   * @throws ServiceException if a service exception occurs
+   */
+  S3InputStream(String bucketName, String key, S3Service client, long pos) throws ServiceException {
+    mBucketName = bucketName;
+    mKey = key;
+    mClient = client;
+    mPos = pos;
+    mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
+    mInputStream = new BufferedInputStream(mObject.getDataInputStream());
+  }
+
   @Override
   public void close() throws IOException {
     mInputStream.close();

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -337,8 +337,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
   public InputStream openAtPosition(String path, long pos) throws IOException {
     try {
       path = stripPrefixIfPresent(path);
-      S3Object obj = mClient.getObject(mBucketName, path, null, null, null, null, pos, null);
-      return obj.getDataInputStream();
+      return new S3InputStream(mBucketName, path, mClient, pos);
     } catch (ServiceException e) {
       LOG.error("Failed to open file {} at position {}:", path, pos, e);
       return null;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -326,6 +326,25 @@ public class S3UnderFileSystem extends UnderFileSystem {
     }
   }
 
+  /**
+   * Opens a S3 object at position and returns the input stream.
+   *
+   * @param path the S3 object path
+   * @param pos the position to open at
+   * @return the opened input stream
+   * @throws IOException if failed to open file at position
+   */
+  public InputStream openAtPosition(String path, long pos) throws IOException {
+    try {
+      path = stripPrefixIfPresent(path);
+      S3Object obj = mClient.getObject(mBucketName, path, null, null, null, null, pos, null);
+      return obj.getDataInputStream();
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file {} at position {}:", path, pos, e);
+      return null;
+    }
+  }
+
   @Override
   public boolean rename(String src, String dst) throws IOException {
     if (!exists(src)) {

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -327,7 +327,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
   }
 
   /**
-   * Opens a S3 object at position and returns the input stream.
+   * Opens a S3 object at given position and returns the opened input stream.
    *
    * @param path the S3 object path
    * @param pos the position to open at


### PR DESCRIPTION
This PR includes an improvement for `openAtPosition` when delegation is turned on. Implementation of `openAtPosition` is added for S3UnderFileSystem, to save redundant close and reopen S3InputStream.

A simple benchmark was run locally, doing a Read from a 10MB S3 THROUGH file, with read buffer size = 2M. That being said, with delegation on, `openAtPosition` will be called for 5 times. The logs measure the time elapsed for `OpenAtPosition`. The data shows that this PR would save > 40% time of `OpenAtPosition` call, for each 2M chunk.

Before this PR.
```
➜  tachyon git:(branch-1.1-s3) ✗ time ./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
Copied /file10M.txt to /tmp/file10M.txt
./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
1.18s user 0.15s system 6% cpu 20.415 total

2016-06-02 13:38:01,067 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 147 (ms)
2016-06-02 13:38:01,067 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 148 (ms)
2016-06-02 13:38:04,242 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 1021 (ms)
2016-06-02 13:38:04,614 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 1393 (ms)
2016-06-02 13:38:07,532 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 373 (ms)
2016-06-02 13:38:07,923 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 764 (ms)
2016-06-02 13:38:10,655 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 433 (ms)
2016-06-02 13:38:11,042 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 820 (ms)
2016-06-02 13:38:13,636 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 392 (ms)
2016-06-02 13:38:14,033 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 789 (ms)

➜  tachyon git:(branch-1.1-s3) ✗ time ./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
Copied /file10M.txt to /tmp/file10M.txt
./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
1.16s user 0.14s system 7% cpu 17.565 total

2016-06-02 13:38:24,595 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 109 (ms)
2016-06-02 13:38:24,596 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 110 (ms)
2016-06-02 13:38:27,223 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 382 (ms)
2016-06-02 13:38:27,595 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 754 (ms)
2016-06-02 13:38:30,007 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 482 (ms)
2016-06-02 13:38:30,474 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 949 (ms)
2016-06-02 13:38:33,067 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 377 (ms)
2016-06-02 13:38:33,457 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 766 (ms)
2016-06-02 13:38:36,996 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition ufs.open took 368 (ms)
2016-06-02 13:38:37,404 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 775 (ms)
```

After this PR:
```
git:(branch-1.1-s3) ✗ time ./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
Copied /file10M.txt to /tmp/file10M.txt
./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
1.17s user 0.14s system 7% cpu 16.462 total

2016-06-02 13:35:22,860 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 222 (ms)
2016-06-02 13:35:22,860 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 222 (ms)
2016-06-02 13:35:25,622 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 487 (ms)
2016-06-02 13:35:25,623 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 487 (ms)
2016-06-02 13:35:28,143 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 376 (ms)
2016-06-02 13:35:28,143 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 376 (ms)
2016-06-02 13:35:30,708 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 384 (ms)
2016-06-02 13:35:30,709 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 384 (ms)
2016-06-02 13:35:33,786 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 397 (ms)
2016-06-02 13:35:33,786 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 397 (ms)

➜  tachyon git:(branch-1.1-s3) ✗ time ./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
Copied /file10M.txt to /tmp/file10M.txt
./bin/alluxio fs copyToLocal /file10M.txt /tmp/file10M.txt
1.15s user 0.15s system 8% cpu 15.916 total

2016-06-02 13:40:15,297 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 162 (ms)
2016-06-02 13:40:15,298 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 162 (ms)
2016-06-02 13:40:17,972 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 409 (ms)
2016-06-02 13:40:17,972 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 409 (ms)
2016-06-02 13:40:20,694 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 295 (ms)
2016-06-02 13:40:20,695 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 295 (ms)
2016-06-02 13:40:23,851 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 398 (ms)
2016-06-02 13:40:23,852 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 398 (ms)
2016-06-02 13:40:26,481 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - S3OpenAtPosition took 390 (ms)
2016-06-02 13:40:26,482 INFO  logger.type (UnderFileSystemManager.java:openAtPosition) - OpenAtPosition total took 390 (ms)
```
