### PR TITLE
[Revert] Revert default remote read buffer size to 8MB

### DIFF
--- a/conf/alluxio-site.properties.template
+++ b/conf/alluxio-site.properties.template
@@ -68,7 +68,7 @@ alluxio.worker.web.port=30000
 # User properties
 alluxio.user.block.master.client.threads=10
 alluxio.user.block.worker.client.threads=128
-alluxio.user.block.remote.read.buffer.size.bytes=4KB
+alluxio.user.block.remote.read.buffer.size.bytes=8MB
 alluxio.user.block.size.bytes.default=512MB
 alluxio.user.failed.space.request.limits=3
 alluxio.user.file.buffer.bytes=1MB

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -145,7 +145,7 @@ alluxio.worker.web.port=30000
 # User properties
 alluxio.user.block.master.client.threads=10
 alluxio.user.block.worker.client.threads=128
-alluxio.user.block.remote.read.buffer.size.bytes=4KB
+alluxio.user.block.remote.read.buffer.size.bytes=8MB
 alluxio.user.block.remote.reader.class=alluxio.client.netty.NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class=alluxio.client.netty.NettyRemoteBlockWriter
 alluxio.user.block.size.bytes.default=512MB

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -127,7 +127,7 @@ public class ConfigurationTest {
 
     long longBytesValue =
         sDefaultConfiguration.getBytes(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES);
-    Assert.assertEquals(Constants.KB * 4, longBytesValue);
+    Assert.assertEquals(Constants.MB * 8, longBytesValue);
 
     longBytesValue = sDefaultConfiguration.getBytes(Constants.NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX);
     Assert.assertEquals(Constants.MB * 16, longBytesValue);
@@ -254,7 +254,7 @@ public class ConfigurationTest {
     Assert.assertEquals(Constants.MB, longValue);
 
     longValue = sDefaultConfiguration.getBytes(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES);
-    Assert.assertEquals(4 * Constants.KB, longValue);
+    Assert.assertEquals(8 * Constants.MB, longValue);
   }
 
   /**

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -1,7 +1,7 @@
 propertyName,defaultValue
 alluxio.user.block.master.client.threads,10
 alluxio.user.block.worker.client.threads,128
-alluxio.user.block.remote.read.buffer.size.bytes,4KB
+alluxio.user.block.remote.read.buffer.size.bytes,8 MB
 alluxio.user.block.remote.reader.class,alluxio.client.netty.&#8203;NettyRemoteBlockReader
 alluxio.user.block.remote.writer.class,alluxio.client.netty.&#8203;NettyRemoteBlockWriter
 alluxio.user.block.size.bytes.default,512MB


### PR DESCRIPTION
In RC5 testing, we found setting alluxio.user.block.remote.read.buffer.size.bytes=4KB would cause significant remote read performance drop, when client-size buffer size is also set to a small value, like 4KB. We should keep the remote read buffer size to be 8MB.