### PR TITLE
[ALLUXIO-1975] Fix issue with manual heartbeat scheduling

### DIFF
--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatScheduler.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatScheduler.java
@@ -66,7 +66,9 @@ public final class HeartbeatScheduler {
   }
 
   /**
-   * @param name the name of a timer to remove from the scheduler
+   * Removes a timer name from the scheduler if it exists.
+   *
+   * @param name the name to remove
    */
   public static void removeTimer(String name) {
     try (LockResource r = new LockResource(sLock)) {
@@ -75,11 +77,20 @@ public final class HeartbeatScheduler {
   }
 
   /**
-   * @param timer a timer to remove from the scheduler
+   * Removes a timer from the scheduler.
+   *
+   * This method will fail if the timer is not in the scheduler.
+   *
+   * @param timer the timer to remove
    */
   public static void removeTimer(ScheduledTimer timer) {
-    Preconditions.checkNotNull(timer);
-    removeTimer(timer.getThreadName());
+    Preconditions.checkNotNull(timer, "timer");
+    try (LockResource r = new LockResource(sLock)) {
+      ScheduledTimer removedTimer = sTimers.remove(timer.getThreadName());
+      Preconditions.checkNotNull(removedTimer, "sTimers should contain %s", timer.getThreadName());
+      Preconditions.checkState(removedTimer == timer,
+          "sTimers should contain the timer being removed");
+    }
   }
 
   /**

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatScheduler.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatScheduler.java
@@ -68,9 +68,9 @@ public final class HeartbeatScheduler {
   /**
    * Removes a timer name from the scheduler if it exists.
    *
-   * @param name the name to remove
+   * @param name the name to clear
    */
-  public static void removeTimer(String name) {
+  public static void clearTimer(String name) {
     try (LockResource r = new LockResource(sLock)) {
       sTimers.remove(name);
     }

--- a/core/common/src/main/java/alluxio/heartbeat/ScheduledTimer.java
+++ b/core/common/src/main/java/alluxio/heartbeat/ScheduledTimer.java
@@ -55,7 +55,7 @@ public final class ScheduledTimer implements HeartbeatTimer {
     mTickCondition = mLock.newCondition();
     mScheduled = false;
     // There should never be more than one scheduled timer with the same name.
-    HeartbeatScheduler.removeTimer(mThreadName);
+    HeartbeatScheduler.clearTimer(mThreadName);
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/MasterSourceTest.java
+++ b/core/server/src/test/java/alluxio/master/MasterSourceTest.java
@@ -39,6 +39,7 @@ import com.codahale.metrics.Counter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -121,6 +122,12 @@ public final class MasterSourceTest {
     mCounters = MasterContext.getMasterSource().getMetricRegistry().getCounters();
 
     mUfs = UnderFileSystem.get(AlluxioURI.SEPARATOR, MasterContext.getConf());
+  }
+
+  @After
+  public void after() throws Exception {
+    mBlockMaster.stop();
+    mFileSystemMaster.stop();
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -127,14 +127,6 @@ public final class FileSystemMasterTest {
   }
 
   /**
-   * Resets the {@link MasterContext} after a test ran.
-   */
-  @After
-  public void after() {
-    MasterContext.reset();
-  }
-
-  /**
    * Sets up the dependencies before a test runs.
    *
    * @throws Exception if creating the temporary folder, starting the masters or register the
@@ -168,6 +160,16 @@ public final class FileSystemMasterTest {
         ImmutableMap.of("MEM", Constants.MB * 1L, "SSD", Constants.MB * 1L),
         ImmutableMap.of("MEM", Constants.KB * 1L, "SSD", Constants.KB * 1L),
         new HashMap<String, List<Long>>());
+  }
+
+  /**
+   * Resets global state after each test run.
+   */
+  @After
+  public void after() throws Exception {
+    mFileSystemMaster.stop();
+    mBlockMaster.stop();
+    MasterContext.reset();
   }
 
   /**
@@ -1010,7 +1012,8 @@ public final class FileSystemMasterTest {
    */
   @Test
   public void lostFilesDetectionTest() throws Exception {
-    HeartbeatScheduler.await(HeartbeatContext.MASTER_LOST_FILES_DETECTION, 5, TimeUnit.SECONDS);
+    Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.MASTER_LOST_FILES_DETECTION, 5,
+        TimeUnit.SECONDS));
 
     createFileWithSingleBlock(NESTED_FILE_URI);
     long fileId = mFileSystemMaster.getFileId(NESTED_FILE_URI);

--- a/core/server/src/test/java/alluxio/master/lineage/LineageMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/lineage/LineageMasterTest.java
@@ -27,6 +27,7 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.LineageInfo;
 
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,6 +70,11 @@ public final class LineageMasterTest {
     mLineageMaster = new LineageMaster(mFileSystemMaster, journal);
     mLineageMaster.start(true);
     mJob = new CommandLineJob("test", new JobConf("output"));
+  }
+
+  @After
+  public void after() throws Exception {
+    mLineageMaster.stop();
   }
 
   /**


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1975

Previously we had flakiness due to the following flow:

1. Unit test 1 creates a Master, e.g. FileSystemMaster, which uses a heartbeat thread. The heartbeat thread X is initialized to use the scheduled timer.
2. The scheduled timer becomes ready to schedule and adds itself to the `sTimers` map in `HeartbeatScheduler`. This creates a mapping from the string "X" to the timer object.
3. The test calls schedule, removing the timer from `sTimers` and executing a heartbeat. After the heartbeat has executed, the timer adds itself back to `sTimers`.
4. Unit test 1 ends and the Master is stopped. `sTimers` is static and doesn't care (it still holds the mapping from "X" to the timer).
5. Unit test 2 begins and creates a new Master and new timer named "X"
6. Unit test 2 calls `HeartbeatScheduler.await()` to wait for the timer to become ready to schedule. This call immediately returns because the key "X" exists in the `sTimers` map. This indicates to the test that it's safe to call `schedule` even though the timer is not actually ready to schedule.
7. The test fails because it relied on the heartbeat happening, but it never actually happened.

This issue is resolved by having timers clear their name from `sTimers` when they are constructed so that their past incarnations can't make it look like they are ready to schedule.

This pattern probably applies to more unit tests than just the one in ALLUXIO-1975.