### PR TITLE
[SMALLFIX] Disable delegation by default

### DIFF
--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -164,8 +164,8 @@ alluxio.user.lineage.enabled=false
 alluxio.user.lineage.master.client.threads=10
 alluxio.user.network.netty.timeout.ms=30000
 alluxio.user.network.netty.worker.threads=0
-alluxio.user.ufs.delegation.enabled=true
-alluxio.user.ufs.delegation.read.buffer.size.bytes=2MB
+alluxio.user.ufs.delegation.enabled=false
+alluxio.user.ufs.delegation.read.buffer.size.bytes=8MB
 alluxio.user.ufs.delegation.write.buffer.size.bytes=2MB
 
 # Fuse properties

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -19,6 +19,6 @@ alluxio.user.lineage.enabled,false
 alluxio.user.lineage.master.client.threads,10
 alluxio.user.network.netty.timeout.ms,3000
 alluxio.user.network.netty.worker.threads,0
-alluxio.user.ufs.delegation.enabled,true
-alluxio.user.ufs.delegation.read.buffer.size.bytes,2MB
+alluxio.user.ufs.delegation.enabled,false
+alluxio.user.ufs.delegation.read.buffer.size.bytes,8MB
 alluxio.user.ufs.delegation.write.buffer.size.bytes,2MB


### PR DESCRIPTION
Since delegation is being introduced in this version, turn it off by default. Also updates the ufs read buffer size to be equal to our remote read buffer size.