### PR TITLE
[ALLUXIO-1994] Delete the code in line 68 in EvictorUtils

### DIFF
--- a/core/server/src/main/java/alluxio/worker/block/evictor/EvictorUtils.java
+++ b/core/server/src/main/java/alluxio/worker/block/evictor/EvictorUtils.java
@@ -65,7 +65,6 @@ public final class EvictorUtils {
         if (dirView.getCommittedBytes() + dirView.getAvailableBytes() >= bytesToBeAvailable
             && dirView.getAvailableBytes() > maxFreeSize) {
           selectedDirView = dirView;
-          maxFreeSize = dirView.getAvailableBytes();
         }
       }
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1994
> The code "maxFreeSize = dirView.getAvailableBytes()" in line 68 of EvictorUtils is not needed because the code is not in a for-loop like the code before and we can delete it.