### PR TITLE
[DOCFIX] Add a `bootstrap-conf` command snippet in the Chinese version of `docs/en/Configuring-Alluxio-with-HDFS.md`

### DIFF
--- a/docs/cn/Configuring-Alluxio-with-HDFS.md
+++ b/docs/cn/Configuring-Alluxio-with-HDFS.md
@@ -26,7 +26,12 @@ priority: 3
 
 # 配置Alluxio
 
-要运行Alluxio二进制包，一定要先创建配置文件，从template文件创建一个配置文件：
+要运行Alluxio二进制包，一定要先创建配置文件，你可以使用`bootstrap-conf` 命令来创建自己的配置文件。
+举个例子，假如你正在本地运行Alluxio，那么就应该把`ALLUXIO_MASTER_HOSTNAME`设置为`localhost`
+
+{% include Configuring-Alluxio-with-HDFS/bootstrap-conf.md %}
+
+另外你也可以从template文件创建一个配置文件然后手动修改它的内容：
 
 {% include Common-Commands/copy-alluxio-env.md %}
 


### PR DESCRIPTION
This PR fixes issue with JIRA ticket [ALLUXIO-1979](https://alluxio.atlassian.net/browse/ALLUXIO-1979)

In `docs/en/Configuring-Alluxio-with-HDFS.md` of the English version there is a `bootstrap-conf` command snippet added in the `Configuring Alluxio` section. This PR translate it into Chinese and add it in the corresponding page of the Chinese version.