### PR TITLE
[DOCFIX]Update "System Configuration" to "Configuration" in docs to be consistent with the Web UI navigation bar

### DIFF
--- a/docs/cn/Web-Interface.md
+++ b/docs/cn/Web-Interface.md
@@ -41,7 +41,7 @@ Alluxio master 主页如下所示:
 
 ## 配置页面
 
-查看当前系统的配置信息，点击屏幕上方导航栏的"System Configuration"。
+查看当前系统的配置信息，点击屏幕上方导航栏的"Configuration"。
 
 ![configurations]({{site.data.img.screenshot_systemConfiguration}})
 


### PR DESCRIPTION
"System Configuration" has been updated to "Configuration" in the Web UI navigation bar. 