### PR TITLE
[DOCFIX] Add a `bootstrap-conf` command snippet in the Chinese version of `docs/en/Configuring-Alluxio-with-secure-HDFS.md`

### DIFF
--- a/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
+++ b/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
@@ -28,7 +28,12 @@ priority: 3
 
 # 配置Alluxio
 
-要运行二进制包，一定要先创建配置文件，从template文件创建一个配置文件：
+要运行二进制包，一定要先创建配置文件，，你可以使用`bootstrap-conf` 命令来创建自己的配置文件。
+举个例子，假如你正在本地运行Alluxio，那么就应该把`ALLUXIO_MASTER_HOSTNAME`设置为`localhost`
+                   
+{% include Configuring-Alluxio-with-HDFS/bootstrap-conf.md %}
+                   
+另外你也可以从template文件创建一个配置文件然后手动修改它的内容：
 
 {% include Common-Commands/copy-alluxio-env.md %}
 


### PR DESCRIPTION
This PR fixes issue with JIRA ticket [ALLUXIO-1983](https://alluxio.atlassian.net/browse/ALLUXIO-1983)

(**Note**: The fixed file is *different* from that in #3459 which fixed Configuring-Alluxio-with-**HDFS**.md, while this PR fixes Configuring-Alluxio-with-**secure-HDFS**.md. I also left some comment under #3466)

In `docs/en/Configuring-Alluxio-with-secure-HDFS.md` of the English version there is a `bootstrap-conf` command snippet added in the `Configuring Alluxio` section. This PR translate it into Chinese and add it in the corresponding page of the Chinese version.