### PR TITLE
[SMALLFIX] Write shell error messages to stderr

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -44,7 +44,7 @@ function printUsage {
 function bootstrapConf {
   local usage="Usage: $0 bootstrap-conf <alluxio_master_hostname> [local|hdfs|s3|gcs|glusterfs|swift]"
   if [[ $# -lt 1 ]]; then
-    echo ${usage}
+    echo ${usage} >&2
     exit 1
   fi
   local master=${1}
@@ -101,7 +101,7 @@ function bootstrapConf {
       ALLUXIO_UNDERFS_ADDRESS="swift://swift-container/"
       ;;
     *)
-      echo ${usage}
+      echo ${usage} >&2
       exit 1
       ;;
   esac
@@ -160,7 +160,7 @@ function killAll {
 
 function copyDir {
   if [[ $# -ne 1 ]]; then
-    echo "Usage: alluxio copyDir <path>"
+    echo "Usage: alluxio copyDir <path>" >&2
     exit 1
   fi
 
@@ -187,7 +187,7 @@ function runJavaClass {
       ALLUXIO_SHELL_JAVA_OPTS+=" -D${OPTARG}"
       ;;
     \?)
-      echo "Invalid option: -${OPTARG}"
+      echo "Invalid option: -${OPTARG}" >&2
       printUsage
       exit 1
       ;;
@@ -274,8 +274,8 @@ function main {
     runJavaClass "$@"
   ;;
   "loadufs")
-    echo "The \"alluxio loadufs <AlluxioURI> <UfsURI>\" command is deprecated since version 1.1."
-    echo "Use the \"alluxio fs mount <AlluxioURI> <UfsURI>\" command followed by the \"alluxio fs ls -R <AlluxioURI>\" command instead."
+    echo "The \"alluxio loadufs <AlluxioURI> <UfsURI>\" command is deprecated since version 1.1." >&2
+    echo "Use the \"alluxio fs mount <AlluxioURI> <UfsURI>\" command followed by the \"alluxio fs ls -R <AlluxioURI>\" command instead." >&2
     exit 1
   ;;
   "runClass")
@@ -344,7 +344,7 @@ function main {
     runJavaClass "$@"
   ;;
   *)
-    echo "Unsupported command ${COMMAND}"
+    echo "Unsupported command ${COMMAND}" >&2
     printUsage
     exit 1
   ;;

--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -73,7 +73,7 @@ function mem_size_to_bytes() {
       BYTE_SIZE=${SIZE}
       ;;
     *)
-      echo "Please specify ALLUXIO_WORKER_MEMORY_SIZE in a correct form."
+      echo "Please specify ALLUXIO_WORKER_MEMORY_SIZE in a correct form." >&2
       exit 1
   esac
 }
@@ -148,7 +148,7 @@ function mount_ramfs_linux() {
   TOTAL_MEM=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
   if [[ ${TOTAL_MEM} -lt ${BYTE_SIZE} ]]; then
     echo "ERROR: Memory(${TOTAL_MEM}) is less than requested ramdisk size(${BYTE_SIZE}). Please
-    reduce ALLUXIO_WORKER_MEMORY_SIZE"
+    reduce ALLUXIO_WORKER_MEMORY_SIZE" >&2
     exit 1
   fi
 
@@ -157,7 +157,7 @@ function mount_ramfs_linux() {
   if mount | grep ${F} > /dev/null; then
     umount -f ${F}
     if [[ $? -ne 0 ]]; then
-      echo "ERROR: umount RamFS ${F} failed"
+      echo "ERROR: umount RamFS ${F} failed" >&2
       exit 1
     fi
   else
@@ -176,8 +176,8 @@ function mount_ramfs_mac() {
   fi
 
   if [[ ${ALLUXIO_RAM_FOLDER} != "/Volumes/"* ]]; then
-    echo "Invalid ALLUXIO_RAM_FOLDER: ${ALLUXIO_RAM_FOLDER}"
-    echo "ALLUXIO_RAM_FOLDER must set to /Volumes/[name] on Mac OS X."
+    echo "Invalid ALLUXIO_RAM_FOLDER: ${ALLUXIO_RAM_FOLDER}" >&2
+    echo "ALLUXIO_RAM_FOLDER must set to /Volumes/[name] on Mac OS X." >&2
     exit 1
   fi
 
@@ -228,6 +228,6 @@ case "${1}" in
     esac
     ;;
   *)
-    echo -e ${USAGE}
+    echo -e ${USAGE} >&2
     exit 1
 esac

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -86,8 +86,8 @@ check_mount_mode() {
       if [[ $? -ne 0 ]]; then
         if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X
-          echo "ERROR: NoMount is not supported on Mac OS X."
-          echo -e "${USAGE}"
+          echo "ERROR: NoMount is not supported on Mac OS X." >&2
+          echo -e "${USAGE}" >&2
           exit 1
         else
           echo "WARNING: Overriding ALLUXIO_RAM_FOLDER to /dev/shm to use tmpFS now."
@@ -103,11 +103,11 @@ check_mount_mode() {
     ;;
     *)
       if [[ -z $1 ]]; then
-        echo "This command requires a mount mode be specified"
+        echo "This command requires a mount mode be specified" >&2
       else
-        echo "Invalid mount mode: $1"
+        echo "Invalid mount mode: $1" >&2
       fi
-      echo -e "${USAGE}"
+      echo -e "${USAGE}" >&2
       exit 1
   esac
 }
@@ -123,8 +123,8 @@ do_mount() {
     NoMount)
       ;;
     *)
-      echo "This command requires a mount mode be specified"
-      echo -e "${USAGE}"
+      echo "This command requires a mount mode be specified" >&2
+      echo -e "${USAGE}" >&2
       exit 1
   esac
 }
@@ -157,7 +157,7 @@ start_master() {
 start_worker() {
   do_mount $1
   if  [ ${MOUNT_FAILED} -ne 0 ] ; then
-    echo "Mount failed, not starting worker"
+    echo "Mount failed, not starting worker" >&2
     exit 1
   fi
 
@@ -218,7 +218,7 @@ main() {
         wait="true"
         ;;
       *)
-        echo -e "${USAGE}"
+        echo -e "${USAGE}" >&2
         exit 1
         ;;
     esac
@@ -228,8 +228,8 @@ main() {
 
   ACTION=$1
   if [[ -z "${ACTION}" ]]; then
-    echo "Error: no ACTION specified"
-    echo -e "${USAGE}"
+    echo "Error: no ACTION specified" >&2
+    echo -e "${USAGE}" >&2
     exit 1
   fi
   shift
@@ -252,7 +252,7 @@ main() {
 
   FORMAT=$1
   if [[ ! -z "${FORMAT}" && "${FORMAT}" != "-f" ]]; then
-    echo -e "${USAGE}"
+    echo -e "${USAGE}" >&2
     exit 1
   fi
 
@@ -295,8 +295,8 @@ main() {
       ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" restart_worker
       ;;
     *)
-    echo "Error: Invalid ACTION: ${ACTION}"
-    echo -e "${USAGE}"
+    echo "Error: Invalid ACTION: ${ACTION}" >&2
+    echo -e "${USAGE}" >&2
     exit 1
   esac
   sleep 2

--- a/bin/alluxio-stop.sh
+++ b/bin/alluxio-stop.sh
@@ -61,8 +61,8 @@ case "${WHAT}" in
     exit 0
     ;;
   *)
-    echo "Error: Invalid component: ${WHAT}"
-    echo -e "${USAGE}"
+    echo "Error: Invalid component: ${WHAT}" >&2
+    echo -e "${USAGE}" >&2
     exit 1
     ;;
 esac

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -21,7 +21,7 @@ USAGE="Usage: alluxio-workers.sh command..."
 
 # if no args specified, show usage
 if [[ $# -le 0 ]]; then
-  echo ${USAGE}
+  echo ${USAGE} >&2
   exit 1
 fi
 


### PR DESCRIPTION
This is an issue when our scripts are run through 3rd-party applications which may only report stderr when errors occur.