### PR TITLE
[SMALLFIX] Read entire buffer in buffered instreams

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/BufferedBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/BufferedBlockInStream.java
@@ -110,7 +110,7 @@ public abstract class BufferedBlockInStream extends BlockInStream {
     }
 
     int toRead = (int) Math.min(len, remaining());
-    if (mBufferIsValid && mBuffer.remaining() > toRead) { // data is fully contained in the buffer
+    if (mBufferIsValid && mBuffer.remaining() >= toRead) { // data is fully contained in the buffer
       mBuffer.get(b, off, toRead);
       mPos += toRead;
       mBlockIsRead = true;

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -107,7 +107,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
       return -1;
     }
 
-    if (mIsBufferValid && mBuffer.remaining() > len) { // data is fully contained in the buffer
+    if (mIsBufferValid && mBuffer.remaining() >= len) { // data is fully contained in the buffer
       mBuffer.get(b, off, len);
       mPos += len;
       return len;

--- a/core/client/src/test/java/alluxio/client/block/BufferedBlockInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/block/BufferedBlockInStreamTest.java
@@ -33,7 +33,8 @@ public class BufferedBlockInStreamTest {
   @Before
   public void before() {
     mBufferSize =
-        Configuration.createDefaultConf().getBytes(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES);
+        Configuration.createDefaultConf().getBytes(
+            Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES);
     mBlockSize = mBufferSize * 10;
     mTestStream = new TestBufferedBlockInStream(1L, 0, mBlockSize);
   }
@@ -97,11 +98,11 @@ public class BufferedBlockInStreamTest {
     int size = (int) mBlockSize / 10;
     byte[] readBytes = new byte[size];
 
-    // Read first 10th bytes
+    // Read first 1/10th bytes
     Assert.assertEquals(size, mTestStream.read(readBytes));
     Assert.assertTrue(BufferUtils.equalIncreasingByteArray(0, size, readBytes));
 
-    // Read next 10th bytes
+    // Read next 1/10th bytes
     Assert.assertEquals(size, mTestStream.read(readBytes));
     Assert.assertTrue(BufferUtils.equalIncreasingByteArray(size, size, readBytes));
 

--- a/core/client/src/test/java/alluxio/client/block/BufferedBlockInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/block/BufferedBlockInStreamTest.java
@@ -48,7 +48,7 @@ public class BufferedBlockInStreamTest {
   @Test
   public void singleByteReadTest() throws Exception {
     for (int i = 0; i < mBlockSize; i++) {
-      Assert.assertEquals(i, mTestStream.read());
+      Assert.assertEquals(i & 0xFF, mTestStream.read());
     }
   }
 
@@ -108,7 +108,7 @@ public class BufferedBlockInStreamTest {
 
     // Read with offset and length
     Assert.assertEquals(1, mTestStream.read(readBytes, size - 1, 1));
-    Assert.assertEquals(size * 2, readBytes[size - 1]);
+    Assert.assertEquals(size * 2 & 0xFF, readBytes[size - 1]);
   }
 
   /**

--- a/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
@@ -94,9 +94,12 @@ public class UnderFileSystemFileInStreamTest {
    */
   @Test
   public void readBulkBufferedTest() throws Exception {
-    byte[] b = new byte[FILE_SIZE / 2];
-    Assert.assertEquals(FILE_SIZE / 2, mTestStream.read(b));
-    Assert.assertEquals(FILE_SIZE / 2, mTestStream.read(b));
+    int readLen = FILE_SIZE / 2;
+    byte[] b = new byte[readLen];
+    Assert.assertEquals(readLen, mTestStream.read(b));
+    Assert.assertTrue(BufferUtils.equalIncreasingByteArray(0, readLen, b));
+    Assert.assertEquals(readLen, mTestStream.read(b));
+    Assert.assertTrue(BufferUtils.equalIncreasingByteArray(readLen, readLen, b));
     // One call to get the data since buffer size == file size
     Mockito.verify(mMockReader).read(Mockito.any(InetSocketAddress.class), Mockito.anyLong(),
         Mockito.anyLong(), Mockito.anyLong());

--- a/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
@@ -81,7 +81,7 @@ public class UnderFileSystemFileInStreamTest {
    */
   @Test
   public void readByteBufferedTest() throws Exception {
-    for (int i = 0; i < FILE_SIZE; i ++) {
+    for (int i = 0; i < FILE_SIZE; i++) {
       Assert.assertEquals((byte) mTestStream.read(), mData[i]);
     }
     // One call to get the data since buffer size == file size

--- a/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/UnderFileSystemFileInStreamTest.java
@@ -63,6 +63,7 @@ public class UnderFileSystemFileInStreamTest {
         });
     mTestStream = new UnderFileSystemFileInStream(mockAddr, FILE_ID);
     Whitebox.setInternalState(mTestStream, "mReader", mMockReader);
+    Whitebox.setInternalState(mTestStream, "mBuffer", ByteBuffer.allocate(FILE_SIZE));
   }
 
   /**
@@ -80,12 +81,25 @@ public class UnderFileSystemFileInStreamTest {
    */
   @Test
   public void readByteBufferedTest() throws Exception {
-    for (int i = 0; i < FILE_SIZE; i++) {
+    for (int i = 0; i < FILE_SIZE; i ++) {
       Assert.assertEquals((byte) mTestStream.read(), mData[i]);
     }
-    // One call to get the data, second call to verify end of file
-    Mockito.verify(mMockReader, Mockito.times(2)).read(Mockito.any(InetSocketAddress.class),
-        Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+    // One call to get the data since buffer size == file size
+    Mockito.verify(mMockReader).read(Mockito.any(InetSocketAddress.class), Mockito.anyLong(),
+        Mockito.anyLong(), Mockito.anyLong());
+  }
+
+  /**
+   * Tests the internal buffering of the class.
+   */
+  @Test
+  public void readBulkBufferedTest() throws Exception {
+    byte[] b = new byte[FILE_SIZE / 2];
+    Assert.assertEquals(FILE_SIZE / 2, mTestStream.read(b));
+    Assert.assertEquals(FILE_SIZE / 2, mTestStream.read(b));
+    // One call to get the data since buffer size == file size
+    Mockito.verify(mMockReader).read(Mockito.any(InetSocketAddress.class), Mockito.anyLong(),
+        Mockito.anyLong(), Mockito.anyLong());
   }
 
   /**


### PR DESCRIPTION
Fixes a bug where the buffer would not be read from if the read goes exactly to the end of the buffer.