### PR TITLE
[ALLUXIO-1739] Keep state on delegation reads

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileSystemWorker.java
@@ -178,7 +178,8 @@ public final class FileSystemWorker extends AbstractWorker {
   /**
    * Opens a stream to the under file system file denoted by the temporary file id. This call
    * will skip to the position specified in the file before returning the stream. The caller of
-   * this method is required to close the stream after they have finished operations on it.
+   * this method should not close this stream. Resources will automatically be cleaned up when
+   * {@link #closeUfsFile(long, long)} is called.
    *
    * @param tempUfsFileId the worker specific temporary file id for the file in the under storage
    * @param position the absolute position in the file to position the stream at before returning

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -379,10 +380,11 @@ public final class UnderFileSystemManager {
   public void cleanupSession(long sessionId) {
     Set<InputStreamAgent> toClose;
     synchronized (mInputStreamAgents) {
-      toClose = mInputStreamAgents.getByField(mInputStreamAgentSessionIdIndex, sessionId);
+      toClose =
+          new HashSet<>(mInputStreamAgents.getByField(mInputStreamAgentSessionIdIndex, sessionId));
       mInputStreamAgents.removeByField(mInputStreamAgentSessionIdIndex, sessionId);
     }
-    // close is done outside of the synchronized block as it may be expensive
+    // close is done outside of the synchronized block since it may be expensive
     for (InputStreamAgent agent : toClose) {
       try {
         agent.close();
@@ -393,10 +395,11 @@ public final class UnderFileSystemManager {
 
     Set<OutputStreamAgent> toCancel;
     synchronized (mOutputStreamAgents) {
-      toCancel = mOutputStreamAgents.getByField(mOuputStreamAgentSessionIdIndex, sessionId);
+      toCancel =
+          new HashSet<>(mOutputStreamAgents.getByField(mOuputStreamAgentSessionIdIndex, sessionId));
       mOutputStreamAgents.removeByField(mOuputStreamAgentSessionIdIndex, sessionId);
     }
-    // cancel is done outside of the synchronized block as it may be expensive
+    // cancel is done outside of the synchronized block since it may be expensive
     for (OutputStreamAgent agent : toCancel) {
       try {
         agent.cancel();
@@ -404,7 +407,6 @@ public final class UnderFileSystemManager {
         LOG.warn("Failed to cancel output stream agent for file: " + agent.mUri);
       }
     }
-
   }
 
   /**

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -165,8 +165,10 @@ public final class UnderFileSystemManager {
      * @throws IOException if an error occurs when interacting with the UFS
      */
     private void close() throws IOException {
-      mStream.close();
-      mStream = null;
+      if (mStream != null) {
+        mStream.close();
+        mStream = null;
+      }
     }
 
     /**

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -127,7 +127,7 @@ public final class UnderFileSystemManager {
     /** The string form of the uri to the file in the under file system. */
     private final String mUri;
 
-    /** The initial position of the stream, valid if mStream != null. */
+    /** The initial position of the stream, only valid if mStream != null. */
     private long mInitPos;
     /** The underlying stream to read data from. */
     private CountingInputStream mStream;
@@ -172,10 +172,12 @@ public final class UnderFileSystemManager {
     }
 
     /**
-     * Checks if the current stream can be reused to serve the request. If so, the current
-     * stream is returned. Otherwise, opens a new input stream to the file this agent references
-     * and closes the previous stream. The new stream will be at the specified position when it
-     * is returned to the caller.
+     * Checks if the current stream can be reused to serve the request. If so, the current stream is
+     * updated to the specified position and returned. Otherwise, opens a new input stream to the
+     * file this agent references and closes the previous stream. The new stream will be at the
+     * specified position when it is returned to the caller. This stream should not be closed by
+     * the caller and will be automatically closed by the agent as long as the agent's close
+     * method is called.
      *
      * @param position the absolute position in the file to start the stream at
      * @return an input stream to the file starting at the specified position, null if the position
@@ -187,7 +189,7 @@ public final class UnderFileSystemManager {
         return null;
       }
 
-      // If no stream has been created or if we need to go backward, make a new cached stream.
+      // If no stream has been created or if we need to go backward, make a new stream and cache it.
       if (mStream == null || mInitPos + mStream.getCount() > position) {
         if (mStream != null) { // Close the existing stream if needed
           mStream.close();

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -181,16 +181,12 @@ public final class UnderFileSystemManager {
      * @throws IOException if an error occurs when interacting with the UFS
      */
     private InputStream openAtPosition(long position) throws IOException {
-      if (position >= mLength) {
+      if (position >= mLength) { // Position is at EOF
         return null;
       }
 
-      LOG.info("Open at position {}", position);
-
       // If no stream has been created or if we need to go backward, make a new cached stream.
       if (mStream == null || mInitPos + mStream.getCount() > position) {
-        LOG.info("Creating new stream at position {}", position);
-
         if (mStream != null) { // Close the existing stream if needed
           mStream.close();
         }
@@ -219,7 +215,6 @@ public final class UnderFileSystemManager {
           throw new IOException(ExceptionMessage.FAILED_SKIP.getMessage(toSkip));
         }
       }
-      LOG.info("Returning stream, possibly cached");
       return mStream;
     }
   }

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -94,7 +94,7 @@ public class UnderFileSystemDataServerHandler {
       ChannelFuture future = ctx.writeAndFlush(resp);
       future.addListener(ChannelFutureListener.CLOSE);
     } catch (Exception e) {
-      LOG.error("Failed to read ufs file, may have been closed due to the client timing out.", e);
+      LOG.error("Failed to read ufs file, may have been closed due to a client timeout.", e);
       RPCFileReadResponse resp =
           RPCFileReadResponse.createErrorResponse(req, RPCResponse.Status.UFS_READ_FAILED);
       ChannelFuture future = ctx.writeAndFlush(resp);

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -94,7 +94,7 @@ public class UnderFileSystemDataServerHandler {
       ChannelFuture future = ctx.writeAndFlush(resp);
       future.addListener(ChannelFutureListener.CLOSE);
     } catch (Exception e) {
-      LOG.error("Failed to read ufs file", e);
+      LOG.error("Failed to read ufs file, may have been closed due to the client timing out.", e);
       RPCFileReadResponse resp =
           RPCFileReadResponse.createErrorResponse(req, RPCResponse.Status.UFS_READ_FAILED);
       ChannelFuture future = ctx.writeAndFlush(resp);

--- a/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -74,8 +74,8 @@ public class UnderFileSystemDataServerHandler {
     long length = req.getLength();
     byte[] data = new byte[(int) length];
 
-    // TODO(calvin): This can be more efficient for sequential reads if we keep state
-    try (InputStream in = mWorker.getUfsInputStream(ufsFileId, offset)) {
+    try {
+      InputStream in = mWorker.getUfsInputStream(ufsFileId, offset);
       int bytesRead = 0;
       if (in != null) { // if we have not reached the end of the file
         while (bytesRead < length) {

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -299,7 +299,7 @@ public final class UnderFileSystemManagerTest {
     UnderFileSystemManager manager = new UnderFileSystemManager();
     long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
     InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     Mockito.verify(mMockInputStream, Mockito.never()).skip(position);
     in.close();
   }
@@ -316,7 +316,7 @@ public final class UnderFileSystemManagerTest {
     UnderFileSystemManager manager = new UnderFileSystemManager();
     long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
     InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     Mockito.verify(mMockInputStream).skip(position);
     in.close();
   }
@@ -333,7 +333,7 @@ public final class UnderFileSystemManagerTest {
     UnderFileSystemManager manager = new UnderFileSystemManager();
     long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
     InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     long nextPosition = 100;
     Mockito.when(mMockInputStream.skip(nextPosition)).thenReturn(nextPosition);
     in.skip(nextPosition - position);
@@ -355,7 +355,7 @@ public final class UnderFileSystemManagerTest {
     UnderFileSystemManager manager = new UnderFileSystemManager();
     long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
     InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     long nextPosition = 100;
     Mockito.when(mMockInputStream.skip(nextPosition)).thenReturn(nextPosition);
     in.skip(nextPosition - position);
@@ -407,20 +407,30 @@ public final class UnderFileSystemManagerTest {
     long id2 = manager.openFile(secondSessionId, new AlluxioURI(uniqPath2));
     // Both files should be accessible
     InputStream in1 = manager.getInputStreamAtPosition(id1, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in1, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in1));
     InputStream in2 = manager.getInputStreamAtPosition(id2, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in2, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in2));
     in1.close();
     in2.close();
     // Clean up second session
     manager.cleanupSession(secondSessionId);
     // First file should still be available
     in1 = manager.getInputStreamAtPosition(id1, position);
-    Assert.assertEquals(mMockInputStream, Whitebox.getInternalState(in1, "in"));
+    Assert.assertEquals(mMockInputStream, getInternalInputStream(in1));
     in1.close();
     // Second file should no longer be available
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(id2));
     manager.getInputStreamAtPosition(id2, position);
+  }
+
+  /**
+   * Used to enable equality checks on the underlying stream.
+   *
+   * @param in the wrapper stream
+   * @return the internal input stream of a wrapper input stream.
+   */
+  private InputStream getInternalInputStream(InputStream in) {
+    return (InputStream) Whitebox.getInternalState(in, "in");
   }
 }

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -56,7 +56,7 @@ public final class UnderFileSystemManagerTest {
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
-  /** The manager object to test */
+  /** The manager object to test. */
   private UnderFileSystemManager mManager;
   /** The mock input stream returned whenever a ufs file is read. */
   private InputStream mMockInputStream;

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -29,6 +29,8 @@ import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -54,18 +56,24 @@ public final class UnderFileSystemManagerTest {
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
+  /** The manager object to test */
+  private UnderFileSystemManager mManager;
   /** The mock input stream returned whenever a ufs file is read. */
   private InputStream mMockInputStream;
   /** The mock output stream returned whenever a ufs file is created. */
   private OutputStream mMockOutputStream;
   /** The mock under file system client. */
   private UnderFileSystem mMockUfs;
+  /** The filename in the under storage. */
+  private AlluxioURI mUri;
 
   @Before
   public void before() throws Exception {
+    mManager = new UnderFileSystemManager();
     mMockUfs = Mockito.mock(UnderFileSystem.class);
     mMockOutputStream = Mockito.mock(OutputStream.class);
     mMockInputStream = Mockito.mock(InputStream.class);
+    mUri = new AlluxioURI(PathUtils.uniqPath());
     Mockito.when(mMockUfs.create(Mockito.anyString())).thenReturn(mMockOutputStream);
     Mockito.when(mMockUfs.open(Mockito.anyString())).thenReturn(mMockInputStream);
     Mockito.when(mMockUfs.rename(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
@@ -73,6 +81,12 @@ public final class UnderFileSystemManagerTest {
     PowerMockito.mockStatic(UnderFileSystem.class);
     BDDMockito.given(UnderFileSystem.get(Mockito.anyString(), Mockito.any(Configuration.class)))
         .willReturn(mMockUfs);
+    Mockito.when(mMockInputStream.skip(Mockito.anyInt())).thenAnswer(new Answer() {
+      public Object answer(InvocationOnMock invocation) {
+        Object[] args = invocation.getArguments();
+        return args[0];
+      }
+    });
   }
 
   /**
@@ -81,10 +95,8 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void createUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
+    mManager.createFile(SESSION_ID, mUri);
+    Mockito.verify(mMockUfs).create(Mockito.contains(mUri.toString()));
     Mockito.verify(mMockUfs).connectFromWorker(Mockito.any(Configuration.class),
         Mockito.anyString());
   }
@@ -94,12 +106,10 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void createExistingUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
     mThrown.expect(FileAlreadyExistsException.class);
-    mThrown.expectMessage(ExceptionMessage.FAILED_UFS_CREATE.getMessage(uniqPath));
-    manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
+    mThrown.expectMessage(ExceptionMessage.FAILED_UFS_CREATE.getMessage(mUri.toString()));
+    mManager.createFile(SESSION_ID, mUri);
   }
 
   /**
@@ -107,12 +117,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void completeUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
-    manager.completeFile(SESSION_ID, id, null, null);
-    Mockito.verify(mMockUfs).rename(Mockito.contains(uniqPath), Mockito.eq(uniqPath));
+    long id = mManager.createFile(SESSION_ID, mUri);
+    mManager.completeFile(SESSION_ID, id, null, null);
+    Mockito.verify(mMockUfs).rename(Mockito.contains(mUri.toString()), Mockito.eq(mUri.toString()));
   }
 
   /**
@@ -120,15 +127,11 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void completeUfsFileWithOwnerTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     String user = "User";
     String group = "Group";
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
-    manager.completeFile(SESSION_ID, id, user, group);
-    Mockito.verify(mMockUfs).rename(Mockito.contains(uniqPath), Mockito.eq(uniqPath));
-    Mockito.verify(mMockUfs).setOwner(uniqPath, user, group);
+    long id = mManager.createFile(SESSION_ID, mUri);
+    mManager.completeFile(SESSION_ID, id, user, group);
+    Mockito.verify(mMockUfs).setOwner(mUri.toString(), user, group);
   }
 
   /**
@@ -136,10 +139,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void completeNonExistentUfsFileTest() throws Exception {
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(INVALID_FILE_ID));
-    manager.completeFile(SESSION_ID, INVALID_FILE_ID, null, null);
+    mManager.completeFile(SESSION_ID, INVALID_FILE_ID, null, null);
   }
 
   /**
@@ -147,14 +149,11 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void completeUfsFileInvalidSessionTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
+    long id = mManager.createFile(SESSION_ID, mUri);
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         PreconditionMessage.ERR_UFS_MANAGER_OPERATION_INVALID_SESSION.toString(), "complete"));
-    manager.completeFile(INVALID_SESSION_ID, id, null, null);
+    mManager.completeFile(INVALID_SESSION_ID, id, null, null);
   }
 
   /**
@@ -162,12 +161,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void cancelUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
-    manager.cancelFile(SESSION_ID, id);
-    Mockito.verify(mMockUfs).delete(Mockito.contains(uniqPath), Mockito.eq(false));
+    long id = mManager.createFile(SESSION_ID, mUri);
+    mManager.cancelFile(SESSION_ID, id);
+    Mockito.verify(mMockUfs).delete(Mockito.contains(mUri.toString()), Mockito.eq(false));
   }
 
   /**
@@ -175,10 +171,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void cancelNonExistentUfsFileTest() throws Exception {
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(INVALID_FILE_ID));
-    manager.cancelFile(SESSION_ID, INVALID_FILE_ID);
+    mManager.cancelFile(SESSION_ID, INVALID_FILE_ID);
   }
 
   /**
@@ -186,14 +181,11 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void cancelUfsFileInvalidSessionTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).create(Mockito.contains(uniqPath));
+    long id = mManager.createFile(SESSION_ID, mUri);
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         PreconditionMessage.ERR_UFS_MANAGER_OPERATION_INVALID_SESSION.toString(), "cancel"));
-    manager.cancelFile(INVALID_SESSION_ID, id);
+    mManager.cancelFile(INVALID_SESSION_ID, id);
   }
 
   /**
@@ -202,11 +194,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void openUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Mockito.verify(mMockUfs).exists(uniqPath);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    mManager.openFile(SESSION_ID, new AlluxioURI(mUri.toString()));
+    Mockito.verify(mMockUfs).exists(mUri.toString());
     Mockito.verify(mMockUfs).connectFromWorker(Mockito.any(Configuration.class),
         Mockito.anyString());
   }
@@ -216,27 +206,23 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void openNonExistentUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(false);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(false);
     mThrown.expect(FileDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(uniqPath));
-    manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
+    mThrown.expectMessage(ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(mUri.toString()));
+    mManager.openFile(SESSION_ID, mUri);
   }
 
   /**
-   * Tests closing an opened file invalidates the id.
+   * Tests closing an open file invalidates the id.
    */
   @Test
   public void closeUfsFileTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    manager.closeFile(SESSION_ID, id);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, new AlluxioURI(mUri.toString()));
+    mManager.closeFile(SESSION_ID, id);
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(id));
-    manager.closeFile(SESSION_ID, id);
+    mManager.closeFile(SESSION_ID, id);
   }
 
   /**
@@ -244,10 +230,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void closeNonExistentUfsFileTest() throws Exception {
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(INVALID_FILE_ID));
-    manager.closeFile(SESSION_ID, INVALID_FILE_ID);
+    mManager.closeFile(SESSION_ID, INVALID_FILE_ID);
   }
 
   /**
@@ -255,10 +240,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void closeUfsFileInvalidSessionTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
     UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
+    long id = manager.openFile(SESSION_ID, mUri);
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String
         .format(PreconditionMessage.ERR_UFS_MANAGER_OPERATION_INVALID_SESSION.toString(), "close"));
@@ -270,10 +254,8 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getOutputStreamTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.createFile(SESSION_ID, new AlluxioURI(uniqPath));
-    Assert.assertEquals(mMockOutputStream, manager.getOutputStream(id));
+    long id = mManager.createFile(SESSION_ID, mUri);
+    Assert.assertEquals(mMockOutputStream, mManager.getOutputStream(id));
   }
 
   /**
@@ -281,10 +263,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getNonExistentOutputStreamTest() throws Exception {
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(INVALID_FILE_ID));
-    manager.getOutputStream(INVALID_FILE_ID);
+    mManager.getOutputStream(INVALID_FILE_ID);
   }
 
   /**
@@ -292,13 +273,10 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getInputStreamTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     long position = 0L;
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    Mockito.when(mMockInputStream.skip(position)).thenReturn(position);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    InputStream in = manager.getInputStreamAtPosition(id, position);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, mUri);
+    InputStream in = mManager.getInputStreamAtPosition(id, position);
     Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     Mockito.verify(mMockInputStream, Mockito.never()).skip(position);
     in.close();
@@ -309,57 +287,46 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getInputStreamAtPositionTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     long position = FILE_LENGTH - 1;
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    Mockito.when(mMockInputStream.skip(position)).thenReturn(position);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    InputStream in = manager.getInputStreamAtPosition(id, position);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, mUri);
+    InputStream in = mManager.getInputStreamAtPosition(id, position);
     Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     Mockito.verify(mMockInputStream).skip(position);
     in.close();
   }
 
   /**
-   * Tests getting an input stream to a valid file at a position returns the correct input
-   * stream, then reading and getting the next position returns the same stream.
+   * Tests getting an input stream returns the cached stream if the cached stream is positioned
+   * correctly.
    */
   @Test
   public void getInputStreamAtPositionCacheTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     long position = 0;
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     long nextPosition = 100;
-    Mockito.when(mMockInputStream.skip(nextPosition)).thenReturn(nextPosition);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, mUri);
+    InputStream in = mManager.getInputStreamAtPosition(id, position);
     in.skip(nextPosition - position);
-    InputStream in2 = manager.getInputStreamAtPosition(id, nextPosition);
+    InputStream in2 = mManager.getInputStreamAtPosition(id, nextPosition);
     Assert.assertEquals(in, in2);
     Mockito.verify(mMockInputStream, Mockito.never()).skip(position);
     in.close();
   }
 
   /**
-   * Tests getting an input stream to a valid file at a position returns the correct input
-   * stream, then reading a backward position gets another input stream.
+   * Tests getting an input stream returns a new stream if the cached stream is positioned beyond
+   * the requested position.
    */
   @Test
   public void getInputStreamAtPositionInvalidCacheTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     long position = 0;
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    InputStream in = manager.getInputStreamAtPosition(id, position);
-    Assert.assertEquals(mMockInputStream, getInternalInputStream(in));
     long nextPosition = 100;
-    Mockito.when(mMockInputStream.skip(nextPosition)).thenReturn(nextPosition);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, mUri);
+    InputStream in = mManager.getInputStreamAtPosition(id, position);
     in.skip(nextPosition - position);
-    InputStream in2 = manager.getInputStreamAtPosition(id, position);
+    InputStream in2 = mManager.getInputStreamAtPosition(id, position);
     Assert.assertNotEquals(in, in2);
     in.close();
     in2.close();
@@ -370,13 +337,10 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getInputStreamAtEOFTest() throws Exception {
-    String uniqPath = PathUtils.uniqPath();
     long position = FILE_LENGTH;
-    Mockito.when(mMockUfs.exists(uniqPath)).thenReturn(true);
-    Mockito.when(mMockInputStream.skip(position)).thenReturn(position);
-    UnderFileSystemManager manager = new UnderFileSystemManager();
-    long id = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath));
-    InputStream in = manager.getInputStreamAtPosition(id, position);
+    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
+    long id = mManager.openFile(SESSION_ID, mUri);
+    InputStream in = mManager.getInputStreamAtPosition(id, position);
     Assert.assertEquals(null, in);
     Mockito.verify(mMockInputStream, Mockito.never()).skip(position);
   }
@@ -386,10 +350,9 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void getNonExistentInputStreamTest() throws Exception {
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(INVALID_FILE_ID));
-    manager.getInputStreamAtPosition(INVALID_FILE_ID, 0L);
+    mManager.getInputStreamAtPosition(INVALID_FILE_ID, 0L);
   }
 
   /**
@@ -397,38 +360,36 @@ public final class UnderFileSystemManagerTest {
    */
   @Test
   public void cleanSessionsTest() throws Exception {
-    String uniqPath1 = PathUtils.uniqPath();
     String uniqPath2 = PathUtils.uniqPath();
-    long secondSessionId = SESSION_ID + 1;
+    long sessionId2 = SESSION_ID + 1;
     long position = 0L;
-    UnderFileSystemManager manager = new UnderFileSystemManager();
     Mockito.when(mMockUfs.exists(Mockito.anyString())).thenReturn(true);
-    long id1 = manager.openFile(SESSION_ID, new AlluxioURI(uniqPath1));
-    long id2 = manager.openFile(secondSessionId, new AlluxioURI(uniqPath2));
+    long id1 = mManager.openFile(SESSION_ID, mUri);
+    long id2 = mManager.openFile(sessionId2, new AlluxioURI(uniqPath2));
     // Both files should be accessible
-    InputStream in1 = manager.getInputStreamAtPosition(id1, position);
+    InputStream in1 = mManager.getInputStreamAtPosition(id1, position);
     Assert.assertEquals(mMockInputStream, getInternalInputStream(in1));
-    InputStream in2 = manager.getInputStreamAtPosition(id2, position);
+    InputStream in2 = mManager.getInputStreamAtPosition(id2, position);
     Assert.assertEquals(mMockInputStream, getInternalInputStream(in2));
     in1.close();
     in2.close();
     // Clean up second session
-    manager.cleanupSession(secondSessionId);
+    mManager.cleanupSession(sessionId2);
     // First file should still be available
-    in1 = manager.getInputStreamAtPosition(id1, position);
+    in1 = mManager.getInputStreamAtPosition(id1, position);
     Assert.assertEquals(mMockInputStream, getInternalInputStream(in1));
     in1.close();
     // Second file should no longer be available
     mThrown.expect(FileDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.BAD_WORKER_FILE_ID.getMessage(id2));
-    manager.getInputStreamAtPosition(id2, position);
+    mManager.getInputStreamAtPosition(id2, position);
   }
 
   /**
    * Used to enable equality checks on the underlying stream.
    *
    * @param in the wrapper stream
-   * @return the internal input stream of a wrapper input stream.
+   * @return the internal input stream of a wrapper input stream
    */
   private InputStream getInternalInputStream(InputStream in) {
     return (InputStream) Whitebox.getInternalState(in, "in");


### PR DESCRIPTION
Keeps state to improve the performance when reading from an under storage like S3 where each open is fairly expensive. Performance is about the same as no delegation.