### PR TITLE
[SMALLFIX] Clean up in the core module

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -173,9 +173,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getStatus(path);
-    } catch (FileDoesNotExistException e) {
-      throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-    } catch (InvalidPathException e) {
+    } catch (FileDoesNotExistException | InvalidPathException e) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
     } finally {
       mContext.releaseMasterClient(masterClient);

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -79,7 +79,7 @@ public final class FileSystemUtils {
    * The method will deliberately block anyway for the specified amount of time, waiting for the
    * file to be created and eventually completed. Note also that the file might be moved or deleted
    * while it is waited upon. In such cases the method will throw the a {@link AlluxioException}
-   * with the appropriate {@link AlluxioExceptionType}
+   * with the appropriate {@link AlluxioException.AlluxioExceptionType}
    * <p/>
    * <i>IMPLEMENTATION NOTES</i> This method is implemented by periodically polling the master about
    * the file status. The polling period is controlled by the

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -97,8 +97,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       } else {
         throw new IOException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(uri));
       }
-    } catch (InvalidPathException e) {
-      throw new IOException(e);
     } catch (AlluxioException e) {
       throw new IOException(e);
     }

--- a/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -103,7 +103,7 @@ public final class HadoopUtils {
     StringBuilder sb = new StringBuilder();
     sb.append("HadoopFileStatus: Path: ").append(fs.getPath());
     sb.append(" , Length: ").append(fs.getLen());
-    sb.append(" , IsDir: ").append(fs.isDir());
+    sb.append(" , IsDir: ").append(fs.isDirectory());
     sb.append(" , BlockReplication: ").append(fs.getReplication());
     sb.append(" , BlockSize: ").append(fs.getBlockSize());
     sb.append(" , ModificationTime: ").append(fs.getModificationTime());

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -188,9 +188,8 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
       throw new IOException("Cannot read from a closed stream.");
     }
     if (mAlluxioFileInputStream != null) {
-      int ret = 0;
       try {
-        ret = mAlluxioFileInputStream.read(buffer, offset, length);
+        int ret = mAlluxioFileInputStream.read(buffer, offset, length);
         if (mStatistics != null && ret != -1) {
           mStatistics.incrementBytesRead(ret);
         }

--- a/core/client/src/test/java/alluxio/client/lineage/LineageFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/client/lineage/LineageFileSystemTest.java
@@ -111,7 +111,7 @@ public final class LineageFileSystemTest {
     CreateFileOptions options =
         CreateFileOptions.defaults().setBlockSizeBytes(TEST_BLOCK_SIZE).setTtl(0);
     FileOutStream outStream = mAlluxioLineageFileSystem.createFile(path, options);
-    Assert.assertTrue(outStream instanceof FileOutStream);
+    Assert.assertTrue(outStream != null);
     Assert.assertFalse(outStream instanceof LineageFileOutStream);
     Assert.assertFalse(outStream instanceof DummyFileOutputStream);
     // verify client is released


### PR DESCRIPTION
Some minor fixed in the **core** module.

*BaseFileSystem*: Collapsed exception handling
*FileSystemUtils*: Fixed documentation
*AbstractFileSystem*: Collapsed exception handling
*HadoopUtils*: Fixed deprecation
*HdfsFileInputStream*: Removed redundant initializer
*LineageFileSystemTest*: Simplified ```instanceof``` statement