### PR TITLE
[SMALLFIX] Clean up in the examples module

### DIFF
--- a/examples/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/examples/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -22,7 +22,12 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.util.CommonUtils;
 
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/examples/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/examples/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -22,12 +22,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.util.CommonUtils;
 
-import org.apache.commons.cli.BasicParser;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,8 +124,6 @@ public final class JournalCrashTest {
               if (!(e instanceof FileAlreadyExistsException)) {
                 throw e;
               }
-            } catch (Exception e) {
-              throw e;
             }
             sFileSystem.delete(testURI);
           } else if (ClientOpType.CREATE_RENAME_FILE == mOpType) {
@@ -141,8 +134,6 @@ public final class JournalCrashTest {
               if (!(e instanceof FileAlreadyExistsException)) {
                 throw e;
               }
-            } catch (Exception e) {
-              throw e;
             }
             sFileSystem.rename(testURI, new AlluxioURI(testURI + "-rename"));
           }
@@ -328,7 +319,7 @@ public final class JournalCrashTest {
     options.addOption("renames", true,
         "Number of Client Threads to request create/rename operations");
     options.addOption("testDir", true, "Test Directory on Alluxio");
-    CommandLineParser parser = new BasicParser();
+    CommandLineParser parser = new DefaultParser();
     CommandLine cmd = null;
     boolean ret = true;
     try {

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -81,14 +81,11 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
 
   private void write(FileSystem alluxioClient) throws IOException, AlluxioException {
     FileOutStream fileOutStream = createFile(alluxioClient, mFilePath, mDeleteIfExists);
-    DataOutputStream os = new DataOutputStream(fileOutStream);
-    try {
+    try (DataOutputStream os = new DataOutputStream(fileOutStream)) {
       os.writeInt(mLength);
       for (int i = 0; i < mLength; i++) {
         os.writeInt(i);
       }
-    } finally {
-      os.close();
     }
   }
 
@@ -110,16 +107,13 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
   private boolean read(FileSystem alluxioClient) throws IOException, AlluxioException {
     OpenFileOptions options = OpenFileOptions.defaults().setReadType(mReadType);
 
-    DataInputStream input = new DataInputStream(alluxioClient.openFile(mFilePath, options));
-    try {
+    try (DataInputStream input = new DataInputStream(alluxioClient.openFile(mFilePath, options))) {
       int length = input.readInt();
       for (int i = 0; i < length; i++) {
         if (input.readInt() != i) {
           return false;
         }
       }
-    } finally {
-      input.close();
     }
     return true;
   }

--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -47,7 +47,6 @@ public final class Performance {
   private static final String FOLDER = "/mnt/ramdisk/";
 
   private static FileSystem sFileSystem = null;
-  private static HostAndPort sMasterAddress = null;
   private static String sFileName = null;
   private static int sBlockSizeBytes = -1;
   private static long sBlocksPerFile = -1;
@@ -606,7 +605,7 @@ public final class Performance {
       System.exit(-1);
     }
 
-    sMasterAddress = HostAndPort.fromString(args[0]);
+    HostAndPort masterAddress = HostAndPort.fromString(args[0]);
     sFileName = args[1];
     sBlockSizeBytes = Integer.parseInt(args[2]);
     sBlocksPerFile = Long.parseLong(args[3]);
@@ -617,7 +616,7 @@ public final class Performance {
     sBaseFileNumber = Integer.parseInt(args[8]);
 
     sFileBytes = sBlocksPerFile * sBlockSizeBytes;
-    sFilesBytes = 1L * sFileBytes * sFiles;
+    sFilesBytes = sFileBytes * sFiles;
 
     Configuration configuration = ClientContext.getConf();
 
@@ -631,8 +630,8 @@ public final class Performance {
 
     CommonUtils.warmUpLoop();
 
-    configuration.set(Constants.MASTER_HOSTNAME, sMasterAddress.getHostText());
-    configuration.set(Constants.MASTER_RPC_PORT, Integer.toString(sMasterAddress.getPort()));
+    configuration.set(Constants.MASTER_HOSTNAME, masterAddress.getHostText());
+    configuration.set(Constants.MASTER_RPC_PORT, Integer.toString(masterAddress.getPort()));
 
     if (testCase == 1) {
       sResultPrefix = "AlluxioFilesWriteTest " + sResultPrefix;

--- a/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
@@ -40,7 +40,6 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private final int mPartitionLength = Constants.MB;
-  private final int mValueLength = mPartitionLength / 2;
   private final int mNumKeyValuePairs = 10;
 
   private AlluxioURI mStoreUri;
@@ -80,7 +79,8 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
       // Keys are 0, 1, 2, etc.
       byte[] key = ByteBuffer.allocate(4).putInt(i).array();
       // Values are byte arrays of length {@link #mValueLength}.
-      byte[] value = BufferUtils.getIncreasingByteArray(mValueLength);
+      int valueLength = mPartitionLength / 2;
+      byte[] value = BufferUtils.getIncreasingByteArray(valueLength);
       writer.put(key, value);
       mKeyValuePairs.put(ByteBuffer.wrap(key), ByteBuffer.wrap(value));
     }

--- a/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
@@ -40,8 +40,8 @@ public final class ShowKeyValueStore {
         System.out.printf("%s %s%n", key, value);
         break;
       default:
-        throw new RuntimeException(String.format("Unknown scope: %s, should be one of key/value/all",
-                scope));
+        throw new RuntimeException(
+                String.format("Unknown scope: %s, should be one of key/value/all", scope));
     }
   }
 

--- a/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
@@ -29,15 +29,19 @@ public final class ShowKeyValueStore {
         pair.getKey()));
     String value = FormatUtils.byteArrayToHexString(BufferUtils.newByteArrayFromByteBuffer(
         pair.getValue()));
-    if (scope.equals("key")) {
-      System.out.println(key);
-    } else if (scope.equals("value")) {
-      System.out.println(value);
-    } else if (scope.equals("all")) {
-      System.out.printf("%s %s%n", key, value);
-    } else {
-      throw new RuntimeException(String.format("Unknown scope: %s, should be one of key/value/all",
-          scope));
+    switch (scope) {
+      case "key":
+        System.out.println(key);
+        break;
+      case "value":
+        System.out.println(value);
+        break;
+      case "all":
+        System.out.printf("%s %s%n", key, value);
+        break;
+      default:
+        throw new RuntimeException(String.format("Unknown scope: %s, should be one of key/value/all",
+                scope));
     }
   }
 


### PR DESCRIPTION
Minor fixes in the **examples** module.

*JournalCrashTest*: Removed the exception rethrows and fixed deprecation
*BasicNonByteBufferOperations*: introduced automatic resource management in try
*Performance*: Made field a local variable
*KeyValueStoreOperations*: Made a field a local variable
*ShowKeyValueStore*: Converted if-else-statements into switch statement