### PR TITLE
[SMALLFIX] Yarn improvements

### DIFF
--- a/integration/bin/alluxio-application-master.sh
+++ b/integration/bin/alluxio-application-master.sh
@@ -24,5 +24,6 @@ echo "Launching Application Master"
 
 "${JAVA}" -cp "${CLASSPATH}" \
   ${ALLUXIO_JAVA_OPTS} \
+  -Dalluxio.logger.type=Console \
   -Xmx256M \
   alluxio.yarn.ApplicationMaster $@

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -54,6 +54,7 @@ JAR_LOCAL=${ALLUXIO_HOME}/assembly/target/alluxio-assemblies-${VERSION}-jar-with
 
 echo "Uploading files to HDFS to distribute alluxio runtime"
 
+${HADOOP_HOME}/bin/hadoop fs -mkdir -p ${HDFS_PATH}
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${ALLUXIO_TARFILE} ${HDFS_PATH}/$ALLUXIO_TARFILE
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${JAR_LOCAL} ${HDFS_PATH}/alluxio.jar
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${SCRIPT_DIR}/alluxio-yarn-setup.sh ${HDFS_PATH}/alluxio-yarn-setup.sh

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -15,14 +15,15 @@
 #  alluxio-yarn.sh <numWorkers> <pathHdfs>
 
 function printUsage {
-  echo "Usage: alluxio-yarn.sh <numWorkers> <pathHdfs>"
+  echo "Usage: alluxio-yarn.sh <numWorkers> <pathHdfs> [masterAddress]"
   echo -e "  numWorkers        \tNumber of Alluxio workers to launch"
   echo -e "  pathHdfs          \tPath on HDFS to put alluxio jar and distribute it to YARN"
+  echo -e "  masterAddress     \tYarn node to launch the Alluxio master on, defaults to ALLUXIO_MASTER_HOSTNAME"
   echo
-  echo "Example: ./alluxio-yarn.sh 10 hdfs://localhost:9000/tmp/"
+  echo "Example: ./alluxio-yarn.sh 10 hdfs://localhost:9000/tmp/ ip-172-31-5-205.ec2.internal"
 }
 
-if [[ "$#" != 2 ]]; then
+if [[ "$#" -lt 2 ]] || [[ "$#" -gt 3 ]]; then
   printUsage
   exit 1
 fi
@@ -41,6 +42,8 @@ source "${SCRIPT_DIR}/common.sh"
 
 NUM_WORKERS=$1
 HDFS_PATH=$2
+MASTER_ADDRESS=$3
+
 ALLUXIO_TARFILE="alluxio.tar.gz"
 rm -rf $ALLUXIO_TARFILE
 tar -C $ALLUXIO_HOME -zcf $ALLUXIO_TARFILE \
@@ -69,5 +72,5 @@ export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
 ${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \
     -num_workers $NUM_WORKERS \
-    -master_address ${ALLUXIO_MASTER_HOSTNAME:-localhost} \
+    -master_address ${MASTER_ADDRESS:-${ALLUXIO_MASTER_HOSTNAME}} \
     -resource_path ${HDFS_PATH}

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -63,6 +63,7 @@ echo "Starting YARN client to launch Alluxio on YARN"
 
 # Add Alluxio java options to the yarn options so that alluxio.yarn.Client can be configured via
 # alluxio java options
+ALLUXIO_JAVA_OPTS="${ALLUXIO_JAVA_OPTS} -Dalluxio.logger.type=Console"
 export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
 ${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \

--- a/integration/bin/common.sh
+++ b/integration/bin/common.sh
@@ -16,6 +16,3 @@ DEFAULT_LIBEXEC_DIR="${SCRIPT_DIR}/../../libexec"
 ALLUXIO_LIBEXEC_DIR="${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}"
 source "${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh"
 # TODO: Remove for v2.0 release, below line in support of backwards compatibility
-MASTER_HOSTNAME="${ALLUXIO_MASTER_ADDRESS:-localhost}"
-ALLUXIO_MASTER_HOSTNAME="${MASTER_HOSTNAME:-localhost}"
-ALLUXIO_HOME="${ALLUXIO_HOME:-${SCRIPT_DIR}/../..}"

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -313,10 +313,7 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
     String[] nodes = {mMasterAddress};
 
     // Make container request for Alluxio master to ResourceManager
-    boolean relaxLocality = true;
-    if (!mMasterAddress.equals("localhost")) {
-      relaxLocality = false;
-    }
+    boolean relaxLocality = mMasterAddress.equals("localhost");
     ContainerRequest masterContainerAsk = new ContainerRequest(masterResource, nodes,
         null /* any racks */, MASTER_PRIORITY, relaxLocality);
     LOG.info("Making resource request for Alluxio master: cpu {} memory {} MB on node {}",


### PR DESCRIPTION
- Set the logger type for Yarn Client and Application Master(AM) so that we can see their logs in userlogs/.../stdout.
- Exit the client after it launches the AM to make it easier to run the client programmatically, and because the information it provided after launch wasn't very useful.
- Add command-line option for providing the name of the yarn node to run Alluxio Master on. This is especially useful on EC2 where yarn names its nodes using internal DNS names, which might differ from ALLUXIO_MASTER_HOSTNAME.