### PR TITLE
[SMALLFIX] Yarn improvements

### DIFF
--- a/docs/_includes/Running-Alluxio-on-EC2-Yarn/script-output.md
+++ b/docs/_includes/Running-Alluxio-on-EC2-Yarn/script-output.md
@@ -13,9 +13,7 @@ SLF4J: Found binding in [jar:file:/hadoop/share/hadoop/common/lib/slf4j-log4j12-
 SLF4J: Found binding in [jar:file:/alluxio/clients/client/target/alluxio-core-client-1.0.0-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
 SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
-ApplicationMaster command: {{JAVA_HOME}}/bin/java -Xmx256M alluxio.yarn.ApplicationMaster 3 /alluxio localhost 1><LOG_DIR>/stdout 2><LOG_DIR>/stderr 
+ApplicationMaster command: {{JAVA_HOME}}/bin/java -Xmx256M alluxio.yarn.ApplicationMaster 3 /alluxio localhost 1><LOG_DIR>/stdout 2><LOG_DIR>/stderr
 Submitting application of id application_1445469376652_0002 to ResourceManager
 15/10/22 00:01:19 INFO impl.YarnClientImpl: Submitted application application_1445469376652_0002
-2015/10/22 00:01:29 Got application report from ASM for appId=2, clientToAMToken=null, appDiagnostics=, appMasterHost=, appQueue=default, appMasterRpcPort=0, appStartTime=1445472079196, yarnAppState=RUNNING, distributedFinalState=UNDEFINED, appTrackingUrl=http://AlluxioMaster:8088/proxy/application_1445469376652_0002/A, appUser=ec2-user
-2015/10/22 00:01:39 Got application report from ASM for appId=2, clientToAMToken=null, appDiagnostics=, appMasterHost=, appQueue=default, appMasterRpcPort=0, appStartTime=1445472079196, yarnAppState=RUNNING, distributedFinalState=UNDEFINED, appTrackingUrl=http://AlluxioMaster:8088/proxy/application_1445469376652_0002/A, appUser=ec2-user
 ```

--- a/docs/_includes/Running-Alluxio-on-EC2-Yarn/script-output.md
+++ b/docs/_includes/Running-Alluxio-on-EC2-Yarn/script-output.md
@@ -2,7 +2,7 @@
 Using $HADOOP_HOME set to '/hadoop'
 SLF4J: Class path contains multiple SLF4J bindings.
 SLF4J: Found binding in [jar:file:/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: Found binding in [jar:file:/alluxio/clients/client/target/alluxio-core-client-1.0.0-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: Found binding in [jar:file:/alluxio/clients/client/target/alluxio-core-client-{{site.ALLUXIO_RELEASED_VERSION}}-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
 SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
 Initializing Client
@@ -10,7 +10,7 @@ Starting Client
 15/10/22 00:01:17 INFO client.RMProxy: Connecting to ResourceManager at AlluxioMaster/172.31.22.124:8050
 SLF4J: Class path contains multiple SLF4J bindings.
 SLF4J: Found binding in [jar:file:/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: Found binding in [jar:file:/alluxio/clients/client/target/alluxio-core-client-1.0.0-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: Found binding in [jar:file:/alluxio/clients/client/target/alluxio-core-client-{{site.ALLUXIO_RELEASED_VERSION}}-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
 SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
 ApplicationMaster command: {{JAVA_HOME}}/bin/java -Xmx256M alluxio.yarn.ApplicationMaster 3 /alluxio localhost 1><LOG_DIR>/stdout 2><LOG_DIR>/stderr

--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -123,24 +123,22 @@ but it makes the build run significantly faster.
 To customize Alluxio master and worker with specific properties (e.g., tiered storage setup on each
 worker), one can refer to [Configuration settings](Configuration-Settings.html) for more
 information. To ensure your configuration can be read by both the ApplicationMaster and Alluxio
-master/workers, put `alluxio-site.properties` under `${ALLUXIO_HOME}/conf` on each EC2 machine.
+master/workers, put `alluxio-site.properties` under `~/.alluxio/` on each EC2 machine.
 
 # Start Alluxio
 
-Use script `integration/bin/alluxio-yarn.sh` to start Alluxio. This script requires three arguments:
-1. A path pointing to `${ALLUXIO_HOME}` on each machine so YARN NodeManager can access Alluxio
-scripts and binaries to launch masters and workers. With our EC2 setup, this path is `/alluxio`.
-2. The total number of Alluxio workers to start.
-3. A HDFS path to distribute the binaries for Alluxio ApplicationMaster.
+Use script `integration/bin/alluxio-yarn.sh` to start Alluxio. This script takes three arguments:
+
+1. The total number of Alluxio workers to start. (required)
+2. An HDFS path to distribute the binaries for Alluxio ApplicationMaster. (required)
+3. The Yarn name for the node on which to run the Alluxio Master (optional, defaults to `ALLUXIO_MASTER_HOSTNAME`)
 
 For example, here we launch an Alluxio cluster with 3 worker nodes, where an HDFS temp directory is
-`hdfs://AlluxioMaster:9000/tmp/` and each YARN container can access Alluxio in `/alluxio`
+`hdfs://AlluxioMaster:9000/tmp/`
 
 {% include Running-Alluxio-on-EC2-Yarn/three-arguments.md %}
 
-This script will first upload the binaries with YARN client and ApplicationMaster to the HDFS path
-specified, then inform YARN to run the client binary jar. The script will keep running with
-ApplicationMaster status reported. You can also check `http://AlluxioMaster:8088` in the browser to
+This script will launch an Alluxio Application Master on Yarn, which will then request containers for the Alluxio master and workers. You can also check `http://AlluxioMaster:8088` in the browser to
 access the Web UIs and watch the status of the Alluxio job as well as the application ID.
 
 The output of the above script may produce output like the following:
@@ -150,11 +148,6 @@ The output of the above script may produce output like the following:
 From the output, we know the application ID to run Alluxio is
 **`application_1445469376652_0002`**. This application ID is needed to kill the application.
 
-NOTE: currently Alluxio YARN framework does not guarantee to start the Alluxio master on the
-AlluxioMaster machine; use the YARN Web UI to read the logs of this YARN application. The log
-of this application records which machine is used to launch an Alluxio master container like:
-
-{% include Running-Alluxio-on-EC2-Yarn/log-Alluxio-master.md %}
 
 # Test Alluxio
 

--- a/integration/bin/alluxio-application-master.sh
+++ b/integration/bin/alluxio-application-master.sh
@@ -24,5 +24,6 @@ echo "Launching Application Master"
 
 "${JAVA}" -cp "${CLASSPATH}" \
   ${ALLUXIO_JAVA_OPTS} \
+  -Dalluxio.logger.type=Console \
   -Xmx256M \
   alluxio.yarn.ApplicationMaster $@

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -54,6 +54,7 @@ JAR_LOCAL=${ALLUXIO_HOME}/assembly/target/alluxio-assemblies-${VERSION}-jar-with
 
 echo "Uploading files to HDFS to distribute alluxio runtime"
 
+${HADOOP_HOME}/bin/hadoop fs -mkdir -p ${HDFS_PATH}
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${ALLUXIO_TARFILE} ${HDFS_PATH}/$ALLUXIO_TARFILE
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${JAR_LOCAL} ${HDFS_PATH}/alluxio.jar
 ${HADOOP_HOME}/bin/hadoop fs -put -f ${SCRIPT_DIR}/alluxio-yarn-setup.sh ${HDFS_PATH}/alluxio-yarn-setup.sh

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -15,14 +15,15 @@
 #  alluxio-yarn.sh <numWorkers> <pathHdfs>
 
 function printUsage {
-  echo "Usage: alluxio-yarn.sh <numWorkers> <pathHdfs>"
+  echo "Usage: alluxio-yarn.sh <numWorkers> <pathHdfs> [masterAddress]"
   echo -e "  numWorkers        \tNumber of Alluxio workers to launch"
   echo -e "  pathHdfs          \tPath on HDFS to put alluxio jar and distribute it to YARN"
+  echo -e "  masterAddress     \tYarn node to launch the Alluxio master on, defaults to ALLUXIO_MASTER_HOSTNAME"
   echo
-  echo "Example: ./alluxio-yarn.sh 10 hdfs://localhost:9000/tmp/"
+  echo "Example: ./alluxio-yarn.sh 10 hdfs://localhost:9000/tmp/ ip-172-31-5-205.ec2.internal"
 }
 
-if [[ "$#" != 2 ]]; then
+if [[ "$#" -lt 2 ]] || [[ "$#" -gt 3 ]]; then
   printUsage
   exit 1
 fi
@@ -41,6 +42,8 @@ source "${SCRIPT_DIR}/common.sh"
 
 NUM_WORKERS=$1
 HDFS_PATH=$2
+MASTER_ADDRESS=$3
+
 ALLUXIO_TARFILE="alluxio.tar.gz"
 rm -rf $ALLUXIO_TARFILE
 tar -C $ALLUXIO_HOME -zcf $ALLUXIO_TARFILE \
@@ -69,5 +72,5 @@ export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
 ${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \
     -num_workers $NUM_WORKERS \
-    -master_address ${ALLUXIO_MASTER_HOSTNAME:-localhost} \
+    -master_address ${MASTER_ADDRESS:-${ALLUXIO_MASTER_HOSTNAME}} \
     -resource_path ${HDFS_PATH}

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -63,6 +63,7 @@ echo "Starting YARN client to launch Alluxio on YARN"
 
 # Add Alluxio java options to the yarn options so that alluxio.yarn.Client can be configured via
 # alluxio java options
+ALLUXIO_JAVA_OPTS="${ALLUXIO_JAVA_OPTS} -Dalluxio.logger.type=Console"
 export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
 ${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -42,7 +42,7 @@ source "${SCRIPT_DIR}/common.sh"
 
 NUM_WORKERS=$1
 HDFS_PATH=$2
-MASTER_ADDRESS=$3
+MASTER_ADDRESS=${3:-${ALLUXIO_MASTER_HOSTNAME}}
 
 ALLUXIO_TARFILE="alluxio.tar.gz"
 rm -rf $ALLUXIO_TARFILE
@@ -72,5 +72,5 @@ export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
 ${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \
     -num_workers $NUM_WORKERS \
-    -master_address ${MASTER_ADDRESS:-${ALLUXIO_MASTER_HOSTNAME}} \
+    -master_address ${MASTER_ADDRESS} \
     -resource_path ${HDFS_PATH}

--- a/integration/bin/common.sh
+++ b/integration/bin/common.sh
@@ -16,6 +16,3 @@ DEFAULT_LIBEXEC_DIR="${SCRIPT_DIR}/../../libexec"
 ALLUXIO_LIBEXEC_DIR="${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}"
 source "${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh"
 # TODO: Remove for v2.0 release, below line in support of backwards compatibility
-MASTER_HOSTNAME="${ALLUXIO_MASTER_ADDRESS:-localhost}"
-ALLUXIO_MASTER_HOSTNAME="${MASTER_HOSTNAME:-localhost}"
-ALLUXIO_HOME="${ALLUXIO_HOME:-${SCRIPT_DIR}/../..}"

--- a/integration/bin/common.sh
+++ b/integration/bin/common.sh
@@ -15,4 +15,3 @@ SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
 DEFAULT_LIBEXEC_DIR="${SCRIPT_DIR}/../../libexec"
 ALLUXIO_LIBEXEC_DIR="${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}"
 source "${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh"
-# TODO: Remove for v2.0 release, below line in support of backwards compatibility

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -313,10 +313,7 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
     String[] nodes = {mMasterAddress};
 
     // Make container request for Alluxio master to ResourceManager
-    boolean relaxLocality = true;
-    if (!mMasterAddress.equals("localhost")) {
-      relaxLocality = false;
-    }
+    boolean relaxLocality = mMasterAddress.equals("localhost");
     ContainerRequest masterContainerAsk = new ContainerRequest(masterResource, nodes,
         null /* any racks */, MASTER_PRIORITY, relaxLocality);
     LOG.info("Making resource request for Alluxio master: cpu {} memory {} MB on node {}",


### PR DESCRIPTION
- Set the logger type for Yarn Client and Application Master(AM) so that we can see their logs in userlogs/.../stdout.
- Exit the client after it launches the AM to make it easier to run the client programmatically, and because the information it provided after launch wasn't very useful.
- Add command-line option for providing the name of the yarn node to run Alluxio Master on. This is especially useful on EC2 where yarn names its nodes using internal DNS names, which might differ from ALLUXIO_MASTER_HOSTNAME.