### PR TITLE
[ALLUXIO-2015] Allocate a default heap size for workers (standalone cluster)

### DIFF
--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -51,8 +51,8 @@
 # ALLUXIO_MASTER_JAVA_OPTS
 
 # Config properties set for Alluxio worker daemon. (Default: "")
-# E.g. "-Dalluxio.worker.port=49999"
-ALLUXIO_WORKER_JAVA_OPTS="-Xms2048M -Xmx2048M"
+# E.g. "-Dalluxio.worker.port=49999" to set worker port, "-Xms2048M -Xmx2048M" to limit the heap size of worker. 
+# ALLUXIO_WORKER_JAVA_OPTS
 
 # Config properties set for Alluxio shell. (Default: "")
 # E.g. "-Dalluxio.user.file.writetype.default=THROUGH"

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -52,7 +52,7 @@
 
 # Config properties set for Alluxio worker daemon. (Default: "")
 # E.g. "-Dalluxio.worker.port=49999"
-# ALLUXIO_WORKER_JAVA_OPTS
+ALLUXIO_WORKER_JAVA_OPTS="-Xms2048M -Xmx2048M"
 
 # Config properties set for Alluxio shell. (Default: "")
 # E.g. "-Dalluxio.user.file.writetype.default=THROUGH"


### PR DESCRIPTION
Currently, the worker's JVM size is specified as an integration property `alluxio.integration.worker.resource.mem`. It is only applied to YARN and Mesos clusters but not to standalone cluster. It's necessary to setup a default heap size to control the memory resource consumed by the worker's JVM.

In addition, https://github.com/Alluxio/alluxio/pull/3557 is used to fix the memory "leak" caused by the use of MappedByteBuffer. 