### PR TITLE
[SMALLFIX] Clean up in the shell module

### DIFF
--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -66,12 +66,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
    * @return the URI of the master
    */
   public String getUri() {
-    return new StringBuilder()
-        .append(Constants.HEADER_FT)
-        .append(mHostname)
-        .append(":")
-        .append(getMaster().getRPCLocalPort())
-        .toString();
+    return Constants.HEADER_FT + mHostname + ":" + getMaster().getRPCLocalPort();
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/CatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CatCommand.java
@@ -53,16 +53,13 @@ public final class CatCommand extends WithWildCardPathCommand {
 
       if (!status.isFolder()) {
         OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
-        FileInStream is = mFileSystem.openFile(path, options);
         byte[] buf = new byte[512];
-        try {
+        try (FileInStream is = mFileSystem.openFile(path, options)) {
           int read = is.read(buf);
           while (read != -1) {
             System.out.write(buf, 0, read);
             read = is.read(buf);
           }
-        } finally {
-          is.close();
         }
       } else {
         throw new IOException(ExceptionMessage.PATH_MUST_BE_FILE.getMessage(path));

--- a/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
@@ -176,8 +176,7 @@ public final class CopyToLocalCommand extends AbstractShellCommand {
           RandomStringUtils.randomAlphanumeric(8));
       File tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);
 
-      Closer closer = Closer.create();
-      try {
+      try (Closer closer = Closer.create()) {
         OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
         FileInStream is = closer.register(mFileSystem.openFile(srcPath, options));
         FileOutputStream out = closer.register(new FileOutputStream(tmpDst));
@@ -189,11 +188,10 @@ public final class CopyToLocalCommand extends AbstractShellCommand {
         }
         if (!tmpDst.renameTo(dstFile)) {
           throw new IOException(
-              "Failed to rename " + tmpDst.getPath() + " to destination " + dstFile.getPath());
+                  "Failed to rename " + tmpDst.getPath() + " to destination " + dstFile.getPath());
         }
         System.out.println("Copied " + srcPath + " to " + dstFile.getPath());
       } finally {
-        closer.close();
         tmpDst.delete();
       }
     } catch (AlluxioException e) {

--- a/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyToLocalCommand.java
@@ -188,7 +188,7 @@ public final class CopyToLocalCommand extends AbstractShellCommand {
         }
         if (!tmpDst.renameTo(dstFile)) {
           throw new IOException(
-                  "Failed to rename " + tmpDst.getPath() + " to destination " + dstFile.getPath());
+              "Failed to rename " + tmpDst.getPath() + " to destination " + dstFile.getPath());
         }
         System.out.println("Copied " + srcPath + " to " + dstFile.getPath());
       } finally {

--- a/shell/src/main/java/alluxio/shell/command/TailCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/TailCommand.java
@@ -67,9 +67,7 @@ public final class TailCommand extends WithWildCardPathCommand {
 
     if (!status.isFolder()) {
       OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
-      FileInStream is = null;
-      try {
-        is = mFileSystem.openFile(path, options);
+      try (FileInStream is = mFileSystem.openFile(path, options)) {
         byte[] buf = new byte[numOfBytes];
         long bytesToRead;
         if (status.getLength() > numOfBytes) {
@@ -84,8 +82,6 @@ public final class TailCommand extends WithWildCardPathCommand {
         }
       } catch (AlluxioException e) {
         throw new IOException(e.getMessage());
-      } finally {
-        is.close();
       }
     } else {
       throw new IOException(ExceptionMessage.PATH_MUST_BE_FILE.getMessage(path));


### PR DESCRIPTION
Minor fixes in the **shell** module.

*MultiMasterLocalAlluxioCluster*: Changed the usage from StringBuilder to String to simply the return statement.
*CatCommand*: Introduced automatic resource management in try statement.
*CopyToLocalCommand*: Introduced automatic resource management in try statement.
*TailCommand*: Introduced automatic resource management in try statement.