### PR TITLE
[SMALLFIX] Clean up in the test module

### DIFF
--- a/tests/src/test/java/alluxio/client/keyvalue/KeyValueSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/keyvalue/KeyValueSystemIntegrationTest.java
@@ -304,12 +304,9 @@ public final class KeyValueSystemIntegrationTest {
   }
 
   private int getPartitionNumber(AlluxioURI storeUri) throws Exception {
-    KeyValueMasterClient client =
-        new KeyValueMasterClient(ClientContext.getMasterAddress(), ClientContext.getConf());
-    try {
+    try (KeyValueMasterClient client = new KeyValueMasterClient(ClientContext.getMasterAddress(),
+        ClientContext.getConf())) {
       return client.getPartitionInfo(storeUri).size();
-    } finally {
-      client.close();
     }
   }
 

--- a/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
@@ -223,7 +223,9 @@ public final class FileSystemRenameIntegrationTest {
     sTFS.mkdirs(dirA);
     FSDataOutputStream o = sTFS.create(fileA);
     o.writeBytes("Test Bytes");
-    o.hflush();
+    // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
+    // FSDataOutputStream.hflush will be the new one.
+    o.sync();
 
     Assert.assertTrue(sTFS.rename(dirA, dirB));
 

--- a/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
@@ -223,7 +223,7 @@ public final class FileSystemRenameIntegrationTest {
     sTFS.mkdirs(dirA);
     FSDataOutputStream o = sTFS.create(fileA);
     o.writeBytes("Test Bytes");
-    o.sync();
+    o.hflush();
 
     Assert.assertTrue(sTFS.rename(dirA, dirB));
 

--- a/tests/src/test/java/alluxio/hadoop/FileSystemStatisticsTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemStatisticsTest.java
@@ -100,11 +100,15 @@ public class FileSystemStatisticsTest {
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 
-    sTFS.getDefaultBlockSize(new Path("/testFile-create"));
+    // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
+    // FileSystem.getDefaultBlockSize(new Path("/testFile-create")) will be the new one.
+    sTFS.getDefaultBlockSize();
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 
-    sTFS.getDefaultReplication(new Path("/testFile-create"));
+    // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
+    // FileSystem.geDefaultReplication(new Path("/testFile-create")) will be the new one.
+    sTFS.getDefaultReplication();
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 

--- a/tests/src/test/java/alluxio/hadoop/FileSystemStatisticsTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemStatisticsTest.java
@@ -100,11 +100,11 @@ public class FileSystemStatisticsTest {
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 
-    sTFS.getDefaultBlockSize();
+    sTFS.getDefaultBlockSize(new Path("/testFile-create"));
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 
-    sTFS.getDefaultReplication();
+    sTFS.getDefaultReplication(new Path("/testFile-create"));
     Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
     Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
 

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -622,7 +622,7 @@ public class DFSIOIntegrationTest implements Tool {
      * type.
      *
      * @param current offset
-     * @return
+     * @return the next offset for reading
      */
     private long nextOffset(long current) {
       if (mSkipSize == 0) {

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -102,7 +102,7 @@ public class FileSystemMasterIntegrationTest {
       if (concurrencyDepth > 0) {
         ExecutorService executor = Executors.newCachedThreadPool();
         try {
-          ArrayList<Future<Void>> futures = new ArrayList<Future<Void>>(FILES_PER_NODE);
+          ArrayList<Future<Void>> futures = new ArrayList<>(FILES_PER_NODE);
           for (int i = 0; i < FILES_PER_NODE; i++) {
             Callable<Void> call = (new ConcurrentCreator(depth - 1, concurrencyDepth - 1,
                 path.join(Integer.toString(i))));
@@ -273,11 +273,11 @@ public class FileSystemMasterIntegrationTest {
         try {
           CreateDirectoryOptions options = CreateDirectoryOptions.defaults().setRecursive(true);
           mFsMaster.createDirectory(dstPath.getParent(), options);
-        } catch (FileAlreadyExistsException e) {
-          // This is an acceptable exception to get, since we don't know if the parent has been
-          // created yet by another thread.
-        } catch (InvalidPathException e) {
-          // This could happen if we are renaming something that's a child of the root.
+        } catch (FileAlreadyExistsException | InvalidPathException e) {
+          // FileAlreadyExistsException: This is an acceptable exception to get, since we don't know
+          // if the parent has been created yet by another thread.
+          // InvalidPathException: This could happen if we are renaming something that's a child of
+          // the root.
         }
         mFsMaster.rename(srcPath, dstPath);
         Assert.assertEquals(fileId, mFsMaster.getFileId(dstPath));


### PR DESCRIPTION
Minor fixes in the **test** module.

*KeyValueSystemIntegrationTest*: Introduced automatic resource management in try statement.
*FileSystemRenameIntegrationTest*: Fixed deprecation.
*FileSystemStatisticsTest*: Fixed deprecation.
*DFSIOIntegrationTest*: Added documentation.
*FileSystemMasterIntegrationTest*: Removed explicit argument type and simplified exception handling.