### PR TITLE
[ALLUXIO-2019] Fix the unrelease of the connections between hiveserver and alluxio master

### DIFF
--- a/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
@@ -270,13 +270,12 @@ public enum BlockStoreContext {
   @SuppressFBWarnings
   public void reset() {
     if (mLocalBlockWorkerClientPool != null) {
-         mLocalBlockWorkerClientPool.close();
+      mLocalBlockWorkerClientPool.close();
     }
     mLocalBlockWorkerClientPoolInitialized = false;
-    if(null != mBlockMasterClientPool) {
-         return;
+    if (null != mBlockMasterClientPool) {
+      return;
     }
     mBlockMasterClientPool = new BlockMasterClientPool(ClientContext.getMasterAddress());
-
   }
 }

--- a/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
@@ -269,13 +269,13 @@ public enum BlockStoreContext {
    */
   @SuppressFBWarnings
   public void reset() {
+    if (mBlockMasterClientPool != null) {
+      mBlockMasterClientPool.close();
+    }
     if (mLocalBlockWorkerClientPool != null) {
       mLocalBlockWorkerClientPool.close();
     }
-    mLocalBlockWorkerClientPoolInitialized = false;
-    if (null != mBlockMasterClientPool) {
-      return;
-    }
     mBlockMasterClientPool = new BlockMasterClientPool(ClientContext.getMasterAddress());
+    mLocalBlockWorkerClientPoolInitialized = false;
   }
 }

--- a/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/block/BlockStoreContext.java
@@ -269,13 +269,14 @@ public enum BlockStoreContext {
    */
   @SuppressFBWarnings
   public void reset() {
-    if (mBlockMasterClientPool != null) {
-      mBlockMasterClientPool.close();
-    }
     if (mLocalBlockWorkerClientPool != null) {
-      mLocalBlockWorkerClientPool.close();
+         mLocalBlockWorkerClientPool.close();
+    }
+    mLocalBlockWorkerClientPoolInitialized = false;
+    if(null != mBlockMasterClientPool) {
+         return;
     }
     mBlockMasterClientPool = new BlockMasterClientPool(ClientContext.getMasterAddress());
-    mLocalBlockWorkerClientPoolInitialized = false;
+
   }
 }

--- a/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -72,8 +72,8 @@ public enum FileSystemContext {
    * {@link ClientContext}.
    */
   public void reset() {
-    if(null != mFileSystemMasterClientPool) {
-        return;
+    if (null != mFileSystemMasterClientPool) {
+      return;
     }
     mFileSystemMasterClientPool.close();
     mFileSystemMasterClientPool =

--- a/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -72,11 +72,20 @@ public enum FileSystemContext {
    * {@link ClientContext}.
    */
   public void reset() {
-    if (null != mFileSystemMasterClientPool) {
+    if (null != mFileSystemMasterClientPool && isMasterChange()) {
       return;
     }
-    mFileSystemMasterClientPool.close();
-    mFileSystemMasterClientPool =
-        new FileSystemMasterClientPool(ClientContext.getMasterAddress());
+    mFileSystemMasterClientPool = new FileSystemMasterClientPool(ClientContext.getMasterAddress());
+  }
+
+  private boolean isMasterChange() {
+    if (null == mFileSystemMasterClientPool.getmMasterAddress()) {
+      return true;
+    }
+
+    if (!mFileSystemMasterClientPool.getmMasterAddress().equals(ClientContext.getMasterAddress())) {
+      return true;
+    }
+    return false;
   }
 }

--- a/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client-internal/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -72,6 +72,9 @@ public enum FileSystemContext {
    * {@link ClientContext}.
    */
   public void reset() {
+    if(null != mFileSystemMasterClientPool) {
+        return;
+    }
     mFileSystemMasterClientPool.close();
     mFileSystemMasterClientPool =
         new FileSystemMasterClientPool(ClientContext.getMasterAddress());

--- a/core/client-internal/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
+++ b/core/client-internal/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
@@ -23,6 +23,9 @@ import javax.annotation.concurrent.ThreadSafe;
 final class FileSystemMasterClientPool extends ResourcePool<FileSystemMasterClient> {
   private final InetSocketAddress mMasterAddress;
 
+  public InetSocketAddress getmMasterAddress() {
+    return mMasterAddress;
+  }
   /**
    * Creates a new file stream master client pool.
    *


### PR DESCRIPTION
1. Fix the issue https://alluxio.atlassian.net/browse/ALLUXIO-2019, "The number of connection between hiveserver and alluxio increases whenever connect to hiveserver and the connections haven't been released even the client has been closed"
2. Add  judgement statements
"if(null != mFileSystemMasterClientPool) {
                return;
        }"
to the functiuon "FileSystemContext.INSTANCE.reset()" and 
"  if(null != mBlockMasterClientPool) {
                return;
          }" to the function "BlockStoreContext.INSTANCE.reset()" .
 The new connection will be created only when xxPool is null as below:

FileSystemContext.java
 public void reset() {
        _if(null != mFileSystemMasterClientPool) {
                return;
        }_
        mFileSystemMasterClientPool.close();
        mFileSystemMasterClientPool =
        new FileSystemMasterClientPool(ClientContext.getMasterAddress());
  }

BlockStoreContext.java
  public void reset() {
        if (mLocalBlockWorkerClientPool != null) {
                  mLocalBlockWorkerClientPool.close();
          }
          mLocalBlockWorkerClientPoolInitialized = false;
       _if(null != mBlockMasterClientPool) {
                return;
          }_
//        mBlockMasterClientPool.close();
      mBlockMasterClientPool = new BlockMasterClientPool(ClientContext.getMasterAddress());

  }