### PR TITLE
[SMALLFIX] Fixing ambiguous reference compilation error.

### DIFF
--- a/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -123,9 +123,8 @@ public final class AlluxioBlockStoreTest {
     BufferedBlockInStream stream = sBlockStore.getInStream(BLOCK_ID);
 
     Assert.assertTrue(stream instanceof LocalBlockInStream);
-    Assert.assertEquals(BLOCK_ID, Whitebox.getInternalState(stream, "mBlockId"));
-    Assert.assertEquals(BLOCK_LENGTH,
-        Whitebox.getInternalState(stream, "mBlockSize"));
+    Assert.assertEquals(BLOCK_ID, (long) Whitebox.getInternalState(stream, "mBlockId"));
+    Assert.assertEquals(BLOCK_LENGTH, (long) Whitebox.getInternalState(stream, "mBlockSize"));
   }
 
   /**
@@ -143,9 +142,8 @@ public final class AlluxioBlockStoreTest {
     BufferedBlockInStream stream = sBlockStore.getInStream(BLOCK_ID);
 
     Assert.assertTrue(stream instanceof RemoteBlockInStream);
-    Assert.assertEquals(BLOCK_ID, Whitebox.getInternalState(stream, "mBlockId"));
-    Assert.assertEquals(BLOCK_LENGTH,
-        Whitebox.getInternalState(stream, "mBlockSize"));
+    Assert.assertEquals(BLOCK_ID, (long) Whitebox.getInternalState(stream, "mBlockId"));
+    Assert.assertEquals(BLOCK_LENGTH, (long) Whitebox.getInternalState(stream, "mBlockSize"));
     Assert.assertEquals(new InetSocketAddress(WORKER_HOSTNAME_REMOTE, WORKER_DATA_PORT),
         Whitebox.getInternalState(stream, "mWorkerInetSocketAddress"));
   }


### PR DESCRIPTION
This fixes the following compilation error reported on the mailing list:

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /dfml/dfml_installs/alluxio-1.1.0/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java:[126,11] reference to assertEquals is ambiguous
  both method assertEquals(java.lang.Object,java.lang.Object) in org.junit.Assert and method assertEquals(long,long) in org.junit.Assert match
[ERROR] /dfml/dfml_installs/alluxio-1.1.0/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java:[127,11] reference to assertEquals is ambiguous
  both method assertEquals(java.lang.Object,java.lang.Object) in org.junit.Assert and method assertEquals(long,long) in org.junit.Assert match
[ERROR] /dfml/dfml_installs/alluxio-1.1.0/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java:[146,11] reference to assertEquals is ambiguous
  both method assertEquals(java.lang.Object,java.lang.Object) in org.junit.Assert and method assertEquals(long,long) in org.junit.Assert match
[ERROR] /dfml/dfml_installs/alluxio-1.1.0/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java:[147,11] reference to assertEquals is ambiguous
  both method assertEquals(java.lang.Object,java.lang.Object) in org.junit.Assert and method assertEquals(long,long) in org.junit.Assert match
[INFO] 4 errors
``` 