### PR TITLE
[SMALLFIX] upgrade commons-lang's version to 2.6

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
upgrade commons-lang's version to 2.6. We are compiling commons-lang to our client jars (with dependency). Spark uses 2.6 which has a function ClassUtils#isAssignable(a, b, c) that doesn't appear in 2.4

stack trace:
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
java.lang.NoSuchMethodError: org.apache.commons.lang.ClassUtils.isAssignable([Ljava/lang/Class;[Ljava/lang/Class;Z)Z
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$makeCopy$1$$anonfun$7.apply(TreeNode.scala:393)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$makeCopy$1$$anonfun$7.apply(TreeNode.scala:384)
  at scala.collection.IndexedSeqOptimized$$anonfun$1.apply(IndexedSeqOptimized.scala:50)
  at scala.collection.IndexedSeqOptimized$$anonfun$1.apply(IndexedSeqOptimized.scala:50)
  at scala.collection.IndexedSeqOptimized$class.segmentLength(IndexedSeqOptimized.scala:195)
  at scala.collection.mutable.ArrayOps$ofRef.segmentLength(ArrayOps.scala:186)
  at scala.collection.GenSeqLike$class.prefixLength(GenSeqLike.scala:93)
  at scala.collection.mutable.ArrayOps$ofRef.prefixLength(ArrayOps.scala:186)
  at scala.collection.IndexedSeqOptimized$class.find(IndexedSeqOptimized.scala:50)
  at scala.collection.mutable.ArrayOps$ofRef.find(ArrayOps.scala:186)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$makeCopy$1.apply(TreeNode.scala:384)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$makeCopy$1.apply(TreeNode.scala:373)
  at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:49)
  at org.apache.spark.sql.catalyst.trees.TreeNode.makeCopy(TreeNode.scala:373)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformChildren(TreeNode.scala:357)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:270)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformDown$1.apply(TreeNode.scala:270)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformDown$1.apply(TreeNode.scala:270)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$5.apply(TreeNode.scala:307)
  at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
  at scala.collection.Iterator$class.foreach(Iterator.scala:893)
  at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
  at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:59)
  at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:104)
  at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:48)
  at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:310)
