### PR TITLE
[ALLUXIO-2025] Improve AbstractFileSystem.listStatus(Path path) method for exception process

### DIFF
--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -41,7 +41,7 @@ fi
 for worker in $(echo ${HOSTLIST}); do
   echo "$(date +"%F %H:%M:%S,$(date +"%s%N" | cut -c 11- | cut -c 1-3)")
    INFO ${WORKER_ACTION_TYPE}  Connecting to ${worker} as ${USER}..." >> ${ALLUXIO_TASK_LOG}
-  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t ${worker} ${LAUNCHER} \
+  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
    $"${@// /\\ }" >> ${ALLUXIO_TASK_LOG} 2>&1&
 done
 

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -41,7 +41,7 @@ fi
 for worker in $(echo ${HOSTLIST}); do
   echo "$(date +"%F %H:%M:%S,$(date +"%s%N" | cut -c 11- | cut -c 1-3)")
    INFO ${WORKER_ACTION_TYPE}  Connecting to ${worker} as ${USER}..." >> ${ALLUXIO_TASK_LOG}
-  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
+  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t ${worker} ${LAUNCHER} \
    $"${@// /\\ }" >> ${ALLUXIO_TASK_LOG} 2>&1&
 done
 

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -457,7 +457,11 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     try {
       statuses = sFileSystem.listStatus(uri);
     } catch (AlluxioException e) {
-      throw new IOException(e);
+      if (e instanceof FileDoesNotExistException) {
+        throw new FileNotFoundException(HadoopUtils.getPathWithoutScheme(path));
+      } else {
+        throw new IOException(e);
+      }
     }
 
     FileStatus[] ret = new FileStatus[statuses.size()];

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -456,7 +456,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     List<URIStatus> statuses;
     try {
       statuses = sFileSystem.listStatus(uri);
-    } catch (FileDoesNotExistException fnte) {
+    } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(HadoopUtils.getPathWithoutScheme(path));
     } catch (AlluxioException e) {
       throw new IOException(e);

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -456,12 +456,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     List<URIStatus> statuses;
     try {
       statuses = sFileSystem.listStatus(uri);
+    } catch (FileDoesNotExistException fnte) {
+      throw new FileNotFoundException(HadoopUtils.getPathWithoutScheme(path));
     } catch (AlluxioException e) {
-      if (e instanceof FileDoesNotExistException) {
-        throw new FileNotFoundException(HadoopUtils.getPathWithoutScheme(path));
-      } else {
-        throw new IOException(e);
-      }
+      throw new IOException(e);
     }
 
     FileStatus[] ret = new FileStatus[statuses.size()];


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2025

if there is a FileDoesNotExistException throw FileNotFoundException ,so the user like hbase can handle

exception more accurate.