### PR TITLE
[Doc fix] Fixed bad reference in docs

### DIFF
--- a/docs/cn/Configuring-Alluxio-with-S3.md
+++ b/docs/cn/Configuring-Alluxio-with-S3.md
@@ -16,7 +16,7 @@ priority: 0
 
 例如，如果你在本地机器上运行Alluxio，`ALLUXIO_MASTER_HOSTNAME`应该设置为`localhost`。
 
-{% include Configuring-Alluxio-with-s3/bootstrap-conf.md %}
+{% include Configuring-Alluxio-with-s3/bootstrap.md %}
 
 或者，你也可以由template文件创建配置文件并手动设置配置内容：
 

--- a/docs/cn/Configuring-Alluxio-with-S3.md
+++ b/docs/cn/Configuring-Alluxio-with-S3.md
@@ -16,7 +16,7 @@ priority: 0
 
 例如，如果你在本地机器上运行Alluxio，`ALLUXIO_MASTER_HOSTNAME`应该设置为`localhost`。
 
-{% include Configuring-Alluxio-with-s3/bootstrap.md %}
+{% include Configuring-Alluxio-with-s3/bootstrap-conf.md %}
 
 或者，你也可以由template文件创建配置文件并手动设置配置内容：
 


### PR DESCRIPTION
@aaudiber @gpang Fixed a bad file reference in the docs which was causing the jekyll build to fail. Reference `docs/_includes/Configuring-Alluxio-with-s3/` for the directory which the reference was to.