### PR TITLE
[DOCFIX] Remove erroneous `</pre>` tag

### DIFF
--- a/docs/en/Configuration-Settings.md
+++ b/docs/en/Configuration-Settings.md
@@ -31,7 +31,7 @@ following environment variables:
 <table class="table table-striped">
 <tr><th>Environment Variable</th><th>Meaning</th></tr>
 <tr>
-  <td><code class="highlighter-rouge">ALLUXIO_MASTER_HOSTNAME</code></pre></td>
+  <td><code class="highlighter-rouge">ALLUXIO_MASTER_HOSTNAME</code></td>
   <td>hostname of Alluxio master, defaults to localhost.</td>
 </tr>
 <tr>


### PR DESCRIPTION
@aaudiber @gpang Noticed an issue with an erroneous `</pre>` tag showing up in the rendered view of this doc. Removed the tag. 