### PR TITLE
[ALLUXIO-1950] Improve cleanup of test cluster directories

### DIFF
--- a/core/common/src/test/java/alluxio/CommonTestUtils.java
+++ b/core/common/src/test/java/alluxio/CommonTestUtils.java
@@ -51,7 +51,7 @@ public final class CommonTestUtils {
 
   // This directory should be used over the system temp directory for creating temporary files
   // during tests. We recursively delete this directory on JVM exit.
-  private static File sAlluxioTestDirectory = createTestingDirectory();
+  public static final File ALLUXIO_TEST_DIRECTORY = createTestingDirectory();
 
   /**
    * Traverses a chain of potentially private fields using {@link Whitebox}.
@@ -201,13 +201,6 @@ public final class CommonTestUtils {
   }
 
   /**
-   * @return the directory to be used for temporary files in Alluxio tests
-   */
-  public static synchronized File getAlluxioTestDirectory() {
-    return sAlluxioTestDirectory;
-  }
-
-  /**
    * Creates the Alluxio testing directory, deleting the previous one if it still exists.
    *
    * @return the directory
@@ -244,7 +237,7 @@ public final class CommonTestUtils {
    * @return the created directory
    */
   public static File createTemporaryDirectory(String prefix) {
-    File file = new File(getAlluxioTestDirectory(), prefix + "-" + UUID.randomUUID());
+    File file = new File(ALLUXIO_TEST_DIRECTORY, prefix + "-" + UUID.randomUUID());
     try {
       file.createNewFile();
     } catch (IOException e) {

--- a/core/common/src/test/java/alluxio/CommonTestUtils.java
+++ b/core/common/src/test/java/alluxio/CommonTestUtils.java
@@ -51,7 +51,7 @@ public final class CommonTestUtils {
 
   // This directory should be used over the system temp directory for creating temporary files
   // during tests. We recursively delete this directory on JVM exit.
-  private static File sAlluxioTestDirectory;
+  private static File sAlluxioTestDirectory = createTestingDirectory();
 
   /**
    * Traverses a chain of potentially private fields using {@link Whitebox}.
@@ -204,9 +204,6 @@ public final class CommonTestUtils {
    * @return the directory to be used for temporary files in Alluxio tests
    */
   public static synchronized File getAlluxioTestDirectory() {
-    if (sAlluxioTestDirectory == null) {
-      sAlluxioTestDirectory = createTestingDirectory();
-    }
     return sAlluxioTestDirectory;
   }
 

--- a/core/common/src/test/java/alluxio/CommonTestUtils.java
+++ b/core/common/src/test/java/alluxio/CommonTestUtils.java
@@ -12,14 +12,18 @@
 package alluxio;
 
 import alluxio.util.CommonUtils;
+import alluxio.util.io.FileUtils;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.testing.EqualsTester;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -28,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Common utilities for testing.
@@ -43,6 +48,10 @@ public final class CommonTestUtils {
       .put(long.class, Lists.newArrayList((long) 40, (long) 41))
       .put(float.class, Lists.newArrayList((float) 50, (float) 51))
       .put(double.class, Lists.newArrayList((double) 60, (double) 61)).build();
+
+  // This directory should be used over the system temp directory for creating temporary files
+  // during tests. We recursively delete this directory on JVM exit.
+  private static File sAlluxioTestDirectory;
 
   /**
    * Traverses a chain of potentially private fields using {@link Whitebox}.
@@ -189,5 +198,61 @@ public final class CommonTestUtils {
       fields.addAll(Arrays.asList(c.getDeclaredFields()));
     }
     return fields;
+  }
+
+  /**
+   * @return the directory to be used for temporary files in Alluxio tests
+   */
+  public static synchronized File getAlluxioTestDirectory() {
+    if (sAlluxioTestDirectory == null) {
+      sAlluxioTestDirectory = createTestingDirectory();
+    }
+    return sAlluxioTestDirectory;
+  }
+
+  /**
+   * Creates the Alluxio testing directory, deleting the previous one if it still exists.
+   *
+   * @return the directory
+   */
+  private static File createTestingDirectory() {
+    final File tmpDir = new File(System.getProperty("java.io.tmpdir"), "alluxio-tests");
+    if (tmpDir.exists()) {
+      try {
+        FileUtils.deletePathRecursively(tmpDir.getAbsolutePath());
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to delete previous Alluxio testing directory", e);
+      }
+    }
+    if (!tmpDir.mkdir()) {
+      throw new RuntimeException(
+          "Failed to create testing directory " + tmpDir.getAbsolutePath());
+    }
+    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+      public void run() {
+        try {
+          FileUtils.deletePathRecursively(tmpDir.getAbsolutePath());
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to clean up Alluxio testing directory", e);
+        }
+      }
+    }));
+    return tmpDir;
+  }
+
+  /**
+   * Creates a directory with the given prefix inside the Alluxio temporary directory.
+   *
+   * @param prefix a prefix to use in naming the temporary directory
+   * @return the created directory
+   */
+  public static File createTemporaryDirectory(String prefix) {
+    File file = new File(getAlluxioTestDirectory(), prefix + "-" + UUID.randomUUID());
+    try {
+      file.createNewFile();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return file;
   }
 }

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -67,6 +67,12 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -11,6 +11,7 @@
 
 package alluxio.master;
 
+import alluxio.CommonTestUtils;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
@@ -21,7 +22,6 @@ import alluxio.security.LoginUser;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.util.CommonUtils;
 import alluxio.util.UnderFileSystemUtils;
-import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.AlluxioWorker;
@@ -32,7 +32,6 @@ import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -466,19 +465,7 @@ public abstract class AbstractLocalAlluxioCluster {
    *
    * @throws IOException when the operation fails
    */
-  protected void setAlluxioHome() throws IOException {
-    mHome =
-        File.createTempFile("Alluxio", "U" + System.currentTimeMillis()).getAbsolutePath();
-    // Make a copy of mHome.
-    final String home = mHome;
-    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-      public void run() {
-        try {
-          FileUtils.deletePathRecursively(home);
-        } catch (IOException e) {
-          // The directory is already cleaned up.
-        }
-      }
-    }));
+  protected void setAlluxioHome() {
+    mHome = CommonTestUtils.createTemporaryDirectory("test-cluster").getAbsolutePath();
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1950

Instead of creating temp directories in /tmp, we will create them in /tmp/alluxio-tests/ and delete this directory at the start and end of testing.