### PR TITLE
[DOCFIX] Update master docs version to master

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ kramdown:
   syntax_highlighter: rouge
 
 # These allow the documentation to be updated with new releases of Alluxio.
-ALLUXIO_RELEASED_VERSION: 1.1.0
+ALLUXIO_RELEASED_VERSION: master
 ALLUXIO_MASTER_VERSION_SHORT: 1.2.0-SNAPSHOT
 
 # These attach the pages of different languages with different 'lang' attributes


### PR DESCRIPTION
master hasn't been released yet, so we should call its "released version" master