### PR TITLE
[DOCFIX] Rename reserved categories variable

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,7 @@ defaults:
 # Each language has a particular version of category names
 # When supporting a new language version, do not change the 'group' attribute in .md page files
 # Instead, just add the group name of that language below
-categories:
+categoryInfo:
   User Guide:
     en: User Guides
     cn: 用户指南

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -67,10 +67,10 @@
                 {% for groupName in categories %}
                     <li class="dropdown">
                         {% if page.group == groupName %}
-                            <a href="#" class="dropdown-toggle active" data-toggle="dropdown">{{site.categories.[groupName].[page.lang]}}<b
+                            <a href="#" class="dropdown-toggle active" data-toggle="dropdown">{{site.categoryInfo.[groupName].[page.lang]}}<b
                                 class="caret"></b></a>
                         {% else %}
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{site.categories.[groupName].[page.lang]}}<b
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{site.categoryInfo.[groupName].[page.lang]}}<b
                                 class="caret"></b></a>
                         {% endif %}
 


### PR DESCRIPTION
categories is a reserved word in Jekyll and our usage breaks in later versions.