### PR TITLE
[SMALLFIX] Save one RPC on expected case when deleting a file from UFS

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1029,12 +1029,11 @@ public final class FileSystemMaster extends AbstractMaster {
               String ufsUri = resolution.getUri().toString();
               UnderFileSystem ufs = resolution.getUfs();
               if (!ufs.delete(ufsUri, true)) {
-                if (!ufs.exists(ufsUri)) {
-                  LOG.warn("The file to delete does not exist in under file system: {}", ufsUri);
-                  return;
+                if (ufs.exists(ufsUri)) {
+                  LOG.error("Failed to delete {} from the under file system", ufsUri);
+                  throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
                 }
-                LOG.error("Failed to delete {} from the under file system", ufsUri);
-                throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
+                LOG.warn("The file to delete does not exist in under file system: {}", ufsUri);
               }
             }
           } catch (InvalidPathException e) {

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1028,9 +1028,11 @@ public final class FileSystemMaster extends AbstractMaster {
               MountTable.Resolution resolution = mMountTable.resolve(alluxioUriToDel);
               String ufsUri = resolution.getUri().toString();
               UnderFileSystem ufs = resolution.getUfs();
-              if (!ufs.exists(ufsUri)) {
-                LOG.warn("Deleted file does not exist in the underfs: {}", ufsUri);
-              } else if (!ufs.delete(ufsUri, true)) {
+              if (!ufs.delete(ufsUri, true)) {
+                if (!ufs.exists(ufsUri)) {
+                  LOG.warn("The file to delete does not exist in under file system: {}", ufsUri);
+                  return;
+                }
                 LOG.error("Failed to delete {} from the under file system", ufsUri);
                 throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
               }


### PR DESCRIPTION
Current approach always make two RPCs to delete files on UFS even on expected case, which could potentially slow down the master.