### PR TITLE
[SMALLFIX] Improve handling of Alluxio test directory

### DIFF
--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -1,6 +1,6 @@
 /*
  * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
- * (the “License”). You may not use this work except in compliance with the License, which is
+ * (the "License"). You may not use this work except in compliance with the License, which is
  * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 public final class AlluxioTestDirectory {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  private static final int MAX_FILE_AGE_HOURS = 2;
+  private static final int MAX_FILE_AGE_HOURS = 1;
 
   // This directory should be used over the system temp directory for creating temporary files
   // during tests. We recursively delete this directory on JVM exit.

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -35,8 +35,10 @@ public final class AlluxioTestDirectory {
 
   private static final int MAX_FILE_AGE_HOURS = 1;
 
-  // This directory should be used over the system temp directory for creating temporary files
-  // during tests. We recursively delete this directory on JVM exit.
+  /**
+   * This directory should be used over the system temp directory for creating temporary files
+   * during tests. We recursively delete this directory on JVM exit.
+   */
   public static final File ALLUXIO_TEST_DIRECTORY = createTestingDirectory();
 
   /**

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -1,0 +1,105 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the “License”). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import com.google.common.base.Throwables;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.AgeFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.UUID;
+
+/**
+ * Class for managing creation and cleanup of an Alluxio test directory.
+ *
+ * The Alluxio test directory is created as a subdirectory of the system temp directory, and on
+ * class initialization it deletes files and directories older than the maximum age.
+ */
+public final class AlluxioTestDirectory {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  private static final int MAX_FILE_AGE_HOURS = 2;
+
+  // This directory should be used over the system temp directory for creating temporary files
+  // during tests. We recursively delete this directory on JVM exit.
+  public static final File ALLUXIO_TEST_DIRECTORY = createTestingDirectory();
+
+  /**
+   * Creates a directory with the given prefix inside the Alluxio temporary directory.
+   *
+   * @param prefix a prefix to use in naming the temporary directory
+   * @return the created directory
+   */
+  public static File createTemporaryDirectory(String prefix) {
+    final File file = new File(ALLUXIO_TEST_DIRECTORY, prefix + "-" + UUID.randomUUID());
+    try {
+      file.createNewFile();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+      public void run() {
+        try {
+          alluxio.util.io.FileUtils.deletePathRecursively(file.getAbsolutePath());
+        } catch (IOException e) {
+          LOG.warn("Failed to clean up Alluxio test directory {}", file.getAbsolutePath(), e);
+        }
+      }
+    }));
+    return file;
+  }
+
+  /**
+   * Creates the Alluxio testing directory and attempts to delete old files from the previous one.
+   *
+   * @return the testing directory
+   */
+  private static File createTestingDirectory() {
+    final File tmpDir = new File(System.getProperty("java.io.tmpdir"), "alluxio-tests");
+    if (tmpDir.exists()) {
+      cleanUpOldFiles(tmpDir);
+    }
+    if (!tmpDir.exists()) {
+      if (!tmpDir.mkdir()) {
+        throw new RuntimeException(
+            "Failed to create testing directory " + tmpDir.getAbsolutePath());
+      }
+    }
+    return tmpDir;
+  }
+
+  /**
+   * Deletes files in the given directory which are older than 2 hours.
+   *
+   * @param dir the directory to clean up
+   */
+  private static void cleanUpOldFiles(File dir) {
+    Iterator<File> filesToDelete = FileUtils.iterateFilesAndDirs(dir,
+        new AgeFileFilter(
+            new Date(System.currentTimeMillis() - MAX_FILE_AGE_HOURS * Constants.HOUR_MS)),
+        TrueFileFilter.TRUE);
+    while (filesToDelete.hasNext()) {
+      File file = filesToDelete.next();
+      try {
+        alluxio.util.io.FileUtils.deletePathRecursively(file.getAbsolutePath());
+      } catch (Exception e) {
+        LOG.warn("Failed to delete {}", file.getAbsolutePath(), e);
+      }
+    }
+  }
+}

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -11,7 +11,7 @@
 
 package alluxio.master;
 
-import alluxio.CommonTestUtils;
+import alluxio.AlluxioTestDirectory;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
@@ -466,6 +466,6 @@ public abstract class AbstractLocalAlluxioCluster {
    * @throws IOException when the operation fails
    */
   protected void setAlluxioHome() {
-    mHome = CommonTestUtils.createTemporaryDirectory("test-cluster").getAbsolutePath();
+    mHome = AlluxioTestDirectory.createTemporaryDirectory("test-cluster").getAbsolutePath();
   }
 }


### PR DESCRIPTION
Previously we made the dangerous assumption that only one
process would run the tests at a time per node. This was
violated by pull request builds running at the same time as
Alluxio master builds. This change removes the assumption by
only deleting files older than 2 hours.