### PR TITLE
[SMALLFIX] Remove the hardcoded read type (CACHE) from HdfsFileInputStream

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -14,6 +14,7 @@ package alluxio.hadoop;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
+import alluxio.client.ClientContext;
 import alluxio.client.ReadType;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
@@ -86,8 +87,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
     try {
       mFileInfo = fs.getStatus(uri);
       mHdfsPath = new Path(mFileInfo.getUfsPath());
-      mAlluxioFileInputStream =
-          fs.openFile(uri, OpenFileOptions.defaults());
+      mAlluxioFileInputStream = fs.openFile(uri, OpenFileOptions.defaults());
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(
           ExceptionMessage.HDFS_FILE_NOT_FOUND.getMessage(mHdfsPath, uri));

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -14,8 +14,6 @@ package alluxio.hadoop;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
-import alluxio.client.ClientContext;
-import alluxio.client.ReadType;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -87,7 +87,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
       mFileInfo = fs.getStatus(uri);
       mHdfsPath = new Path(mFileInfo.getUfsPath());
       mAlluxioFileInputStream =
-          fs.openFile(uri, OpenFileOptions.defaults().setReadType(ReadType.CACHE));
+          fs.openFile(uri, OpenFileOptions.defaults());
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(
           ExceptionMessage.HDFS_FILE_NOT_FOUND.getMessage(mHdfsPath, uri));

--- a/tests/src/test/java/alluxio/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -14,7 +14,6 @@ package alluxio.hadoop;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
-import alluxio.client.ClientContext;
 import alluxio.client.FileSystemTestUtils;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
@@ -82,7 +81,7 @@ public final class HdfsFileInputStreamIntegrationTest {
   }
 
   private void openUfsInStream(ReadType readType) throws IOException {
-    ClientContext.getConf().set(Constants.USER_FILE_READ_TYPE_DEFAULT, readType.name());
+    alluxio.Configuration.set(Constants.USER_FILE_READ_TYPE_DEFAULT, readType.name());
     FileSystemTestUtils.createByteFile(sFileSystem, UFS_ONLY_FILE, WriteType.THROUGH, FILE_LEN);
     mUfsInputStream = new HdfsFileInputStream(
         new AlluxioURI(UFS_ONLY_FILE), new Configuration(), BUFFER_SIZE, null);
@@ -94,6 +93,7 @@ public final class HdfsFileInputStreamIntegrationTest {
   @Test
   public void availableTest() throws IOException {
     Assert.assertEquals(FILE_LEN, mInMemInputStream.available());
+    openUfsInStream(ReadType.NO_CACHE);
     Assert.assertEquals(FILE_LEN, mUfsInputStream.available());
 
     // Advance the streams and check available() again.

--- a/tests/src/test/java/alluxio/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -78,10 +78,12 @@ public final class HdfsFileInputStreamIntegrationTest {
   }
 
   private void createUfsInStream(ReadType readType) throws IOException {
+    String defaultReadType = alluxio.Configuration.get(Constants.USER_FILE_READ_TYPE_DEFAULT);
     alluxio.Configuration.set(Constants.USER_FILE_READ_TYPE_DEFAULT, readType.name());
     FileSystemTestUtils.createByteFile(mFileSystem, UFS_ONLY_FILE, WriteType.THROUGH, FILE_LEN);
     mUfsInputStream = new HdfsFileInputStream(
         new AlluxioURI(UFS_ONLY_FILE), new Configuration(), BUFFER_SIZE, null);
+    alluxio.Configuration.set(Constants.USER_FILE_READ_TYPE_DEFAULT, defaultReadType);
   }
 
   /**


### PR DESCRIPTION
Right now, the read type of `HdfsFileInputStream` is hardcoded and can not accept the user's specification defined in configuration file `alluxio-site.properties`. This PR is used to activate the setting of `alluxio.user.file.readtype.default` for Hadoop and Spark workloads.