### PR TITLE
[DOCFIX] Update master version in 0.8

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,4 +6,4 @@ kramdown:
 
 # These allow the documentation to be updated with new releases of Tachyon.
 TACHYON_RELEASED_VERSION: 0.8.2
-TACHYON_MASTER_VERSION_SHORT: 0.8.3-SNAPSHOT
+TACHYON_MASTER_VERSION_SHORT: 0.8.2


### PR DESCRIPTION
The latest 0.8 docs should display themselves as 0.8.2 docs, not as 0.8.3-SNAPSHOT docs.