### PR TITLE
[DOCFIX] Update master version in 1.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ kramdown:
 
 # These allow the documentation to be updated with new releases of Alluxio.
 ALLUXIO_RELEASED_VERSION: 1.0.1
-ALLUXIO_MASTER_VERSION_SHORT: 1.0.2-SNAPSHOT
+ALLUXIO_MASTER_VERSION_SHORT: 1.0.1
 
 # These attach the pages of different languages with different 'lang' attributes
 defaults:


### PR DESCRIPTION
The latest 1.0 docs should display themselves as 1.0.1 docs, not as 1.0.2-SNAPSHOT docs