### PR TITLE
Revert "[DOCFIX] Update master docs version to master"

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ kramdown:
   syntax_highlighter: rouge
 
 # These allow the documentation to be updated with new releases of Alluxio.
-ALLUXIO_RELEASED_VERSION: master
+ALLUXIO_RELEASED_VERSION: 1.1.0
 ALLUXIO_MASTER_VERSION_SHORT: 1.2.0-SNAPSHOT
 
 # These attach the pages of different languages with different 'lang' attributes


### PR DESCRIPTION
Reverts Alluxio/alluxio#3577

The released version is used to create a link to the latest version of alluxio, so it should point to 1.1.0 on master.