### PR TITLE
[SMALLFIX] Add swiftauth as acceptable authentication method for Swift UFS

### DIFF
--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -95,6 +95,10 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
       config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
       config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
+    } else if (authMethod != null && authMethod.equals("swiftauth")) {
+      config.setAuthenticationMethod(AuthenticationMethod.BASIC);
+      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
     } else {
       config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
       // tempauth requires authentication header to be of the form tenant:user.

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -91,12 +91,15 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     }
     config.setAuthUrl(configuration.get(Constants.SWIFT_AUTH_URL_KEY));
     String authMethod = configuration.get(Constants.SWIFT_AUTH_METHOD_KEY);
-    if (authMethod != null && authMethod.equals("keystone")) {
-      config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
-      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
-      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
-    } else if (authMethod != null && authMethod.equals("swiftauth")) {
-      config.setAuthenticationMethod(AuthenticationMethod.BASIC);
+    if (authMethod != null) {
+      switch (authMethod) {
+        case "keystone":
+          config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
+          break;
+        case "swiftauth":
+          config.setAuthenticationMethod(AuthenticationMethod.BASIC);
+          break;
+      }
       config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
       config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
     } else {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -92,6 +92,8 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     config.setAuthUrl(configuration.get(Constants.SWIFT_AUTH_URL_KEY));
     String authMethod = configuration.get(Constants.SWIFT_AUTH_METHOD_KEY);
     if (authMethod != null) {
+      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
+      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
       switch (authMethod) {
         case "keystone":
           config.setAuthenticationMethod(AuthenticationMethod.KEYSTONE);
@@ -99,16 +101,14 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
         case "swiftauth":
           config.setAuthenticationMethod(AuthenticationMethod.BASIC);
           break;
+        default:
+          config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
+          // tempauth requires authentication header to be of the form tenant:user.
+          // JOSS however generates header of the form user:tenant.
+          // To resolve this, we switch user with tenant
+          config.setTenantName(configuration.get(Constants.SWIFT_USER_KEY));
+          config.setUsername(configuration.get(Constants.SWIFT_TENANT_KEY));
       }
-      config.setUsername(configuration.get(Constants.SWIFT_USER_KEY));
-      config.setTenantName(configuration.get(Constants.SWIFT_TENANT_KEY));
-    } else {
-      config.setAuthenticationMethod(AuthenticationMethod.TEMPAUTH);
-      // tempauth requires authentication header to be of the form tenant:user.
-      // JOSS however generates header of the form user:tenant.
-      // To resolve this, we switch user with tenant
-      config.setTenantName(configuration.get(Constants.SWIFT_USER_KEY));
-      config.setUsername(configuration.get(Constants.SWIFT_TENANT_KEY));
     }
 
     ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Authentication using swiftauth was not supported. Dreamobjects requires said method.