### PR TITLE
[SMALLFIX] Increase lineageRecoveryTest timeout

### DIFF
--- a/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
@@ -127,7 +127,7 @@ public class LineageMasterIntegrationTest {
   /**
    * Tests that a lineage job is executed when the output file for the lineage is reported as lost.
    */
-  @Test(timeout = 20000)
+  @Test(timeout = 30000)
   public void lineageRecoveryTest() throws Exception {
     final File logFile = mFolder.newFile();
     // Delete the log file so that when it starts to exist we know that it was created by the
@@ -157,7 +157,7 @@ public class LineageMasterIntegrationTest {
           throw Throwables.propagate(e);
         }
       }
-    }, 10 * Constants.SECOND_MS);
+    }, 20 * Constants.SECOND_MS);
   }
 
   /**


### PR DESCRIPTION
This has occasionally been timing out. This PR increases the timeout to make it clearer whether jenkins is just running slowly, or the test is actually getting stuck.