### PR TITLE
[ALLUXIO-2044] Correct UFS not initialized for some UnderStorageClusters during integration test

### DIFF
--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -21,6 +21,7 @@ import alluxio.exception.ConnectionFailedException;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterPrivateAccess;
 import alluxio.security.LoginUser;
+import alluxio.underfs.LocalFileSystemCluster;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.util.CommonUtils;
 import alluxio.util.UnderFileSystemUtils;
@@ -30,7 +31,6 @@ import alluxio.worker.AlluxioWorker;
 import alluxio.worker.WorkerIdRegistry;
 
 import com.google.common.base.Joiner;
-import org.apache.commons.lang.StringUtils;
 import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -242,7 +242,7 @@ public abstract class AbstractLocalAlluxioCluster {
     // If we are using anything except LocalFileSystemCluster as UnderFS,
     // we need to update the UNDERFS_ADDRESS to point to the cluster's current address.
     // This must happen after UFS is started with UnderFileSystemCluster.get().
-    if (!StringUtils.isEmpty(UnderFileSystemCluster.getUnderFSClass())) {
+    if (!UnderFileSystemCluster.getUnderFSClass().equals(LocalFileSystemCluster.class.getName())) {
       String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
       Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
     }

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -242,7 +242,7 @@ public abstract class AbstractLocalAlluxioCluster {
     // If we are using anything except LocalFileSystemCluster as UnderFS,
     // we need to update the UNDERFS_ADDRESS to point to the cluster's current address.
     // This must happen after UFS is started with UnderFileSystemCluster.get().
-    if (!UnderFileSystemCluster.getUnderFSClass().equals(LocalFileSystemCluster.class.getName())) {
+    if (!mUfsCluster.getClass().getName().equals(LocalFileSystemCluster.class.getName())) {
       String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
       Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
     }

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -241,14 +241,8 @@ public abstract class AbstractLocalAlluxioCluster {
     // If we are using the LocalMiniDFSCluster or S3UnderStorageCluster or OSSUnderStorageCluster,
     // we need to update the UNDERFS_ADDRESS to point to the cluster's current address.
     // This must happen after UFS is started with UnderFileSystemCluster.get().
-    // TODO(andrew): Move logic to the alluxio-tests module so that we can use instanceof here
-    // instead of comparing classnames.
-    if (mUfsCluster.getClass().getSimpleName().equals("LocalMiniDFSCluster")
-        || mUfsCluster.getClass().getSimpleName().equals("S3UnderStorageCluster")
-        || mUfsCluster.getClass().getSimpleName().equals("OSSUnderStorageCluster")) {
-      String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
-      Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
-    }
+    String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
+    Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -30,6 +30,7 @@ import alluxio.worker.AlluxioWorker;
 import alluxio.worker.WorkerIdRegistry;
 
 import com.google.common.base.Joiner;
+import org.apache.commons.lang.StringUtils;
 import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -238,11 +239,13 @@ public abstract class AbstractLocalAlluxioCluster {
     UnderFileSystemUtils
         .touch(PathUtils.concatPath(journalFolder, "_format_" + System.currentTimeMillis()));
 
-    // If we are using the LocalMiniDFSCluster or S3UnderStorageCluster or OSSUnderStorageCluster,
+    // If we are using anything except LocalFileSystemCluster as UnderFS,
     // we need to update the UNDERFS_ADDRESS to point to the cluster's current address.
     // This must happen after UFS is started with UnderFileSystemCluster.get().
-    String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
-    Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
+    if (!StringUtils.isEmpty(UnderFileSystemCluster.getUnderFSClass())) {
+      String ufsAddress = mUfsCluster.getUnderFilesystemAddress() + mHome;
+      Configuration.set(Constants.UNDERFS_ADDRESS, ufsAddress);
+    }
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -48,7 +48,7 @@ public abstract class UnderFileSystemCluster {
 
   private static final String INTEGRATION_UFS_PROFILE_KEY = "ufs";
 
-  private static String sUnderFSClass = null;
+  private static String sUnderFSClass;
 
   private static UnderFileSystemCluster sUnderFSCluster = null;
 
@@ -88,11 +88,10 @@ public abstract class UnderFileSystemCluster {
    * @return the {@link UnderFileSystemCluster}
    */
   public static UnderFileSystemCluster getUnderFilesystemCluster(String baseDir) {
-    final String ufsClass = System.getProperty(INTEGRATION_UFS_PROFILE_KEY);
+    sUnderFSClass = System.getProperty(INTEGRATION_UFS_PROFILE_KEY);
 
-    if (!StringUtils.isEmpty(ufsClass)) {
+    if (!StringUtils.isEmpty(sUnderFSClass)) {
       try {
-        sUnderFSClass = ufsClass;
         UnderFileSystemCluster ufsCluster =
             (UnderFileSystemCluster) Class.forName(sUnderFSClass).getConstructor(String.class)
                 .newInstance(baseDir);
@@ -114,9 +113,6 @@ public abstract class UnderFileSystemCluster {
    * @return the {@link UnderFileSystem} class name
    */
   public static synchronized String getUnderFSClass() {
-    if (sUnderFSClass == null) {
-      sUnderFSClass = LocalFileSystemCluster.class.getName();
-    }
     return sUnderFSClass;
   }
 

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -48,7 +48,7 @@ public abstract class UnderFileSystemCluster {
 
   private static final String INTEGRATION_UFS_PROFILE_KEY = "ufs";
 
-  private static String sUnderFSClass;
+  private static String sUnderFSClass = null;
 
   private static UnderFileSystemCluster sUnderFSCluster = null;
 
@@ -88,10 +88,11 @@ public abstract class UnderFileSystemCluster {
    * @return the {@link UnderFileSystemCluster}
    */
   public static UnderFileSystemCluster getUnderFilesystemCluster(String baseDir) {
-    sUnderFSClass = System.getProperty(INTEGRATION_UFS_PROFILE_KEY);
+    final String ufsClass = System.getProperty(INTEGRATION_UFS_PROFILE_KEY);
 
-    if (!StringUtils.isEmpty(sUnderFSClass)) {
+    if (!StringUtils.isEmpty(ufsClass)) {
       try {
+        sUnderFSClass = ufsClass;
         UnderFileSystemCluster ufsCluster =
             (UnderFileSystemCluster) Class.forName(sUnderFSClass).getConstructor(String.class)
                 .newInstance(baseDir);
@@ -113,6 +114,9 @@ public abstract class UnderFileSystemCluster {
    * @return the {@link UnderFileSystem} class name
    */
   public static synchronized String getUnderFSClass() {
+    if (sUnderFSClass == null) {
+      sUnderFSClass = LocalFileSystemCluster.class.getName();
+    }
     return sUnderFSClass;
   }
 

--- a/minicluster/src/test/java/alluxio/underfs/UnderFileSystemClusterTest.java
+++ b/minicluster/src/test/java/alluxio/underfs/UnderFileSystemClusterTest.java
@@ -64,20 +64,13 @@ public class UnderFileSystemClusterTest {
   }
 
   /**
-   * Tests that the {UnderFileSystemCluster{@link #readEOFReturnsNegativeTest()} method will return
-   * true only when the cluster type is "alluxio.underfs.hdfs.LocalMiniDFSCluster".
+   * Tests that the {@link UnderFileSystemCluster#getUnderFSClass()} method will return
+   * LocalFileSystemCluster by default.
    */
   @Test
-  public void readEOFReturnsNegativeTest() {
-    Whitebox.setInternalState(UnderFileSystemCluster.class, "sUnderFSClass",
-        (String) null);
+  public void getUnderFSClassTest() {
     String underFSClass = UnderFileSystemCluster.getUnderFSClass();
-    Assert.assertNull(underFSClass);
-
-    Whitebox.setInternalState(UnderFileSystemCluster.class, "sUnderFSClass",
-        "XXXX");
-    underFSClass = UnderFileSystemCluster.getUnderFSClass();
-    Assert.assertFalse("alluxio.underfs.hdfs.LocalMiniDFSCluster".equals(underFSClass));
+    Assert.assertEquals("alluxio.underfs.LocalFileSystemCluster", underFSClass);
 
     Whitebox.setInternalState(UnderFileSystemCluster.class, "sUnderFSClass",
         "alluxio.underfs.hdfs.LocalMiniDFSCluster");

--- a/minicluster/src/test/java/alluxio/underfs/UnderFileSystemClusterTest.java
+++ b/minicluster/src/test/java/alluxio/underfs/UnderFileSystemClusterTest.java
@@ -64,13 +64,14 @@ public class UnderFileSystemClusterTest {
   }
 
   /**
-   * Tests that the {@link UnderFileSystemCluster#getUnderFSClass()} method will return
-   * LocalFileSystemCluster by default.
+   * Tests the {@link UnderFileSystemCluster#getUnderFSClass()} method.
    */
   @Test
   public void getUnderFSClassTest() {
+    Whitebox.setInternalState(UnderFileSystemCluster.class, "sUnderFSClass",
+        (String) null);
     String underFSClass = UnderFileSystemCluster.getUnderFSClass();
-    Assert.assertEquals("alluxio.underfs.LocalFileSystemCluster", underFSClass);
+    Assert.assertNull(underFSClass);
 
     Whitebox.setInternalState(UnderFileSystemCluster.class, "sUnderFSClass",
         "alluxio.underfs.hdfs.LocalMiniDFSCluster");

--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -23,6 +23,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.CreateFileOptions;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
+import alluxio.underfs.hdfs.LocalMiniDFSCluster;
 import alluxio.util.io.BufferUtils;
 
 import org.junit.Assert;
@@ -98,7 +99,7 @@ public abstract class AbstractFileOutStreamIntegrationTest {
       InputStream is = ufs.open(checkpointPath);
       byte[] res = new byte[(int) status.getLength()];
       String underFSClass = UnderFileSystemCluster.getUnderFSClass();
-      if ("alluxio.underfs.hdfs.LocalMiniDFSCluster".equals(underFSClass)
+      if (LocalMiniDFSCluster.class.getName().equals(underFSClass)
           && 0 == res.length) {
         // Returns -1 for zero-sized byte array to indicate no more bytes available here.
         Assert.assertEquals(-1, is.read(res));


### PR DESCRIPTION
This fix intends to set the correct UNDERFS_ADDRESS for gcs, swift, glusterfs in addition to the previously hard coded hdfs, s3 and oss.
