### PR TITLE
[SMALLFIX] Fix seek contract test

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -98,6 +98,9 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
 
   @Override
   public int available() throws IOException {
+    if (mClosed) {
+      throw new IOException("Cannot query available bytes from a closed stream.");
+    }
     return (int) mAlluxioFileInputStream.remaining();
   }
 


### PR DESCRIPTION
The test requires that available throws an IOException when the stream is closed.

Followup to https://github.com/Alluxio/alluxio/pull/3618