### PR TITLE
[SMALLFIX] Improve directories permission propagation to UFS.

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -35,6 +35,7 @@ import alluxio.proto.journal.File.InodeFileEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.security.authorization.Permission;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.SecurityUtils;
 import alluxio.util.io.PathUtils;
 
@@ -627,7 +628,10 @@ public final class InodeTree implements JournalCheckpointStreamable {
       UnderFileSystem ufs = resolution.getUfs();
       // Persists only the last directory, recursively creating necessary parent directories. Even
       // if the directory already exists in the ufs, we mark it as persisted.
-      if (ufs.exists(ufsUri) || ufs.mkdirs(ufsUri, true)) {
+      Permission perm = new Permission(lastToPersistInode.getOwner(), lastToPersistInode.getGroup(),
+          lastToPersistInode.getMode());
+      MkdirsOptions mkdirsOptions = new MkdirsOptions().setCreateParent(true).setPermission(perm);
+      if (ufs.exists(ufsUri) || ufs.mkdirs(ufsUri, mkdirsOptions)) {
         for (Inode<?> inode : toPersistDirectories) {
           inode.setPersistenceState(PersistenceState.PERSISTED);
         }

--- a/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -307,6 +307,7 @@ public final class FileDataManager {
       final int maxRetry = 10;
       int numRetry = 0;
       // TODO(peis): Retry only if we are making progress.
+      // TODO(chaomin): figure out a way to get parent permission in Alluxio namespace.
       for (; numRetry < maxRetry; numRetry++) {
         if (mUfs.mkdirs(parentPath, true) || mUfs.exists(parentPath)) {
           break;

--- a/tests/src/test/java/alluxio/client/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/PersistPermissionIntegrationTest.java
@@ -1,0 +1,129 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.IntegrationTestUtils;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
+import alluxio.master.file.meta.PersistenceState;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.hdfs.HdfsUnderFileSystem;
+import alluxio.underfs.local.LocalUnderFileSystem;
+import alluxio.util.CommonUtils;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests of file permission propagation for persist and async persist.
+ */
+public final class PersistPermissionIntegrationTest extends AbstractFileOutStreamIntegrationTest {
+  private String mUfsRoot;
+  private UnderFileSystem mUfs;
+
+  @Before
+  @Override
+  public void before() throws Exception {
+    super.before();
+
+    mUfsRoot = PathUtils.concatPath(
+        mLocalAlluxioClusterResource.get().getMasterConf().get(Constants.UNDERFS_ADDRESS));
+    mUfs = UnderFileSystem.get(mUfsRoot, mLocalAlluxioClusterResource.get().getMasterConf());
+  }
+
+  @Test
+  public void syncPersistPermissionTest() throws Exception {
+    if (!(mUfs instanceof LocalUnderFileSystem) && !(mUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
+    FileOutStream os = mFileSystem.createFile(filePath, mWriteBoth);
+    os.write((byte) 0);
+    os.write((byte) 1);
+    os.close();
+
+    // Check the file is persisted
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+    Assert.assertTrue(status.isCompleted());
+    short fileMode = (short) status.getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+
+    // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
+    Assert.assertEquals(fileMode, mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath)));
+    Assert.assertEquals(parentMode,
+        mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath.getParent())));
+  }
+
+  @Test
+  public void asyncPersistPermissionTest() throws Exception {
+    if (!(mUfs instanceof LocalUnderFileSystem) && !(mUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
+    FileOutStream os = mFileSystem.createFile(filePath, mWriteAsync);
+    os.write((byte) 0);
+    os.write((byte) 1);
+    os.close();
+
+    CommonUtils.sleepMs(1);
+    // check the file is completed but not persisted
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.IN_PROGRESS.toString(), status.getPersistenceState());
+    Assert.assertTrue(status.isCompleted());
+    short fileMode = (short) status.getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+
+    IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+
+    status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+
+    // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
+    Assert.assertEquals(fileMode, mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath)));
+    Assert.assertEquals(parentMode,
+        mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath.getParent())));
+  }
+
+  @Test
+  public void asyncPersistEmptyFilePermissionTest() throws Exception {
+    if (!(mUfs instanceof LocalUnderFileSystem) && !(mUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createFile(filePath, mWriteAsync).close();
+
+    // check the file is completed but not persisted
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertNotEquals(PersistenceState.PERSISTED, status.getPersistenceState());
+    Assert.assertTrue(status.isCompleted());
+    short fileMode = (short) status.getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+
+    IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+
+    status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+
+    // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
+    Assert.assertEquals(fileMode, mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath)));
+    Assert.assertEquals(parentMode,
+        mUfs.getMode(PathUtils.concatPath(mUfsRoot, filePath.getParent())));
+  }
+}

--- a/tests/src/test/java/alluxio/client/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/PersistPermissionIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
+import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.IntegrationTestUtils;
 import alluxio.client.file.FileOutStream;
@@ -39,9 +40,8 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
   public void before() throws Exception {
     super.before();
 
-    mUfsRoot = PathUtils.concatPath(
-        mLocalAlluxioClusterResource.get().getMasterConf().get(Constants.UNDERFS_ADDRESS));
-    mUfs = UnderFileSystem.get(mUfsRoot, mLocalAlluxioClusterResource.get().getMasterConf());
+    mUfsRoot = PathUtils.concatPath(Configuration.get(Constants.UNDERFS_ADDRESS));
+    mUfs = UnderFileSystem.get(mUfsRoot);
   }
 
   @Test

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -380,13 +380,12 @@ public final class FileSystemAclIntegrationTest {
     Assert.assertEquals((int) parentMode,
         (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dirA)));
 
-    // Rename from fileA to fileB, file and its parent permission should be in sync with the source
+    // Rename from dirA to dirB, file and its parent permission should be in sync with the source
     // dirA.
     Path fileB = new Path("/root/dirB/fileB");
     Path dirB = fileB.getParent();
     sTFS.rename(dirA, dirB);
     Assert.assertEquals((int) parentMode,
         (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, fileB.getParent())));
-    sTFS.rename(fileA, fileB);
   }
 }

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -381,12 +381,13 @@ public final class FileSystemAclIntegrationTest {
     Assert.assertEquals((int) parentMode,
         (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dirA)));
 
+    // Rename from fileA to fileB, file and its parent permission should be in sync with the source
+    // dirA.
     Path fileB = new Path("/root/dirB/fileB");
     Path dirB = fileB.getParent();
     sTFS.rename(dirA, dirB);
     Assert.assertEquals((int) parentMode,
         (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, fileB.getParent())));
-    // TODO(chaomin): Add rename from fileA to fileB, a parent directory of fileB will be created
-    // recursively, and its permission should be in sync with the source dirA.
+    sTFS.rename(fileA, fileB);
   }
 }

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -327,4 +327,66 @@ public final class FileSystemAclIntegrationTest {
     Assert.assertEquals(defaultOwner, fs.getOwner());
     Assert.assertEquals(defaultGroup, fs.getGroup());
   }
+
+  /**
+   * Tests the directory permission propagation to UFS.
+   */
+  @Test
+  public void directoryPermissionForUfsTest() throws IOException {
+    if (!(sUfs instanceof LocalUnderFileSystem) && !(sUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    Path dir = new Path("/root/dir/");
+    sTFS.mkdirs(dir);
+
+    FileStatus fs = sTFS.getFileStatus(dir);
+    String defaultOwner = fs.getOwner();
+    Short dirMode = fs.getPermission().toShort();
+    FileStatus parentFs = sTFS.getFileStatus(dir.getParent());
+    Short parentMode = parentFs.getPermission().toShort();
+
+    Assert.assertEquals(defaultOwner, sUfs.getOwner(PathUtils.concatPath(sUfsRoot, dir)));
+    Assert.assertEquals((int) dirMode,
+        (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dir)));
+    Assert.assertEquals((int) parentMode,
+        (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dir.getParent())));
+
+    short newMode = (short) 0755;
+    FsPermission newPermission = new FsPermission(newMode);
+    sTFS.setPermission(dir, newPermission);
+
+    Assert.assertEquals((int) newMode,
+        (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dir)));
+  }
+
+  /**
+   * Tests the parent directory permission when mkdirs recursively.
+   */
+  @Test
+  public void parentDirectoryPermissionForUfsTest() throws IOException {
+    if (!(sUfs instanceof LocalUnderFileSystem) && !(sUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    Path fileA = new Path("/root/dirA/fileA");
+    Path dirA = fileA.getParent();
+    sTFS.mkdirs(dirA);
+    short parentMode = (short) 0700;
+    FsPermission newPermission = new FsPermission(parentMode);
+    sTFS.setPermission(dirA, newPermission);
+
+    create(sTFS, fileA);
+
+    Assert.assertEquals((int) parentMode,
+        (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, dirA)));
+
+    Path fileB = new Path("/root/dirB/fileB");
+    Path dirB = fileB.getParent();
+    sTFS.rename(dirA, dirB);
+    Assert.assertEquals((int) parentMode,
+        (int) sUfs.getMode(PathUtils.concatPath(sUfsRoot, fileB.getParent())));
+    // TODO(chaomin): Add rename from fileA to fileB, a parent directory of fileB will be created
+    // recursively, and its permission should be in sync with the source dirA.
+  }
 }


### PR DESCRIPTION
One TODO still left in `FileDataManager.java` when delegation is turned on, because worker can't easily get the status of a Alluxio directory.