### PR TITLE
[ALLUXIO-2031] fix Pseudo-terminal error when use alluxio on centos7

### DIFF
--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -41,7 +41,7 @@ fi
 for worker in $(echo ${HOSTLIST}); do
   echo "$(date +"%F %H:%M:%S,$(date +"%s%N" | cut -c 11- | cut -c 1-3)")
    INFO ${WORKER_ACTION_TYPE}  Connecting to ${worker} as ${USER}..." >> ${ALLUXIO_TASK_LOG}
-  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t ${worker} ${LAUNCHER} \
+  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
    $"${@// /\\ }" >> ${ALLUXIO_TASK_LOG} 2>&1&
 done
 


### PR DESCRIPTION
On centos7 when try to start alluxio in cluster model will get error :
   Pseudo-terminal will not be allocated because stdin is not a terminal.
   sudo: sorry, you must have a tty to run sudo
   Mount failed, not starting worker.
For detail please see:https://alluxio.atlassian.net/browse/ALLUXIO-2031