### PR TITLE
[ALLUXIO-2048] remove id index in inode directory

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -32,13 +32,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class InodeDirectory extends Inode<InodeDirectory> {
-  private IndexedSet.FieldIndex<Inode<?>> mIdIndex = new IndexedSet.FieldIndex<Inode<?>>() {
-    @Override
-    public Object getFieldValue(Inode<?> o) {
-      return o.getId();
-    }
-  };
-
   private IndexedSet.FieldIndex<Inode<?>> mNameIndex = new IndexedSet.FieldIndex<Inode<?>>() {
     @Override
     public Object getFieldValue(Inode<?> o) {
@@ -47,7 +40,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
   };
 
   @SuppressWarnings("unchecked")
-  private IndexedSet<Inode<?>> mChildren = new IndexedSet<>(mIdIndex, mNameIndex);
+  private IndexedSet<Inode<?>> mChildren = new IndexedSet<>(mNameIndex);
 
   private boolean mMountPoint;
 
@@ -83,14 +76,6 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   public void addChild(Inode<?> child) {
     mChildren.add(child);
-  }
-
-  /**
-   * @param id the inode id of the child
-   * @return the inode with the given id, or null if there is no child with that id
-   */
-  public Inode<?> getChild(long id) {
-    return mChildren.getFirstByField(mIdIndex, id);
   }
 
   /**

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -190,8 +190,7 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
   }
 
   /**
-   * Tests the {@link InodeDirectory#getChild(String)}
-   * methods.
+   * Tests the {@link InodeDirectory#getChild(String)} methods.
    */
   @Test
   public void getChildTest() {

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -190,7 +190,7 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
   }
 
   /**
-   * Tests the {@link InodeDirectory#getChild(long)} and {@link InodeDirectory#getChild(String)}
+   * Tests the {@link InodeDirectory#getChild(String)}
    * methods.
    */
   @Test
@@ -209,13 +209,6 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
         runtime.totalMemory() - runtime.freeMemory(), nFiles));
 
     long start = System.currentTimeMillis();
-    for (int i = 0; i < nFiles; i++) {
-      Assert.assertEquals(inodes[i], inodeDirectory.getChild(createInodeFileId(i + 1)));
-    }
-    LOG.info(String.format("getChild(int fid) called sequentially %d times, cost %d ms", nFiles,
-        System.currentTimeMillis() - start));
-
-    start = System.currentTimeMillis();
     for (int i = 0; i < nFiles; i++) {
       Assert.assertEquals(inodes[i], inodeDirectory.getChild(String.format("testFile%d", i + 1)));
     }


### PR DESCRIPTION
The id index in Inode directory is only used by test file while it takes a lot of memory. We can remove this index to optimize memory.