### PR TITLE
[SMALLFIX] Fix wrong use of Configuration in ufs creation

### DIFF
--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
@@ -72,15 +72,15 @@ public final class GCSUnderFileSystemFactory implements UnderFileSystemFactory {
    * @return true if both access and secret key are present, false otherwise
    */
   private boolean addAndCheckGoogleCredentials(Configuration configuration) {
+    // TODO(binfan): remove System.getProperty as it is covered by configuration
     String accessKeyConf = Constants.GCS_ACCESS_KEY;
-    if (System.getProperty(accessKeyConf) != null && configuration.get(accessKeyConf) == null) {
+    if (System.getProperty(accessKeyConf) != null && !configuration.containsKey(accessKeyConf)) {
       configuration.set(accessKeyConf, System.getProperty(accessKeyConf));
     }
     String secretKeyConf = Constants.GCS_SECRET_KEY;
-    if (System.getProperty(secretKeyConf) != null && configuration.get(secretKeyConf) == null) {
+    if (System.getProperty(secretKeyConf) != null && !configuration.containsKey(secretKeyConf)) {
       configuration.set(secretKeyConf, System.getProperty(secretKeyConf));
     }
-    return configuration.get(accessKeyConf) != null
-        && configuration.get(secretKeyConf) != null;
+    return configuration.containsKey(accessKeyConf) && configuration.containsKey(secretKeyConf);
   }
 }

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystemFactory.java
@@ -72,15 +72,15 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
    * @return true if both access and secret key are present, false otherwise
    */
   private boolean addAndCheckAWSCredentials(Configuration configuration) {
+    // TODO(binfan): remove System.getProperty as it is covered by configuration
     String accessKeyConf = Constants.S3_ACCESS_KEY;
-    if (System.getProperty(accessKeyConf) != null && configuration.get(accessKeyConf) == null) {
+    if (System.getProperty(accessKeyConf) != null && !configuration.containsKey(accessKeyConf)) {
       configuration.set(accessKeyConf, System.getProperty(accessKeyConf));
     }
     String secretKeyConf = Constants.S3_SECRET_KEY;
-    if (System.getProperty(secretKeyConf) != null && configuration.get(secretKeyConf) == null) {
+    if (System.getProperty(secretKeyConf) != null && !configuration.containsKey(secretKeyConf)) {
       configuration.set(secretKeyConf, System.getProperty(secretKeyConf));
     }
-    return configuration.get(accessKeyConf) != null
-        && configuration.get(secretKeyConf) != null;
+    return configuration.containsKey(accessKeyConf) && configuration.containsKey(secretKeyConf);
   }
 }


### PR DESCRIPTION
`configuration.get` will throw `RuntimeException` when key is not recognized with default value.
The current code may trigger the wrong exception when aws/gcs credential not set, confusing users.

Before this fix, the error message in master.log is like "invalid configuration key fs.gcs.accessKeyId` when user forget to set this key, which is very confusing. 

After this fix, the error message becomes: "Google Credentials not available, cannot create GCS Under File System."