### PR TITLE
[ALLUXIO-2053] alluio-start.sh not use -f in the getopts anymore

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -19,7 +19,7 @@ BIN=$(cd "$( dirname "$0" )"; pwd)
 
 #start up alluxio
 
-USAGE="Usage: alluxio-start.sh [-fhNw] ACTION [MOPT]
+USAGE="Usage: alluxio-start.sh [-hNw] ACTION [MOPT] [-f]
 Where ACTION is one of:
   all [MOPT]     \tStart master and all workers.
   local [MOPT]   \tStart a master and worker locally.


### PR DESCRIPTION
The -f option are not using in the getopts in the bin/alluxio-start.sh shell script anymore, the getopts just contains "hNw" options, not "fhNw" anymore.
I also noticed that the "-f" option should given(or not) after the "MOPT" or as the "MOPT",so we should remove the "-f" option from [-fhNw] and move it to the tail of command as another option?
like below:

```
bin/alluxio-start.sh all NoMount

bin/alluxio-start.sh local NoMount -f

bin/alluxio-start.sh -N master -f
```