### PR TITLE
[SMALLFIX] Mount ramdisk only if set

### DIFF
--- a/integration/bin/alluxio-worker-mesos.sh
+++ b/integration/bin/alluxio-worker-mesos.sh
@@ -16,8 +16,11 @@ source "${SCRIPT_DIR}/common.sh"
 ALLUXIO_WORKER_JAVA_OPTS="${ALLUXIO_WORKER_JAVA_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 MESOS_LIBRARY_PATH="${MESOS_LIBRARY_PATH:-/usr/local/lib}"
 
-echo Mount ramdisk on worker
-${ALLUXIO_HOME}/bin/alluxio-mount.sh SudoMount
+# Try to mount ramdisk
+if [[ "${ALLUXIO_RAM_FOLDER}" == "/mnt/ramdisk" ]]; then
+    echo Mount ramdisk on worker
+    ${ALLUXIO_HOME}/bin/alluxio-mount.sh SudoMount
+fi
 
 mkdir -p "${ALLUXIO_LOGS_DIR}"
 
@@ -30,6 +33,6 @@ mkdir -p "${ALLUXIO_LOGS_DIR}"
   -Dalluxio.master.hostname="${ALLUXIO_MASTER_HOSTNAME}" \
   -Dalluxio.worker.tieredstore.levels=1 \
   -Dalluxio.worker.tieredstore.level0.alias=MEM \
-  -Dalluxio.worker.tieredstore.level0.dirs.path="/mnt/ramdisk" \
+  -Dalluxio.worker.tieredstore.level0.dirs.path="${ALLUXIO_RAM_FOLDER}" \
   -Dalluxio.worker.tieredstore.level0.dirs.quota="${ALLUXIO_WORKER_MEMORY_SIZE}" \
   alluxio.mesos.AlluxioWorkerExecutor > "${ALLUXIO_LOGS_DIR}"/worker.out 2>&1

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
@@ -135,9 +135,10 @@ public class AlluxioFramework {
           }
         }
 
-        LOG.info("Received offer {} with cpus {} and mem {} MB and hasMasterPorts {}",
-            offer.getId().getValue(), offerCpu, offerMem,
-            OfferUtils.hasAvailableMasterPorts(offer));
+        LOG.info("Received offer {} with cpus {} and mem {} MB, hasAvailableMasterPorts {}, "
+            + "hasAvailableWorkerPorts {}", offer.getId().getValue(), offerCpu, offerMem,
+            OfferUtils.hasAvailableMasterPorts(offer),
+            OfferUtils.hasAvailableWorkerPorts(offer));
 
         Protos.ExecutorInfo.Builder executorBuilder = Protos.ExecutorInfo.newBuilder();
         List<Protos.Resource> resources;


### PR DESCRIPTION
Currently ramdisk must be mounted on the Mesos workers. This makes it impossible to use tmpfs/shm in environments where ramdisk is not allowed (permission denied). This patch mounts ramdisk only when ALLUXIO_RAM_FOLDER is set to /mnt/ramdisk.
