### PR TITLE
[ALLUXIO-1481] More informative 'ls' output.

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class LsCommand extends WithWildCardPathCommand {
-  public static final String STATE_FOLDER = "";
+  public static final String STATE_FOLDER = "Directory";
   public static final String STATE_FILE_IN_MEMORY = "In Memory";
   public static final String STATE_FILE_NOT_IN_MEMORY = "Not In Memory";
 


### PR DESCRIPTION
Addresses: https://alluxio.atlassian.net/browse/ALLUXIO-1481

Before this PR:

```
$ ./bin/alluxio fs ls -R /
24.00B    07-08-2016 12:20:41:998                 /default_tests_files
80.00B    07-08-2016 12:20:41:998  In Memory      /default_tests_files/Basic_CACHE_PROMOTE_MUST_CACHE
...
```

After this PR:

```
$ ./bin/alluxio fs ls -R /
24.00B    07-08-2016 12:20:41:998  Directory      /default_tests_files
80.00B    07-08-2016 12:20:41:998  In Memory      /default_tests_files/Basic_CACHE_PROMOTE_MUST_CACHE
...
```