### PR TITLE
[DOCFIX] Update docs with new component labeling guidelines

### DIFF
--- a/docs/en/Contributing-Getting-Started.md
+++ b/docs/en/Contributing-Getting-Started.md
@@ -222,7 +222,8 @@ you want to submit the pull request for.
 For the title of the pull request, the title should be prefixed by the JIRA ticket name. Therefore,
 the title will look something like **[ALLUXIO-1234] Awesome Feature**.
 
-Add a GitHub label for whichever Alluxio component you think your change best falls under.
+Add a GitHub label for whichever Alluxio component your pull request fits into. Components correspond 
+with root-level directories in the Alluxio repository.
 
 In the first line of the description box, please add a link back to the JIRA ticket. The link will
 look something like: `https://alluxio.atlassian.net/browse/ALLUXIO-####`

--- a/docs/en/Contributing-Getting-Started.md
+++ b/docs/en/Contributing-Getting-Started.md
@@ -33,7 +33,7 @@ If you do not have Java installed, download and install [the Java SDK](http://ww
 
 Alluxio uses Maven to manage the build process. If you do not have Maven already installed, you can
 [download Maven](https://maven.apache.org/download.cgi), and
-[install Maven](https://maven.apache.org/install.html). 
+[install Maven](https://maven.apache.org/install.html).
 
 ### Git
 
@@ -73,7 +73,7 @@ $ git clone https://github.com/YOUR-USERNAME/alluxio.git
 $ cd alluxio
 ```
 
-This will create the clone under the `alluxio/` directory. 
+This will create the clone under the `alluxio/` directory.
 
 In order to pull changes from the open source Alluxio code base into your clone, you should create a
 new remote that points to the Alluxio repository. In the directory of your newly created clone, run:
@@ -198,7 +198,7 @@ If you want more details, please visit [instructions on how to create commits](h
 ## Sending a Pull Request
 
 After you have finished all the changes to address the JIRA ticket, you are ready to submit a pull
-request to the Alluxio project! Here are [detailed instructions on sending a pull request](https://help.github.com/articles/using-pull-requests/), 
+request to the Alluxio project! Here are [detailed instructions on sending a pull request](https://help.github.com/articles/using-pull-requests/),
 but the following is a common way to do it.
 
 After you have created all necessary local commits, you can push all your commits to your repository
@@ -221,6 +221,8 @@ you want to submit the pull request for.
 
 For the title of the pull request, the title should be prefixed by the JIRA ticket name. Therefore,
 the title will look something like **[ALLUXIO-1234] Awesome Feature**.
+
+Add a GitHub label for whichever Alluxio component you think your change best falls under.
 
 In the first line of the description box, please add a link back to the JIRA ticket. The link will
 look something like: `https://alluxio.atlassian.net/browse/ALLUXIO-####`

--- a/docs/en/Contributing-to-Alluxio.md
+++ b/docs/en/Contributing-to-Alluxio.md
@@ -64,6 +64,10 @@ For a tutorial, see the GitHub guides on
 [ALLUXIO-100] Implement an awesome new feature
 ~~~~~
 
+-   Add a GitHub label describing which component of Alluxio your change falls under. If you're
+    unsure, pick whichever component you think fits best, and the maintainer of the component
+    will relabel the pull request if necessary.
+
 -   In the description field of the pull request, please include a link to the JIRA ticket.
 
 

--- a/docs/en/Contributing-to-Alluxio.md
+++ b/docs/en/Contributing-to-Alluxio.md
@@ -65,8 +65,8 @@ For a tutorial, see the GitHub guides on
 ~~~~~
 
 -   Add a GitHub label describing which component of Alluxio your change falls under. If you're
-    unsure, pick whichever component you think fits best, and the maintainer of the component
-    will relabel the pull request if necessary.
+    unsure, pick whichever component you modified the most (components correspond with root-level 
+    directories).
 
 -   In the description field of the pull request, please include a link to the JIRA ticket.
 


### PR DESCRIPTION
Apologies in advance for deleting trailing whitespace, but I don't think we want trailing whitespace in our markdown files, and many editors remove trailing whitespace by default.