### PR TITLE
[SMALLFIX] Clean up temporary zookeeper directory

### DIFF
--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -45,7 +45,7 @@ public final class AlluxioTestDirectory {
   public static File createTemporaryDirectory(String prefix) {
     final File file = new File(ALLUXIO_TEST_DIRECTORY, prefix + "-" + UUID.randomUUID());
     if (!file.mkdir()) {
-      throw new RuntimeException("Failed to created directory " + file.getAbsolutePath());
+      throw new RuntimeException("Failed to create directory " + file.getAbsolutePath());
     }
 
     Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -11,7 +11,6 @@
 
 package alluxio;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,11 +44,10 @@ public final class AlluxioTestDirectory {
    */
   public static File createTemporaryDirectory(String prefix) {
     final File file = new File(ALLUXIO_TEST_DIRECTORY, prefix + "-" + UUID.randomUUID());
-    try {
-      file.createNewFile();
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
+    if (!file.mkdir()) {
+      throw new RuntimeException("Failed to created directory " + file.getAbsolutePath());
     }
+
     Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
       public void run() {
         try {

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -11,6 +11,7 @@
 
 package alluxio.master;
 
+import alluxio.AlluxioTestDirectory;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
@@ -47,7 +48,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     mNumOfMasters = masters;
 
     try {
-      mCuratorServer = new TestingServer();
+      mCuratorServer = new TestingServer(-1, AlluxioTestDirectory.createTemporaryDirectory("zk"));
       LOG.info("Started testing zookeeper: {}", mCuratorServer.getConnectString());
     } catch (Exception e) {
       throw Throwables.propagate(e);


### PR DESCRIPTION
If we don't specify that we want it to use our temporary tests folder as its work directory, it will create a "TIMESTAMP-0" directory in the java temp directory.