### PR TITLE
[ALLUXIO-2079] Set Constructor of alluxio.underfs.UnderFileSystemRegistry  to be private

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
@@ -74,9 +74,7 @@ public final class UnderFileSystemRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static boolean sInit = false;
 
-  /**
-   * Constructs a new {@link UnderFileSystemRegistry}.
-   */
+  // prevent instantiation
   private UnderFileSystemRegistry() {}
 
   static {

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
@@ -77,7 +77,7 @@ public final class UnderFileSystemRegistry {
   /**
    * Constructs a new {@link UnderFileSystemRegistry}.
    */
-  public UnderFileSystemRegistry() {}
+  private UnderFileSystemRegistry() {}
 
   static {
     // Call the actual initializer which is a synchronized method for thread safety purposes


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2079
The UnderFileSystemRegistry object created by create method. The Constructor should be private.