### PR TITLE
[DOCFIX] Clarify mounting in gluster/nfs docs

### DIFF
--- a/docs/_includes/Configuring-Alluxio-with-GlusterFS/glusterfs-file.md
+++ b/docs/_includes/Configuring-Alluxio-with-GlusterFS/glusterfs-file.md
@@ -1,1 +1,1 @@
-    /alluxio_vol/default_tests_files/BasicFile_STORE_SYNC_PERSIST
+    /mnt/gluster/default_tests_files/BasicFile_STORE_SYNC_PERSIST

--- a/docs/_includes/Configuring-Alluxio-with-GlusterFS/underfs-address.md
+++ b/docs/_includes/Configuring-Alluxio-with-GlusterFS/underfs-address.md
@@ -1,3 +1,3 @@
 ```bash
-ALLUXIO_UNDERFS_ADDRESS=/alluxio_vol
+ALLUXIO_UNDERFS_ADDRESS=/mnt/gluster
 ```

--- a/docs/_includes/Configuring-Alluxio-with-NFS/nfs-file.md
+++ b/docs/_includes/Configuring-Alluxio-with-NFS/nfs-file.md
@@ -1,1 +1,1 @@
-    /alluxio_vol/default_tests_files/BasicFile_STORE_SYNC_PERSIST
+    /mnt/nfs/default_tests_files/BasicFile_STORE_SYNC_PERSIST

--- a/docs/_includes/Configuring-Alluxio-with-NFS/underfs-address.md
+++ b/docs/_includes/Configuring-Alluxio-with-NFS/underfs-address.md
@@ -1,3 +1,3 @@
 ```bash
-ALLUXIO_UNDERFS_ADDRESS=/alluxio_vol
+ALLUXIO_UNDERFS_ADDRESS=/mnt/nfs
 ```

--- a/docs/en/Configuring-Alluxio-with-GlusterFS.md
+++ b/docs/en/Configuring-Alluxio-with-GlusterFS.md
@@ -20,14 +20,14 @@ For example, if you are running Alluxio on your local machine, `ALLUXIO_MASTER_H
 
 {% include Configuring-Alluxio-with-GlusterFS/bootstrapConf.md %}
 
-Alternatively, you can also create the configuration file from the template and set the contents manually. 
+Alternatively, you can also create the configuration file from the template and set the contents manually.
 
 {% include Common-Commands/copy-alluxio-env.md %}
 
 # Configuring Alluxio
 
 Assuming the GlusterFS bricks are co-located with Alluxio nodes, the GlusterFS volume is mounted at
-`/alluxio_vol`, the following environment variable assignment needs to be added to 
+`/mnt/gluster`, the following environment variable assignment needs to be added to
 `conf/alluxio-env.sh`:
 
 {% include Configuring-Alluxio-with-GlusterFS/underfs-address.md %}

--- a/docs/en/Configuring-Alluxio-with-NFS.md
+++ b/docs/en/Configuring-Alluxio-with-NFS.md
@@ -21,7 +21,7 @@ Then, if you haven't already done so, create your configuration file from the te
 # Configuring Alluxio
 
 Assuming the NFS clients are co-located with Alluxio nodes, all the NFS shares are mounted at directory
-`/alluxio_vol`, the following environment variable assignment needs to be added to 
+`/mnt/nfs`, the following environment variable assignment needs to be added to
 `conf/alluxio-env.sh`:
 
 {% include Configuring-Alluxio-with-NFS/underfs-address.md %}


### PR DESCRIPTION
Rename the mount point to be more obviously a mount point since `vol` can mean something else.