### PR TITLE
[SMALLFIX] Remove user/group in UnderFileSystem object and cache to

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -155,10 +155,7 @@ public enum ExceptionMessage {
   // security
   AUTHENTICATION_IS_NOT_ENABLED("Authentication is not enabled"),
   AUTHORIZED_CLIENT_USER_IS_NULL("The client user is not authorized so as to be null in server"),
-  GROUP_IS_NULL("Group cannot be null when constructing Permission"),
   INVALID_SET_ACL_OPTIONS("Invalid set acl options: {0}, {1}, {2}"),
-  MODE_IS_NULL("Mode cannot be null when constructing Permission"),
-  OWNER_IS_NULL("Owner cannot be null when constructing Permission"),
   PERMISSION_DENIED("Permission denied: {0}"),
   SECURITY_IS_NOT_ENABLED("Security is not enabled"),
 

--- a/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
@@ -57,6 +57,9 @@ public enum PreconditionMessage {
   MUST_SET_OWNER("The owner must be set"),
   MUST_SET_GROUP("The group must be set"),
   MUST_SET_MODE("The mode must be set"),
+  PERMISSION_GROUP_IS_NULL("Group cannot be null when constructing Permission"),
+  PERMISSION_MODE_IS_NULL("Mode cannot be null when constructing Permission"),
+  PERMISSION_OWNER_IS_NULL("Owner cannot be null when constructing Permission"),
   PERSIST_ONLY_FOR_FILE("Only files can be persisted"),
   PROTOCOL_NULL_WHEN_CONNECTED(
       "The client protocol should never be null when the client is connected"),

--- a/core/common/src/main/java/alluxio/security/authorization/Permission.java
+++ b/core/common/src/main/java/alluxio/security/authorization/Permission.java
@@ -13,6 +13,7 @@ package alluxio.security.authorization;
 
 import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
+import alluxio.exception.PreconditionMessage;
 import alluxio.security.LoginUser;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
@@ -46,9 +47,9 @@ public final class Permission {
    * @param mode the {@link Mode}
    */
   public Permission(String owner, String group, Mode mode) {
-    Preconditions.checkNotNull(owner, "Owner cannot be null when constructing Permission");
-    Preconditions.checkNotNull(group, "Group cannot be null when constructing Permission");
-    Preconditions.checkNotNull(mode, "Mode cannot be null when constructing Permission");
+    Preconditions.checkNotNull(owner, PreconditionMessage.PERMISSION_OWNER_IS_NULL);
+    Preconditions.checkNotNull(group, PreconditionMessage.PERMISSION_GROUP_IS_NULL);
+    Preconditions.checkNotNull(mode, PreconditionMessage.PERMISSION_MODE_IS_NULL);
     mOwner = owner;
     mGroup = group;
     mMode = mode;

--- a/core/common/src/main/java/alluxio/security/authorization/Permission.java
+++ b/core/common/src/main/java/alluxio/security/authorization/Permission.java
@@ -46,9 +46,9 @@ public final class Permission {
    * @param mode the {@link Mode}
    */
   public Permission(String owner, String group, Mode mode) {
-    Preconditions.checkNotNull(owner, ExceptionMessage.OWNER_IS_NULL.getMessage());
-    Preconditions.checkNotNull(group, ExceptionMessage.GROUP_IS_NULL.getMessage());
-    Preconditions.checkNotNull(mode, ExceptionMessage.MODE_IS_NULL.getMessage());
+    Preconditions.checkNotNull(owner, "Owner cannot be null when constructing Permission");
+    Preconditions.checkNotNull(group, "Group cannot be null when constructing Permission");
+    Preconditions.checkNotNull(mode, "Mode cannot be null when constructing Permission");
     mOwner = owner;
     mGroup = group;
     mMode = mode;


### PR DESCRIPTION
avoid expensive calls to Configuration.get

`UnderFileSystem.get` calls `Configuration.get` every time. `Configuration.get` is expensive. Since mOwner/mGroup are not actually used for now, we can remove them.