### PR TITLE
[ALLUXIO-2064] Replacing integer literal with predefined sizes in Constants

### DIFF
--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -54,7 +54,7 @@ public final class FileSystemAclIntegrationTest {
   private static final int BLOCK_SIZE = 1024;
   @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource(Constants.GB, BLOCK_SIZE,
+      new LocalAlluxioClusterResource(100*Constants.MB, BLOCK_SIZE,
           Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName(),
           Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
   private static String sUfsRoot;

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -54,7 +54,7 @@ public final class FileSystemAclIntegrationTest {
   private static final int BLOCK_SIZE = 1024;
   @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource(100000000, BLOCK_SIZE,
+      new LocalAlluxioClusterResource(Constants.GB, BLOCK_SIZE,
           Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName(),
           Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
   private static String sUfsRoot;

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -54,7 +54,7 @@ public final class FileSystemAclIntegrationTest {
   private static final int BLOCK_SIZE = 1024;
   @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource(100*Constants.MB, BLOCK_SIZE,
+      new LocalAlluxioClusterResource(100 * Constants.MB, BLOCK_SIZE,
           Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName(),
           Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
   private static String sUfsRoot;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2064

Replaced an integer literal with Constants.GB when creating the LocalAlluxioClusterResource object in FileSystemAclIntegrationTest.