### PR TITLE
[ALLUXIO-2092] Fix expected value in test for  Swift UFS InputStream

### DIFF
--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -23,6 +23,7 @@ import alluxio.client.file.options.CreateFileOptions;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.underfs.hdfs.LocalMiniDFSCluster;
+import alluxio.underfs.swift.SwiftUnderStorageCluster;
 import alluxio.util.io.BufferUtils;
 
 import org.junit.Assert;
@@ -97,8 +98,8 @@ public abstract class AbstractFileOutStreamIntegrationTest {
       InputStream is = ufs.open(checkpointPath);
       byte[] res = new byte[(int) status.getLength()];
       String underFSClass = UnderFileSystemCluster.getUnderFSClass();
-      if (LocalMiniDFSCluster.class.getName().equals(underFSClass)
-          && 0 == res.length) {
+      if ((LocalMiniDFSCluster.class.getName().equals(underFSClass)
+          || SwiftUnderStorageCluster.class.getName().equals(underFSClass)) && 0 == res.length) {
         // Returns -1 for zero-sized byte array to indicate no more bytes available here.
         Assert.assertEquals(-1, is.read(res));
       } else {


### PR DESCRIPTION
InputStream should expect a return value -1 and not 0 for an empty stream.

https://alluxio.atlassian.net/browse/ALLUXIO-2092