### PR TITLE
[SMALLFIX] Fix a get local file mode test under different OS.

### DIFF
--- a/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
@@ -254,8 +254,9 @@ public class FileUtilsTest {
 
     File tmpFile755 = mTestFolder.newFile("dir/0755");
     tmpFile755.setReadable(true, false /* owner only */);
-    tmpFile755.setWritable(true, true /* owner only */);
+    tmpFile755.setWritable(false, false /* owner only */);
     tmpFile755.setExecutable(true, false /* owner only */);
+    tmpFile755.setWritable(true, true /* owner only */);
 
     File tmpFile444 = mTestFolder.newFile("dir/0444");
     tmpFile444.setReadOnly();


### PR DESCRIPTION
Reset all modes should make the test work for various default modes, such as ubuntu has default mode '0664'