### PR TITLE
[ALLUXIO-2117] Add caching in user to groups mapping.

### DIFF
--- a/core/client/src/test/java/alluxio/client/file/options/CompleteUfsFileOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/CompleteUfsFileOptionsTest.java
@@ -43,7 +43,8 @@ public final class CompleteUfsFileOptionsTest {
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityOwnerGroupMapping to map owner "foo" to group "foo".
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
 
     CompleteUfsFileOptions options = CompleteUfsFileOptions.defaults();
 

--- a/core/client/src/test/java/alluxio/client/file/options/CreateUfsFileOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/CreateUfsFileOptionsTest.java
@@ -43,7 +43,8 @@ public final class CreateUfsFileOptionsTest {
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityOwnerGroupMapping to map owner "foo" to group "foo".
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
 
     CreateUfsFileOptions options = CreateUfsFileOptions.defaults();
 

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -473,7 +473,7 @@ public final class Constants {
   public static final String SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP =
       "alluxio.security.authorization.permission.supergroup";
   // Group Mapping
-  public static final String SECURITY_GROUP_MAPPING = "alluxio.security.group.mapping.class";
+  public static final String SECURITY_GROUP_MAPPING_CLASS = "alluxio.security.group.mapping.class";
   public static final String SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS =
       "alluxio.security.group.mapping.cache.timeout.ms";
 

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -474,6 +474,8 @@ public final class Constants {
       "alluxio.security.authorization.permission.supergroup";
   // Group Mapping
   public static final String SECURITY_GROUP_MAPPING = "alluxio.security.group.mapping.class";
+  public static final String SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS =
+      "alluxio.security.group.mapping.cache.timeout.ms";
 
   // Security related constant value
   public static final int DEFAULT_FILE_SYSTEM_UMASK = 0022;

--- a/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * Class to map user to groups. It maintains a cache for user to groups mapping. The underlying
  * implementation depends on {@link GroupMappingService}.
  */
-public class CachedGroupMapping {
+public class CachedGroupMapping implements GroupMappingService {
   /** The underlying implementation of GroupMappingService. */
   private final GroupMappingService mService;
   /** Whether the cache is enabled. Set timeout to non-positive value to disable cache. */
@@ -46,9 +46,9 @@ public class CachedGroupMapping {
   private static final long MAXSIZE = 10000;
 
   /** Create an executor service that provide ListenableFuture instances. */
-  private ThreadFactory mThreadFactory = new ThreadFactoryBuilder()
+  private final ThreadFactory mThreadFactory = new ThreadFactoryBuilder()
       .setNameFormat("UserGroupMappingCachePool-%d").setDaemon(true).build();
-  private ExecutorService mParentExecutor = Executors.newSingleThreadExecutor(mThreadFactory);
+  private final ExecutorService mParentExecutor = Executors.newSingleThreadExecutor(mThreadFactory);
   private final ListeningExecutorService mExecutorService =
       MoreExecutors.listeningDecorator(mParentExecutor);
 

--- a/core/common/src/main/java/alluxio/security/group/GroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMapping.java
@@ -1,0 +1,86 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.group;
+
+import alluxio.Configuration;
+import alluxio.Constants;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class to map user to groups. It maintain a cache for user to groups mapping. The underlying
+ * implementation depends on {@link GroupMappingService}.
+ */
+public class GroupMapping {
+  /** The underlying implementation of GroupMappingService. */
+  private GroupMappingService mEnv;
+  /** Whether the cache is enabled. Set timeout to non-positive value to disable cache */
+  private boolean mCacheEnabled;
+  /** A loading cache for user to groups mapping, refresh periodically. */
+  private LoadingCache<String, List<String>> mCache;
+
+  /**
+   * Default constructor to initialize cache.
+   */
+  public GroupMapping() {
+    mEnv = GroupMappingService.Factory.getUserToGroupsMappingService();
+    long timeoutMs = Long.parseLong(Configuration.get(
+        Constants.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS));
+    mCacheEnabled = timeoutMs > 0;
+    if (mCacheEnabled) {
+      mCache = CacheBuilder.newBuilder()
+          .refreshAfterWrite(timeoutMs, TimeUnit.MILLISECONDS)
+          .expireAfterWrite(10 * timeoutMs, TimeUnit.MILLISECONDS)
+          .build(new GroupMappingCacheLoader());
+    }
+  }
+
+  /**
+   * Class to reload cache from underlying user group mapping service implementation.
+   */
+  private class GroupMappingCacheLoader extends CacheLoader<String, List<String>> {
+    /**
+     * Constructs a new {@link GroupMappingCacheLoader}.
+     */
+    public GroupMappingCacheLoader() {}
+
+    @Override
+    public List<String> load(String user) throws IOException {
+      return mEnv.getGroups(user);
+    }
+  }
+
+  /**
+   * Gets a list of groups for the given user.
+   *
+   * @param user user name
+   * @return the list of groups that the user belongs to
+   * @throws IOException if failed to get groups
+   */
+  public List<String> getGroups(String user) throws IOException {
+    if (!mCacheEnabled) {
+      return mEnv.getGroups(user);
+    }
+    try {
+      return mCache.get(user);
+    } catch (ExecutionException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/security/group/GroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMapping.java
@@ -29,9 +29,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class GroupMapping {
   /** The underlying implementation of GroupMappingService. */
-  private GroupMappingService mEnv;
+  private final GroupMappingService mEnv;
   /** Whether the cache is enabled. Set timeout to non-positive value to disable cache */
-  private boolean mCacheEnabled;
+  private final boolean mCacheEnabled;
   /** A loading cache for user to groups mapping, refresh periodically. */
   private LoadingCache<String, List<String>> mCache;
 
@@ -81,6 +81,15 @@ public class GroupMapping {
       return mCache.get(user);
     } catch (ExecutionException e) {
       throw new IOException(e);
+    }
+  }
+
+  /**
+   * Invalidates and refreshes the cache.
+   */
+  public void refreshCache() {
+    if (mCacheEnabled) {
+      mCache.invalidateAll();
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -39,67 +39,36 @@ public interface GroupMappingService {
 
     // TODO(chaomin): maintain a map from SECURITY_GROUP_MAPPING_CLASS name to cachedGroupMapping.
     // Currently the single global cached GroupMappingService assumes that there is no dynamic
-    // configuration change for {@link Constants#SECURITY_GROUP_MAPPING_CALSS}.
-    private static GroupMappingService sGroupMappingService = null;
+    // configuration change for {@link Constants#SECURITY_GROUP_MAPPING_CLASS}.
     private static CachedGroupMapping sCachedGroupMapping = null;
 
     // prevent instantiation
     private Factory() {}
 
     /**
-     * Gets the groups mapping service being used to map user-to-groups.
+     * Gets the cached groups mapping service being used to map user-to-groups.
      *
      * @return the groups mapping service being used to map user-to-groups
      */
     public static GroupMappingService get() {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Creating new Groups object");
-      }
-      try {
-        if (sGroupMappingService == null) {
-          synchronized (Factory.class) {
-            if (sGroupMappingService == null) {
-              sGroupMappingService = CommonUtils.createNewClassInstance(
-                  Configuration.<GroupMappingService>getClass(
-                      Constants.SECURITY_GROUP_MAPPING_CLASS), null, null);
-            }
-          }
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-      return sGroupMappingService;
-    }
-
-    /**
-     * Gets the cached user-to-groups mapping object.
-     *
-     * @return the cached user-to-groups mapping object
-     */
-    public static CachedGroupMapping getCachedGroupMapping() {
       if (sCachedGroupMapping == null) {
         synchronized (Factory.class) {
           if (sCachedGroupMapping == null) {
-            sCachedGroupMapping = new CachedGroupMapping(get());
+            try {
+              LOG.debug("Creating new Groups object");
+              GroupMappingService groupMappingService = CommonUtils.createNewClassInstance(
+                  Configuration.<GroupMappingService>getClass(
+                      Constants.SECURITY_GROUP_MAPPING_CLASS), null, null);
+              sCachedGroupMapping = new CachedGroupMapping(groupMappingService);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
           }
         }
       }
       return sCachedGroupMapping;
     }
 
-    /**
-     * Resets the cache for GroupMappingService and CachedGroupMapping.
-     */
-    public static void resetCache() {
-      if (sGroupMappingService != null || sCachedGroupMapping != null) {
-        synchronized (Factory.class) {
-          if (sGroupMappingService != null || sCachedGroupMapping != null) {
-            sGroupMappingService = null;
-            sCachedGroupMapping = null;
-          }
-        }
-      }
-    }
   }
 
   /**

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -86,6 +86,20 @@ public interface GroupMappingService {
       }
       return sCachedGroupMapping;
     }
+
+    /**
+     * Resets the cache for GroupMappingService and CachedGroupMapping.
+     */
+    public static void resetCache() {
+      if (sGroupMappingService != null || sCachedGroupMapping != null) {
+        synchronized (Factory.class) {
+          if (sGroupMappingService != null || sCachedGroupMapping != null) {
+            sGroupMappingService = null;
+            sCachedGroupMapping = null;
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -12,7 +12,7 @@
 package alluxio.util;
 
 import alluxio.Constants;
-import alluxio.security.group.GroupMapping;
+import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 import alluxio.util.ShellUtils.ExitCodeException;
 
@@ -212,16 +212,27 @@ public final class CommonUtils {
   }
 
   /**
-   * Using {@link GroupMappingService} to get the primary group name.
+   * Gets the primary group name of a user.
    *
    * @param userName Alluxio user name
    * @return primary group name
    * @throws IOException if getting group failed
    */
   public static String getPrimaryGroupName(String userName) throws IOException {
-    GroupMapping groupMapping = new GroupMapping();
-    List<String> groups = groupMapping.getGroups(userName);
+    List<String> groups = getGroups(userName);
     return (groups != null && groups.size() > 0) ? groups.get(0) : "";
+  }
+
+  /**
+   * Using {@link CachedGroupMapping} to get the group list of a user.
+   *
+   * @param userName Alluxio user name
+   * @return the group list of the user
+   * @throws IOException if getting group list failed
+   */
+  public static List<String> getGroups(String userName) throws IOException {
+    CachedGroupMapping cachedGroupMapping = GroupMappingService.Factory.getCachedGroupMapping();
+    return cachedGroupMapping.getGroups(userName);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -231,8 +231,8 @@ public final class CommonUtils {
    * @throws IOException if getting group list failed
    */
   public static List<String> getGroups(String userName) throws IOException {
-    CachedGroupMapping cachedGroupMapping = GroupMappingService.Factory.getCachedGroupMapping();
-    return cachedGroupMapping.getGroups(userName);
+    GroupMappingService groupMappingService = GroupMappingService.Factory.get();
+    return groupMappingService.getGroups(userName);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -12,6 +12,7 @@
 package alluxio.util;
 
 import alluxio.Constants;
+import alluxio.security.group.GroupMapping;
 import alluxio.security.group.GroupMappingService;
 import alluxio.util.ShellUtils.ExitCodeException;
 
@@ -218,9 +219,8 @@ public final class CommonUtils {
    * @throws IOException if getting group failed
    */
   public static String getPrimaryGroupName(String userName) throws IOException {
-    GroupMappingService groupMappingService =
-        GroupMappingService.Factory.getUserToGroupsMappingService();
-    List<String> groups = groupMappingService.getGroups(userName);
+    GroupMapping groupMapping = new GroupMapping();
+    List<String> groups = groupMapping.getGroups(userName);
     return (groups != null && groups.size() > 0) ? groups.get(0) : "";
   }
 

--- a/core/common/src/main/resources/alluxio-default.properties
+++ b/core/common/src/main/resources/alluxio-default.properties
@@ -73,6 +73,7 @@ alluxio.security.authorization.permission.umask=022
 alluxio.security.authorization.permission.enabled=false
 alluxio.security.authorization.permission.supergroup=supergroup
 alluxio.security.group.mapping.class=alluxio.security.group.provider.ShellBasedUnixGroupsMapping
+alluxio.security.group.mapping.cache.timeout.ms=60000
 
 # Master properties
 alluxio.master.file.async.persist.handler=alluxio.master.file.async.DefaultAsyncPersistHandler

--- a/core/common/src/test/java/alluxio/security/GroupMappingServiceTestUtils.java
+++ b/core/common/src/test/java/alluxio/security/GroupMappingServiceTestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security;
+
+import alluxio.security.group.CachedGroupMapping;
+import alluxio.security.group.GroupMappingService;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.reflect.Whitebox;
+
+/**
+ * Test utils to reset cache in GroupMappingService.
+ */
+@PrepareForTest(GroupMappingService.Factory.class)
+public final class GroupMappingServiceTestUtils {
+  /**
+   * Resets the cache for GroupMappingService.
+   */
+  public static void resetCache() {
+    Whitebox.setInternalState(GroupMappingService.Factory.class, "sCachedGroupMapping",
+        (CachedGroupMapping) null);
+  }
+}

--- a/core/common/src/test/java/alluxio/security/authorization/PermissionTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/PermissionTest.java
@@ -87,7 +87,8 @@ public final class PermissionTest {
     verifyPermission("", "", (short) 0777, permission);
 
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
     AuthenticatedClientUser.set("test_client_user");
 
     // When authentication is enabled, user and group are inferred from thrift transport
@@ -110,7 +111,8 @@ public final class PermissionTest {
     // When authentication is enabled, user and group are inferred from login module
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "test_login_user");
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
     Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
 
     permission.setOwnerFromLoginModule();

--- a/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
+++ b/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
@@ -31,8 +31,9 @@ public final class GroupMappingServiceTest {
   public void groupTest() throws Throwable {
     String userName = "alluxio-user1";
 
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
-    GroupMappingService groups = GroupMappingService.Factory.getUserToGroupsMappingService();
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
+    GroupMappingService groups = GroupMappingService.Factory.get();
 
     Assert.assertNotNull(groups);
     Assert.assertNotNull(groups.getGroups(userName));

--- a/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
@@ -58,7 +58,8 @@ public final class CreateOptionsTest {
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityUserGroupMapping to map user "foo" to group "foo".
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
 
     CreateOptions options = new CreateOptions();
 

--- a/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
@@ -59,7 +59,8 @@ public final class MkdirsOptionsTest {
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityUserGroupMapping to map user "foo" to group "foo".
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, IdentityUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
 
     MkdirsOptions options = new MkdirsOptions();
 

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.util;
 
+import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 
 import com.google.common.collect.Lists;
@@ -209,23 +210,26 @@ public class CommonUtilsTest {
   }
 
   /**
-   * Test for the {@link CommonUtils#getPrimaryGroupName(String)} method.
+   * Test for the {@link CommonUtils#getGroups(String)} and
+   * {@link CommonUtils#getPrimaryGroupName(String)} method.
    */
   @Test
-  public void userPrimaryGroupTest() throws Throwable {
+  public void getGroupsTest() throws Throwable {
     String userName = "alluxio-user1";
     String userGroup1 = "alluxio-user1-group1";
     String userGroup2 = "alluxio-user1-group2";
     List<String> userGroups = new ArrayList<>();
     userGroups.add(userGroup1);
     userGroups.add(userGroup2);
-    GroupMappingService groupService = PowerMockito.mock(GroupMappingService.class);
-    PowerMockito.when(groupService.getGroups(Mockito.anyString())).thenReturn(
+    CachedGroupMapping cachedGroupService = PowerMockito.mock(CachedGroupMapping.class);
+    PowerMockito.when(cachedGroupService.getGroups(Mockito.anyString())).thenReturn(
         Lists.newArrayList(userGroup1, userGroup2));
     PowerMockito.mockStatic(GroupMappingService.Factory.class);
-    Mockito.when(
-        GroupMappingService.Factory.getUserToGroupsMappingService())
-        .thenReturn(groupService);
+    Mockito.when(GroupMappingService.Factory.getCachedGroupMapping())
+        .thenReturn(cachedGroupService);
+
+    List<String> groups = CommonUtils.getGroups(userName);
+    Assert.assertEquals(Arrays.asList(userGroup1, userGroup2), groups);
 
     String primaryGroup = CommonUtils.getPrimaryGroupName(userName);
     Assert.assertNotNull(primaryGroup);

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -225,8 +225,7 @@ public class CommonUtilsTest {
     PowerMockito.when(cachedGroupService.getGroups(Mockito.anyString())).thenReturn(
         Lists.newArrayList(userGroup1, userGroup2));
     PowerMockito.mockStatic(GroupMappingService.Factory.class);
-    Mockito.when(GroupMappingService.Factory.getCachedGroupMapping())
-        .thenReturn(cachedGroupService);
+    Mockito.when(GroupMappingService.Factory.get()).thenReturn(cachedGroupService);
 
     List<String> groups = CommonUtils.getGroups(userName);
     Assert.assertEquals(Arrays.asList(userGroup1, userGroup2), groups);

--- a/core/server/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -23,7 +23,7 @@ import alluxio.master.file.meta.LockedInodePath;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
-import alluxio.security.group.GroupMapping;
+import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
@@ -47,9 +47,6 @@ public final class PermissionChecker {
   /** The super group of Alluxio file system. All users in this group have super permission. */
   private final String mFileSystemSuperGroup;
 
-  /** This provides user groups mapping service. */
-  private final GroupMapping mGroupMapping;
-
   /**
    * Constructs a {@link PermissionChecker} instance for Alluxio file system.
    *
@@ -61,7 +58,6 @@ public final class PermissionChecker {
         Configuration.getBoolean(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
     mFileSystemSuperGroup =
         Configuration.get(Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP);
-    mGroupMapping = new GroupMapping();
   }
 
   /**
@@ -176,7 +172,7 @@ public final class PermissionChecker {
    */
   private List<String> getGroups(String user) throws AccessControlException {
     try {
-      return mGroupMapping.getGroups(user);
+      return CommonUtils.getGroups(user);
     } catch (IOException e) {
       throw new AccessControlException(
           ExceptionMessage.PERMISSION_DENIED.getMessage(e.getMessage()));

--- a/core/server/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -23,7 +23,7 @@ import alluxio.master.file.meta.LockedInodePath;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
-import alluxio.security.group.GroupMappingService;
+import alluxio.security.group.GroupMapping;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
@@ -48,7 +48,7 @@ public final class PermissionChecker {
   private final String mFileSystemSuperGroup;
 
   /** This provides user groups mapping service. */
-  private final GroupMappingService mGroupMappingService;
+  private final GroupMapping mGroupMapping;
 
   /**
    * Constructs a {@link PermissionChecker} instance for Alluxio file system.
@@ -61,7 +61,7 @@ public final class PermissionChecker {
         Configuration.getBoolean(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
     mFileSystemSuperGroup =
         Configuration.get(Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP);
-    mGroupMappingService = GroupMappingService.Factory.getUserToGroupsMappingService();
+    mGroupMapping = new GroupMapping();
   }
 
   /**
@@ -176,7 +176,7 @@ public final class PermissionChecker {
    */
   private List<String> getGroups(String user) throws AccessControlException {
     try {
-      return mGroupMappingService.getGroups(user);
+      return mGroupMapping.getGroups(user);
     } catch (IOException e) {
       throw new AccessControlException(
           ExceptionMessage.PERMISSION_DENIED.getMessage(e.getMessage()));

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -138,7 +138,8 @@ public final class PermissionCheckTest {
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_LOGIN_USERNAME, "admin");
     // authorization
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, FakeUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        FakeUserGroupsMapping.class.getName());
     Configuration.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     Configuration.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, TEST_SUPER_GROUP);
 

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -167,7 +167,8 @@ public final class PermissionCheckerTest {
 
     blockMaster.start(true);
 
-    Configuration.set(Constants.SECURITY_GROUP_MAPPING, FakeUserGroupsMapping.class.getName());
+    Configuration.set(Constants.SECURITY_GROUP_MAPPING_CLASS,
+        FakeUserGroupsMapping.class.getName());
     Configuration.set(Constants.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     Configuration.set(Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, TEST_SUPER_GROUP);

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -21,6 +21,7 @@ import alluxio.exception.ConnectionFailedException;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterPrivateAccess;
 import alluxio.security.LoginUser;
+import alluxio.security.group.GroupMappingService;
 import alluxio.underfs.LocalFileSystemCluster;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.util.CommonUtils;
@@ -423,6 +424,7 @@ public abstract class AbstractLocalAlluxioCluster {
    */
   protected void reset() {
     ClientTestUtils.resetClient();
+    GroupMappingService.Factory.resetCache();
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -20,8 +20,8 @@ import alluxio.client.util.ClientTestUtils;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterPrivateAccess;
+import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.security.LoginUser;
-import alluxio.security.group.GroupMappingService;
 import alluxio.underfs.LocalFileSystemCluster;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.util.CommonUtils;
@@ -424,7 +424,7 @@ public abstract class AbstractLocalAlluxioCluster {
    */
   protected void reset() {
     ClientTestUtils.resetClient();
-    GroupMappingService.Factory.resetCache();
+    GroupMappingServiceTestUtils.resetCache();
   }
 
   /**

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -547,7 +547,7 @@ public class JournalIntegrationTest {
   @LocalAlluxioClusterResource.Config(confParams = {
       Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
       Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-      Constants.SECURITY_GROUP_MAPPING, FakeUserGroupsMapping.FULL_CLASS_NAME})
+      Constants.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.FULL_CLASS_NAME})
   public void setAclTest() throws Exception {
     AlluxioURI filePath = new AlluxioURI("/file");
 

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -103,7 +103,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   @Test
   @LocalAlluxioClusterResource.Config(
       confParams = {Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING,
+          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING_CLASS,
           "alluxio.security.group.provider.IdentityUserGroupsMapping",
           Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls"})
   public void lsTest() throws IOException, AlluxioException {
@@ -159,7 +159,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   @Test
   @LocalAlluxioClusterResource.Config(
       confParams = {Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING,
+          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING_CLASS,
           "alluxio.security.group.provider.IdentityUserGroupsMapping",
           Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_lsWildcard"})
   public void lsWildcardTest() throws IOException, AlluxioException {
@@ -209,7 +209,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   @Test
   @LocalAlluxioClusterResource.Config(
       confParams = {Constants.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING,
+          Constants.SECURITY_AUTHENTICATION_TYPE, "SIMPLE", Constants.SECURITY_GROUP_MAPPING_CLASS,
           "alluxio.security.group.provider.IdentityUserGroupsMapping",
           Constants.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_lsr"})
   public void lsrTest() throws IOException, AlluxioException {


### PR DESCRIPTION
This PR implements the 1) solution in https://alluxio.atlassian.net/browse/ALLUXIO-2117

Implement a cache for user to groups mapping, which is refreshed every time interval (by default 1 min). Once the system admin updates user to groups mapping, it needs 1 min to propagate to take effect in Alluxio namespace.