### PR TITLE
[ALLUXIO-2119] Remove use of whitebox in BaseFileSystem

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -55,14 +55,14 @@ public class BaseFileSystem implements FileSystem {
   private final FileSystemContext mContext;
 
   /**
-   * @return the {@link BaseFileSystem}
+   * @return a {@link BaseFileSystem}
    */
   public static BaseFileSystem get() {
-    return new BaseFileSystem();
+    return new BaseFileSystem(FileSystemContext.INSTANCE);
   }
 
-  protected BaseFileSystem() {
-    mContext = FileSystemContext.INSTANCE;
+  protected BaseFileSystem(FileSystemContext context) {
+    mContext = context;
   }
 
   @Override

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.annotation.PublicApi;
 import alluxio.client.file.BaseFileSystem;
 import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.CreateFileOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
@@ -41,7 +42,7 @@ public class LineageFileSystem extends BaseFileSystem {
   }
 
   protected LineageFileSystem() {
-    super();
+    super(FileSystemContext.INSTANCE);
     mLineageContext = LineageContext.INSTANCE;
   }
 

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
@@ -38,12 +38,12 @@ public class LineageFileSystem extends BaseFileSystem {
    * @return the current lineage file system for Alluxio
    */
   public static synchronized LineageFileSystem get() {
-    return new LineageFileSystem();
+    return new LineageFileSystem(FileSystemContext.INSTANCE, LineageContext.INSTANCE);
   }
 
-  protected LineageFileSystem() {
-    super(FileSystemContext.INSTANCE);
-    mLineageContext = LineageContext.INSTANCE;
+  protected LineageFileSystem(FileSystemContext fileSystemContext, LineageContext lineageContext) {
+    super(fileSystemContext);
+    mLineageContext = lineageContext;
   }
 
   /**

--- a/core/client/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -36,7 +36,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +56,9 @@ public final class BaseFileSystemTest {
   private FileSystemMasterClient mFileSystemMasterClient;
 
   private class DummyAlluxioFileSystem extends BaseFileSystem {
+    public DummyAlluxioFileSystem(FileSystemContext context) {
+      super(context);
+    }
   }
 
   /**
@@ -64,9 +66,8 @@ public final class BaseFileSystemTest {
    */
   @Before
   public void before() {
-    mFileSystem = new DummyAlluxioFileSystem();
     mFileContext = PowerMockito.mock(FileSystemContext.class);
-    Whitebox.setInternalState(mFileSystem, "mContext", mFileContext);
+    mFileSystem = new DummyAlluxioFileSystem(mFileContext);
     mFileSystemMasterClient = PowerMockito.mock(FileSystemMasterClient.class);
     Mockito.when(mFileContext.acquireMasterClient()).thenReturn(mFileSystemMasterClient);
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2119

Using dependency injection to make dependencies explicit instead of using whitebox.