### PR TITLE
[SMALLFIX] Run tests in a deterministic order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,8 @@
           <configuration>
             <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M</argLine>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
+            <!-- Alphabetical order on even hours, reverse-alphabetical on odd hours  -->
+            <runOrder>hourly</runOrder>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
         </plugin>


### PR DESCRIPTION
This makes it much easier to reproduce issues caused by interference between tests.