### PR TITLE
[ALLUXIO-2119] Remove use of whitebox in TtlBucketListTest

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/Inode.java
@@ -161,6 +161,15 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
   }
 
   /**
+   * @param creationTimeMs the creation time to use (in milliseconds)
+   * @return the updated object
+   */
+  public T setCreationTimeMs(long creationTimeMs) {
+    mCreationTimeMs = creationTimeMs;
+    return getThis();
+  }
+
+  /**
    * @param deleted the deleted flag to use
    * @return the updated object
    */

--- a/core/server/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/Inode.java
@@ -46,10 +46,10 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
 
   private final ReentrantReadWriteLock mLock;
 
-  protected Inode(long id) {
+  protected Inode(long id, boolean isDirectory) {
     mCreationTimeMs = System.currentTimeMillis();
     mDeleted = false;
-    mDirectory = false;
+    mDirectory = isDirectory;
     mGroup = "";
     mId = id;
     mLastModificationTimeMs = mCreationTimeMs;

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -54,7 +54,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @param id the id to use
    */
   private InodeDirectory(long id) {
-    super(id);
+    super(id, true);
     mDirectory = true;
     mMountPoint = false;
   }

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -55,14 +55,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   private InodeDirectory(long id) {
     super(id, true);
-    mDirectory = true;
     mMountPoint = false;
-  }
-
-  private InodeDirectory(long id, long creationTimeMs) {
-    this(id);
-    mCreationTimeMs = creationTimeMs;
-
     mDirectChildrenLoaded = false;
   }
 
@@ -210,7 +203,8 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
   public static InodeDirectory fromJournalEntry(InodeDirectoryEntry entry) {
     Permission permission =
         new Permission(entry.getOwner(), entry.getGroup(), (short) entry.getMode());
-    return new InodeDirectory(entry.getId(), entry.getCreationTimeMs())
+    return new InodeDirectory(entry.getId())
+        .setCreationTimeMs(entry.getCreationTimeMs())
         .setName(entry.getName())
         .setParentId(entry.getParentId())
         .setPersistenceState(PersistenceState.valueOf(entry.getPersistenceState()))

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -41,7 +41,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     }
   };
 
-  /** use UniqueFieldIndex directly for name index rather than using IndexedSet */
+  /** Use UniqueFieldIndex directly for name index rather than using IndexedSet. */
   private FieldIndex<Inode<?>> mChildren = new UniqueFieldIndex<Inode<?>>(NAME_INDEX);
 
   private boolean mMountPoint;

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -41,7 +41,6 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     }
   };
 
-  @SuppressWarnings("unchecked")
   /** use UniqueFieldIndex directly for name index rather than using IndexedSet */
   private FieldIndex<Inode<?>> mChildren = new UniqueFieldIndex<Inode<?>>(NAME_INDEX);
 

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -296,8 +296,8 @@ public final class InodeFile extends Inode<InodeFile> {
    * @param fileOptions options to create this file
    * @return the {@link InodeFile} representation
    */
-  public static InodeFile create(long blockContainerId, long parentId, String name, long creationTimeMs,
-      CreateFileOptions fileOptions) {
+  public static InodeFile create(long blockContainerId, long parentId, String name,
+      long creationTimeMs, CreateFileOptions fileOptions) {
     Permission permission = new Permission(fileOptions.getPermission()).applyFileUMask();
     return new InodeFile(blockContainerId)
         .setBlockSizeBytes(fileOptions.getBlockSizeBytes())

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -283,6 +283,7 @@ public final class InodeFile extends Inode<InodeFile> {
         .setBlockSizeBytes(entry.getBlockSizeBytes())
         .setCacheable(entry.getCacheable())
         .setCompleted(entry.getCompleted())
+        .setCreationTimeMs(entry.getCreationTimeMs())
         .setLastModificationTimeMs(entry.getLastModificationTimeMs())
         .setLength(entry.getLength())
         .setParentId(entry.getParentId())
@@ -298,15 +299,17 @@ public final class InodeFile extends Inode<InodeFile> {
    * @param id id of this inode
    * @param parentId id of the parent of this inode
    * @param name name of this inode
+   * @param creationTimeMs the creation time for this inode
    * @param fileOptions options to create this file
    * @return the {@link InodeFile} representation
    */
-  public static InodeFile create(long id, long parentId, String name,
+  public static InodeFile create(long id, long parentId, String name, long creationTimeMs,
       CreateFileOptions fileOptions) {
     Permission permission = new Permission(fileOptions.getPermission()).applyFileUMask();
     return new InodeFile(id)
         .setParentId(parentId)
         .setName(name)
+        .setCreationTimeMs(creationTimeMs)
         .setBlockSizeBytes(fileOptions.getBlockSizeBytes())
         .setTtl(fileOptions.getTtl())
         .setPersistenceState(fileOptions.isPersisted() ? PersistenceState.PERSISTED :
@@ -328,6 +331,7 @@ public final class InodeFile extends Inode<InodeFile> {
         .setLength(getLength())
         .setCompleted(isCompleted())
         .setCacheable(isCacheable())
+        .setCreationTimeMs(getCreationTimeMs())
         .addAllBlocks(getBlockIds())
         .setTtl(getTtl())
         .setOwner(getOwner())

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -609,7 +609,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
       if (options instanceof CreateFileOptions) {
         CreateFileOptions fileOptions = (CreateFileOptions) options;
         lastInode = InodeFile.create(mContainerIdGenerator.getNewContainerId(),
-            currentInodeDirectory.getId(), name, fileOptions);
+            currentInodeDirectory.getId(), name, System.currentTimeMillis(), fileOptions);
         // Lock the created inode before subsequent operations, and add it to the lock group.
         lockList.lockWrite(lastInode);
         if (currentInodeDirectory.isPinned()) {

--- a/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractInodeTest {
   }
 
   protected InodeFile createInodeFile(long id) {
-    return InodeFile.create(id, 1, "testFile" + id,
+    return InodeFile.create(id, 1, "testFile" + id, 0,
         CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB)
             .setPermission(TEST_PERMISSION));
   }

--- a/core/server/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
@@ -17,10 +17,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,26 +33,16 @@ public class TtlBucketListTest {
   private static final long BUCKET2_START = BUCKET1_END;
   private static final long BUCKET2_END =  BUCKET2_START + BUCKET_INTERVAL;
   private static final InodeFile BUCKET1_FILE1 =
-      InodeFile.create(0, 0, "ignored", CreateFileOptions.defaults().setTtl(BUCKET1_START));
+      InodeFile.create(0, 0, "ignored", 0, CreateFileOptions.defaults().setTtl(BUCKET1_START));
   private static final InodeFile BUCKET1_FILE2 =
-      InodeFile.create(1, 0, "ignored", CreateFileOptions.defaults().setTtl(BUCKET1_END - 1));
+      InodeFile.create(1, 0, "ignored", 0, CreateFileOptions.defaults().setTtl(BUCKET1_END - 1));
   private static final InodeFile BUCKET2_FILE =
-      InodeFile.create(2, 0, "ignored", CreateFileOptions.defaults().setTtl(BUCKET2_START));
+      InodeFile.create(2, 0, "ignored", 0, CreateFileOptions.defaults().setTtl(BUCKET2_START));
 
   private TtlBucketList mBucketList;
 
   @ClassRule
   public static TtlIntervalRule sTtlIntervalRule = new TtlIntervalRule(BUCKET_INTERVAL);
-
-  /**
-   * Sets up the TTL interval before a single test runs.
-   */
-  @BeforeClass
-  public static void beforeClass() {
-    Whitebox.setInternalState(BUCKET1_FILE1, "mCreationTimeMs", 0);
-    Whitebox.setInternalState(BUCKET1_FILE2, "mCreationTimeMs", 0);
-    Whitebox.setInternalState(BUCKET2_FILE, "mCreationTimeMs", 0);
-  }
 
   /**
    * Sets up a new {@link TtlBucketList} before a test runs.

--- a/core/server/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -74,8 +74,8 @@ public class TtlBucketTest {
    */
   @Test
   public void addAndRemoveFileTest() {
-    InodeFile mFileTtl1 = InodeFile.create(0, 0, "test1", CreateFileOptions.defaults().setTtl(1));
-    InodeFile mFileTtl2 = InodeFile.create(1, 0, "test1", CreateFileOptions.defaults().setTtl(2));
+    InodeFile mFileTtl1 = InodeFile.create(0, 0, "test1", 0, CreateFileOptions.defaults().setTtl(1));
+    InodeFile mFileTtl2 = InodeFile.create(1, 0, "test1", 0, CreateFileOptions.defaults().setTtl(2));
     Assert.assertTrue(mBucket.getFiles().isEmpty());
 
     mBucket.addFile(mFileTtl1);

--- a/core/server/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -74,8 +74,10 @@ public class TtlBucketTest {
    */
   @Test
   public void addAndRemoveFileTest() {
-    InodeFile mFileTtl1 = InodeFile.create(0, 0, "test1", 0, CreateFileOptions.defaults().setTtl(1));
-    InodeFile mFileTtl2 = InodeFile.create(1, 0, "test1", 0, CreateFileOptions.defaults().setTtl(2));
+    InodeFile mFileTtl1 =
+        InodeFile.create(0, 0, "test1", 0, CreateFileOptions.defaults().setTtl(1));
+    InodeFile mFileTtl2 =
+        InodeFile.create(1, 0, "test1", 0, CreateFileOptions.defaults().setTtl(2));
     Assert.assertTrue(mBucket.getFiles().isEmpty());
 
     mBucket.addFile(mFileTtl1);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2119

@gpang was it intentional that we don't restore `creationTimeMs` from the journal? Do you think it would make sense to journal Inode's `lastModificationTime`?