### PR TITLE
[ALLUXIO-2119] Heartbeat context test cleanup

### DIFF
--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -11,6 +11,7 @@
 
 package alluxio.heartbeat;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,6 +55,13 @@ public final class HeartbeatContext {
   }
 
   private HeartbeatContext() {} // to prevent initialization
+
+  /**
+   * @return the mapping from executor thread names to timer classes
+   */
+  public static synchronized Map<String, Class<? extends HeartbeatTimer>> getTimerClasses() {
+    return Collections.unmodifiableMap(sTimerClasses);
+  }
 
   /**
    * @param name a name of a heartbeat executor thread

--- a/core/common/src/test/java/alluxio/heartbeat/HeartbeatContextTest.java
+++ b/core/common/src/test/java/alluxio/heartbeat/HeartbeatContextTest.java
@@ -11,89 +11,29 @@
 
 package alluxio.heartbeat;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Unit tests for {@link HeartbeatContext}.
  */
 public class HeartbeatContextTest {
-
-  /**
-   * Tests the timer classes to be not null.
-   */
   @Test
-  public void timerClassesCheckTest() {
-    checkNotNull(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING);
-    checkNotNull(HeartbeatContext.MASTER_FILE_RECOMPUTATION);
-    checkNotNull(HeartbeatContext.MASTER_LOST_WORKER_DETECTION);
-    checkNotNull(HeartbeatContext.MASTER_TTL_CHECK);
-    checkNotNull(HeartbeatContext.WORKER_BLOCK_SYNC);
-    checkNotNull(HeartbeatContext.WORKER_CLIENT);
-    checkNotNull(HeartbeatContext.WORKER_FILESYSTEM_MASTER_SYNC);
-    checkNotNull(HeartbeatContext.WORKER_PIN_LIST_SYNC);
-  }
-
-  /**
-   * Tests that the instances of the context are correctly.
-   */
-  @Test
-  public void checkInstanceOfTest() {
-    checkInstanceOf(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING,
-        HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.MASTER_FILE_RECOMPUTATION,
-        HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.MASTER_LOST_WORKER_DETECTION,
-        HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.MASTER_TTL_CHECK, HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.WORKER_BLOCK_SYNC, HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.WORKER_CLIENT, HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.WORKER_FILESYSTEM_MASTER_SYNC,
-        HeartbeatContext.SLEEPING_TIMER_CLASS);
-    checkInstanceOf(HeartbeatContext.WORKER_PIN_LIST_SYNC, HeartbeatContext.SLEEPING_TIMER_CLASS);
-  }
-
-  /**
-   * Tests that a new timer class can be added correctly.
-   */
-  @Test
-  public void addNewTimerClassesTest() throws Exception {
-    String testSleeping = "TEST_SLEEPING_%s";
-    String testScheduled = "TEST_SCHEDULED_%s";
-
-    Map<Class<? extends HeartbeatTimer>, List<String>> timerMap = new HashMap<>();
-    timerMap.put(HeartbeatContext.SLEEPING_TIMER_CLASS,
-        Arrays.asList(String.format(testSleeping, "1"), String.format(testSleeping, "2")));
-    timerMap.put(HeartbeatContext.SCHEDULED_TIMER_CLASS,
-        Arrays.asList(String.format(testScheduled, "2"), String.format(testScheduled, "1"),
-            String.format(testScheduled, "3")));
-
-    for (Class<? extends HeartbeatTimer> timerClass : timerMap.keySet()) {
-      for (String name : timerMap.get(timerClass)) {
-        Whitebox.invokeMethod(HeartbeatContext.class, "setTimerClass", name, timerClass);
-        checkInstanceOf(name, timerClass);
-      }
+  public void allThreadsUseSleepingTimer() {
+    for (String threadName : HeartbeatContext.getTimerClasses().keySet()) {
+      Class<? extends HeartbeatTimer> timerClass = HeartbeatContext.getTimerClass(threadName);
+      Assert.assertTrue(timerClass.isAssignableFrom(SleepingTimer.class));
     }
-
-    // check that the standard classes are still in place
-    timerClassesCheckTest();
-    checkInstanceOfTest();
   }
 
-  private void checkNotNull(String name) {
-    Assert.assertNotNull(String.format("%s must be valued", name),
-        HeartbeatContext.getTimerClass(name));
-  }
-
-  private void checkInstanceOf(String name, Class<? extends HeartbeatTimer> timerClass) {
-    Assert.assertTrue(
-        String.format("%s must be an instance of %s", name, timerClass.getCanonicalName()),
-        HeartbeatContext.getTimerClass(name).isAssignableFrom(timerClass));
+  @Test
+  public void canUpdateToScheduledTimer() throws Exception {
+    try (ManuallyScheduleHeartbeat.Resource h = new ManuallyScheduleHeartbeat.Resource(
+        ImmutableList.of(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING))) {
+      Class<? extends HeartbeatTimer> timerClass =
+          HeartbeatContext.getTimerClass(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING);
+      Assert.assertTrue(timerClass.isAssignableFrom(ScheduledTimer.class));
+    }
   }
 }

--- a/core/common/src/test/java/alluxio/heartbeat/HeartbeatContextTest.java
+++ b/core/common/src/test/java/alluxio/heartbeat/HeartbeatContextTest.java
@@ -28,12 +28,13 @@ public class HeartbeatContextTest {
   }
 
   @Test
-  public void canUpdateToScheduledTimer() throws Exception {
-    try (ManuallyScheduleHeartbeat.Resource h = new ManuallyScheduleHeartbeat.Resource(
-        ImmutableList.of(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING))) {
-      Class<? extends HeartbeatTimer> timerClass =
-          HeartbeatContext.getTimerClass(HeartbeatContext.MASTER_CHECKPOINT_SCHEDULING);
-      Assert.assertTrue(timerClass.isAssignableFrom(ScheduledTimer.class));
+  public void canTemporarilySwitchToScheduledTimer() throws Exception {
+    try (ManuallyScheduleHeartbeat.Resource h =
+        new ManuallyScheduleHeartbeat.Resource(ImmutableList.of(HeartbeatContext.WORKER_CLIENT))) {
+      Assert.assertTrue(HeartbeatContext.getTimerClass(HeartbeatContext.WORKER_CLIENT)
+          .isAssignableFrom(ScheduledTimer.class));
     }
+    Assert.assertTrue(HeartbeatContext.getTimerClass(HeartbeatContext.WORKER_CLIENT)
+        .isAssignableFrom(SleepingTimer.class));
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2119

1. Checking that constants are not null is a waste of space.
2. `checkInstanceOfTest` is generalized to check that all heartbeat threads use `SleepingTimer` by default.
3. `addNewTimerClassesTest` is changed to use `ManuallyScheduleHeartbeat` to test a more realistic scenario.