### PR TITLE
[ALLUXIO-2119] Avoid use of whitebox in FileDataManagerTest

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -31,6 +31,7 @@ import alluxio.worker.SessionCleanupCallback;
 import alluxio.worker.block.BlockWorker;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.RateLimiter;
 import org.apache.thrift.TProcessor;
 
 import java.io.IOException;
@@ -77,7 +78,8 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
 
     mSessions = new Sessions();
     UnderFileSystem ufs = UnderFileSystem.get(Configuration.get(Constants.UNDERFS_ADDRESS));
-    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), ufs);
+    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), ufs,
+        RateLimiter.create(Configuration.getBytes(Constants.WORKER_FILE_PERSIST_RATE_LIMIT)));
     mUnderFileSystemManager = new UnderFileSystemManager();
 
     // Setup AbstractMasterClient

--- a/core/server/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -21,6 +21,7 @@ import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.security.authorization.Permission;
 import alluxio.thrift.FileSystemWorkerClientService;
+import alluxio.underfs.UnderFileSystem;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
@@ -75,7 +76,8 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
         ThreadFactoryUtils.build("file-system-worker-heartbeat-%d", true)));
 
     mSessions = new Sessions();
-    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker));
+    UnderFileSystem ufs = UnderFileSystem.get(Configuration.get(Constants.UNDERFS_ADDRESS));
+    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), ufs);
     mUnderFileSystemManager = new UnderFileSystemManager();
 
     // Setup AbstractMasterClient

--- a/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -73,7 +73,7 @@ public final class FileDataManager {
   private final Object mLock = new Object();
 
   /** A per worker rate limiter to throttle async persistence. */
-  private RateLimiter mPersistenceRateLimiter;
+  private final RateLimiter mPersistenceRateLimiter;
 
   /**
    * Creates a new instance of {@link FileDataManager}.

--- a/core/server/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -101,7 +101,7 @@ public final class FileDataManagerTest {
    */
   @Test
   public void clearPersistedFilesTest() throws Exception {
-    writeFileWithBlocks(1L, ImmutableList.of(1L, 2L));
+    writeFileWithBlocks(1L, ImmutableList.of(2L, 3L));
     mManager.clearPersistedFiles(ImmutableList.of(1L));
     Assert.assertEquals(Collections.emptyList(), mManager.getPersistedFiles());
   }

--- a/core/server/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -113,8 +113,6 @@ public final class FileDataManagerTest {
   public void persistFileRateLimitingTest() throws Exception {
     Configuration.set(Constants.WORKER_FILE_PERSIST_RATE_LIMIT_ENABLED, "true");
     Configuration.set(Constants.WORKER_FILE_PERSIST_RATE_LIMIT, "100");
-    mUfs = Mockito.mock(UnderFileSystem.class);
-    mBlockWorker = Mockito.mock(BlockWorker.class);
     mMockRateLimiter =
         new MockRateLimiter(Configuration.getBytes(Constants.WORKER_FILE_PERSIST_RATE_LIMIT));
     mManager = new FileDataManager(mBlockWorker, mUfs, mMockRateLimiter.getGuavaRateLimiter());


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2119

1. Inject `UnderFileSystem` and `RateLimiter` into `FileDataManagerTest` instead of modifying them via Whitebox. 
2. Changes the implementation of `clearPersistFilesTest` to work without Whitebox
3. Move the construction of the mocks and `FileDataManger` to `@Before` since this is shared between almost every test