### PR TITLE
[ALLUXIO-2173] Load metadata for non-persisted directory 

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1934,7 +1934,6 @@ public final class FileSystemMaster extends AbstractMaster {
    * @param inodePath the {@link LockedInodePath} to load the metadata for
    * @param options the load metadata options
    */
-  // TODO(peis): Add a unit test for this function.
   private long loadMetadataIfNotExistAndJournal(LockedInodePath inodePath,
       LoadMetadataOptions options) {
     boolean inodeExists = inodePath.fullPathExists();

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -743,8 +743,8 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * Creates a file (not a directory) for a given path.
-   * <p>
+   * Creates a file (not actory) for a given path.
+   * <p> dire
    * Writes to the journal.
    *
    * @param inodePath the file to create
@@ -1804,15 +1804,9 @@ public final class FileSystemMaster extends AbstractMaster {
     UnderFileSystem ufs = resolution.getUfs();
     try {
       if (!ufs.exists(ufsUri.toString())) {
-        // The root is special as it is considered as PERSISTED by default.
-        // We try to load root once. If it doesn't exist, do not try it again.
-        if (path.isRoot()) {
-          InodeDirectory inode = (InodeDirectory) inodePath.getInode();
-          inode.setDirectChildrenLoaded(true);
-          return AsyncJournalWriter.INVALID_FLUSH_COUNTER;
-        }
-        throw new FileDoesNotExistException(
-            ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path.getPath()));
+        InodeDirectory inode = (InodeDirectory) inodePath.getInode();
+        inode.setDirectChildrenLoaded(true);
+        return AsyncJournalWriter.INVALID_FLUSH_COUNTER;
       }
       if (ufs.isFile(ufsUri.toString())) {
         return loadFileMetadataAndJournal(inodePath, resolution, options);
@@ -1935,8 +1929,7 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * Loads metadata for the path if it is (non-existing || (persisted && load direct children is
-   * set).
+   * Loads metadata for the path if it is (non-existing || load direct children is set).
    *
    * @param inodePath the {@link LockedInodePath} to load the metadata for
    * @param options the load metadata options
@@ -1949,8 +1942,7 @@ public final class FileSystemMaster extends AbstractMaster {
     if (inodeExists) {
       try {
         Inode<?> inode = inodePath.getInode();
-        loadDirectChildren =
-            inode.isDirectory() && inode.isPersisted() && options.isLoadDirectChildren();
+        loadDirectChildren = inode.isDirectory() && options.isLoadDirectChildren();
       } catch (FileDoesNotExistException e) {
         // This should never happen.
         throw new RuntimeException(e);

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -743,8 +743,8 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * Creates a file (not actory) for a given path.
-   * <p> dire
+   * Creates a file (not a directory) for a given path.
+   * <p>
    * Writes to the journal.
    *
    * @param inodePath the file to create

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -519,7 +519,8 @@ public final class FileSystemMasterTest {
     Assert.assertFalse(
         mFileSystemMaster.getFileInfo(new AlluxioURI("/mnt/local/folder")).isPersisted());
 
-    List<FileInfo> fileInfoList = mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
+    List<FileInfo> fileInfoList =
+        mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
     Assert.assertEquals(2, fileInfoList.size());
     // listStatus should have loaded files (folder, folder/file1, folder/file2), so now 6 paths
     // exist.

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -507,25 +507,34 @@ public final class FileSystemMasterTest {
     AlluxioURI folder = new AlluxioURI("/mnt/local/folder");
     mFileSystemMaster.createDirectory(folder, CreateDirectoryOptions.defaults());
 
+    Assert.assertFalse(
+        mFileSystemMaster.getFileInfo(new AlluxioURI("/mnt/local/folder")).isPersisted());
+
     // Create files in ufs.
     Files.createDirectory(Paths.get(ufsMount.join("folder").getPath()));
     Files.createFile(Paths.get(ufsMount.join("folder").join("file1").getPath()));
     Files.createFile(Paths.get(ufsMount.join("folder").join("file2").getPath()));
 
-    List<FileInfo> fileInfoList =
-        mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
+    // getStatus won't mark folder as persisted.
+    Assert.assertFalse(
+        mFileSystemMaster.getFileInfo(new AlluxioURI("/mnt/local/folder")).isPersisted());
+
+    List<FileInfo> fileInfoList = mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
     Assert.assertEquals(2, fileInfoList.size());
     // listStatus should have loaded files (folder, folder/file1, folder/file2), so now 6 paths
     // exist.
     Assert.assertEquals(6, mFileSystemMaster.getNumberOfPaths());
 
     Set<String> paths = new HashSet<>();
-    for (FileInfo fileInfo : fileInfoList) {
-      paths.add(fileInfo.getPath());
+    for (FileInfo f : fileInfoList) {
+      paths.add(f.getPath());
     }
     Assert.assertEquals(2, paths.size());
     Assert.assertTrue(paths.contains("/mnt/local/folder/file1"));
     Assert.assertTrue(paths.contains("/mnt/local/folder/file2"));
+
+    Assert.assertTrue(
+        mFileSystemMaster.getFileInfo(new AlluxioURI("/mnt/local/folder")).isPersisted());
   }
 
   @Test

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -491,7 +491,6 @@ public final class FileSystemMasterTest {
 
   /**
    * Tests listing status on a non-persisted directory.
-   * @throws Exception
    */
   @Test
   public void listStatusWithLoadMetadataNonPersistedDirTest() throws Exception {
@@ -516,7 +515,8 @@ public final class FileSystemMasterTest {
     List<FileInfo> fileInfoList =
         mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
     Assert.assertEquals(2, fileInfoList.size());
-    // listStatus should have loaded files (folder, folder/file1, folder/file2), so now 6 paths exist.
+    // listStatus should have loaded files (folder, folder/file1, folder/file2), so now 6 paths
+    // exist.
     Assert.assertEquals(6, mFileSystemMaster.getNumberOfPaths());
 
     Set<String> paths = new HashSet<>();

--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -489,6 +489,45 @@ public final class FileSystemMasterTest {
     Assert.assertEquals(6, mFileSystemMaster.getNumberOfPaths());
   }
 
+  /**
+   * Tests listing status on a non-persisted directory.
+   * @throws Exception
+   */
+  @Test
+  public void listStatusWithLoadMetadataNonPersistedDirTest() throws Exception {
+    AlluxioURI ufsMount = new AlluxioURI(mTestFolder.newFolder().getAbsolutePath());
+    mFileSystemMaster.createDirectory(new AlluxioURI("/mnt/"), CreateDirectoryOptions.defaults());
+
+    // Create ufs file
+    mFileSystemMaster.mount(new AlluxioURI("/mnt/local"), ufsMount, MountOptions.defaults());
+
+    // 3 directories exist.
+    Assert.assertEquals(3, mFileSystemMaster.getNumberOfPaths());
+
+    // Create a drectory in alluxio which is not persisted.
+    AlluxioURI folder = new AlluxioURI("/mnt/local/folder");
+    mFileSystemMaster.createDirectory(folder, CreateDirectoryOptions.defaults());
+
+    // Create files in ufs.
+    Files.createDirectory(Paths.get(ufsMount.join("folder").getPath()));
+    Files.createFile(Paths.get(ufsMount.join("folder").join("file1").getPath()));
+    Files.createFile(Paths.get(ufsMount.join("folder").join("file2").getPath()));
+
+    List<FileInfo> fileInfoList =
+        mFileSystemMaster.listStatus(folder, ListStatusOptions.defaults());
+    Assert.assertEquals(2, fileInfoList.size());
+    // listStatus should have loaded files (folder, folder/file1, folder/file2), so now 6 paths exist.
+    Assert.assertEquals(6, mFileSystemMaster.getNumberOfPaths());
+
+    Set<String> paths = new HashSet<>();
+    for (FileInfo fileInfo : fileInfoList) {
+      paths.add(fileInfo.getPath());
+    }
+    Assert.assertEquals(2, paths.size());
+    Assert.assertTrue(paths.contains("/mnt/local/folder/file1"));
+    Assert.assertTrue(paths.contains("/mnt/local/folder/file2"));
+  }
+
   @Test
   public void listStatusTest() throws Exception {
     final int files = 10;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2173

We added the logic to skip loading metadata for non-persisted directory because Alluxio loads metadata for directories that is not present in ufs everytime. Too many exceptions were thrown. 

But this can be problematic if the user creates a directory in Alluxio first and then creates files in that directory in ufs. "alluxio fs ls -f" won't be able to load metadata for that directory because it is non-persisted.  (see the unittest for an example).
