### PR TITLE
[ALLUXIO-1826] Remove error message constants in FileInStream

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -67,12 +67,6 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
   protected final FileSystemContext mContext;
   /** File information. */
   protected URIStatus mStatus;
-  /** Constant error message for block ID not cached. */
-  protected static final String BLOCK_ID_NOT_CACHED =
-      "The block with ID {} could not be cached into Alluxio storage.";
-  /** Error message for cache collision. */
-  private static final String BLOCK_ID_EXISTS_SO_NOT_CACHED =
-      "The block with ID {} is already stored in the target worker, canceling the cache request.";
 
   /** If the stream is closed, this can only go from false to true. */
   protected boolean mClosed;
@@ -390,9 +384,12 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       // This can happen if there are two readers trying to cache the same block. The first one
       // created the block (either as temp block or committed block). The second sees this
       // exception.
-      LOG.info(BLOCK_ID_EXISTS_SO_NOT_CACHED, getCurrentBlockId());
+      LOG.info(
+              "The block with ID {} is already stored in the target worker, canceling the cache "
+                      +  "request.", getCurrentBlockId());
     } else {
-      LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId());
+      LOG.warn("The block with ID {} could not be cached into Alluxio storage.",
+              getCurrentBlockId());
     }
     closeOrCancelCacheStream();
   }
@@ -474,7 +471,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     } catch (IOException e) {
       handleCacheStreamIOException(e);
     } catch (AlluxioException e) {
-      LOG.warn(BLOCK_ID_NOT_CACHED, blockId, e);
+      LOG.warn("The block with ID {} could not be cached into Alluxio storage.", blockId, e);
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -385,11 +385,11 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       // created the block (either as temp block or committed block). The second sees this
       // exception.
       LOG.info(
-              "The block with ID {} is already stored in the target worker, canceling the cache "
-                      +  "request.", getCurrentBlockId());
+          "The block with ID {} is already stored in the target worker, canceling the cache "
+              + "request.", getCurrentBlockId());
     } else {
       LOG.warn("The block with ID {} could not be cached into Alluxio storage.",
-              getCurrentBlockId());
+          getCurrentBlockId());
     }
     closeOrCancelCacheStream();
   }


### PR DESCRIPTION
Instead of having constants for log messages (BLOCK_ID_NOT_CACHED, BLOCK_ID_EXISTS_SO_NOT_CACHED) in the class, we can inline the String where it appears to be consistent with the rest of the codebase.

https://alluxio.atlassian.net/browse/ALLUXIO-1826