### PR TITLE
 [SMALLFIX] remove util.Properties in Configuration codebase

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
@@ -19,8 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -60,7 +60,7 @@ public final class ConfUtils {
   public static void mergeHadoopConfiguration(org.apache.hadoop.conf.Configuration source) {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system
     // Push Alluxio configuration to the Job configuration
-    Properties alluxioConfProperties = new Properties();
+    HashMap<String, String> alluxioConfProperties = new HashMap<String, String>();
     // Load any Alluxio configuration parameters existing in the Hadoop configuration.
     for (Map.Entry<String, String> entry : source) {
       String propertyName = entry.getKey();

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -100,16 +100,13 @@ public final class Configuration {
    */
   private static void init(String sitePropertiesFile, boolean includeSystemProperties) {
     // Load default
-    Properties defaultProps = ConfigurationUtils.loadPropertiesFromResource(DEFAULT_PROPERTIES);
-    if (defaultProps == null) {
-      throw new RuntimeException(
-          ExceptionMessage.DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST.getMessage());
-    }
+    ConfigurationUtils.loadPropertiesFromResource(DEFAULT_PROPERTIES, PROPERTIES);
+
     // Override runtime default
-    defaultProps.setProperty(Constants.MASTER_HOSTNAME, NetworkAddressUtils.getLocalHostName(250));
-    defaultProps.setProperty(Constants.WORKER_NETWORK_NETTY_CHANNEL,
+    PROPERTIES.put(Constants.MASTER_HOSTNAME, NetworkAddressUtils.getLocalHostName(250));
+    PROPERTIES.put(Constants.WORKER_NETWORK_NETTY_CHANNEL,
         String.valueOf(ChannelType.defaultType()));
-    defaultProps.setProperty(Constants.USER_NETWORK_NETTY_CHANNEL,
+    PROPERTIES.put(Constants.USER_NETWORK_NETTY_CHANNEL,
         String.valueOf(ChannelType.defaultType()));
 
     String confPaths;
@@ -117,26 +114,17 @@ public final class Configuration {
     if (System.getProperty(Constants.SITE_CONF_DIR) != null) {
       confPaths = System.getProperty(Constants.SITE_CONF_DIR);
     } else {
-      confPaths = defaultProps.getProperty(Constants.SITE_CONF_DIR);
+      confPaths = PROPERTIES.get(Constants.SITE_CONF_DIR);
     }
     String[] confPathList = confPaths.split(",");
 
     // Load site specific properties file
-    Properties siteProps = ConfigurationUtils
-        .searchPropertiesFile(sitePropertiesFile, confPathList);
+    ConfigurationUtils.searchPropertiesFile(sitePropertiesFile, confPathList, PROPERTIES);
 
     // Load system properties
-    Properties systemProps = new Properties();
     if (includeSystemProperties) {
-      systemProps.putAll(System.getProperties());
+      mergeProperties(System.getProperties());
     }
-
-    // Now lets combine, order matters here
-    mergeProperties(defaultProps);
-    if (siteProps != null) {
-      mergeProperties(siteProps);
-    }
-    mergeProperties(systemProps);
 
     String masterHostname = PROPERTIES.get(Constants.MASTER_HOSTNAME);
     String masterPort = PROPERTIES.get(Constants.MASTER_RPC_PORT);

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -13,8 +13,10 @@ package alluxio.util;
 
 import alluxio.Configuration;
 import alluxio.Constants;
+import alluxio.exception.ExceptionMessage;
 import alluxio.util.io.PathUtils;
 
+import io.netty.util.internal.chmv8.ConcurrentHashMapV8;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +27,6 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -38,28 +39,96 @@ public final class ConfigurationUtils {
   private ConfigurationUtils() {} // prevent instantiation
 
   /**
+   * Reads a property list (key and element pairs) from the input byte stream. The input stream is
+   * in a simple line-oriented format and is assumed to use the ISO 8859-1 character encoding; that
+   * is each byte is one Latin1 character. Characters not in Latin1, and certain special characters,
+   * are represented in keys and elements using Unicode escapes as defined in section 3.3 of
+   * <cite>The Java&trade; Language Specification</cite>. The specified stream remains open after
+   * this method returns.
+   *
+   * @param inStream the input stream
+   * @param destination the destination map to store the result
+   * @exception IOException if an error occurred when reading from the input stream
+   * @throws IllegalArgumentException if the input stream contains a malformed Unicode escape
+   *         sequence
+   */
+  public static void load(InputStream inStream, ConcurrentHashMapV8<String, String> destination)
+      throws IOException {
+    LineReader lr = new LineReader(inStream);
+    char[] convtBuf = new char[1024];
+    int limit;
+    int keyLen;
+    int valueStart;
+    char c;
+    boolean hasSep;
+    boolean precedingBackslash;
+
+    while ((limit = lr.readLine()) >= 0) {
+      c = 0;
+      keyLen = 0;
+      valueStart = limit;
+      hasSep = false;
+
+      // System.out.println("line=<" + new String(mLineBuf, 0, limit) + ">");
+      precedingBackslash = false;
+      while (keyLen < limit) {
+        c = lr.mLineBuf[keyLen];
+        // need check if escaped.
+        if ((c == '=' || c == ':') && !precedingBackslash) {
+          valueStart = keyLen + 1;
+          hasSep = true;
+          break;
+        } else if ((c == ' ' || c == '\t' || c == '\f') && !precedingBackslash) {
+          valueStart = keyLen + 1;
+          break;
+        }
+        if (c == '\\') {
+          precedingBackslash = !precedingBackslash;
+        } else {
+          precedingBackslash = false;
+        }
+        keyLen++;
+      }
+      while (valueStart < limit) {
+        c = lr.mLineBuf[valueStart];
+        if (c != ' ' && c != '\t' && c != '\f') {
+          if (!hasSep && (c == '=' || c == ':')) {
+            hasSep = true;
+          } else {
+            break;
+          }
+        }
+        valueStart++;
+      }
+      String key = loadConvert(lr.mLineBuf, 0, keyLen, convtBuf);
+      String value = loadConvert(lr.mLineBuf, valueStart, limit - valueStart, convtBuf);
+      destination.put(key, value);
+    }
+  }
+
+  /**
    * Loads properties from resource. This method will search Classpath for the properties file with
    * the given resourceName.
    *
    * @param resourceName filename of the properties file
-   * @return a set of properties on success, or null if failed
+   * @param destination the destination map to store the result
    */
-  public static Properties loadPropertiesFromResource(String resourceName) {
-    Properties properties = new Properties();
-
+  public static void loadPropertiesFromResource(String resourceName,
+      ConcurrentHashMapV8<String, String> destination) {
     InputStream inputStream =
         Configuration.class.getClassLoader().getResourceAsStream(resourceName);
     if (inputStream == null) {
-      return null;
+      throw new RuntimeException(
+          ExceptionMessage.DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST.getMessage());
     }
 
     try {
-      properties.load(inputStream);
+      load(inputStream, destination);
     } catch (IOException e) {
       LOG.error("Unable to load default Alluxio properties file {}", resourceName, e);
-      return null;
+      throw new RuntimeException(
+          ExceptionMessage.DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST.getMessage());
     }
-    return properties;
   }
 
   /**
@@ -67,20 +136,20 @@ public final class ConfigurationUtils {
    * file.
    *
    * @param filePath the absolute path of the file to load properties
-   * @return a set of properties on success, or null if failed
+   * @param destination the destination map to store the result
+   * @return true on success, false if failed
    */
-  public static Properties loadPropertiesFromFile(String filePath) {
-    Properties properties = new Properties();
-
+  public static boolean loadPropertiesFromFile(String filePath,
+      ConcurrentHashMapV8<String, String> destination) {
     try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
-      properties.load(fileInputStream);
+      load(fileInputStream, destination);
+      return true;
     } catch (FileNotFoundException e) {
-      return null;
+      return false;
     } catch (IOException e) {
       LOG.error("Unable to load properties file {}", filePath, e);
-      return null;
+      return false;
     }
-    return properties;
   }
 
   /**
@@ -88,23 +157,22 @@ public final class ConfigurationUtils {
    *
    * @param propertiesFile the file to load properties
    * @param confPathList a list of paths to search the propertiesFile
-   * @return loaded properties on success, or null if failed
+   * @param destination the destination map to store the result
    */
-  public static Properties searchPropertiesFile(String propertiesFile,
-      String[] confPathList) {
+  public static void searchPropertiesFile(String propertiesFile, String[] confPathList,
+      ConcurrentHashMapV8<String, String> destination) {
     if (propertiesFile == null || confPathList == null) {
-      return null;
+      return;
     }
     for (String path : confPathList) {
       String file = PathUtils.concatPath(path, propertiesFile);
-      Properties properties = loadPropertiesFromFile(file);
-      if (properties != null) {
+      Boolean succeed = loadPropertiesFromFile(file, destination);
+      if (succeed) {
         // If a site conf is successfully loaded, stop trying different paths
         LOG.info("Configuration file {} loaded.", file);
-        return properties;
+        break;
       }
     }
-    return loadPropertiesFromResource(propertiesFile);
   }
 
   /**
@@ -168,5 +236,204 @@ public final class ConfigurationUtils {
       }
     }
     return valid;
+  }
+
+  /*
+   * Read in a "logical line" from an InputStream/Reader, skip all comment and blank lines and
+   * filter out those leading whitespace characters (\u0020, \u0009 and \u000c) from the beginning
+   * of a "natural line". Method returns the char length of the "logical line" and stores the line
+   * in "mLineBuf".
+   */
+  static class LineReader {
+    public LineReader(InputStream inStream) {
+      mInStream = inStream;
+      mInByteBuf = new byte[8192];
+      mLineBuf = new char[1024];
+    }
+
+    byte[] mInByteBuf;
+    char[] mLineBuf;
+    int mInLimit = 0;
+    int mInOff = 0;
+    InputStream mInStream;
+
+    int readLine() throws IOException {
+      int len = 0;
+      char c = 0;
+
+      boolean skipWhiteSpace = true;
+      boolean isCommentLine = false;
+      boolean isNewLine = true;
+      boolean appendedLineBegin = false;
+      boolean precedingBackslash = false;
+      boolean skipLF = false;
+
+      while (true) {
+        if (mInOff >= mInLimit) {
+          mInLimit = mInStream.read(mInByteBuf);
+          mInOff = 0;
+          if (mInLimit <= 0) {
+            if (len == 0 || isCommentLine) {
+              return -1;
+            }
+            return len;
+          }
+        }
+        if (mInStream != null) {
+          // The line below is equivalent to calling a
+          // ISO8859-1 decoder.
+          c = (char) (0xff & mInByteBuf[mInOff++]);
+        }
+        if (skipLF) {
+          skipLF = false;
+          if (c == '\n') {
+            continue;
+          }
+        }
+        if (skipWhiteSpace) {
+          if (c == ' ' || c == '\t' || c == '\f') {
+            continue;
+          }
+          if (!appendedLineBegin && (c == '\r' || c == '\n')) {
+            continue;
+          }
+          skipWhiteSpace = false;
+          appendedLineBegin = false;
+        }
+        if (isNewLine) {
+          isNewLine = false;
+          if (c == '#' || c == '!') {
+            isCommentLine = true;
+            continue;
+          }
+        }
+
+        if (c != '\n' && c != '\r') {
+          mLineBuf[len++] = c;
+          if (len == mLineBuf.length) {
+            int newLength = mLineBuf.length * 2;
+            if (newLength < 0) {
+              newLength = Integer.MAX_VALUE;
+            }
+            char[] buf = new char[newLength];
+            System.arraycopy(mLineBuf, 0, buf, 0, mLineBuf.length);
+            mLineBuf = buf;
+          }
+          // flip the preceding backslash flag
+          if (c == '\\') {
+            precedingBackslash = !precedingBackslash;
+          } else {
+            precedingBackslash = false;
+          }
+        } else {
+          // reached EOL
+          if (isCommentLine || len == 0) {
+            isCommentLine = false;
+            isNewLine = true;
+            skipWhiteSpace = true;
+            len = 0;
+            continue;
+          }
+          if (mInOff >= mInLimit) {
+            mInLimit = mInStream.read(mInByteBuf);
+            mInOff = 0;
+            if (mInLimit <= 0) {
+              return len;
+            }
+          }
+          if (precedingBackslash) {
+            len -= 1;
+            // skip the leading whitespace characters in following line
+            skipWhiteSpace = true;
+            appendedLineBegin = true;
+            precedingBackslash = false;
+            if (c == '\r') {
+              skipLF = true;
+            }
+          } else {
+            return len;
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * Converts encoded &#92;uxxxx to unicode chars and changes special saved chars to their original
+   * forms
+   */
+  private static String loadConvert(char[] in, int off, int len, char[] convtBuf) {
+    if (convtBuf.length < len) {
+      int newLen = len * 2;
+      if (newLen < 0) {
+        newLen = Integer.MAX_VALUE;
+      }
+      convtBuf = new char[newLen];
+    }
+    char aChar;
+    char[] out = convtBuf;
+    int outLen = 0;
+    int end = off + len;
+
+    while (off < end) {
+      aChar = in[off++];
+      if (aChar == '\\') {
+        aChar = in[off++];
+        if (aChar == 'u') {
+          // Read the xxxx
+          int value = 0;
+          for (int i = 0; i < 4; i++) {
+            aChar = in[off++];
+            switch (aChar) {
+              case '0':
+              case '1':
+              case '2':
+              case '3':
+              case '4':
+              case '5':
+              case '6':
+              case '7':
+              case '8':
+              case '9':
+                value = (value << 4) + aChar - '0';
+                break;
+              case 'a':
+              case 'b':
+              case 'c':
+              case 'd':
+              case 'e':
+              case 'f':
+                value = (value << 4) + 10 + aChar - 'a';
+                break;
+              case 'A':
+              case 'B':
+              case 'C':
+              case 'D':
+              case 'E':
+              case 'F':
+                value = (value << 4) + 10 + aChar - 'A';
+                break;
+              default:
+                throw new IllegalArgumentException("Malformed \\uxxxx encoding.");
+            }
+          }
+          out[outLen++] = (char) value;
+        } else {
+          if (aChar == 't') {
+            aChar = '\t';
+          } else if (aChar == 'r') {
+            aChar = '\r';
+          } else if (aChar == 'n') {
+            aChar = '\n';
+          } else if (aChar == 'f') {
+            aChar = '\f';
+          }
+          out[outLen++] = aChar;
+        }
+      } else {
+        out[outLen++] = aChar;
+      }
+    }
+    return new String(out, 0, outLen);
   }
 }

--- a/core/server/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
@@ -73,7 +73,7 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
   private SortedSet<Pair<String, String>> getSortedProperties() {
     TreeSet<Pair<String, String>> rtn = new TreeSet<>();
     for (Map.Entry<String, String> entry : Configuration.toMap().entrySet()) {
-      String key = entry.getKey().toString();
+      String key = entry.getKey();
       if (key.startsWith(ALLUXIO_CONF_PREFIX) && !ALLUXIO_CONF_EXCLUDES.contains(key)) {
         rtn.add(new ImmutablePair<>(key, Configuration.get(key)));
       }


### PR DESCRIPTION
remove the using of Properties in Configuration related codebase.

`load`, `LineReader` and 'loadConvert' are originally from Properties lib with some small modification.
