### PR TITLE
[ALLUXIO-2180] Translate S3/S3A bucket owner and ACL to Alluxio permission.

### DIFF
--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -77,7 +77,7 @@ public final class S3UnderFileSystem extends UnderFileSystem {
   /** The owner name of the bucket. */
   private final String mBucketOwner;
 
-  /** The owner id of the bucket. */
+  /** The AWS id of the bucket owner. */
   private final String mBucketOwnerId;
 
   /** The permission mode by the owner to the bucket. */

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -25,6 +25,7 @@ import org.jets3t.service.Jets3tProperties;
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.StorageObjectsChunk;
+import org.jets3t.service.acl.AccessControlList;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.model.S3Object;
 import org.jets3t.service.model.StorageObject;
@@ -72,6 +73,15 @@ public final class S3UnderFileSystem extends UnderFileSystem {
 
   /** Prefix of the bucket, for example s3n://my-bucket-name/ . */
   private final String mBucketPrefix;
+
+  /** The owner name of the bucket. */
+  private final String mBucketOwner;
+
+  /** The owner id of the bucket. */
+  private final String mBucketOwnerId;
+
+  /** The permission mode by the owner to the bucket. */
+  private final short mBucketMode;
 
   static {
     try {
@@ -139,6 +149,11 @@ public final class S3UnderFileSystem extends UnderFileSystem {
     LOG.debug("Initializing S3 underFs with properties: {}", props.getProperties());
     mClient = new RestS3Service(awsCredentials, null, null, props);
     mBucketPrefix = PathUtils.normalizePath(Constants.HEADER_S3N + mBucketName, PATH_SEPARATOR);
+
+    AccessControlList acl = mClient.getBucketAcl(mBucketName);
+    mBucketOwner = acl.getOwner().getDisplayName();
+    mBucketOwnerId = acl.getOwner().getId();
+    mBucketMode = S3Utils.translateBucketAcl(acl, mBucketOwnerId);
   }
 
   @Override
@@ -386,22 +401,22 @@ public final class S3UnderFileSystem extends UnderFileSystem {
   @Override
   public void setMode(String path, short mode) throws IOException {}
 
-  // No ACL integration currently, returns default empty value
+  // Returns the bucket owner.
   @Override
   public String getOwner(String path) throws IOException {
-    return "";
+    return mBucketOwner;
   }
 
-  // No ACL integration currently, returns default empty value
+  // No group in S3 ACL, returns the bucket owner.
   @Override
   public String getGroup(String path) throws IOException {
-    return "";
+    return mBucketOwner;
   }
 
-  // No ACL integration currently, returns default value
+  // Returns the translated mode by the owner of the bucket.
   @Override
   public short getMode(String path) throws IOException {
-    return Constants.DEFAULT_FILE_SYSTEM_MODE;
+    return mBucketMode;
   }
 
   /**

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3Utils.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3Utils.java
@@ -13,6 +13,7 @@ package alluxio.underfs.s3;
 
 import org.jets3t.service.acl.AccessControlList;
 import org.jets3t.service.acl.GrantAndPermission;
+import org.jets3t.service.acl.GranteeInterface;
 import org.jets3t.service.acl.GroupGrantee;
 import org.jets3t.service.acl.Permission;
 
@@ -30,21 +31,21 @@ public final class S3Utils {
   public static short translateBucketAcl(AccessControlList acl, String bucketOwnerId) {
     short mode = (short) 0;
     for (GrantAndPermission gp : acl.getGrantAndPermissions()) {
+      Permission perm = gp.getPermission();
+      GranteeInterface grantee = gp.getGrantee();
       // If the bucket is readable by the owner, add r and x to the owner mode.
-      if (gp.getPermission().equals(Permission.PERMISSION_READ)) {
-        if (gp.getGrantee().getIdentifier().equals(bucketOwnerId)
-            || gp.getGrantee().equals(GroupGrantee.ALL_USERS)
-            || gp.getGrantee().equals(GroupGrantee.AUTHENTICATED_USERS)) {
-          mode |= (short) 0500;
-        }
+      if (perm.equals(Permission.PERMISSION_READ)
+          && (grantee.getIdentifier().equals(bucketOwnerId)
+              || grantee.equals(GroupGrantee.ALL_USERS)
+              || grantee.equals(GroupGrantee.AUTHENTICATED_USERS))) {
+        mode |= (short) 0500;
       }
       // If the bucket is writable by the owner, +w to the owner mode.
-      if (gp.getPermission().equals(Permission.PERMISSION_WRITE)) {
-        if (gp.getGrantee().getIdentifier().equals(bucketOwnerId)
-            || gp.getGrantee().equals(GroupGrantee.ALL_USERS)
-            || gp.getGrantee().equals(GroupGrantee.AUTHENTICATED_USERS)) {
-          mode |= (short) 0200;
-        }
+      if (perm.equals(Permission.PERMISSION_WRITE)
+          && (grantee.getIdentifier().equals(bucketOwnerId)
+              || grantee.equals(GroupGrantee.ALL_USERS)
+              || grantee.equals(GroupGrantee.AUTHENTICATED_USERS))) {
+        mode |= (short) 0200;
       }
     }
     return mode;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3Utils.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3Utils.java
@@ -1,0 +1,54 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3;
+
+import org.jets3t.service.acl.AccessControlList;
+import org.jets3t.service.acl.GrantAndPermission;
+import org.jets3t.service.acl.GroupGrantee;
+import org.jets3t.service.acl.Permission;
+
+/**
+ * Util functions for S3N under file system.
+ */
+public final class S3Utils {
+  /**
+   * Translates S3 bucket owner ACL to Alluxio owner mode.
+   *
+   * @param acl the acl of S3 bucket
+   * @param bucketOwnerId the bucket owner id
+   * @return the translated posix mode in short format
+   */
+  public static short translateBucketAcl(AccessControlList acl, String bucketOwnerId) {
+    short mode = (short) 0;
+    for (GrantAndPermission gp : acl.getGrantAndPermissions()) {
+      // If the bucket is readable by the owner, add r and x to the owner mode.
+      if (gp.getPermission().equals(Permission.PERMISSION_READ)) {
+        if (gp.getGrantee().getIdentifier().equals(bucketOwnerId)
+            || gp.getGrantee().equals(GroupGrantee.ALL_USERS)
+            || gp.getGrantee().equals(GroupGrantee.AUTHENTICATED_USERS)) {
+          mode |= (short) 0500;
+        }
+      }
+      // If the bucket is writable by the owner, +w to the owner mode.
+      if (gp.getPermission().equals(Permission.PERMISSION_WRITE)) {
+        if (gp.getGrantee().getIdentifier().equals(bucketOwnerId)
+            || gp.getGrantee().equals(GroupGrantee.ALL_USERS)
+            || gp.getGrantee().equals(GroupGrantee.AUTHENTICATED_USERS)) {
+          mode |= (short) 0200;
+        }
+      }
+    }
+    return mode;
+  }
+
+  private S3Utils() {} // prevent instantiation
+}

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 /**
  * Tests for {@link S3Utils} methods.
  */
-public class S3UtilsTest {
+public final class S3UtilsTest {
 
   /**
    * Tests for {@link S3Utils#translateBucketAcl(AccessControlList, String)}.

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
@@ -44,9 +44,6 @@ public final class S3UtilsTest {
     mAcl.setOwner(owner);
   }
 
-  /**
-   * Tests for {@link S3Utils#translateBucketAcl(AccessControlList, String)}.
-   */
   @Test
   public void translateOwnerAclTest() {
     // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
@@ -62,14 +59,8 @@ public final class S3UtilsTest {
     mAcl.grantPermission(mOwnerGrantee, Permission.PERMISSION_WRITE_ACP);
     Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(mAcl, OTHER));
-
-    // Revoke permission to owner.
-    mAcl.revokeAllPermissions(mOwnerGrantee);
   }
 
-  /**
-   * Tests for translating bucket acl granted to "everyone".
-   */
   @Test
   public void translateEveryoneAclTest() {
     GroupGrantee allUsersGrantee = GroupGrantee.ALL_USERS;
@@ -83,14 +74,8 @@ public final class S3UtilsTest {
     mAcl.grantPermission(allUsersGrantee, Permission.PERMISSION_WRITE);
     Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, OTHER));
-
-    // Revoke permission to "everyone".
-    mAcl.revokeAllPermissions(allUsersGrantee);
   }
 
-  /**
-   * Tests for translating bucket acl granted to all authenticated users.
-   */
   @Test
   public void translateAuthenticatedUserAclTest() {
     // Add READ only permission to "all authenticated users".
@@ -104,6 +89,5 @@ public final class S3UtilsTest {
     mAcl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_WRITE);
     Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, OTHER));
-    mAcl.revokeAllPermissions(authenticatedUsersGrantee);
   }
 }

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3;
+
+import org.jets3t.service.acl.AccessControlList;
+import org.jets3t.service.acl.CanonicalGrantee;
+import org.jets3t.service.acl.GroupGrantee;
+import org.jets3t.service.acl.Permission;
+import org.jets3t.service.model.StorageOwner;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link S3Utils} methods.
+ */
+public class S3UtilsTest {
+
+  /**
+   * Tests for {@link S3Utils#translateBucketAcl(AccessControlList, String)}.
+   */
+  @Test
+  public void translateBucketAclTest() {
+    // Set up owner id, name and ownerGrantee.
+    final String id = "123456789012";
+    final String name = "foo";
+    final String other = "987654321098";
+    StorageOwner owner = new StorageOwner(id /* id */, name /* display name */);
+    CanonicalGrantee ownerGrantee = new CanonicalGrantee(id);
+    ownerGrantee.setDisplayName(name);
+
+    // Create a acl with the owner.
+    AccessControlList acl = new AccessControlList();
+    acl.setOwner(owner);
+
+    // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
+    acl.grantPermission(ownerGrantee, Permission.PERMISSION_READ);
+    acl.grantPermission(ownerGrantee, Permission.PERMISSION_READ_ACP);
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(acl, other));
+
+    // Grant WRITE permission to the owner. Check the translated mode is 0700.
+    acl.grantPermission(ownerGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
+    // Add WRITE permission to the owner. Check the translated mode is still 0700.
+    acl.grantPermission(ownerGrantee, Permission.PERMISSION_WRITE_ACP);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(acl, other));
+
+    GroupGrantee allUsersGrantee = GroupGrantee.ALL_USERS;
+    // Keep the ownerGrantee and permission, while adding another grantee "everyone".
+    // Assign READ only permission to "everyone".
+    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ);
+    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ_ACP);
+    // Check the translated mode is kept 0700.
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, other));
+
+    // Revoke all permission for ownerGrantee and only leave permission for "everyone".
+    acl.revokeAllPermissions(ownerGrantee);
+    // Check the translated mode is now 0500, because owner write permission is revoked.
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
+    // Add WRITE permission to "everyone", and check the translated mode becomes 0700.
+    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, other));
+
+    // Revoke permission to "everyone".
+    acl.revokeAllPermissions(allUsersGrantee);
+    // Add READ only permission to "all authenticated users".
+    GroupGrantee authenticatedUsersGrantee = GroupGrantee.AUTHENTICATED_USERS;
+    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ);
+    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ_ACP);
+    // Check the mode is 0500.
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, other));
+    // Add WRITE permission to "all authenticated users" and check permission.
+    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, other));
+  }
+}

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
@@ -34,14 +34,13 @@ public final class S3UtilsTest {
 
   @Before
   public void before() throws Exception {
-    // Set up owner id, name and mOwnerGrantee.
-    StorageOwner owner = new StorageOwner(ID /* id */, NAME /* display name */);
+    // Setup owner.
     mOwnerGrantee = new CanonicalGrantee(ID);
     mOwnerGrantee.setDisplayName(NAME);
 
-    // Create a mAcl with the owner.
+    // Setup the acl.
     mAcl = new AccessControlList();
-    mAcl.setOwner(owner);
+    mAcl.setOwner(new StorageOwner(ID, NAME));
   }
 
   @Test

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UtilsTest.java
@@ -17,6 +17,7 @@ import org.jets3t.service.acl.GroupGrantee;
 import org.jets3t.service.acl.Permission;
 import org.jets3t.service.model.StorageOwner;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -24,67 +25,85 @@ import org.junit.Test;
  */
 public final class S3UtilsTest {
 
+  private static final String NAME = "foo";
+  private static final String ID = "123456789012";
+  private static final String OTHER = "987654321098";
+
+  private CanonicalGrantee mOwnerGrantee;
+  private AccessControlList mAcl;
+
+  @Before
+  public void before() throws Exception {
+    // Set up owner id, name and mOwnerGrantee.
+    StorageOwner owner = new StorageOwner(ID /* id */, NAME /* display name */);
+    mOwnerGrantee = new CanonicalGrantee(ID);
+    mOwnerGrantee.setDisplayName(NAME);
+
+    // Create a mAcl with the owner.
+    mAcl = new AccessControlList();
+    mAcl.setOwner(owner);
+  }
+
   /**
    * Tests for {@link S3Utils#translateBucketAcl(AccessControlList, String)}.
    */
   @Test
-  public void translateBucketAclTest() {
-    // Set up owner id, name and ownerGrantee.
-    final String id = "123456789012";
-    final String name = "foo";
-    final String other = "987654321098";
-    StorageOwner owner = new StorageOwner(id /* id */, name /* display name */);
-    CanonicalGrantee ownerGrantee = new CanonicalGrantee(id);
-    ownerGrantee.setDisplayName(name);
-
-    // Create a acl with the owner.
-    AccessControlList acl = new AccessControlList();
-    acl.setOwner(owner);
-
+  public void translateOwnerAclTest() {
     // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
-    acl.grantPermission(ownerGrantee, Permission.PERMISSION_READ);
-    acl.grantPermission(ownerGrantee, Permission.PERMISSION_READ_ACP);
-    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(mOwnerGrantee, Permission.PERMISSION_READ);
+    mAcl.grantPermission(mOwnerGrantee, Permission.PERMISSION_READ_ACP);
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(mAcl, OTHER));
 
     // Grant WRITE permission to the owner. Check the translated mode is 0700.
-    acl.grantPermission(ownerGrantee, Permission.PERMISSION_WRITE);
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
-    // Add WRITE permission to the owner. Check the translated mode is still 0700.
-    acl.grantPermission(ownerGrantee, Permission.PERMISSION_WRITE_ACP);
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(mOwnerGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
+    // Add WRITE_ACP permission to the owner. Check the translated mode is still 0700.
+    mAcl.grantPermission(mOwnerGrantee, Permission.PERMISSION_WRITE_ACP);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0000, S3Utils.translateBucketAcl(mAcl, OTHER));
 
+    // Revoke permission to owner.
+    mAcl.revokeAllPermissions(mOwnerGrantee);
+  }
+
+  /**
+   * Tests for translating bucket acl granted to "everyone".
+   */
+  @Test
+  public void translateEveryoneAclTest() {
     GroupGrantee allUsersGrantee = GroupGrantee.ALL_USERS;
-    // Keep the ownerGrantee and permission, while adding another grantee "everyone".
     // Assign READ only permission to "everyone".
-    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ);
-    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ_ACP);
-    // Check the translated mode is kept 0700.
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, other));
-
-    // Revoke all permission for ownerGrantee and only leave permission for "everyone".
-    acl.revokeAllPermissions(ownerGrantee);
+    mAcl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ);
+    mAcl.grantPermission(allUsersGrantee, Permission.PERMISSION_READ_ACP);
     // Check the translated mode is now 0500, because owner write permission is revoked.
-    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(mAcl, OTHER));
     // Add WRITE permission to "everyone", and check the translated mode becomes 0700.
-    acl.grantPermission(allUsersGrantee, Permission.PERMISSION_WRITE);
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(allUsersGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, OTHER));
 
     // Revoke permission to "everyone".
-    acl.revokeAllPermissions(allUsersGrantee);
+    mAcl.revokeAllPermissions(allUsersGrantee);
+  }
+
+  /**
+   * Tests for translating bucket acl granted to all authenticated users.
+   */
+  @Test
+  public void translateAuthenticatedUserAclTest() {
     // Add READ only permission to "all authenticated users".
     GroupGrantee authenticatedUsersGrantee = GroupGrantee.AUTHENTICATED_USERS;
-    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ);
-    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ_ACP);
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ);
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_READ_ACP);
     // Check the mode is 0500.
-    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(acl, other));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0500, S3Utils.translateBucketAcl(mAcl, OTHER));
     // Add WRITE permission to "all authenticated users" and check permission.
-    acl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_WRITE);
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.PERMISSION_WRITE);
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0700, S3Utils.translateBucketAcl(mAcl, OTHER));
+    mAcl.revokeAllPermissions(authenticatedUsersGrantee);
   }
 }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -92,7 +92,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
   /** The owner name of the bucket. */
   private final String mBucketOwner;
 
-  /** The owner id of the bucket. */
+  /** The AWS id of the bucket owner. */
   private final String mBucketOwnerId;
 
   /** The permission mode by the owner to the bucket. */

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -29,6 +29,7 @@ import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
@@ -87,6 +88,15 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   /** Transfer Manager for efficient I/O to s3. */
   private final TransferManager mManager;
+
+  /** The owner name of the bucket. */
+  private final String mBucketOwner;
+
+  /** The owner id of the bucket. */
+  private final String mBucketOwnerId;
+
+  /** The permission mode by the owner to the bucket. */
+  private final short mBucketMode;
 
   static {
     byte[] dirByteHash = DigestUtils.md5(new byte[0]);
@@ -149,6 +159,11 @@ public class S3AUnderFileSystem extends UnderFileSystem {
     TransferManagerConfiguration transferConf = new TransferManagerConfiguration();
     transferConf.setMultipartCopyThreshold(MULTIPART_COPY_THRESHOLD);
     mManager.setConfiguration(transferConf);
+
+    AccessControlList acl = mClient.getBucketAcl(mBucketName);
+    mBucketOwner = acl.getOwner().getDisplayName();
+    mBucketOwnerId = acl.getOwner().getId();
+    mBucketMode = S3AUtils.translateBucketAcl(acl, mBucketOwnerId);
   }
 
   @Override
@@ -396,28 +411,32 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   // No ACL integration currently, no-op
   @Override
-  public void setOwner(String path, String user, String group) {}
+  public void setOwner(String path, String user, String group) {
+    // Do not allow setting S3 owner via Alluxio yet.
+  }
 
   // No ACL integration currently, no-op
   @Override
-  public void setMode(String path, short mode) throws IOException {}
+  public void setMode(String path, short mode) throws IOException {
+    // Do not allow setting S3 owner permission via Alluxio yet.
+  }
 
-  // No ACL integration currently, returns default empty value
+  // Returns the bucket owner.
   @Override
   public String getOwner(String path) throws IOException {
-    return "";
+    return mBucketOwner;
   }
 
-  // No ACL integration currently, returns default empty value
+  // No group in S3 ACL, returns the bucket owner.
   @Override
   public String getGroup(String path) throws IOException {
-    return "";
+    return mBucketOwner;
   }
 
-  // No ACL integration currently, returns default value
+  // Returns the translated mode by the owner of the bucket.
   @Override
   public short getMode(String path) throws IOException {
-    return Constants.DEFAULT_FILE_SYSTEM_MODE;
+    return mBucketMode;
   }
 
   /**

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
@@ -13,6 +13,7 @@ package alluxio.underfs.s3a;
 
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.Grantee;
 import com.amazonaws.services.s3.model.GroupGrantee;
 import com.amazonaws.services.s3.model.Permission;
 
@@ -30,23 +31,21 @@ public final class S3AUtils {
   public static short translateBucketAcl(AccessControlList acl, String bucketOwnerId) {
     short mode = (short) 0;
     for (Grant grant : acl.getGrantsAsList()) {
+      Permission perm = grant.getPermission();
+      Grantee grantee = grant.getGrantee();
       // If the bucket is readable by the owner, add r and x to the owner mode.
-      if (grant.getPermission().equals(Permission.Read)) {
-        if (grant.getGrantee().getIdentifier().equals(bucketOwnerId)
-            || grant.getGrantee().equals(GroupGrantee.AllUsers)
-            || grant.getGrantee().equals(GroupGrantee.AuthenticatedUsers)) {
-          mode |= (short) 0500;
-        }
+      if (perm.equals(Permission.Read)
+          && (grantee.getIdentifier().equals(bucketOwnerId)
+              || grantee.equals(GroupGrantee.AllUsers)
+              || grantee.equals(GroupGrantee.AuthenticatedUsers))) {
+        mode |= (short) 0500;
       }
-    }
-    for (Grant grant : acl.getGrantsAsList()) {
       // If the bucket is writable by the owner, +w to the owner mode.
-      if (grant.getPermission().equals(Permission.Write)) {
-        if (grant.getGrantee().getIdentifier().equals(bucketOwnerId)
-            || grant.getGrantee().equals(GroupGrantee.AllUsers)
-            || grant.getGrantee().equals(GroupGrantee.AuthenticatedUsers)) {
-          mode |= (short) 0200;
-        }
+      if (perm.equals(Permission.Write)
+          && (grantee.getIdentifier().equals(bucketOwnerId)
+              || grantee.equals(GroupGrantee.AllUsers)
+              || grantee.equals(GroupGrantee.AuthenticatedUsers))) {
+        mode |= (short) 0200;
       }
     }
     return mode;

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
@@ -1,0 +1,56 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3a;
+
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.GroupGrantee;
+import com.amazonaws.services.s3.model.Permission;
+
+/**
+ * Util functions for S3A under file system.
+ */
+public final class S3AUtils {
+  /**
+   * Translates S3 bucket owner ACL to Alluxio owner mode.
+   *
+   * @param acl the acl of S3 bucket
+   * @param bucketOwnerId the bucket owner id
+   * @return the translated posix mode in short format
+   */
+  public static short translateBucketAcl(AccessControlList acl, String bucketOwnerId) {
+    short mode = (short) 0;
+    for (Grant grant : acl.getGrantsAsList()) {
+      // If the bucket is readable by the owner, add r and x to the owner mode.
+      if (grant.getPermission().equals(Permission.Read)) {
+        if (grant.getGrantee().getIdentifier().equals(bucketOwnerId)
+            || grant.getGrantee().equals(GroupGrantee.AllUsers)
+            || grant.getGrantee().equals(GroupGrantee.AuthenticatedUsers)) {
+          mode |= (short) 0500;
+        }
+      }
+    }
+    for (Grant grant : acl.getGrantsAsList()) {
+      // If the bucket is writable by the owner, +w to the owner mode.
+      if (grant.getPermission().equals(Permission.Write)) {
+        if (grant.getGrantee().getIdentifier().equals(bucketOwnerId)
+            || grant.getGrantee().equals(GroupGrantee.AllUsers)
+            || grant.getGrantee().equals(GroupGrantee.AuthenticatedUsers)) {
+          mode |= (short) 0200;
+        }
+      }
+    }
+    return mode;
+  }
+
+  private S3AUtils() {} // prevent instantiation
+}

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -44,9 +44,6 @@ public final class S3AUtilsTest {
     mAcl.setOwner(owner);
   }
 
-  /**
-   * Tests for {@link S3AUtils#translateBucketAcl(AccessControlList, String)}.
-   */
   @Test
   public void translateOwnerAclTest() {
     // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
@@ -62,14 +59,8 @@ public final class S3AUtilsTest {
     mAcl.grantPermission(mOwnerGrantee, Permission.WriteAcp);
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(mAcl, OTHER));
-
-    // Revoke permission to owner.
-    mAcl.revokeAllPermissions(mOwnerGrantee);
   }
 
-  /**
-   * Tests for translating bucket acl granted to "everyone".
-   */
   @Test
   public void translateEveryoneAclTest() {
     GroupGrantee allUsersGrantee = GroupGrantee.AllUsers;
@@ -83,14 +74,8 @@ public final class S3AUtilsTest {
     mAcl.grantPermission(allUsersGrantee, Permission.Write);
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, OTHER));
-
-    // Revoke permission to "everyone".
-    mAcl.revokeAllPermissions(allUsersGrantee);
   }
 
-  /**
-   * Tests for translating bucket acl granted to all authenticated users.
-   */
   @Test
   public void translateAuthenticatedUserAclTest() {
     // Add READ only permission to "all authenticated users".
@@ -104,6 +89,5 @@ public final class S3AUtilsTest {
     mAcl.grantPermission(authenticatedUsersGrantee, Permission.Write);
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, OTHER));
-    mAcl.revokeAllPermissions(authenticatedUsersGrantee);
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -34,14 +34,13 @@ public final class S3AUtilsTest {
 
   @Before
   public void before() throws Exception {
-    // Set up owner id, name and mOwnerGrantee.
-    Owner owner = new Owner(ID /* id */, NAME /* display name */);
+    // Setup owner.
     mOwnerGrantee = new CanonicalGrantee(ID);
     mOwnerGrantee.setDisplayName(NAME);
 
-    // Create a mAcl with the owner.
+    // Setup the acl.
     mAcl = new AccessControlList();
-    mAcl.setOwner(owner);
+    mAcl.setOwner(new Owner(ID, NAME));
   }
 
   @Test

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -18,74 +18,92 @@ import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.Permission;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Tests for {@link S3AUtils} methods.
  */
 public final class S3AUtilsTest {
+  private static final String NAME = "foo";
+  private static final String ID = "123456789012";
+  private static final String OTHER = "987654321098";
+
+  private CanonicalGrantee mOwnerGrantee;
+  private AccessControlList mAcl;
+
+  @Before
+  public void before() throws Exception {
+    // Set up owner id, name and mOwnerGrantee.
+    Owner owner = new Owner(ID /* id */, NAME /* display name */);
+    mOwnerGrantee = new CanonicalGrantee(ID);
+    mOwnerGrantee.setDisplayName(NAME);
+
+    // Create a mAcl with the owner.
+    mAcl = new AccessControlList();
+    mAcl.setOwner(owner);
+  }
 
   /**
    * Tests for {@link S3AUtils#translateBucketAcl(AccessControlList, String)}.
    */
   @Test
-  public void translateBucketAclTest() {
-    // Set up owner id, name and ownerGrantee.
-    final String id = "123456789012";
-    final String name = "foo";
-    final String other = "987654321098";
-    Owner owner = new Owner(id /* id */, name /* display name */);
-    CanonicalGrantee ownerGrantee = new CanonicalGrantee(id);
-    ownerGrantee.setDisplayName(name);
-
-    // Create a acl with the owner.
-    AccessControlList acl = new AccessControlList();
-    acl.setOwner(owner);
-
+  public void translateOwnerAclTest() {
     // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
-    acl.grantPermission(ownerGrantee, Permission.Read);
-    acl.grantPermission(ownerGrantee, Permission.ReadAcp);
-    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(mOwnerGrantee, Permission.Read);
+    mAcl.grantPermission(mOwnerGrantee, Permission.ReadAcp);
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(mAcl, OTHER));
 
     // Grant WRITE permission to the owner. Check the translated mode is 0700.
-    acl.grantPermission(ownerGrantee, Permission.Write);
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    mAcl.grantPermission(mOwnerGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     // Add WRITE permission to the owner. Check the translated mode is still 0700.
-    acl.grantPermission(ownerGrantee, Permission.WriteAcp);
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(mOwnerGrantee, Permission.WriteAcp);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(mAcl, OTHER));
 
+    // Revoke permission to owner.
+    mAcl.revokeAllPermissions(mOwnerGrantee);
+  }
+
+  /**
+   * Tests for translating bucket acl granted to "everyone".
+   */
+  @Test
+  public void translateEveryoneAclTest() {
     GroupGrantee allUsersGrantee = GroupGrantee.AllUsers;
-    // Keep the ownerGrantee and permission, while adding another grantee "everyone".
     // Assign READ only permission to "everyone".
-    acl.grantPermission(allUsersGrantee, Permission.Read);
-    acl.grantPermission(allUsersGrantee, Permission.ReadAcp);
-    // Check the translated mode is kept 0700.
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, other));
-
-    // Revoke all permission for ownerGrantee and only leave permission for "everyone".
-    acl.revokeAllPermissions(ownerGrantee);
+    mAcl.grantPermission(allUsersGrantee, Permission.Read);
+    mAcl.grantPermission(allUsersGrantee, Permission.ReadAcp);
     // Check the translated mode is now 0500, because owner write permission is revoked.
-    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(mAcl, OTHER));
     // Add WRITE permission to "everyone", and check the translated mode becomes 0700.
-    acl.grantPermission(allUsersGrantee, Permission.Write);
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(allUsersGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, OTHER));
 
     // Revoke permission to "everyone".
-    acl.revokeAllPermissions(allUsersGrantee);
+    mAcl.revokeAllPermissions(allUsersGrantee);
+  }
+
+  /**
+   * Tests for translating bucket acl granted to all authenticated users.
+   */
+  @Test
+  public void translateAuthenticatedUserAclTest() {
     // Add READ only permission to "all authenticated users".
     GroupGrantee authenticatedUsersGrantee = GroupGrantee.AuthenticatedUsers;
-    acl.grantPermission(authenticatedUsersGrantee, Permission.Read);
-    acl.grantPermission(authenticatedUsersGrantee, Permission.ReadAcp);
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.Read);
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.ReadAcp);
     // Check the mode is 0500.
-    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, other));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(mAcl, OTHER));
     // Add WRITE permission to "all authenticated users" and check permission.
-    acl.grantPermission(authenticatedUsersGrantee, Permission.Write);
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
-    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, other));
+    mAcl.grantPermission(authenticatedUsersGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, OTHER));
+    mAcl.revokeAllPermissions(authenticatedUsersGrantee);
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -58,7 +58,7 @@ public final class S3AUtilsTest {
     // Grant WRITE permission to the owner. Check the translated mode is 0700.
     mAcl.grantPermission(mOwnerGrantee, Permission.Write);
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
-    // Add WRITE permission to the owner. Check the translated mode is still 0700.
+    // Add WRITE_ACP permission to the owner. Check the translated mode is still 0700.
     mAcl.grantPermission(mOwnerGrantee, Permission.WriteAcp);
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(mAcl, OTHER));

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3a;
+
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CanonicalGrantee;
+import com.amazonaws.services.s3.model.GroupGrantee;
+import com.amazonaws.services.s3.model.Owner;
+import com.amazonaws.services.s3.model.Permission;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link S3AUtils} methods.
+ */
+public class S3AUtilsTest {
+
+  /**
+   * Tests for {@link S3AUtils#translateBucketAcl(AccessControlList, String)}.
+   */
+  @Test
+  public void translateBucketAclTest() {
+    // Set up owner id, name and ownerGrantee.
+    final String id = "123456789012";
+    final String name = "foo";
+    final String other = "987654321098";
+    Owner owner = new Owner(id /* id */, name /* display name */);
+    CanonicalGrantee ownerGrantee = new CanonicalGrantee(id);
+    ownerGrantee.setDisplayName(name);
+
+    // Create a acl with the owner.
+    AccessControlList acl = new AccessControlList();
+    acl.setOwner(owner);
+
+    // Grant only READ, READ_ACP permission to the owner. Check the translated mode is 0500.
+    acl.grantPermission(ownerGrantee, Permission.Read);
+    acl.grantPermission(ownerGrantee, Permission.ReadAcp);
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(acl, other));
+
+    // Grant WRITE permission to the owner. Check the translated mode is 0700.
+    acl.grantPermission(ownerGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    // Add WRITE permission to the owner. Check the translated mode is still 0700.
+    acl.grantPermission(ownerGrantee, Permission.WriteAcp);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(acl, other));
+
+    GroupGrantee allUsersGrantee = GroupGrantee.AllUsers;
+    // Keep the ownerGrantee and permission, while adding another grantee "everyone".
+    // Assign READ only permission to "everyone".
+    acl.grantPermission(allUsersGrantee, Permission.Read);
+    acl.grantPermission(allUsersGrantee, Permission.ReadAcp);
+    // Check the translated mode is kept 0700.
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, other));
+
+    // Revoke all permission for ownerGrantee and only leave permission for "everyone".
+    acl.revokeAllPermissions(ownerGrantee);
+    // Check the translated mode is now 0500, because owner write permission is revoked.
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
+    // Add WRITE permission to "everyone", and check the translated mode becomes 0700.
+    acl.grantPermission(allUsersGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, other));
+
+    // Revoke permission to "everyone".
+    acl.revokeAllPermissions(allUsersGrantee);
+    // Add READ only permission to "all authenticated users".
+    GroupGrantee authenticatedUsersGrantee = GroupGrantee.AuthenticatedUsers;
+    acl.grantPermission(authenticatedUsersGrantee, Permission.Read);
+    acl.grantPermission(authenticatedUsersGrantee, Permission.ReadAcp);
+    // Check the mode is 0500.
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0500, S3AUtils.translateBucketAcl(acl, other));
+    // Add WRITE permission to "all authenticated users" and check permission.
+    acl.grantPermission(authenticatedUsersGrantee, Permission.Write);
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, id));
+    Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(acl, other));
+  }
+}

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 /**
  * Tests for {@link S3AUtils} methods.
  */
-public class S3AUtilsTest {
+public final class S3AUtilsTest {
 
   /**
    * Tests for {@link S3AUtils#translateBucketAcl(AccessControlList, String)}.


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2180

This PR adds the support to inherited S3 bucket ACL to Alluxio permission, limited to owner only. 
- S3 bucket ACL entry has 5 types of permission: `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
- Map READ to 0500 (which should be the only `READ_ONLY` mode to the owner), and the 
`WRITE`/`FULL_CONTROL` to be 0700 (read/write/exec to the owner).
- The object-level ACL is not used here because there's typically only object READ permission by the owner. WRITE permission is not applicable to S3 objects.
- chown/chgrp/chmod are still not propagated to S3 UFS.

Future work:
- Add similar translation in GCS and Swift.
- Currently `group` and `others` mode bits are only 0. We could add an option in Mount to support sharing the mounted dir in Alluxio with other users.