### PR TITLE
[SMALLFIX] Remove empty java.security.krb5.realm/kdc options

### DIFF
--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -84,8 +84,6 @@ fi
 ALLUXIO_JAVA_OPTS+=" -Dlog4j.configuration=file:${ALLUXIO_CONF_DIR}/log4j.properties"
 ALLUXIO_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"
 ALLUXIO_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
-ALLUXIO_JAVA_OPTS+=" -Djava.security.krb5.realm="
-ALLUXIO_JAVA_OPTS+=" -Djava.security.krb5.kdc="
 
 # Master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}


### PR DESCRIPTION
After #3095, empty java.security.krb5.realm/kdc options will be added to ALLUXIO_JAVA_OPTS in all os platforms, which conflicts with the option: java.security.krb5.conf in secure hadoop env.

A simple solution is to remove the empty options and let user export krb5 options if needed. 