### PR TITLE
[SMALLFIX] Support yarn RM HA during getting RM delegation token

### DIFF
--- a/integration/yarn/src/main/java/alluxio/yarn/Client.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/Client.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.YarnClientApplication;
+import org.apache.hadoop.yarn.client.ClientRMProxy;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Apps;
@@ -318,7 +319,7 @@ public final class Client {
       org.apache.hadoop.conf.Configuration config = mYarnClient.getConfig();
       Token<TokenIdentifier> token = ConverterUtils.convertFromYarn(
           mYarnClient.getRMDelegationToken(new org.apache.hadoop.io.Text(tokenRenewer)),
-          YarnUtils.getRMAddress(config));
+          ClientRMProxy.getRMDelegationTokenService(config));
       LOG.info("Added RM delegation token: " + token);
       credentials.addToken(token.getService(), token);
 

--- a/integration/yarn/src/main/java/alluxio/yarn/YarnUtils.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/YarnUtils.java
@@ -13,7 +13,6 @@ package alluxio.yarn;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -30,7 +29,6 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,17 +148,6 @@ public final class YarnUtils {
     commandBuilder.addArg("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stdout");
     commandBuilder.addArg("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stderr");
     return commandBuilder.toString();
-  }
-
-  /**
-   * Get yarn resource manager ip address.
-   *
-   * @param config yarn configuration
-   * @return the ip address of yarn resource manager
-   */
-  public static InetSocketAddress getRMAddress(Configuration config) {
-    return config.getSocketAddr(YarnConfiguration.RM_ADDRESS,
-        YarnConfiguration.DEFAULT_RM_ADDRESS, YarnConfiguration.DEFAULT_RM_PORT);
   }
 
   private YarnUtils() {} // this utils class should not be instantiated


### PR DESCRIPTION
In yarn RM HA mode, there will be multi resource manager addresses with one is active and others are standby. So we need to get RM delegation token for all of them.