### PR TITLE
[ALLUXIO-2189] Reference webdoc when seeing transport framesize wrong in error message

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -47,7 +47,7 @@ public abstract class AbstractClient implements Client {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** The pattern of exception message when client and server transport frame sizes do not match. */
-  private static final Pattern FRAME_SIZE_EXCEPTION_PATTERN=
+  private static final Pattern FRAME_SIZE_EXCEPTION_PATTERN =
       Pattern.compile("Frame size \\((\\d+)\\) larger than max length");
 
   /** The number of times to retry a particular RPC. */

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -185,7 +185,7 @@ public abstract class AbstractClient implements Client {
           // pointing to the helper page.
           LOG.error("Failed to set up a connection to " + getServiceName() + " "
               + mMode + " @ " + mAddress + " due to the mismatched transport. Please refer to "
-              + RuntimeConstants.ALLUXIO_WEB_DOC + "/en/Debugging-Guide.html "
+              + RuntimeConstants.ALLUXIO_DOCS_URL + "/en/Debugging-Guide.html "
               + "for the possible reasons and suggestions.");
         }
         throw e;

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -180,7 +180,7 @@ public abstract class AbstractClient implements Client {
         checkVersion(getClient(), getServiceVersion());
         return;
       } catch (IOException e) {
-        if (FRAME_SIZE_EXCEPTION_PATTERN.matcher(e.toString()).find()) {
+        if (FRAME_SIZE_EXCEPTION_PATTERN.matcher(e.getMessage()).find()) {
           // See an error like "Frame size (67108864) larger than max length (16777216)!",
           // pointing to the helper page.
           LOG.error("Failed to set up a connection to " + getServiceName() + " "

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -183,7 +183,7 @@ public abstract class AbstractClient implements Client {
         if (FRAME_SIZE_EXCEPTION_PATTERN.matcher(e.getMessage()).find()) {
           // See an error like "Frame size (67108864) larger than max length (16777216)!",
           // pointing to the helper page.
-          String debugDocsUrl = RuntimeConstants.ALLUXIO_DOCS_URL + "en/Debugging-Guide.html";
+          String debugDocsUrl = RuntimeConstants.ALLUXIO_DOCS_URL + "/en/Debugging-Guide.html";
           String message = String.format("Failed to connect to %s %s @ %s: %s. "
               + "This exception may be caused by wrong network configurations. "
               + "Please consult %s for common solutions to address this problem.",

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -183,10 +183,12 @@ public abstract class AbstractClient implements Client {
         if (FRAME_SIZE_EXCEPTION_PATTERN.matcher(e.getMessage()).find()) {
           // See an error like "Frame size (67108864) larger than max length (16777216)!",
           // pointing to the helper page.
-          LOG.error("Failed to set up a connection to " + getServiceName() + " "
-              + mMode + " @ " + mAddress + " due to the mismatched transport. Please refer to "
-              + RuntimeConstants.ALLUXIO_DOCS_URL + "/en/Debugging-Guide.html "
-              + "for the possible reasons and suggestions.");
+          String debugDocsUrl = RuntimeConstants.ALLUXIO_DOCS_URL + "en/Debugging-Guide.html";
+          String message = String.format("Failed to connect to %s %s @ %s: %s. "
+              + "This exception may be caused by wrong network configurations. "
+              + "Please consult %s for common solutions to address this problem.",
+              getServiceName(), mMode, mAddress, e.getMessage(), debugDocsUrl);
+          throw new IOException(message, e);
         }
         throw e;
       } catch (TTransportException e) {

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -185,7 +185,7 @@ public abstract class AbstractClient implements Client {
           // pointing to the helper page.
           String debugDocsUrl = RuntimeConstants.ALLUXIO_DOCS_URL + "/en/Debugging-Guide.html";
           String message = String.format("Failed to connect to %s %s @ %s: %s. "
-              + "This exception may be caused by wrong network configurations. "
+              + "This exception may be caused by incorrect network configuration. "
               + "Please consult %s for common solutions to address this problem.",
               getServiceName(), mMode, mAddress, e.getMessage(), debugDocsUrl);
           throw new IOException(message, e);

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -18,10 +18,10 @@ public final class RuntimeConstants {
   static {
     VERSION = Configuration.get(PropertyKey.VERSION);
     if (Configuration.get(PropertyKey.VERSION).endsWith("SNAPSHOT")) {
-      ALLUXIO_WEB_DOC = "http://www.alluxio.org/docs/master/";
+      ALLUXIO_DOCS_URL = "http://www.alluxio.org/docs/master/";
     } else {
       String[] numbers = Configuration.get(PropertyKey.VERSION).split("\\.");
-      ALLUXIO_WEB_DOC = String.format("http://www.alluxio.org/docs/%s.%s", numbers[0], numbers[1]);
+      ALLUXIO_DOCS_URL = String.format("http://www.alluxio.org/docs/%s.%s", numbers[0], numbers[1]);
     }
   }
 
@@ -33,7 +33,7 @@ public final class RuntimeConstants {
       "target/alluxio-" + VERSION + "-jar-with-dependencies.jar";
 
   /** The URL to Alluxio documentation for this version on project web site. */
-  public static final String ALLUXIO_WEB_DOC;
+  public static final String ALLUXIO_DOCS_URL;
 
   private RuntimeConstants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -20,8 +20,9 @@ public final class RuntimeConstants {
     if (Configuration.get(PropertyKey.VERSION).endsWith("SNAPSHOT")) {
       ALLUXIO_DOCS_URL = "http://www.alluxio.org/docs/master/";
     } else {
-      String[] numbers = Configuration.get(PropertyKey.VERSION).split("\\.");
-      ALLUXIO_DOCS_URL = String.format("http://www.alluxio.org/docs/%s.%s", numbers[0], numbers[1]);
+      String[] majorMinor = Configuration.get(PropertyKey.VERSION).split("\\.");
+      ALLUXIO_DOCS_URL = String.format(
+          "http://www.alluxio.org/docs/%s.%s", majorMinor[0], majorMinor[1]);
     }
   }
 

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -18,7 +18,7 @@ public final class RuntimeConstants {
   static {
     VERSION = Configuration.get(PropertyKey.VERSION);
     if (Configuration.get(PropertyKey.VERSION).endsWith("SNAPSHOT")) {
-      ALLUXIO_DOCS_URL = "http://www.alluxio.org/docs/master/";
+      ALLUXIO_DOCS_URL = "http://www.alluxio.org/docs/master";
     } else {
       String[] majorMinor = Configuration.get(PropertyKey.VERSION).split("\\.");
       ALLUXIO_DOCS_URL = String.format(

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -17,6 +17,12 @@ package alluxio;
 public final class RuntimeConstants {
   static {
     VERSION = Configuration.get(PropertyKey.VERSION);
+    if (Configuration.get(PropertyKey.VERSION).endsWith("SNAPSHOT")) {
+      ALLUXIO_WEB_DOC = "http://www.alluxio.org/docs/master/";
+    } else {
+      String[] numbers = Configuration.get(PropertyKey.VERSION).split("\\.");
+      ALLUXIO_WEB_DOC = String.format("http://www.alluxio.org/docs/%s.%s", numbers[0], numbers[1]);
+    }
   }
 
   /** The version of this Alluxio instance. */
@@ -25,6 +31,9 @@ public final class RuntimeConstants {
   /** The relative path to the Alluxio target jar. */
   public static final String ALLUXIO_JAR =
       "target/alluxio-" + VERSION + "-jar-with-dependencies.jar";
+
+  /** The URL to Alluxio documentation for this version on project web site. */
+  public static final String ALLUXIO_WEB_DOC;
 
   private RuntimeConstants() {} // prevent instantiation
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2189

before:
```bash
$ hadoop fs -libjars core/client/target/alluxio-core-client-1.3.0-SNAPSHOT-jar-with-dependencies.jar  -ls alluxio://localhost:19998/
16/08/15 15:38:25 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/08/15 15:38:25 INFO logger.type: initialize(alluxio://localhost:19998/, Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml). Connecting to Alluxio: alluxio://localhost:19998/
16/08/15 15:38:25 INFO logger.type: alluxio://localhost:19998 alluxio://localhost:19998
16/08/15 15:38:25 INFO logger.type: Loading Alluxio properties from Hadoop configuration: {}
16/08/15 15:38:25 INFO logger.type: Configuration file /etc/alluxio/alluxio-site.properties loaded.
16/08/15 15:38:25 INFO logger.type: getFileStatus(alluxio://localhost:19998/)
16/08/15 15:38:25 INFO logger.type: Alluxio client (version 1.3.0-SNAPSHOT) is trying to connect with FileSystemMasterClient master @ localhost/127.0.0.1:19998
16/08/15 15:38:25 INFO logger.type: Client registered with FileSystemMasterClient master @ localhost/127.0.0.1:19998
ls: alluxio.org.apache.thrift.transport.TTransportException: Frame size (67108864) larger than max length (16777216)!
```
after:

```bash
$ hadoop fs -libjars core/client/target/alluxio-core-client-1.3.0-SNAPSHOT-jar-with-dependencies.jar  -ls alluxio://localhost:19998/
16/08/15 17:29:13 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/08/15 17:29:13 INFO logger.type: initialize(alluxio://localhost:19998/, Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml). Connecting to Alluxio: alluxio://localhost:19998/
16/08/15 17:29:13 INFO logger.type: alluxio://localhost:19998 alluxio://localhost:19998
16/08/15 17:29:13 INFO logger.type: Loading Alluxio properties from Hadoop configuration: {}
16/08/15 17:29:13 INFO logger.type: Configuration file /etc/alluxio/alluxio-site.properties loaded.
16/08/15 17:29:13 INFO logger.type: getFileStatus(alluxio://localhost:19998/)
16/08/15 17:29:13 INFO logger.type: Alluxio client (version 1.3.0-SNAPSHOT) is trying to connect with FileSystemMasterClient master @ localhost/127.0.0.1:19998
16/08/15 17:29:13 INFO logger.type: Client registered with FileSystemMasterClient master @ localhost/127.0.0.1:19998
16/08/15 17:29:13 ERROR logger.type: Failed to set up the connection between client and FileSystemMasterClient master @ localhost/127.0.0.1:19998 due to mismatched transport. Please refer to http://www.alluxio.org/docs/master/en/Debugging-Guide.html for the possible reasons and suggestions.
ls: alluxio.org.apache.thrift.transport.TTransportException: Frame size (67108864) larger than max length (16777216)!
```