### PR TITLE
[ALLUXIO-2198] [SMALLFIX] Skip permission change to UFS file if the

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -2473,21 +2473,25 @@ public final class FileSystemMaster extends AbstractMaster {
     }
     // If the file is persisted in UFS, also update corresponding owner/group/permission.
     if ((ownerGroupChanged || permissionChanged) && inode.isPersisted()) {
-      MountTable.Resolution resolution = mMountTable.resolve(inodePath.getUri());
-      String ufsUri = resolution.getUri().toString();
-      UnderFileSystem ufs = resolution.getUfs();
-      if (ownerGroupChanged) {
-        try {
-          ufs.setOwner(ufsUri, inode.getOwner(), inode.getGroup());
-        } catch (IOException e) {
-          throw new AccessControlException("Could not setOwner for UFS file " + ufsUri, e);
+      if (inode instanceof InodeFile && ((InodeFile) inode).isCompleted() == false) {
+        LOG.debug("Alluxio does not propagate chown/chgrp/chmod to UFS for incomplete files.");
+      } else {
+        MountTable.Resolution resolution = mMountTable.resolve(inodePath.getUri());
+        String ufsUri = resolution.getUri().toString();
+        UnderFileSystem ufs = resolution.getUfs();
+        if (ownerGroupChanged) {
+          try {
+            ufs.setOwner(ufsUri, inode.getOwner(), inode.getGroup());
+          } catch (IOException e) {
+            throw new AccessControlException("Could not setOwner for UFS file " + ufsUri, e);
+          }
         }
-      }
-      if (permissionChanged) {
-        try {
-          ufs.setMode(ufsUri, inode.getMode());
-        } catch (IOException e) {
-          throw new AccessControlException("Could not setMode for UFS file " + ufsUri, e);
+        if (permissionChanged) {
+          try {
+            ufs.setMode(ufsUri, inode.getMode());
+          } catch (IOException e) {
+            throw new AccessControlException("Could not setMode for UFS file " + ufsUri, e);
+          }
         }
       }
     }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -2473,7 +2473,7 @@ public final class FileSystemMaster extends AbstractMaster {
     }
     // If the file is persisted in UFS, also update corresponding owner/group/permission.
     if ((ownerGroupChanged || permissionChanged) && inode.isPersisted()) {
-      if (inode instanceof InodeFile && ((InodeFile) inode).isCompleted() == false) {
+      if ((inode instanceof InodeFile) && !((InodeFile) inode).isCompleted()) {
         LOG.debug("Alluxio does not propagate chown/chgrp/chmod to UFS for incomplete files.");
       } else {
         MountTable.Resolution resolution = mMountTable.resolve(inodePath.getUri());


### PR DESCRIPTION
Alluxio file is not completed yet.

https://alluxio.atlassian.net/browse/ALLUXIO-2198

When Alluxio creates a file persisted in UFS, it first creates a temporary UFS file and then renames to final destination when the Alluxio file is completed. Alluxio chown/chgrp/chown propagation to UFS file would fail before the Alluxio file is completed, because the mapped UFS file does not exist yet.

Furthermore, we should flush the latest metadata to UFS final file when the Alluxio file is completed. However that would introduce an extra RPC to UFS for each completeFile metadata op, so it's not included in this PR yet. For now, we claim that `Alluxio does not propagate chown/chgrp/chmod to UFS for incomplete files`.