### PR TITLE
[SMALLFIX] Increase DFSIOTest timeouts

### DIFF
--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -242,7 +242,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_WRITE, execTime);
   }
 
-  @Test(timeout = 25000)
+  @Test(timeout = 50000)
   public void read() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
@@ -252,7 +252,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ, execTime);
   }
 
-  @Test(timeout = 25000)
+  @Test(timeout = 50000)
   public void readRandom() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
@@ -263,7 +263,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_RANDOM, execTime);
   }
 
-  @Test(timeout = 25000)
+  @Test(timeout = 50000)
   public void readBackward() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
@@ -274,7 +274,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_BACKWARD, execTime);
   }
 
-  @Test(timeout = 25000)
+  @Test(timeout = 50000)
   public void readSkip() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
@@ -285,7 +285,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_SKIP, execTime);
   }
 
-  @Test(timeout = 25000)
+  @Test(timeout = 50000)
   public void readLargeSkip() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());
@@ -297,7 +297,7 @@ public class DFSIOIntegrationTest implements Tool {
   }
 
   // TODO(hy): Should active this unit test after ALLUXIO-25 has been solved
-  // @Test (timeout = 25000)
+  // @Test (timeout = 50000)
   public void append() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, sBench.getConf());


### PR DESCRIPTION
Sometimes Jenkins is having a bad day and times out on some of these tests.