### PR TITLE
[SMALLFIX] Fix a few potential null pointers in shell

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
@@ -87,13 +87,15 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
    */
   private void copyFromLocalDir(File srcDir, AlluxioURI dstPath)
       throws AlluxioException, IOException {
-    if (!srcDir.canRead()) {
-      throw new IOException(srcDir + " (Permission denied)");
-    }
     boolean dstExistedBefore = mFileSystem.exists(dstPath);
     createDstDir(dstPath);
     List<String> errorMessages = new ArrayList<>();
     File[] fileList = srcDir.listFiles();
+    if (fileList == null) {
+      String errMsg = String.format("copyFromLocal %s %s failed!",
+              srcDir.toString(), dstPath.toString());
+      throw new IOException(errMsg);
+    }
     int misFiles = 0;
     for (File srcFile : fileList) {
       AlluxioURI newURI = new AlluxioURI(dstPath, new AlluxioURI(srcFile.getName()));
@@ -238,12 +240,14 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
         closer.close();
       }
     } else {
-      if (!src.canRead()) {
-        throw new IOException(src + " (Permission denied)");
-      }
       mFileSystem.createDirectory(dstPath);
       List<String> errorMessages = new ArrayList<>();
       File[] fileList = src.listFiles();
+      if (fileList == null) {
+        String errMsg = String.format("copyFromLocal %s %s partially failed!",
+                src.toString(), dstPath.toString());
+        throw new IOException(errMsg);
+      }
       int misFiles = 0;
       for (File srcFile : fileList) {
         AlluxioURI newURI = new AlluxioURI(dstPath, new AlluxioURI(srcFile.getName()));

--- a/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
@@ -87,6 +87,9 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
    */
   private void copyFromLocalDir(File srcDir, AlluxioURI dstPath)
       throws AlluxioException, IOException {
+    if (!srcDir.canRead()) {
+      throw new IOException(srcDir + " (Permission denied)");
+    }
     boolean dstExistedBefore = mFileSystem.exists(dstPath);
     createDstDir(dstPath);
     List<String> errorMessages = new ArrayList<>();
@@ -235,6 +238,9 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
         closer.close();
       }
     } else {
+      if (!src.canRead()) {
+        throw new IOException(src + " (Permission denied)");
+      }
       mFileSystem.createDirectory(dstPath);
       List<String> errorMessages = new ArrayList<>();
       File[] fileList = src.listFiles();

--- a/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
@@ -92,8 +92,7 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
     List<String> errorMessages = new ArrayList<>();
     File[] fileList = srcDir.listFiles();
     if (fileList == null) {
-      String errMsg = String.format("copyFromLocal %s %s failed!",
-              srcDir.toString(), dstPath.toString());
+      String errMsg = String.format("Failed to list files for directory %s", srcDir);
       throw new IOException(errMsg);
     }
     int misFiles = 0;
@@ -244,8 +243,7 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
       List<String> errorMessages = new ArrayList<>();
       File[] fileList = src.listFiles();
       if (fileList == null) {
-        String errMsg = String.format("copyFromLocal %s %s partially failed!",
-                src.toString(), dstPath.toString());
+        String errMsg = String.format("Failed to list files for directory %s", src);
         throw new IOException(errMsg);
       }
       int misFiles = 0;

--- a/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
@@ -93,7 +93,8 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
     File[] fileList = srcDir.listFiles();
     if (fileList == null) {
       String errMsg = String.format("Failed to list files for directory %s", srcDir);
-      throw new IOException(errMsg);
+      errorMessages.add(errMsg);
+      fileList = new File[0];
     }
     int misFiles = 0;
     for (File srcFile : fileList) {
@@ -244,7 +245,8 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
       File[] fileList = src.listFiles();
       if (fileList == null) {
         String errMsg = String.format("Failed to list files for directory %s", src);
-        throw new IOException(errMsg);
+        errorMessages.add(errMsg);
+        fileList = new File[0];
       }
       int misFiles = 0;
       for (File srcFile : fileList) {

--- a/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
@@ -187,7 +187,8 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(srcOuterDir.getAbsolutePath() + " (Permission denied)\n", mOutput.toString());
+    Assert.assertEquals(srcOuterDir.getAbsolutePath() + " (Permission denied)\n",
+            mOutput.toString());
   }
 
   @Test
@@ -207,9 +208,9 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(srcInnerDir.getAbsolutePath() + " (Permission denied)\n", mOutput.toString());
+    Assert.assertEquals(srcInnerDir.getAbsolutePath() + " (Permission denied)\n",
+            mOutput.toString());
   }
-
 
   @Test
   public void copyFromLocalDirToExistingFile() throws IOException, AlluxioException {

--- a/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
@@ -171,6 +171,47 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
   }
 
   @Test
+  public void copyFromLocalDirNotReadable() throws IOException, AlluxioException {
+    // Copy a directory from local to Alluxio filesystem, which the destination uri was not created
+    // before.
+    File srcOuterDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir");
+    File srcInnerDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir/innerDir");
+    File emptyDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir/emptyDir");
+    srcOuterDir.mkdir();
+    srcInnerDir.mkdir();
+    emptyDir.mkdir();
+    generateFileContent("/outerDir/srcFile1", BufferUtils.getIncreasingByteArray(10));
+    generateFileContent("/outerDir/innerDir/srcFile2", BufferUtils.getIncreasingByteArray(10));
+
+    srcOuterDir.setReadable(false);
+    int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
+
+    Assert.assertEquals(-1, ret);
+    Assert.assertEquals(srcOuterDir.getAbsolutePath() + " (Permission denied)\n", mOutput.toString());
+  }
+
+  @Test
+  public void copyFromLocalDirNotReadableInnerDir() throws IOException, AlluxioException {
+    // Copy a directory from local to Alluxio filesystem, which the destination uri was not created
+    // before.
+    File srcOuterDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir");
+    File srcInnerDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir/innerDir");
+    File emptyDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/outerDir");
+    srcOuterDir.mkdir();
+    srcInnerDir.mkdir();
+    emptyDir.mkdir();
+    generateFileContent("/outerDir/srcFile1", BufferUtils.getIncreasingByteArray(10));
+    generateFileContent("/outerDir/innerDir/srcFile2", BufferUtils.getIncreasingByteArray(10));
+
+    srcInnerDir.setReadable(false);
+    int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
+
+    Assert.assertEquals(-1, ret);
+    Assert.assertEquals(srcInnerDir.getAbsolutePath() + " (Permission denied)\n", mOutput.toString());
+  }
+
+
+  @Test
   public void copyFromLocalDirToExistingFile() throws IOException, AlluxioException {
     // Copy a directory from local to a file which exists in Alluxio filesystem. This case should
     // fail.

--- a/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
@@ -61,7 +61,7 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     File innerDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/localDir/innerDir");
     innerDir.mkdir();
     File innerFile = generateFileContent("/localDir/innerDir/innerFile1",
-            BufferUtils.getIncreasingByteArray(30));
+        BufferUtils.getIncreasingByteArray(30));
     innerFile.setReadable(false);
     Assert.assertEquals(-1, mFsShell.run(cmd));
     Assert.assertTrue(mFileSystem.exists(alluxioDirPath));
@@ -76,7 +76,7 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     File localDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/localDir");
     localDir.mkdir();
     File testFile =
-            generateFileContent("/localDir/testFile", BufferUtils.getIncreasingByteArray(10));
+        generateFileContent("/localDir/testFile", BufferUtils.getIncreasingByteArray(10));
     File testDir = testFile.getParentFile();
     AlluxioURI alluxioDirPath = new AlluxioURI("/testDir");
     // Create the destination directory before call command of 'copyFromLocal'.
@@ -103,7 +103,7 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     File innerDir = new File(mLocalAlluxioCluster.getAlluxioHome() + "/localDir/innerDir");
     innerDir.mkdir();
     File innerFile = generateFileContent("/localDir/innerDir/innerFile1",
-            BufferUtils.getIncreasingByteArray(30));
+        BufferUtils.getIncreasingByteArray(30));
     innerFile.setReadable(false);
     Assert.assertEquals(-1, mFsShell.run(cmd));
     Assert.assertTrue(mFileSystem.exists(alluxioDirPath));
@@ -187,8 +187,8 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals("copyFromLocal " + srcOuterDir.getAbsolutePath() + " /dstDir failed!\n",
-            mOutput.toString());
+    Assert.assertEquals("Failed to list files for directory "
+        + srcOuterDir.getAbsolutePath() + "\n", mOutput.toString());
   }
 
   @Test
@@ -208,9 +208,8 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals("copyFromLocal " + srcInnerDir.getAbsolutePath()
-                    + " /dstDir/innerDir partially failed!\n",
-            mOutput.toString());
+    Assert.assertEquals("Failed to list files for directory "
+        + srcInnerDir.getAbsolutePath() + "\n", mOutput.toString());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CopyFromLocalCommandTest.java
@@ -187,7 +187,7 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(srcOuterDir.getAbsolutePath() + " (Permission denied)\n",
+    Assert.assertEquals("copyFromLocal " + srcOuterDir.getAbsolutePath() + " /dstDir failed!\n",
             mOutput.toString());
   }
 
@@ -208,7 +208,8 @@ public final class CopyFromLocalCommandTest extends AbstractAlluxioShellTest {
     int ret = mFsShell.run("copyFromLocal", srcOuterDir.getPath() + "/", "/dstDir");
 
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(srcInnerDir.getAbsolutePath() + " (Permission denied)\n",
+    Assert.assertEquals("copyFromLocal " + srcInnerDir.getAbsolutePath()
+                    + " /dstDir/innerDir partially failed!\n",
             mOutput.toString());
   }
 

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -91,8 +91,10 @@ public class LocalUnderFileSystem extends UnderFileSystem {
     boolean success = true;
     if (recursive && file.isDirectory()) {
       String[] files = file.list();
-      for (String child : files) {
-        success = success && delete(PathUtils.concatPath(path, child), true);
+      if (files != null) {
+        for (String child : files) {
+          success = success && delete(PathUtils.concatPath(path, child), true);
+        }
       }
     }
 

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -91,6 +91,9 @@ public class LocalUnderFileSystem extends UnderFileSystem {
     boolean success = true;
     if (recursive && file.isDirectory()) {
       String[] files = file.list();
+
+      // File.list() will return null if an I/O error occurs.
+      // e.g.: Reading an non-readable directory
       if (files != null) {
         for (String child : files) {
           success = success && delete(PathUtils.concatPath(path, child), true);


### PR DESCRIPTION
This PR is for a few potentials NPEs in alluxio shell when using copyFromLocal. 
The case a dir is not readable is rare though.

./bin/alluxio fs copyFromLocal nonReadableDir /destDir

```
Exception in thread "main" java.lang.NullPointerException
	at alluxio.shell.command.CopyFromLocalCommand.copyFromLocalDir(CopyFromLocalCommand.java:95)
	at alluxio.shell.command.CopyFromLocalCommand.copyFromLocal(CopyFromLocalCommand.java:189)
	at alluxio.shell.command.CopyFromLocalCommand.run(CopyFromLocalCommand.java:75)
	at alluxio.cli.AlluxioShell.run(AlluxioShell.java:177)
	at alluxio.cli.AlluxioShell.main(AlluxioShell.java:65)
```
