### PR TITLE
[SMALLFIX] Small fixes in several classes

### DIFF
--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -141,7 +141,7 @@ public class ConfigurationTest {
         Lists.newArrayList("a", "b", "c"), Configuration.getList(PropertyKey.WEB_THREADS, ","));
   }
 
-  private static enum TestEnum {
+  private enum TestEnum {
     VALUE
   }
 

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
@@ -72,11 +72,7 @@ public final class FileSystemMasterWorkerServiceHandler
       throws AlluxioTException, TException {
     try {
       return mFileSystemMaster.workerHeartbeat(workerId, persistedFiles);
-    } catch (FileDoesNotExistException e) {
-      throw e.toThrift();
-    } catch (InvalidPathException e) {
-      throw e.toThrift();
-    } catch (AccessControlException e) {
+    } catch (FileDoesNotExistException | InvalidPathException | AccessControlException e) {
       throw e.toThrift();
     }
   }

--- a/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -255,9 +255,7 @@ public final class FileDataManager {
         BufferUtils.fastCopy(inputChannel, outputChannel);
         reader.close();
       }
-    } catch (BlockDoesNotExistException e) {
-      errors.add(e);
-    } catch (InvalidWorkerStateException e) {
+    } catch (BlockDoesNotExistException | InvalidWorkerStateException e) {
       errors.add(e);
     } finally {
       // make sure all the locks are released

--- a/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CopyFromLocalCommand.java
@@ -210,9 +210,8 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
         dstPath = dstPath.join(src.getName());
       }
 
-      Closer closer = Closer.create();
       FileOutStream os = null;
-      try {
+      try (Closer closer = Closer.create()) {
         os = closer.register(mFileSystem.createFile(dstPath));
         FileInputStream in = closer.register(new FileInputStream(src));
         FileChannel channel = closer.register(in.getChannel());
@@ -231,8 +230,6 @@ public final class CopyFromLocalCommand extends AbstractShellCommand {
           }
         }
         throw e;
-      } finally {
-        closer.close();
       }
     } else {
       mFileSystem.createDirectory(dstPath);

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -114,14 +114,14 @@ public class DFSIOIntegrationTest implements Tool {
     org.apache.hadoop.conf.Configuration.addDefaultResource("mapred-site.xml");
   }
 
-  private static enum TestType {
+  private enum TestType {
     TEST_TYPE_READ("read"), TEST_TYPE_WRITE("write"), TEST_TYPE_CLEANUP("cleanup"),
         TEST_TYPE_APPEND("append"), TEST_TYPE_READ_RANDOM("random read"),
         TEST_TYPE_READ_BACKWARD("backward read"), TEST_TYPE_READ_SKIP("skip read");
 
     private String mType;
 
-    private TestType(String t) {
+    TestType(String t) {
       mType = t;
     }
 
@@ -132,12 +132,12 @@ public class DFSIOIntegrationTest implements Tool {
     }
   }
 
-  static enum ByteMultiple {
+  enum ByteMultiple {
     B(1L), KB(0x400L), MB(0x100000L), GB(0x40000000L), TB(0x10000000000L);
 
     private long mMultiplier;
 
-    private ByteMultiple(long mult) {
+    ByteMultiple(long mult) {
       mMultiplier = mult;
     }
 
@@ -388,7 +388,7 @@ public class DFSIOIntegrationTest implements Tool {
     // AbstractIOMapper
     void collectStats(OutputCollector<Text, Text> output, String name, long execTime, Long objSize)
         throws IOException {
-      long totalSize = objSize.longValue();
+      long totalSize = objSize;
       float ioRateMbSec = (float) totalSize * 1000 / (execTime * MEGA);
       LOG.info("Number of bytes processed = " + totalSize);
       LOG.info("Exec time = " + execTime);
@@ -442,7 +442,7 @@ public class DFSIOIntegrationTest implements Tool {
         reporter.setStatus("writing " + name + "@" + (totalSize - nrRemaining) + "/" + totalSize
             + " ::host = " + mHostname);
       }
-      return Long.valueOf(totalSize);
+      return totalSize;
     }
   }
 
@@ -506,7 +506,7 @@ public class DFSIOIntegrationTest implements Tool {
         reporter.setStatus("writing " + name + "@" + (totalSize - nrRemaining) + "/" + totalSize
             + " ::host = " + mHostname);
       }
-      return Long.valueOf(totalSize);
+      return totalSize;
     }
   }
 
@@ -549,7 +549,7 @@ public class DFSIOIntegrationTest implements Tool {
         reporter.setStatus("reading " + name + "@" + actualSize + "/" + totalSize + " ::host = "
             + mHostname);
       }
-      return Long.valueOf(actualSize);
+      return actualSize;
     }
   }
 
@@ -612,7 +612,7 @@ public class DFSIOIntegrationTest implements Tool {
         reporter.setStatus("reading " + name + "@" + actualSize + "/" + totalSize + " ::host = "
             + mHostname);
       }
-      return Long.valueOf(actualSize);
+      return actualSize;
     }
 
     /**


### PR DESCRIPTION
- Removed not needed static declaration of inner enum in
  ConfigurationTest
- Introduced automatic resource management in CopyFromLocalCommand
- Removed not needed accessor and static declarations and not needed
  casts in DFSIOIntegrationTest
- Collapsed multiple catch statements into one in FileDataManager
- Collapsed multiple catch statements into one in
  FileSystemMasterWorkerServiceHandler