### PR TITLE
[SMALLFIX] Small fixes in several classes

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -104,7 +104,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
 
   @SuppressWarnings("unchecked")
   /** use UniqueFieldIndex directly for Id index rather than using IndexedSet */
-  private final FieldIndex<Inode<?>> mInodes = new UniqueFieldIndex<Inode<?>>(ID_INDEX);
+  private final FieldIndex<Inode<?>> mInodes = new UniqueFieldIndex<>(ID_INDEX);
   /** A set of inode ids representing pinned inode files. */
   private final Set<Long> mPinnedInodeFileIds = new ConcurrentHashSet<>(64, 0.90f, 64);
 

--- a/core/server/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -268,9 +268,7 @@ public final class LineageMaster extends AbstractMaster {
   private void deleteLineageFromEntry(DeleteLineageEntry entry) {
     try {
       deleteLineageInternal(entry.getLineageId(), entry.getCascade());
-    } catch (LineageDoesNotExistException e) {
-      LOG.error("Failed to delete lineage {}", entry.getLineageId(), e);
-    } catch (LineageDeletionException e) {
+    } catch (LineageDoesNotExistException | LineageDeletionException e) {
       LOG.error("Failed to delete lineage {}", entry.getLineageId(), e);
     }
   }

--- a/core/server/src/main/java/alluxio/metrics/sink/MetricsServlet.java
+++ b/core/server/src/main/java/alluxio/metrics/sink/MetricsServlet.java
@@ -59,7 +59,7 @@ public class MetricsServlet implements Sink {
       @Override
       protected void doGet(HttpServletRequest request, HttpServletResponse response)
           throws ServletException, IOException {
-        response.setContentType(String.format("text/json;charset=utf-8"));
+        response.setContentType("text/json;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
         String result = mObjectMapper.writeValueAsString(mMetricsRegistry);

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -46,6 +46,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -525,13 +526,13 @@ public final class InodeTreeTest {
     InodeDirectory nested = (InodeDirectory) root.getChild("nested");
     InodeDirectory test = (InodeDirectory) nested.getChild("test");
     Inode<?> file = test.getChild("file");
-    verifyJournal(mTree, Lists.newArrayList(root, nested, test, file));
+    verifyJournal(mTree, Arrays.asList(root, nested, test, file));
 
     // add a sibling of test and verify journaling is in correct order (breadth first)
     createPath(mTree, new AlluxioURI("/nested/test1/file1"), sNestedFileOptions);
     InodeDirectory test1 = (InodeDirectory) nested.getChild("test1");
     Inode<?> file1 = test1.getChild("file1");
-    verifyJournal(mTree, Lists.newArrayList(root, nested, test, test1, file, file1));
+    verifyJournal(mTree, Arrays.asList(root, nested, test, test1, file, file1));
   }
 
   /**

--- a/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
@@ -92,9 +92,9 @@ public class MasterFaultToleranceIntegrationTest {
     Assert.assertEquals(answers.size(), files.size());
     for (Pair<Long, AlluxioURI> answer : answers) {
       Assert.assertEquals(answer.getSecond().toString(),
-              mFileSystem.getStatus(answer.getSecond()).getPath());
+          mFileSystem.getStatus(answer.getSecond()).getPath());
       Assert.assertEquals(answer.getFirst().longValue(),
-              mFileSystem.getStatus(answer.getSecond()).getFileId());
+          mFileSystem.getStatus(answer.getSecond()).getFileId());
     }
   }
 

--- a/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
@@ -81,20 +81,20 @@ public class MasterFaultToleranceIntegrationTest {
   }
 
   /**
-   * Tells if the results can match the answer.
+   * Tells if the results can match the answers.
    *
-   * @param answer the correct results
+   * @param answers the correct results
    */
-  private void faultTestDataCheck(List<Pair<Long, AlluxioURI>> answer) throws IOException,
+  private void faultTestDataCheck(List<Pair<Long, AlluxioURI>> answers) throws IOException,
       AlluxioException {
     List<String> files = FileSystemTestUtils.listFiles(mFileSystem, AlluxioURI.SEPARATOR);
     Collections.sort(files);
-    Assert.assertEquals(answer.size(), files.size());
-    for (int k = 0; k < answer.size(); k++) {
-      Assert.assertEquals(answer.get(k).getSecond().toString(),
-          mFileSystem.getStatus(answer.get(k).getSecond()).getPath());
-      Assert.assertEquals(answer.get(k).getFirst().longValue(),
-          mFileSystem.getStatus(answer.get(k).getSecond()).getFileId());
+    Assert.assertEquals(answers.size(), files.size());
+    for (Pair<Long, AlluxioURI> answer : answers) {
+      Assert.assertEquals(answer.getSecond().toString(),
+              mFileSystem.getStatus(answer.getSecond()).getPath());
+      Assert.assertEquals(answer.getFirst().longValue(),
+              mFileSystem.getStatus(answer.getSecond()).getFileId());
     }
   }
 


### PR DESCRIPTION
- Used <> generic in InodeTree
- Switched to java.util.Arrays in InodeTreeTest
- Collapsed multiple catch statements into one in LineageMaster
- Used foreach instead of for in MasterFaultToleranceIntegrationTest
- Removed not needed String.format in MetricsServlet