### PR TITLE
[SMALLFIX] Various improvements.

### DIFF
--- a/core/server/src/main/java/alluxio/worker/DefaultAlluxioWorker.java
+++ b/core/server/src/main/java/alluxio/worker/DefaultAlluxioWorker.java
@@ -257,20 +257,12 @@ public final class DefaultAlluxioWorker implements AlluxioWorkerService {
     mDataServer.close();
     mThriftServer.stop();
     mThriftServerSocket.close();
-    mWorkerMetricsSystem.stop();
     try {
       mWebServer.shutdownWebServer();
     } catch (Exception e) {
       LOG.error("Failed to stop web server", e);
     }
     mWorkerMetricsSystem.stop();
-
-    // TODO(binfan): investigate why we need to close dataserver again. There used to be a comment
-    // saying the reason to stop and close again is due to some issues in Thrift.
-    while (!mDataServer.isClosed()) {
-      mDataServer.close();
-      CommonUtils.sleepMs(100);
-    }
   }
 
   private void registerServices(TMultiplexedProcessor processor, Map<String, TProcessor> services) {

--- a/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -68,8 +68,6 @@ public final class NettyDataServer implements DataServer {
 
   @Override
   public void close() throws IOException {
-    boolean completed;
-
     int quietPeriodSecs =
         Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD);
     int timeoutSecs = Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT);
@@ -84,6 +82,7 @@ public final class NettyDataServer implements DataServer {
     // channel. If 2) or 3) times out, the respective EventLoopGroup failed to shut down
     // gracefully and its shutdown is forced.
 
+    boolean completed;
     completed =
         mChannelFuture.channel().close().awaitUninterruptibly(timeoutSecs, TimeUnit.SECONDS);
     if (!completed) {

--- a/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -66,11 +66,11 @@ public final class NettyDataServer implements DataServer {
     int quietPeriodSecs =
         Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD);
     int timeoutSecs = Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT);
-    // TODO(binfan): investigate when timeoutSecs is zero (e.g., set in integration tests), does
-    // this still complete successfully.
     mChannelFuture.channel().close().awaitUninterruptibly(timeoutSecs, TimeUnit.SECONDS);
-    mBootstrap.group().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
-    mBootstrap.childGroup().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
+    mBootstrap.group().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS)
+        .awaitUninterruptibly(timeoutSecs, TimeUnit.SECONDS);
+    mBootstrap.childGroup().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS)
+        .awaitUninterruptibly(timeoutSecs, TimeUnit.SECONDS);
   }
 
   private ServerBootstrap createBootstrap() {

--- a/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
@@ -53,12 +53,12 @@ import java.util.List;
  * Integration tests for the lineage module.
  */
 public class LineageMasterIntegrationTest {
-  protected static final int BLOCK_SIZE_BYTES = 128;
-  protected static final long WORKER_CAPACITY_BYTES = Constants.GB;
-  protected static final int BUFFER_BYTES = 100;
-  protected static final String OUT_FILE = "/test";
-  protected static final int RECOMPUTE_INTERVAL_MS = 1000;
-  protected static final int CHECKPOINT_INTERVAL_MS = 100;
+  private static final int BLOCK_SIZE_BYTES = 128;
+  private static final long WORKER_CAPACITY_BYTES = Constants.GB;
+  private static final int BUFFER_BYTES = 100;
+  private static final String OUT_FILE = "/test";
+  private static final int RECOMPUTE_INTERVAL_MS = 1000;
+  private static final int CHECKPOINT_INTERVAL_MS = 100;
 
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -75,7 +75,7 @@ public class LineageMasterIntegrationTest {
           .setProperty(PropertyKey.MASTER_LINEAGE_CHECKPOINT_INTERVAL_MS,
               Integer.toString(CHECKPOINT_INTERVAL_MS));
 
-  protected CommandLineJob mJob;
+  private CommandLineJob mJob;
 
   @Before
   public void before() throws Exception {
@@ -210,11 +210,11 @@ public class LineageMasterIntegrationTest {
     tl.deleteLineage(lineageId, options);
   }
 
-  protected LineageMasterClient getLineageMasterClient() {
+  private LineageMasterClient getLineageMasterClient() {
     return new LineageMasterClient(mLocalAlluxioClusterResource.get().getMaster().getAddress());
   }
 
-  protected FileSystemMasterClient getFileSystemMasterClient() {
+  private FileSystemMasterClient getFileSystemMasterClient() {
     return new FileSystemMasterClient(mLocalAlluxioClusterResource.get().getMaster().getAddress());
   }
 }


### PR DESCRIPTION
This PR makes fixes various minor issues:

- removes duplicate call to stop the worker metrics system
- uses the proper API (as opposed to sleeping in a loop) to wait for the data server executor groups to shutdown; this speeds up integration tests from 4:50 to 4:30 on my machine
- replaces unnecessary `protected`qualifiers  with `private`
