### PR TITLE
[ALLUXIO-2211] Fix recursive loadMetadata of a Swift directory

### DIFF
--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -15,8 +15,15 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.options.CreateDirectoryOptions;
+import alluxio.client.file.options.CreateFileOptions;
+import alluxio.client.file.options.ListStatusOptions;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.FileAlreadyExistsException;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
+import alluxio.wire.LoadMetadataType;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -370,6 +377,54 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
       Assert.assertTrue(mUfs.exists(testDirDstChild));
       Assert.assertTrue(mUfs.exists(testDirFinalDst));
       Assert.assertTrue(mUfs.exists(testDirChildFinalDst));
+    }
+  }
+
+  /**
+   * Tests load metadata on list.
+   */
+  @Test
+  public void loadMetadata() throws Exception {
+    String dirName = "loadMetaDataRoot";
+
+    String rootDir = PathUtils.concatPath(mUnderfsAddress, dirName);
+    mUfs.mkdirs(rootDir, true);
+
+    String rootFile1 = PathUtils.concatPath(rootDir, "file1");
+    createEmptyFile(rootFile1);
+
+    String rootFile2 = PathUtils.concatPath(rootDir, "file2");
+    createEmptyFile(rootFile2);
+
+    AlluxioURI rootAlluxioURI = new AlluxioURI("/" + dirName);
+    FileSystem client = mLocalAlluxioClusterResource.get().getClient();
+    client.listStatus(rootAlluxioURI,
+        ListStatusOptions.defaults().setLoadMetadataType(LoadMetadataType.Always));
+
+    try {
+      client.createDirectory(rootAlluxioURI, CreateDirectoryOptions.defaults());
+      Assert.fail("create is expected to fail with FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      Assert.assertEquals(
+          ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(rootAlluxioURI), e.getMessage());
+    }
+
+    AlluxioURI file1URI = rootAlluxioURI.join("file1");
+    try {
+      client.createFile(file1URI, CreateFileOptions.defaults());
+      Assert.fail("create is expected to fail with FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      Assert.assertEquals(
+          ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(file1URI), e.getMessage());
+    }
+
+    AlluxioURI file2URI = rootAlluxioURI.join("file2");
+    try {
+      client.createFile(file2URI, CreateFileOptions.defaults());
+      Assert.fail("create is expected to fail with FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      Assert.assertEquals(
+          ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(file2URI), e.getMessage());
     }
   }
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -578,7 +578,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
    */
   private String[] listHelper(String path, boolean recursive) throws IOException {
     String prefix = PathUtils.normalizePath(stripContainerPrefixIfPresent(path), PATH_SEPARATOR);
-    prefix = prefix.equals(PATH_SEPARATOR) ? "" : prefix;
+    prefix = CommonUtils.stripPrefixIfPresent(prefix, PATH_SEPARATOR);
 
     Collection<DirectoryOrObject> objects = listInternal(prefix, recursive);
     Set<String> children = new HashSet<>();
@@ -592,6 +592,10 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       } else {
         foundSelf = true;
       }
+    }
+
+    if (self.length() == 0) {
+      foundSelf = true;
     }
 
     if (!foundSelf) {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -423,7 +423,8 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
    * @return true if the path is the root, false otherwise
    */
   private boolean isRoot(final String path) {
-    return addFolderSuffixIfNotPresent(path).equals(mContainerPrefix);
+    final String pathWithSuffix = addFolderSuffixIfNotPresent(path);
+    return pathWithSuffix.equals(mContainerPrefix) || pathWithSuffix.equals(PATH_SEPARATOR);
   }
 
   @Override
@@ -594,7 +595,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       }
     }
 
-    if (self.length() == 0) {
+    if (isRoot(self)) {
       foundSelf = true;
     }
 


### PR DESCRIPTION
This addresses https://alluxio.atlassian.net/browse/ALLUXIO-2211.

The core problem is that FileSystemMaster:loadMetadataAndJournal calls list as follows:
String[] files = ufs.list(ufsUri.getPath());

getPath eliminates the 'swift://container/' scheme from the uri. The Swift UFS and some others I presume expect that the scheme is present. Although others are more robust to an absence. This PR makes Swift more robust.

I will address correct loadMetadataAndJournal to pass the fully qualified path to a UFS in a later PR which establishes a contract with all UFSs.