### PR TITLE
[SMALLFIX] Ensure that wire types are Serializable

### DIFF
--- a/core/common/src/main/java/alluxio/wire/BlockInfo.java
+++ b/core/common/src/main/java/alluxio/wire/BlockInfo.java
@@ -16,6 +16,7 @@ import alluxio.annotation.PublicApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,10 +27,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
-public final class BlockInfo {
+public final class BlockInfo implements Serializable {
+  private static final long serialVersionUID = 5646834366222004646L;
+
   private long mBlockId;
   private long mLength;
-  private List<BlockLocation> mLocations = new ArrayList<>();
+  private ArrayList<BlockLocation> mLocations = new ArrayList<>();
 
   /**
    * Creates a new instance of {@link BlockInfo}.
@@ -95,7 +98,7 @@ public final class BlockInfo {
    */
   public BlockInfo setLocations(List<BlockLocation> locations) {
     Preconditions.checkNotNull(locations);
-    mLocations = locations;
+    mLocations = new ArrayList<>(locations);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/BlockLocation.java
+++ b/core/common/src/main/java/alluxio/wire/BlockLocation.java
@@ -16,6 +16,8 @@ import alluxio.annotation.PublicApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -23,7 +25,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
-public final class BlockLocation {
+public final class BlockLocation implements Serializable {
+  private static final long serialVersionUID = 9017017197104411532L;
+
   private long mWorkerId;
   private WorkerNetAddress mWorkerAddress = new WorkerNetAddress();
   private String mTierAlias = "";

--- a/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
+++ b/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
@@ -16,6 +16,8 @@ import alluxio.annotation.PublicApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -24,7 +26,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 // TODO(jiri): Consolidate with alluxio.job.CommandLineJob.
-public final class CommandLineJobInfo {
+public final class CommandLineJobInfo implements Serializable {
+  private static final long serialVersionUID = 1058314411139470750L;
+
   private String mCommand = "";
   private JobConfInfo mConf = new JobConfInfo();
 

--- a/core/common/src/main/java/alluxio/wire/FileBlockInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileBlockInfo.java
@@ -17,6 +17,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,10 +28,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
-public final class FileBlockInfo {
+public final class FileBlockInfo implements Serializable {
+  private static final long serialVersionUID = -3313640897617385301L;
+
   private BlockInfo mBlockInfo = new BlockInfo();
   private long mOffset;
-  private List<String> mUfsLocations = new ArrayList<>();
+  private ArrayList<String> mUfsLocations = new ArrayList<>();
 
   /**
    * Creates a new instance of {@link FileBlockInfo}.
@@ -46,7 +49,7 @@ public final class FileBlockInfo {
     mBlockInfo = new BlockInfo(fileBlockInfo.getBlockInfo());
     mOffset = fileBlockInfo.getOffset();
     if (fileBlockInfo.getUfsStringLocationsSize() != 0) {
-      mUfsLocations = fileBlockInfo.getUfsStringLocations();
+      mUfsLocations = new ArrayList<>(fileBlockInfo.getUfsStringLocations());
     } else if (fileBlockInfo.getUfsLocationsSize() != 0) {
       for (alluxio.thrift.WorkerNetAddress address : fileBlockInfo.getUfsLocations()) {
         mUfsLocations
@@ -101,7 +104,7 @@ public final class FileBlockInfo {
    */
   public FileBlockInfo setUfsLocations(List<String> ufsLocations) {
     Preconditions.checkNotNull(ufsLocations);
-    mUfsLocations = ufsLocations;
+    mUfsLocations = new ArrayList<>(ufsLocations);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -14,6 +14,7 @@ package alluxio.wire;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +25,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 // TODO(jiri): Consolidate with URIStatus.
-public final class FileInfo {
+public final class FileInfo implements Serializable {
+  private static final long serialVersionUID = 7119966306934831779L;
+
   private long mFileId;
   private String mName = "";
   private String mPath = "";
@@ -37,7 +40,7 @@ public final class FileInfo {
   private boolean mPinned;
   private boolean mCacheable;
   private boolean mPersisted;
-  private List<Long> mBlockIds = new ArrayList<>();
+  private ArrayList<Long> mBlockIds = new ArrayList<>();
   private int mInMemoryPercentage;
   private long mLastModificationTimeMs;
   private long mTtl;
@@ -46,7 +49,7 @@ public final class FileInfo {
   private int mMode;
   private String mPersistenceState = "";
   private boolean mMountPoint;
-  private List<FileBlockInfo> mFileBlockInfos = new ArrayList<>();
+  private ArrayList<FileBlockInfo> mFileBlockInfos = new ArrayList<>();
 
   /**
    * Creates a new instance of {@link FileInfo}.
@@ -71,7 +74,7 @@ public final class FileInfo {
     mPinned = fileInfo.isPinned();
     mCacheable = fileInfo.isCacheable();
     mPersisted = fileInfo.isPersisted();
-    mBlockIds = fileInfo.getBlockIds();
+    mBlockIds = new ArrayList<>(fileInfo.getBlockIds());
     mInMemoryPercentage = fileInfo.getInMemoryPercentage();
     mLastModificationTimeMs = fileInfo.getLastModificationTimeMs();
     mTtl = fileInfo.getTtl();
@@ -359,7 +362,7 @@ public final class FileInfo {
    */
   public FileInfo setBlockIds(List<Long> blockIds) {
     Preconditions.checkNotNull(blockIds);
-    mBlockIds = blockIds;
+    mBlockIds = new ArrayList<>(blockIds);
     return this;
   }
 
@@ -443,7 +446,7 @@ public final class FileInfo {
    * @return the file descriptor
    */
   public FileInfo setFileBlockInfos(List<FileBlockInfo> fileBlockInfos) {
-    mFileBlockInfos = fileBlockInfos;
+    mFileBlockInfos = new ArrayList<>(fileBlockInfos);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/JobConfInfo.java
+++ b/core/common/src/main/java/alluxio/wire/JobConfInfo.java
@@ -16,6 +16,8 @@ import alluxio.annotation.PublicApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -24,7 +26,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 // TODO(jiri): Consolidate with alluxio.job.JobConf
-public final class JobConfInfo {
+public final class JobConfInfo implements Serializable {
+  private static final long serialVersionUID = -7905777467753059106L;
+
   private String mOutputFile = "";
 
   /**

--- a/core/common/src/main/java/alluxio/wire/LineageInfo.java
+++ b/core/common/src/main/java/alluxio/wire/LineageInfo.java
@@ -16,6 +16,7 @@ import alluxio.annotation.PublicApi;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,14 +27,16 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
-public final class LineageInfo {
+public final class LineageInfo implements Serializable {
+  private static final long serialVersionUID = -6407439859190160616L;
+
   private long mId;
-  private List<String> mInputFiles = new ArrayList<>();
-  private List<String> mOutputFiles = new ArrayList<>();
+  private ArrayList<String> mInputFiles = new ArrayList<>();
+  private ArrayList<String> mOutputFiles = new ArrayList<>();
   private CommandLineJobInfo mJob = new CommandLineJobInfo();
   private long mCreationTimeMs;
-  private List<Long> mParents = new ArrayList<>();
-  private List<Long> mChildren = new ArrayList<>();
+  private ArrayList<Long> mParents = new ArrayList<>();
+  private ArrayList<Long> mChildren = new ArrayList<>();
 
   /**
    * Creates a new instance of {@link LineageInfo}.
@@ -47,12 +50,12 @@ public final class LineageInfo {
    */
   protected LineageInfo(alluxio.thrift.LineageInfo lineageInfo) {
     mId = lineageInfo.getId();
-    mInputFiles = lineageInfo.getInputFiles();
-    mOutputFiles = lineageInfo.getOutputFiles();
+    mInputFiles = new ArrayList<>(lineageInfo.getInputFiles());
+    mOutputFiles = new ArrayList<>(lineageInfo.getOutputFiles());
     mJob = new CommandLineJobInfo(lineageInfo.getJob());
     mCreationTimeMs = lineageInfo.getCreationTimeMs();
-    mParents = lineageInfo.getParents();
-    mChildren = lineageInfo.getChildren();
+    mParents = new ArrayList<>(lineageInfo.getParents());
+    mChildren = new ArrayList<>(lineageInfo.getChildren());
   }
 
   /**
@@ -119,7 +122,7 @@ public final class LineageInfo {
    */
   public LineageInfo setInputFiles(List<String> inputFiles) {
     Preconditions.checkNotNull(inputFiles);
-    mInputFiles = inputFiles;
+    mInputFiles = new ArrayList<>(inputFiles);
     return this;
   }
 
@@ -129,7 +132,7 @@ public final class LineageInfo {
    */
   public LineageInfo setOutputFiles(List<String> outputFiles) {
     Preconditions.checkNotNull(outputFiles);
-    mOutputFiles = outputFiles;
+    mOutputFiles = new ArrayList<>(outputFiles);
     return this;
   }
 
@@ -158,7 +161,7 @@ public final class LineageInfo {
    */
   public LineageInfo setParents(List<Long> parents) {
     Preconditions.checkNotNull(parents);
-    mParents = parents;
+    mParents = new ArrayList<>(parents);
     return this;
   }
 
@@ -168,7 +171,7 @@ public final class LineageInfo {
    */
   public LineageInfo setChildren(List<Long> children) {
     Preconditions.checkNotNull(children);
-    mChildren = children;
+    mChildren = new ArrayList<>(children);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/LockBlockResult.java
+++ b/core/common/src/main/java/alluxio/wire/LockBlockResult.java
@@ -14,13 +14,17 @@ package alluxio.wire;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * The lock block operation result.
  */
 @NotThreadSafe
-public final class LockBlockResult {
+public final class LockBlockResult implements Serializable {
+  private static final long serialVersionUID = -2217323649674837526L;
+
   private long mLockId;
   private String mBlockPath = "";
 

--- a/core/common/src/main/java/alluxio/wire/MountPointInfo.java
+++ b/core/common/src/main/java/alluxio/wire/MountPointInfo.java
@@ -16,13 +16,16 @@ import alluxio.underfs.UnderFileSystem;
 import com.google.common.base.Objects;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * The mount point descriptor.
  */
-public class MountPointInfo {
+public class MountPointInfo implements Serializable {
+  private static final long serialVersionUID = -2912330427506888886L;
+
   private static final long UNKNOWN_CAPACITY_BYTES = -1;
   private static final long UNKNOWN_USED_BYTES = -1;
 
@@ -31,7 +34,7 @@ public class MountPointInfo {
   private long mUfsCapacityBytes = UNKNOWN_CAPACITY_BYTES;
   private long mUfsUsedBytes = UNKNOWN_USED_BYTES;
   private boolean mReadOnly;
-  private Map<String, String> mProperties = new HashMap<>();
+  private HashMap<String, String> mProperties = new HashMap<>();
   private boolean mShared;
 
   /**
@@ -138,7 +141,7 @@ public class MountPointInfo {
    * @return the mount point descriptor
    */
   public MountPointInfo setProperties(Map<String, String> properties) {
-    mProperties = properties;
+    mProperties = new HashMap<>(properties);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/WorkerInfo.java
+++ b/core/common/src/main/java/alluxio/wire/WorkerInfo.java
@@ -14,13 +14,17 @@ package alluxio.wire;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * The worker descriptor.
  */
 @NotThreadSafe
-public final class WorkerInfo {
+public final class WorkerInfo implements Serializable {
+  private static final long serialVersionUID = -454711814438216780L;
+
   private long mId;
   private WorkerNetAddress mAddress = new WorkerNetAddress();
   private int mLastContactSec;

--- a/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -14,13 +14,17 @@ package alluxio.wire;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * The network address of a worker.
  */
 @NotThreadSafe
-public final class WorkerNetAddress {
+public final class WorkerNetAddress implements Serializable {
+  private static final long serialVersionUID = 5822347646342091434L;
+
   private String mHost = "";
   private int mRpcPort;
   private int mDataPort;


### PR DESCRIPTION
Explicitly use `HashMap` and `ArrayList` since they are `Serializable` but `Map` and `List` are not.