### PR TITLE
[ALLUXIO-2158] Remove redundant initialization in LocalFirstPolicy.java

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
+++ b/core/client/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
@@ -27,7 +27,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class LocalFirstPolicy implements FileWriteLocationPolicy {
-  private String mLocalHostName = null;
+  private String mLocalHostName;
 
   /**
    * Constructs a {@link LocalFirstPolicy}.


### PR DESCRIPTION
Remove redundant initialization in LocalFirstPolicy.java
private String mLocalHostName = null; can be simplified to private String mLocalHostName;

jira ticket: https://alluxio.atlassian.net/browse/ALLUXIO-2158