### PR TITLE
[SMALLFIX] Use hostname instead of ip:port as the ufs block location

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -211,7 +211,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
       FileStatus fStatus = mFileSystem.getFileStatus(new Path(path));
       BlockLocation[] bLocations = mFileSystem.getFileBlockLocations(fStatus, offset, 1);
       if (bLocations.length > 0) {
-        String[] names = bLocations[0].getNames();
+        String[] names = bLocations[0].getHosts();
         Collections.addAll(ret, names);
       }
     } catch (IOException e) {


### PR DESCRIPTION
Two reasons:
1. Alluxio uses hostname when returning cached block locations. 
2. Keep it consistent with Spark.  https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/rdd/ReliableCheckpointRDD.scala & line = 89
https://github.com/apache/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/util/HdfsUtils.scala & line = 72

