### PR TITLE
[SMALLFIX] Improve error message when configuration is undefined

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -202,7 +202,7 @@ public final class Configuration {
     String rawValue = PROPERTIES.get(key.toString());
     if (rawValue == null) {
       // if key is not found among the default properties
-      throw new RuntimeException(ExceptionMessage.INVALID_CONFIGURATION_KEY.getMessage(key));
+      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
     }
     return lookup(rawValue);
   }

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -145,7 +145,6 @@ public enum ExceptionMessage {
 
   // configuration
   DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST("The default Alluxio properties file does not exist"),
-  INVALID_CONFIGURATION_KEY("Invalid configuration key {0}"),
   INVALID_CONFIGURATION_VALUE("Invalid value {0} for configuration key {1}"),
   KEY_NOT_BOOLEAN("Configuration cannot evaluate key {0} as boolean"),
   KEY_NOT_BYTES("Configuration cannot evaluate key {0} as bytes"),
@@ -153,6 +152,7 @@ public enum ExceptionMessage {
   KEY_NOT_FLOAT("Configuration cannot evaluate key {0} as float"),
   KEY_NOT_INTEGER("Configuration cannot evaluate key {0} as integer"),
   KEY_NOT_LONG("Configuration cannot evaluate key {0} as long"),
+  UNDEFINED_CONFIGURATION_KEY("No value set for configuration key {0}"),
   UNKNOWN_PROPERTY("Unknown property for {0} {1}"),
 
   // security


### PR DESCRIPTION
"Invalid configuration key" makes it sound like the key is mis-typed or unsupported, but it actually just means that no value was set for that key.