### PR TITLE
[SMALLFIX] Quiet down line ending check

### DIFF
--- a/build/style/check_no_windows_line_endings.sh
+++ b/build/style/check_no_windows_line_endings.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-git status
+git status >> /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     # we aren't in a git repo, no need to run this check
     exit 0


### PR DESCRIPTION
no need to show the output of git status during the build