### PR TITLE
[SMALLFIX] handle NPE in shell utils

### DIFF
--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -193,7 +193,11 @@ public final class AlluxioShellUtils {
       return res;
     }
     if (pFile.isDirectory() && pFile.canRead()) {
-      for (File file : pFile.listFiles()) {
+      File[] fileList = pFile.listFiles();
+      if (fileList == null) {
+        return res;
+      }
+      for (File file : fileList) {
         if (match(file.getPath(), inputPath)) { // if it matches
           res.add(file);
         } else {


### PR DESCRIPTION
Same as previous PR for CopyFromLocalCommand.java, in AlluxioShellUtils.java, File.listFiles() could return null. 
http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/solaris/native/java/io/UnixFileSystem_md.c