### PR TITLE
[SMALLFIX] JOSS range parameters fix

### DIFF
--- a/underfs/swift/src/main/java/alluxio/underfs/swift/MidPartLongRange.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/MidPartLongRange.java
@@ -17,14 +17,14 @@ import org.javaswift.joss.headers.object.range.AbstractRange;
  * A range in a Swift object. This class is a substitute for JOSS MidPartRange which takes 'int'
  * parameters that might overflow for large objects.
  */
-public class SwiftRange extends AbstractRange {
+public class MidPartLongRange extends AbstractRange {
   /**
    * Constructor for a range in a Swift object.
    *
    * @param startPos starting position in bytes
    * @param endPos ending position in bytes
    */
-  public SwiftRange(long startPos, long endPos) {
+  public MidPartLongRange(long startPos, long endPos) {
     super(startPos, endPos);
   }
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -124,7 +124,7 @@ public class SwiftInputStream extends InputStream {
     DownloadInstructions downloadInstructions  = new DownloadInstructions();
     final long blockSize = getBlockSize();
     final long endPos = mPos + blockSize - (mPos % blockSize);
-    downloadInstructions.setRange(new SwiftRange(mPos, endPos));
+    downloadInstructions.setRange(new MidPartLongRange(mPos, endPos));
     mStream = storedObject.downloadObjectAsInputStream(downloadInstructions);
   }
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftRange.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftRange.java
@@ -25,7 +25,7 @@ public class SwiftRange extends AbstractRange {
    * @param endPos ending position in bytes
    */
   public SwiftRange(long startPos, long endPos) {
-    super(startPos, endPos - startPos);
+    super(startPos, endPos);
   }
 
   @Override
@@ -35,6 +35,6 @@ public class SwiftRange extends AbstractRange {
 
   @Override
   public long getTo(int byteArrayLength) {
-    return this.offset + this.length;
+    return this.length;
   }
 }


### PR DESCRIPTION
Even though the JOSS AbstractRange parameter is named 'length', it actually expects 'end position' to be passed.

Ref: RANGE_HEADER_VALUE_PREFIX in https://github.com/javaswift/joss/blob/bf0b8e411a1022e167e034ba4c3482670d46b6fe/src/main/java/org/javaswift/joss/headers/object/range/AbstractRange.java

Ref: http://developer.openstack.org/api-ref/object-storage/index.html?expanded=get-object-content-and-metadata-detail