### PR TITLE
[SMALLFIX] Disable the HDFS cache in HDFS under storage file system

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -115,7 +115,8 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
       hadoopConf.set("fs.hdfs.impl", ufsHdfsImpl);
     }
 
-    // Disable the instance cache to use the input configuration. Configurable from system property
+    // Disable hdfs client caching so that input configuration is respected. Configurable from
+    // system property
     hadoopConf.set("fs.hdfs.impl.disable.cache",
         System.getProperty("fs.hdfs.impl.disable.cache", "true"));
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -115,11 +115,9 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
       hadoopConf.set("fs.hdfs.impl", ufsHdfsImpl);
     }
 
-    // To disable the instance cache for hdfs client, otherwise it causes the
-    // FileSystem closed exception. Being configurable for unit/integration
-    // test only, and not expose to the end-user currently.
+    // Disable the instance cache to use the input configuration. Configurable from system property
     hadoopConf.set("fs.hdfs.impl.disable.cache",
-        System.getProperty("fs.hdfs.impl.disable.cache", "false"));
+        System.getProperty("fs.hdfs.impl.disable.cache", "true"));
 
     HdfsUnderFileSystemUtils.addKey(hadoopConf, PropertyKey.UNDERFS_HDFS_CONFIGURATION);
   }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -52,7 +52,7 @@ public final class HdfsUnderFileSystemTest {
     org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     mMockHdfsUnderFileSystem.prepareConfiguration("", conf);
     Assert.assertEquals("org.apache.hadoop.hdfs.DistributedFileSystem", conf.get("fs.hdfs.impl"));
-    Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache",false));
+    Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache", false));
     Assert.assertNotNull(conf.get(PropertyKey.UNDERFS_HDFS_CONFIGURATION.toString()));
   }
 

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -19,6 +19,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.URI;
+
 /**
  * Tests {@link HdfsUnderFileSystem}.
  */
@@ -32,8 +34,8 @@ public final class HdfsUnderFileSystemTest {
   }
 
   /**
-   * Tests the {@link HdfsUnderFileSystem#getUnderFSType()} method.
-   * Confirm the UnderFSType for HdfsUnderFileSystem
+   * Tests the {@link HdfsUnderFileSystem#getUnderFSType()} method. Confirm the UnderFSType for
+   * HdfsUnderFileSystem.
    */
   @Test
   public void getUnderFSType() throws Exception {
@@ -50,7 +52,30 @@ public final class HdfsUnderFileSystemTest {
     org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     mMockHdfsUnderFileSystem.prepareConfiguration("", conf);
     Assert.assertEquals("org.apache.hadoop.hdfs.DistributedFileSystem", conf.get("fs.hdfs.impl"));
-    Assert.assertFalse(conf.getBoolean("fs.hdfs.impl.disable.cache", false));
+    Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache",false));
     Assert.assertNotNull(conf.get(PropertyKey.UNDERFS_HDFS_CONFIGURATION.toString()));
+  }
+
+  /**
+   * Tests the HDFS client caching is disabled.
+   *
+   * @throws Exception
+   */
+  public void disableHdfsCacheTest() throws Exception {
+    // create a default hadoop configuration
+    org.apache.hadoop.conf.Configuration hadoopConf = new org.apache.hadoop.conf.Configuration();
+    String underfsAddress = "hdfs://localhost";
+    URI u = new URI(underfsAddress);
+    org.apache.hadoop.fs.FileSystem hadoopFs = org.apache.hadoop.fs.FileSystem.get(u, hadoopConf);
+    // use the replication to test the default value
+    Assert.assertEquals("3", hadoopFs.getConf().get("dfs.replication"));
+
+    // create a new configuration with updated dfs replication value
+    org.apache.hadoop.conf.Configuration hadoopConf1 = new org.apache.hadoop.conf.Configuration();
+    hadoopConf1.set("dfs.replication", "1");
+    HdfsUnderFileSystem hdfs =
+        new HdfsUnderFileSystem(new AlluxioURI(underfsAddress), hadoopConf1);
+    Assert.assertEquals("1",
+        ((org.apache.hadoop.conf.Configuration) hdfs.getConf()).get("dfs.replication"));
   }
 }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -58,15 +58,13 @@ public final class HdfsUnderFileSystemTest {
 
   /**
    * Tests the HDFS client caching is disabled.
-   *
-   * @throws Exception
    */
   public void disableHdfsCacheTest() throws Exception {
     // create a default hadoop configuration
     org.apache.hadoop.conf.Configuration hadoopConf = new org.apache.hadoop.conf.Configuration();
     String underfsAddress = "hdfs://localhost";
-    URI u = new URI(underfsAddress);
-    org.apache.hadoop.fs.FileSystem hadoopFs = org.apache.hadoop.fs.FileSystem.get(u, hadoopConf);
+    URI uri = new URI(underfsAddress);
+    org.apache.hadoop.fs.FileSystem hadoopFs = org.apache.hadoop.fs.FileSystem.get(uri, hadoopConf);
     // use the replication to test the default value
     Assert.assertEquals("3", hadoopFs.getConf().get("dfs.replication"));
 


### PR DESCRIPTION
Disables the HDFS client cache when constructing the HDFS under storage file system, so that the configuration passed in will be effective. 

Otherwise an application may create an HDFS client directly or indirectly, and that will shadow the configurations during the under storage file system construction.

