### PR TITLE
[SMALLFIX] Refactor netty UnderFileSystemFile reader and writer.

### DIFF
--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileReader.java
@@ -55,8 +55,8 @@ public interface UnderFileSystemFileReader extends Closeable {
    *
    * @param address the worker address to read from
    * @param ufsFileId the worker specific file id referencing the file to read
-   * @param offset the offset in the file to read from
-   * @param length the length to read
+   * @param offset the offset in bytes in the file to read from
+   * @param length the length in bytes to read
    * @return a byte buffer with the requested data, null if EOF is reached
    * @throws IOException if an error occurs communicating with the worker
    */

--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileReader.java
@@ -1,0 +1,66 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.util.CommonUtils;
+
+import com.google.common.base.Throwables;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+/**
+ * The interface to read an under file system file through a worker's data server.
+ */
+public interface UnderFileSystemFileReader extends Closeable {
+
+  /**
+   * The factory for the {@link UnderFileSystemFileReader}.
+   */
+  class Factory {
+
+    private Factory() {} // prevent instantiation
+
+    /**
+     * Factory for {@link UnderFileSystemFileReader}.
+     *
+     * @return a new instance of {@link UnderFileSystemFileReader}
+     */
+    public static UnderFileSystemFileReader create() {
+      try {
+        return CommonUtils.createNewClassInstance(
+            Configuration.<UnderFileSystemFileReader>getClass(
+                PropertyKey.USER_UFS_FILE_READER_CLASS), null, null);
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  /**
+   * Reads data from the specified worker for a file in the under file system.
+   *
+   * @param address the worker address to read from
+   * @param ufsFileId the worker specific file id referencing the file to read
+   * @param offset the offset in the file to read from
+   * @param length the length to read
+   * @return a byte buffer with the requested data, null if EOF is reached
+   * @throws IOException if an error occurs communicating with the worker
+   */
+  ByteBuffer read(InetSocketAddress address, long ufsFileId, long offset, long length)
+      throws IOException;
+}
+

--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
@@ -1,0 +1,66 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.util.CommonUtils;
+
+import com.google.common.base.Throwables;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/**
+ * The interface to write an under file system file through a worker's data server.
+ */
+public interface UnderFileSystemFileWriter extends Closeable {
+
+  /**
+   * The factory for the {@link UnderFileSystemFileWriter}.
+   */
+  class Factory {
+
+    private Factory() {} // prevent instantiation
+
+    /**
+     * Factory for {@link UnderFileSystemFileWriter}.
+     *
+     * @return a new instance of {@link UnderFileSystemFileWriter}
+     */
+    public static UnderFileSystemFileWriter create() {
+      try {
+        return CommonUtils.createNewClassInstance(
+            Configuration.<UnderFileSystemFileWriter>getClass(
+                PropertyKey.USER_UFS_FILE_WRITER_CLASS), null, null);
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  /**
+   * Writes data to the file in the under file system.
+   *
+   * @param address worker address to write the data to
+   * @param ufsFileId worker file id referencing the file
+   * @param fileOffset where in the file to start writing, only sequential writes are supported
+   * @param bytes data to write
+   * @param offset start offset of the data
+   * @param length length to write
+   * @throws IOException if an error occurs during the write
+   */
+  void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
+             int offset, int length) throws IOException;
+}
+

--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
@@ -54,10 +54,11 @@ public interface UnderFileSystemFileWriter extends Closeable {
    *
    * @param address worker address to write the data to
    * @param ufsFileId worker file id referencing the file
-   * @param fileOffset where in the file to start writing, only sequential writes are supported
+   * @param fileOffset the offset in bytes where in the file to start writing, only sequential
+   *                   writes are supported
    * @param bytes data to write
-   * @param offset start offset of the data
-   * @param length length to write
+   * @param offset start offset in bytes of the data to write
+   * @param length length to write in bytes
    * @throws IOException if an error occurs during the write
    */
   void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,

--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
@@ -61,6 +61,6 @@ public interface UnderFileSystemFileWriter extends Closeable {
    * @throws IOException if an error occurs during the write
    */
   void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
-             int offset, int length) throws IOException;
+      int offset, int length) throws IOException;
 }
 

--- a/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/UnderFileSystemFileWriter.java
@@ -56,12 +56,12 @@ public interface UnderFileSystemFileWriter extends Closeable {
    * @param ufsFileId worker file id referencing the file
    * @param fileOffset the offset in bytes where in the file to start writing, only sequential
    *                   writes are supported
-   * @param bytes data to write
-   * @param offset start offset in bytes of the data to write
-   * @param length length to write in bytes
+   * @param source source data to write
+   * @param offset start offset in bytes of the data in byte array source
+   * @param length length in bytes to write
    * @throws IOException if an error occurs during the write
    */
-  void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
+  void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] source,
       int offset, int length) throws IOException;
 }
 

--- a/core/client/src/main/java/alluxio/client/file/DelegatedUnderStoreStreamFactory.java
+++ b/core/client/src/main/java/alluxio/client/file/DelegatedUnderStoreStreamFactory.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.block.UnderStoreBlockInStream.UnderStoreStreamFactory;
 import alluxio.client.file.options.CloseUfsFileOptions;
 import alluxio.client.file.options.OpenUfsFileOptions;
-import alluxio.client.netty.NettyUnderFileSystemFileReader;
+import alluxio.client.UnderFileSystemFileReader;
 import alluxio.exception.AlluxioException;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public final class DelegatedUnderStoreStreamFactory implements UnderStoreStreamF
   @Override
   public InputStream create() {
     return new UnderFileSystemFileInStream(mClient.getWorkerDataServerAddress(), mFileId,
-        new NettyUnderFileSystemFileReader());
+        UnderFileSystemFileReader.Factory.create());
   }
 
   @Override

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileInStream.java
@@ -13,7 +13,7 @@ package alluxio.client.file;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.client.netty.NettyUnderFileSystemFileReader;
+import alluxio.client.UnderFileSystemFileReader;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.io.BufferUtils;
 
@@ -40,7 +40,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
   /** Flag indicating EOF has been reached. */
   private boolean mEOF;
   /** Reader to the worker, currently only implemented through Netty. */
-  private final NettyUnderFileSystemFileReader mReader;
+  private final UnderFileSystemFileReader mReader;
   /** Address of the worker to write to. */
   private final InetSocketAddress mAddress;
   /** Worker file id referencing the file to write to. */
@@ -60,7 +60,7 @@ public final class UnderFileSystemFileInStream extends InputStream {
    * @param reader a reader for reading from the worker
    */
   public UnderFileSystemFileInStream(InetSocketAddress address, long ufsFileId,
-      NettyUnderFileSystemFileReader reader) {
+      UnderFileSystemFileReader reader) {
     mAddress = address;
     mUfsFileId = ufsFileId;
     mReader = reader;

--- a/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnderFileSystemFileOutStream.java
@@ -13,7 +13,7 @@ package alluxio.client.file;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.client.netty.NettyUnderFileSystemFileWriter;
+import alluxio.client.UnderFileSystemFileWriter;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.io.BufferUtils;
 
@@ -37,7 +37,7 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
   /** Java heap buffer to buffer writes before flushing them to the worker. */
   private final ByteBuffer mBuffer;
   /** Writer to the worker, currently only implemented through Netty. */
-  private final NettyUnderFileSystemFileWriter mWriter;
+  private final UnderFileSystemFileWriter mWriter;
   /** Address of the worker to write to. */
   private final InetSocketAddress mAddress;
   /** Worker file id referencing the file to write to. */
@@ -88,7 +88,7 @@ public final class UnderFileSystemFileOutStream extends OutputStream {
     mBuffer = allocateBuffer();
     mAddress = address;
     mUfsFileId = ufsFileId;
-    mWriter = new NettyUnderFileSystemFileWriter();
+    mWriter = UnderFileSystemFileWriter.Factory.create();
     mFlushedBytes = 0;
     mWrittenBytes = 0;
     mClosed = false;

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -12,6 +12,7 @@
 package alluxio.client.netty;
 
 import alluxio.Constants;
+import alluxio.client.UnderFileSystemFileReader;
 import alluxio.exception.ExceptionMessage;
 import alluxio.network.protocol.RPCErrorResponse;
 import alluxio.network.protocol.RPCFileReadRequest;
@@ -25,7 +26,6 @@ import io.netty.channel.ChannelFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * reader in order to clean up any lingering data from the last read.
  */
 @NotThreadSafe
-public final class NettyUnderFileSystemFileReader implements Closeable {
+public final class NettyUnderFileSystemFileReader implements UnderFileSystemFileReader {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** Netty bootstrap for the connection. */
@@ -58,16 +58,7 @@ public final class NettyUnderFileSystemFileReader implements Closeable {
     mClientBootstrap = NettyClient.createClientBootstrap(mHandler);
   }
 
-  /**
-   * Reads data from the specified worker for a file in the under file system.
-   *
-   * @param address the worker address to read from
-   * @param ufsFileId the worker specific file id referencing the file to read
-   * @param offset the offset in the file to read from
-   * @param length the length to read
-   * @return a byte buffer with the requested data, null if EOF is reached
-   * @throws IOException if an error occurs communicating with the worker
-   */
+  @Override
   public ByteBuffer read(InetSocketAddress address, long ufsFileId, long offset, long length)
       throws IOException {
     // For a zero length read, directly return without trying the Netty call.

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
@@ -56,7 +56,7 @@ public final class NettyUnderFileSystemFileWriter implements UnderFileSystemFile
   }
 
   @Override
-  public void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
+  public void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] source,
       int offset, int length) throws IOException {
     SingleResponseListener listener = null;
     try {
@@ -67,7 +67,7 @@ public final class NettyUnderFileSystemFileWriter implements UnderFileSystemFile
       listener = new SingleResponseListener();
       mHandler.addListener(listener);
       channel.writeAndFlush(new RPCFileWriteRequest(ufsFileId, fileOffset, length,
-          new DataByteArrayChannel(bytes, offset, length)));
+          new DataByteArrayChannel(source, offset, length)));
 
       RPCResponse response = listener.get(NettyClient.TIMEOUT_MS, TimeUnit.MILLISECONDS);
       channel.close().sync();

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
@@ -12,6 +12,7 @@
 package alluxio.client.netty;
 
 import alluxio.Constants;
+import alluxio.client.UnderFileSystemFileWriter;
 import alluxio.exception.ExceptionMessage;
 import alluxio.network.protocol.RPCErrorResponse;
 import alluxio.network.protocol.RPCFileWriteRequest;
@@ -38,7 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * concurrently. This class does not keep lingering resources and does not need to be closed.
  */
 @NotThreadSafe
-public final class NettyUnderFileSystemFileWriter {
+public final class NettyUnderFileSystemFileWriter implements UnderFileSystemFileWriter {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** Netty bootstrap for the connection. */
@@ -54,17 +55,7 @@ public final class NettyUnderFileSystemFileWriter {
     mClientBootstrap = NettyClient.createClientBootstrap(mHandler);
   }
 
-  /**
-   * Writes data to the file in the under file system.
-   *
-   * @param address worker address to write the data to
-   * @param ufsFileId worker file id referencing the file
-   * @param fileOffset where in the file to start writing, only sequential writes are supported
-   * @param bytes data to write
-   * @param offset start offset of the data
-   * @param length length to write
-   * @throws IOException if an error occurs during the write
-   */
+  @Override
   public void write(InetSocketAddress address, long ufsFileId, long fileOffset, byte[] bytes,
       int offset, int length) throws IOException {
     SingleResponseListener listener = null;
@@ -107,4 +98,7 @@ public final class NettyUnderFileSystemFileWriter {
       }
     }
   }
+
+  @Override
+  public void close() {}
 }

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -236,6 +236,10 @@ public enum PropertyKey {
       "8MB"),
   USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES(Name.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES,
       "2MB"),
+  USER_UFS_FILE_READER_CLASS(Name.USER_UFS_FILE_READER_CLASS,
+      "alluxio.client.netty.NettyUnderFileSystemFileReader"),
+  USER_UFS_FILE_WRITER_CLASS(Name.USER_UFS_FILE_WRITER_CLASS,
+      "alluxio.client.netty.NettyUnderFileSystemFileWriter"),
 
   //
   // FUSE integration related properties
@@ -611,6 +615,10 @@ public enum PropertyKey {
         "alluxio.user.ufs.delegation.read.buffer.size.bytes";
     public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES =
         "alluxio.user.ufs.delegation.write.buffer.size.bytes";
+    public static final String USER_UFS_FILE_READER_CLASS =
+        "alluxio.user.ufs.file.reader.class";
+    public static final String USER_UFS_FILE_WRITER_CLASS =
+        "alluxio.user.ufs.file.writer.class";
 
     //
     // FUSE integration related properties

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -65,3 +65,11 @@ alluxio.user.ufs.delegation.write.buffer.size.bytes:
   Size of the write buffer when writing to the ufs through the Alluxio worker. Each write request
   will write at least this many bytes, unless the write is at the end of the file. This property
   has no effect if the delegation flag is turned off.
+alluxio.user.ufs.file.reader.class:
+  Selects networking stack to run the client with for reading from under file system through a
+  worker's data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileReader`
+  (remote read using netty) is valid.
+alluxio.user.ufs.file.writer.class:
+  Selects networking stack to run the client with for writing to under file system through a
+  worker's data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileWriter`
+  (remote write using netty) is valid.

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -22,3 +22,5 @@ alluxio.user.network.netty.worker.threads,0
 alluxio.user.ufs.delegation.enabled,false
 alluxio.user.ufs.delegation.read.buffer.size.bytes,8MB
 alluxio.user.ufs.delegation.write.buffer.size.bytes,2MB
+alluxio.user.ufs.file.reader.class,alluxio.client.netty.&#8203;NettyUnderFileSystemFileReader
+alluxio.user.ufs.file.writer.class,alluxio.client.netty.&#8203;NettyUnderFileSystemFileWriter


### PR DESCRIPTION
To make code structure consistent with `RemoteBlockReader` and `RemoteBlockWriter`.