### PR TITLE
[ALLUXIO-1956] Java 8 fix for Hadoop 2.6

### DIFF
--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -79,6 +79,16 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <!--
+          Newer versions of hadoop-client include the old javax.servlet:servlet-api jar.
+          This is excluded to prevent conflicts with the newer javax.servlet:javax.servlet-api jar.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1956
Excludes the older servlet-api which is brought in by hadoop client. The artifact ID was changed so we cannot rely on dependency management to resolve this.