### PR TITLE
[DOCFIX] Fix cn docs ported from master branch

### DIFF
--- a/docs/cn/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/cn/Running-Alluxio-Fault-Tolerant.md
@@ -99,6 +99,11 @@ Zookeeper和共享文件系统都正常运行时，需要在每个主机上配�
 
 只要以上参数配置正确，worker就可以咨询ZooKeeper，找到当前应当连接的master。所以，worker无需设置`ALLUXIO_MASTER_HOSTNAME`。
 
+> 注意: 当在容错模式下运行Alluxio, worker的默认心跳超时时间可能太短。
+> 为了能在master进行故障转移时正确处理master的状态，建议将worker的默认心跳超时时间设置的长点。
+> 增加worker上的默认超时时间，可以通过修改`conf/alluxio-site.properties`下的配置参数
+> `alluxio.worker.block.heartbeat.timeout.ms` 至一个大些的值（至少几分钟）。
+
 ### Client配置
 
 无需为容错模式配置更多的参数，只要以下两项：


### PR DESCRIPTION
I update the chinese version docs to the latest. Add the extra instructions about setting "worker heartbeat timeout value" to a larger value to avoid exceptions when master failover.

The problem is mentioned in [Alluxio User Group](https://groups.google.com/forum/#!topic/alluxio-users/W9Ryj4HCcxI)