### PR TITLE
[SMALLFIX] Remove update ufs path on client side.

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -119,6 +119,15 @@ public class FileOutStream extends AbstractOutStream {
     mPreviousBlockOutStreams = new LinkedList<>();
     mUfsDelegation = Configuration.getBoolean(PropertyKey.USER_UFS_DELEGATION_ENABLED);
     if (mUnderStorageType.isSyncPersist()) {
+      // Get the ufs path from the master.
+      FileSystemMasterClient client = mContext.acquireMasterClient();
+      try {
+        mUfsPath = client.getStatus(mUri).getUfsPath();
+      } catch (AlluxioException e) {
+        throw new IOException(e);
+      } finally {
+        mContext.releaseMasterClient(client);
+      }
       if (mUfsDelegation) {
         mFileSystemWorkerClient = mContext.createWorkerClient();
         try {


### PR DESCRIPTION
This is unnecessary since we will not be able to recover the new path if a rename operation has occurred.