### PR TITLE
[SMALLFIX] Exclude jsp from hadoop client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
We rely on 2.2+, but hadoop-client uses 2.1