### PR TITLE
[SMALLFIX] Update rest integration test

### DIFF
--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -148,6 +148,8 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         getEndpoint(AlluxioMasterRestServiceHandler.GET_UFS_CAPACITY_BYTES), NO_PARAMS,
         HttpMethod.GET, null).call();
 
+    // Capacity should be greater than 0, or -1 which means capacity is not applicable for the
+    // under storage (ie. for an object store in the cloud)
     Assert.assertTrue(Long.valueOf(ufsCapacity) > 0 || Long.valueOf(ufsCapacity) == -1);
   }
 
@@ -164,6 +166,8 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         getEndpoint(AlluxioMasterRestServiceHandler.GET_UFS_FREE_BYTES), NO_PARAMS, HttpMethod.GET,
         null).call();
 
+    // Free space should be greater than 0, or -1 which means free space is not applicable for the
+    // under storage (ie. for an object store in the cloud)
     Assert.assertTrue(Long.valueOf(ufsFreeBytes) > 0 || Long.valueOf(ufsFreeBytes) == -1);
   }
 

--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -164,7 +164,8 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         getEndpoint(AlluxioMasterRestServiceHandler.GET_UFS_FREE_BYTES), NO_PARAMS, HttpMethod.GET,
         null).call();
 
-    Assert.assertTrue(Long.valueOf(ufsFreeBytes) > 0 || Long.valueOf(ufsFreeBytes) == -1);  }
+    Assert.assertTrue(Long.valueOf(ufsFreeBytes) > 0 || Long.valueOf(ufsFreeBytes) == -1);
+  }
 
   @Test
   public void getCapacityBytesOnTiers() throws Exception {

--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -148,7 +148,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         getEndpoint(AlluxioMasterRestServiceHandler.GET_UFS_CAPACITY_BYTES), NO_PARAMS,
         HttpMethod.GET, null).call();
 
-    Assert.assertTrue(Long.valueOf(ufsCapacity) > 0);
+    Assert.assertTrue(Long.valueOf(ufsCapacity) > 0 || Long.valueOf(ufsCapacity) == -1);
   }
 
   @Test
@@ -164,8 +164,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         getEndpoint(AlluxioMasterRestServiceHandler.GET_UFS_FREE_BYTES), NO_PARAMS, HttpMethod.GET,
         null).call();
 
-    Assert.assertTrue(Long.valueOf(ufsFreeBytes) > 0);
-  }
+    Assert.assertTrue(Long.valueOf(ufsFreeBytes) > 0 || Long.valueOf(ufsFreeBytes) == -1);  }
 
   @Test
   public void getCapacityBytesOnTiers() throws Exception {


### PR DESCRIPTION
UFSes can return -1 when it is unknown how much capacity is available (ie. object storage).