### PR TITLE
[SMALLFIX] Configuration parameter for UFS listing length

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -45,6 +45,7 @@ public enum PropertyKey {
   // UFS related properties
   //
   UNDERFS_ADDRESS(Name.UNDERFS_ADDRESS, "${alluxio.work.dir}/underFSStorage"),
+  UNDERFS_LISTING_LENGTH(Name.UNDERFS_LISTING_LENGTH, 1000),
   UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING(Name.UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING, ""),
   UNDERFS_GLUSTERFS_IMPL(Name.UNDERFS_GLUSTERFS_IMPL,
       "org.apache.hadoop.fs.glusterfs.GlusterFileSystem"),
@@ -369,6 +370,7 @@ public enum PropertyKey {
     // UFS related properties
     //
     public static final String UNDERFS_ADDRESS = "alluxio.underfs.address";
+    public static final String UNDERFS_LISTING_LENGTH = "alluxio.underfs.listing.length";
     public static final String UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING =
         "alluxio.underfs.gcs.owner.id.to.username.mapping";
     public static final String UNDERFS_GLUSTERFS_IMPL = "alluxio.underfs.glusterfs.impl";

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -59,6 +59,14 @@ public abstract class UnderFileSystem {
    */
   private boolean mProvidesStorage = true;
 
+  /** Maximum length for a single listing query. */
+  private static final int MAX_LISTING_LENGTH = 1000;
+
+  /** Length of each list request. */
+  protected static final int LISTING_LENGTH =
+      Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH) > MAX_LISTING_LENGTH ?
+          MAX_LISTING_LENGTH : Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH);
+
   private static final Cache UFS_CACHE = new Cache();
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -64,8 +64,8 @@ public abstract class UnderFileSystem {
 
   /** Length of each list request. */
   protected static final int LISTING_LENGTH =
-      Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH) > MAX_LISTING_LENGTH ?
-          MAX_LISTING_LENGTH : Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH);
+      Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH) > MAX_LISTING_LENGTH
+          ? MAX_LISTING_LENGTH : Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH);
 
   private static final Cache UFS_CACHE = new Cache();
 

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -17,6 +17,7 @@ alluxio.underfs.glusterfs.mapred.&#8203;system.dir,glusterfs:///mapred/system
 alluxio.underfs.hdfs.configuration,${alluxio.conf.dir}/core-site.xml
 alluxio.underfs.hdfs.impl,org.apache.hadoop.hdfs.&#8203;DistributedFileSystem
 alluxio.underfs.hdfs.prefixes,"hdfs://,glusterfs:///"
+alluxio.underfs.listing.length,1000
 alluxio.underfs.object.store.mount.shared.publicly,false
 alluxio.underfs.s3.owner.id.to.username.mapping,No default
 alluxio.underfs.s3.endpoint,No default

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -43,6 +43,9 @@ alluxio.underfs.hdfs.impl:
 alluxio.underfs.hdfs.prefixes:
   Optionally, specify which prefixes should run through the Apache Hadoop implementation of
   UnderFileSystem. The delimiter is any whitespace and/or ','.
+alluxio.underfs.listing.length:
+  The maximum number of directory entries to list in a single query to under file system. If the
+  total number of entries is greater than the specified length, multiple queries will be issued.
 alluxio.underfs.object.store.mount.shared.publicly:
   Whether or not to share object storage under storage system mounted point with all Alluxio users.
   Note that this configuration has no effect on HDFS nor local UFS. The default value is false.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -259,6 +259,7 @@
                 <!-- Change "s3n://my-bucket/alluxio-test" to the name of your
                      S3 bucket for this test -->
                 <s3Bucket>s3n://my-bucket/alluxio-test</s3Bucket>
+                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -298,6 +299,7 @@
                 <fs.oss.endpoint>http://oss-cn-hangzhou.aliyuncs.com</fs.oss.endpoint>
                 <!-- Change "your-bucket" to your oss bucket for this test -->
                 <ossBucket>oss://your-bucket/alluxio-test/</ossBucket>
+                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -337,6 +339,7 @@
                 <!-- Change "container/folder" to contain the testing container  -->
                 <!-- Keep the structure in form container/folder -->
                 <containerKey>swift://container/folder</containerKey>
+                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -369,6 +372,7 @@
                 <!-- Change "gs://my-bucket/alluxio-test" to the name of your
                      gcs bucket for this test -->
                 <gcsBucket>gs://my-bucket/alluxio-test</gcsBucket>
+                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -259,7 +259,6 @@
                 <!-- Change "s3n://my-bucket/alluxio-test" to the name of your
                      S3 bucket for this test -->
                 <s3Bucket>s3n://my-bucket/alluxio-test</s3Bucket>
-                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -299,7 +298,6 @@
                 <fs.oss.endpoint>http://oss-cn-hangzhou.aliyuncs.com</fs.oss.endpoint>
                 <!-- Change "your-bucket" to your oss bucket for this test -->
                 <ossBucket>oss://your-bucket/alluxio-test/</ossBucket>
-                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -339,7 +337,6 @@
                 <!-- Change "container/folder" to contain the testing container  -->
                 <!-- Keep the structure in form container/folder -->
                 <containerKey>swift://container/folder</containerKey>
-                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -372,7 +369,6 @@
                 <!-- Change "gs://my-bucket/alluxio-test" to the name of your
                      gcs bucket for this test -->
                 <gcsBucket>gs://my-bucket/alluxio-test</gcsBucket>
-                <alluxio.underfs.listing.length>50</alluxio.underfs.listing.length>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -13,6 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
+import alluxio.ConfigurationTestUtils;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
@@ -43,13 +44,9 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
       new LocalAlluxioClusterResource.Builder().build();
   private String mUnderfsAddress = null;
   private UnderFileSystem mUfs = null;
-  private int mUfsListingLength = -1;
 
   @Before
   public final void before() throws Exception {
-    if (Configuration.containsKey(PropertyKey.UNDERFS_LISTING_LENGTH)) {
-      mUfsListingLength = Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH);
-    }
     Configuration.set(PropertyKey.UNDERFS_LISTING_LENGTH, 50);
     mUnderfsAddress = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(mUnderfsAddress + AlluxioURI.SEPARATOR);
@@ -57,9 +54,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
 
   @After
   public final void after() throws Exception {
-    if (mUfsListingLength > 0) {
-      Configuration.set(PropertyKey.UNDERFS_LISTING_LENGTH, mUfsListingLength);
-    }
+    ConfigurationTestUtils.resetConfiguration();
   }
 
   /**

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -45,6 +45,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
 
   @Before
   public final void before() throws Exception {
+    Configuration.set(PropertyKey.UNDERFS_LISTING_LENGTH, 50);
     mUnderfsAddress = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(mUnderfsAddress + AlluxioURI.SEPARATOR);
   }

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -446,7 +446,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
 
     String topLevelDirectory = PathUtils.concatPath(mUnderfsAddress, "topLevelDir");
 
-    final int numFiles = 1500;
+    final int numFiles = 100;
 
     String[] children = new String[numFiles + numFiles];
 

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -25,6 +25,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.LoadMetadataType;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,12 +43,23 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
       new LocalAlluxioClusterResource.Builder().build();
   private String mUnderfsAddress = null;
   private UnderFileSystem mUfs = null;
+  private int mUfsListingLength = -1;
 
   @Before
   public final void before() throws Exception {
+    if (Configuration.containsKey(PropertyKey.UNDERFS_LISTING_LENGTH)) {
+      mUfsListingLength = Configuration.getInt(PropertyKey.UNDERFS_LISTING_LENGTH);
+    }
     Configuration.set(PropertyKey.UNDERFS_LISTING_LENGTH, 50);
     mUnderfsAddress = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(mUnderfsAddress + AlluxioURI.SEPARATOR);
+  }
+
+  @After
+  public final void after() throws Exception {
+    if (mUfsListingLength > 0) {
+      Configuration.set(PropertyKey.UNDERFS_LISTING_LENGTH, mUfsListingLength);
+    }
   }
 
   /**

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -59,9 +59,6 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
   /** Value used to indicate folder structure in GCS. */
   private static final String PATH_SEPARATOR = "/";
 
-  /** Length of each list request in GCS. */
-  private static final long LISTING_LENGTH = 1000L;
-
   private static final byte[] DIR_HASH;
 
   /** Jets3t GCS client. */

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -56,9 +56,6 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
   /** Value used to indicate folder structure in OSS. */
   private static final String PATH_SEPARATOR = "/";
 
-  /** Length of each list request in S3. */
-  private static final int LISTING_LENGTH = 1000;
-
   /** Aliyun OSS client. */
   private final OSSClient mClient;
 

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -61,9 +61,6 @@ public final class S3UnderFileSystem extends UnderFileSystem {
   /** Value used to indicate folder structure in S3. */
   private static final String PATH_SEPARATOR = "/";
 
-  /** Length of each list request in S3. */
-  private static final long LISTING_LENGTH = 1000L;
-
   private static final byte[] DIR_HASH;
 
   /** Jets3t S3 client. */

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -73,9 +73,6 @@ public class S3AUnderFileSystem extends UnderFileSystem {
   /** Static hash for a directory's empty contents. */
   private static final String DIR_HASH;
 
-  /** Length of each list request in S3. */
-  private static final int LISTING_LENGTH = 1000;
-
   /** Threshold to do multipart copy. */
   private static final long MULTIPART_COPY_THRESHOLD = 100 * Constants.MB;
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -73,9 +73,6 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
   /** Suffix for an empty file to flag it as a directory. */
   private static final String FOLDER_SUFFIX = PATH_SEPARATOR;
 
-  /** Maximum number of directory entries to fetch at once. */
-  private static final int DIR_PAGE_SIZE = 1000;
-
   /** Number of retries in case of Swift internal errors. */
   private static final int NUM_RETRIES = 3;
 
@@ -248,7 +245,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
 
       // For a file, recursive delete will not find any children
       PaginationMap paginationMap = container.getPaginationMap(
-          PathUtils.normalizePath(strippedPath, PATH_SEPARATOR), DIR_PAGE_SIZE);
+          PathUtils.normalizePath(strippedPath, PATH_SEPARATOR), LISTING_LENGTH);
       for (int page = 0; page < paginationMap.getNumberOfPages(); page++) {
         for (StoredObject childObject : container.list(paginationMap, page)) {
           deleteObject(childObject);
@@ -666,7 +663,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     // TODO(adit): UnderFileSystem interface should be changed to support pagination
     ArrayDeque<DirectoryOrObject> results = new ArrayDeque<>();
     Container container = mAccount.getContainer(mContainerName);
-    PaginationMap paginationMap = container.getPaginationMap(prefix, DIR_PAGE_SIZE);
+    PaginationMap paginationMap = container.getPaginationMap(prefix, LISTING_LENGTH);
     for (int page = 0; page < paginationMap.getNumberOfPages(); page++) {
       if (!recursive) {
         // If not recursive, use delimiter to limit results fetched


### PR DESCRIPTION
Large directory list and delete test pagination in the UFS. To speed up testing the parameter "alluxio.underfs.listing.length" can be set to a small number, allowing testing pagination for smaller directories.

S3 returns a maximum of 1000 list items. Didn't find similar documentation for other UFSs.