### PR TITLE
[SMALLFIX] Remove conflicting commons-codec version, which has been dependency-managed

### DIFF
--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/underfs/gcs/pom.xml
+++ b/underfs/gcs/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Addressing issues reported here on our mailing list:
https://groups.google.com/forum/#!topic/alluxio-users/3VTRH6kXz0g

in parent `pom.xml`, there is one entry in `dependencyManagement` section:
```xml
      <dependency>
        <groupId>commons-codec</groupId>
        <artifactId>commons-codec</artifactId>
        <version>1.10</version>
      </dependency>
```