### PR TITLE
[SMALLFIX] [branch-1.3] Remove excessive logging messages w.r.t. metrics system

### DIFF
--- a/core/client/src/main/java/alluxio/client/ClientContext.java
+++ b/core/client/src/main/java/alluxio/client/ClientContext.java
@@ -22,13 +22,13 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import javax.annotation.concurrent.ThreadSafe;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * A shared context in each client JVM. It provides common functionality such as the Alluxio
  * configuration and master address.
  */
-@ThreadSafe
+@NotThreadSafe
 public final class ClientContext {
   private static ExecutorService sBlockClientExecutorService;
   private static ExecutorService sFileClientExecutorService;

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -420,7 +420,9 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
       Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, Boolean.toString(isZookeeperMode()));
 
+      // These must be reset to pick up the change to the master address.
       // TODO(andrew): We should reset key value system in this situation - see ALLUXIO-1706.
+      ClientContext.init();
       FileSystemContext.INSTANCE.reset();
       LineageContext.INSTANCE.reset();
 

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -420,9 +420,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
       Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, Boolean.toString(isZookeeperMode()));
 
-      // These must be reset to pick up the change to the master address.
       // TODO(andrew): We should reset key value system in this situation - see ALLUXIO-1706.
-      ClientContext.init();
       FileSystemContext.INSTANCE.reset();
       LineageContext.INSTANCE.reset();
 

--- a/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -40,7 +42,9 @@ public final class MetricsConfig {
    */
   public MetricsConfig(String configFile) {
     mProperties = new Properties();
-    loadConfigFile(configFile);
+    if (Files.exists(Paths.get(configFile))) {
+      loadConfigFile(configFile);
+    }
     removeInstancePrefix();
   }
 
@@ -94,22 +98,10 @@ public final class MetricsConfig {
    * @param configFile the metrics config file
    */
   private void loadConfigFile(String configFile) {
-    InputStream is = null;
-    try {
-      is = new FileInputStream(configFile);
-      if (is != null) {
-        mProperties.load(is);
-      }
-    } catch (Exception e) {
-      LOG.error("Error loading metrics configuration file.");
-    } finally {
-      if (is != null) {
-        try {
-          is.close();
-        } catch (Exception e) {
-          LOG.error(e.getMessage(), e);
-        }
-      }
+    try (InputStream is = new FileInputStream(configFile)) {
+      mProperties.load(is);
+    } catch(Exception e) {
+      LOG.error("Error loading metrics configuration file.", e);
     }
   }
 

--- a/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
@@ -100,7 +100,7 @@ public final class MetricsConfig {
   private void loadConfigFile(String configFile) {
     try (InputStream is = new FileInputStream(configFile)) {
       mProperties.load(is);
-    } catch(Exception e) {
+    } catch (Exception e) {
       LOG.error("Error loading metrics configuration file.", e);
     }
   }

--- a/examples/src/main/java/alluxio/cli/TestRunner.java
+++ b/examples/src/main/java/alluxio/cli/TestRunner.java
@@ -12,7 +12,10 @@
 package alluxio.cli;
 
 import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
+import alluxio.client.ClientContext;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
@@ -89,6 +92,10 @@ public final class TestRunner {
     }
     AlluxioURI masterLocation = new AlluxioURI(args[0]);
     AlluxioURI testDir = new AlluxioURI(TEST_PATH);
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, masterLocation.getHost());
+    Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(masterLocation.getPort()));
+    ClientContext.init();
+
     FileSystem fs = FileSystem.Factory.get();
     if (fs.exists(testDir)) {
       fs.delete(testDir, DeleteOptions.defaults().setRecursive(true));
@@ -146,11 +153,11 @@ public final class TestRunner {
     switch (opType) {
       case Basic:
         result =
-            CliUtils.runExample(new BasicOperations(masterLocation, filePath, readType, writeType));
+            CliUtils.runExample(new BasicOperations(filePath, readType, writeType));
         break;
       case BasicNonByteBuffer:
         result = CliUtils.runExample(
-            new BasicNonByteBufferOperations(masterLocation, filePath, readType, writeType, true,
+            new BasicNonByteBufferOperations(filePath, readType, writeType, true,
                 20));
         break;
       default:

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.client.AlluxioStorageType;
-import alluxio.client.ClientContext;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -73,7 +73,6 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
   public Boolean call() throws Exception {
     Configuration.set(PropertyKey.MASTER_HOSTNAME, mMasterLocation.getHost());
     Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
-    ClientContext.init();
     FileSystem alluxioClient = FileSystem.Factory.get();
     write(alluxioClient);
     return read(alluxioClient);

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -43,7 +43,6 @@ import java.util.concurrent.Callable;
  * </p>
  */
 public final class BasicNonByteBufferOperations implements Callable<Boolean> {
-  private final AlluxioURI mMasterLocation;
   private final AlluxioURI mFilePath;
   private final ReadType mReadType;
   private final WriteType mWriteType;
@@ -51,16 +50,14 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
   private final int mLength;
 
   /**
-   * @param masterLocation the location of the master
    * @param filePath the path for the files
    * @param readType the {@link ReadType}
    * @param writeType the {@link WriteType}
    * @param deleteIfExists delete files if they already exist
    * @param length the number of files
    */
-  public BasicNonByteBufferOperations(AlluxioURI masterLocation, AlluxioURI filePath, ReadType
-      readType, WriteType writeType, boolean deleteIfExists, int length) {
-    mMasterLocation = masterLocation;
+  public BasicNonByteBufferOperations(AlluxioURI filePath, ReadType readType, WriteType writeType,
+      boolean deleteIfExists, int length) {
     mFilePath = filePath;
     mWriteType = writeType;
     mReadType = readType;
@@ -70,8 +67,6 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
 
   @Override
   public Boolean call() throws Exception {
-    Configuration.set(PropertyKey.MASTER_HOSTNAME, mMasterLocation.getHost());
-    Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
     FileSystem alluxioClient = FileSystem.Factory.get();
     write(alluxioClient);
     return read(alluxioClient);

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -12,9 +12,7 @@
 package alluxio.examples;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
-import alluxio.PropertyKey;
 import alluxio.client.AlluxioStorageType;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
-import alluxio.client.ClientContext;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -68,7 +68,6 @@ public class BasicOperations implements Callable<Boolean> {
   public Boolean call() throws Exception {
     Configuration.set(PropertyKey.MASTER_HOSTNAME, mMasterLocation.getHost());
     Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
-    ClientContext.init();
     FileSystem fs = FileSystem.Factory.get();
     writeFile(fs);
     return readFile(fs);

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -12,9 +12,7 @@
 package alluxio.examples;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
 import alluxio.Constants;
-import alluxio.PropertyKey;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -44,20 +44,16 @@ public class BasicOperations implements Callable<Boolean> {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static final int NUMBERS = 20;
 
-  private final AlluxioURI mMasterLocation;
   private final AlluxioURI mFilePath;
   private final OpenFileOptions mReadOptions;
   private final CreateFileOptions mWriteOptions;
 
   /**
-   * @param masterLocation the location of the master
    * @param filePath the path for the files
    * @param readType the {@link ReadType}
    * @param writeType the {@link WriteType}
    */
-  public BasicOperations(AlluxioURI masterLocation, AlluxioURI filePath, ReadType readType,
-                         WriteType writeType) {
-    mMasterLocation = masterLocation;
+  public BasicOperations(AlluxioURI filePath, ReadType readType, WriteType writeType) {
     mFilePath = filePath;
     mReadOptions = OpenFileOptions.defaults().setReadType(readType);
     mWriteOptions = CreateFileOptions.defaults().setWriteType(writeType);
@@ -65,8 +61,6 @@ public class BasicOperations implements Callable<Boolean> {
 
   @Override
   public Boolean call() throws Exception {
-    Configuration.set(PropertyKey.MASTER_HOSTNAME, mMasterLocation.getHost());
-    Configuration.set(PropertyKey.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
     FileSystem fs = FileSystem.Factory.get();
     writeFile(fs);
     return readFile(fs);


### PR DESCRIPTION
When doing `alluxio runTests`, it outputs to console messages unnecessary. This PR removes these logs.
Especially, the metrics config file is optional
```bash
2016-09-30 11:00:41,442 ERROR type (MetricsConfig.java:loadConfigFile) - Error loading metrics configuration file.
2016-09-30 11:00:41,442 WARN  type (MetricsSystem.java:startSinksFromConfig) - Sinks have already been started.
```

@peisun1115 