### PR TITLE
[DOCFIX] S3 docs fix

### DIFF
--- a/docs/_includes/Configuring-Alluxio-with-S3/bootstrapConf.md
+++ b/docs/_includes/Configuring-Alluxio-with-S3/bootstrapConf.md
@@ -1,3 +1,3 @@
 ```bash
-$ ./bin/alluxio bootstrapConf <ALLUXIO_MASTER_HOSTNAME> s3 
+$ ./bin/alluxio bootstrapConf <ALLUXIO_MASTER_HOSTNAME>
 ```


### PR DESCRIPTION
We don't need to specify the ufs anymore.