### PR TITLE
[ALLUXIO-2142] - Removed newline from containsObject method

### DIFF
--- a/core/common/src/main/java/alluxio/collections/NonUniqueFieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/NonUniqueFieldIndex.java
@@ -104,7 +104,6 @@ public class NonUniqueFieldIndex<T> implements FieldIndex<T> {
     if (set == null) {
       return false;
     }
-
     return set.contains(object);
   }
 

--- a/core/common/src/main/java/alluxio/collections/UniqueFieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/UniqueFieldIndex.java
@@ -75,7 +75,6 @@ public class UniqueFieldIndex<T> implements FieldIndex<T> {
     if (res == null) {
       return false;
     }
-
     return res == object;
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2142

Removed newline before last return statement from containsObject() in NonUniqueFieldIndex.java and UniqueFieldIndex.java