### PR TITLE
[SMALLFIX] Delegation create optimization

### DIFF
--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -273,11 +273,7 @@ public final class UnderFileSystemManager {
       UnderFileSystem ufs = UnderFileSystem.get(mUri);
       ufs.connectFromWorker(
           NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));
-      if (ufs.exists(mUri)) {
-        throw new FileAlreadyExistsException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(mUri));
-      }
-      mStream = ufs.create(mTemporaryUri,
-          new CreateOptions().setPermission(mPermission));
+      mStream = ufs.create(mTemporaryUri, new CreateOptions().setPermission(mPermission));
     }
 
     /**

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -14,7 +14,6 @@ package alluxio.worker.file;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
-import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.security.authorization.Mode;

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -105,17 +105,6 @@ public final class UnderFileSystemManagerTest {
   }
 
   /**
-   * Tests creating an already existing file with the manager will throw the appropriate exception.
-   */
-  @Test
-  public void createExistingUfsFile() throws Exception {
-    Mockito.when(mMockUfs.exists(mUri.toString())).thenReturn(true);
-    mThrown.expect(FileAlreadyExistsException.class);
-    mThrown.expectMessage(ExceptionMessage.FAILED_UFS_CREATE.getMessage(mUri.toString()));
-    mManager.createFile(SESSION_ID, mUri, Permission.defaults());
-  }
-
-  /**
    * Tests completing a file with the manager will call {@link UnderFileSystem#rename}.
    */
   @Test


### PR DESCRIPTION
Removes an unnecessary exists check, the logic consistent with the case when delegation is disabled.

The exists check should not pass in normal operation since the URI is a temporary path. Only on client retries could this be a problem, and in that case it is better to allow the client to continue with a new file (since it has not written any data) instead of throwing an exception.