### PR TITLE
[SMALLFIX] Do not retry if socket times out in transport.open

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -194,7 +194,7 @@ public abstract class AbstractClient implements Client {
       } catch (TTransportException e) {
         LOG.error("Failed to connect (" + retry.getRetryCount() + ") to " + getServiceName() + " "
             + mMode + " @ " + mAddress + " : " + e.getMessage());
-        if (e.getMessage().contains("java.net.SocketTimeoutException")) {
+        if (e.getCause() instanceof java.net.SocketTimeoutException) {
           // Do not retry if socket timeout.
           String message = "Thrift transport open times out. Please check whether the "
               + "authentication types match between client and server. Note that NOSASL client "

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -194,6 +194,13 @@ public abstract class AbstractClient implements Client {
       } catch (TTransportException e) {
         LOG.error("Failed to connect (" + retry.getRetryCount() + ") to " + getServiceName() + " "
             + mMode + " @ " + mAddress + " : " + e.getMessage());
+        if (e.getMessage().contains("java.net.SocketTimeoutException")) {
+          // Do not retry if socket timeout.
+          String message = "Thrift transport open times out. Please check whether the "
+              + "authentication types match between client and server. Note that NOSASL client "
+              + "is not able to connect to servers with SIMPLE security mode.";
+          throw new IOException(message, e);
+        }
         if (!retry.attemptRetry()) {
           break;
         }

--- a/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
@@ -144,6 +144,13 @@ public abstract class ThriftClientPool<T extends AlluxioService.Client>
         LOG.error(
             "Failed to connect (" + retry.getRetryCount() + ") to " + getServiceNameForLogging()
                 + " @ " + mAddress, e);
+        if (e.getMessage().contains("java.net.SocketTimeoutException")) {
+          // Do not retry if socket timeout.
+          String message = "Thrift transport open times out. Please check whether the "
+              + "authentication types match between client and server. Note that NOSASL client "
+              + "is not able to connect to servers with SIMPLE security mode.";
+          throw new IOException(message, e);
+        }
         if (!retry.attemptRetry()) {
           throw new IOException(e);
         }

--- a/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
@@ -144,7 +144,7 @@ public abstract class ThriftClientPool<T extends AlluxioService.Client>
         LOG.error(
             "Failed to connect (" + retry.getRetryCount() + ") to " + getServiceNameForLogging()
                 + " @ " + mAddress, e);
-        if (e.getMessage().contains("java.net.SocketTimeoutException")) {
+        if (e.getCause() instanceof java.net.SocketTimeoutException) {
           // Do not retry if socket timeout.
           String message = "Thrift transport open times out. Please check whether the "
               + "authentication types match between client and server. Note that NOSASL client "


### PR DESCRIPTION
@calvinjia @peisun1115 

This should be the right way to fix the hanging client issue when a SIPMLE client tries to connect with a NOSASL server, as opposed to https://github.com/Alluxio/alluxio/pull/4008

Also, `alluxio.security.authentication.socket.timeout.ms` default to 10min seems a bit too long, is it mainly for remote object storage which can be pretty slow?