### PR TITLE
[SMALLFIX] [branch-1.3] Improve server related dependency

### DIFF
--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -47,11 +47,22 @@
       <version>4.0.28.Final</version>
     </dependency>
     <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <!-- A runtime dependency needed for Rest API service -->
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <version>${jersey.version}</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -61,15 +61,15 @@
       <exclusions>
         <exclusion>
           <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-json</artifactId>
+          <groupId>com.sun.jersey.contribs</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-server</artifactId>
+          <groupId>com.sun.jersey.jersey-test-framework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
When a library is directly referenced in the source code, putting it directly in the corresponding pom file is considered as a good practice. This PR does some tuning in pom files regarding the conflict between `com.sun.jersey`(1.x) and `org.glassfish.jersey` (2.x):
1. make use of `org.glassfish.jersey.core:jersey-server` explicit (also `javax.ws.rs:javax.ws.rs-api`)
2. better exclude classes of `com.sun.jersey` from module `tests`. 