### PR TITLE
[SMALLFIX] Skip folder check on get file size

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -319,10 +319,11 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   @Override
   public long getFileSize(String path) throws IOException {
-    ObjectMetadata details = getObjectDetails(path);
-    if (details != null) {
+    try {
+      ObjectMetadata details = mClient.getObjectMetadata(mBucketName, stripPrefixIfPresent(path));
       return details.getContentLength();
-    } else {
+    } catch (AmazonClientException e) {
+      LOG.error("Error fetching file size, assuming file does not exist", e);
       throw new FileNotFoundException(path);
     }
   }


### PR DESCRIPTION
`getObjectDetails` will try to find a folder, but `getFileSize` only applies to files. 