### PR TITLE
[SMALLFIX] Add an option to disable netty channel pool

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -241,6 +241,7 @@ public enum PropertyKey {
   USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX(Name.USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX, 1024),
   USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS(
       Name.USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS, 300 * Constants.SECOND_MS),
+  USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE(Name.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE, false),
   USER_UFS_DELEGATION_ENABLED(Name.USER_UFS_DELEGATION_ENABLED, true),
   USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES(Name.USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES,
       "8MB"),
@@ -633,6 +634,8 @@ public enum PropertyKey {
         "alluxio.user.network.netty.channel.pool.size.max";
     public static final String USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS =
         "alluxio.user.network.netty.channel.pool.gc.threshold.ms";
+    public static final String USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE =
+        "alluxio.user.network.netty.channel.pool.disable";
     public static final String USER_UFS_DELEGATION_ENABLED = "alluxio.user.ufs.delegation.enabled";
     public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.ufs.delegation.read.buffer.size.bytes";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -241,7 +241,7 @@ public enum PropertyKey {
   USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX(Name.USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX, 1024),
   USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS(
       Name.USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS, 300 * Constants.SECOND_MS),
-  USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE(Name.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE, false),
+  USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED(Name.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED, false),
   USER_UFS_DELEGATION_ENABLED(Name.USER_UFS_DELEGATION_ENABLED, true),
   USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES(Name.USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES,
       "8MB"),
@@ -634,8 +634,8 @@ public enum PropertyKey {
         "alluxio.user.network.netty.channel.pool.size.max";
     public static final String USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS =
         "alluxio.user.network.netty.channel.pool.gc.threshold.ms";
-    public static final String USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE =
-        "alluxio.user.network.netty.channel.pool.disable";
+    public static final String USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED =
+        "alluxio.user.network.netty.channel.pool.disabled";
     public static final String USER_UFS_DELEGATION_ENABLED = "alluxio.user.ufs.delegation.enabled";
     public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.ufs.delegation.read.buffer.size.bytes";

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import javax.annotation.PropertyKey;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -40,13 +40,13 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class NettyChannelPool extends DynamicResourcePool<Channel> {
   private static final int NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE = 10;
-  private Callable<Bootstrap> mBootstrap;
-  private final long mGcThresholdMs;
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("NettyChannelPoolGcThreads-%d", true));
   private static final boolean POOL_DISABLED =
       Configuration.getBoolean(alluxio.PropertyKey.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE);
+  private Callable<Bootstrap> mBootstrap;
+  private final long mGcThresholdMs;
 
   /**
    * Creates a netty channel pool instance with a minimum capacity of 1.
@@ -113,9 +113,9 @@ public final class NettyChannelPool extends DynamicResourcePool<Channel> {
   @Override
   protected boolean isHealthy(Channel channel) {
     if (POOL_DISABLED) {
-      // If we always returns false here, channels acquired by acquire will always be a newly
-      // created channel. With this feature turned on, 1.3.0 client will be backward compatible
-      // with 1.2.0 server.
+      // If we always return false here, channels acquired by NettyChannelPool#acquire() will always
+      // be newly created channel. With this feature turned on, >= 1.3.0 client will be backward
+      // compatible with <= 1.2.0 server.
       return false;
     }
     return channel.isActive();

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -43,7 +43,7 @@ public final class NettyChannelPool extends DynamicResourcePool<Channel> {
       new ScheduledThreadPoolExecutor(NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("NettyChannelPoolGcThreads-%d", true));
   private static final boolean POOL_DISABLED =
-      Configuration.getBoolean(alluxio.PropertyKey.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLE);
+      Configuration.getBoolean(alluxio.PropertyKey.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED);
   private Callable<Bootstrap> mBootstrap;
   private final long mGcThresholdMs;
 

--- a/docs/_data/table/cn/user-configuration.yml
+++ b/docs/_data/table/cn/user-configuration.yml
@@ -50,8 +50,7 @@ alluxio.user.network.netty.channel.pool.size.max:
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   netty网络通道会被关闭如果它被闲置超过这个时间。
 alluxio.user.network.netty.channel.pool.disable:
-  禁用netty网络通道池特性。设置这个选项为真如果客户端的版本 >= 1.3.0 但是服务器版本 <= 1.2.0。
-  Disable netty channel pool. This should be turned on if > 1.3.0 client is used with <= 1.2.0 server.
+  禁用netty网络通道池特性。设置这个选项为真如果客户端的版本 >= 1.3.0 但是服务器版本 <= 1.2.x。
 alluxio.user.ufs.delegation.enabled:
   是否使用worker对ufs数据进行代理。将该项设置为false会让client直接与ufs通信，目前该特性还处于实验阶段，若设置为true，可能在某些workload下会对性能有影响。
 alluxio.user.ufs.delegation.read.buffer.size.bytes:

--- a/docs/_data/table/cn/user-configuration.yml
+++ b/docs/_data/table/cn/user-configuration.yml
@@ -49,7 +49,7 @@ alluxio.user.network.netty.channel.pool.size.max:
   netty网络通道池的最大容量。
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   netty网络通道会被关闭如果它被闲置超过这个时间。
-alluxio.user.network.netty.channel.pool.disable:
+alluxio.user.network.netty.channel.pool.disabled:
   禁用netty网络通道池特性。设置这个选项为真如果客户端的版本 >= 1.3.0 但是服务器版本 <= 1.2.x。
 alluxio.user.ufs.delegation.enabled:
   是否使用worker对ufs数据进行代理。将该项设置为false会让client直接与ufs通信，目前该特性还处于实验阶段，若设置为true，可能在某些workload下会对性能有影响。

--- a/docs/_data/table/cn/user-configuration.yml
+++ b/docs/_data/table/cn/user-configuration.yml
@@ -49,6 +49,9 @@ alluxio.user.network.netty.channel.pool.size.max:
   netty网络通道池的最大容量。
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   netty网络通道会被关闭如果它被闲置超过这个时间。
+alluxio.user.network.netty.channel.pool.disable:
+  禁用netty网络通道池特性。设置这个选项为真如果客户端的版本 >= 1.3.0 但是服务器版本 <= 1.2.0。
+  Disable netty channel pool. This should be turned on if > 1.3.0 client is used with <= 1.2.0 server.
 alluxio.user.ufs.delegation.enabled:
   是否使用worker对ufs数据进行代理。将该项设置为false会让client直接与ufs通信，目前该特性还处于实验阶段，若设置为true，可能在某些workload下会对性能有影响。
 alluxio.user.ufs.delegation.read.buffer.size.bytes:

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -62,7 +62,7 @@ alluxio.user.network.netty.channel.pool.size.max:
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   A netty channel is closed if it has been idle for more than this threshold.
 alluxio.user.network.netty.channel.pool.disable:
-  Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.0.
+  Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.x.
 alluxio.user.ufs.delegation.enabled:
   Flag for delegating ufs data operations to the worker, enabled by default. When enabled, the
   client does not require any under storage libraries. Set this to false to use the client to

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -61,6 +61,8 @@ alluxio.user.network.netty.channel.pool.size.max:
   The maximum number of netty channels cached in the netty channel pool.
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   A netty channel is closed if it has been idle for more than this threshold.
+alluxio.user.network.netty.channel.pool.disable:
+  Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.0.
 alluxio.user.ufs.delegation.enabled:
   Flag for delegating ufs data operations to the worker, enabled by default. When enabled, the
   client does not require any under storage libraries. Set this to false to use the client to

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -61,7 +61,7 @@ alluxio.user.network.netty.channel.pool.size.max:
   The maximum number of netty channels cached in the netty channel pool.
 alluxio.user.network.netty.channel.pool.gc.threshold.ms:
   A netty channel is closed if it has been idle for more than this threshold.
-alluxio.user.network.netty.channel.pool.disable:
+alluxio.user.network.netty.channel.pool.disabled:
   Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.x.
 alluxio.user.ufs.delegation.enabled:
   Flag for delegating ufs data operations to the worker, enabled by default. When enabled, the


### PR DESCRIPTION
This is to provide an option to make >=1.3.0 client backward compatible with <=1.2.0 server