### PR TITLE
[ALLUXIO-2215] Fixed the heartbeat thread crashing during the async persist

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -2424,8 +2424,12 @@ public final class FileSystemMaster extends AbstractMaster {
   public FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException {
     for (long fileId : persistedFiles) {
-      // Permission checking for each file is performed inside setAttribute
-      setAttribute(getPath(fileId), SetAttributeOptions.defaults().setPersisted(true));
+      try {
+        // Permission checking for each file is performed inside setAttribute
+        setAttribute(getPath(fileId), SetAttributeOptions.defaults().setPersisted(true));
+      } catch (FileDoesNotExistException | AccessControlException | InvalidPathException e) {
+        LOG.error("Failed to set file {} as persisted, because {}", fileId, e);
+      }
     }
 
     // get the files for the given worker to persist

--- a/core/server/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
@@ -16,6 +16,7 @@ import alluxio.Constants;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.thrift.AlluxioService;
+import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.FileSystemCommand;
 import alluxio.thrift.FileSystemMasterWorkerService;
 import alluxio.wire.FileInfo;
@@ -109,13 +110,13 @@ public final class FileSystemMasterClient extends AbstractMasterClient {
    * @param persistedFiles the files which have been persisted since the last heartbeat
    * @return the command for file system worker
    * @throws IOException if file persistence fails
-   * @throws ConnectionFailedException if network connection failed
+   * @throws AlluxioException if an error occurs on Alluxio master
    */
   public synchronized FileSystemCommand heartbeat(final long workerId,
-      final List<Long> persistedFiles) throws ConnectionFailedException, IOException {
-    return retryRPC(new RpcCallable<FileSystemCommand>() {
+      final List<Long> persistedFiles) throws IOException, AlluxioException {
+    return retryRPC(new RpcCallableThrowsAlluxioTException<FileSystemCommand>() {
       @Override
-      public FileSystemCommand call() throws TException {
+      public FileSystemCommand call() throws AlluxioTException, TException {
         return mClient.heartbeat(workerId, persistedFiles);
       }
     });

--- a/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -14,7 +14,6 @@ package alluxio.worker.file;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
-import alluxio.exception.ConnectionFailedException;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.thrift.CommandType;
 import alluxio.thrift.FileSystemCommand;
@@ -86,7 +85,7 @@ final class FileWorkerMasterSyncExecutor implements HeartbeatExecutor {
     FileSystemCommand command;
     try {
       command = mMasterClient.heartbeat(mWorkerId.get(), persistedFiles);
-    } catch (IOException | ConnectionFailedException e) {
+    } catch (Exception e) {
       LOG.error("Failed to heartbeat to master", e);
       return;
     }

--- a/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -14,6 +14,7 @@ package alluxio.worker.file;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.exception.AlluxioException;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.thrift.CommandType;
 import alluxio.thrift.FileSystemCommand;
@@ -85,7 +86,7 @@ final class FileWorkerMasterSyncExecutor implements HeartbeatExecutor {
     FileSystemCommand command;
     try {
       command = mMasterClient.heartbeat(mWorkerId.get(), persistedFiles);
-    } catch (Exception e) {
+    } catch (IOException | AlluxioException e) {
       LOG.error("Failed to heartbeat to master", e);
       return;
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2215

When the file being async persisted is deleted from master, the worker heartbeat after the persist will crash due to the file not exist failure. This PR addresses the issue by logging the issues on master, but not returning exception to the heartbeat request.