### PR TITLE
[SMALLFIX] Fix vagrant script setting master hostname

### DIFF
--- a/deploy/vagrant/provision/start_alluxio_on_standalone.yml
+++ b/deploy/vagrant/provision/start_alluxio_on_standalone.yml
@@ -6,7 +6,7 @@
 - hosts: AlluxioMaster*
   tasks:
     - name: set master address to own hostname
-      shell: sed -i "s/export ALLUXIO_MASTER_HOSTNAME=.*/export ALLUXIO_MASTER_HOSTNAME=$(hostname -A | cut -d' ' -f1)/g" /alluxio/conf/alluxio-env.sh
+      shell: sed -i "s/ALLUXIO_MASTER_HOSTNAME=.*/ALLUXIO_MASTER_HOSTNAME=$(hostname -A | cut -d' ' -f1)/g" /alluxio/conf/alluxio-env.sh
 
     - include: roles/alluxio/tasks/start_master.yml
 


### PR DESCRIPTION
We no longer use export for alluxio-env.sh