### PR TITLE
[SMALLFIX] Update the deploy module to respect the new alluxio-env.sh layout

### DIFF
--- a/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
+++ b/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
@@ -15,6 +15,7 @@
 - name: set ufs related info in alluxio-env.sh
   script: roles/ufs_{{ ufs }}/files/config_alluxio.sh
   environment:
+    ALLUXIO_VERSION_LESSTHAN_1_1: "{{ alluxio_version_lessthan_1_1 }}"
     S3_BUCKET: "{{ s3_bucket }}"
     S3_ID: "{{ s3_id }}"
     S3_KEY: "{{ s3_key }}"
@@ -49,12 +50,21 @@
     dest=/alluxio/conf/alluxio-env.sh
     regexp='^export ALLUXIO_WORKER_MEMORY_SIZE=.*'
     replace='export ALLUXIO_WORKER_MEMORY_SIZE={{ alluxio_memory }}'
+  when: alluxio_version_lessthan_1_1
+
+- name: set worker memory in alluxio-env.sh
+  replace: >
+    dest=/alluxio/conf/alluxio-env.sh
+    regexp='^ALLUXIO_WORKER_MEMORY_SIZE=.*'
+    replace='ALLUXIO_WORKER_MEMORY_SIZE={{ alluxio_memory }}'
+  when: not alluxio_version_lessthan_1_1
 
 - name: let alluxio ssh to workers in parallel when start
   replace: >
     dest=/alluxio/conf/alluxio-env.sh
     regexp='ALLUXIO_SSH_FOREGROUND="yes"'
     replace='ALLUXIO_SSH_FOREGROUND=""'
+  when: alluxio_version_lessthan_1_1
 
 - name: set ALLUXIO_JAR in libexec/alluxio-config.sh
   script: alluxio_jar.sh

--- a/deploy/vagrant/provision/roles/ufs_gcs/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_gcs/files/config_alluxio.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cat >> ~/.bashrc << EOF
+if [[ ${ALLUXIO_VERSION_LESSTHAN_1_1} == true ]]; then
+  cat >> ~/.bashrc << EOF
 export ALLUXIO_UNDERFS_ADDRESS="gs://${GCS_BUCKET}"
 
 export ALLUXIO_JAVA_OPTS+="
@@ -8,3 +9,13 @@ export ALLUXIO_JAVA_OPTS+="
   -Dfs.gcs.secretAccessKey=${GCS_KEY}
 "
 EOF
+else
+  cat >> /alluxio/conf/alluxio-env.sh << EOF
+ALLUXIO_UNDERFS_ADDRESS="gs://${GCS_BUCKET}"
+
+ALLUXIO_JAVA_OPTS+="
+  -Dfs.gcs.accessKeyId=${GCS_ID}
+  -Dfs.gcs.secretAccessKey=${GCS_KEY}
+"
+EOF
+fi

--- a/deploy/vagrant/provision/roles/ufs_hadoop1/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_hadoop1/files/config_alluxio.sh
@@ -3,7 +3,12 @@
 # The last node in /alluxio/conf/workers is the master for under filesystem,
 # this is guaranteed by generation process of /alluxio/conf/workers in script vagrant/create.
 UFS_MASTER=$(tail -n1 /alluxio/conf/workers)
-
-cat >> ~/.bashrc << EOF
+if [[ ${ALLUXIO_VERSION_LESSTHAN_1_1} == true ]]; then
+  cat >> ~/.bashrc << EOF
 export ALLUXIO_UNDERFS_ADDRESS="hdfs://${UFS_MASTER}:9000"
 EOF
+else
+  cat >> /alluxio/conf/alluxio-env.sh << EOF
+ALLUXIO_UNDERFS_ADDRESS="hdfs://${UFS_MASTER}:9000"
+EOF
+fi

--- a/deploy/vagrant/provision/roles/ufs_hadoop2/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_hadoop2/files/config_alluxio.sh
@@ -4,6 +4,12 @@
 # this is guaranteed by generation process of /alluxio/conf/workers in script vagrant/create.
 UFS_MASTER=$(tail -n1 /alluxio/conf/workers)
 
-cat >> ~/.bashrc << EOF
+if [[ ${ALLUXIO_VERSION_LESSTHAN_1_1} == true ]]; then
+  cat >> ~/.bashrc << EOF
 export ALLUXIO_UNDERFS_ADDRESS="hdfs://${UFS_MASTER}:9000"
 EOF
+else
+  cat >> /alluxio/conf/alluxio-env.sh << EOF
+ALLUXIO_UNDERFS_ADDRESS="hdfs://${UFS_MASTER}:9000"
+EOF
+fi

--- a/deploy/vagrant/provision/roles/ufs_s3/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_s3/files/config_alluxio.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cat >> ~/.bashrc << EOF
+if [[ ${ALLUXIO_VERSION_LESSTHAN_1_1} == true ]]; then
+  cat >> ~/.bashrc << EOF
 export ALLUXIO_UNDERFS_ADDRESS="s3n://${S3_BUCKET}"
 
 export ALLUXIO_JAVA_OPTS+="
@@ -8,6 +9,16 @@ export ALLUXIO_JAVA_OPTS+="
   -Dfs.s3n.awsAccessKeyId=${S3_ID}
 "
 EOF
+else
+  cat >> /alluxio/conf/alluxio-env.sh << EOF
+ALLUXIO_UNDERFS_ADDRESS="s3n://${S3_BUCKET}"
+
+ALLUXIO_JAVA_OPTS+="
+  -Dfs.s3n.awsSecretAccessKey=${S3_KEY}
+  -Dfs.s3n.awsAccessKeyId=${S3_ID}
+"
+EOF
+fi
 
 # For Alluxio version earlier than 0.8, remove schema "s3n" from default prefixes to be handled by HdfsUnderFileSystem.
 # This property is changed to "alluxio.underfs.hdfs.prefixes" after version 0.8 and s3n is not included by default.

--- a/deploy/vagrant/provision/roles/ufs_swift/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_swift/files/config_alluxio.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cat >> ~/.bashrc << EOF
+if [[ ${ALLUXIO_VERSION_LESSTHAN_1_1} == true ]]; then
+  cat >> ~/.bashrc << EOF
 export ALLUXIO_UNDERFS_ADDRESS="swift://${SWIFT_CONTAINER}"
 
 export ALLUXIO_JAVA_OPTS+="
@@ -12,3 +13,17 @@ export ALLUXIO_JAVA_OPTS+="
   -Dfs.swift.auth.method=${SWIFT_AUTH_METHOD}
 "
 EOF
+else
+  cat >> /alluxio/conf/alluxio-env.sh << EOF
+ALLUXIO_UNDERFS_ADDRESS="swift://${SWIFT_CONTAINER}"
+
+ALLUXIO_JAVA_OPTS+="
+  -Dfs.swift.user=${SWIFT_USER}
+  -Dfs.swift.tenant=${SWIFT_TENANT}
+  -Dfs.swift.password=${SWIFT_PASSWORD}
+  -Dfs.swift.auth.url=${SWIFT_AUTH_URL}
+  -Dfs.swift.use.public.url=${SWIFT_USE_PUBLIC_URL}
+  -Dfs.swift.auth.method=${SWIFT_AUTH_METHOD}
+"
+EOF
+fi


### PR DESCRIPTION
Layout of alluxio-env.sh is updated after release 1.1, and in branch-1.3, the layout of alluxio-env.sh generated by `alluxio bootstrapConf` is updated again, this PR updates the deploy module to respect these new layouts, and keep backward compatibility for older layouts as well.