### PR TITLE
[ALLUXIO-2127] Improve Javadoc spacing in FileInStream

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -633,6 +633,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
 
   /**
    * Reads the remaining of the current block.
+   * 
    * @throws IOException if read or cache write fails
    */
   private void readCurrentBlockToEnd() throws IOException {


### PR DESCRIPTION
Add a newline between the description and the `@throws` tags in the javadoc of `readCurrentBlockToEnd` method.

[https://alluxio.atlassian.net/browse/ALLUXIO-2127](https://alluxio.atlassian.net/browse/ALLUXIO-2127)