### PR TITLE
[ALLUXIO-2126] The javadoc in FileInStream.java for the variable mPos can be one line

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -72,9 +72,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
 
   /** If the stream is closed, this can only go from false to true. */
   protected boolean mClosed;
-  /**
-   * Current position of the file instream.
-   */
+  /** Current position of the file instream. */
   protected long mPos;
 
   /**


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2126

I Merged the javadoc in FileInStream.java for the variable mPos into one line.