### PR TITLE
[ALLUXIO-2103]Update javadoc for FieldIndex#size()

### DIFF
--- a/core/common/src/main/java/alluxio/collections/FieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/FieldIndex.java
@@ -89,7 +89,7 @@ public interface FieldIndex<T> extends Iterable<T> {
   Iterator<T> iterator();
 
   /**
-   * @return the number of objects in this indexed set
+   * @return the number of objects in this index set
    */
   int size();
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2103
The javadoc for FieldIndex.java size() says: "in this indexed set". Instead, it should say "in this index".