### PR TITLE
[ALLUXIO-2301][DOCFIX]Remove the description of isConnected function in AbstractClient.java

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -227,8 +227,6 @@ public abstract class AbstractClient implements Client {
   }
 
   /**
-   * Returns the connected status of the client.
-   *
    * @return true if this client is connected to the remote
    */
   public synchronized boolean isConnected() {


### PR DESCRIPTION
Only keep the @return since it is a getter function.
Issue: https://alluxio.atlassian.net/browse/ALLUXIO-2301
Author: Zixuan Wang, MG1633082, Nanjing University.