### PR TITLE
[ALLUXIO-2338] Improve error handling in NetworkAddressUtils#getLocalHostName

### DIFF
--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -324,7 +324,6 @@ public final class NetworkAddressUtils {
       sLocalHost = InetAddress.getByName(getLocalIpAddress(timeoutMs)).getCanonicalHostName();
       return sLocalHost;
     } catch (UnknownHostException e) {
-      LOG.error(e.getMessage(), e);
       throw Throwables.propagate(e);
     }
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2338
Right now we handle an exception by both logging and rethrowing the exception. This isn't great because the code which catches the thrown exception will also log it, so we will log the same exception multiple times.
We should remove the log statement.