### PR TITLE
[SMALLFIX] Fix javadoc in BlockWorker.java

### DIFF
--- a/core/server/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -189,7 +189,7 @@ public interface BlockWorker extends Worker {
   BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException;
 
   /**
-   * Gets the meta data of a specific block from local storage.
+   * Gets the metadata of a specific block from local storage.
    * <p>
    * Unlike {@link #getVolatileBlockMeta(long)}, this method requires the lock id returned by a
    * previously acquired {@link #lockBlock(long, long)}.


### PR DESCRIPTION
This file refers to metadata as "meta data". We should correct this to "metadata".