### PR TITLE
[SMALLFIX] Exclude alluxio-site.properties from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,7 @@
 
             <!-- Build and Packaging Exclusions -->
             <exclude>build/**/*</exclude>
+            <exclude>conf/alluxio-site.properties</exclude>
             <exclude>dev/scripts/tarballs/**/*</exclude>
             <exclude>dev/scripts/workdir/**/*</exclude>
             <exclude>**/.checkstyle</exclude>


### PR DESCRIPTION
We don't revision this file so there's no reason it needs to be license-checked