### PR TITLE
[ALLUXIO-2318]  javadoc param for "inode" should link to Inode

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -409,7 +409,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
   /**
    * Appends components of the path from a given inode.
    *
-   * @param inode the inode to compute the path for
+   * @param inode the {@link Inode}  to compute the path for
    * @param builder a {@link StringBuilder} that is updated with the path components
    * @throws FileDoesNotExistException if an inode in the path does not exist
    */

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -409,7 +409,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
   /**
    * Appends components of the path from a given inode.
    *
-   * @param inode the {@link Inode}  to compute the path for
+   * @param inode the {@link Inode} to compute the path for
    * @param builder a {@link StringBuilder} that is updated with the path components
    * @throws FileDoesNotExistException if an inode in the path does not exist
    */


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2318
For method computePathForInode() in InodeTree.java, the javadoc param for "inode" should link to Inode.