### PR TITLE
[ALLUXIO-2304] Remove the unnecessary description for getMasterAddress

### DIFF
--- a/core/common/src/main/java/alluxio/LeaderInquireClient.java
+++ b/core/common/src/main/java/alluxio/LeaderInquireClient.java
@@ -71,8 +71,6 @@ public final class LeaderInquireClient {
   }
 
   /**
-   * Gets the address of the master.
-   *
    * @return the address of the master
    */
   public synchronized String getMasterAddress() {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2304
Remove the unnecessary description for getMasterAddress, only the @returns clause is necessary.