### PR TITLE
[ALLUXIO-2101] Update javadoc for FieldIndex class comments

### DIFF
--- a/core/common/src/main/java/alluxio/collections/FieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/FieldIndex.java
@@ -15,12 +15,12 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * An interface representing an index for this {@link IndexedSet}, each index for this set must
+ * An interface representing an index for {@link IndexedSet}, each index for this set must
  * implement the interface to define how to get the value of the field chosen as the index. Users
  * must use the same instance of the implementation of this interface as the parameter in all
  * methods of {@link IndexedSet} to represent the same index.
  *
- * @param <T> type of objects in this {@link IndexedSet}
+ * @param <T> type of objects in {@link IndexedSet}
  */
 public interface FieldIndex<T> extends Iterable<T> {
   /**


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2101
In the javadoc class comments for FieldIndex.java, there are several places where it says "this IndexedSet". These should be updated to just say "IndexedSet".