### PR TITLE
[SMALLFIX] close connection when rpc fails to avoid leaking connections

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -41,6 +41,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * The base class for clients.
  */
+// TODO(peis): Consolidate this to ThriftClientPool.
 @ThreadSafe
 public abstract class AbstractClient implements Client {
 
@@ -201,6 +202,7 @@ public abstract class AbstractClient implements Client {
               + "is not able to connect to servers with SIMPLE security mode.";
           throw new IOException(message, e);
         }
+        // TODO(peis): Consider closing the connection here as well.
         if (!retry.attemptRetry()) {
           break;
         }
@@ -321,6 +323,7 @@ public abstract class AbstractClient implements Client {
         throw Throwables.propagate(AlluxioException.fromThrift(e));
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
+        mProtocol.getTransport().close();
         mConnected = false;
       }
     }
@@ -352,6 +355,7 @@ public abstract class AbstractClient implements Client {
         throw new IOException(e);
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
+        mProtocol.getTransport().close();
         mConnected = false;
       }
     }


### PR DESCRIPTION
We see "too many files open error" in fsmeta tests.