### PR TITLE
[ALLUXIO-2349]Improve error handling in GCSUnderFileSystemFactory#create "@nicefish666"

### DIFF
--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
@@ -55,7 +55,7 @@ public final class GCSUnderFileSystemFactory implements UnderFileSystemFactory {
     }
 
     String err = "Google Credentials not available, cannot create GCS Under File System.";
-    LOG.error(err);
+    
     throw Throwables.propagate(new IOException(err));
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2349
Right now we handle an exception by both logging and rethrowing the exception. This isn't great because the code which catches the thrown exception will also log it, so we will log the same exception multiple times.
We should remove the log statement.