### PR TITLE
[ALLUXIO-2325] Remove unused method getInode in InodeTree

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1075,11 +1075,6 @@ public final class InodeTree implements JournalCheckpointStreamable {
     private final boolean mFound;
 
     /**
-     * The found inode when the traversal succeeds; otherwise the last path component navigated.
-     */
-    private final Inode<?> mInode;
-
-    /**
      * The list of non-persisted inodes encountered during the traversal.
      */
     private final List<Inode<?>> mNonPersisted;
@@ -1106,7 +1101,6 @@ public final class InodeTree implements JournalCheckpointStreamable {
     private TraversalResult(boolean found, List<Inode<?>> nonPersisted,
         List<Inode<?>> inodes, InodeLockList lockList) {
       mFound = found;
-      mInode = inodes.get(inodes.size() - 1);
       mNonPersisted = nonPersisted;
       mInodes = inodes;
       mLockList = lockList;

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1116,10 +1116,6 @@ public final class InodeTree implements JournalCheckpointStreamable {
       return mFound;
     }
 
-    Inode<?> getInode() {
-      return mInode;
-    }
-
     /**
      * @return the list of non-persisted inodes encountered during the traversal
      */


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2325
Removed unused method getInode() and member variable mInode in InodeTree, and adjust related method TraversalResult().
modified by dg1533502