### PR TITLE
[ALLUXIO-2392] Bug in alluxio-start.sh when batch start workers

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -285,8 +285,7 @@ main() {
       run_safe
       ;;
     workers)
-      ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" "${MOPT}" \
-       "${ALLUXIO_MASTER_HOSTNAME}"
+      ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" "${MOPT}"
       ;;
     restart_worker)
       restart_worker


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2392

I configured 50 slaves and use the HDFS UnderFS to the alluxio cluster. After I configured and start the master using:

```
bin/alluxio format 
bin/alluxio-start master
```
everything goes fine. And then when I try to start all the workers using: 
```
bin/alluxio-start.sh workers SudoMount
```
no slave started correctly.

After debuged the start script, I found that it is because a bug in the start script as below:

```bash
259   case "${ACTION}" in
......
287     workers)
288       ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" "${MOPT}" \
289        "${ALLUXIO_MASTER_HOSTNAME}"
290       ;;
```

It added the `${ALLUXIO_MASTER_HOSTNAME}`  in the tail of the bash command which will launched at every slaves to start the worker. And this parameter seems like no use and will make the script launched at slaves through ssh fail because of the below logic in `alluxio-start.sh`:

```bash
253   FORMAT=$1
254   if [[ ! -z "${FORMAT}" && "${FORMAT}" != "-f" ]]; then
255     echo -e "${USAGE}" >&2
256     exit 1
257   fi
```
in the above code , the `FORMAT` will be set as `${ALLUXIO_MASTER_HOSTNAME}`, which is the hostname of the master, and will not be empty and `-f`, makes the script start worker fail.

The solution is sample, remove the ${ALLUXIO_MASTER_HOSTNAME} in the tail of the bash command.

BTW: I really don't know why the `${ALLUXIO_MASTER_HOSTNAME}` will be added here, maybe I missed something, please check.