### PR TITLE
[ALLUXIO-2323] Remove unnecessary suppresswarning annotation in InodeTree

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -103,8 +103,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
   /** Mount table manages the file system mount points. */
   private final MountTable mMountTable;
 
-  @SuppressWarnings("unchecked")
-  /** use UniqueFieldIndex directly for ID index rather than using IndexedSet */
+  /** Use UniqueFieldIndex directly for ID index rather than using IndexedSet. */
   private final FieldIndex<Inode<?>> mInodes = new UniqueFieldIndex<>(ID_INDEX);
   /** A set of inode ids representing pinned inode files. */
   private final Set<Long> mPinnedInodeFileIds = new ConcurrentHashSet<>(64, 0.90f, 64);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2323
Annotation @SuppressWarnings("unchecked") is not needed for variable mInodes