### PR TITLE
[SMALLFIX] Clear client pool  in JournalShutdownIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -78,8 +78,8 @@ public class JournalShutdownIntegrationTest {
         // expected since the master will shutdown at a certain time.
         while (true) {
           if (mOpType == 0) {
-            try (FileOutStream stream = mFileSystem
-                .createFile(new AlluxioURI(TEST_FILE_DIR + mSuccessNum))) {
+            try {
+              mFileSystem.createFile(new AlluxioURI(TEST_FILE_DIR + mSuccessNum)).close();
             } catch (IOException e) {
               break;
             }

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -16,7 +16,11 @@ import alluxio.AuthenticatedUserRule;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.SystemPropertyRule;
+import alluxio.client.block.BlockStoreContextTestUtils;
+import alluxio.client.block.RetryHandlingBlockWorkerClientTestUtils;
+import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemWorkerClientTestUtils;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.ListStatusOptions;
@@ -74,8 +78,8 @@ public class JournalShutdownIntegrationTest {
         // expected since the master will shutdown at a certain time.
         while (true) {
           if (mOpType == 0) {
-            try {
-              mFileSystem.createFile(new AlluxioURI(TEST_FILE_DIR + mSuccessNum)).close();
+            try (FileOutStream stream = mFileSystem
+                .createFile(new AlluxioURI(TEST_FILE_DIR + mSuccessNum))) {
             } catch (IOException e) {
               break;
             }
@@ -113,6 +117,9 @@ public class JournalShutdownIntegrationTest {
   public final void after() throws Exception {
     mExecutorsForClient.shutdown();
     ConfigurationTestUtils.resetConfiguration();
+    RetryHandlingBlockWorkerClientTestUtils.reset();
+    FileSystemWorkerClientTestUtils.reset();
+    BlockStoreContextTestUtils.resetPool();
   }
 
   @Before


### PR DESCRIPTION
https://github.com/Alluxio/alluxio/pull/4157 should fix the leak. This PR is to make sure the resource is reset in the JournalShutdownIntegrationTest so that JournalShutdownIntegrationTest can fail instead of the one runs after it.