### PR TITLE
[ALLUXIO-2310]improve javadoc for LeaderSelectorClient (getName)

### DIFF
--- a/core/common/src/main/java/alluxio/LeaderSelectorClient.java
+++ b/core/common/src/main/java/alluxio/LeaderSelectorClient.java
@@ -99,8 +99,6 @@ public final class LeaderSelectorClient implements Closeable, LeaderSelectorList
   }
 
   /**
-   * Gets the name of the leader.
-   *
    * @return the leader name
    */
   public String getName() {


### PR DESCRIPTION
Remove the unnecessary javadoc description for getName, only the @returns clause is necessary.