### PR TITLE
[SMALLFIX] Improve shell error handling of RuntimeExceptions

### DIFF
--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -13,7 +13,6 @@ package alluxio.cli;
 
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
-import alluxio.exception.AlluxioException;
 import alluxio.shell.command.ShellCommand;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
@@ -176,7 +175,7 @@ public final class AlluxioShell implements Closeable {
     try {
       command.run(cmdline);
       return 0;
-    } catch (AlluxioException | IOException e) {
+    } catch (Exception e) {
       System.out.println(e.getMessage());
       LOG.error("Error running " + StringUtils.join(argv, " "), e);
       return -1;

--- a/tests/src/test/java/alluxio/shell/command/SetTtlCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/SetTtlCommandTest.java
@@ -103,8 +103,7 @@ public final class SetTtlCommandTest extends AbstractAlluxioShellTest {
   @Test
   public void setTtlNegativeTest() throws IOException {
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 1);
-    mException.expect(IllegalArgumentException.class);
-    mException.expectMessage("TTL value must be >= 0");
     mFsShell.run("setTtl", "/testFile", "-1");
+    Assert.assertTrue(mOutput.toString().contains("TTL value must be >= 0"));
   }
 }


### PR DESCRIPTION
We should print error messages to the user, not propagate runtime exceptions