### PR TITLE
[ALLUXIO-2284]Mark class JmxSink as final in JmxSink.java

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/sink/JmxSink.java
+++ b/core/common/src/main/java/alluxio/metrics/sink/JmxSink.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A sink which listens for new metrics and exposes them as namespaces MBeans.
  */
 @ThreadSafe
-public class JmxSink implements Sink {
+public final class JmxSink implements Sink {
   private JmxReporter mReporter;
 
   /**


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2284
public class JmxSink implements Sink {
should be
public final class JmxSink implements Sink {
as this class is not expected to have subclasses