### PR TITLE
[SMALLFIX] Close resources to avoid resource leaks

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/BlockStoreContext.java
+++ b/core/client/src/main/java/alluxio/client/block/BlockStoreContext.java
@@ -155,28 +155,17 @@ public final class BlockStoreContext {
   }
 
   /**
-   * Obtains a client for a worker with the given address.
+   * Creates a client for a worker with the given address.
    *
    * @param address the address of the worker to get a client to
    * @return a {@link BlockWorkerClient} connected to the worker with the given worker RPC address
    * @throws IOException if it fails to create a client for a given hostname (e.g. no Alluxio
    *         worker is available for the given worker RPC address)
    */
-  public BlockWorkerClient acquireWorkerClient(WorkerNetAddress address) throws IOException {
+  public BlockWorkerClient createWorkerClient(WorkerNetAddress address) throws IOException {
     Preconditions.checkNotNull(address, ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
     long clientId = IdUtils.getRandomNonNegativeLong();
     return new RetryHandlingBlockWorkerClient(address, clientId);
-  }
-
-  /**
-   * Releases the {@link BlockWorkerClient} by directly closing it.
-   *
-   * @param blockWorkerClient the worker client to release, the client should not be accessed after
-   *        this method is called
-   */
-  public void releaseWorkerClient(BlockWorkerClient blockWorkerClient) {
-    Preconditions.checkNotNull(blockWorkerClient);
-    blockWorkerClient.close();
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class LocalBlockInStream extends BufferedBlockInStream {
-  /** Helper to manage closables. */
+  /** Helper to manage closeables. */
   private final Closer mCloser;
   /** Client to communicate with the local worker. */
   private final BlockWorkerClient mBlockWorkerClient;
@@ -57,8 +57,9 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
     mContext = context;
 
     mCloser = Closer.create();
-    mBlockWorkerClient = mContext.acquireWorkerClient(workerNetAddress);
     try {
+      mBlockWorkerClient = mContext.createWorkerClient(workerNetAddress);
+      mCloser.register(mBlockWorkerClient);
       LockBlockResult result = mBlockWorkerClient.lockBlock(blockId);
       if (result == null) {
         throw new IOException(ExceptionMessage.BLOCK_NOT_LOCALLY_AVAILABLE.getMessage(mBlockId));
@@ -66,7 +67,7 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
       mReader = new LocalFileBlockReader(result.getBlockPath());
       mCloser.register(mReader);
     } catch (IOException e) {
-      mContext.releaseWorkerClient(mBlockWorkerClient);
+      mCloser.close();
       throw e;
     }
   }
@@ -89,14 +90,12 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
       }
       mBlockWorkerClient.unlockBlock(mBlockId);
     } finally {
-      mContext.releaseWorkerClient(mBlockWorkerClient);
+      mClosed = true;
       mCloser.close();
       if (mBuffer != null && mBuffer.isDirect()) {
         BufferUtils.cleanDirectBuffer(mBuffer);
       }
     }
-
-    mClosed = true;
   }
 
   @Override

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
@@ -63,16 +63,16 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
     }
 
     mCloser = Closer.create();
-    mBlockWorkerClient = mContext.acquireWorkerClient(workerNetAddress);
-
     try {
+      mBlockWorkerClient = mContext.createWorkerClient(workerNetAddress);
+      mCloser.register(mBlockWorkerClient);
       long initialSize = Configuration.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
       String blockPath = mBlockWorkerClient.requestBlockLocation(mBlockId, initialSize);
       mReservedBytes += initialSize;
       mWriter = new LocalFileBlockWriter(blockPath);
       mCloser.register(mWriter);
     } catch (IOException e) {
-      mContext.releaseWorkerClient(mBlockWorkerClient);
+      mCloser.close();
       throw e;
     }
   }
@@ -82,13 +82,13 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
     if (mClosed) {
       return;
     }
-    mCloser.close();
     try {
       mBlockWorkerClient.cancelBlock(mBlockId);
     } catch (AlluxioException e) {
       throw new IOException(e);
     } finally {
-      releaseAndClose();
+      mClosed = true;
+      mCloser.close();
     }
   }
 
@@ -97,19 +97,19 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
     if (mClosed) {
       return;
     }
-    flush();
-    mCloser.close();
-    if (mWrittenBytes > 0) {
-      try {
-        mBlockWorkerClient.cacheBlock(mBlockId);
-      } catch (AlluxioException e) {
-        throw new IOException(e);
-      } finally {
-        releaseAndClose();
+    try {
+      flush();
+      if (mWrittenBytes > 0) {
+        try {
+          mBlockWorkerClient.cacheBlock(mBlockId);
+        } catch (AlluxioException e) {
+          throw new IOException(e);
+        }
+        Metrics.BLOCKS_WRITTEN_LOCAL.inc();
       }
-      Metrics.BLOCKS_WRITTEN_LOCAL.inc();
-    } else {
-      releaseAndClose();
+    } finally {
+      mClosed = true;
+      mCloser.close();
     }
   }
 
@@ -144,14 +144,6 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
     mFlushedBytes += len;
 
     Metrics.BYTES_WRITTEN_LOCAL.inc(len);
-  }
-
-  /**
-   * Releases {@link #mBlockWorkerClient} and sets {@link #mClosed} to true.
-   */
-  private void releaseAndClose() {
-    mContext.releaseWorkerClient(mBlockWorkerClient);
-    mClosed = true;
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -71,7 +71,7 @@ public final class RetryHandlingBlockWorkerClient
   private final WorkerNetAddress mWorkerNetAddress;
   private final InetSocketAddress mRpcAddress;
 
-  private ScheduledFuture<?> mHeartbeat = null;
+  private final ScheduledFuture<?> mHeartbeat;
 
   /**
    * Creates a {@link RetryHandlingBlockWorkerClient}. Set sessionId to null if no session ID is
@@ -114,6 +114,8 @@ public final class RetryHandlingBlockWorkerClient
           Configuration.getInt(PropertyKey.USER_HEARTBEAT_INTERVAL_MS), TimeUnit.MILLISECONDS);
 
       NUM_ACTIVE_SESSIONS.incrementAndGet();
+    } else {
+      mHeartbeat = null;
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -39,6 +39,7 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
+import com.google.common.io.Closer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,6 +119,7 @@ public class FileOutStream extends AbstractOutStream {
     mUnderOutStreamFactory = underOutStreamFactory;
     mPreviousBlockOutStreams = new LinkedList<>();
     mUfsDelegation = Configuration.getBoolean(PropertyKey.USER_UFS_DELEGATION_ENABLED);
+
     if (mUnderStorageType.isSyncPersist()) {
       // Get the ufs path from the master.
       FileSystemMasterClient client = mContext.acquireMasterClient();
@@ -187,8 +189,8 @@ public class FileOutStream extends AbstractOutStream {
     CompleteFileOptions options = CompleteFileOptions.defaults();
     if (mUnderStorageType.isSyncPersist()) {
       if (mUfsDelegation) {
-        mUnderStorageOutputStream.close();
         try {
+          mUnderStorageOutputStream.close();
           if (mCanceled) {
             mFileSystemWorkerClient.cancelUfsFile(mUfsFileId, CancelUfsFileOptions.defaults());
           } else {
@@ -383,6 +385,7 @@ public class FileOutStream extends AbstractOutStream {
       mContext.releaseMasterClient(masterClient);
     }
   }
+
 
   /**
    * Class that contains metrics about FileOutStream.

--- a/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
@@ -80,7 +80,7 @@ public class FileSystemWorkerClient
   /** Address of the rpc server on the worker. */
   private final InetSocketAddress mWorkerRpcServerAddress;
 
-  private ScheduledFuture<?> mHeartbeat = null;
+  private final ScheduledFuture<?> mHeartbeat;
 
   /**
    * Constructor for a client that communicates with the {@link FileSystemWorkerClientService}.

--- a/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -67,7 +67,7 @@ public final class AlluxioBlockStoreTest {
 
     BlockStoreContext blockStoreContext = PowerMockito.mock(BlockStoreContext.class);
     // Mock block store context to return our mock clients
-    Mockito.when(blockStoreContext.acquireWorkerClient(Mockito.any(WorkerNetAddress.class)))
+    Mockito.when(blockStoreContext.createWorkerClient(Mockito.any(WorkerNetAddress.class)))
         .thenReturn(mBlockWorkerClient);
     Mockito.when(blockStoreContext.acquireMasterClientResource()).thenReturn(
         new DummyCloseableResource<>(mMasterClient));

--- a/tests/src/test/java/alluxio/master/ServiceSocketBindIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/ServiceSocketBindIntegrationTest.java
@@ -62,7 +62,7 @@ public class ServiceSocketBindIntegrationTest {
 
     // connect Worker RPC service
     WorkerNetAddress workerAddress = mLocalAlluxioCluster.getWorkerAddress();
-    mBlockWorkerClient = BlockStoreContext.get().acquireWorkerClient(workerAddress);
+    mBlockWorkerClient = BlockStoreContext.get().createWorkerClient(workerAddress);
 
     // connect Worker data service
     mWorkerDataService = SocketChannel
@@ -88,7 +88,7 @@ public class ServiceSocketBindIntegrationTest {
   private void closeServices() throws Exception {
     mWorkerWebService.disconnect();
     mWorkerDataService.close();
-    BlockStoreContext.get().releaseWorkerClient(mBlockWorkerClient);
+    mBlockWorkerClient.close();
     mMasterWebService.disconnect();
     mBlockMasterClient.close();
   }
@@ -165,13 +165,13 @@ public class ServiceSocketBindIntegrationTest {
     // Connect to Worker RPC service on loopback, while Worker is listening on local hostname.
     try {
       mBlockWorkerClient =
-          BlockStoreContext.get().acquireWorkerClient(mLocalAlluxioCluster.getWorkerAddress());
+          BlockStoreContext.get().createWorkerClient(mLocalAlluxioCluster.getWorkerAddress());
       mBlockMasterClient.connect();
       Assert.fail("Client should not have successfully connected to Worker RPC service.");
     } catch (Exception e) {
       // This is expected, since Work RPC service is NOT listening on loopback.
     } finally {
-      BlockStoreContext.get().releaseWorkerClient(mBlockWorkerClient);
+      mBlockWorkerClient.close();
     }
 
     // connect Worker data service on loopback, while Worker is listening on local hostname.

--- a/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
@@ -97,7 +97,7 @@ public class DataServerIntegrationTest {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
 
     mBlockWorkerClient = BlockStoreContext.get()
-        .acquireWorkerClient(mLocalAlluxioClusterResource.get().getWorkerAddress());
+        .createWorkerClient(mLocalAlluxioClusterResource.get().getWorkerAddress());
     mBlockMasterClient = new RetryHandlingBlockMasterClient(
         new InetSocketAddress(mLocalAlluxioClusterResource.get().getHostname(),
             mLocalAlluxioClusterResource.get().getMasterRpcPort()));
@@ -106,7 +106,7 @@ public class DataServerIntegrationTest {
   @After
   public final void after() throws Exception {
     mBlockMasterClient.close();
-    BlockStoreContext.get().releaseWorkerClient(mBlockWorkerClient);
+    mBlockWorkerClient.close();
   }
 
   /**


### PR DESCRIPTION
Fix some patterns that can leak resources in the "constructors" or "closes".