### PR TITLE
[SMALLFIX] Reduce the size of the worker heartbeat threadpools to save on threads.

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -60,8 +60,7 @@ public final class RetryHandlingBlockWorkerClient
     extends AbstractThriftClient<BlockWorkerClientService.Client> implements BlockWorkerClient {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static final ScheduledExecutorService HEARTBEAT_POOL = Executors.newScheduledThreadPool(
-      Configuration.getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_THREADS),
-      ThreadFactoryUtils.build("block-worker-heartbeat-%d", true));
+      5, ThreadFactoryUtils.build("block-worker-heartbeat-%d", true));
   private static final ExecutorService HEARTBEAT_CANCEL_POOL = Executors.newFixedThreadPool(5,
       ThreadFactoryUtils.build("block-worker-heartbeat-cancel-%d", true));
 

--- a/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
@@ -62,8 +62,7 @@ public class FileSystemWorkerClient
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static final ScheduledExecutorService HEARTBEAT_POOL = Executors.newScheduledThreadPool(
-      Configuration.getInt(PropertyKey.USER_FILE_WORKER_CLIENT_THREADS),
-      ThreadFactoryUtils.build("file-worker-heartbeat-%d", true));
+      5, ThreadFactoryUtils.build("file-worker-heartbeat-%d", true));
   private static final ExecutorService HEARTBEAT_CANCEL_POOL = Executors.newFixedThreadPool(5,
       ThreadFactoryUtils.build("file-worker-heartbeat-cancel-%d", true));
 


### PR DESCRIPTION
Its unnecessary to have a hundred+ threads for heartbeats.