### PR TITLE
[ALLUXIO-2106]Update the javadoc class comments for NonUniqueFieldIndex. It says: "in this {@link IndexedSet}", but it should say "in this index". 

### DIFF
--- a/core/common/src/main/java/alluxio/collections/NonUniqueFieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/NonUniqueFieldIndex.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A class representing a non-unique index. A non-unique index is
  * an index where an index value can map to one or more objects.
  *
- * @param <T> type of objects in this {@link IndexedSet}
+ * @param <T> type of objects in this index
  */
 @ThreadSafe
 public class NonUniqueFieldIndex<T> implements FieldIndex<T> {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2106
Update the javadoc class comments for NonUniqueFieldIndex. It says: "in this {@link IndexedSet}", but it should say "in this index". 