### PR TITLE
[SMALLFIX] Check isFile instead of exists in s3a mkdirs to avoid race conditions.

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -374,7 +374,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
     if (isFolder(path)) {
       return true;
     }
-    if (exists(path)) {
+    if (isFile(path)) {
       LOG.error("Cannot create directory {} because it is already a file.", path);
       return false;
     }


### PR DESCRIPTION
Prevents failing unnecessarily on concurrent folder create.