### PR TITLE
[ALLUXIO-2395] add ganglia metrics sink support in alluxio

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -61,6 +61,14 @@
 #   unit      seconds       Units of poll period
 #   prefix    EMPTY STRING  Prefix to prepend to metric name
 
+# alluxio.metrics.sink.GangliaSink
+#   Name:     Default:      Description:
+#   host      NONE          Hostname of Ganglia gmond
+#   port      8649          Port of Ganglia gmond
+#   period    10            Poll period
+#   unit      seconds       Units of poll period
+#   ttl       1             time to live value
+
 ## Examples
 # Enable JmxSink by class name
 # sink.jmx.class=alluxio.metrics.sink.JmxSink
@@ -84,3 +92,10 @@
 # Polling directory for CsvSink
 # sink.csv.directory=/tmp/
 
+# Enable GangliaSink
+# sink.ganglia.class=alluxio.metrics.sink.GangliaSink
+# sink.ganglia.host=localhost
+# sink.ganglia.port=8649
+# sink.ganglia.period=10
+# sink.ganglia.unit=seconds
+# sink.ganglia.ttl=1

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -98,6 +98,16 @@
       <artifactId>metrics-graphite</artifactId>
       <version>${metrics.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-ganglia</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>info.ganglia.gmetric4j</groupId>
+      <artifactId>gmetric4j</artifactId>
+      <version>${gmetric4j.version}</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/core/common/src/main/java/alluxio/metrics/sink/GangliaSink.java
+++ b/core/common/src/main/java/alluxio/metrics/sink/GangliaSink.java
@@ -1,0 +1,119 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics.sink;
+
+import alluxio.metrics.MetricsSystem;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ganglia.GangliaReporter;
+
+import info.ganglia.gmetric4j.gmetric.GMetric;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A sink which publishes metric values to a Ganglia.
+ */
+@ThreadSafe
+public class GangliaSink implements Sink {
+  private static final String GANGLIA_DEFAULT_PORT = "8649";
+  private static final int GANGLIA_DEFAULT_PERIOD = 10;
+  private static final String GANGLIA_DEFAULT_UNIT = "SECONDS";
+  private static final String GANGLIA_DEFAULT_TTL = "1";
+
+  private static final String GANGLIA_KEY_HOST = "host";
+  private static final String GANGLIA_KEY_PORT = "port";
+  private static final String GANGLIA_KEY_PERIOD = "period";
+  private static final String GANGLIA_KEY_UNIT = "unit";
+  private static final String GANGLIA_KEY_TTL = "ttl";
+
+  private GangliaReporter mReporter;
+  private Properties mProperties;
+
+  /**
+   * Creates a new {@link GangliaSink} with a {@link Properties} and {@link MetricRegistry}.
+   *
+   * @param properties the properties which may contain polling period and unit properties
+   * @param registry the metric registry to register
+   * @throws IllegalArgumentException if the {@code host} or {@code port} property is missing
+   * @throws IOException if the ganglia metric initialize fail
+   */
+  public GangliaSink(Properties properties, MetricRegistry registry)
+          throws IllegalArgumentException, IOException {
+    mProperties = properties;
+    String host = properties.getProperty(GANGLIA_KEY_HOST);
+    if (host == null) {
+      throw new IllegalArgumentException("Ganglia sink requires 'host' properties");
+    }
+    String port = properties.getProperty(GANGLIA_KEY_PORT);
+    if (port == null) {
+      port = GANGLIA_DEFAULT_PORT;
+    }
+    String ttl = properties.getProperty(GANGLIA_KEY_TTL);
+    if (ttl == null) {
+      ttl = GANGLIA_DEFAULT_TTL;
+    }
+    final GMetric ganglia = new GMetric(host,
+            Integer.parseInt(port),
+            GMetric.UDPAddressingMode.MULTICAST, Integer.parseInt(ttl));
+
+    mReporter = GangliaReporter.forRegistry(registry)
+            .convertRatesTo(TimeUnit.SECONDS)
+            .convertDurationsTo(TimeUnit.MILLISECONDS)
+            .build(ganglia);
+    MetricsSystem.checkMinimalPollingPeriod(getPollUnit(), getPollPeriod());
+  }
+
+  @Override
+  public void start() {
+    mReporter.start(getPollPeriod(), getPollUnit());
+  }
+
+  @Override
+  public void stop() {
+    mReporter.stop();
+  }
+
+  @Override
+  public void report() {
+    mReporter.report();
+  }
+
+  /**
+   * Gets the polling period.
+   *
+   * @return the polling period set by properties. If it is not set, a default value 10 is
+   *         returned.
+   */
+  private int getPollPeriod() {
+    String period = mProperties.getProperty(GANGLIA_KEY_PERIOD);
+    return period != null ? Integer.parseInt(period) : GANGLIA_DEFAULT_PERIOD;
+  }
+
+  /**
+   * Gets the polling time unit.
+   *
+   * @return the polling time unit set by properties, If it is not set, a default value SECONDS is
+   *         returned.
+   */
+  private TimeUnit getPollUnit() {
+    String unit = mProperties.getProperty(GANGLIA_KEY_UNIT);
+    if (unit == null) {
+      unit = GANGLIA_DEFAULT_UNIT;
+    }
+    return TimeUnit.valueOf(unit.toUpperCase());
+  }
+}

--- a/docs/cn/Metrics-System.md
+++ b/docs/cn/Metrics-System.md
@@ -23,6 +23,7 @@ Alluxio的度量指标信息被分配到各种相关Alluxio组件的实例中。
 * JmxSink: 查看JMX控制台中寄存器的度量信息。
 * GraphiteSink: 给Graphite服务器发送度量信息。
 * MetricsServlet: 添加Web UI中的servlet，作为JSON数据来为度量指标数据服务。
+* GangliaSink: 向Ganglia监控进程发送度量信息。
 
 # 配置
 度指标量系统可以通过配置文件进行配置，Alluxio中该文件默认位于`$ALLUXIO_HOME/conf/metrics.properties`。自定义文件位置可以通过`alluxio.metrics.conf.file`配置项来指定。Alluxio在conf目录下提供了一个metrics.properties.template文件，其包括所有可配置属性。默认情况下，MetricsServlet是生效的，你可以发送HTTP请求"/metrics/json"来获取一个以JSON格式表示的所有已注册度量信息的快照。

--- a/docs/en/Metrics-System.md
+++ b/docs/en/Metrics-System.md
@@ -30,6 +30,7 @@ Each instance can report to zero or more sinks.
 * JmxSink: Registers metrics for viewing in a JMX console.
 * GraphiteSink: Sends metrics to a Graphite server.
 * MetricsServlet: Adds a servlet in Web UI to serve metrics data as JSON data.
+* GangliaSink: Sends metrics to Ganglia daemons.
 
 # Configuration
 The metrics system is configured via a configuration file that Alluxio expects to be present at

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
     <build.path>build</build.path>
     <log4j.version>1.2.17</log4j.version>
     <metrics.version>3.1.2</metrics.version>
+    <gmetric4j.version>1.0.7</gmetric4j.version>
     <powermock.version>1.6.1</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.2</slf4j.version>


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2395

In my company, bigdata clusters environments, we use ganglia heavily to monitoring and debugging, and I noticed that alluxio doesn't support ganglia metrics sink currently.
There are somebody(like me) really needs this support.So it might be a choice to provide ganglia metrics sinker in alluxio.