### PR TITLE
[ALLUXIO-2299] Mark member variable mMountTable "final" in class MountTable

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -57,7 +57,7 @@ public final class MountTable implements JournalCheckpointStreamable {
 
   /** Maps from Alluxio path string, to {@link MountInfo}. */
   @GuardedBy("mLock")
-  private Map<String, MountInfo> mMountTable;
+  private final Map<String, MountInfo> mMountTable;
 
   /**
    * Creates a new instance of {@link MountTable}.

--- a/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -57,7 +57,7 @@ public final class MountTable implements JournalCheckpointStreamable {
 
   /** Maps from Alluxio path string, to {@link MountInfo}. */
   @GuardedBy("mLock")
-  private final Map<String, MountInfo> mMountTable;
+  private Map<String, MountInfo> mMountTable;
 
   /**
    * Creates a new instance of {@link MountTable}.


### PR DESCRIPTION
[https://alluxio.atlassian.net/browse/ALLUXIO-2299](https://alluxio.atlassian.net/browse/ALLUXIO-2299)
In MountTable.java, 
change
`private Map<String, MountInfo> mMountTable;`
to be
`private final Map<String, MountInfo> mMountTable;`
as this member variable is no more changed after init