### PR TITLE
[ALLUXIO-2336] Fixed specifier character handling in LsCommand

### DIFF
--- a/core/server/src/main/java/alluxio/web/UIFileInfo.java
+++ b/core/server/src/main/java/alluxio/web/UIFileInfo.java
@@ -22,6 +22,8 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -180,9 +182,11 @@ public final class UIFileInfo {
 
   /**
    * @return the absolute path
+   * @throws UnsupportedEncodingException when the given encoding for the format string is not
+   *                                      supported
    */
-  public String getAbsolutePath() {
-    return mAbsolutePath;
+  public String getAbsolutePath() throws UnsupportedEncodingException {
+    return URLDecoder.decode(mAbsolutePath, "UTF-8");
   }
 
   /**
@@ -280,12 +284,14 @@ public final class UIFileInfo {
 
   /**
    * @return the file name
+   * @throws UnsupportedEncodingException when the given encoding for the format string is not
+   *                                      supported
    */
-  public String getName() {
+  public String getName() throws UnsupportedEncodingException {
     if (AlluxioURI.SEPARATOR.equals(mAbsolutePath)) {
       return "root";
     } else {
-      return mName;
+      return URLDecoder.decode(mName, "UTF-8");
     }
   }
 

--- a/core/server/src/main/java/alluxio/web/UIFileInfo.java
+++ b/core/server/src/main/java/alluxio/web/UIFileInfo.java
@@ -22,8 +22,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -182,11 +180,9 @@ public final class UIFileInfo {
 
   /**
    * @return the absolute path
-   * @throws UnsupportedEncodingException when the given encoding for the format string is not
-   *                                      supported
    */
-  public String getAbsolutePath() throws UnsupportedEncodingException {
-    return URLDecoder.decode(mAbsolutePath, "UTF-8");
+  public String getAbsolutePath() {
+    return mAbsolutePath;
   }
 
   /**
@@ -284,14 +280,12 @@ public final class UIFileInfo {
 
   /**
    * @return the file name
-   * @throws UnsupportedEncodingException when the given encoding for the format string is not
-   *                                      supported
    */
-  public String getName() throws UnsupportedEncodingException {
+  public String getName() {
     if (AlluxioURI.SEPARATOR.equals(mAbsolutePath)) {
       return "root";
     } else {
-      return URLDecoder.decode(mName, "UTF-8");
+      return mName;
     }
   }
 

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -25,6 +25,8 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -53,10 +55,12 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param inMemory whether the file is in memory
    * @param path path of the file or folder
    * @return the formatted string according to acl and isFolder
+   * @throws UnsupportedEncodingException when the given encoding for the format string is not
+   *                                      supported
    */
   public static String formatLsString(boolean acl, boolean isFolder, String permission,
       String userName, String groupName, long size, long createTimeMs, boolean inMemory,
-      String path) {
+      String path) throws UnsupportedEncodingException {
     String memoryState;
     if (isFolder) {
       memoryState = STATE_FOLDER;
@@ -64,12 +68,13 @@ public final class LsCommand extends WithWildCardPathCommand {
       memoryState = inMemory ? STATE_FILE_IN_MEMORY : STATE_FILE_NOT_IN_MEMORY;
     }
     if (acl) {
-      return String.format(Constants.LS_FORMAT, permission, userName, groupName,
+      return URLDecoder.decode(String.format(Constants.LS_FORMAT, permission, userName, groupName,
           FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
-          memoryState, path);
+          memoryState, path), "UTF-8");
     } else {
-      return String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(size),
-          CommandUtils.convertMsToDate(createTimeMs), memoryState, path);
+      return URLDecoder.decode(String.format(Constants.LS_FORMAT_NO_ACL,
+          FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
+          memoryState, path), "UTF-8");
     }
   }
 

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -68,9 +68,8 @@ public final class LsCommand extends WithWildCardPathCommand {
           FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
           memoryState, path);
     } else {
-      return String.format(Constants.LS_FORMAT_NO_ACL,
-          FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
-          memoryState, path);
+      return String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(size),
+          CommandUtils.convertMsToDate(createTimeMs), memoryState, path);
     }
   }
 

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -25,8 +25,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -55,12 +53,10 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param inMemory whether the file is in memory
    * @param path path of the file or folder
    * @return the formatted string according to acl and isFolder
-   * @throws UnsupportedEncodingException when the given encoding for the format string is not
-   *                                      supported
    */
   public static String formatLsString(boolean acl, boolean isFolder, String permission,
       String userName, String groupName, long size, long createTimeMs, boolean inMemory,
-      String path) throws UnsupportedEncodingException {
+      String path) {
     String memoryState;
     if (isFolder) {
       memoryState = STATE_FOLDER;
@@ -68,13 +64,13 @@ public final class LsCommand extends WithWildCardPathCommand {
       memoryState = inMemory ? STATE_FILE_IN_MEMORY : STATE_FILE_NOT_IN_MEMORY;
     }
     if (acl) {
-      return URLDecoder.decode(String.format(Constants.LS_FORMAT, permission, userName, groupName,
+      return String.format(Constants.LS_FORMAT, permission, userName, groupName,
           FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
-          memoryState, path), "UTF-8");
+          memoryState, path);
     } else {
-      return URLDecoder.decode(String.format(Constants.LS_FORMAT_NO_ACL,
+      return String.format(Constants.LS_FORMAT_NO_ACL,
           FormatUtils.getSizeFromBytes(size), CommandUtils.convertMsToDate(createTimeMs),
-          memoryState, path), "UTF-8");
+          memoryState, path);
     }
   }
 

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -119,7 +119,7 @@ public final class LsCommand extends WithWildCardPathCommand {
     }
     List<URIStatus> statuses = listStatusSortedByIncreasingCreationTime(path, options);
     for (URIStatus status : statuses) {
-      System.out.format(formatLsString(SecurityUtils.isSecurityEnabled(), status.isFolder(),
+      System.out.print(formatLsString(SecurityUtils.isSecurityEnabled(), status.isFolder(),
           FormatUtils.formatMode((short) status.getMode(), status.isFolder()), status.getOwner(),
           status.getGroup(), status.getLength(), status.getCreationTimeMs(),
           100 == status.getInMemoryPercentage(), status.getPath()));

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -262,9 +262,8 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, fileName, WriteType.MUST_CACHE, 10);
     URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
     mFsShell.run("ls", "/");
-    String expected =
-        getLsNoAclResultStr("/localhost%2C61764%2C1476207067267..meta.1476207073442.meta",
-        file.getCreationTimeMs(), 10, LsCommand.STATE_FILE_IN_MEMORY);
+    String expected = getLsNoAclResultStr(fileName, file.getCreationTimeMs(), 10,
+        LsCommand.STATE_FILE_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -262,7 +262,8 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, fileName, WriteType.MUST_CACHE, 10);
     URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
     mFsShell.run("ls", "/");
-    String expected = getLsNoAclResultStr("/localhost,61764,1476207067267..meta.1476207073442.meta",
+    String expected =
+        getLsNoAclResultStr("/localhost%2C61764%2C1476207067267..meta.1476207073442.meta",
         file.getCreationTimeMs(), 10, LsCommand.STATE_FILE_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -249,4 +249,21 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
         files[3].isFolder());
     Assert.assertEquals(expected, mOutput.toString());
   }
+
+  /**
+   * Tests ls command with a file where the file name includes a specifier character.
+   */
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
+  public void lsWithFormatSpecifierCharacter() throws IOException, AlluxioException {
+    String fileName = "/localhost%2C61764%2C1476207067267..meta.1476207073442.meta";
+    FileSystemTestUtils.createByteFile(mFileSystem, fileName, WriteType.MUST_CACHE, 10);
+    URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
+    mFsShell.run("ls", "/");
+    String expected = getLsNoAclResultStr("/localhost,61764,1476207067267..meta.1476207073442.meta",
+        file.getCreationTimeMs(), 10, LsCommand.STATE_FILE_IN_MEMORY);
+    Assert.assertEquals(expected, mOutput.toString());
+  }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2336

- Specifier characters used by String.format cause an error in the ls
  shell command
- Fixed this and the ls shell command can now handle specifier
  characters in a file name
- Added test for this behavior