### PR TITLE
[ALLUXIO-1904] Changed creation of reader in RemoteBlockInStream

### DIFF
--- a/core/client/src/main/java/alluxio/client/RemoteBlockReader.java
+++ b/core/client/src/main/java/alluxio/client/RemoteBlockReader.java
@@ -31,6 +31,7 @@ public interface RemoteBlockReader extends Closeable {
    * The factory for the {@link RemoteBlockReader}.
    */
   class Factory {
+    static RemoteBlockReader sReader = null;
 
     private Factory() {} // prevent instantiation
 
@@ -47,6 +48,25 @@ public interface RemoteBlockReader extends Closeable {
       } catch (Exception e) {
         throw Throwables.propagate(e);
       }
+    }
+
+    /**
+     * Factory for {@link RemoteBlockReader}. Creates a new instance if it not already exists.
+     *
+     * @return a new instance of {@link RemoteBlockReader} if it not already exists
+     */
+    public static RemoteBlockReader createIfNotExist() {
+      if (sReader == null) {
+        try {
+          sReader = CommonUtils.createNewClassInstance(
+              Configuration.<RemoteBlockReader>getClass(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS),
+              null, null);
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+
+      return sReader;
     }
   }
 

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -146,8 +146,7 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
     int toRead = (int) Math.min(len, remaining());
     int bytesLeft = toRead;
     while (bytesLeft > 0) {
-      // TODO(calvin): Fix needing to recreate reader each time.
-      try (RemoteBlockReader reader = RemoteBlockReader.Factory.create()) {
+      try (RemoteBlockReader reader = RemoteBlockReader.Factory.createIfNotExist()) {
         ByteBuffer data = reader.readRemoteBlock(mWorkerInetSocketAddress, mBlockId, getPosition(),
             bytesLeft, mLockId, mBlockWorkerClient.getSessionId());
         int bytesRead = data.remaining();

--- a/core/client/src/test/java/alluxio/client/RemoteBlockReaderTest.java
+++ b/core/client/src/test/java/alluxio/client/RemoteBlockReaderTest.java
@@ -1,0 +1,76 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.Configuration;
+import alluxio.ConfigurationTestUtils;
+import alluxio.PropertyKey;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+public class RemoteBlockReaderTest {
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+
+  @After
+  public void after() {
+    ConfigurationTestUtils.resetConfiguration();
+    RemoteBlockReader.Factory.sReader = null;
+  }
+
+  @Test
+  public void createFromMockClass() {
+    RemoteBlockReader mock = Mockito.mock(RemoteBlockReader.class);
+    Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, mock.getClass().getName());
+    Assert.assertTrue(RemoteBlockReader.Factory.create().getClass().equals(mock.getClass()));
+  }
+
+  @Test
+  public void createFailed() {
+    Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, "unknown");
+    mThrown.expect(RuntimeException.class);
+    RemoteBlockReader.Factory.create();
+  }
+
+  @Test
+  public void createIfNotExistFromMockClass() {
+    RemoteBlockReader mock = Mockito.mock(RemoteBlockReader.class);
+    Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, mock.getClass().getName());
+    Assert.assertTrue(RemoteBlockReader.Factory.createIfNotExist().getClass()
+        .equals(mock.getClass()));
+  }
+
+  @Test
+  public void createIfNotExistFailed() {
+    Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, "unknown");
+    mThrown.expect(RuntimeException.class);
+    RemoteBlockReader.Factory.createIfNotExist();
+  }
+
+  @Test
+  public void createIfNotExistNoNewInstance() {
+    Assert.assertNull(RemoteBlockReader.Factory.sReader);
+
+    RemoteBlockReader reader = RemoteBlockReader.Factory.createIfNotExist();
+
+    Assert.assertTrue(reader.equals(RemoteBlockReader.Factory.sReader));
+
+    RemoteBlockReader reader1 = RemoteBlockReader.Factory.createIfNotExist();
+
+    Assert.assertTrue(reader1 == reader);
+  }
+}

--- a/core/client/src/test/java/alluxio/client/RemoteBlockReaderTest.java
+++ b/core/client/src/test/java/alluxio/client/RemoteBlockReaderTest.java
@@ -36,7 +36,7 @@ public class RemoteBlockReaderTest {
   public void createFromMockClass() {
     RemoteBlockReader mock = Mockito.mock(RemoteBlockReader.class);
     Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, mock.getClass().getName());
-    Assert.assertTrue(RemoteBlockReader.Factory.create().getClass().equals(mock.getClass()));
+    Assert.assertEquals(mock.getClass(), RemoteBlockReader.Factory.create().getClass());
   }
 
   @Test
@@ -50,8 +50,7 @@ public class RemoteBlockReaderTest {
   public void createIfNotExistFromMockClass() {
     RemoteBlockReader mock = Mockito.mock(RemoteBlockReader.class);
     Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READER_CLASS, mock.getClass().getName());
-    Assert.assertTrue(RemoteBlockReader.Factory.createIfNotExist().getClass()
-        .equals(mock.getClass()));
+    Assert.assertEquals(mock.getClass(), RemoteBlockReader.Factory.createIfNotExist().getClass());
   }
 
   @Test
@@ -66,11 +65,9 @@ public class RemoteBlockReaderTest {
     Assert.assertNull(RemoteBlockReader.Factory.sReader);
 
     RemoteBlockReader reader = RemoteBlockReader.Factory.createIfNotExist();
-
-    Assert.assertTrue(reader.equals(RemoteBlockReader.Factory.sReader));
+    Assert.assertEquals(reader, RemoteBlockReader.Factory.sReader);
 
     RemoteBlockReader reader1 = RemoteBlockReader.Factory.createIfNotExist();
-
     Assert.assertTrue(reader1 == reader);
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1904
- Added method to RemoteBlockReader.Factory which only creates a new
  instance if none already exists
- Changed the RemoteBlockReader creation in
  RemoteBlockInStream#readFromRemote
- Added tests for RemoteBlockReader.Factory
