### PR TITLE
[SMALLFIX] Minor fixes of variables in different classes

### DIFF
--- a/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
@@ -205,16 +205,14 @@ public abstract class ThriftClientPool<T extends AlluxioService.Client>
       }
     }
 
-    long serviceVersionFound = -1;
     try {
-      serviceVersionFound = client.getServiceVersion();
+      long serviceVersionFound = client.getServiceVersion();
       synchronized (this) {
         mServerVersionFound = serviceVersionFound;
         if (mServerVersionFound != mServiceVersion) {
           throw new IOException(ExceptionMessage.INCOMPATIBLE_VERSION
               .getMessage(mServiceName, mServiceVersion, mServerVersionFound));
         }
-        return;
       }
     } catch (TTransportException e) {
       closeResource(client);

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -127,9 +127,8 @@ public abstract class UnderFileSystem {
      * @return the UFS instance
      */
     UnderFileSystem get(String path, Object ufsConf) {
-      UnderFileSystem cachedFs = null;
       Key key = new Key(new AlluxioURI(path));
-      cachedFs = mUnderFileSystemMap.get(key);
+      UnderFileSystem cachedFs = mUnderFileSystemMap.get(key);
       if (cachedFs != null) {
         return cachedFs;
       }

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -460,7 +460,6 @@ public final class InodeTreeTest {
   public void deleteInode() throws Exception {
     InodeTree.CreatePathResult createResult =
         createPath(mTree, NESTED_URI, sNestedDirectoryOptions);
-    List<Inode<?>> created = createResult.getCreated();
 
     // all inodes under root
     try (LockedInodePath inodePath = mTree.lockFullInodePath(0, InodeTree.LockMode.WRITE)) {
@@ -552,7 +551,7 @@ public final class InodeTreeTest {
     mTree.addInodeFromJournal(root.toJournalEntry());
 
     // re-init the root since the tree was reset above
-    root = mTree.getRoot();
+    mTree.getRoot();
 
     try (
         LockedInodePath inodePath = mTree

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -433,8 +433,7 @@ public class FileSystemMasterIntegrationTest {
   @Test
   public void lastModificationTimeRename() throws Exception {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryOptions.defaults());
-    long fileId =
-        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), CreateFileOptions.defaults());
+    mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), CreateFileOptions.defaults());
     long opTimeMs = TEST_CURRENT_TIME;
 
     try (InodePathPair inodePathPair = mInodeTree.lockInodePathPair(
@@ -598,7 +597,7 @@ public class FileSystemMasterIntegrationTest {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryOptions.defaults());
     long ttl = 1;
     CreateFileOptions options = CreateFileOptions.defaults().setTtl(ttl);
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), options);
+    mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), options);
 
     try (InodePathPair inodePathPair = mInodeTree.lockInodePathPair(
         new AlluxioURI("/testFolder/testFile1"), InodeTree.LockMode.WRITE_PARENT,

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
@@ -150,7 +150,6 @@ public class OSSOutputStreamTest {
     BufferedInputStream inputStream = PowerMockito.mock(BufferedInputStream.class);
     PowerMockito.whenNew(BufferedInputStream.class)
             .withArguments(Mockito.any(FileInputStream.class)).thenReturn(inputStream);
-    ObjectMetadata objMeta = new ObjectMetadata();
     PowerMockito
             .when(mOssClient.putObject(Mockito.anyString(), Mockito.anyString(),
                     Mockito.any(InputStream.class), Mockito.any(ObjectMetadata.class)))


### PR DESCRIPTION
- Removed two not needed variables in FileSystemMasterIntegrationTest
- Removed two not needed variables in InodeTreeTest
- Removed not needed variable in OSSOutputStreamTest
- Moved variable into try-statement and removed not needed return statement in ThriftClientPool
- Inlined variable in UnderFileSystem