### PR TITLE
[SMALLFIX] Removed variables and removed equals check in some classes

### DIFF
--- a/core/client/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -337,7 +337,6 @@ public final class BaseFileSystemTest {
   @Test
   public void openException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    URIStatus status = new URIStatus(new FileInfo());
     Mockito.when(mFileSystemMasterClient.getStatus(file)).thenThrow(EXCEPTION);
     OpenFileOptions openOptions = OpenFileOptions.defaults();
     try {

--- a/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -189,8 +189,6 @@ public class AlluxioURITest {
     AlluxioURI uri2 = new AlluxioURI(uri1.toString());
     Assert.assertEquals(queryMap, uri1.getQueryMap());
     Assert.assertEquals(uri1.getQueryMap(), uri2.getQueryMap());
-    Map<String, String> m1 = uri1.getQueryMap();
-    Map<String, String> m2 = uri2.getQueryMap();
   }
 
   /**

--- a/core/server/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -432,7 +432,6 @@ public class BlockWorkerTest {
   @Test
   public void sessionHeartbeat() {
     long sessionId = mRandom.nextLong();
-    long metricIncrease = 3;
 
     mBlockWorker.sessionHeartbeat(sessionId);
     verify(mSessions).sessionHeartbeat(sessionId);

--- a/core/server/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -127,7 +127,7 @@ public class AllocatorTestBase {
       StorageTier pTier = pDir.getParentTier();
 
       Assert.assertTrue(pDir.getDirIndex() == dirIndex);
-      Assert.assertTrue(pTier.getTierAlias().equals(tierAlias));
+      Assert.assertEquals(tierAlias, pTier.getTierAlias());
 
       //update the dir meta info
       pDir.addBlockMeta(new BlockMeta(mTestBlockId, blockSize, pDir));

--- a/core/server/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -127,7 +127,7 @@ public class AllocatorTestBase {
       StorageTier pTier = pDir.getParentTier();
 
       Assert.assertTrue(pDir.getDirIndex() == dirIndex);
-      Assert.assertTrue(pTier.getTierAlias() == tierAlias);
+      Assert.assertTrue(pTier.getTierAlias().equals(tierAlias));
 
       //update the dir meta info
       pDir.addBlockMeta(new BlockMeta(mTestBlockId, blockSize, pDir));

--- a/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
@@ -42,7 +42,7 @@ public class GCSUnderStorageCluster extends UnderFileSystemCluster {
     super(baseDir);
     mGCSBucket =
         PathUtils.concatPath(System.getProperty(INTEGRATION_GCS_BUCKET), UUID.randomUUID());
-    Preconditions.checkState(mGCSBucket != null && mGCSBucket != "",
+    Preconditions.checkState(mGCSBucket != null && !mGCSBucket.equals(""),
         PreconditionMessage.GCS_BUCKET_MUST_BE_SET.toString(), INTEGRATION_GCS_BUCKET);
     mBaseDir = PathUtils.concatPath(mGCSBucket, UUID.randomUUID());
     mStarted = false;

--- a/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
@@ -41,7 +41,7 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   public S3UnderStorageCluster(String baseDir) {
     super(baseDir);
     mS3Bucket = PathUtils.concatPath(System.getProperty(INTEGRATION_S3_BUCKET), UUID.randomUUID());
-    Preconditions.checkState(mS3Bucket != null && mS3Bucket != "",
+    Preconditions.checkState(mS3Bucket != null && !mS3Bucket.equals(""),
         PreconditionMessage.S3_BUCKET_MUST_BE_SET.toString(), INTEGRATION_S3_BUCKET);
     mBaseDir = PathUtils.concatPath(mS3Bucket, UUID.randomUUID());
     mStarted = false;


### PR DESCRIPTION
- Introduced equals check in AllocatorTestBase
- Removed two not needed variables in AlluxioURITest
- Removed variable in BaseFileSystemTest
- Removed variable in BlockWorkerTest
- Introduced equals check in GCSUnderStorageCluster
- Introduced equals check in S3UnderStorageCluster