### PR TITLE
[ALLUXIO-2402] Make MAX_AVAILABLE in ClientRWLock configurable.

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -189,8 +189,8 @@ public enum PropertyKey {
   WORKER_PRINCIPAL(Name.WORKER_PRINCIPAL, null),
   WORKER_RPC_PORT(Name.WORKER_RPC_PORT, 29998),
   WORKER_SESSION_TIMEOUT_MS(Name.WORKER_SESSION_TIMEOUT_MS, 60000),
+  WORKER_TIERED_STORE_BLOCK_LOCK_READERS(Name.WORKER_TIERED_STORE_BLOCK_LOCK_READERS, 1000),
   WORKER_TIERED_STORE_BLOCK_LOCKS(Name.WORKER_TIERED_STORE_BLOCK_LOCKS, 1000),
-  WORKER_TIERED_STORE_BLOCK_PARALLEL(Name.WORKER_TIERED_STORE_BLOCK_PARALLEL, 1000),
   WORKER_TIERED_STORE_LEVEL0_ALIAS(Name.WORKER_TIERED_STORE_LEVEL0_ALIAS, "MEM"),
   WORKER_TIERED_STORE_LEVEL0_DIRS_PATH(Name.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH, "/mnt/ramdisk"),
   WORKER_TIERED_STORE_LEVEL0_DIRS_QUOTA(Name.WORKER_TIERED_STORE_LEVEL0_DIRS_QUOTA,
@@ -559,10 +559,10 @@ public enum PropertyKey {
     public static final String WORKER_PRINCIPAL = "alluxio.worker.principal";
     public static final String WORKER_RPC_PORT = "alluxio.worker.port";
     public static final String WORKER_SESSION_TIMEOUT_MS = "alluxio.worker.session.timeout.ms";
+    public static final String WORKER_TIERED_STORE_BLOCK_LOCK_READERS =
+         "alluxio.worker.tieredstore.block.lock.readers";
     public static final String WORKER_TIERED_STORE_BLOCK_LOCKS =
         "alluxio.worker.tieredstore.block.locks";
-    public static final String WORKER_TIERED_STORE_BLOCK_PARALLEL =
-        "alluxio.worker.tieredstore.block.parallel";
     public static final String WORKER_TIERED_STORE_LEVEL0_ALIAS =
         "alluxio.worker.tieredstore.level0.alias";
     public static final String WORKER_TIERED_STORE_LEVEL0_DIRS_PATH =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -190,6 +190,7 @@ public enum PropertyKey {
   WORKER_RPC_PORT(Name.WORKER_RPC_PORT, 29998),
   WORKER_SESSION_TIMEOUT_MS(Name.WORKER_SESSION_TIMEOUT_MS, 60000),
   WORKER_TIERED_STORE_BLOCK_LOCKS(Name.WORKER_TIERED_STORE_BLOCK_LOCKS, 1000),
+  WORKER_TIERED_STORE_BLOCK_PARALLEL(Name.WORKER_TIERED_STORE_BLOCK_PARALLEL, 1000),
   WORKER_TIERED_STORE_LEVEL0_ALIAS(Name.WORKER_TIERED_STORE_LEVEL0_ALIAS, "MEM"),
   WORKER_TIERED_STORE_LEVEL0_DIRS_PATH(Name.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH, "/mnt/ramdisk"),
   WORKER_TIERED_STORE_LEVEL0_DIRS_QUOTA(Name.WORKER_TIERED_STORE_LEVEL0_DIRS_QUOTA,
@@ -560,6 +561,8 @@ public enum PropertyKey {
     public static final String WORKER_SESSION_TIMEOUT_MS = "alluxio.worker.session.timeout.ms";
     public static final String WORKER_TIERED_STORE_BLOCK_LOCKS =
         "alluxio.worker.tieredstore.block.locks";
+    public static final String WORKER_TIERED_STORE_BLOCK_PARALLEL =
+        "alluxio.worker.tieredstore.block.parallel";
     public static final String WORKER_TIERED_STORE_LEVEL0_ALIAS =
         "alluxio.worker.tieredstore.level0.alias";
     public static final String WORKER_TIERED_STORE_LEVEL0_DIRS_PATH =

--- a/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -11,6 +11,9 @@
 
 package alluxio.worker.block;
 
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,9 +30,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ClientRWLock implements ReadWriteLock {
-  // TODO(bin): Make this const a configurable.
   /** Total number of permits. This value decides the max number of concurrent readers. */
-  private static final int MAX_AVAILABLE = 1000;
+  private static final int MAX_AVAILABLE =
+          Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_PARALLEL);
   /** Underlying Semaphore. */
   private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, true);
   /** Reference count. */

--- a/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ClientRWLock implements ReadWriteLock {
   /** Total number of permits. This value decides the max number of concurrent readers. */
   private static final int MAX_AVAILABLE =
-          Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_PARALLEL);
+          Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
   /** Underlying Semaphore. */
   private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, true);
   /** Reference count. */

--- a/docs/_data/table/cn/worker-configuration.yml
+++ b/docs/_data/table/cn/worker-configuration.yml
@@ -61,10 +61,10 @@ alluxio.worker.port:
   Alluxio worker节点运行端口。
 alluxio.worker.session.timeout.ms:
   worker和client连接的超时时间（单位：毫秒），超时后表明该会话失效。
+alluxio.worker.tieredstore.block.lock.readers:
+  一个Alluxio数据块锁最大允许的并行读数目。
 alluxio.worker.tieredstore.block.locks:
   一个Alluxio数据块worker的数据块锁数目。较大值会达到更好的锁粒度，但会使用更多空间。
-alluxio.worker.tieredstore.block.parallel:
-  一个Alluxio数据块锁最大允许的并行读数目。
 alluxio.worker.tieredstore.levels:
   worker上的存储层数目。
 alluxio.worker.tieredstore.level0.alias:

--- a/docs/_data/table/cn/worker-configuration.yml
+++ b/docs/_data/table/cn/worker-configuration.yml
@@ -63,6 +63,8 @@ alluxio.worker.session.timeout.ms:
   worker和client连接的超时时间（单位：毫秒），超时后表明该会话失效。
 alluxio.worker.tieredstore.block.locks:
   一个Alluxio数据块worker的数据块锁数目。较大值会达到更好的锁粒度，但会使用更多空间。
+alluxio.worker.tieredstore.block.parallel:
+  一个Alluxio数据块锁最大允许的并行读数目。
 alluxio.worker.tieredstore.levels:
   worker上的存储层数目。
 alluxio.worker.tieredstore.level0.alias:

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -77,11 +77,11 @@ alluxio.worker.port:
 alluxio.worker.session.timeout.ms:
   Timeout (in milliseconds) between worker and client connection indicating a lost session
   connection.
+alluxio.worker.tieredstore.block.lock.readers:
+  The max number of concurrent readers for a block lock.
 alluxio.worker.tieredstore.block.locks:
   Total number of block locks for an Alluxio block worker. Larger value leads to finer locking
   granularity, but uses more space.
-alluxio.worker.tieredstore.block.parallel:
-  The max number of concurrent readers for a block lock.
 alluxio.worker.tieredstore.levels:
   The number of storage tiers on the worker
 alluxio.worker.tieredstore.level0.alias:

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -80,6 +80,8 @@ alluxio.worker.session.timeout.ms:
 alluxio.worker.tieredstore.block.locks:
   Total number of block locks for an Alluxio block worker. Larger value leads to finer locking
   granularity, but uses more space.
+alluxio.worker.tieredstore.block.parallel:
+  The max number of concurrent readers for a block lock.
 alluxio.worker.tieredstore.levels:
   The number of storage tiers on the worker
 alluxio.worker.tieredstore.level0.alias:

--- a/docs/_data/table/worker-configuration.csv
+++ b/docs/_data/table/worker-configuration.csv
@@ -26,6 +26,7 @@ alluxio.worker.network.netty.worker.threads,0
 alluxio.worker.port,29998
 alluxio.worker.session.timeout.ms,60000
 alluxio.worker.tieredstore.block.locks,1000
+alluxio.worker.tieredstore.block.parallel,1000
 alluxio.worker.tieredstore.levels,1
 alluxio.worker.tieredstore.level0.alias,MEM
 alluxio.worker.tieredstore.level0.dirs.path,/mnt/ramdisk/

--- a/docs/_data/table/worker-configuration.csv
+++ b/docs/_data/table/worker-configuration.csv
@@ -25,8 +25,8 @@ alluxio.worker.network.netty.watermark.low,8192
 alluxio.worker.network.netty.worker.threads,0
 alluxio.worker.port,29998
 alluxio.worker.session.timeout.ms,60000
+alluxio.worker.tieredstore.block.lock.readers,1000
 alluxio.worker.tieredstore.block.locks,1000
-alluxio.worker.tieredstore.block.parallel,1000
 alluxio.worker.tieredstore.levels,1
 alluxio.worker.tieredstore.level0.alias,MEM
 alluxio.worker.tieredstore.level0.dirs.path,/mnt/ramdisk/


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2402

Make MAX_AVAILABLE in ClientRWLock configurable.

There is a exist property key as:

```
WORKER_TIERED_STORE_BLOCK_LOCKS = "alluxio.worker.tieredstore.block.locks";
```

As the code shows, this key is used to set how much block locks a Worker can have. And the MAX_AVAILABLE in ClientRWLock is to control a block lock's permit. These two config keys seems not exactly the same. So I add another key.

Please confirm if the new key's below name is acceptable:

```
WORKER_TIERED_STORE_BLOCK_PARALLEL = "alluxio.worker.tieredstore.block.parallel"
```
