### PR TITLE
[ALLUXIO-2337] Improve error handling in FaultTolerantAlluxioMaster constructor

### DIFF
--- a/core/server/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
+++ b/core/server/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
@@ -59,7 +59,6 @@ final class FaultTolerantAlluxioMaster extends AlluxioMaster {
       mLeaderSelectorClient =
           new LeaderSelectorClient(zkAddress, zkElectionPath, zkLeaderPath, zkName);
     } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
       throw Throwables.propagate(e);
     }
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2337

Right now the constructor does

    } catch (Exception e) {
      LOG.error(e.getMessage(), e);
      throw Throwables.propagate(e);
    }
  }

Both logging and throwing at the same time is superfluous since the place which catches the thrown exception will also log, so we will log the same exception multiple times. We should remove the
LOG.error(e.getMessage(), e);
statement