### PR TITLE
[SMALLFIX] Exit at the end of format

### DIFF
--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -106,6 +106,7 @@ public final class Format {
       LOG.info(USAGE);
       System.exit(-1);
     }
+    System.exit(0);
   }
 
   private Format() {}  // Prevent instantiation.


### PR DESCRIPTION
Prevents format from hanging in rare situations.