### PR TITLE
[SMALLFIX] Fixes ttl propagation on checkpointing.

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -297,8 +297,7 @@ public final class FileSystemMaster extends AbstractMaster {
     if (innerEntry instanceof InodeFileEntry) {
       try {
         mInodeTree.addInodeFromJournal(entry);
-        // Add the file to TTL buckets if applicable. The insert automatically rejects files without
-        // a TTL set.
+        // Add the file to TTL buckets, the insert automatically rejects files without a TTL set.
         InodeFile file = InodeFile.fromJournalEntry((InodeFileEntry) innerEntry);
         mTtlBuckets.insert(file);
       } catch (AccessControlException e) {

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -297,9 +297,11 @@ public final class FileSystemMaster extends AbstractMaster {
     if (innerEntry instanceof InodeFileEntry) {
       try {
         mInodeTree.addInodeFromJournal(entry);
-        // Add the file to TTL buckets, the insert automatically rejects files without a TTL set.
-        InodeFile file = InodeFile.fromJournalEntry((InodeFileEntry) innerEntry);
-        mTtlBuckets.insert(file);
+        // Add the file to TTL buckets, the insert automatically rejects files w/ Constants.NO_TTL
+        InodeFileEntry inodeFileEntry = (InodeFileEntry) innerEntry;
+        if (inodeFileEntry.hasTtl()) {
+          mTtlBuckets.insert(InodeFile.fromJournalEntry(inodeFileEntry));
+        }
       } catch (AccessControlException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
The internal representation is a set, so we do not need to worry about duplicates.