### PR TITLE
[SMALLFIX] Cleanup UFS API

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -216,28 +216,6 @@ public abstract class UnderFileSystem {
   public abstract String getUnderFSType();
 
   /**
-   * Determines if the given path is on a Hadoop under file system
-   *
-   * To decide if a path should use the hadoop implementation, we check
-   * {@link String#startsWith(String)} to see if the configured schemas are found.
-   *
-   * @param path the path in under filesystem
-   * @return true if the given path is on a Hadoop under file system, false otherwise
-   */
-  public static boolean isHadoopUnderFS(final String path) {
-    // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
-    // FileSystem.getFileSystemClass() without any need for having users explicitly declare the file
-    // system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop are
-    // supported this is not an option and we have to continue to use this method.
-    for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
-      if (path.startsWith(prefix)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Checks whether the underFS provides storage.
    *
    * @return true if the under filesystem provides storage, false otherwise

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -247,43 +247,6 @@ public abstract class UnderFileSystem {
   }
 
   /**
-   * Transform an input string like hdfs://host:port/dir, hdfs://host:port, file:///dir, /dir into a
-   * pair of address and path. The returned pairs are ("hdfs://host:port", "/dir"),
-   * ("hdfs://host:port", "/"), ("/", "/dir") and ("/", "/dir") respectively.
-   *
-   * @param path the input path string
-   * @return null if path does not start with alluxio://, alluxio-ft://, hdfs://, s3://, s3n://,
-   *         file://, /. Or a pair of strings denoting the under FS address and the relative path
-   *         relative to that address. For local FS (with prefixes file:// or /), the under FS
-   *         address is "/" and the path starts with "/".
-   */
-  // TODO(calvin): See if this method is still necessary
-  public static Pair<String, String> parse(AlluxioURI path) {
-    Preconditions.checkArgument(path != null, "path may not be null");
-
-    if (path.hasScheme()) {
-      String header = path.getScheme() + "://";
-      String authority = (path.hasAuthority()) ? path.getAuthority() : "";
-      if (header.equals(Constants.HEADER) || header.equals(Constants.HEADER_FT)
-          || isHadoopUnderFS(header) || header.equals(Constants.HEADER_S3)
-          || header.equals(Constants.HEADER_S3A) || header.equals(Constants.HEADER_S3N)
-          || header.equals(Constants.HEADER_OSS) || header.equals(Constants.HEADER_GCS)) {
-        if (path.getPath().isEmpty()) {
-          return new Pair<>(header + authority, AlluxioURI.SEPARATOR);
-        } else {
-          return new Pair<>(header + authority, path.getPath());
-        }
-      } else if (header.equals("file://")) {
-        return new Pair<>(AlluxioURI.SEPARATOR, path.getPath());
-      }
-    } else if (path.isPathAbsolute()) {
-      return new Pair<>(AlluxioURI.SEPARATOR, path.getPath());
-    }
-
-    return null;
-  }
-
-  /**
    * Constructs an {@link UnderFileSystem}.
    *
    * @param uri the {@link AlluxioURI} used to create this ufs

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
-import alluxio.collections.Pair;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.io.PathUtils;

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
@@ -11,9 +11,6 @@
 
 package alluxio.underfs;
 
-import alluxio.AlluxioURI;
-import alluxio.collections.Pair;
-
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -22,67 +19,6 @@ import org.junit.Test;
  * Unit tests for {@link UnderFileSystem}.
  */
 public final class UnderFileSystemTest {
-  /**
-   * Tests the {@link UnderFileSystem#parse(AlluxioURI)} method.
-   */
-  @Test
-  public void parse() {
-    Pair<String, String> result = UnderFileSystem.parse(new AlluxioURI("/path"));
-    Assert.assertEquals(result.getFirst(), "/");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("file:///path"));
-    Assert.assertEquals(result.getFirst(), "/");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("alluxio://localhost:19998"));
-    Assert.assertEquals(result.getFirst(), "alluxio://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/");
-
-    result = UnderFileSystem.parse(new AlluxioURI("alluxio://localhost:19998/"));
-    Assert.assertEquals(result.getFirst(), "alluxio://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/");
-
-    result = UnderFileSystem.parse(new AlluxioURI("alluxio://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "alluxio://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("alluxio-ft://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "alluxio-ft://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("hdfs://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "hdfs://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("s3://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "s3://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("s3a://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "s3a://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("s3n://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "s3n://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    result = UnderFileSystem.parse(new AlluxioURI("oss://localhost:19998"));
-    Assert.assertEquals(result.getFirst(), "oss://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/");
-
-    result = UnderFileSystem.parse(new AlluxioURI("oss://localhost:19998/"));
-    Assert.assertEquals(result.getFirst(), "oss://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/");
-
-    result = UnderFileSystem.parse(new AlluxioURI("oss://localhost:19998/path"));
-    Assert.assertEquals(result.getFirst(), "oss://localhost:19998");
-    Assert.assertEquals(result.getSecond(), "/path");
-
-    Assert.assertEquals(UnderFileSystem.parse(AlluxioURI.EMPTY_URI), null);
-    Assert.assertEquals(UnderFileSystem.parse(new AlluxioURI("anythingElse")), null);
-  }
-
   /**
    * Tests the {@link UnderFileSystemRegistry#find(String)} method when using a core
    * factory.

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -41,26 +41,15 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
 
   @Override
   public boolean supportsPath(String path) {
-    return path != null && isHadoopUnderFS(path);
-  }
-
-/**
-   * Determines if the given path is on a Hadoop under file system
-   *
-   * To decide if a path should use the hadoop implementation, we check
-   * {@link String#startsWith(String)} to see if the configured schemas are found.
-   *
-   * @param path the path in under filesystem
-   * @return true if the given path is on a Hadoop under file system, false otherwise
-   */
-  public static boolean isHadoopUnderFS(final String path) {
-    // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
-    // FileSystem.getFileSystemClass() without any need for having users explicitly declare the file
-    // system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop are
-    // supported this is not an option and we have to continue to use this method.
-    for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
-      if (path.startsWith(prefix)) {
-        return true;
+    if (path != null) {
+      // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
+      // FileSystem.getFileSystemClass() without any need for having users explicitly declare the file
+      // system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop are
+      // supported this is not an option and we have to continue to use this method.
+      for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
+        if (path.startsWith(prefix)) {
+          return true;
+        }
       }
     }
     return false;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -43,9 +43,9 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
   public boolean supportsPath(String path) {
     if (path != null) {
       // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
-      // FileSystem.getFileSystemClass() without any need for having users explicitly declare the file
-      // system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop are
-      // supported this is not an option and we have to continue to use this method.
+      // FileSystem.getFileSystemClass() without any need for having users explicitly declare the
+      // file system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop
+      // are supported this is not an option and we have to continue to use this method.
       for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
         if (path.startsWith(prefix)) {
           return true;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -44,7 +44,6 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
     return path != null && isHadoopUnderFS(path);
   }
 
-
 /**
    * Determines if the given path is on a Hadoop under file system
    *

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -12,6 +12,8 @@
 package alluxio.underfs.hdfs;
 
 import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemFactory;
 
@@ -39,6 +41,29 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
 
   @Override
   public boolean supportsPath(String path) {
-    return path != null && UnderFileSystem.isHadoopUnderFS(path);
+    return path != null && isHadoopUnderFS(path);
+  }
+
+
+/**
+   * Determines if the given path is on a Hadoop under file system
+   *
+   * To decide if a path should use the hadoop implementation, we check
+   * {@link String#startsWith(String)} to see if the configured schemas are found.
+   *
+   * @param path the path in under filesystem
+   * @return true if the given path is on a Hadoop under file system, false otherwise
+   */
+  public static boolean isHadoopUnderFS(final String path) {
+    // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
+    // FileSystem.getFileSystemClass() without any need for having users explicitly declare the file
+    // system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop are
+    // supported this is not an option and we have to continue to use this method.
+    for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
+      if (path.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Remove unnecessary parse function and move isHadoopUnderFS to Hdfs factory.