### PR TITLE
[SMALLFIX] Update surefire version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.14</version>
+          <version>2.19.1</version>
           <configuration>
             <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M</argLine>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>


### PR DESCRIPTION
This allows us to run our tests with multiple forked JVMs, giving a very significant speedup.

Running with `-DforkCount=8`, my integration test time went from 6:42 to 2:02.

@apc999 @calvinjia