### PR TITLE
[SMALLFIX] Fix Mesos when root tarball directory is "alluxio"

### DIFF
--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
@@ -288,7 +288,7 @@ public class AlluxioScheduler implements Scheduler {
     // installed at PropertyKey.HOME.
     if (installAlluxioFromUrl()) {
       commands.add("rm *.tar.gz");
-      commands.add("mv alluxio-* alluxio");
+      commands.add("mv alluxio* alluxio");
     }
     String home = installAlluxioFromUrl() ? "alluxio" : Configuration.get(PropertyKey.HOME);
     commands


### PR DESCRIPTION
Previously we assumed that Alluxio distribution tarballs have a root directory named `alluxio-version`. This change still works for that case, but now also works when the root directory is named just `alluxio`.