### PR TITLE
[ALLUXIO-1621] Removed test-only methods from LocalAlluxioMaster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -152,7 +152,7 @@ public final class LocalAlluxioMaster {
   }
 
   /**
-   * @return the externally resolvable address of the master (used by unit test only)
+   * @return the externally resolvable address of the master
    */
   public InetSocketAddress getAddress() {
     return mAlluxioMaster.getMasterAddress();
@@ -166,39 +166,12 @@ public final class LocalAlluxioMaster {
   }
 
   /**
-   * Gets the actual bind hostname on RPC service (used by unit test only).
-   *
-   * @return the RPC bind hostname
-   */
-  public String getRPCBindHost() {
-    return mAlluxioMaster.getRPCBindHost();
-  }
-
-  /**
-   * Gets the actual port that the RPC service is listening on (used by unit test only).
+   * Gets the actual port that the RPC service is listening on.
    *
    * @return the RPC local port
    */
   public int getRPCLocalPort() {
     return mAlluxioMaster.getRPCLocalPort();
-  }
-
-  /**
-   * Gets the actual bind hostname on web service (used by unit test only).
-   *
-   * @return the Web bind hostname
-   */
-  public String getWebBindHost() {
-    return mAlluxioMaster.getWebBindHost();
-  }
-
-  /**
-   * Gets the actual port that the web service is listening on (used by unit test only).
-   *
-   * @return the Web local port
-   */
-  public int getWebLocalPort() {
-    return mAlluxioMaster.getWebLocalPort();
   }
 
   /**

--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -40,7 +40,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
   @Before
   public void before() {
     mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getMaster().getWebLocalPort();
+    mPort = mResource.get().getMaster().getInternalMaster().getWebLocalPort();
     mServicePrefix = AlluxioMasterRestServiceHandler.SERVICE_PREFIX;
 
     MetricsSystem.resetAllCounters();

--- a/tests/src/test/java/alluxio/master/ServiceSocketBindIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/ServiceSocketBindIntegrationTest.java
@@ -188,8 +188,8 @@ public class ServiceSocketBindIntegrationTest {
     // connect Master Web service on loopback, while Master is listening on local hostname.
     try {
       mMasterWebService = (HttpURLConnection) new URL(
-          "http://127.0.0.1:" + mLocalAlluxioCluster.getMaster().getWebLocalPort() + "/home")
-          .openConnection();
+          "http://127.0.0.1:" + mLocalAlluxioCluster.getMaster().getInternalMaster()
+              .getWebLocalPort() + "/home").openConnection();
       Assert.assertEquals(200, mMasterWebService.getResponseCode());
       Assert.fail("Client should not have successfully connected to Master Web service.");
     } catch (IOException e) {

--- a/tests/src/test/java/alluxio/master/block/BlockMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/block/BlockMasterClientRestApiTest.java
@@ -37,7 +37,7 @@ public final class BlockMasterClientRestApiTest extends RestApiTest {
   @Before
   public void before() throws Exception {
     mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getMaster().getWebLocalPort();
+    mPort = mResource.get().getMaster().getInternalMaster().getWebLocalPort();
     mServicePrefix = BlockMasterClientRestServiceHandler.SERVICE_PREFIX;
   }
 

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterClientRestApiTest.java
@@ -50,7 +50,7 @@ public final class FileSystemMasterClientRestApiTest extends RestApiTest {
   @Before
   public void before() throws Exception {
     mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getMaster().getWebLocalPort();
+    mPort = mResource.get().getMaster().getInternalMaster().getWebLocalPort();
     mServicePrefix = FileSystemMasterClientRestServiceHandler.SERVICE_PREFIX;
     mFileSystemMaster = mResource.get().getMaster().getInternalMaster().getFileSystemMaster();
   }

--- a/tests/src/test/java/alluxio/master/lineage/LineageMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/lineage/LineageMasterClientRestApiTest.java
@@ -52,7 +52,7 @@ public final class LineageMasterClientRestApiTest extends RestApiTest {
   @Before
   public void before() throws Exception {
     mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getMaster().getWebLocalPort();
+    mPort = mResource.get().getMaster().getInternalMaster().getWebLocalPort();
     mServicePrefix = LineageMasterClientRestServiceHandler.SERVICE_PREFIX;
     mLineageClient = LineageFileSystem.get(FileSystemContext.INSTANCE, LineageContext.INSTANCE);
     mMaster = mResource.get().getMaster().getInternalMaster();

--- a/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
@@ -49,7 +49,7 @@ public class WebServerIntegrationTest {
       throws IOException {
     int port;
     if (serviceType == ServiceType.MASTER_WEB) {
-      port = mLocalAlluxioClusterResource.get().getMaster().getWebLocalPort();
+      port = mLocalAlluxioClusterResource.get().getMaster().getInternalMaster().getWebLocalPort();
     } else {
       port = mLocalAlluxioClusterResource.get().getWorker().getWebLocalPort();
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-1621
- Removed methods marked as test-only from LocalAlluxioMaster
- Changed usage of the removed getWebLocalPort in tests to the internal master
