### PR TITLE
[SMALLFIX] Change default test forking strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,11 +372,10 @@
           <version>2.19.1</version>
           <configuration>
             <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M</argLine>
-            <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
-            <!-- Alphabetical order on even hours, reverse-alphabetical on odd hours  -->
-            <runOrder>alphabetical</runOrder>
             <forkCount>2</forkCount>
+            <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
+            <runOrder>alphabetical</runOrder>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,9 @@
             <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M</argLine>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <!-- Alphabetical order on even hours, reverse-alphabetical on odd hours  -->
-            <runOrder>hourly</runOrder>
+            <runOrder>alphabetical</runOrder>
+            <forkCount>2</forkCount>
+            <reuseForks>false</reuseForks>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
         </plugin>


### PR DESCRIPTION
1. Set `reuseForks` to false so that a new JVM is used for each test class. This improves test isolation.
2. Set `forkCount` to 2. This will run two tests at a time in separate JVMs, offsetting the speed cost of setting `reuseForks` to false
3. Set `runOrder` to alphabetical. Now that test classes are run in separate JVMs, it doesn't matter what order they run in, so we might as well use a simple deterministic order.