### PR TITLE
[SMALLFIX] Fix the recursive UFS mkdirs with permission

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1533,25 +1533,24 @@ public final class FileSystemMaster extends AbstractMaster {
       String ufsDstUri = mMountTable.resolve(dstPath).getUri().toString();
       // Create ancestor directories from top to the bottom. We cannot use recursive create parents
       // here because the permission for the ancestors can be different.
-      Stack<AlluxioURI> dirsToMake = new Stack<>();
+      Stack<String> ufsDirsToMake = new Stack<>();
       AlluxioURI curUfsDirPath = new AlluxioURI(ufsDstUri).getParent();
       while (!ufs.exists(curUfsDirPath.toString())) {
-        dirsToMake.push(curUfsDirPath);
+        ufsDirsToMake.push(curUfsDirPath.toString());
         curUfsDirPath = curUfsDirPath.getParent();
       }
       List<Inode<?>> dstInodeList = dstInodePath.getInodeList();
       // The dst inode does not exist yet, so the last inode in the list is the existing parent.
-      int index = dstInodeList.size() - dirsToMake.size();
-      while (!dirsToMake.empty()) {
-        AlluxioURI dirToMake = dirsToMake.pop();
+      int index = dstInodeList.size() - ufsDirsToMake.size();
+      while (!ufsDirsToMake.empty()) {
+        String ufsDirToMake = ufsDirsToMake.pop();
         Inode<?> curInode = dstInodeList.get(index);
         Permission perm = new Permission(curInode.getOwner(), curInode.getGroup(),
             curInode.getMode());
         MkdirsOptions mkdirsOptions = new MkdirsOptions().setCreateParent(false)
             .setPermission(perm);
-        if (!ufs.mkdirs(dirToMake.toString(), mkdirsOptions)) {
-          throw new IOException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(
-              dirToMake.toString()));
+        if (!ufs.mkdirs(ufsDirToMake, mkdirsOptions)) {
+          throw new IOException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(ufsDirToMake));
         }
         ++index;
       }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -121,6 +121,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.Future;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -1530,15 +1531,29 @@ public final class FileSystemMaster extends AbstractMaster {
       String ufsSrcUri = resolution.getUri().toString();
       UnderFileSystem ufs = resolution.getUfs();
       String ufsDstUri = mMountTable.resolve(dstPath).getUri().toString();
-      String parentUri = new AlluxioURI(ufsDstUri).getParent().toString();
-      if (!ufs.exists(parentUri)) {
-        Permission parentPerm = new Permission(srcParentInode.getOwner(), srcParentInode.getGroup(),
-            srcParentInode.getMode());
-        MkdirsOptions parentMkdirsOptions = new MkdirsOptions().setCreateParent(true)
-            .setPermission(parentPerm);
-        if (!ufs.mkdirs(parentUri, parentMkdirsOptions)) {
-          throw new IOException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(parentUri));
+      // Create ancestor directories from top to the bottom. We cannot use recursive create parents
+      // here because the permission for the ancestors can be different.
+      Stack<AlluxioURI> dirsToMake = new Stack<>();
+      AlluxioURI curUfsDirPath = new AlluxioURI(ufsDstUri).getParent();
+      while (!ufs.exists(curUfsDirPath.toString())) {
+        dirsToMake.push(curUfsDirPath);
+        curUfsDirPath = curUfsDirPath.getParent();
+      }
+      List<Inode<?>> dstInodeList = dstInodePath.getInodeList();
+      // The dst inode does not exist yet, so the last inode in the list is the existing parent.
+      int index = dstInodeList.size() - dirsToMake.size();
+      while (!dirsToMake.empty()) {
+        AlluxioURI dirToMake = dirsToMake.pop();
+        Inode<?> curInode = dstInodeList.get(index);
+        Permission perm = new Permission(curInode.getOwner(), curInode.getGroup(),
+            curInode.getMode());
+        MkdirsOptions mkdirsOptions = new MkdirsOptions().setCreateParent(false)
+            .setPermission(perm);
+        if (!ufs.mkdirs(dirToMake.toString(), mkdirsOptions)) {
+          throw new IOException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(
+              dirToMake.toString()));
         }
+        ++index;
       }
       if (!ufs.rename(ufsSrcUri, ufsDstUri)) {
         throw new IOException(

--- a/tests/src/test/java/alluxio/shell/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/PersistCommandTest.java
@@ -154,11 +154,11 @@ public final class PersistCommandTest extends AbstractAlluxioShellTest {
     }
     AlluxioURI testFile = new AlluxioURI("/grand/parent/file");
     AlluxioURI grandParent = new AlluxioURI("/grand");
-    short grandPathMode = (short) 0777;
+    short grandParentMode = (short) 0777;
     FileSystemTestUtils.createByteFile(mFileSystem, testFile, WriteType.MUST_CACHE, 10);
     URIStatus status = mFileSystem.getStatus(testFile);
     Assert.assertFalse(status.isPersisted());
-    mFileSystem.setAttribute(grandParent, SetAttributeOptions.defaults().setMode(grandPathMode));
+    mFileSystem.setAttribute(grandParent, SetAttributeOptions.defaults().setMode(grandParentMode));
     int ret = mFsShell.run("persist", testFile.toString());
 
     Assert.assertEquals(0, ret);
@@ -170,7 +170,7 @@ public final class PersistCommandTest extends AbstractAlluxioShellTest {
     Assert.assertEquals(fileMode, ufs.getMode(PathUtils.concatPath(ufsRoot, testFile)));
     Assert.assertEquals(parentMode,
         ufs.getMode(PathUtils.concatPath(ufsRoot, testFile.getParent())));
-    Assert.assertEquals(grandPathMode,
+    Assert.assertEquals(grandParentMode,
         ufs.getMode(PathUtils.concatPath(ufsRoot, grandParent)));
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/PersistCommandTest.java
@@ -17,9 +17,15 @@ import alluxio.ConfigurationTestUtils;
 import alluxio.PropertyKey;
 import alluxio.client.FileSystemTestUtils;
 import alluxio.client.WriteType;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.options.SetAttributeOptions;
 import alluxio.exception.ExceptionMessage;
 import alluxio.shell.AbstractAlluxioShellTest;
 import alluxio.shell.AlluxioShellUtilsTest;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.hdfs.HdfsUnderFileSystem;
+import alluxio.underfs.local.LocalUnderFileSystem;
+import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -136,5 +142,35 @@ public final class PersistCommandTest extends AbstractAlluxioShellTest {
     Assert.assertEquals("persisted file " + testFilePath + " with size 10\n" + testFilePath
         + " is already persisted\n", mOutput.toString());
     checkFilePersisted(new AlluxioURI("/testPersist/testFile"), 10);
+  }
+
+  @Test
+  public void persistWithAncestorPermission() throws Exception {
+    String ufsRoot = PathUtils.concatPath(Configuration.get(PropertyKey.UNDERFS_ADDRESS));
+    UnderFileSystem ufs = UnderFileSystem.get(ufsRoot);
+    if (!(ufs instanceof LocalUnderFileSystem) && !(ufs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    AlluxioURI testFile = new AlluxioURI("/grand/parent/file");
+    AlluxioURI grandParent = new AlluxioURI("/grand");
+    short grandPathMode = (short) 0777;
+    FileSystemTestUtils.createByteFile(mFileSystem, testFile, WriteType.MUST_CACHE, 10);
+    URIStatus status = mFileSystem.getStatus(testFile);
+    Assert.assertFalse(status.isPersisted());
+    mFileSystem.setAttribute(grandParent, SetAttributeOptions.defaults().setMode(grandPathMode));
+    int ret = mFsShell.run("persist", testFile.toString());
+
+    Assert.assertEquals(0, ret);
+    checkFilePersisted(testFile, 10);
+
+    // Check the permission of the created file and ancestor dir are in-sync between Alluxio and UFS
+    short fileMode = (short) status.getMode();
+    short parentMode = (short) mFileSystem.getStatus(testFile.getParent()).getMode();
+    Assert.assertEquals(fileMode, ufs.getMode(PathUtils.concatPath(ufsRoot, testFile)));
+    Assert.assertEquals(parentMode,
+        ufs.getMode(PathUtils.concatPath(ufsRoot, testFile.getParent())));
+    Assert.assertEquals(grandPathMode,
+        ufs.getMode(PathUtils.concatPath(ufsRoot, grandParent)));
   }
 }


### PR DESCRIPTION
We should never call mkdirs with `createParent=true` because UFS does not know about the ancestor inode permission in Alluxio namespace. Instead, all the missing ancestor directories in UFS should be created from top to the bottom, with the corresponding permission in inode.

Currently there are two places where we set `createParent` to true, one is persist command, the other one is rename with creating missing dst partent directories in UFS.