### PR TITLE
[SMALLFIX] Hadoop journal integration fix

### DIFF
--- a/tests/src/test/java/alluxio/UnderFileSystemSpy.java
+++ b/tests/src/test/java/alluxio/UnderFileSystemSpy.java
@@ -42,7 +42,9 @@ public final class UnderFileSystemSpy implements Closeable {
    * @param prefix the path prefix to intercept UFS calls on
    * @param ufs the under file system to spy
    */
-  public UnderFileSystemSpy(final String prefix, UnderFileSystem ufs) {
+  public UnderFileSystemSpy(AlluxioURI uri) {
+    UnderFileSystem ufs = UnderFileSystem.get(uri.toString());
+    final String prefix = uri.getScheme() == null ? "/" : uri.getScheme();
     mUfsSpy = Mockito.spy(ufs);
     mFactory = new UnderFileSystemFactory() {
       @Override

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -627,8 +627,8 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    try (UnderFileSystemSpy ufsSpy =
-        new UnderFileSystemSpy("/", new LocalUnderFileSystem(new AlluxioURI("/")))) {
+    UnderFileSystem ufs = UnderFileSystem.get("/");
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy("/", ufs)) {
       doThrow(new RuntimeException("Failed to delete")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/checkpoint.data"), anyBoolean());
       try {

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -627,7 +627,7 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    UnderFileSystem ufs = UnderFileSystem.get("/");
+    UnderFileSystem ufs = UnderFileSystem.get(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
     try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy("/", ufs)) {
       doThrow(new RuntimeException("Failed to delete")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/checkpoint.data"), anyBoolean());

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -601,7 +601,8 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
+    AlluxioURI journal = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journal)) {
       doThrow(new RuntimeException("Failed to rename")).when(ufsSpy.get())
           .rename(Mockito.contains("FileSystemMaster/checkpoint.data.tmp"), anyString());
       try {
@@ -625,7 +626,8 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
+    AlluxioURI journal = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journal)) {
       doThrow(new RuntimeException("Failed to delete")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/checkpoint.data"), anyBoolean());
       try {
@@ -646,7 +648,8 @@ public class JournalIntegrationTest {
   public void failWhileDeletingCompletedLogs() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     mFileSystem.createFile(file).close();
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
+    AlluxioURI journal = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journal)) {
       doThrow(new RuntimeException("Failed to delete completed log")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/completed"), anyBoolean());
       try {

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -601,9 +601,7 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    AlluxioURI journalUri = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
-    UnderFileSystem ufs = UnderFileSystem.get(journalUri.toString());
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journalUri.getScheme(), ufs)) {
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
       doThrow(new RuntimeException("Failed to rename")).when(ufsSpy.get())
           .rename(Mockito.contains("FileSystemMaster/checkpoint.data.tmp"), anyString());
       try {
@@ -627,9 +625,7 @@ public class JournalIntegrationTest {
     // Restart the master once so that it creates a checkpoint file.
     mLocalAlluxioCluster.stopFS();
     createFsMasterFromJournal();
-    AlluxioURI journalUri = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
-    UnderFileSystem ufs = UnderFileSystem.get(journalUri.toString());
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journalUri.getScheme(), ufs)) {
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
       doThrow(new RuntimeException("Failed to delete")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/checkpoint.data"), anyBoolean());
       try {
@@ -650,9 +646,7 @@ public class JournalIntegrationTest {
   public void failWhileDeletingCompletedLogs() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     mFileSystem.createFile(file).close();
-    AlluxioURI journalUri = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
-    UnderFileSystem ufs = UnderFileSystem.get(journalUri.toString());
-    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journalUri.getScheme(), ufs)) {
+    try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))) {
       doThrow(new RuntimeException("Failed to delete completed log")).when(ufsSpy.get())
           .delete(Mockito.contains("FileSystemMaster/completed"), anyBoolean());
       try {


### PR DESCRIPTION
This is required to fix the build for the hadoop profiles. Previously, the local under filesystem would be mocked even when testing the hadoop under filesystem. This changes the tests to mock whatever UFS the journal is stored in.