### PR TITLE
[ALLUXIO-2417]add a method to  solve ERROR : Frame size (67108864) la…

### DIFF
--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -63,7 +63,7 @@ master和worker日志对于理解Alluxio master节点和worker节点的运行过
 Alluxio通过配置`alluxio.security.authentication.type`来提供不同的用户身份验证(Security.html#authentication)的方法。
 如果客户端和服务器的这项配置属性不一致，这种错误将会发生。(例如，客户端的属性为默认值`NOSASL`,而服务器端设为`SIMPLE`)
 有关如何设定Alluxio的集群和应用的问题，用户请参照[Configuration-Settings](Configuration-Settings.html)
-- Spark调用Alluxio文件时报错，一般直接下载编译好的alluxio文件会出现该错误，alluxio-0.7.1没有该问题，但是alluxio-1.3.0会有。
+- Spark调用Alluxio-1.3.0文件时报错，如果是直接下载编译好的alluxio文件进行安装的，一般会出现该错误。
 解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html)；
 编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
 

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -63,6 +63,7 @@ master和worker日志对于理解Alluxio master节点和worker节点的运行过
 Alluxio通过配置`alluxio.security.authentication.type`来提供不同的用户身份验证(Security.html#authentication)的方法。
 如果客户端和服务器的这项配置属性不一致，这种错误将会发生。(例如，客户端的属性为默认值`NOSASL`,而服务器端设为`SIMPLE`)
 有关如何设定Alluxio的集群和应用的问题，用户请参照[Configuration-Settings](Configuration-Settings.html)
+- Spark调用Alluxio文件时报错，一般直接下载编译好的文件会出现该错误。解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html);编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
 
 ####　向Alluxio拷贝数据或者写数据时出现如下问题 "Failed to cache: Not enough space to store block on worker",为什么？
 

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -63,7 +63,9 @@ master和worker日志对于理解Alluxio master节点和worker节点的运行过
 Alluxio通过配置`alluxio.security.authentication.type`来提供不同的用户身份验证(Security.html#authentication)的方法。
 如果客户端和服务器的这项配置属性不一致，这种错误将会发生。(例如，客户端的属性为默认值`NOSASL`,而服务器端设为`SIMPLE`)
 有关如何设定Alluxio的集群和应用的问题，用户请参照[Configuration-Settings](Configuration-Settings.html)
-- Spark调用Alluxio文件时报错，一般直接下载编译好的alluxio文件会出现该错误，alluxio-0.7.1没有该问题，但是alluxio-1.3.0会有。解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html)；编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
+- Spark调用Alluxio文件时报错，一般直接下载编译好的alluxio文件会出现该错误，alluxio-0.7.1没有该问题，但是alluxio-1.3.0会有。
+解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html)；
+编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
 
 ####　向Alluxio拷贝数据或者写数据时出现如下问题 "Failed to cache: Not enough space to store block on worker",为什么？
 

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -63,7 +63,7 @@ master和worker日志对于理解Alluxio master节点和worker节点的运行过
 Alluxio通过配置`alluxio.security.authentication.type`来提供不同的用户身份验证(Security.html#authentication)的方法。
 如果客户端和服务器的这项配置属性不一致，这种错误将会发生。(例如，客户端的属性为默认值`NOSASL`,而服务器端设为`SIMPLE`)
 有关如何设定Alluxio的集群和应用的问题，用户请参照[Configuration-Settings](Configuration-Settings.html)
-- Spark调用Alluxio文件时报错，一般直接下载编译好的文件会出现该错误。解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html);编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
+- Spark调用Alluxio文件时报错，一般直接下载编译好的alluxio文件会出现该错误，alluxio-0.7.1没有该问题，但是alluxio-1.3.0会有。解决办法：需要Alluxio client需要在编译时指定Spark选项，具体参考[Running-Spark-on-Alluxio](Running-Spark-on-Alluxio.html)；编译好的依赖包也可以直接下载，下载地址：<a href="http://downloads.alluxio.org/downloads/files/1.3.0/alluxio-1.3.0-spark-client-jar-with-dependencies.jar"> 依赖包下载 </a>。
 
 ####　向Alluxio拷贝数据或者写数据时出现如下问题 "Failed to cache: Not enough space to store block on worker",为什么？
 


### PR DESCRIPTION
see https://alluxio.atlassian.net/browse/ALLUXIO-2417

spark-shell call alluxio file ,error:
```

16/11/09 21:31:05 ERROR : Frame size (67108864) larger than max length (16384000)!
tachyon.org.apache.thrift.transport.TTransportException: Frame size (67108864) larger than max length (16384000)!
	at tachyon.org.apache.thrift.transport.TFramedTransport.readFrame(TFramedTransport.java:137)
	at tachyon.org.apache.thrift.transport.TFramedTransport.read(TFramedTransport.java:101)
	at tachyon.org.apache.thrift.transport.TTransport.readAll(TTransport.java:84)
	at tachyon.org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:362)
	at tachyon.org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:284)
	at tachyon.org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:191)
	at tachyon.org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
	at tachyon.thrift.MasterService$Client.recv_user_getUserId(MasterService.java:715)
	at tachyon.thrift.MasterService$Client.user_getUserId(MasterService.java:703)
	at tachyon.master.MasterClient.connect(MasterClient.java:210)
	at tachyon.master.MasterClient.user_heartbeat(MasterClient.java:672)
	at tachyon.master.MasterClientHeartbeatExecutor.heartbeat(MasterClientHeartbeatExecutor.java:37)
	at tachyon.HeartbeatThread.run(HeartbeatThread.java:51)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```