### PR TITLE
[SMALLFIX] Improve error message when java is not installed

### DIFF
--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -38,6 +38,11 @@ if [[ -z "$ALLUXIO_SYSTEM_INSTALLATION" ]]; then
   ALLUXIO_JARS="${ALLUXIO_HOME}/assembly/target/alluxio-assemblies-${VERSION}-jar-with-dependencies.jar"
 fi
 
+if [[ -z "$(which java)" ]]; then
+  echo "Cannot find `java` command"
+  exit 1
+fi
+
 JAVA_HOME=${JAVA_HOME:-"$(dirname $(which java))/.."}
 JAVA=${JAVA:-"${JAVA_HOME}/bin/java"}
 


### PR DESCRIPTION
Before this change, the line 

```bash
JAVA_HOME=${JAVA_HOME:-"$(dirname $(which java))/.."}
```

would complain that `dirname` requires an operand when `which java` turned up empty
```bash
dirname: missing operand
Try 'dirname --help' for more information.
```