### PR TITLE
[SMALLFIX] Do not load site properties when running tests

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -108,11 +108,14 @@ public final class Configuration {
     merge(defaultProps);
     merge(systemProps);
 
-    // Load site specific properties file if not in test mode
+    // Load site specific properties file if not in test mode. Note that we decide whether in test
+    // mode by default properties and system properties (via getBoolean). If it is not in test mode
+    // the PROPERTIES will be updated again.
     if (!getBoolean(PropertyKey.TEST_MODE)) {
       String confPaths = get(PropertyKey.SITE_CONF_DIR);
       String[] confPathList = confPaths.split(",");
       Properties siteProps = ConfigurationUtils.searchPropertiesFile(SITE_PROPERTIES, confPathList);
+      // Update site properties and system properties in order
       if (siteProps != null) {
         merge(siteProps);
         merge(systemProps);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -61,9 +61,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class Configuration {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  /** File to set customized properties for Alluxio server (both master and worker) and client. */
-  private static final String SITE_PROPERTIES = "alluxio-site.properties";
-
   /** Regex string to find "${key}" for variable substitution. */
   private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
   /** Regex to find ${key} for variable substitution. */
@@ -72,26 +69,20 @@ public final class Configuration {
   private static final ConcurrentHashMapV8<String, String> PROPERTIES =
       new ConcurrentHashMapV8<>();
 
+  /** File to set customized properties for Alluxio server (both master and worker) and client. */
+  public static final String SITE_PROPERTIES = "alluxio-site.properties";
+
   static {
     defaultInit();
   }
 
   /**
-   * The default configuration.
-   */
-  public static void defaultInit() {
-    init(SITE_PROPERTIES);
-  }
-
-  /**
-   * Initializes the {@link Configuration} class with Alluxio configuration properties.
+   * Initializes the default {@link Configuration}.
    *
    * The order of preference is (1) system properties, (2) properties in the specified file, (3)
    * default property values.
-   *
-   * @param sitePropertiesFile path to a file containing site-wide Alluxio properties
    */
-  public static void init(String sitePropertiesFile) {
+  public static void defaultInit() {
     // Load default
     Properties defaultProps = new Properties();
     for (PropertyKey key : PropertyKey.values()) {
@@ -121,8 +112,7 @@ public final class Configuration {
     if (!getBoolean(PropertyKey.TEST_MODE)) {
       String confPaths = get(PropertyKey.SITE_CONF_DIR);
       String[] confPathList = confPaths.split(",");
-      Properties siteProps = ConfigurationUtils
-          .searchPropertiesFile(sitePropertiesFile, confPathList);
+      Properties siteProps = ConfigurationUtils.searchPropertiesFile(SITE_PROPERTIES, confPathList);
       if (siteProps != null) {
         merge(siteProps);
         merge(systemProps);

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -316,7 +316,7 @@ public class ConfigurationTest {
   @Test
   public void sitePropertiesNotLoadedInTest() throws Exception {
     Properties props = new Properties();
-    props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "wrong_logger");
+    props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "TEST_LOGGER");
     File propsFile = mFolder.newFile(Configuration.SITE_PROPERTIES);
     props.store(new FileOutputStream(propsFile), "ignored header");
     // Avoid interference from system properties. Reset SITE_CONF_DIR to include the temp
@@ -335,7 +335,7 @@ public class ConfigurationTest {
   @Test
   public void sitePropertiesLoadedNotInTest() throws Exception {
     Properties props = new Properties();
-    props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "wrong_logger");
+    props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "TEST_LOGGER");
     File propsFile = mFolder.newFile(Configuration.SITE_PROPERTIES);
     props.store(new FileOutputStream(propsFile), "ignored header");
     // Avoid interference from system properties. Reset SITE_CONF_DIR to include the temp
@@ -348,8 +348,7 @@ public class ConfigurationTest {
          SetAndRestoreSystemProperty p3 =
              new SetAndRestoreSystemProperty(PropertyKey.TEST_MODE.toString(), "false")) {
       Configuration.defaultInit();
-      Assert.assertEquals("wrong_logger", Configuration.get(PropertyKey.LOGGER_TYPE));
+      Assert.assertEquals("TEST_LOGGER", Configuration.get(PropertyKey.LOGGER_TYPE));
     }
   }
-
 }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -32,7 +32,7 @@ public class ConfigurationTest {
   public final ExpectedException mThrown = ExpectedException.none();
 
   @Rule
-  public final TemporaryFolder mFolder= new TemporaryFolder();
+  public final TemporaryFolder mFolder = new TemporaryFolder();
 
   @After
   public void after() {
@@ -43,7 +43,7 @@ public class ConfigurationTest {
   public void defaultLoggerCorrectlyLoaded() throws Exception {
     // Avoid interference from system properties. site-properties will not be loaded during tests
     try (SetAndRestoreSystemProperty p =
-        new SetAndRestoreSystemProperty(PropertyKey.LOGGER_TYPE.toString(), null)){
+        new SetAndRestoreSystemProperty(PropertyKey.LOGGER_TYPE.toString(), null)) {
       String loggerType = Configuration.get(PropertyKey.LOGGER_TYPE);
       Assert.assertEquals("Console", loggerType);
     }
@@ -317,7 +317,7 @@ public class ConfigurationTest {
   public void sitePropertiesNotLoadedInTest() throws Exception {
     Properties props = new Properties();
     props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "wrong_logger");
-    File propsFile= mFolder.newFile(Configuration.SITE_PROPERTIES);
+    File propsFile = mFolder.newFile(Configuration.SITE_PROPERTIES);
     props.store(new FileOutputStream(propsFile), "ignored header");
     // Avoid interference from system properties. Reset SITE_CONF_DIR to include the temp
     // site-properties file
@@ -336,7 +336,7 @@ public class ConfigurationTest {
   public void sitePropertiesLoadedNotInTest() throws Exception {
     Properties props = new Properties();
     props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "wrong_logger");
-    File propsFile= mFolder.newFile(Configuration.SITE_PROPERTIES);
+    File propsFile = mFolder.newFile(Configuration.SITE_PROPERTIES);
     props.store(new FileOutputStream(propsFile), "ignored header");
     // Avoid interference from system properties. Reset SITE_CONF_DIR to include the temp
     // site-properties file

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,9 @@
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <runOrder>alphabetical</runOrder>
+            <systemPropertyVariables>
+              <alluxio.test.mode>true</alluxio.test.mode>
+            </systemPropertyVariables>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
         </plugin>


### PR DESCRIPTION
Avoid properties set in `alluxio-site.properties` affecting test results.