### PR TITLE
[SMALLFIX] Ignore hadoop-1 for set mode test.

### DIFF
--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -441,8 +441,9 @@ public final class FileSystemAclIntegrationTest {
    */
   @Test
   public void loadFileMetadataMode() throws Exception {
-    if (!(sUfs instanceof LocalUnderFileSystem) && !(sUfs instanceof HdfsUnderFileSystem)) {
-      // Skip non-local and non-HDFS UFSs.
+    if (!(sUfs instanceof LocalUnderFileSystem)
+        && !(sUfs instanceof HdfsUnderFileSystem && HadoopClientTestUtils.isHadoop2x())) {
+      // Skip non-local and non-HDFS-2 UFSs.
       return;
     }
     List<Integer> permissionValues =


### PR DESCRIPTION
The set mode semantics in hadoop-1 is different. Ignoring the load metadata mode test for hadoop-1 to fix master build with `-Phadoop-1 -PhdfsTest`