### PR TITLE
[ALLUXIO-2410] Check consistency flag

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -487,7 +487,7 @@ public enum PropertyKey {
     public static final String MASTER_RETRY = "alluxio.master.retry";
     public static final String MASTER_RPC_PORT = "alluxio.master.port";
     public static final String MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
-        "alluxio.master.startup.consistencycheck.enabled";
+        "alluxio.master.startup.consistency.check.enabled";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
         "alluxio.master.tieredstore.global.level0.alias";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -136,6 +136,7 @@ public enum PropertyKey {
   MASTER_PRINCIPAL(Name.MASTER_PRINCIPAL, null),
   MASTER_RETRY(Name.MASTER_RETRY, 29),
   MASTER_RPC_PORT(Name.MASTER_RPC_PORT, 19998),
+  MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED(Name.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, true),
   MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS, "MEM"),
   MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS, "SSD"),
   MASTER_TIERED_STORE_GLOBAL_LEVEL2_ALIAS(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL2_ALIAS, "HDD"),
@@ -485,6 +486,8 @@ public enum PropertyKey {
     public static final String MASTER_PRINCIPAL = "alluxio.master.principal";
     public static final String MASTER_RETRY = "alluxio.master.retry";
     public static final String MASTER_RPC_PORT = "alluxio.master.port";
+    public static final String MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
+        "alluxio.master.startup.consistencycheck.enabled";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
         "alluxio.master.tieredstore.global.level0.alias";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS =

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -437,25 +437,6 @@ public final class FileSystemMaster extends AbstractMaster {
   }
 
   /**
-   * @return the status of the startup consistency check and inconsistent paths if it is complete
-   */
-  public StartupConsistencyCheck getStartupConsistencyCheck() {
-    if (Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.DISABLED, null);
-    }
-    if (!mStartupConsistencyCheck.isDone()) {
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.RUNNING, null);
-    }
-    try {
-      List<AlluxioURI> inconsistentUris = mStartupConsistencyCheck.get();
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.COMPLETE, inconsistentUris);
-    } catch (Exception e) {
-      LOG.warn("Failed to complete start up consistency check.", e);
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.FAILED, null);
-    }
-  }
-
-  /**
    * Class to represent the status and result of the startup consistency check.
    */
   public static class StartupConsistencyCheck {
@@ -489,6 +470,25 @@ public final class FileSystemMaster extends AbstractMaster {
      */
     public List<AlluxioURI> getInconsistentUris() {
       return mInconsistentUris;
+    }
+  }
+
+  /**
+   * @return the status of the startup consistency check and inconsistent paths if it is complete
+   */
+  public StartupConsistencyCheck getStartupConsistencyCheck() {
+    if (Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
+      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.DISABLED, null);
+    }
+    if (!mStartupConsistencyCheck.isDone()) {
+      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.RUNNING, null);
+    }
+    try {
+      List<AlluxioURI> inconsistentUris = mStartupConsistencyCheck.get();
+      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.COMPLETE, inconsistentUris);
+    } catch (Exception e) {
+      LOG.warn("Failed to complete start up consistency check.", e);
+      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.FAILED, null);
     }
   }
 

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -440,6 +440,9 @@ public final class FileSystemMaster extends AbstractMaster {
    * Class to represent the status and result of the startup consistency check.
    */
   public static class StartupConsistencyCheck {
+    /**
+     * State of the check.
+     */
     public enum Status {
       DISABLED, RUNNING, FAILED, COMPLETE
     }
@@ -477,7 +480,7 @@ public final class FileSystemMaster extends AbstractMaster {
    * @return the status of the startup consistency check and inconsistent paths if it is complete
    */
   public StartupConsistencyCheck getStartupConsistencyCheck() {
-    if (Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
+    if (!Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
       return new StartupConsistencyCheck(StartupConsistencyCheck.Status.DISABLED, null);
     }
     if (!mStartupConsistencyCheck.isDone()) {

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -439,7 +439,7 @@ public final class FileSystemMaster extends AbstractMaster {
   /**
    * Class to represent the status and result of the startup consistency check.
    */
-  public static class StartupConsistencyCheck {
+  public static class StartupConsistencyCheckResult {
     /**
      * State of the check.
      */
@@ -456,7 +456,7 @@ public final class FileSystemMaster extends AbstractMaster {
      * @param status the state of the check
      * @param inconsistentUris the uris which are inconsistent with the underlying storage
      */
-    public StartupConsistencyCheck(Status status, List<AlluxioURI> inconsistentUris) {
+    public StartupConsistencyCheckResult(Status status, List<AlluxioURI> inconsistentUris) {
       mStatus = status;
       mInconsistentUris = inconsistentUris;
     }
@@ -479,19 +479,20 @@ public final class FileSystemMaster extends AbstractMaster {
   /**
    * @return the status of the startup consistency check and inconsistent paths if it is complete
    */
-  public StartupConsistencyCheck getStartupConsistencyCheck() {
+  public StartupConsistencyCheckResult getStartupConsistencyCheck() {
     if (!Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.DISABLED, null);
+      return new StartupConsistencyCheckResult(StartupConsistencyCheckResult.Status.DISABLED, null);
     }
     if (!mStartupConsistencyCheck.isDone()) {
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.RUNNING, null);
+      return new StartupConsistencyCheckResult(StartupConsistencyCheckResult.Status.RUNNING, null);
     }
     try {
       List<AlluxioURI> inconsistentUris = mStartupConsistencyCheck.get();
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.COMPLETE, inconsistentUris);
+      return new StartupConsistencyCheckResult(StartupConsistencyCheckResult.Status.COMPLETE,
+          inconsistentUris);
     } catch (Exception e) {
       LOG.warn("Failed to complete start up consistency check.", e);
-      return new StartupConsistencyCheck(StartupConsistencyCheck.Status.FAILED, null);
+      return new StartupConsistencyCheckResult(StartupConsistencyCheckResult.Status.FAILED, null);
     }
   }
 

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -439,14 +439,14 @@ public final class FileSystemMaster extends AbstractMaster {
   /**
    * Class to represent the status and result of the startup consistency check.
    */
-  public static class StartupConsistencyCheckResult {
-    /** Result for a disabled check */
+  public static final class StartupConsistencyCheckResult {
+    /** Result for a disabled check. */
     private static final StartupConsistencyCheckResult DISABLED =
         new StartupConsistencyCheckResult(Status.DISABLED, null);
-    /** Result for a failed check */
+    /** Result for a failed check. */
     private static final StartupConsistencyCheckResult FAILED =
         new StartupConsistencyCheckResult(Status.FAILED, null);
-    /** Result for a running check */
+    /** Result for a running check. */
     private static final StartupConsistencyCheckResult RUNNING =
         new StartupConsistencyCheckResult(Status.RUNNING, null);
 

--- a/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.StorageTierAssoc;
 import alluxio.master.AlluxioMaster;
+import alluxio.master.file.FileSystemMaster;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.FormatUtils;
 
@@ -190,12 +191,13 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
             FormatUtils.getSizeFromBytes(mMaster.getBlockMaster().getCapacityBytes()
                 - mMaster.getBlockMaster().getUsedBytes()));
 
-    List<AlluxioURI> inconsistentUris = mMaster.getFileSystemMaster().getStartupConsistencyCheck();
-    if (inconsistentUris == null) { // incomplete
-      request.setAttribute("consistencyCheckComplete", false);
-    } else { // complete
-      request.setAttribute("consistencyCheckComplete", true);
-      request.setAttribute("inconsistentPaths", inconsistentUris.size());
+    FileSystemMaster.StartupConsistencyCheck check =
+        mMaster.getFileSystemMaster().getStartupConsistencyCheck();
+    request.setAttribute("consistencyCheckStatus", check.getStatus());
+    if (check.getStatus() == FileSystemMaster.StartupConsistencyCheck.Status.COMPLETE) {
+      request.setAttribute("inconsistentPaths", check.getInconsistentUris().size());
+    } else {
+      request.setAttribute("inconsistentPaths", 0);
     }
 
     String ufsRoot = Configuration.get(PropertyKey.UNDERFS_ADDRESS);

--- a/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -190,10 +190,10 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
             FormatUtils.getSizeFromBytes(mMaster.getBlockMaster().getCapacityBytes()
                 - mMaster.getBlockMaster().getUsedBytes()));
 
-    FileSystemMaster.StartupConsistencyCheck check =
+    FileSystemMaster.StartupConsistencyCheckResult check =
         mMaster.getFileSystemMaster().getStartupConsistencyCheck();
     request.setAttribute("consistencyCheckStatus", check.getStatus());
-    if (check.getStatus() == FileSystemMaster.StartupConsistencyCheck.Status.COMPLETE) {
+    if (check.getStatus() == FileSystemMaster.StartupConsistencyCheckResult.Status.COMPLETE) {
       request.setAttribute("inconsistentPaths", check.getInconsistentUris().size());
     } else {
       request.setAttribute("inconsistentPaths", 0);

--- a/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -11,7 +11,6 @@
 
 package alluxio.web;
 
-import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;

--- a/core/server/src/main/webapp/general.jsp
+++ b/core/server/src/main/webapp/general.jsp
@@ -60,10 +60,10 @@
                   <th><%= request.getAttribute("liveWorkerNodes") %></th>
                 </tr>
                 <tr>
-                  <th>Startup Consistency Check Complete:</th>
-                  <th><%= request.getAttribute("consistencyCheckComplete") %></th>
+                  <th>Startup Consistency Check:</th>
+                  <th><%= request.getAttribute("consistencyCheckStatus") %></th>
                 </tr>
-                <% if (((Boolean) request.getAttribute("consistencyCheckComplete")) && (Integer) request.getAttribute("inconsistentPaths") != 0) { %>
+                <% if ((Integer) request.getAttribute("inconsistentPaths") != 0) { %>
                   <tr>
                     <th><font color="red">Inconsistent Files on Startup (run fs checkConsistency for details):</font></th>
                     <th><font color="red"><%= request.getAttribute("inconsistentPaths") %></font></th>

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -37,7 +37,7 @@ alluxio.master.port:
   The port that Alluxio master node runs on.
 alluxio.master.retry:
   The number of retries that the client connects to master
-alluxio.master.startup.consistencycheck.enabled:
+alluxio.master.startup.consistency.check.enabled:
   Whether the system should be checked for consistency with the underlying storage on startup.
   During the time the check is running, Alluxio will be in read only mode. Enabled by default.
 alluxio.master.ttl.checker.interval.ms:

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -37,6 +37,9 @@ alluxio.master.port:
   The port that Alluxio master node runs on.
 alluxio.master.retry:
   The number of retries that the client connects to master
+alluxio.master.startup.consistencycheck.enabled:
+  Whether the system should be checked for consistency with the underlying storage on startup.
+  During the time the check is running, Alluxio will be in read only mode. Enabled by default.
 alluxio.master.ttl.checker.interval.ms:
   Time interval (in milliseconds) to periodically delete the files with expired ttl value.
 alluxio.master.web.bind.host:

--- a/docs/_data/table/master-configuration.csv
+++ b/docs/_data/table/master-configuration.csv
@@ -15,6 +15,7 @@ alluxio.master.lineage.recompute.interval.ms,600000
 alluxio.master.lineage.recompute.log.path,${alluxio.logs.dir}/recompute.log
 alluxio.master.port,19998
 alluxio.master.retry,29
+alluxio.master.startup.consistencycheck.enabled,true
 alluxio.master.ttl.checker.interval.ms,3600000
 alluxio.master.web.bind.host,0.0.0.0
 alluxio.master.web.hostname,localhost

--- a/docs/_data/table/master-configuration.csv
+++ b/docs/_data/table/master-configuration.csv
@@ -15,7 +15,7 @@ alluxio.master.lineage.recompute.interval.ms,600000
 alluxio.master.lineage.recompute.log.path,${alluxio.logs.dir}/recompute.log
 alluxio.master.port,19998
 alluxio.master.retry,29
-alluxio.master.startup.consistencycheck.enabled,true
+alluxio.master.startup.consistency.check.enabled,true
 alluxio.master.ttl.checker.interval.ms,3600000
 alluxio.master.web.bind.host,0.0.0.0
 alluxio.master.web.hostname,localhost

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -214,6 +214,7 @@ public abstract class AbstractLocalAlluxioCluster {
     Configuration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.toString(1000));
     Configuration.set(PropertyKey.MASTER_WORKER_THREADS_MIN, "1");
     Configuration.set(PropertyKey.MASTER_WORKER_THREADS_MAX, "100");
+    Configuration.set(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, false);
 
     Configuration.set(PropertyKey.MASTER_BIND_HOST, mHostname);
     Configuration.set(PropertyKey.MASTER_WEB_BIND_HOST, mHostname);

--- a/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
+++ b/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
@@ -111,7 +111,7 @@ public class StartupConsistencyCheckTest {
       @Override
       public Boolean apply(Void aVoid) {
         return master.getStartupConsistencyCheck().getStatus()
-            == FileSystemMaster.StartupConsistencyCheck.Status.COMPLETE;
+            == FileSystemMaster.StartupConsistencyCheckResult.Status.COMPLETE;
       }
     }, Constants.MINUTE_MS);
   }

--- a/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
+++ b/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
@@ -76,13 +76,14 @@ public class StartupConsistencyCheckTest {
     mCluster.stopFS();
     final FileSystemMaster master = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
     waitForStartupConsistencyCheck(master);
-    Assert.assertTrue(master.getStartupConsistencyCheck().isEmpty());
+    Assert.assertTrue(master.getStartupConsistencyCheck().getInconsistentUris().isEmpty());
   }
 
   /**
    * Tests that an inconsistent Alluxio system's startup check correctly detects the inconsistent
    * files.
    */
+  @Test
   public void inconsistent() throws Exception {
     String topLevelFileUfsPath = mFileSystem.getStatus(TOP_LEVEL_FILE).getUfsPath();
     String secondLevelDirUfsPath = mFileSystem.getStatus(SECOND_LEVEL_DIR).getUfsPath();
@@ -93,7 +94,7 @@ public class StartupConsistencyCheckTest {
     final FileSystemMaster master = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
     waitForStartupConsistencyCheck(master);
     List expected = Lists.newArrayList(TOP_LEVEL_FILE, SECOND_LEVEL_DIR, THIRD_LEVEL_FILE);
-    List result = master.getStartupConsistencyCheck();
+    List result = master.getStartupConsistencyCheck().getInconsistentUris();
     Collections.sort(expected);
     Collections.sort(result);
     Assert.assertEquals(expected, result);

--- a/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
+++ b/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
@@ -50,6 +50,7 @@ public class StartupConsistencyCheckTest {
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
+          .setProperty(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, "true")
           .build();
 
   @Before
@@ -109,8 +110,9 @@ public class StartupConsistencyCheckTest {
     CommonUtils.waitFor("Startup consistency check completion", new Function<Void, Boolean>() {
       @Override
       public Boolean apply(Void aVoid) {
-        return master.getStartupConsistencyCheck() != null;
+        return master.getStartupConsistencyCheck().getStatus()
+            == FileSystemMaster.StartupConsistencyCheck.Status.COMPLETE;
       }
-    }, Constants.SECOND_MS);
+    }, Constants.MINUTE_MS);
   }
 }


### PR DESCRIPTION
Allows the consistency check to propagate more info to the user and be disabled (enabled by default).
https://alluxio.atlassian.net/browse/ALLUXIO-2410