### PR TITLE
[SMALLFIX] Only set appropriate property for enabling zookeeper for different alluxio versions

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -69,6 +69,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               alluxio_dist:    alluxio_dist,
               alluxio_memory:  AlluxioV.memory,
               alluxio_version: alluxio_version,
+              alluxio_version_lessthan_0_8: AlluxioV.v_lt_0_8,
               alluxio_version_lessthan_1_1: AlluxioV.v_lt_1_1,
               alluxio_masters: AlluxioV.masters,
               alluxio_platform: alluxio_platform,

--- a/deploy/vagrant/core/EnvSetup.rb
+++ b/deploy/vagrant/core/EnvSetup.rb
@@ -88,8 +88,10 @@ class AlluxioVersion
     # Determine if the version is less than 1.1, only for release and github release branch types
     major = Integer(major) rescue nil
     minor = Integer(minor) rescue nil
+    @v_lt_0_8 = false
     @v_lt_1_1 = false
     if not major.nil? and not minor.nil?
+      @v_lt_0_8 = ((major == 0) and (minor < 8))
       @v_lt_1_1 = ((major < 1) or (major == 1 and minor < 1))
     end
 
@@ -111,6 +113,10 @@ class AlluxioVersion
 
   def masters
     return @masters
+  end
+
+  def v_lt_0_8
+    return @v_lt_0_8
   end
 
   def v_lt_1_1

--- a/deploy/vagrant/provision/roles/alluxio/files/zookeeper.sh
+++ b/deploy/vagrant/provision/roles/alluxio/files/zookeeper.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 ALLUXIO_SITE=/alluxio/conf/alluxio-site.properties
-# For Alluxio version >= 0.8
-echo "alluxio.zookeeper.enabled=true" >> "$ALLUXIO_SITE"
-# For earlier Alluxio version
-echo "alluxio.usezookeeper=true" >> "$ALLUXIO_SITE"
+if [[ ${ALLUXIO_VERSION_LESSTHAN_0_8} == true ]]; then
+  echo "alluxio.usezookeeper=true" >> "$ALLUXIO_SITE"
+else
+  echo "alluxio.zookeeper.enabled=true" >> "$ALLUXIO_SITE"
+fi
 
 echo "alluxio.zookeeper.address=AlluxioMaster:2181" >> "$ALLUXIO_SITE"

--- a/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
+++ b/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
@@ -35,6 +35,8 @@
 
 - name: set usezookeeper and zookeeper address if number of masters is larger than 1
   script: zookeeper.sh
+  environment:
+    ALLUXIO_VERSION_LESSTHAN_0_8: "{{ alluxio_version_lessthan_0_8 }}"
   when: alluxio_masters > 1
 
 - name: set journal folder as a shared folder in underfs for fault tolerance


### PR DESCRIPTION
In latest master branch, a precondition is added, where unknown configuration properties cause error. This PR updates the deploy module to only set known properties for the specific version of alluxio.