### PR TITLE
[SMALLFIX] Do not write to temporary file for active journal log

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -310,7 +310,7 @@ public abstract class UnderFileSystem {
    * @throws IOException if a non-Alluxio error occurs
    */
   public OutputStream create(String path, CreateOptions options) throws IOException {
-    if (!options.getEnsureAtomic()) {
+    if (!options.isEnsureAtomic()) {
       return createDirect(path, options);
     }
     return new NonAtomicFileOutputStream(path, options, this);

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -310,6 +310,9 @@ public abstract class UnderFileSystem {
    * @throws IOException if a non-Alluxio error occurs
    */
   public OutputStream create(String path, CreateOptions options) throws IOException {
+    if (!options.getEnsureAtomic()) {
+      return createDirect(path, options);
+    }
     return new NonAtomicFileOutputStream(path, options, this);
   }
 

--- a/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
@@ -39,17 +39,17 @@ public final class CreateOptions {
   }
 
   /**
-   * @return ensure atomic
-   */
-  public boolean getEnsureAtomic() {
-    return mEnsureAtomic;
-  }
-
-  /**
    * @return the permission
    */
   public Permission getPermission() {
     return mPermission;
+  }
+
+  /**
+   * @return ensure atomic
+   */
+  public boolean isEnsureAtomic() {
+    return mEnsureAtomic;
   }
 
   /**
@@ -95,7 +95,7 @@ public final class CreateOptions {
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-        .add("ensure_atomic", mEnsureAtomic)
+        .add("ensureAtomic", mEnsureAtomic)
         .add("permission", mPermission)
         .toString();
   }

--- a/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
@@ -24,6 +24,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class CreateOptions {
+  // Ensure writes are not readable till close.
+  private boolean mEnsureAtomic;
+
   // Permission to set for the file being created.
   private Permission mPermission;
 
@@ -31,7 +34,15 @@ public final class CreateOptions {
    * Constructs a default {@link CreateOptions}.
    */
   public CreateOptions() {
+    mEnsureAtomic = true;
     mPermission = Permission.defaults().applyFileUMask();
+  }
+
+  /**
+   * @return ensure atomic
+   */
+  public boolean getEnsureAtomic() {
+    return mEnsureAtomic;
   }
 
   /**
@@ -39,6 +50,17 @@ public final class CreateOptions {
    */
   public Permission getPermission() {
     return mPermission;
+  }
+
+  /**
+   * Sets ensure atomic.
+   *
+   * @param atomic whether to ensure created stream is atomic
+   * @return the updated option object
+   */
+  public CreateOptions setEnsureAtomic(boolean atomic) {
+    mEnsureAtomic = atomic;
+    return this;
   }
 
   /**
@@ -61,17 +83,19 @@ public final class CreateOptions {
       return false;
     }
     CreateOptions that = (CreateOptions) o;
-    return Objects.equal(mPermission, that.mPermission);
+    return (mEnsureAtomic == that.mEnsureAtomic)
+        && Objects.equal(mPermission, that.mPermission);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mPermission);
+    return Objects.hashCode(mEnsureAtomic, mPermission);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
+        .add("ensure_atomic", mEnsureAtomic)
         .add("permission", mPermission)
         .toString();
   }

--- a/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
@@ -46,14 +46,16 @@ public final class CreateOptions {
   }
 
   /**
-   * @return ensure atomic
+   * @return true, if writes are guaranteed to be atomic
    */
   public boolean isEnsureAtomic() {
     return mEnsureAtomic;
   }
 
   /**
-   * Sets ensure atomic.
+   * Set atomicity guarantees. When true, writes to the created stream must become readable all at
+   * once or not at all. The destination path is created only after closing the given stream. When,
+   * false the stream may or may not be atomic.
    *
    * @param atomic whether to ensure created stream is atomic
    * @return the updated option object

--- a/core/server/src/main/java/alluxio/master/journal/JournalWriter.java
+++ b/core/server/src/main/java/alluxio/master/journal/JournalWriter.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.CreateOptions;
 import alluxio.util.UnderFileSystemUtils;
 
 import com.google.common.base.Preconditions;
@@ -351,7 +352,7 @@ public final class JournalWriter {
       mJournalFormatter = journalFormatter;
       mJournalWriter = journalWriter;
       mMaxLogSize = Configuration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
-      mRawOutputStream = mUfs.create(mCurrentLogPath);
+      mRawOutputStream = mUfs.create(mCurrentLogPath, new CreateOptions().setEnsureAtomic(false));
       LOG.info("Opened current log file: {}", mCurrentLogPath);
       mDataOutputStream = new DataOutputStream(mRawOutputStream);
     }
@@ -438,7 +439,7 @@ public final class JournalWriter {
     private void rotateLog() throws IOException {
       mDataOutputStream.close();
       mJournalWriter.completeCurrentLog();
-      mRawOutputStream = mUfs.create(mCurrentLogPath);
+      mRawOutputStream = mUfs.create(mCurrentLogPath, new CreateOptions().setEnsureAtomic(false));
       LOG.info("Opened current log file: {}", mCurrentLogPath);
       mDataOutputStream = new DataOutputStream(mRawOutputStream);
     }

--- a/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
+++ b/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
@@ -64,7 +64,6 @@ public class JournalWriterTest {
     JournalWriter mockJournalWriter = PowerMockito.mock(JournalWriter.class);
     OutputStream mockOutStream = mock(OutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
     doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 
@@ -91,7 +90,6 @@ public class JournalWriterTest {
     JournalWriter mockJournalWriter = PowerMockito.mock(JournalWriter.class);
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
     doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 
@@ -119,7 +117,6 @@ public class JournalWriterTest {
     JournalWriter mockJournalWriter = PowerMockito.mock(JournalWriter.class);
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
     doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 

--- a/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
+++ b/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
@@ -13,6 +13,7 @@ package alluxio.master.journal;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -64,7 +65,7 @@ public class JournalWriterTest {
     OutputStream mockOutStream = mock(OutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+    doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,
@@ -91,7 +92,7 @@ public class JournalWriterTest {
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+    doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,
@@ -119,7 +120,7 @@ public class JournalWriterTest {
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
-    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+    doReturn(mockOutStream).when(mockUfs).create(eq(mJournal.getCurrentLogFilePath()),
         any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,

--- a/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
+++ b/core/server/src/test/java/alluxio/master/journal/JournalWriterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import alluxio.master.journal.JournalWriter.EntryOutputStream;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.CreateOptions;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.junit.Assert;
@@ -63,6 +64,8 @@ public class JournalWriterTest {
     OutputStream mockOutStream = mock(OutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
+    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+        any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,
         mJournal.getCurrentLogFilePath(), mJournal.getJournalFormatter(), mockJournalWriter);
@@ -88,6 +91,8 @@ public class JournalWriterTest {
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
+    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+        any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,
         mJournal.getCurrentLogFilePath(), mJournal.getJournalFormatter(), mockJournalWriter);
@@ -114,6 +119,8 @@ public class JournalWriterTest {
     FSDataOutputStream mockOutStream = mock(FSDataOutputStream.class);
     UnderFileSystem mockUfs = mock(UnderFileSystem.class);
     doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath());
+    doReturn(mockOutStream).when(mockUfs).create(mJournal.getCurrentLogFilePath(),
+        any(CreateOptions.class));
 
     EntryOutputStream entryOutStream = new EntryOutputStream(mockUfs,
         mJournal.getCurrentLogFilePath(), mJournal.getJournalFormatter(), mockJournalWriter);

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -195,6 +195,13 @@ public abstract class AbstractLocalAlluxioCluster {
   }
 
   /**
+   * Stop the workers only.
+   *
+   * @throws Exception when operation fails
+   */
+  public abstract void stopWorkers() throws Exception;
+
+  /**
    * Creates a default {@link Configuration} for testing.
    *
    * @throws IOException when the operation fails

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -120,11 +120,8 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
   @Override
   public void stopFS() throws Exception {
     LOG.info("stop Alluxio filesystem");
-
     // Stopping Workers before stopping master speeds up tests
-    for (AlluxioWorkerService worker : mWorkers) {
-      worker.stop();
-    }
+    stopWorkers();
     mMaster.stop();
   }
 
@@ -133,5 +130,12 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
     super.stop();
     // clear HDFS client caching
     System.clearProperty("fs.hdfs.impl.disable.cache");
+  }
+
+  @Override
+  public void stopWorkers() throws Exception {
+    for (AlluxioWorkerService worker : mWorkers) {
+      worker.stop();
+    }
   }
 }

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -209,14 +209,19 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
 
   @Override
   public void stopFS() throws Exception {
-    for (AlluxioWorkerService worker : mWorkers) {
-      worker.stop();
-    }
+    stopWorkers();
     for (int k = 0; k < mNumOfMasters; k++) {
       // TODO(jiri): use stop() instead of kill() (see ALLUXIO-2045)
       mMasters.get(k).kill();
     }
     LOG.info("Stopping testing zookeeper: {}", mCuratorServer.getConnectString());
     mCuratorServer.stop();
+  }
+
+  @Override
+  public void stopWorkers() throws Exception {
+    for (AlluxioWorkerService worker : mWorkers) {
+      worker.stop();
+    }
   }
 }

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -13,9 +13,12 @@ package alluxio.master;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
+import alluxio.Configuration;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
+import alluxio.PropertyKey;
 import alluxio.SystemPropertyRule;
+import alluxio.client.WriteType;
 import alluxio.client.block.BlockStoreContextTestUtils;
 import alluxio.client.block.RetryHandlingBlockWorkerClientTestUtils;
 import alluxio.client.file.FileSystem;
@@ -134,6 +137,7 @@ public class JournalShutdownIntegrationTest {
    * Reproduce the journal and check if the state is correct.
    */
   private void reproduceAndCheckState(int successFiles) throws Exception {
+    Assert.assertNotEquals(successFiles, 0);
     FileSystemMaster fsMaster = createFsMasterFromJournal();
 
     int actualFiles =
@@ -164,6 +168,7 @@ public class JournalShutdownIntegrationTest {
     // Setup and start the local alluxio cluster.
     LocalAlluxioCluster cluster = new LocalAlluxioCluster();
     cluster.initConfiguration();
+    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
     cluster.start();
     mCreateFileThread = new ClientThread(0, cluster.getClient());
     mExecutorsForClient.submit(mCreateFileThread);
@@ -171,7 +176,7 @@ public class JournalShutdownIntegrationTest {
   }
 
   @Test
-  public void singleMasterJournalCrashIntegration() throws Exception {
+  public void singleMasterJournalStopIntegration() throws Exception {
     LocalAlluxioCluster cluster = setupSingleMasterCluster();
     CommonUtils.sleepMs(TEST_TIME_MS);
     // Shutdown the cluster
@@ -186,7 +191,7 @@ public class JournalShutdownIntegrationTest {
   }
 
   @Test
-  public void singleMasterJournalKillIntegration() throws Exception {
+  public void singleMasterJournalCrashIntegration() throws Exception {
     LocalAlluxioCluster cluster = setupSingleMasterCluster();
     CommonUtils.sleepMs(TEST_TIME_MS);
     cluster.stopWorkers();
@@ -203,7 +208,7 @@ public class JournalShutdownIntegrationTest {
 
   @Ignore
   @Test
-  public void multiMasterJournalCrashIntegration() throws Exception {
+  public void multiMasterJournalStopIntegration() throws Exception {
     MultiMasterLocalAlluxioCluster cluster = setupMultiMasterCluster();
     // Kill the leader one by one.
     for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -185,6 +185,22 @@ public class JournalShutdownIntegrationTest {
     cluster.stopUFS();
   }
 
+  @Test
+  public void singleMasterJournalKillIntegration() throws Exception {
+    LocalAlluxioCluster cluster = setupSingleMasterCluster();
+    CommonUtils.sleepMs(TEST_TIME_MS);
+    cluster.stopWorkers();
+    // Crash the master
+    cluster.getMaster().kill();
+    CommonUtils.sleepMs(TEST_TIME_MS);
+    // Ensure the client threads are stopped.
+    mExecutorsForClient.shutdown();
+    mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS);
+    reproduceAndCheckState(mCreateFileThread.getSuccessNum());
+    // clean up
+    cluster.stopUFS();
+  }
+
   @Ignore
   @Test
   public void multiMasterJournalCrashIntegration() throws Exception {


### PR DESCRIPTION
Current journal entry log may not be closed before a crash. Make sure that the log is readable before a close by using CreateOptions.ensureAtomic = false.