### PR TITLE
[SMALLFIX] Fix path printed by generate-tarball.sh

### DIFF
--- a/dev/scripts/generate-tarball.sh
+++ b/dev/scripts/generate-tarball.sh
@@ -54,4 +54,4 @@ TARGET=${TARBALL_DIR}/${PREFIX}.tar.gz
 gtar -czf ${TARGET} ${PREFIX} --exclude-vcs
 popd > /dev/null
 
-echo "Generated tarball at ${THIS}/${TARGET}"
+echo "Generated tarball at ${TARGET}"


### PR DESCRIPTION
${TARGET} is already an absolute path