### PR TITLE
[SMALLFIX] Fix concurrency bug in journal test

### DIFF
--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -135,7 +135,7 @@ public class JournalShutdownIntegrationTest {
     // Shutdown the cluster
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination();
+    awaitClientTermination(TEST_TIME_MS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
@@ -149,7 +149,7 @@ public class JournalShutdownIntegrationTest {
     // Crash the master
     cluster.getMaster().kill();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination();
+    awaitClientTermination(TEST_TIME_MS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
@@ -165,16 +165,16 @@ public class JournalShutdownIntegrationTest {
     }
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination();
+    awaitClientTermination(3 * TEST_TIME_MS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
   }
 
-  private void awaitClientTermination() throws Exception {
+  private void awaitClientTermination(long timeInMs) throws Exception {
     // Ensure the client threads are stopped.
     mExecutorsForClient.shutdownNow();
-    if (!mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS)) {
+    if (!mExecutorsForClient.awaitTermination(timeInMs, TimeUnit.MILLISECONDS)) {
       throw new Exception("Client thread did not terminate");
     }
   }

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -33,7 +33,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -78,7 +77,7 @@ public class JournalShutdownIntegrationTest {
       try {
         // This infinity loop will be broken if something crashes or fail to create. This is
         // expected since the master will shutdown at a certain time.
-        while (true) {
+        while (!Thread.interrupted()) {
           if (mOpType == 0) {
             try {
               mFileSystem.createFile(new AlluxioURI(TEST_FILE_DIR + mSuccessNum)).close();
@@ -183,7 +182,7 @@ public class JournalShutdownIntegrationTest {
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
     // Ensure the client threads are stopped.
-    mExecutorsForClient.shutdown();
+    mExecutorsForClient.shutdownNow();
     mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
@@ -199,14 +198,13 @@ public class JournalShutdownIntegrationTest {
     cluster.getMaster().kill();
     CommonUtils.sleepMs(TEST_TIME_MS);
     // Ensure the client threads are stopped.
-    mExecutorsForClient.shutdown();
+    mExecutorsForClient.shutdownNow();
     mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
   }
 
-  @Ignore
   @Test
   public void multiMasterJournalStopIntegration() throws Exception {
     MultiMasterLocalAlluxioCluster cluster = setupMultiMasterCluster();
@@ -218,9 +216,8 @@ public class JournalShutdownIntegrationTest {
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
     // Ensure the client threads are stopped.
-    mExecutorsForClient.shutdown();
-    while (!mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS)) {
-    }
+    mExecutorsForClient.shutdownNow();
+    mExecutorsForClient.awaitTermination(TEST_TIME_MS, TimeUnit.MILLISECONDS);
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -102,6 +102,7 @@ public class JournalShutdownIntegrationTest {
     }
   }
 
+  private static final long SHUTDOWN_TIME_MS = 3 * Constants.SECOND_MS;
   private static final String TEST_FILE_DIR = "/files/";
   private static final int TEST_NUM_MASTERS = 3;
   private static final long TEST_TIME_MS = Constants.SECOND_MS;
@@ -135,7 +136,7 @@ public class JournalShutdownIntegrationTest {
     // Shutdown the cluster
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination(TEST_TIME_MS);
+    awaitClientTermination();
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
@@ -149,7 +150,7 @@ public class JournalShutdownIntegrationTest {
     // Crash the master
     cluster.getMaster().kill();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination(TEST_TIME_MS);
+    awaitClientTermination();
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
@@ -165,16 +166,16 @@ public class JournalShutdownIntegrationTest {
     }
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
-    awaitClientTermination(3 * TEST_TIME_MS);
+    awaitClientTermination();
     reproduceAndCheckState(mCreateFileThread.getSuccessNum());
     // clean up
     cluster.stopUFS();
   }
 
-  private void awaitClientTermination(long timeInMs) throws Exception {
+  private void awaitClientTermination() throws Exception {
     // Ensure the client threads are stopped.
     mExecutorsForClient.shutdownNow();
-    if (!mExecutorsForClient.awaitTermination(timeInMs, TimeUnit.MILLISECONDS)) {
+    if (!mExecutorsForClient.awaitTermination(SHUTDOWN_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw new Exception("Client thread did not terminate");
     }
   }


### PR DESCRIPTION
mExecutorsForClient.shutdown() did not shutdown the creator client thread which lead to a concurrency bug.