### PR TITLE
[ALLUXIO-2416] Split UFS delete into deleteFile and deleteDirectory

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -192,7 +192,7 @@ public class FileOutStream extends AbstractOutStream {
           if (mCanceled) {
             // TODO(yupeng): Handle this special case in under storage integrations.
             mUnderStorageOutputStream.close();
-            ufs.delete(mUfsPath, false);
+            ufs.deleteFile(mUfsPath);
           } else {
             mUnderStorageOutputStream.flush();
             mUnderStorageOutputStream.close();

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -145,7 +145,8 @@ public class FileOutStream extends AbstractOutStream {
         } else {
           UnderFileSystem ufs = UnderFileSystem.get(mUfsPath);
           // TODO(jiri): Implement collection of temporary files left behind by dead clients.
-          CreateOptions createOptions = new CreateOptions().setPermission(options.getPermission());
+          CreateOptions createOptions =
+              CreateOptions.defaults().setPermission(options.getPermission());
           mUnderStorageOutputStream = mCloser.register(ufs.create(mUfsPath, createOptions));
 
           // Set delegation related vars to null as we are not using worker delegation for ufs ops

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -164,7 +164,7 @@ public final class FileSystemUtils {
         URIStatus parentStatus = fs.getStatus(uri.getParent());
         Permission parentPerm = new Permission(parentStatus.getOwner(), parentStatus.getGroup(),
             (short) parentStatus.getMode());
-        MkdirsOptions parentMkdirsOptions = new MkdirsOptions().setCreateParent(true)
+        MkdirsOptions parentMkdirsOptions = MkdirsOptions.defaults().setCreateParent(true)
             .setPermission(parentPerm);
         if (!ufs.mkdirs(parentPath, parentMkdirsOptions)) {
           throw new IOException("Failed to create " + parentPath);
@@ -174,7 +174,7 @@ public final class FileSystemUtils {
       Permission perm = new Permission(uriStatus.getOwner(), uriStatus.getGroup(),
           (short) uriStatus.getMode());
       OutputStream out = closer.register(ufs.create(dstPath.toString(),
-          new CreateOptions().setPermission(perm)));
+          CreateOptions.defaults().setPermission(perm)));
       ret = IOUtils.copyLarge(in, out);
     } catch (Exception e) {
       throw closer.rethrow(e);

--- a/core/client/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -292,7 +292,7 @@ public class FileOutStreamTest {
     // Don't persist or complete the file if the stream was canceled
     verify(mFileSystemMasterClient, times(0)).completeFile(FILE_NAME,
         CompleteFileOptions.defaults());
-    verify(mUnderFileSystem).delete(anyString(), eq(false));
+    verify(mUnderFileSystem).deleteFile(anyString());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -27,10 +27,11 @@ import java.io.OutputStream;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A {@link NonAtomicFileOutputStream} writes to a temporary file and renames on close.
+ * A {@link AtomicFileOutputStream} writes to a temporary file and renames on close. This ensures
+ * that writing to the stream is atomic, i.e., all writes become readable only after a close.
  */
 @NotThreadSafe
-public class NonAtomicFileOutputStream extends OutputStream {
+public class AtomicFileOutputStream extends OutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private UnderFileSystem mUfs;
@@ -41,14 +42,14 @@ public class NonAtomicFileOutputStream extends OutputStream {
   private boolean mClosed = false;
 
   /**
-   * Constructs a new {@link NonAtomicFileOutputStream}.
+   * Constructs a new {@link AtomicFileOutputStream}.
    *
    * @param path path being written to
    * @param options create options for destination file
    * @param ufs the calling {@link UnderFileSystem}
    * @throws IOException when a non Alluxio error occurs
    */
-  public NonAtomicFileOutputStream(String path, CreateOptions options, UnderFileSystem ufs)
+  public AtomicFileOutputStream(String path, CreateOptions options, UnderFileSystem ufs)
       throws IOException {
     mOptions = options;
     mPermanentPath = path;

--- a/core/common/src/main/java/alluxio/underfs/NonAtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/NonAtomicFileOutputStream.java
@@ -80,7 +80,7 @@ public class NonAtomicFileOutputStream extends OutputStream {
     mTemporaryOutputStream.close();
 
     if (!mUfs.renameFile(mTemporaryPath, mPermanentPath)) {
-      if (!mUfs.delete(mTemporaryPath, false)) {
+      if (!mUfs.deleteFile(mTemporaryPath)) {
         LOG.error("Failed to delete temporary file {}", mTemporaryPath);
       }
       throw new IOException(

--- a/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
@@ -1,0 +1,66 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Information about a file or a directory in the under file system.
+ */
+@NotThreadSafe
+public class UnderFileStatus {
+  private final boolean mIsDirectory;
+  private final String mName;
+
+  /**
+   * Create new instance for under file information.
+   *
+   * @param name relative path of file or directory
+   * @param isDirectory whether the path is a directory
+   */
+  public UnderFileStatus(String name, boolean isDirectory) {
+    mIsDirectory = isDirectory;
+    mName = name;
+  }
+
+  public boolean isDirectory() {
+    return mIsDirectory;
+  }
+
+  public boolean isFile() {
+    return !mIsDirectory;
+  }
+
+  public String getName() {
+    return mName;
+  }
+
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  /**
+   * Convert an array of UFS file status to a listing result where each element in the array is
+   * a file or directory name.
+   *
+   * @param children array of internal listing
+   * @return array of file or directory names
+   */
+  public static String[] toListingResult(UnderFileStatus[] children) {
+    String[] ret = new String[children.length];
+    for (int i = 0; i < children.length; ++i) {
+      ret[i] = children[i].getName();
+    }
+    return ret;
+  }
+}

--- a/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
@@ -32,14 +32,23 @@ public class UnderFileStatus {
     mName = name;
   }
 
+  /**
+   * @return true, if the path is a directory
+   */
   public boolean isDirectory() {
     return mIsDirectory;
   }
 
+  /**
+   * @return true, if the path is a file
+   */
   public boolean isFile() {
     return !mIsDirectory;
   }
 
+  /**
+   * @return name of file or directory
+   */
   public String getName() {
     return mName;
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -328,9 +328,9 @@ public abstract class UnderFileSystem {
   /**
    * Deletes a directory from the under file system with the indicated name.
    *
-   * @param path the path of the directory to delete
-   * @param options delete options
-   * @return true if succeed, false otherwise
+   * @param path of the directory to delete
+   * @param options for directory delete semantics
+   * @return true if directory was found and deleted, false otherwise
    * @throws IOException if a non-Alluxio error occurs
    */
   public abstract boolean deleteDirectory(String path, DeleteOptions options) throws IOException;
@@ -338,8 +338,8 @@ public abstract class UnderFileSystem {
   /**
    * Deletes a file from the under file system with the indicated name.
    *
-   * @param path the path of the file to delete
-   * @return true if succeed, false otherwise
+   * @param path of the file to delete
+   * @return true if file was found and deleted, false otherwise
    * @throws IOException if a non-Alluxio error occurs
    */
   public abstract boolean deleteFile(String path) throws IOException;

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -189,6 +189,56 @@ public abstract class UnderFileSystem {
   }
 
   /**
+   * Information about a file or a directory in the under file system.
+   */
+  protected static class UnderFileInfo {
+    private final boolean mIsDirectory;
+    private final String mName;
+
+    /**
+     * Create new instance for under file information.
+     *
+     * @param name relative path of file or directory
+     * @param isDirectory whether the path is a directory
+     */
+    public UnderFileInfo(String name, boolean isDirectory) {
+      mIsDirectory = isDirectory;
+      mName = name;
+    }
+
+    public boolean isDirectory() {
+      return mIsDirectory;
+    }
+
+    public boolean isFile() {
+      return !mIsDirectory;
+    }
+
+    public String getName() {
+      return mName;
+    }
+
+    @Override
+    public String toString() {
+      return getName();
+    }
+  }
+
+  /**
+   * Convert an internal listing result to UFS API result.
+   *
+   * @param children array of internal listing
+   * @return array of file or directory names
+   */
+  protected String[] getListingResult(UnderFileInfo[] children) {
+    String[] ret = new String[children.length];
+    for (int i = 0; i < children.length; ++i) {
+      ret[i] = children[i].getName();
+    }
+    return ret;
+  }
+
+  /**
    * Gets the UnderFileSystem instance according to its schema.
    *
    * @param path the file path storing over the ufs

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -297,7 +297,7 @@ public abstract class UnderFileSystem {
    * @throws IOException if a non-Alluxio error occurs
    */
   public OutputStream create(String path) throws IOException {
-    return create(path, new CreateOptions());
+    return create(path, CreateOptions.defaults());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -189,57 +189,6 @@ public abstract class UnderFileSystem {
   }
 
   /**
-   * Information about a file or a directory in the under file system.
-   */
-  protected static class UnderFileStatus {
-    private final boolean mIsDirectory;
-    private final String mName;
-
-    /**
-     * Create new instance for under file information.
-     *
-     * @param name relative path of file or directory
-     * @param isDirectory whether the path is a directory
-     */
-    public UnderFileStatus(String name, boolean isDirectory) {
-      mIsDirectory = isDirectory;
-      mName = name;
-    }
-
-    public boolean isDirectory() {
-      return mIsDirectory;
-    }
-
-    public boolean isFile() {
-      return !mIsDirectory;
-    }
-
-    public String getName() {
-      return mName;
-    }
-
-    @Override
-    public String toString() {
-      return getName();
-    }
-
-    /**
-     * Convert an array of UFS file status to a listing result where each element in the array is
-     * a file or directory name.
-     *
-     * @param children array of internal listing
-     * @return array of file or directory names
-     */
-    public static String[] toListingResult(UnderFileStatus[] children) {
-      String[] ret = new String[children.length];
-      for (int i = 0; i < children.length; ++i) {
-        ret[i] = children[i].getName();
-      }
-      return ret;
-    }
-  }
-
-  /**
    * Gets the UnderFileSystem instance according to its schema.
    *
    * @param path the file path storing over the ufs

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -191,7 +191,7 @@ public abstract class UnderFileSystem {
   /**
    * Information about a file or a directory in the under file system.
    */
-  protected static class UnderFileInfo {
+  protected static class UnderFileStatus {
     private final boolean mIsDirectory;
     private final String mName;
 
@@ -201,7 +201,7 @@ public abstract class UnderFileSystem {
      * @param name relative path of file or directory
      * @param isDirectory whether the path is a directory
      */
-    public UnderFileInfo(String name, boolean isDirectory) {
+    public UnderFileStatus(String name, boolean isDirectory) {
       mIsDirectory = isDirectory;
       mName = name;
     }
@@ -222,20 +222,21 @@ public abstract class UnderFileSystem {
     public String toString() {
       return getName();
     }
-  }
 
-  /**
-   * Convert an internal listing result to UFS API result.
-   *
-   * @param children array of internal listing
-   * @return array of file or directory names
-   */
-  protected String[] getListingResult(UnderFileInfo[] children) {
-    String[] ret = new String[children.length];
-    for (int i = 0; i < children.length; ++i) {
-      ret[i] = children[i].getName();
+    /**
+     * Convert an array of UFS file status to a listing result where each element in the array is
+     * a file or directory name.
+     *
+     * @param children array of internal listing
+     * @return array of file or directory names
+     */
+    public static String[] toListingResult(UnderFileStatus[] children) {
+      String[] ret = new String[children.length];
+      for (int i = 0; i < children.length; ++i) {
+        ret[i] = children[i].getName();
+      }
+      return ret;
     }
-    return ret;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -311,7 +311,7 @@ public abstract class UnderFileSystem {
    * @throws IOException if a non-Alluxio error occurs
    */
   public OutputStream create(String path, CreateOptions options) throws IOException {
-    return new NonAtomicFileOutputStream(path, options, this);
+    return new AtomicFileOutputStream(path, options, this);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -16,6 +16,7 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.io.PathUtils;
 
@@ -325,14 +326,23 @@ public abstract class UnderFileSystem {
   public abstract OutputStream createDirect(String path, CreateOptions options) throws IOException;
 
   /**
-   * Deletes a file or folder from the under file system with the indicated name.
+   * Deletes a directory from the under file system with the indicated name.
    *
-   * @param path the file or folder name
-   * @param recursive the boolean indicates whether we delete folder and its children
+   * @param path the path of the directory to delete
+   * @param options delete options
    * @return true if succeed, false otherwise
    * @throws IOException if a non-Alluxio error occurs
    */
-  public abstract boolean delete(String path, boolean recursive) throws IOException;
+  public abstract boolean deleteDirectory(String path, DeleteOptions options) throws IOException;
+
+  /**
+   * Deletes a file from the under file system with the indicated name.
+   *
+   * @param path the path of the file to delete
+   * @return true if succeed, false otherwise
+   * @throws IOException if a non-Alluxio error occurs
+   */
+  public abstract boolean deleteFile(String path) throws IOException;
 
   /**
    * Gets the block size of a file in under file system, in bytes.

--- a/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
@@ -28,9 +28,16 @@ public final class CreateOptions {
   private Permission mPermission;
 
   /**
+   * @return the default {@link CreateOptions}
+   */
+  public static CreateOptions defaults() {
+    return new CreateOptions();
+  }
+
+  /**
    * Constructs a default {@link CreateOptions}.
    */
-  public CreateOptions() {
+  private CreateOptions() {
     mPermission = Permission.defaults().applyFileUMask();
   }
 

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -23,8 +23,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class DeleteOptions {
-  // Whether to not delete the directory itself
-  private boolean mChildrenOnly;
   // Whether to delete a directory with children
   private boolean mRecursive;
 
@@ -32,15 +30,7 @@ public final class DeleteOptions {
    * Constructs a default {@link DeleteOptions}.
    */
   public DeleteOptions() {
-    mChildrenOnly = false;
     mRecursive = false;
-  }
-
-  /**
-   * @return whether to delete children only
-   */
-  public boolean isChildrenOnly() {
-    return mChildrenOnly;
   }
 
   /**
@@ -48,17 +38,6 @@ public final class DeleteOptions {
    */
   public boolean isRecursive() {
     return mRecursive;
-  }
-
-  /**
-   * Sets whether to delete children only.
-   *
-   * @param childrenOnly whether to delete children only
-   * @return the updated option object
-   */
-  public DeleteOptions setChildrenOnly(boolean childrenOnly) {
-    mChildrenOnly = childrenOnly;
-    return this;
   }
 
   /**
@@ -81,19 +60,17 @@ public final class DeleteOptions {
       return false;
     }
     DeleteOptions that = (DeleteOptions) o;
-    return Objects.equal(mChildrenOnly, that.mChildrenOnly)
-        && Objects.equal(mRecursive, that.mRecursive);
+    return Objects.equal(mRecursive, that.mRecursive);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mChildrenOnly, mRecursive);
+    return Objects.hashCode(mRecursive);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-        .add("childrenOnly", mChildrenOnly)
         .add("recursive", mRecursive)
         .toString();
   }

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -11,11 +11,11 @@
 
 package alluxio.underfs.options;
 
-import javax.annotation.concurrent.NotThreadSafe;
+import alluxio.annotation.PublicApi;
 
 import com.google.common.base.Objects;
 
-import alluxio.annotation.PublicApi;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * Method options for deleting a directory in UnderFileSystem.
@@ -25,7 +25,7 @@ import alluxio.annotation.PublicApi;
 public final class DeleteOptions {
   // Whether to not delete the directory itself
   private boolean mChildrenOnly;
-  // Whether to delete a directory recursively
+  // Whether to delete a directory with children
   private boolean mRecursive;
 
   /**
@@ -53,7 +53,7 @@ public final class DeleteOptions {
   /**
    * Sets whether to delete children only.
    *
-   * @param  whether to delete children only
+   * @param childrenOnly whether to delete children only
    * @return the updated option object
    */
   public DeleteOptions setChildrenOnly(boolean childrenOnly) {

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -39,7 +39,7 @@ public final class DeleteOptions {
   /**
    * @return whether to delete children only
    */
-  public boolean getChildrenOnly() {
+  public boolean isChildrenOnly() {
     return mChildrenOnly;
   }
 

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -44,9 +44,9 @@ public final class DeleteOptions {
   }
 
   /**
-   * @return recursive
+   * @return whether to delete a non-empty directory
    */
-  public boolean getRecursive() {
+  public boolean isRecursive() {
     return mRecursive;
   }
 

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -1,0 +1,100 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.options;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import com.google.common.base.Objects;
+
+import alluxio.annotation.PublicApi;
+
+/**
+ * Method options for deleting a directory in UnderFileSystem.
+ */
+@PublicApi
+@NotThreadSafe
+public final class DeleteOptions {
+  // Whether to not delete the directory itself
+  private boolean mChildrenOnly;
+  // Whether to delete a directory recursively
+  private boolean mRecursive;
+
+  /**
+   * Constructs a default {@link DeleteOptions}.
+   */
+  public DeleteOptions() {
+    mChildrenOnly = false;
+    mRecursive = false;
+  }
+
+  /**
+   * @return whether to delete children only
+   */
+  public boolean getChildrenOnly() {
+    return mChildrenOnly;
+  }
+
+  /**
+   * @return recursive
+   */
+  public boolean getRecursive() {
+    return mRecursive;
+  }
+
+  /**
+   * Sets whether to delete children only.
+   *
+   * @param  whether to delete children only
+   * @return the updated option object
+   */
+  public DeleteOptions setChildrenOnly(boolean childrenOnly) {
+    mChildrenOnly = childrenOnly;
+    return this;
+  }
+
+  /**
+   * Sets recursive delete.
+   *
+   * @param recursive whether to delete recursively
+   * @return the updated option object
+   */
+  public DeleteOptions setRecursive(boolean recursive) {
+    mRecursive = recursive;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DeleteOptions)) {
+      return false;
+    }
+    DeleteOptions that = (DeleteOptions) o;
+    return Objects.equal(mChildrenOnly, that.mChildrenOnly)
+        && Objects.equal(mRecursive, that.mRecursive);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mChildrenOnly, mRecursive);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("children_only", mChildrenOnly)
+        .add("recursive", mRecursive)
+        .toString();
+  }
+}

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -93,7 +93,7 @@ public final class DeleteOptions {
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-        .add("children_only", mChildrenOnly)
+        .add("childrenOnly", mChildrenOnly)
         .add("recursive", mRecursive)
         .toString();
   }

--- a/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -27,9 +27,16 @@ public final class DeleteOptions {
   private boolean mRecursive;
 
   /**
+   * @return the default {@link DeleteOptions}
+   */
+  public static DeleteOptions defaults() {
+    return new DeleteOptions();
+  }
+
+  /**
    * Constructs a default {@link DeleteOptions}.
    */
-  public DeleteOptions() {
+  private DeleteOptions() {
     mRecursive = false;
   }
 

--- a/core/common/src/main/java/alluxio/underfs/options/MkdirsOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/MkdirsOptions.java
@@ -30,9 +30,16 @@ public final class MkdirsOptions {
   private boolean mCreateParent;
 
   /**
+   * @return the default {@link CreateDirectoryOptions}
+   */
+  public static MkdirsOptions defaults() {
+    return new MkdirsOptions();
+  }
+
+  /**
    * Constructs a default {@link MkdirsOptions}.
    */
-  public MkdirsOptions() {
+  private MkdirsOptions() {
     mPermission = Permission.defaults().applyDirectoryUMask();
     // By default create parent is true.
     mCreateParent = true;

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -12,6 +12,7 @@
 package alluxio.util;
 
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 
 import com.google.common.base.Throwables;
 
@@ -36,7 +37,8 @@ public final class UnderFileSystemUtils {
   public static void deleteDirIfExists(final String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
-    if (ufs.isDirectory(path) && !ufs.delete(path, true)) {
+    if (ufs.isDirectory(path)
+        && !ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true))) {
       throw new IOException("Folder " + path + " already exists but can not be deleted.");
     }
   }
@@ -78,7 +80,7 @@ public final class UnderFileSystemUtils {
     UnderFileSystem ufs = UnderFileSystem.get(path);
     try {
       if (ufs.isFile(path)) {
-        ufs.delete(path, false);
+        ufs.deleteFile(path);
       }
     } catch (IOException e) {
       throw Throwables.propagate(e);

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -38,7 +38,7 @@ public final class UnderFileSystemUtils {
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
     if (ufs.isDirectory(path)
-        && !ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true))) {
+        && !ufs.deleteDirectory(path, DeleteOptions.defaults().setRecursive(true))) {
       throw new IOException("Folder " + path + " already exists but can not be deleted.");
     }
   }

--- a/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
@@ -38,7 +38,7 @@ public final class CreateOptionsTest {
    */
   @Test
   public void defaults() throws IOException {
-    CreateOptions options = new CreateOptions();
+    CreateOptions options = CreateOptions.defaults();
 
     Permission expectedPs = Permission.defaults().applyFileUMask();
 
@@ -61,7 +61,7 @@ public final class CreateOptionsTest {
     Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
         IdentityUserGroupsMapping.class.getName());
 
-    CreateOptions options = new CreateOptions();
+    CreateOptions options = CreateOptions.defaults();
 
     Permission expectedPs = Permission.defaults().applyFileUMask();
 
@@ -79,7 +79,7 @@ public final class CreateOptionsTest {
   public void fields() {
     Permission perm = Permission.defaults();
 
-    CreateOptions options = new CreateOptions();
+    CreateOptions options = CreateOptions.defaults();
     options.setPermission(perm);
 
     Assert.assertEquals(perm, options.getPermission());

--- a/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
@@ -38,7 +38,7 @@ public final class MkdirsOptionsTest {
    */
   @Test
   public void defaults() throws IOException {
-    MkdirsOptions options = new MkdirsOptions();
+    MkdirsOptions options = MkdirsOptions.defaults();
 
     Permission expectedPs = Permission.defaults().applyDirectoryUMask();
     // Verify the default createParent is true.
@@ -62,7 +62,7 @@ public final class MkdirsOptionsTest {
     Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
         IdentityUserGroupsMapping.class.getName());
 
-    MkdirsOptions options = new MkdirsOptions();
+    MkdirsOptions options = MkdirsOptions.defaults();
 
     Permission expectedPs = Permission.defaults().applyDirectoryUMask();
 
@@ -82,7 +82,7 @@ public final class MkdirsOptionsTest {
   public void fields() {
     boolean createParent = false;
     Permission perm = Permission.defaults();
-    MkdirsOptions options = new MkdirsOptions();
+    MkdirsOptions options = MkdirsOptions.defaults();
     options.setCreateParent(createParent);
     options.setPermission(perm);
 

--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -18,6 +18,7 @@ import alluxio.PropertyKeyFormat;
 import alluxio.RuntimeConstants;
 import alluxio.master.AlluxioMaster;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.PathUtils;
 
@@ -41,11 +42,9 @@ public final class Format {
     UnderFileSystem ufs = UnderFileSystem.get(folder);
     LOG.info("Formatting {}:{}", name, folder);
     if (ufs.isDirectory(folder)) {
-      for (String file : ufs.list(folder)) {
-        if (!ufs.delete(PathUtils.concatPath(folder, file), true)) {
-          LOG.info("Failed to remove {}:{}", name, file);
-          return false;
-        }
+      if (!ufs.deleteDirectory(folder,
+          new DeleteOptions().setChildrenOnly(true).setRecursive(true))) {
+        return false;
       }
     } else if (!ufs.mkdirs(folder, true)) {
       LOG.info("Failed to create {}:{}", name, folder);

--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -45,7 +45,7 @@ public final class Format {
       for (String p : ufs.list(folder)) {
         String childPath = PathUtils.concatPath(folder, p);
         boolean failedToDelete;
-        // TODO (adit); eliminate this isDirectory call after list is updated to listStatus
+        // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
         if (ufs.isDirectory(childPath)) {
           failedToDelete = !ufs.deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
         } else {

--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -47,7 +47,8 @@ public final class Format {
         boolean failedToDelete;
         // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
         if (ufs.isDirectory(childPath)) {
-          failedToDelete = !ufs.deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
+          failedToDelete = !ufs.deleteDirectory(childPath,
+              DeleteOptions.defaults().setRecursive(true));
         } else {
           failedToDelete = !ufs.deleteFile(childPath);
         }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1157,7 +1157,7 @@ public final class FileSystemMaster extends AbstractMaster {
                   }
                 }
               } else {
-                if (!ufs.deleteDirectory(ufsUri, new DeleteOptions().setRecursive(true))) {
+                if (!ufs.deleteDirectory(ufsUri, DeleteOptions.defaults().setRecursive(true))) {
                   failedToDelete = ufs.isDirectory(ufsUri);
                   if (!failedToDelete) {
                     LOG.warn("The directory to delete does not exist in ufs: {}", ufsUri);
@@ -1622,7 +1622,7 @@ public final class FileSystemMaster extends AbstractMaster {
       if (!ufs.isDirectory(parentPath)) {
         Permission parentPerm = new Permission(srcParentInode.getOwner(), srcParentInode.getGroup(),
             srcParentInode.getMode());
-        MkdirsOptions parentMkdirsOptions = new MkdirsOptions().setCreateParent(true)
+        MkdirsOptions parentMkdirsOptions = MkdirsOptions.defaults().setCreateParent(true)
             .setPermission(parentPerm);
         if (!ufs.mkdirs(parentPath, parentMkdirsOptions)) {
           throw new IOException(ExceptionMessage.FAILED_UFS_CREATE.getMessage(parentPath));

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1153,14 +1153,14 @@ public final class FileSystemMaster extends AbstractMaster {
                 if (!ufs.deleteFile(ufsUri)) {
                   fail = ufs.isFile(ufsUri);
                   if (!fail) {
-                    LOG.warn("The file to delete does not exist in under filesystem: {}", ufsUri);
+                    LOG.warn("The file to delete does not exist in ufs: {}", ufsUri);
                   }
                 }
               } else {
                 if (!ufs.deleteDirectory(ufsUri, new DeleteOptions().setRecursive(true))) {
                   fail = ufs.isDirectory(ufsUri);
                   if (!fail) {
-                    LOG.warn("The directory to delete does not exist in under filesystem: {}", ufsUri);
+                    LOG.warn("The directory to delete does not exist in ufs: {}", ufsUri);
                   }
                 }
               }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1161,8 +1161,8 @@ public final class FileSystemMaster extends AbstractMaster {
                 LOG.warn("The directory to delete does not exist in under filesystem: {}", ufsUri);
               }
               if (fail) {
-                  LOG.error("Failed to delete {} from the under filesystem", ufsUri);
-                  throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
+                LOG.error("Failed to delete {} from the under filesystem", ufsUri);
+                throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
               }
             }
           } catch (InvalidPathException e) {

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1148,23 +1148,23 @@ public final class FileSystemMaster extends AbstractMaster {
               MountTable.Resolution resolution = mMountTable.resolve(alluxioUriToDel);
               String ufsUri = resolution.getUri().toString();
               UnderFileSystem ufs = resolution.getUfs();
-              boolean fail = false;
+              boolean failedToDelete = false;
               if (delInode.isFile()) {
                 if (!ufs.deleteFile(ufsUri)) {
-                  fail = ufs.isFile(ufsUri);
-                  if (!fail) {
+                  failedToDelete = ufs.isFile(ufsUri);
+                  if (!failedToDelete) {
                     LOG.warn("The file to delete does not exist in ufs: {}", ufsUri);
                   }
                 }
               } else {
                 if (!ufs.deleteDirectory(ufsUri, new DeleteOptions().setRecursive(true))) {
-                  fail = ufs.isDirectory(ufsUri);
-                  if (!fail) {
+                  failedToDelete = ufs.isDirectory(ufsUri);
+                  if (!failedToDelete) {
                     LOG.warn("The directory to delete does not exist in ufs: {}", ufsUri);
                   }
                 }
               }
-              if (fail) {
+              if (failedToDelete) {
                 LOG.error("Failed to delete {} from the under filesystem", ufsUri);
                 throw new IOException(ExceptionMessage.DELETE_FAILED_UFS.getMessage(ufsUri));
               }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1152,13 +1152,17 @@ public final class FileSystemMaster extends AbstractMaster {
               if (delInode.isFile()) {
                 if (!ufs.deleteFile(ufsUri)) {
                   fail = ufs.isFile(ufsUri);
+                  if (!fail) {
+                    LOG.warn("The file to delete does not exist in under filesystem: {}", ufsUri);
+                  }
                 }
-                LOG.warn("The file to delete does not exist in under filesystem: {}", ufsUri);
               } else {
                 if (!ufs.deleteDirectory(ufsUri, new DeleteOptions().setRecursive(true))) {
                   fail = ufs.isDirectory(ufsUri);
+                  if (!fail) {
+                    LOG.warn("The directory to delete does not exist in under filesystem: {}", ufsUri);
+                  }
                 }
-                LOG.warn("The directory to delete does not exist in under filesystem: {}", ufsUri);
               }
               if (fail) {
                 LOG.error("Failed to delete {} from the under filesystem", ufsUri);

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -638,7 +638,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
       String ufsUri = resolution.getUri().toString();
       UnderFileSystem ufs = resolution.getUfs();
       Permission permission = new Permission(inode.getOwner(), inode.getGroup(), inode.getMode());
-      MkdirsOptions mkdirsOptions = new MkdirsOptions().setCreateParent(false)
+      MkdirsOptions mkdirsOptions = MkdirsOptions.defaults().setCreateParent(false)
           .setPermission(permission);
       if (ufs.isDirectory(ufsUri) || ufs.mkdirs(ufsUri, mkdirsOptions)) {
         inode.setPersistenceState(PersistenceState.PERSISTED);

--- a/core/server/src/main/java/alluxio/master/journal/CheckpointManager.java
+++ b/core/server/src/main/java/alluxio/master/journal/CheckpointManager.java
@@ -110,7 +110,7 @@ public final class CheckpointManager {
         if (checkpointExists) {
           // We crashed after step 4, so we can finish steps 5 and 6.
           mWriter.deleteCompletedLogs();
-          mUfs.delete(mBackupCheckpointPath, false);
+          mUfs.deleteFile(mBackupCheckpointPath);
         } else {
           // We crashed before step 4, so we roll back to the backup checkpoint.
           mUfs.renameFile(mBackupCheckpointPath, mCheckpointPath);

--- a/core/server/src/main/java/alluxio/master/journal/JournalWriter.java
+++ b/core/server/src/main/java/alluxio/master/journal/JournalWriter.java
@@ -204,7 +204,7 @@ public final class JournalWriter {
     for (long i = logNumber - 1; i >= 0; i--) {
       String logFilename = mJournal.getCompletedLogFilePath(i);
       LOG.info("Deleting completed log: {}", logFilename);
-      mUfs.delete(logFilename, true);
+      mUfs.deleteFile(logFilename);
     }
     LOG.info("Finished deleting all completed log files.");
 

--- a/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -232,7 +232,7 @@ public final class FileDataManager {
     FileInfo fileInfo = mBlockWorker.getFileInfo(fileId);
     Permission perm = new Permission(fileInfo.getOwner(), fileInfo.getGroup(),
         (short) fileInfo.getMode());
-    OutputStream outputStream = mUfs.create(dstPath, new CreateOptions().setPermission(perm));
+    OutputStream outputStream = mUfs.create(dstPath, CreateOptions.defaults().setPermission(perm));
     final WritableByteChannel outputChannel = Channels.newChannel(outputStream);
 
     List<Throwable> errors = new ArrayList<>();

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -269,7 +269,7 @@ public final class UnderFileSystemManager {
       UnderFileSystem ufs = UnderFileSystem.get(mUri);
       ufs.connectFromWorker(
           NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));
-      mStream = ufs.create(mUri, new CreateOptions().setPermission(mPermission));
+      mStream = ufs.create(mUri, CreateOptions.defaults().setPermission(mPermission));
     }
 
     /**

--- a/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -281,7 +281,7 @@ public final class UnderFileSystemManager {
       mStream.close();
       UnderFileSystem ufs = UnderFileSystem.get(mUri);
       // TODO(calvin): Log a warning if the delete fails
-      ufs.delete(mUri, false);
+      ufs.deleteFile(mUri);
     }
 
     /**

--- a/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
+++ b/core/server/src/test/java/alluxio/worker/file/UnderFileSystemManagerTest.java
@@ -124,13 +124,13 @@ public final class UnderFileSystemManagerTest {
   }
 
   /**
-   * Tests canceling a file with the manager will call {@link UnderFileSystem#delete}.
+   * Tests canceling a file with the manager will call {@link UnderFileSystem#deleteFile(String)}.
    */
   @Test
   public void cancelUfsFile() throws Exception {
     long id = mManager.createFile(SESSION_ID, mUri, Permission.defaults());
     mManager.cancelFile(SESSION_ID, id);
-    Mockito.verify(mMockUfs).delete(Mockito.contains(mUri.toString()), Mockito.eq(false));
+    Mockito.verify(mMockUfs).deleteFile(Mockito.contains(mUri.toString()));
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -18,6 +18,7 @@ import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.worker.AlluxioWorkerService;
 
 import com.google.common.base.Throwables;
@@ -147,7 +148,8 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
   private void deleteDir(String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
-    if (ufs.isDirectory(path) && !ufs.delete(path, true)) {
+    if (ufs.isDirectory(path)
+        && !ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true))) {
       throw new IOException("Folder " + path + " already exists but can not be deleted.");
     }
   }
@@ -156,7 +158,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
     if (ufs.isDirectory(path)) {
-      ufs.delete(path, true);
+      ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true));
     }
     if (!ufs.mkdirs(path, true)) {
       throw new IOException("Failed to make folder: " + path);

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -149,7 +149,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
     if (ufs.isDirectory(path)
-        && !ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true))) {
+        && !ufs.deleteDirectory(path, DeleteOptions.defaults().setRecursive(true))) {
       throw new IOException("Folder " + path + " already exists but can not be deleted.");
     }
   }
@@ -158,7 +158,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     UnderFileSystem ufs = UnderFileSystem.get(path);
 
     if (ufs.isDirectory(path)) {
-      ufs.deleteDirectory(path, new DeleteOptions().setRecursive(true));
+      ufs.deleteDirectory(path, DeleteOptions.defaults().setRecursive(true));
     }
     if (!ufs.mkdirs(path, true)) {
       throw new IOException("Failed to make folder: " + path);

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -13,7 +13,6 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.underfs.options.DeleteOptions;
-import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -142,7 +142,7 @@ public abstract class UnderFileSystemCluster {
         String childPath = PathUtils.concatPath(path, p);
         // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
         if (ufs.isDirectory(childPath)) {
-          ufs.deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
+          ufs.deleteDirectory(childPath, DeleteOptions.defaults().setRecursive(true));
         } else {
           ufs.deleteFile(childPath);
         }

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -12,6 +12,7 @@
 package alluxio.underfs;
 
 import alluxio.AlluxioURI;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
@@ -137,9 +138,7 @@ public abstract class UnderFileSystemCluster {
     if (isStarted()) {
       String path = getUnderFilesystemAddress() + AlluxioURI.SEPARATOR;
       UnderFileSystem ufs = UnderFileSystem.get(path);
-      for (String p : ufs.list(path)) {
-        ufs.delete(PathUtils.concatPath(path, p), true);
-      }
+      ufs.deleteDirectory(path, new DeleteOptions().setChildrenOnly(true).setRecursive(true));
     }
   }
 

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -13,6 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.underfs.options.DeleteOptions;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -137,7 +138,15 @@ public abstract class UnderFileSystemCluster {
     if (isStarted()) {
       String path = getUnderFilesystemAddress() + AlluxioURI.SEPARATOR;
       UnderFileSystem ufs = UnderFileSystem.get(path);
-      ufs.deleteDirectory(path, new DeleteOptions().setChildrenOnly(true).setRecursive(true));
+      for (String p : ufs.list(path)) {
+        String childPath = PathUtils.concatPath(path, p);
+        // TODO (adit); eliminate this isDirectory call after list is updated to listStatus
+        if (ufs.isDirectory(childPath)) {
+          ufs.deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
+        } else {
+          ufs.deleteFile(childPath);
+        }
+      }
     }
   }
 

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -140,7 +140,7 @@ public abstract class UnderFileSystemCluster {
       UnderFileSystem ufs = UnderFileSystem.get(path);
       for (String p : ufs.list(path)) {
         String childPath = PathUtils.concatPath(path, p);
-        // TODO (adit); eliminate this isDirectory call after list is updated to listStatus
+        // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
         if (ufs.isDirectory(childPath)) {
           ufs.deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
         } else {

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -104,8 +104,7 @@ public class JournalIntegrationTest {
     String journalFolder = mLocalAlluxioCluster.getMaster().getJournalFolder();
     Journal journal = new ReadWriteJournal(
         PathUtils.concatPath(journalFolder, Constants.FILE_SYSTEM_MASTER_NAME));
-    UnderFileSystem.get(journalFolder).delete(journal.getCurrentLogFilePath(),
-        true);
+    UnderFileSystem.get(journalFolder).deleteFile(journal.getCurrentLogFilePath());
   }
 
   private void addBlockTestUtil(URIStatus status)
@@ -629,7 +628,7 @@ public class JournalIntegrationTest {
     AlluxioURI journal = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
     try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journal)) {
       doThrow(new RuntimeException("Failed to delete")).when(ufsSpy.get())
-          .delete(Mockito.contains("FileSystemMaster/checkpoint.data"), anyBoolean());
+          .deleteFile(Mockito.contains("FileSystemMaster/checkpoint.data"));
       try {
         // Restart the master again, but with deleting the checkpoint file failing.
         mLocalAlluxioCluster.stopFS();
@@ -651,7 +650,7 @@ public class JournalIntegrationTest {
     AlluxioURI journal = new AlluxioURI(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER));
     try (UnderFileSystemSpy ufsSpy = new UnderFileSystemSpy(journal)) {
       doThrow(new RuntimeException("Failed to delete completed log")).when(ufsSpy.get())
-          .delete(Mockito.contains("FileSystemMaster/completed"), anyBoolean());
+          .deleteFile(Mockito.contains("FileSystemMaster/completed"));
       try {
         // Restart the master again, but with deleting the checkpoint file failing.
         mLocalAlluxioCluster.stopFS();

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -11,7 +11,6 @@
 
 package alluxio.master;
 
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 

--- a/tests/src/test/java/alluxio/master/file/CheckConsistencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/CheckConsistencyIntegrationTest.java
@@ -21,6 +21,7 @@ import alluxio.client.file.options.CreateFileOptions;
 import alluxio.master.file.options.CheckConsistencyOptions;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 
 import com.google.common.collect.Lists;
 import org.junit.After;
@@ -88,7 +89,7 @@ public class CheckConsistencyIntegrationTest {
   public void inconsistent() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.delete(ufsDirectory, true);
+    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(FILE, DIRECTORY);
     List<AlluxioURI> result =
@@ -106,7 +107,7 @@ public class CheckConsistencyIntegrationTest {
   public void partiallyInconsistent() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsFile);
-    ufs.delete(ufsFile, true);
+    ufs.deleteFile(ufsFile);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
     Assert.assertEquals(expected, mFileSystemMaster
         .checkConsistency(new AlluxioURI("/"), CheckConsistencyOptions.defaults()));
@@ -130,7 +131,7 @@ public class CheckConsistencyIntegrationTest {
     mFileSystem.createFile(thirdLevelFile, fileOptions).close();
     String ufsDirectory = mFileSystem.getStatus(nestedDir).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.delete(ufsDirectory, true);
+    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(nestedDir, thirdLevelFile);
     List<AlluxioURI> result =
@@ -148,7 +149,7 @@ public class CheckConsistencyIntegrationTest {
   public void incorrectFileSize() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsFile);
-    ufs.delete(ufsFile, true);
+    ufs.deleteFile(ufsFile);
     OutputStream out = ufs.create(ufsFile);
     out.write(1);
     out.close();
@@ -165,7 +166,7 @@ public class CheckConsistencyIntegrationTest {
   public void notADirectory() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.delete(ufsDirectory, true);
+    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
     ufs.create(ufsDirectory).close();
     List<AlluxioURI> expected = Lists.newArrayList(DIRECTORY, FILE);
     List<AlluxioURI> result =
@@ -183,7 +184,7 @@ public class CheckConsistencyIntegrationTest {
   public void notAFile() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsFile);
-    ufs.delete(ufsFile, true);
+    ufs.deleteFile(ufsFile);
     ufs.mkdirs(ufsFile, true);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
     Assert.assertEquals(expected, mFileSystemMaster
@@ -198,7 +199,7 @@ public class CheckConsistencyIntegrationTest {
   public void inconsistentFile() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsFile);
-    ufs.delete(ufsFile, true);
+    ufs.deleteFile(ufsFile);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
     Assert.assertEquals(expected, mFileSystemMaster
         .checkConsistency(FILE, CheckConsistencyOptions.defaults()));

--- a/tests/src/test/java/alluxio/master/file/CheckConsistencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/CheckConsistencyIntegrationTest.java
@@ -89,7 +89,7 @@ public class CheckConsistencyIntegrationTest {
   public void inconsistent() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(FILE, DIRECTORY);
     List<AlluxioURI> result =
@@ -131,7 +131,7 @@ public class CheckConsistencyIntegrationTest {
     mFileSystem.createFile(thirdLevelFile, fileOptions).close();
     String ufsDirectory = mFileSystem.getStatus(nestedDir).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(nestedDir, thirdLevelFile);
     List<AlluxioURI> result =
@@ -166,7 +166,7 @@ public class CheckConsistencyIntegrationTest {
   public void notADirectory() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsDirectory);
-    ufs.deleteDirectory(ufsDirectory, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
     ufs.create(ufsDirectory).close();
     List<AlluxioURI> expected = Lists.newArrayList(DIRECTORY, FILE);
     List<AlluxioURI> result =

--- a/tests/src/test/java/alluxio/shell/command/CheckConsistencyCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CheckConsistencyCommandTest.java
@@ -47,7 +47,7 @@ public class CheckConsistencyCommandTest extends AbstractAlluxioShellTest {
         WriteType.CACHE_THROUGH, 20);
     String ufsPath = mFileSystem.getStatus(new AlluxioURI("/testRoot/testDir")).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsPath);
-    ufs.deleteDirectory(ufsPath, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(ufsPath, DeleteOptions.defaults().setRecursive(true));
     mFsShell.run("checkConsistency", "/testRoot");
     StringBuilder expected = new StringBuilder();
     expected.append("The following files are inconsistent:\n");

--- a/tests/src/test/java/alluxio/shell/command/CheckConsistencyCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/CheckConsistencyCommandTest.java
@@ -16,6 +16,7 @@ import alluxio.client.FileSystemTestUtils;
 import alluxio.client.WriteType;
 import alluxio.shell.AbstractAlluxioShellTest;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class CheckConsistencyCommandTest extends AbstractAlluxioShellTest {
         WriteType.CACHE_THROUGH, 20);
     String ufsPath = mFileSystem.getStatus(new AlluxioURI("/testRoot/testDir")).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.get(ufsPath);
-    ufs.delete(ufsPath, true);
+    ufs.deleteDirectory(ufsPath, new DeleteOptions().setRecursive(true));
     mFsShell.run("checkConsistency", "/testRoot");
     StringBuilder expected = new StringBuilder();
     expected.append("The following files are inconsistent:\n");

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.options.ListStatusOptions;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.LoadMetadataType;
@@ -99,7 +100,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
   public void deleteFile() throws IOException {
     String testFile = PathUtils.concatPath(mUnderfsAddress, "testFile");
     createEmptyFile(testFile);
-    mUfs.delete(testFile, false);
+    mUfs.deleteFile(testFile);
     Assert.assertFalse(mUfs.isFile(testFile));
   }
 
@@ -121,15 +122,15 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     mUfs.mkdirs(testDirNonEmptyChildDir, false);
     createEmptyFile(testDirNonEmptyChildFile);
     createEmptyFile(testDirNonEmptyChildDirFile);
-    mUfs.delete(testDirEmpty, false);
+    mUfs.deleteDirectory(testDirEmpty, new DeleteOptions().setRecursive(false));
     Assert.assertFalse(mUfs.isDirectory(testDirEmpty));
     try {
-      mUfs.delete(testDirNonEmpty, false);
+      mUfs.deleteDirectory(testDirNonEmpty, new DeleteOptions().setRecursive(false));
     } catch (IOException e) {
       // Some File systems may throw IOException
     }
     Assert.assertTrue(mUfs.isDirectory(testDirNonEmpty));
-    mUfs.delete(testDirNonEmpty, true);
+    mUfs.deleteDirectory(testDirNonEmpty, new DeleteOptions().setRecursive(true));
     Assert.assertFalse(mUfs.isDirectory(testDirNonEmpty));
     Assert.assertFalse(mUfs.isDirectory(testDirNonEmptyChildDir));
     Assert.assertFalse(mUfs.isFile(testDirNonEmptyChildFile));
@@ -142,7 +143,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
   @Test
   public void deleteLargeDirectory() throws IOException {
     LargeDirectoryConfig config = prepareLargeDirectoryTest();
-    mUfs.delete(config.getTopLevelDirectory(), true);
+    mUfs.deleteDirectory(config.getTopLevelDirectory(), new DeleteOptions().setRecursive(true));
 
     String[] children = config.getChildren();
     for (String child : children) {

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -122,15 +122,15 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     mUfs.mkdirs(testDirNonEmptyChildDir, false);
     createEmptyFile(testDirNonEmptyChildFile);
     createEmptyFile(testDirNonEmptyChildDirFile);
-    mUfs.deleteDirectory(testDirEmpty, new DeleteOptions().setRecursive(false));
+    mUfs.deleteDirectory(testDirEmpty, DeleteOptions.defaults().setRecursive(false));
     Assert.assertFalse(mUfs.isDirectory(testDirEmpty));
     try {
-      mUfs.deleteDirectory(testDirNonEmpty, new DeleteOptions().setRecursive(false));
+      mUfs.deleteDirectory(testDirNonEmpty, DeleteOptions.defaults().setRecursive(false));
     } catch (IOException e) {
       // Some File systems may throw IOException
     }
     Assert.assertTrue(mUfs.isDirectory(testDirNonEmpty));
-    mUfs.deleteDirectory(testDirNonEmpty, new DeleteOptions().setRecursive(true));
+    mUfs.deleteDirectory(testDirNonEmpty, DeleteOptions.defaults().setRecursive(true));
     Assert.assertFalse(mUfs.isDirectory(testDirNonEmpty));
     Assert.assertFalse(mUfs.isDirectory(testDirNonEmptyChildDir));
     Assert.assertFalse(mUfs.isFile(testDirNonEmptyChildFile));
@@ -143,7 +143,8 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
   @Test
   public void deleteLargeDirectory() throws IOException {
     LargeDirectoryConfig config = prepareLargeDirectoryTest();
-    mUfs.deleteDirectory(config.getTopLevelDirectory(), new DeleteOptions().setRecursive(true));
+    mUfs.deleteDirectory(config.getTopLevelDirectory(),
+        DeleteOptions.defaults().setRecursive(true));
 
     String[] children = config.getChildren();
     for (String child : children) {

--- a/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
@@ -67,7 +68,7 @@ public class GCSUnderStorageCluster extends UnderFileSystemCluster {
   public void shutdown() throws IOException {
     LOG.info("Shutting down GCS testing cluster, deleting bucket contents in: " + mGCSBucket);
     UnderFileSystem ufs = UnderFileSystem.get(mGCSBucket);
-    ufs.delete(mGCSBucket, true);
+    ufs.deleteDirectory(mGCSBucket, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
@@ -68,7 +68,7 @@ public class GCSUnderStorageCluster extends UnderFileSystemCluster {
   public void shutdown() throws IOException {
     LOG.info("Shutting down GCS testing cluster, deleting bucket contents in: " + mGCSBucket);
     UnderFileSystem ufs = UnderFileSystem.get(mGCSBucket);
-    ufs.deleteDirectory(mGCSBucket, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(mGCSBucket, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/underfs/oss/OSSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/oss/OSSUnderStorageCluster.java
@@ -34,7 +34,7 @@ public class OSSUnderStorageCluster extends UnderFileSystemCluster {
   @Override
   public void cleanup() throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir);
-    ufs.deleteDirectory(mBaseDir, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(mBaseDir, DeleteOptions.defaults().setRecursive(true));
     mBaseDir = PathUtils.concatPath(mOSSBucket, UUID.randomUUID());
   }
 

--- a/tests/src/test/java/alluxio/underfs/oss/OSSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/oss/OSSUnderStorageCluster.java
@@ -13,6 +13,7 @@ package alluxio.underfs.oss;
 
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.io.PathUtils;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ public class OSSUnderStorageCluster extends UnderFileSystemCluster {
   @Override
   public void cleanup() throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir);
-    ufs.delete(mBaseDir, true);
+    ufs.deleteDirectory(mBaseDir, new DeleteOptions().setRecursive(true));
     mBaseDir = PathUtils.concatPath(mOSSBucket, UUID.randomUUID());
   }
 

--- a/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
@@ -66,7 +67,7 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   public void shutdown() throws IOException {
     LOG.info("Shutting down S3 testing cluster, deleting bucket contents in: " + mS3Bucket);
     UnderFileSystem ufs = UnderFileSystem.get(mS3Bucket);
-    ufs.delete(mS3Bucket, true);
+    ufs.deleteDirectory(mS3Bucket, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
@@ -67,7 +67,7 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   public void shutdown() throws IOException {
     LOG.info("Shutting down S3 testing cluster, deleting bucket contents in: " + mS3Bucket);
     UnderFileSystem ufs = UnderFileSystem.get(mS3Bucket);
-    ufs.deleteDirectory(mS3Bucket, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(mS3Bucket, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/underfs/swift/SwiftUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/swift/SwiftUnderStorageCluster.java
@@ -14,6 +14,7 @@ package alluxio.underfs.swift;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
+import alluxio.underfs.options.DeleteOptions;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -66,7 +67,7 @@ public class SwiftUnderStorageCluster extends UnderFileSystemCluster {
     String oldDir = mBaseDir;
     mBaseDir = mSwiftContainer + UUID.randomUUID();
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir);
-    ufs.delete(oldDir, true);
+    ufs.deleteDirectory(oldDir, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/underfs/swift/SwiftUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/swift/SwiftUnderStorageCluster.java
@@ -67,7 +67,7 @@ public class SwiftUnderStorageCluster extends UnderFileSystemCluster {
     String oldDir = mBaseDir;
     mBaseDir = mSwiftContainer + UUID.randomUUID();
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir);
-    ufs.deleteDirectory(oldDir, new DeleteOptions().setRecursive(true));
+    ufs.deleteDirectory(oldDir, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -216,7 +216,7 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       return deleteInternal(convertToFolderName(path));
     }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -337,7 +337,7 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override
@@ -434,7 +434,7 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
+    return deleteDirectory(src, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -182,14 +182,14 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
   }
 
   @Override
-  public boolean delete(String path, boolean recursive) throws IOException {
-    if (!recursive) {
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    if (!options.getRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
       }
-      if (isDirectory(path) && children.length != 0) {
+      if (children.length != 0) {
         LOG.error("Unable to delete {} because it is a non empty directory. Specify "
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
@@ -209,6 +209,14 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
         return false;
       }
     }
+    if (!options.getChildrenOnly()) {
+      return deleteInternal(path);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
     return deleteInternal(path);
   }
 

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -217,11 +217,8 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      return deleteInternal(convertToFolderName(path));
-    }
-    return true;
+    // Delete the directory itself
+    return deleteInternal(convertToFolderName(path));
   }
 
   @Override

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -419,7 +420,7 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return delete(src, true);
+    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -183,7 +183,7 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
-    if (!options.getRecursive()) {
+    if (!options.isRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
@@ -194,22 +194,23 @@ public final class GCSUnderFileSystem extends UnderFileSystem {
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
       }
-      return deleteInternal(path);
-    }
-    // Get all relevant files
-    String[] pathsToDelete = listInternal(path, true);
-    if (pathsToDelete == null) {
-      LOG.error("Unable to delete {} because listInternal returns null", path);
-      return false;
-    }
-    for (String pathToDelete : pathsToDelete) {
-      // If we fail to deleteInternal one file, stop
-      if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
-        LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+    } else {
+      // Delete children
+      String[] pathsToDelete = listInternal(path, true);
+      if (pathsToDelete == null) {
+        LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
+      }
+      for (String pathToDelete : pathsToDelete) {
+        // If we fail to deleteInternal one file, stop
+        if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
+          LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+          return false;
+        }
       }
     }
     if (!options.getChildrenOnly()) {
+      // Delete the directory itself
       return deleteInternal(path);
     }
     return true;

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -12,6 +12,7 @@
 package alluxio.underfs.gcs;
 
 import alluxio.AlluxioURI;
+import alluxio.underfs.options.DeleteOptions;
 
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.impl.rest.httpclient.GoogleStorageService;
@@ -51,7 +52,7 @@ public class GCSUnderFileSystemTest {
   }
 
   /**
-   * Test case for {@link GCSUnderFileSystem#delete(String, boolean)}.
+   * Test case for {@link GCSUnderFileSystem#deleteDirectory(String, DeleteOptions)}.
    */
   @Test
   public void deleteNonRecursiveOnServiceException() throws IOException, ServiceException {
@@ -59,12 +60,13 @@ public class GCSUnderFileSystemTest {
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
-    boolean result = mGCSUnderFileSystem.delete(PATH, false);
+    boolean result = mGCSUnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(false));
     Assert.assertFalse(result);
   }
 
   /**
-   * Test case for {@link GCSUnderFileSystem#delete(String, boolean)}.
+   * Test case for {@link GCSUnderFileSystem#deleteDirectory(String, DeleteOptions)}.
    */
   @Test
   public void deleteRecursiveOnServiceException() throws IOException, ServiceException {
@@ -72,7 +74,8 @@ public class GCSUnderFileSystemTest {
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
-    boolean result = mGCSUnderFileSystem.delete(PATH, true);
+    boolean result = mGCSUnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -61,7 +61,7 @@ public class GCSUnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mGCSUnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(false));
+        DeleteOptions.defaults().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -75,7 +75,7 @@ public class GCSUnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mGCSUnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(true));
+        DeleteOptions.defaults().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -307,7 +307,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -22,7 +22,6 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
-import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Throwables;
 import org.apache.commons.lang3.StringUtils;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -152,7 +152,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
     if (options.isRecursive() && !options.getChildrenOnly()) {
-      return delete(path, true);
+      return isDirectory(path) && delete(path, true);
     }
     if (options.isRecursive()) {
       // Delete only children
@@ -174,13 +174,16 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
       }
       return true;
     }
-    // Delete the directory itself
-    return delete(path, false);
+    if (!options.getChildrenOnly()) {
+      // Delete the directory itself
+      return delete(path, false);
+    }
+    return true;
   }
 
   @Override
   public boolean deleteFile(String path) throws IOException {
-    return delete(path, false);
+    return isFile(path) && delete(path, false);
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -151,34 +151,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
-    if (options.isRecursive() && !options.isChildrenOnly()) {
-      return isDirectory(path) && delete(path, true);
-    }
-    if (options.isRecursive()) {
-      // Delete only children
-      FileStatus[] files = listStatus(path);
-      if (files == null) {
-        return false;
-      }
-      for (FileStatus childStatus : files) {
-        String childPath = PathUtils.concatPath(path, childStatus.getPath().getName());
-        boolean success;
-        if (childStatus.isDirectory()) {
-          success = deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
-        } else {
-          success = deleteFile(childPath);
-        }
-        if (!success) {
-          return false;
-        }
-      }
-      return true;
-    }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      return delete(path, false);
-    }
-    return true;
+    return isDirectory(path) && delete(path, options.isRecursive());
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -151,7 +151,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
-    if (options.isRecursive() && !options.getChildrenOnly()) {
+    if (options.isRecursive() && !options.isChildrenOnly()) {
       return isDirectory(path) && delete(path, true);
     }
     if (options.isRecursive()) {
@@ -174,7 +174,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
       }
       return true;
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       return delete(path, false);
     }

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -102,7 +102,8 @@ public class LocalUnderFileSystem extends UnderFileSystem {
         for (String child : files) {
           String childPath = PathUtils.concatPath(path, child);
           if (isDirectory(childPath)) {
-            success = success && deleteDirectory(childPath, DeleteOptions.defaults().setRecursive(true));
+            success = success && deleteDirectory(childPath,
+                DeleteOptions.defaults().setRecursive(true));
           } else {
             success = success && deleteFile(PathUtils.concatPath(path, child));
           }

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -109,10 +109,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      success = success && file.delete();
-    }
-    return success;
+    return success && file.delete();
   }
 
   @Override

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -102,7 +102,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
         for (String child : files) {
           String childPath = PathUtils.concatPath(path, child);
           if (isDirectory(childPath)) {
-            success = success && deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
+            success = success && deleteDirectory(childPath, DeleteOptions.defaults().setRecursive(true));
           } else {
             success = success && deleteFile(PathUtils.concatPath(path, child));
           }
@@ -209,7 +209,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -89,6 +89,9 @@ public class LocalUnderFileSystem extends UnderFileSystem {
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
     path = stripPath(path);
     File file = new File(path);
+    if (!file.isDirectory()) {
+      return false;
+    }
     boolean success = true;
     if (options.isRecursive()) {
       String[] files = file.list();
@@ -116,7 +119,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
   public boolean deleteFile(String path) throws IOException {
     path = stripPath(path);
     File file = new File(path);
-    return file.delete();
+    return file.isFile() && file.delete();
   }
 
   @Override

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -90,11 +90,12 @@ public class LocalUnderFileSystem extends UnderFileSystem {
     path = stripPath(path);
     File file = new File(path);
     boolean success = true;
-    if (options.getRecursive()) {
+    if (options.isRecursive()) {
       String[] files = file.list();
+
+      // File.list() will return null if an I/O error occurs.
+      // e.g.: Reading an non-readable directory
       if (files != null) {
-        // File.list() will return null if an I/O error occurs.
-        // e.g.: Reading an non-readable directory
         for (String child : files) {
           String childPath = PathUtils.concatPath(path, child);
           if (isDirectory(childPath)) {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -92,17 +92,16 @@ public class LocalUnderFileSystem extends UnderFileSystem {
     boolean success = true;
     if (options.getRecursive()) {
       String[] files = file.list();
-      if (files == null) {
-        return false;
-      }
-      // File.list() will return null if an I/O error occurs.
-      // e.g.: Reading an non-readable directory
-      for (String child : files) {
-        String childPath = PathUtils.concatPath(path, child);
-        if (isDirectory(childPath)) {
-          success = success && deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
-        } else {
-          success = success && deleteFile(PathUtils.concatPath(path, child));
+      if (files != null) {
+        // File.list() will return null if an I/O error occurs.
+        // e.g.: Reading an non-readable directory
+        for (String child : files) {
+          String childPath = PathUtils.concatPath(path, child);
+          if (isDirectory(childPath)) {
+            success = success && deleteDirectory(childPath, new DeleteOptions().setRecursive(true));
+          } else {
+            success = success && deleteFile(PathUtils.concatPath(path, child));
+          }
         }
       }
     }

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -109,7 +109,7 @@ public class LocalUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       success = success && file.delete();
     }
     return success;

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -89,7 +89,7 @@ public class LocalUnderFileSystemTest {
     mLocalUfs.mkdirs(dirpath, true);
     String filepath = PathUtils.concatPath(dirpath, getUniqueFileName());
     mLocalUfs.create(filepath).close();
-    mLocalUfs.deleteDirectory(dirpath, new DeleteOptions().setRecursive(true));
+    mLocalUfs.deleteDirectory(dirpath, DeleteOptions.defaults().setRecursive(true));
 
     Assert.assertFalse(mLocalUfs.isDirectory(dirpath));
 
@@ -103,7 +103,7 @@ public class LocalUnderFileSystemTest {
     mLocalUfs.mkdirs(dirpath, true);
     String filepath = PathUtils.concatPath(dirpath, getUniqueFileName());
     mLocalUfs.create(filepath).close();
-    mLocalUfs.deleteDirectory(dirpath, new DeleteOptions().setRecursive(false));
+    mLocalUfs.deleteDirectory(dirpath, DeleteOptions.defaults().setRecursive(false));
 
     Assert.assertTrue(mLocalUfs.isDirectory(dirpath));
 

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -12,6 +12,7 @@
 package alluxio.underfs.local;
 
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
@@ -50,7 +51,7 @@ public class LocalUnderFileSystemTest {
 
     Assert.assertTrue(mLocalUfs.isFile(filepath));
 
-    mLocalUfs.delete(filepath, true);
+    mLocalUfs.deleteFile(filepath);
 
     Assert.assertFalse(mLocalUfs.isFile(filepath));
   }
@@ -71,10 +72,10 @@ public class LocalUnderFileSystemTest {
   }
 
   @Test
-  public void delete() throws IOException {
+  public void deleteFile() throws IOException {
     String filepath = PathUtils.concatPath(mLocalUfsRoot, getUniqueFileName());
     mLocalUfs.create(filepath).close();
-    mLocalUfs.delete(filepath, true);
+    mLocalUfs.deleteFile(filepath);
 
     Assert.assertFalse(mLocalUfs.isFile(filepath));
 
@@ -88,7 +89,7 @@ public class LocalUnderFileSystemTest {
     mLocalUfs.mkdirs(dirpath, true);
     String filepath = PathUtils.concatPath(dirpath, getUniqueFileName());
     mLocalUfs.create(filepath).close();
-    mLocalUfs.delete(dirpath, true);
+    mLocalUfs.deleteDirectory(dirpath, new DeleteOptions().setRecursive(true));
 
     Assert.assertFalse(mLocalUfs.isDirectory(dirpath));
 
@@ -102,7 +103,7 @@ public class LocalUnderFileSystemTest {
     mLocalUfs.mkdirs(dirpath, true);
     String filepath = PathUtils.concatPath(dirpath, getUniqueFileName());
     mLocalUfs.create(filepath).close();
-    mLocalUfs.delete(dirpath, false);
+    mLocalUfs.deleteDirectory(dirpath, new DeleteOptions().setRecursive(false));
 
     Assert.assertTrue(mLocalUfs.isDirectory(dirpath));
 

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -145,7 +145,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
-    if (!options.getRecursive()) {
+    if (!options.isRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
@@ -156,22 +156,23 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
       }
-      return deleteInternal(path);
-    }
-    // Get all relevant files
-    String[] pathsToDelete = listInternal(path, true);
-    if (pathsToDelete == null) {
-      LOG.error("Unable to delete {} because listInternal returns null", path);
-      return false;
-    }
-    for (String pathToDelete : pathsToDelete) {
-      // If we fail to deleteInternal one file, stop
-      if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
-        LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+    } else {
+      // Delete children
+      String[] pathsToDelete = listInternal(path, true);
+      if (pathsToDelete == null) {
+        LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
+      }
+      for (String pathToDelete : pathsToDelete) {
+        // If we fail to deleteInternal one file, stop
+        if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
+          LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+          return false;
+        }
       }
     }
     if (!options.getChildrenOnly()) {
+      // Delete the directory itself
       return deleteInternal(path);
     }
     return true;

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -171,11 +171,8 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      return deleteInternal(path);
-    }
-    return true;
+    // Delete the directory itself
+    return deleteInternal(path);
   }
 
   @Override

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -171,7 +171,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       return deleteInternal(path);
     }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -368,7 +369,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return delete(src, true);
+    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -295,7 +295,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
 
   }
 
@@ -375,7 +375,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
+    return deleteDirectory(src, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -144,14 +144,14 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
   }
 
   @Override
-  public boolean delete(String path, boolean recursive) throws IOException {
-    if (!recursive) {
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    if (!options.getRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
       }
-      if (isDirectory(path) && children.length != 0) {
+      if (children.length != 0) {
         LOG.error("Unable to delete {} because it is a non empty directory. Specify "
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
@@ -171,6 +171,14 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
         return false;
       }
     }
+    if (!options.getChildrenOnly()) {
+      return deleteInternal(path);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
     return deleteInternal(path);
   }
 

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -60,7 +60,7 @@ public class OSSUnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mOSSUnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(false));
+        DeleteOptions.defaults().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -73,7 +73,7 @@ public class OSSUnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mOSSUnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(true));
+        DeleteOptions.defaults().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -12,6 +12,7 @@
 package alluxio.underfs.oss;
 
 import alluxio.AlluxioURI;
+import alluxio.underfs.options.DeleteOptions;
 
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.ServiceException;
@@ -51,26 +52,28 @@ public class OSSUnderFileSystemTest {
   }
 
   /**
-   * Test case for {@link OSSUnderFileSystem#delete(String, boolean)}.
+   * Test case for {@link OSSUnderFileSystem#deleteDirectory(String, DeleteOptions)}.
    */
   @Test
   public void deleteNonRecursiveOnServiceException() throws IOException {
     Mockito.when(mClient.listObjects(Matchers.any(ListObjectsRequest.class)))
         .thenThrow(ServiceException.class);
 
-    boolean result = mOSSUnderFileSystem.delete(PATH, false);
+    boolean result = mOSSUnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(false));
     Assert.assertFalse(result);
   }
 
   /**
-   * Test case for {@link OSSUnderFileSystem#delete(String, boolean)}.
+   * Test case for {@link OSSUnderFileSystem#deleteDirectory(String, DeleteOptions)}.
    */
   @Test
   public void deleteRecursiveOnServiceException() throws IOException {
     Mockito.when(mClient.listObjects(Matchers.any(ListObjectsRequest.class)))
         .thenThrow(ServiceException.class);
 
-    boolean result = mOSSUnderFileSystem.delete(PATH, true);
+    boolean result = mOSSUnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -251,11 +251,8 @@ public final class S3UnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      return deleteInternal(path);
-    }
-    return true;
+    // Delete the directory itself
+    return deleteInternal(path);
   }
 
   @Override

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -251,7 +251,7 @@ public final class S3UnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       return deleteInternal(path);
     }

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -463,7 +464,7 @@ public final class S3UnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return delete(src, true);
+    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -373,7 +373,7 @@ public final class S3UnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override
@@ -470,7 +470,7 @@ public final class S3UnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
+    return deleteDirectory(src, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -224,14 +224,14 @@ public final class S3UnderFileSystem extends UnderFileSystem {
   }
 
   @Override
-  public boolean delete(String path, boolean recursive) throws IOException {
-    if (!recursive) {
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    if (!options.getRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
       }
-      if (isDirectory(path) && children.length != 0) {
+      if (children.length != 0) {
         LOG.error("Unable to delete {} because it is a non empty directory. Specify "
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
@@ -251,6 +251,14 @@ public final class S3UnderFileSystem extends UnderFileSystem {
         return false;
       }
     }
+    if (!options.getChildrenOnly()) {
+      return deleteInternal(path);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
     return deleteInternal(path);
   }
 

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UnderFileSystemTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UnderFileSystemTest.java
@@ -12,6 +12,7 @@
 package alluxio.underfs.s3;
 
 import alluxio.AlluxioURI;
+import alluxio.underfs.options.DeleteOptions;
 
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
@@ -60,7 +61,8 @@ public class S3UnderFileSystemTest {
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
-    boolean result = mS3UnderFileSystem.delete(PATH, false);
+    boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -73,7 +75,8 @@ public class S3UnderFileSystemTest {
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
-    boolean result = mS3UnderFileSystem.delete(PATH, true);
+    boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/s3/src/test/java/alluxio/underfs/s3/S3UnderFileSystemTest.java
+++ b/underfs/s3/src/test/java/alluxio/underfs/s3/S3UnderFileSystemTest.java
@@ -62,7 +62,7 @@ public class S3UnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(false));
+        DeleteOptions.defaults().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -76,7 +76,7 @@ public class S3UnderFileSystemTest {
         .thenThrow(ServiceException.class);
 
     boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(true));
+        DeleteOptions.defaults().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -278,7 +278,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       return deleteInternal(path);
     }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -251,14 +251,14 @@ public class S3AUnderFileSystem extends UnderFileSystem {
   }
 
   @Override
-  public boolean delete(String path, boolean recursive) throws IOException {
-    if (!recursive) {
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    if (!options.getRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
       }
-      if (isDirectory(path) && children.length != 0) {
+      if (children.length != 0) {
         LOG.error("Unable to delete {} because it is a non empty directory. Specify "
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
@@ -278,6 +278,14 @@ public class S3AUnderFileSystem extends UnderFileSystem {
         return false;
       }
     }
+    if (!options.getChildrenOnly()) {
+      return deleteInternal(path);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
     return deleteInternal(path);
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -469,7 +470,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return delete(src, true);
+    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
   }
 
   @Override

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -380,7 +380,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override
@@ -477,7 +477,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
+    return deleteDirectory(src, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -252,7 +252,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
-    if (!options.getRecursive()) {
+    if (!options.isRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
@@ -263,22 +263,23 @@ public class S3AUnderFileSystem extends UnderFileSystem {
                 + "recursive as true in order to delete non empty directories.", path);
         return false;
       }
-      return deleteInternal(path);
-    }
-    // Get all relevant files
-    String[] pathsToDelete = listInternal(path, true);
-    if (pathsToDelete == null) {
-      LOG.error("Unable to delete {} because listInternal returns null", path);
-      return false;
-    }
-    for (String pathToDelete : pathsToDelete) {
-      // If we fail to deleteInternal one file, stop
-      if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
-        LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+    } else {
+      // Delete children
+      String[] pathsToDelete = listInternal(path, true);
+      if (pathsToDelete == null) {
+        LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
+      }
+      for (String pathToDelete : pathsToDelete) {
+        // If we fail to deleteInternal one file, stop
+        if (!deleteInternal(PathUtils.concatPath(path, pathToDelete))) {
+          LOG.error("Failed to delete path {}, aborting delete.", pathToDelete);
+          return false;
+        }
       }
     }
     if (!options.getChildrenOnly()) {
+      // Delete the directory itself
       return deleteInternal(path);
     }
     return true;

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -252,6 +252,7 @@ public class S3AUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    // TODO(adit): use bulk delete API
     if (!options.isRecursive()) {
       String[] children = listInternal(path, false);
       if (children == null) {

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -279,11 +279,8 @@ public class S3AUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      return deleteInternal(path);
-    }
-    return true;
+    // Delete the directory itself
+    return deleteInternal(path);
   }
 
   @Override

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -63,7 +63,7 @@ public class S3AUnderFileSystemTest {
         .thenThrow(AmazonClientException.class);
 
     boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(false));
+        DeleteOptions.defaults().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -76,7 +76,7 @@ public class S3AUnderFileSystemTest {
         .thenThrow(AmazonClientException.class);
 
     boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
-        new DeleteOptions().setRecursive(true));
+        DeleteOptions.defaults().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -12,6 +12,7 @@
 package alluxio.underfs.s3a;
 
 import alluxio.AlluxioURI;
+import alluxio.underfs.options.DeleteOptions;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -61,7 +62,8 @@ public class S3AUnderFileSystemTest {
     Mockito.when(mClient.listObjectsV2(Matchers.any(ListObjectsV2Request.class)))
         .thenThrow(AmazonClientException.class);
 
-    boolean result = mS3UnderFileSystem.delete(PATH, false);
+    boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(false));
     Assert.assertFalse(result);
   }
 
@@ -73,7 +75,8 @@ public class S3AUnderFileSystemTest {
     Mockito.when(mClient.listObjectsV2(Matchers.any(ListObjectsV2Request.class)))
         .thenThrow(AmazonClientException.class);
 
-    boolean result = mS3UnderFileSystem.delete(PATH, true);
+    boolean result = mS3UnderFileSystem.deleteDirectory(PATH,
+        new DeleteOptions().setRecursive(true));
     Assert.assertFalse(result);
   }
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -253,7 +253,6 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       }
     }
     boolean foundSelf = false;
-    // For a file, recursive delete will not find any children
     PaginationMap paginationMap = container.getPaginationMap(
         PathUtils.normalizePath(strippedPath, PATH_SEPARATOR), LISTING_LENGTH);
     for (int page = 0; page < paginationMap.getNumberOfPages(); page++) {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -265,7 +265,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.getChildrenOnly()) {
+    if (!options.isChildrenOnly()) {
       // Delete the directory itself
       String strippedFolderPath = addFolderSuffixIfNotPresent(strippedPath);
       return deleteObject(container.getObject(strippedFolderPath));

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -237,6 +237,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    // TODO(adit): use bulk delete API
     LOG.debug("Delete directory {}, recursive {}", path, options.isRecursive());
     final String strippedPath = stripContainerPrefixIfPresent(path);
     Container container = mAccount.getContainer(mContainerName);

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.swift.http.SwiftDirectClient;
 import alluxio.util.CommonUtils;
@@ -500,7 +501,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return delete(src, true);
+    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
   }
 
   @Override
@@ -516,7 +517,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
     }
     String strippedSourcePath = stripContainerPrefixIfPresent(src);
     String strippedDestinationPath = stripContainerPrefixIfPresent(dst);
-    return copy(strippedSourcePath, strippedDestinationPath) && delete(src, false);
+    return copy(strippedSourcePath, strippedDestinationPath) && deleteFile(src);
   }
 
   @Override

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -266,12 +266,9 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
         }
       }
     }
-    if (!options.isChildrenOnly()) {
-      // Delete the directory itself
-      String strippedFolderPath = addFolderSuffixIfNotPresent(strippedPath);
-      return deleteObject(container.getObject(strippedFolderPath));
-    }
-    return true;
+    // Delete the directory itself
+    String strippedFolderPath = addFolderSuffixIfNotPresent(strippedPath);
+    return deleteObject(container.getObject(strippedFolderPath));
   }
 
   @Override

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -361,7 +361,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean mkdirs(String path, boolean createParent) throws IOException {
-    return mkdirs(path, new MkdirsOptions().setCreateParent(createParent));
+    return mkdirs(path, MkdirsOptions.defaults().setCreateParent(createParent));
   }
 
   @Override
@@ -502,7 +502,7 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
       }
     }
     // Delete src and everything under src
-    return deleteDirectory(src, new DeleteOptions().setRecursive(true));
+    return deleteDirectory(src, DeleteOptions.defaults().setRecursive(true));
   }
 
   @Override


### PR DESCRIPTION
Part 3 of UFS refactoring.
- For the UFS.delete call, Alluxio indicates whether the path it is operating on should be a file or a directory.
- GCSUnderFileSystem avoids certain additional RPCs using a new nested class UnderFileStatus to store whether the listing item is a file or a directory. TODO: This will be replicated in other object stores after abstraction in a follow up PR.

JIRA: https://alluxio.atlassian.net/browse/ALLUXIO-2416