### PR TITLE
[SMALLFIX] Fix Permission when listStatus in AbstractFileSystem

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -19,7 +19,6 @@ import alluxio.client.ClientContext;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.CreateDirectoryOptions;
 import alluxio.client.file.options.CreateFileOptions;
@@ -93,11 +92,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     }
     AlluxioURI uri = new AlluxioURI(HadoopUtils.getPathWithoutScheme(path));
     try {
-      if (!sFileSystem.exists(uri)) {
-        return new FSDataOutputStream(sFileSystem.createFile(uri), mStatistics);
-      } else {
+      if (sFileSystem.exists(uri)) {
         throw new IOException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(uri));
       }
+      return new FSDataOutputStream(sFileSystem.createFile(uri), mStatistics);
     } catch (AlluxioException e) {
       throw new IOException(e);
     }
@@ -185,7 +183,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
           throws IOException {
     AlluxioURI parentUri = new AlluxioURI(HadoopUtils.getPathWithoutScheme(path.getParent()));
     ensureExists(parentUri);
-    return this.create(path, permission, overwrite, bufferSize, replication, blockSize, progress);
+    return create(path, permission, overwrite, bufferSize, replication, blockSize, progress);
   }
 
   /**
@@ -301,8 +299,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
     return new FileStatus(fileStatus.getLength(), fileStatus.isFolder(),
         BLOCK_REPLICATION_CONSTANT, fileStatus.getBlockSizeBytes(), fileStatus.getCreationTimeMs(),
-            fileStatus.getCreationTimeMs(), new FsPermission((short) fileStatus.getMode()),
-            fileStatus.getOwner(), fileStatus.getGroup(), new Path(mAlluxioHeader + uri));
+        fileStatus.getCreationTimeMs(), new FsPermission((short) fileStatus.getMode()),
+        fileStatus.getOwner(), fileStatus.getGroup(), new Path(mAlluxioHeader + uri));
   }
 
   /**
@@ -463,9 +461,9 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     FileStatus[] ret = new FileStatus[statuses.size()];
     for (int k = 0; k < statuses.size(); k++) {
       URIStatus status = statuses.get(k);
-      // TODO(hy): Replicate 3 with the number of disk replications.
-      ret[k] = new FileStatus(status.getLength(), status.isFolder(), 3, status.getBlockSizeBytes(),
-          status.getCreationTimeMs(), status.getCreationTimeMs(), null, null, null,
+      ret[k] = new FileStatus(status.getLength(), status.isFolder(), BLOCK_REPLICATION_CONSTANT,
+          status.getBlockSizeBytes(), status.getCreationTimeMs(), status.getCreationTimeMs(),
+          new FsPermission((short) status.getMode()), status.getOwner(), status.getGroup(),
           new Path(mAlluxioHeader + status.getPath()));
     }
     return ret;
@@ -571,13 +569,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   }
 
   private List<FileBlockInfo> getFileBlocks(AlluxioURI path) throws IOException {
-    FileSystemMasterClient master = FileSystemContext.INSTANCE.acquireMasterClient();
     try {
-      return master.getStatus(path).getFileBlockInfos();
+      return sFileSystem.getStatus(path).getFileBlockInfos();
     } catch (AlluxioException e) {
       throw new IOException(e);
-    } finally {
-      FileSystemContext.INSTANCE.releaseMasterClient(master);
     }
   }
 }


### PR DESCRIPTION

- Fix a bug in `listStatus` that Alluxio Hadoop API does not return correct mode/user/group
- some cleanup
  
To test,   run `bin/hadoop fs -ls alluxio://localhost:19998/aaa`
before
```bash
-rw-rw-rw-   3          0 2016-11-19 17:13 alluxio://localhost:19998/aaa/bbb
-rw-rw-rw-   3          0 2016-11-19 17:13 alluxio://localhost:19998/aaa/ccc
```

after
```bash
-rw-r--r--   3 binfan staff          0 2016-11-19 17:13 alluxio://localhost:19998/aaa/bbb
-rw-r--r--   3 binfan staff          0 2016-11-19 17:13 alluxio://localhost:19998/aaa/ccc
```