### PR TITLE
[SMALLFIX] Fix Yarn home for EMR users

### DIFF
--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -38,7 +38,7 @@ else
 fi
 
 if [[ -z "$YARN_HOME" ]]; then
-  echo "\$YARN_HOME is unset, will use \$HADOOP_HOME instead." >&2
+  echo "\$YARN_HOME is unset, will use \$HADOOP_HOME instead."
 fi
 YARN_HOME=${YARN_HOME:-${HADOOP_HOME}}
 

--- a/integration/bin/alluxio-yarn.sh
+++ b/integration/bin/alluxio-yarn.sh
@@ -37,6 +37,11 @@ else
   echo "Using \$HADOOP_HOME set to '$HADOOP_HOME'"
 fi
 
+if [[ -z "$YARN_HOME" ]]; then
+  echo "\$YARN_HOME is unset, will use \$HADOOP_HOME instead." >&2
+fi
+YARN_HOME=${YARN_HOME:-${HADOOP_HOME}}
+
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
 ALLUXIO_HOME="$(cd "${SCRIPT_DIR}/../.."; pwd)"
 
@@ -72,7 +77,7 @@ echo "Starting YARN client to launch Alluxio on YARN"
 ALLUXIO_JAVA_OPTS="${ALLUXIO_JAVA_OPTS} -Dalluxio.logger.type=Console"
 export YARN_OPTS="${YARN_OPTS:-${ALLUXIO_JAVA_OPTS}}"
 
-${HADOOP_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \
+${YARN_HOME}/bin/yarn jar ${JAR_LOCAL} alluxio.yarn.Client \
     -num_workers $NUM_WORKERS \
     -master_address ${MASTER_ADDRESS} \
     -resource_path ${HDFS_PATH}


### PR DESCRIPTION
Adding the ability to override the location Yarn by setting the environment variable $YARN_HOME. On AWS EMR, Hadoop and Yarn reside in separate locations; this fixes that issue.