### PR TITLE
[ALLUXIO-2416] Consistent use of options idiom

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -45,12 +45,12 @@ public class AtomicFileOutputStream extends OutputStream {
    * Constructs a new {@link AtomicFileOutputStream}.
    *
    * @param path path being written to
-   * @param options create options for destination file
    * @param ufs the calling {@link UnderFileSystem}
+   * @param options create options for destination file
    * @throws IOException when a non Alluxio error occurs
    */
-  public AtomicFileOutputStream(String path, CreateOptions options,
-      AtomicFileOutputStreamCallback ufs) throws IOException {
+  public AtomicFileOutputStream(String path, AtomicFileOutputStreamCallback ufs,
+      CreateOptions options) throws IOException {
     mOptions = options;
     mPermanentPath = path;
     mTemporaryPath = PathUtils.temporaryFileName(IdUtils.getRandomNonNegativeLong(), path);

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class AtomicFileOutputStream extends OutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  private UnderFileSystem mUfs;
+  private AtomicFileOutputStreamCallback mUfs;
   private CreateOptions mOptions;
   private String mPermanentPath;
   private String mTemporaryPath;
@@ -49,8 +49,8 @@ public class AtomicFileOutputStream extends OutputStream {
    * @param ufs the calling {@link UnderFileSystem}
    * @throws IOException when a non Alluxio error occurs
    */
-  public AtomicFileOutputStream(String path, CreateOptions options, UnderFileSystem ufs)
-      throws IOException {
+  public AtomicFileOutputStream(String path, CreateOptions options,
+      AtomicFileOutputStreamCallback ufs) throws IOException {
     mOptions = options;
     mPermanentPath = path;
     mTemporaryPath = PathUtils.temporaryFileName(IdUtils.getRandomNonNegativeLong(), path);

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStreamCallback.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStreamCallback.java
@@ -1,0 +1,35 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.underfs.options.CreateOptions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A {@link AtomicFileOutputStreamCallback} is the callback interface used when using a
+ * {@link AtomicFileOutputStream}.
+ */
+public interface AtomicFileOutputStreamCallback extends UnderFileSystem {
+  /**
+   * Creates a file in the under file system with the specified {@link CreateOptions}. This stream
+   * writes directly to the underlying storage without any atomicity guarantees.
+   *
+   * @param path the file name
+   * @param options the options for create
+   * @return A {@code OutputStream} object
+   * @throws IOException if a non-Alluxio error occurs
+   */
+  OutputStream createDirect(String path, CreateOptions options) throws IOException;
+}
+

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -14,6 +14,7 @@ package alluxio.underfs;
 import alluxio.AlluxioURI;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.io.PathUtils;
 
@@ -78,7 +79,10 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UnderFileStatus[] listRecursive(String path) throws IOException {
+  public UnderFileStatus[] listStatus(String path, ListOptions options) throws IOException {
+    if (!options.isRecursive()) {
+      return listStatus(path);
+    }
     // Clean the path by creating a URI and turning it back to a string
     AlluxioURI uri = new AlluxioURI(path);
     path = uri.toString();

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -85,12 +85,12 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
     List<String> returnPaths = new ArrayList<>();
     Queue<String> pathsToProcess = new ArrayDeque<>();
     // We call list initially, so we can return null if the path doesn't denote a directory
-    String[] subpaths = list(path);
+    UnderFileStatus[] subpaths = list(path);
     if (subpaths == null) {
       return null;
     } else {
-      for (String subp : subpaths) {
-        pathsToProcess.add(PathUtils.concatPath(path, subp));
+      for (UnderFileStatus subp : subpaths) {
+        pathsToProcess.add(PathUtils.concatPath(path, subp.getName()));
       }
     }
     while (!pathsToProcess.isEmpty()) {
@@ -99,8 +99,8 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
       // Add all of its subpaths
       subpaths = list(p);
       if (subpaths != null) {
-        for (String subp : subpaths) {
-          pathsToProcess.add(PathUtils.concatPath(p, subp));
+        for (UnderFileStatus subp : subpaths) {
+          pathsToProcess.add(PathUtils.concatPath(p, subp.getName()));
         }
       }
     }

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -66,11 +66,6 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream create(String path, CreateOptions options) throws IOException {
-    return new AtomicFileOutputStream(path, options, this);
-  }
-
-  @Override
   public boolean deleteDirectory(String path) throws IOException {
     return deleteDirectory(path, DeleteOptions.defaults());
   }

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -85,7 +85,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
     List<String> returnPaths = new ArrayList<>();
     Queue<String> pathsToProcess = new ArrayDeque<>();
     // We call list initially, so we can return null if the path doesn't denote a directory
-    UnderFileStatus[] subpaths = list(path);
+    UnderFileStatus[] subpaths = listStatus(path);
     if (subpaths == null) {
       return null;
     } else {
@@ -97,7 +97,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
       String p = pathsToProcess.remove();
       returnPaths.add(p.substring(path.length() + 1));
       // Add all of its subpaths
-      subpaths = list(p);
+      subpaths = listStatus(p);
       if (subpaths != null) {
         for (UnderFileStatus subp : subpaths) {
           pathsToProcess.add(PathUtils.concatPath(p, subp.getName()));

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -16,11 +16,13 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -115,6 +117,11 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
       }
     }
     return returnPaths.toArray(new UnderFileStatus[returnPaths.size()]);
+  }
+
+  @Override
+  public InputStream open(String path) throws IOException {
+    return open(path, OpenOptions.defaults());
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -141,11 +141,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public OutputStream create(String path, CreateOptions options) throws IOException {
-    return createDirect(path, options);
-  }
-
-  @Override
-  public OutputStream createDirect(String path, CreateOptions options) throws IOException {
     if (mkdirs(getParentPath(path))) {
       return createObject(stripPrefixIfPresent(path));
     }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -20,6 +20,7 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
@@ -312,8 +313,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public InputStream open(String path) throws IOException {
-    return openObject(stripPrefixIfPresent(path));
+  public InputStream open(String path, OpenOptions options) throws IOException {
+    return openObject(stripPrefixIfPresent(path), options);
   }
 
   @Override
@@ -625,7 +626,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param key the key to open
    * @return true if successful, false if an exception is thrown
    */
-  protected abstract InputStream openObject(String key) throws IOException;
+  protected abstract InputStream openObject(String key, OpenOptions options) throws IOException;
 
   /**
    * Treating the object store as a file system, checks if the parent directory exists.
@@ -651,7 +652,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param path the path to strip
    * @return the path without the bucket prefix
    */
-  protected String stripPrefixIfPresent(String path) {
+  private String stripPrefixIfPresent(String path) {
     String stripedKey = CommonUtils.stripPrefixIfPresent(path,
         PathUtils.normalizePath(getRootKey(), PATH_SEPARATOR));
     if (!stripedKey.equals(path)) {

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -272,8 +272,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public String[] list(String path) throws IOException {
-    return UnderFileStatus.toListingResult(listInternal(path, false));
+  public UnderFileStatus[] list(String path) throws IOException {
+    return listInternal(path, false);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -308,6 +309,11 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       // Recursively make the parent folders
       return mkdirs(parentKey) && mkdirsInternal(path);
     }
+  }
+
+  @Override
+  public InputStream open(String path) throws IOException {
+    return openObject(stripPrefixIfPresent(path));
   }
 
   @Override
@@ -612,6 +618,14 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   protected boolean mkdirsInternal(String key) {
     return createEmptyObject(convertToFolderName(stripPrefixIfPresent(key)));
   }
+
+  /**
+   * Internal function to open an input stream to an object.
+   *
+   * @param key the key to open
+   * @return true if successful, false if an exception is thrown
+   */
+  protected abstract InputStream openObject(String key) throws IOException;
 
   /**
    * Treating the object store as a file system, checks if the parent directory exists.

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -267,8 +267,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public String[] listRecursive(String path) throws IOException {
-    return UnderFileStatus.toListingResult(listInternal(path, true));
+  public UnderFileStatus[] listRecursive(String path) throws IOException {
+    return listInternal(path, true);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -155,7 +155,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   @Override
   public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
     if (!options.isRecursive()) {
-      UnderFileStatus[] children = listInternal(path, false);
+      UnderFileStatus[] children = listInternal(path, ListOptions.defaults());
       if (children == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
@@ -167,7 +167,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       }
     } else {
       // Delete children
-      UnderFileStatus[] pathsToDelete = listInternal(path, true);
+      UnderFileStatus[] pathsToDelete =
+          listInternal(path, ListOptions.defaults().setRecursive(true));
       if (pathsToDelete == null) {
         LOG.error("Unable to delete {} because listInternal returns null", path);
         return false;
@@ -266,13 +267,13 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public UnderFileStatus[] listStatus(String path) throws IOException {
-    return listInternal(path, false);
+    return listInternal(path, ListOptions.defaults());
   }
 
   @Override
   public UnderFileStatus[] listStatus(String path, ListOptions options)
       throws IOException {
-    return listInternal(path, options.isRecursive());
+    return listInternal(path, options);
   }
 
   @Override
@@ -314,7 +315,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public boolean renameDirectory(String src, String dst) throws IOException {
-    UnderFileStatus[] children = listInternal(src, false);
+    UnderFileStatus[] children = listInternal(src, ListOptions.defaults());
     if (children == null) {
       LOG.error("Failed to list directory {}, aborting rename.", src);
       return false;
@@ -532,11 +533,11 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * folder suffix. Note that, the list results are unsorted.
    *
    * @param path the key to list
-   * @param recursive if true will list children directories as well
+   * @param options for listing
    * @return an array of the file and folder names in this directory
    * @throws IOException if an I/O error occurs
    */
-  protected UnderFileStatus[] listInternal(String path, boolean recursive) throws IOException {
+  protected UnderFileStatus[] listInternal(String path, ListOptions options) throws IOException {
     // if the path not exists, or it is a file, then should return null
     if (!isDirectory(path)) {
       return null;
@@ -545,7 +546,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     path = PathUtils.normalizePath(path, PATH_SEPARATOR);
     path = path.equals(PATH_SEPARATOR) ? "" : path;
     Map<String, Boolean> children = new HashMap<>();
-    ObjectListingResult chunk = getObjectListing(path, recursive);
+    ObjectListingResult chunk = getObjectListing(path, options.isRecursive());
     if (chunk == null) {
       return null;
     }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -272,7 +272,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UnderFileStatus[] list(String path) throws IOException {
+  public UnderFileStatus[] listStatus(String path) throws IOException {
     return listInternal(path, false);
   }
 

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -18,6 +18,7 @@ import alluxio.PropertyKey;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -267,13 +268,14 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UnderFileStatus[] listRecursive(String path) throws IOException {
-    return listInternal(path, true);
+  public UnderFileStatus[] listStatus(String path) throws IOException {
+    return listInternal(path, false);
   }
 
   @Override
-  public UnderFileStatus[] listStatus(String path) throws IOException {
-    return listInternal(path, false);
+  public UnderFileStatus[] listStatus(String path, ListOptions options)
+      throws IOException {
+    return listInternal(path, options.isRecursive());
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileStatus.java
@@ -62,10 +62,10 @@ public class UnderFileStatus {
    * Convert an array of UFS file status to a listing result where each element in the array is
    * a file or directory name.
    *
-   * @param children array of internal listing
+   * @param children array of listing statuses
    * @return array of file or directory names
    */
-  public static String[] toListingResult(UnderFileStatus[] children) {
+  public static String[] convertToNames(UnderFileStatus[] children) {
     if (children == null) {
       return null;
     }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 
 import com.google.common.base.Objects;
@@ -443,25 +444,26 @@ public interface UnderFileSystem {
 
   /**
    * Returns an array of statuses of the files and directories in the directory denoted by this
-   * abstract pathname, and all of its subdirectories.
+   * abstract pathname, with options.
    *
    * <p>
    * If this abstract pathname does not denote a directory, then this method returns {@code null}.
-   * Otherwise an array of statuses is returned, one for each file or directory in the directory and
-   * its subdirectories. Names denoting the directory itself and the directory's parent directory
-   * are not included in the result. Each string is a path relative to the given directory.
+   * Otherwise an array of statuses is returned, one for each file or directory. Names denoting the
+   * directory itself and the directory's parent directory are not included in the result. Each
+   * string is a path relative to the given directory.
    *
    * <p>
    * There is no guarantee that the name strings in the resulting array will appear in any specific
    * order; they are not, in particular, guaranteed to appear in alphabetical order.
    *
    * @param path the abstract pathname to list
+   * @param options for list directory
    * @return An array of statuses naming the files and directories in the directory denoted by this
-   *         abstract pathname and its subdirectories. The array will be empty if the directory is
-   *         empty. Returns {@code null} if this abstract pathname does not denote a directory.
+   *         abstract pathname. The array will be empty if the directory is empty. Returns
+   *         {@code null} if this abstract pathname does not denote a directory.
    * @throws IOException if a non-Alluxio error occurs
    */
-  UnderFileStatus[] listRecursive(String path) throws IOException;
+  UnderFileStatus[] listStatus(String path, ListOptions options) throws IOException;
 
   /**
    * Creates the directory named by this abstract pathname. If the folder already exists, the method

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -434,12 +434,12 @@ public interface UnderFileSystem {
    * order; they are not, in particular, guaranteed to appear in alphabetical order.
    *
    * @param path the abstract pathname to list
-   * @return An array of strings naming the files and directories in the directory denoted by this
+   * @return An array naming the files and directories in the directory denoted by this
    *         abstract pathname. The array will be empty if the directory is empty. Returns
    *         {@code null} if this abstract pathname does not denote a directory.
    * @throws IOException if a non-Alluxio error occurs
    */
-  String[] list(String path) throws IOException;
+  UnderFileStatus[] list(String path) throws IOException;
 
   /**
    * Returns an array of strings naming the files and directories in the directory denoted by this

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -494,6 +495,16 @@ public interface UnderFileSystem {
    * @throws IOException if a non-Alluxio error occurs
    */
   InputStream open(String path) throws IOException;
+
+  /**
+   * Opens an {@link InputStream} at the indicated path.
+   *
+   * @param path the file name
+   * @param options to open input stream
+   * @return The {@code InputStream} object
+   * @throws IOException if a non-Alluxio error occurs
+   */
+  InputStream open(String path, OpenOptions options) throws IOException;
 
   /**
    * Renames a directory from {@code src} to {@code dst} in under file system.

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -420,12 +420,12 @@ public interface UnderFileSystem {
   boolean isFile(String path) throws IOException;
 
   /**
-   * Returns an array of strings naming the files and directories in the directory denoted by this
+   * Returns an array of statuses of the files and directories in the directory denoted by this
    * abstract pathname.
    *
    * <p>
    * If this abstract pathname does not denote a directory, then this method returns {@code null}.
-   * Otherwise an array of strings is returned, one for each file or directory in the directory.
+   * Otherwise an array of statuses is returned, one for each file or directory in the directory.
    * Names denoting the directory itself and the directory's parent directory are not included in
    * the result. Each string is a file name rather than a complete path.
    *
@@ -442,12 +442,12 @@ public interface UnderFileSystem {
   UnderFileStatus[] listStatus(String path) throws IOException;
 
   /**
-   * Returns an array of strings naming the files and directories in the directory denoted by this
+   * Returns an array of statuses of the files and directories in the directory denoted by this
    * abstract pathname, and all of its subdirectories.
    *
    * <p>
    * If this abstract pathname does not denote a directory, then this method returns {@code null}.
-   * Otherwise an array of strings is returned, one for each file or directory in the directory and
+   * Otherwise an array of statuses is returned, one for each file or directory in the directory and
    * its subdirectories. Names denoting the directory itself and the directory's parent directory
    * are not included in the result. Each string is a path relative to the given directory.
    *
@@ -456,12 +456,12 @@ public interface UnderFileSystem {
    * order; they are not, in particular, guaranteed to appear in alphabetical order.
    *
    * @param path the abstract pathname to list
-   * @return An array of strings naming the files and directories in the directory denoted by this
+   * @return An array of statuses naming the files and directories in the directory denoted by this
    *         abstract pathname and its subdirectories. The array will be empty if the directory is
    *         empty. Returns {@code null} if this abstract pathname does not denote a directory.
    * @throws IOException if a non-Alluxio error occurs
    */
-  String[] listRecursive(String path) throws IOException;
+  UnderFileStatus[] listRecursive(String path) throws IOException;
 
   /**
    * Creates the directory named by this abstract pathname. If the folder already exists, the method

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -434,12 +434,12 @@ public interface UnderFileSystem {
    * order; they are not, in particular, guaranteed to appear in alphabetical order.
    *
    * @param path the abstract pathname to list
-   * @return An array naming the files and directories in the directory denoted by this
-   *         abstract pathname. The array will be empty if the directory is empty. Returns
+   * @return An array with the statuses of the files and directories in the directory denoted by
+   *         this abstract pathname. The array will be empty if the directory is empty. Returns
    *         {@code null} if this abstract pathname does not denote a directory.
    * @throws IOException if a non-Alluxio error occurs
    */
-  UnderFileStatus[] list(String path) throws IOException;
+  UnderFileStatus[] listStatus(String path) throws IOException;
 
   /**
    * Returns an array of strings naming the files and directories in the directory denoted by this

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -259,17 +259,6 @@ public interface UnderFileSystem {
   OutputStream create(String path, CreateOptions options) throws IOException;
 
   /**
-   * Creates a file in the under file system with the specified {@link CreateOptions}. This stream
-   * writes directly to the underlying storage without any atomicity guarantees.
-   *
-   * @param path the file name
-   * @param options the options for create
-   * @return A {@code OutputStream} object
-   * @throws IOException if a non-Alluxio error occurs
-   */
-  OutputStream createDirect(String path, CreateOptions options) throws IOException;
-
-  /**
    * Deletes a directory from the under file system with the indicated name non-recursively.
    *
    * @param path of the directory to delete

--- a/core/common/src/main/java/alluxio/underfs/options/ListOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/ListOptions.java
@@ -1,0 +1,84 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.options;
+
+import alluxio.annotation.PublicApi;
+
+import com.google.common.base.Objects;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Method options for listing a directory in UnderFileSystem.
+ */
+@PublicApi
+@NotThreadSafe
+public final class ListOptions {
+  // Whether to list a directory and all its sub-directories
+  private boolean mRecursive;
+
+  /**
+   * @return the default {@link ListOptions}
+   */
+  public static ListOptions defaults() {
+    return new ListOptions();
+  }
+
+  /**
+   * Constructs a default {@link ListOptions}.
+   */
+  private ListOptions() {
+    mRecursive = false;
+  }
+
+  /**
+   * @return whether to list a directory recursively
+   */
+  public boolean isRecursive() {
+    return mRecursive;
+  }
+
+  /**
+   * Sets recursive list.
+   *
+   * @param recursive whether to list recursively
+   * @return the updated option object
+   */
+  public ListOptions setRecursive(boolean recursive) {
+    mRecursive = recursive;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ListOptions)) {
+      return false;
+    }
+    ListOptions that = (ListOptions) o;
+    return Objects.equal(mRecursive, that.mRecursive);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mRecursive);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("recursive", mRecursive)
+        .toString();
+  }
+}

--- a/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
@@ -1,0 +1,84 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.options;
+
+import alluxio.annotation.PublicApi;
+
+import com.google.common.base.Objects;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Method options for file locations in {@link UnderFileSystem}.
+ */
+@PublicApi
+@NotThreadSafe
+public final class OpenOptions {
+  // Offset within file in bytes
+  private long mOffset;
+
+  /**
+   * @return the default {@link OpenOptions}
+   */
+  public static OpenOptions defaults() {
+    return new OpenOptions();
+  }
+
+  /**
+   * Constructs a default {@link OpenOptions}.
+   */
+  private OpenOptions() {
+    mOffset = 0;
+  }
+
+  /**
+   * @return offset within a file in bytes
+   */
+  public long getOffset() {
+    return mOffset;
+  }
+
+  /**
+   * Sets the offset for which locations are to be queried.
+   *
+   * @param offset within a file in bytes
+   * @return the updated option object
+   */
+  public OpenOptions setOffset(long offset) {
+    mOffset = offset;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OpenOptions)) {
+      return false;
+    }
+    OpenOptions that = (OpenOptions) o;
+    return Objects.equal(mOffset, that.mOffset);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mOffset);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("offset", mOffset)
+        .toString();
+  }
+}

--- a/core/common/src/test/java/alluxio/underfs/options/ListOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/ListOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.options;
+
+import alluxio.CommonTestUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+/**
+ * Tests for the {@link ListOptions} class.
+ */
+@RunWith(PowerMockRunner.class)
+public final class ListOptionsTest {
+  /**
+   * Tests for default {@link ListOptions}.
+   */
+  @Test
+  public void defaults() throws IOException {
+    ListOptions options = ListOptions.defaults();
+
+    Assert.assertEquals(false, options.isRecursive());
+  }
+
+  /**
+   * Tests getting and setting fields.
+   */
+  @Test
+  public void fields() {
+    ListOptions options = ListOptions.defaults();
+
+    boolean recursive = false;
+    options.setRecursive(recursive);
+    Assert.assertEquals(recursive, options.isRecursive());
+
+    recursive = true;
+    options.setRecursive(recursive);
+    Assert.assertEquals(recursive, options.isRecursive());
+  }
+
+  @Test
+  public void equalsTest() throws Exception {
+    CommonTestUtils.testEquals(ListOptions.class);
+  }
+}

--- a/core/common/src/test/java/alluxio/underfs/options/OpenOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/OpenOptionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.options;
+
+import alluxio.CommonTestUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+/**
+ * Tests for the {@link OpenOptions} class.
+ */
+@RunWith(PowerMockRunner.class)
+public final class OpenOptionsTest {
+  /**
+   * Tests for default {@link OpenOptions}.
+   */
+  @Test
+  public void defaults() throws IOException {
+    OpenOptions options = OpenOptions.defaults();
+
+    Assert.assertEquals(0, options.getOffset());
+  }
+
+  /**
+   * Tests getting and setting fields.
+   */
+  @Test
+  public void fields() {
+    OpenOptions options = OpenOptions.defaults();
+
+    long[] offsets = {100, 110, 150, 200};
+    for (long offset : offsets) {
+      options.setOffset(offset);
+      Assert.assertEquals(offset, options.getOffset());
+    }
+  }
+
+  @Test
+  public void equalsTest() throws Exception {
+    CommonTestUtils.testEquals(OpenOptions.class);
+  }
+}

--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.PropertyKeyFormat;
 import alluxio.RuntimeConstants;
 import alluxio.master.AlluxioMaster;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.util.UnderFileSystemUtils;
@@ -42,11 +43,10 @@ public final class Format {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(folder);
     LOG.info("Formatting {}:{}", name, folder);
     if (ufs.isDirectory(folder)) {
-      for (String p : ufs.list(folder)) {
-        String childPath = PathUtils.concatPath(folder, p);
+      for (UnderFileStatus p : ufs.list(folder)) {
+        String childPath = PathUtils.concatPath(folder, p.getName());
         boolean failedToDelete;
-        // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
-        if (ufs.isDirectory(childPath)) {
+        if (p.isDirectory()) {
           failedToDelete = !ufs.deleteDirectory(childPath,
               DeleteOptions.defaults().setRecursive(true));
         } else {

--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -43,7 +43,7 @@ public final class Format {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(folder);
     LOG.info("Formatting {}:{}", name, folder);
     if (ufs.isDirectory(folder)) {
-      for (UnderFileStatus p : ufs.list(folder)) {
+      for (UnderFileStatus p : ufs.listStatus(folder)) {
         String childPath = PathUtils.concatPath(folder, p.getName());
         boolean failedToDelete;
         if (p.isDirectory()) {

--- a/core/server/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/src/main/java/alluxio/master/AlluxioMaster.java
@@ -510,7 +510,7 @@ public class AlluxioMaster implements Server {
    */
   private boolean isJournalFormatted(String journalDirectory) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(journalDirectory);
-    UnderFileStatus[] files = ufs.list(journalDirectory);
+    UnderFileStatus[] files = ufs.listStatus(journalDirectory);
     if (files == null) {
       return false;
     }

--- a/core/server/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/src/main/java/alluxio/master/AlluxioMaster.java
@@ -24,6 +24,7 @@ import alluxio.master.lineage.LineageMaster;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.sink.MetricsServlet;
 import alluxio.security.authentication.TransportProvider;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
@@ -509,14 +510,14 @@ public class AlluxioMaster implements Server {
    */
   private boolean isJournalFormatted(String journalDirectory) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(journalDirectory);
-    String[] files = ufs.list(journalDirectory);
+    UnderFileStatus[] files = ufs.list(journalDirectory);
     if (files == null) {
       return false;
     }
     // Search for the format file.
     String formatFilePrefix = Configuration.get(PropertyKey.MASTER_FORMAT_FILE_PREFIX);
-    for (String file : files) {
-      if (file.startsWith(formatFilePrefix)) {
+    for (UnderFileStatus file : files) {
+      if (file.getName().startsWith(formatFilePrefix)) {
         return true;
       }
     }

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1946,7 +1946,7 @@ public final class FileSystemMaster extends AbstractMaster {
         InodeDirectory inode = (InodeDirectory) inodePath.getInode();
 
         if (options.isLoadDirectChildren()) {
-          UnderFileStatus[] files = ufs.list(ufsUri.getPath());
+          UnderFileStatus[] files = ufs.listStatus(ufsUri.getPath());
           LoadMetadataOptions loadMetadataOptions = LoadMetadataOptions.defaults();
           loadMetadataOptions.setLoadDirectChildren(false).setCreateAncestors(false);
 

--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -90,6 +90,7 @@ import alluxio.thrift.FileSystemMasterClientService;
 import alluxio.thrift.FileSystemMasterWorkerService;
 import alluxio.thrift.PersistCommandOptions;
 import alluxio.thrift.PersistFile;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
@@ -1945,15 +1946,17 @@ public final class FileSystemMaster extends AbstractMaster {
         InodeDirectory inode = (InodeDirectory) inodePath.getInode();
 
         if (options.isLoadDirectChildren()) {
-          String[] files = ufs.list(ufsUri.getPath());
+          UnderFileStatus[] files = ufs.list(ufsUri.getPath());
           LoadMetadataOptions loadMetadataOptions = LoadMetadataOptions.defaults();
           loadMetadataOptions.setLoadDirectChildren(false).setCreateAncestors(false);
 
-          for (String file : files) {
-            if (PathUtils.isTemporaryFileName(file) || inode.getChild(file) != null) {
+          for (UnderFileStatus file : files) {
+            if (PathUtils.isTemporaryFileName(file.getName())
+                || inode.getChild(file.getName()) != null) {
               continue;
             }
-            TempInodePathForChild tempInodePath = new TempInodePathForChild(inodePath, file);
+            TempInodePathForChild tempInodePath =
+                new TempInodePathForChild(inodePath, file.getName());
             counter = loadMetadataAndJournal(tempInodePath, loadMetadataOptions);
           }
           inode.setDirectChildrenLoaded(true);

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -138,7 +138,7 @@ public abstract class UnderFileSystemCluster {
     if (isStarted()) {
       String path = getUnderFilesystemAddress() + AlluxioURI.SEPARATOR;
       UnderFileSystem ufs = UnderFileSystem.Factory.get(path);
-      for (UnderFileStatus p : ufs.list(path)) {
+      for (UnderFileStatus p : ufs.listStatus(path)) {
         String childPath = PathUtils.concatPath(path, p.getName());
         if (p.isDirectory()) {
           ufs.deleteDirectory(childPath, DeleteOptions.defaults().setRecursive(true));

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -138,10 +138,9 @@ public abstract class UnderFileSystemCluster {
     if (isStarted()) {
       String path = getUnderFilesystemAddress() + AlluxioURI.SEPARATOR;
       UnderFileSystem ufs = UnderFileSystem.Factory.get(path);
-      for (String p : ufs.list(path)) {
-        String childPath = PathUtils.concatPath(path, p);
-        // TODO(adit); eliminate this isDirectory call after list is updated to listStatus
-        if (ufs.isDirectory(childPath)) {
+      for (UnderFileStatus p : ufs.list(path)) {
+        String childPath = PathUtils.concatPath(path, p.getName());
+        if (p.isDirectory()) {
           ufs.deleteDirectory(childPath, DeleteOptions.defaults().setRecursive(true));
         } else {
           ufs.deleteFile(childPath);

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -144,7 +144,7 @@ public class JournalIntegrationTest {
       writer.getEntryOutputStream().flush();
       writer.getEntryOutputStream().flush();
       UnderFileStatus[] paths = UnderFileSystem.Factory.get(journalFolder)
-          .list(journal.getCompletedDirectory());
+          .listStatus(journal.getCompletedDirectory());
       // Make sure no new empty files were created.
       Assert.assertTrue(paths == null || paths.length == 0);
     } finally {
@@ -204,9 +204,11 @@ public class JournalIntegrationTest {
         FileSystemMaster.getJournalDirectory(mLocalAlluxioCluster.getMaster().getJournalFolder());
     Journal journal = new ReadWriteJournal(journalFolder);
     String completedPath = journal.getCompletedDirectory();
-    Assert.assertTrue(UnderFileSystem.Factory.get(completedPath).list(completedPath).length > 1);
+    Assert.assertTrue(
+        UnderFileSystem.Factory.get(completedPath).listStatus(completedPath).length > 1);
     multiEditLogTestUtil();
-    Assert.assertTrue(UnderFileSystem.Factory.get(completedPath).list(completedPath).length <= 1);
+    Assert.assertTrue(
+        UnderFileSystem.Factory.get(completedPath).listStatus(completedPath).length <= 1);
     multiEditLogTestUtil();
   }
 

--- a/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalIntegrationTest.java
@@ -38,6 +38,7 @@ import alluxio.master.journal.JournalWriter;
 import alluxio.master.journal.ReadWriteJournal;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.group.GroupMappingService;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
@@ -142,7 +143,7 @@ public class JournalIntegrationTest {
       writer.getEntryOutputStream().flush();
       writer.getEntryOutputStream().flush();
       writer.getEntryOutputStream().flush();
-      String[] paths = UnderFileSystem.Factory.get(journalFolder)
+      UnderFileStatus[] paths = UnderFileSystem.Factory.get(journalFolder)
           .list(journal.getCompletedDirectory());
       // Make sure no new empty files were created.
       Assert.assertTrue(paths == null || paths.length == 0);

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -311,14 +311,14 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // lsr from root should return paths relative to the root
     String[] expectedResRoot =
         {"sub1", "sub2", "sub1/sub11", "sub1/sub11/file11", "sub2/file2", "file"};
-    String[] actualResRoot = mUfs.listRecursive(root);
+    UnderFileStatus[] actualResRoot = mUfs.listRecursive(root);
     Arrays.sort(expectedResRoot);
     Arrays.sort(actualResRoot);
     Assert.assertArrayEquals(expectedResRoot, actualResRoot);
 
     // lsr from sub1 should return paths relative to sub1
     String[] expectedResSub1 = {"sub11", "sub11/file11"};
-    String[] actualResSub1 = mUfs.listRecursive(sub1);
+    UnderFileStatus[] actualResSub1 = mUfs.listRecursive(sub1);
     Arrays.sort(expectedResSub1);
     Arrays.sort(actualResSub1);
     Assert.assertArrayEquals(expectedResSub1, actualResSub1);

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -245,7 +245,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     Arrays.sort(expectedResTopDir);
     Arrays.sort(expectedResTopDir2);
     UnderFileStatus [] resTopDirStatus = mUfs.listStatus(testDirNonEmpty);
-    String [] resTopDir = UnderFileStatus.toListingResult(resTopDirStatus);
+    String [] resTopDir = UnderFileStatus.convertToNames(resTopDirStatus);
     Arrays.sort(resTopDir);
     Assert.assertTrue(Arrays.equals(expectedResTopDir, resTopDir)
         || Arrays.equals(expectedResTopDir2, resTopDir));
@@ -282,7 +282,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     }
     Assert.assertEquals(children.length, results.length);
 
-    String[] resultNames = UnderFileStatus.toListingResult(results);
+    String[] resultNames = UnderFileStatus.convertToNames(results);
     Arrays.sort(resultNames);
     for (int i = 0; i < children.length; ++i) {
       Assert.assertTrue(resultNames[i].equals(CommonUtils.stripPrefixIfPresent(children[i],
@@ -323,7 +323,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
         {"sub1", "sub2", "sub1/sub11", "sub1/sub11/file11", "sub2/file2", "file"};
     UnderFileStatus[] actualResRootStatus =
         mUfs.listStatus(root, ListOptions.defaults().setRecursive(true));
-    String[] actualResRoot = UnderFileStatus.toListingResult(actualResRootStatus);
+    String[] actualResRoot = UnderFileStatus.convertToNames(actualResRootStatus);
     Arrays.sort(expectedResRoot);
     Arrays.sort(actualResRoot);
     Assert.assertArrayEquals(expectedResRoot, actualResRoot);
@@ -335,7 +335,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // lsr from sub1 should return paths relative to sub1
     String[] expectedResSub1 = {"sub11", "sub11/file11"};
     String[] actualResSub1 = UnderFileStatus
-        .toListingResult(mUfs.listStatus(sub1, ListOptions.defaults().setRecursive(true)));
+        .convertToNames(mUfs.listStatus(sub1, ListOptions.defaults().setRecursive(true)));
     Arrays.sort(expectedResSub1);
     Arrays.sort(actualResSub1);
     Assert.assertArrayEquals(expectedResSub1, actualResSub1);

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -225,10 +225,10 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
   }
 
   /**
-   * Tests if list correctly returns file names.
+   * Tests if listStatus correctly returns file names.
    */
   @Test
-  public void list() throws IOException {
+  public void listStatus() throws IOException {
     String testDirNonEmpty = PathUtils.concatPath(mUnderfsAddress, "testDirNonEmpty1");
     String testDirNonEmptyChildDir = PathUtils.concatPath(testDirNonEmpty, "testDirNonEmpty2");
     String testDirNonEmptyChildFile = PathUtils.concatPath(testDirNonEmpty, "testDirNonEmptyF");
@@ -243,12 +243,14 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     String [] expectedResTopDir2 = new String[] {"/testDirNonEmpty2", "/testDirNonEmptyF"};
     Arrays.sort(expectedResTopDir);
     Arrays.sort(expectedResTopDir2);
-    UnderFileStatus [] resTopDir = mUfs.listStatus(testDirNonEmpty);
+    String [] resTopDir = UnderFileStatus.toListingResult(mUfs.listStatus(testDirNonEmpty));
     Arrays.sort(resTopDir);
     Assert.assertTrue(Arrays.equals(expectedResTopDir, resTopDir)
         || Arrays.equals(expectedResTopDir2, resTopDir));
-    Assert.assertTrue(mUfs.listStatus(testDirNonEmptyChildDir)[0].equals("testDirNonEmptyChildDirF")
-        || mUfs.listStatus(testDirNonEmptyChildDir)[0].equals("/testDirNonEmptyChildDirF"));
+    Assert.assertTrue(
+        mUfs.listStatus(testDirNonEmptyChildDir)[0].getName().equals("testDirNonEmptyChildDirF")
+            || mUfs.listStatus(testDirNonEmptyChildDir)[0].getName()
+                .equals("/testDirNonEmptyChildDirF"));
   }
 
   /**
@@ -273,9 +275,10 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     }
     Assert.assertEquals(children.length, results.length);
 
-    Arrays.sort(results);
+    String[] resultNames = UnderFileStatus.toListingResult(results);
+    Arrays.sort(resultNames);
     for (int i = 0; i < children.length; ++i) {
-      Assert.assertTrue(results[i].getName().equals(CommonUtils.stripPrefixIfPresent(children[i],
+      Assert.assertTrue(resultNames[i].equals(CommonUtils.stripPrefixIfPresent(children[i],
           PathUtils.normalizePath(config.getTopLevelDirectory(), "/"))));
     }
   }
@@ -311,14 +314,14 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // lsr from root should return paths relative to the root
     String[] expectedResRoot =
         {"sub1", "sub2", "sub1/sub11", "sub1/sub11/file11", "sub2/file2", "file"};
-    UnderFileStatus[] actualResRoot = mUfs.listRecursive(root);
+    String[] actualResRoot = UnderFileStatus.toListingResult(mUfs.listRecursive(root));
     Arrays.sort(expectedResRoot);
     Arrays.sort(actualResRoot);
     Assert.assertArrayEquals(expectedResRoot, actualResRoot);
 
     // lsr from sub1 should return paths relative to sub1
     String[] expectedResSub1 = {"sub11", "sub11/file11"};
-    UnderFileStatus[] actualResSub1 = mUfs.listRecursive(sub1);
+    String[] actualResSub1 = UnderFileStatus.toListingResult(mUfs.listRecursive(sub1));
     Arrays.sort(expectedResSub1);
     Arrays.sort(actualResSub1);
     Assert.assertArrayEquals(expectedResSub1, actualResSub1);

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -244,7 +244,8 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     String [] expectedResTopDir2 = new String[] {"/testDirNonEmpty2", "/testDirNonEmptyF"};
     Arrays.sort(expectedResTopDir);
     Arrays.sort(expectedResTopDir2);
-    String [] resTopDir = UnderFileStatus.toListingResult(mUfs.listStatus(testDirNonEmpty));
+    UnderFileStatus [] resTopDirStatus = mUfs.listStatus(testDirNonEmpty);
+    String [] resTopDir = UnderFileStatus.toListingResult(resTopDirStatus);
     Arrays.sort(resTopDir);
     Assert.assertTrue(Arrays.equals(expectedResTopDir, resTopDir)
         || Arrays.equals(expectedResTopDir2, resTopDir));
@@ -252,6 +253,11 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
         mUfs.listStatus(testDirNonEmptyChildDir)[0].getName().equals("testDirNonEmptyChildDirF")
             || mUfs.listStatus(testDirNonEmptyChildDir)[0].getName()
                 .equals("/testDirNonEmptyChildDirF"));
+    for (int i = 0; i < resTopDir.length; ++i) {
+      Assert.assertEquals(
+          mUfs.isDirectory(PathUtils.concatPath(testDirNonEmpty, resTopDirStatus[i].getName())),
+          resTopDirStatus[i].isDirectory());
+    }
   }
 
   /**
@@ -315,12 +321,17 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // lsr from root should return paths relative to the root
     String[] expectedResRoot =
         {"sub1", "sub2", "sub1/sub11", "sub1/sub11/file11", "sub2/file2", "file"};
-    String[] actualResRoot = UnderFileStatus
-        .toListingResult(mUfs.listStatus(root, ListOptions.defaults().setRecursive(true)));
+    UnderFileStatus[] actualResRootStatus =
+        mUfs.listStatus(root, ListOptions.defaults().setRecursive(true));
+    String[] actualResRoot = UnderFileStatus.toListingResult(actualResRootStatus);
     Arrays.sort(expectedResRoot);
     Arrays.sort(actualResRoot);
     Assert.assertArrayEquals(expectedResRoot, actualResRoot);
-
+    for (int i = 0; i < actualResRoot.length; ++i) {
+      Assert.assertEquals(
+          mUfs.isDirectory(PathUtils.concatPath(root, actualResRootStatus[i].getName())),
+          actualResRootStatus[i].isDirectory());
+    }
     // lsr from sub1 should return paths relative to sub1
     String[] expectedResSub1 = {"sub11", "sub11/file11"};
     String[] actualResSub1 = UnderFileStatus

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -23,6 +23,7 @@ import alluxio.client.file.options.ListStatusOptions;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
@@ -287,12 +288,12 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
    * Tests if list recursive correctly returns all file names in all subdirectories.
    */
   @Test
-  public void listRecursive() throws IOException {
+  public void listStatusRecursive() throws IOException {
     String root = mUnderfsAddress;
     // TODO(andrew): Should this directory be created in LocalAlluxioCluster creation code?
     mUfs.mkdirs(root);
     // Empty lsr should be empty
-    Assert.assertEquals(0, mUfs.listRecursive(root).length);
+    Assert.assertEquals(0, mUfs.listStatus(root).length);
 
     // Create a tree of subdirectories and files
     String sub1 = PathUtils.concatPath(root, "sub1");
@@ -302,7 +303,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     String file2 = PathUtils.concatPath(sub2, "file2");
     String file = PathUtils.concatPath(root, "file");
     // lsr of nonexistent path should be null
-    Assert.assertNull(mUfs.listRecursive(sub1));
+    Assert.assertNull(mUfs.listStatus(sub1, ListOptions.defaults().setRecursive(true)));
 
     mUfs.mkdirs(sub1, MkdirsOptions.defaults().setCreateParent(false));
     mUfs.mkdirs(sub2, MkdirsOptions.defaults().setCreateParent(false));
@@ -314,20 +315,22 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // lsr from root should return paths relative to the root
     String[] expectedResRoot =
         {"sub1", "sub2", "sub1/sub11", "sub1/sub11/file11", "sub2/file2", "file"};
-    String[] actualResRoot = UnderFileStatus.toListingResult(mUfs.listRecursive(root));
+    String[] actualResRoot = UnderFileStatus
+        .toListingResult(mUfs.listStatus(root, ListOptions.defaults().setRecursive(true)));
     Arrays.sort(expectedResRoot);
     Arrays.sort(actualResRoot);
     Assert.assertArrayEquals(expectedResRoot, actualResRoot);
 
     // lsr from sub1 should return paths relative to sub1
     String[] expectedResSub1 = {"sub11", "sub11/file11"};
-    String[] actualResSub1 = UnderFileStatus.toListingResult(mUfs.listRecursive(sub1));
+    String[] actualResSub1 = UnderFileStatus
+        .toListingResult(mUfs.listStatus(sub1, ListOptions.defaults().setRecursive(true)));
     Arrays.sort(expectedResSub1);
     Arrays.sort(actualResSub1);
     Assert.assertArrayEquals(expectedResSub1, actualResSub1);
 
     // lsr of file should be null
-    Assert.assertNull(mUfs.listRecursive(file));
+    Assert.assertNull(mUfs.listStatus(file, ListOptions.defaults().setRecursive(true)));
   }
 
   /**
@@ -340,7 +343,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // make sure the underfs address dir exists already
     mUfs.mkdirs(mUnderfsAddress);
     // empty lsr should be empty
-    Assert.assertEquals(0, mUfs.listRecursive(mUnderfsAddress).length);
+    Assert.assertEquals(0, mUfs.listStatus(mUnderfsAddress).length);
 
     String testDirTop = PathUtils.concatPath(mUnderfsAddress, "testDirTop");
     String testDir1 = PathUtils.concatPath(mUnderfsAddress, "1");

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -243,12 +243,12 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     String [] expectedResTopDir2 = new String[] {"/testDirNonEmpty2", "/testDirNonEmptyF"};
     Arrays.sort(expectedResTopDir);
     Arrays.sort(expectedResTopDir2);
-    UnderFileStatus [] resTopDir = mUfs.list(testDirNonEmpty);
+    UnderFileStatus [] resTopDir = mUfs.listStatus(testDirNonEmpty);
     Arrays.sort(resTopDir);
     Assert.assertTrue(Arrays.equals(expectedResTopDir, resTopDir)
         || Arrays.equals(expectedResTopDir2, resTopDir));
-    Assert.assertTrue(mUfs.list(testDirNonEmptyChildDir)[0].equals("testDirNonEmptyChildDirF")
-        || mUfs.list(testDirNonEmptyChildDir)[0].equals("/testDirNonEmptyChildDirF"));
+    Assert.assertTrue(mUfs.listStatus(testDirNonEmptyChildDir)[0].equals("testDirNonEmptyChildDirF")
+        || mUfs.listStatus(testDirNonEmptyChildDir)[0].equals("/testDirNonEmptyChildDirF"));
   }
 
   /**
@@ -265,7 +265,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // Note: not using CommonUtils.waitFor here because we intend to sleep with a longer interval.
     UnderFileStatus[] results = new UnderFileStatus[] {};
     for (int i = 0; i < 20; i++) {
-      results = mUfs.list(config.getTopLevelDirectory());
+      results = mUfs.listStatus(config.getTopLevelDirectory());
       if (children.length == results.length) {
         break;
       }

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -243,7 +243,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     String [] expectedResTopDir2 = new String[] {"/testDirNonEmpty2", "/testDirNonEmptyF"};
     Arrays.sort(expectedResTopDir);
     Arrays.sort(expectedResTopDir2);
-    String [] resTopDir = mUfs.list(testDirNonEmpty);
+    UnderFileStatus [] resTopDir = mUfs.list(testDirNonEmpty);
     Arrays.sort(resTopDir);
     Assert.assertTrue(Arrays.equals(expectedResTopDir, resTopDir)
         || Arrays.equals(expectedResTopDir2, resTopDir));
@@ -263,7 +263,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
     // See http://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html and
     // https://cloud.google.com/storage/docs/consistency for more details.
     // Note: not using CommonUtils.waitFor here because we intend to sleep with a longer interval.
-    String[] results = new String[] {};
+    UnderFileStatus[] results = new UnderFileStatus[] {};
     for (int i = 0; i < 20; i++) {
       results = mUfs.list(config.getTopLevelDirectory());
       if (children.length == results.length) {
@@ -275,7 +275,7 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
 
     Arrays.sort(results);
     for (int i = 0; i < children.length; ++i) {
-      Assert.assertTrue(results[i].equals(CommonUtils.stripPrefixIfPresent(children[i],
+      Assert.assertTrue(results[i].getName().equals(CommonUtils.stripPrefixIfPresent(children[i],
           PathUtils.normalizePath(config.getTopLevelDirectory(), "/"))));
     }
   }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
@@ -134,24 +135,6 @@ public final class GCSUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   public String getUnderFSType() {
     return "gcs";
-  }
-
-  /**
-   * Opens a GCS object at given position and returns the opened input stream.
-   *
-   * @param path the GCS object path
-   * @param pos the position to open at
-   * @return the opened input stream
-   * @throws IOException if failed to open file at position
-   */
-  public InputStream openAtPosition(String path, long pos) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new GCSInputStream(mBucketName, path, mClient, pos);
-    } catch (ServiceException e) {
-      LOG.error("Failed to open file {} at position {}:", path, pos, e);
-      return null;
-    }
   }
 
   // Setting GCS owner via Alluxio is not supported yet. This is a no-op.
@@ -325,9 +308,9 @@ public final class GCSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
-      return new GCSInputStream(mBucketName, key, mClient);
+      return new GCSInputStream(mBucketName, key, mClient, options.getOffset());
     } catch (ServiceException e) {
       LOG.error("Failed to open file: {}", key, e);
       return null;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -136,17 +136,6 @@ public final class GCSUnderFileSystem extends ObjectUnderFileSystem {
     return "gcs";
   }
 
-  @Override
-  public InputStream open(String path) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new GCSInputStream(mBucketName, path, mClient);
-    } catch (ServiceException e) {
-      LOG.error("Failed to open file: {}", path, e);
-      return null;
-    }
-  }
-
   /**
    * Opens a GCS object at given position and returns the opened input stream.
    *
@@ -334,4 +323,15 @@ public final class GCSUnderFileSystem extends ObjectUnderFileSystem {
   protected String getRootKey() {
     return Constants.HEADER_GCS + mBucketName;
   }
+
+  @Override
+  protected InputStream openObject(String key) throws IOException {
+    try {
+      return new GCSInputStream(mBucketName, key, mClient);
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file: {}", key, e);
+      return null;
+    }
+  }
+
 }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -138,7 +138,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
 
   @Override
   public OutputStream create(String path, CreateOptions options) throws IOException {
-    return new AtomicFileOutputStream(path, options, this);
+    return new AtomicFileOutputStream(path, this, options);
   }
 
   @Override
@@ -362,13 +362,11 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
     while (retryPolicy.attemptRetry()) {
       try {
         FSDataInputStream inputStream = mFileSystem.open(new Path(path));
-        if (options.getOffset() != 0) {
-          try {
-            inputStream.skip(options.getOffset());
-          } catch (IOException e) {
-            inputStream.close();
-            throw e;
-          }
+        try {
+          inputStream.seek(options.getOffset());
+        } catch (IOException e) {
+          inputStream.close();
+          throw e;
         }
         return inputStream;
       } catch (IOException e) {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -261,8 +261,8 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UnderFileStatus[] list(String path) throws IOException {
-    FileStatus[] files = listStatus(path);
+  public UnderFileStatus[] listStatus(String path) throws IOException {
+    FileStatus[] files = listStatusInternal(path);
     if (files != null && !isFile(path)) {
       UnderFileStatus[] rtn = new UnderFileStatus[files.length];
       int i = 0;
@@ -481,7 +481,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem {
    * @return {@code null} if the path is not a directory
    * @throws IOException
    */
-  private FileStatus[] listStatus(String path) throws IOException {
+  private FileStatus[] listStatusInternal(String path) throws IOException {
     FileStatus[] files;
     try {
       files = mFileSystem.listStatus(new Path(path));

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -18,6 +18,8 @@ import alluxio.PropertyKey;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.Permission;
+import alluxio.underfs.AtomicFileOutputStream;
+import alluxio.underfs.AtomicFileOutputStreamCallback;
 import alluxio.underfs.BaseUnderFileSystem;
 import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
@@ -54,7 +56,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * HDFS {@link UnderFileSystem} implementation.
  */
 @ThreadSafe
-public class HdfsUnderFileSystem extends BaseUnderFileSystem {
+public class HdfsUnderFileSystem extends BaseUnderFileSystem
+    implements AtomicFileOutputStreamCallback {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static final int MAX_TRY = 5;
   // TODO(hy): Add a sticky bit and narrow down the permission in hadoop 2.
@@ -131,6 +134,11 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem {
   @Override
   public void close() throws IOException {
     // Don't close; file systems are singletons and closing it here could break other users
+  }
+
+  @Override
+  public OutputStream create(String path, CreateOptions options) throws IOException {
+    return new AtomicFileOutputStream(path, options, this);
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -19,6 +19,7 @@ import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.Permission;
 import alluxio.underfs.BaseUnderFileSystem;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
@@ -260,14 +261,14 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public String[] list(String path) throws IOException {
+  public UnderFileStatus[] list(String path) throws IOException {
     FileStatus[] files = listStatus(path);
     if (files != null && !isFile(path)) {
-      String[] rtn = new String[files.length];
+      UnderFileStatus[] rtn = new UnderFileStatus[files.length];
       int i = 0;
       for (FileStatus status : files) {
         // only return the relative path, to keep consistent with java.io.File.list()
-        rtn[i++] =  status.getPath().getName();
+        rtn[i++] =  new UnderFileStatus(status.getPath().getName(), status.isDirectory());
       }
       return rtn;
     } else {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -24,6 +24,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
 import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -246,9 +247,18 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public InputStream open(String path) throws IOException {
+  public InputStream open(String path, OpenOptions options) throws IOException {
     path = stripPath(path);
-    return new FileInputStream(path);
+    InputStream inputStream = new FileInputStream(path);
+    if (options.getOffset() != 0) {
+      try {
+        inputStream.skip(options.getOffset());
+      } catch (IOException e) {
+        inputStream.close();
+        throw e;
+      }
+    }
+    return inputStream;
   }
 
   @Override

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -196,7 +196,7 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UnderFileStatus[] list(String path) throws IOException {
+  public UnderFileStatus[] listStatus(String path) throws IOException {
     path = stripPath(path);
     File file = new File(path);
     File[] files = file.listFiles();

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -82,7 +82,7 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
 
   @Override
   public OutputStream create(String path, CreateOptions options) throws IOException {
-    return new AtomicFileOutputStream(path, options, this);
+    return new AtomicFileOutputStream(path, this, options);
   }
 
   @Override
@@ -259,7 +259,7 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
   public InputStream open(String path, OpenOptions options) throws IOException {
     path = stripPath(path);
     InputStream inputStream = new FileInputStream(path);
-    if (options.getOffset() != 0) {
+    if (options.getOffset() > 0) {
       try {
         inputStream.skip(options.getOffset());
       } catch (IOException e) {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -17,6 +17,8 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.security.authorization.Mode;
 import alluxio.security.authorization.Permission;
+import alluxio.underfs.AtomicFileOutputStream;
+import alluxio.underfs.AtomicFileOutputStreamCallback;
 import alluxio.underfs.BaseUnderFileSystem;
 import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
@@ -56,7 +58,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * </p>
  */
 @ThreadSafe
-public class LocalUnderFileSystem extends BaseUnderFileSystem {
+public class LocalUnderFileSystem extends BaseUnderFileSystem
+    implements AtomicFileOutputStreamCallback {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /**
@@ -74,7 +77,13 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public void close() throws IOException {}
+  public void close() throws IOException {
+  }
+
+  @Override
+  public OutputStream create(String path, CreateOptions options) throws IOException {
+    return new AtomicFileOutputStream(path, options, this);
+  }
 
   @Override
   public OutputStream createDirect(String path, CreateOptions options) throws IOException {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -18,6 +18,7 @@ import alluxio.PropertyKey;
 import alluxio.security.authorization.Mode;
 import alluxio.security.authorization.Permission;
 import alluxio.underfs.BaseUnderFileSystem;
+import alluxio.underfs.UnderFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
@@ -195,15 +196,15 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public String[] list(String path) throws IOException {
+  public UnderFileStatus[] list(String path) throws IOException {
     path = stripPath(path);
     File file = new File(path);
     File[] files = file.listFiles();
     if (files != null) {
-      String[] rtn = new String[files.length];
+      UnderFileStatus[] rtn = new UnderFileStatus[files.length];
       int i = 0;
       for (File f : files) {
-        rtn[i++] = f.getName();
+        rtn[i++] = new UnderFileStatus(f.getName(), f.isDirectory());
       }
       return rtn;
     } else {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -34,6 +34,9 @@ public class OSSInputStream extends InputStream {
   /** Bucket name of the Alluxio OSS bucket. */
   private final String mBucketName;
 
+  /** Has the stream been closed. */
+  private boolean mClosed;
+
   /** Key of the file in OSS to read. */
   private final String mKey;
 
@@ -76,7 +79,10 @@ public class OSSInputStream extends InputStream {
 
   @Override
   public void close() throws IOException {
-    closeStream();
+    if (!mClosed) {
+      closeStream();
+    }
+    mClosed = true;
   }
 
   @Override
@@ -131,7 +137,10 @@ public class OSSInputStream extends InputStream {
   /**
    * Opens a new stream at mPos if the wrapped stream mStream is null.
    */
-  private void openStream() {
+  private void openStream() throws IOException {
+    if (mClosed) {
+      throw new IOException("Stream closed");
+    }
     if (mInputStream != null) { // stream is already open
       return;
     }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -11,7 +11,11 @@
 
 package alluxio.underfs.oss;
 
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+
 import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
 
 import java.io.BufferedInputStream;
@@ -36,11 +40,10 @@ public class OSSInputStream extends InputStream {
   /** The OSS client for OSS operations. */
   private final OSSClient mOssClient;
 
-  /** The storage object that will be updated on each large skip. */
-  private final OSSObject mObject;
-
   /** The underlying input stream. */
-  private final BufferedInputStream mInputStream;
+  private BufferedInputStream mInputStream;
+  /** The current position of the stream. */
+  private long mPos;
 
   /**
    * Creates a new instance of {@link OSSInputStream}.
@@ -51,33 +54,112 @@ public class OSSInputStream extends InputStream {
    * @throws IOException if an I/O error occurs
    */
   OSSInputStream(String bucketName, String key, OSSClient client) throws IOException {
+    this(bucketName, key, client, 0L);
+  }
+
+  /**
+   * Creates a new instance of {@link OSSInputStream}.
+   *
+   * @param bucketName the name of the bucket
+   * @param key the key of the file
+   * @param client the client for OSS
+   * @param position the position to begin reading from
+   * @throws IOException if an I/O error occurs
+   */
+  OSSInputStream(String bucketName, String key, OSSClient client, long position)
+      throws IOException {
     mBucketName = bucketName;
     mKey = key;
     mOssClient = client;
-    mObject = mOssClient.getObject(mBucketName, mKey);
-    mInputStream = new BufferedInputStream(mObject.getObjectContent());
+    mPos = position;
   }
 
   @Override
   public void close() throws IOException {
-    mInputStream.close();
+    closeStream();
   }
 
   @Override
   public int read() throws IOException {
-    return mInputStream.read();
+    if (mInputStream == null) {
+      openStream();
+    }
+    int value = mInputStream.read();
+    if (value != -1) { // valid data read
+      mPos++;
+      if (mPos % getBlockSize() == 0) {
+        closeStream();
+      }
+    }
+    return value;
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    return mInputStream.read(b, off, len);
+    if (len == 0) {
+      return 0;
+    }
+    if (mInputStream == null) {
+      openStream();
+    }
+    int read = mInputStream.read(b, off, len);
+    if (read != -1) {
+      mPos += read;
+      if (mPos % getBlockSize() == 0) {
+        closeStream();
+      }
+    }
+    return read;
   }
 
   @Override
   public long skip(long n) throws IOException {
-    // TODO(luoli523) currently, the oss sdk doesn't support get the oss Object in a
-    // special position of the stream. It will support this feature in the future.
-    // Now we just read n bytes and discard to skip.
-    return super.skip(n);
+    if (n <= 0) {
+      return 0;
+    }
+    closeStream();
+    mPos += n;
+    openStream();
+    return n;
+  }
+
+  /**
+   * Opens a new stream at mPos if the wrapped stream mStream is null.
+   */
+  private void openStream() {
+    if (mInputStream != null) { // stream is already open
+      return;
+    }
+    GetObjectRequest req = new GetObjectRequest(mBucketName, mKey);
+    final long blockSize = getBlockSize();
+    final long endPos = mPos + blockSize - (mPos % blockSize);
+    req.setRange(mPos, endPos);
+    OSSObject ossObject = mOssClient.getObject(req);
+    mInputStream = new BufferedInputStream(ossObject.getObjectContent());
+  }
+
+  /**
+   * Closes the current stream.
+   */
+  private void closeStream() throws IOException {
+    if (mInputStream == null) {
+      return;
+    }
+    mInputStream.close();
+    mInputStream = null;
+  }
+
+  /**
+   * Block size for reading an object in chunks.
+   *
+   * @return block size in bytes
+   */
+  private long getBlockSize() {
+    return Configuration.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
   }
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -99,17 +99,6 @@ public final class OSSUnderFileSystem extends ObjectUnderFileSystem {
     return "oss";
   }
 
-  @Override
-  public InputStream open(String path) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new OSSInputStream(mBucketName, path, mClient);
-    } catch (ServiceException e) {
-      LOG.error("Failed to open file: {}", path, e);
-      return null;
-    }
-  }
-
   // No ACL integration currently, no-op
   @Override
   public void setOwner(String path, String user, String group) {}
@@ -289,5 +278,15 @@ public final class OSSUnderFileSystem extends ObjectUnderFileSystem {
     ossClientConf.setConnectionTTL(Configuration.getLong(PropertyKey.UNDERFS_OSS_CONNECT_TTL));
     ossClientConf.setMaxConnections(Configuration.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
     return ossClientConf;
+  }
+
+  @Override
+  protected InputStream openObject(String key) throws IOException {
+    try {
+      return new OSSInputStream(mBucketName, key, mClient);
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file: {}", key, e);
+      return null;
+    }
   }
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.io.PathUtils;
 
 import com.aliyun.oss.ClientConfiguration;
@@ -281,9 +282,9 @@ public final class OSSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
-      return new OSSInputStream(mBucketName, key, mClient);
+      return new OSSInputStream(mBucketName, key, mClient, options.getOffset());
     } catch (ServiceException e) {
       LOG.error("Failed to open file: {}", key, e);
       return null;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
@@ -176,24 +177,6 @@ public final class S3UnderFileSystem extends ObjectUnderFileSystem {
   @Override
   public String getUnderFSType() {
     return "s3";
-  }
-
-  /**
-   * Opens a S3 object at given position and returns the opened input stream.
-   *
-   * @param path the S3 object path
-   * @param pos the position to open at
-   * @return the opened input stream
-   * @throws IOException if failed to open file at position
-   */
-  public InputStream openAtPosition(String path, long pos) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new S3InputStream(mBucketName, path, mClient, pos);
-    } catch (ServiceException e) {
-      LOG.error("Failed to open file {} at position {}:", path, pos, e);
-      return null;
-    }
   }
 
   // Setting S3 owner via Alluxio is not supported yet. This is a no-op.
@@ -367,9 +350,9 @@ public final class S3UnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
-      return new S3InputStream(mBucketName, key, mClient);
+      return new S3InputStream(mBucketName, key, mClient, options.getOffset());
     } catch (ServiceException e) {
       LOG.error("Failed to open file: {}", key, e);
       return null;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -178,17 +178,6 @@ public final class S3UnderFileSystem extends ObjectUnderFileSystem {
     return "s3";
   }
 
-  @Override
-  public InputStream open(String path) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new S3InputStream(mBucketName, path, mClient);
-    } catch (ServiceException e) {
-      LOG.error("Failed to open file: {}", path, e);
-      return null;
-    }
-  }
-
   /**
    * Opens a S3 object at given position and returns the opened input stream.
    *
@@ -375,5 +364,15 @@ public final class S3UnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected String getRootKey() {
     return Constants.HEADER_S3N + mBucketName;
+  }
+
+  @Override
+  protected InputStream openObject(String key) throws IOException {
+    try {
+      return new S3InputStream(mBucketName, key, mClient);
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file: {}", key, e);
+      return null;
+    }
   }
 }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -205,17 +205,6 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     return "s3";
   }
 
-  @Override
-  public InputStream open(String path) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new S3AInputStream(mBucketName, path, mClient);
-    } catch (AmazonClientException e) {
-      LOG.error("Failed to open file: {}", path, e);
-      return null;
-    }
-  }
-
   /**
    * Opens a S3 object at given position and returns the opened input stream.
    *
@@ -414,5 +403,15 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected String getRootKey() {
     return Constants.HEADER_S3A + mBucketName;
+  }
+
+  @Override
+  protected InputStream openObject(String key) throws IOException {
+    try {
+      return new S3AInputStream(mBucketName, key, mClient);
+    } catch (AmazonClientException e) {
+      LOG.error("Failed to open file: {}", key, e);
+      return null;
+    }
   }
 }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
@@ -205,24 +206,6 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     return "s3";
   }
 
-  /**
-   * Opens a S3 object at given position and returns the opened input stream.
-   *
-   * @param path the S3 object path
-   * @param pos the position to open at
-   * @return the opened input stream
-   * @throws java.io.IOException if failed to open file at position
-   */
-  public InputStream openAtPosition(String path, long pos) throws IOException {
-    try {
-      path = stripPrefixIfPresent(path);
-      return new S3AInputStream(mBucketName, path, mClient, pos);
-    } catch (AmazonClientException e) {
-      LOG.error("Failed to open file {} at position {}:", path, pos, e);
-      return null;
-    }
-  }
-
   // Setting S3 owner via Alluxio is not supported yet. This is a no-op.
   @Override
   public void setOwner(String path, String user, String group) {}
@@ -406,9 +389,9 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
-      return new S3AInputStream(mBucketName, key, mClient);
+      return new S3AInputStream(mBucketName, key, mClient, options.getOffset());
     } catch (AmazonClientException e) {
       LOG.error("Failed to open file: {}", key, e);
       return null;

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -12,14 +12,11 @@
 package alluxio.underfs.swift;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 
 import org.javaswift.joss.instructions.DownloadInstructions;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.StoredObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
@@ -32,7 +29,6 @@ import java.io.InputStream;
  */
 @NotThreadSafe
 public class SwiftInputStream extends InputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** JOSS Swift account. */
   private final Account mAccount;
@@ -54,9 +50,22 @@ public class SwiftInputStream extends InputStream {
    * @param object path of the object in the container
    */
   public SwiftInputStream(Account account, String container, String object) {
+    this(account, container, object, 0L);
+  }
+
+  /**
+   * Constructor for an input stream to an object in a Swift API based store.
+   *
+   * @param account JOSS account with authentication credentials
+   * @param container the name of container where the object resides
+   * @param object path of the object in the container
+   * @param position the position to begin reading from
+   */
+  public SwiftInputStream(Account account, String container, String object, long position) {
     mAccount = account;
     mContainerName = container;
     mObjectPath = object;
+    mPos = position;
   }
 
   @Override

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -181,11 +181,6 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
     return "swift";
   }
 
-  @Override
-  public InputStream open(String path) throws IOException {
-    return new SwiftInputStream(mAccount, mContainerName, stripPrefixIfPresent(path));
-  }
-
   // Setting Swift owner via Alluxio is not supported yet. This is a no-op.
   @Override
   public void setOwner(String path, String user, String group) {}
@@ -362,5 +357,10 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected String getRootKey() {
     return Constants.HEADER_SWIFT + mContainerName + PATH_SEPARATOR;
+  }
+
+  @Override
+  protected InputStream openObject(String key) throws IOException {
+    return new SwiftInputStream(mAccount, mContainerName, key);
   }
 }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.underfs.swift.http.SwiftDirectClient;
 import alluxio.util.io.PathUtils;
 
@@ -360,7 +361,7 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key) throws IOException {
-    return new SwiftInputStream(mAccount, mContainerName, key);
+  protected InputStream openObject(String key, OpenOptions options) throws IOException {
+    return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset());
   }
 }


### PR DESCRIPTION
This PR addresses the following:
- listRecursive is now an option to list. All variants of list now return a status object instead of just a name. This has the additional information identifying the name as a file or a directory, used to remove the extra RPC on a follow up call.
- openAtPosition is merged into open options. Swift and OSS implementations are added to open stream at given position instead of using skip. LocalUFS and HDFS get implementations using skip internally.
- createDirect is removed from the main UFS API and moved to a callback interface used when employing AtomicFileOutStream.
- UFSs extending ObjectUnderFileSystem consistently work on a 'key' instead of a 'path', where key=stripPrefixIfPresent(path).

JIRA: https://alluxio.atlassian.net/browse/ALLUXIO-2416