### PR TITLE
[SMALLFIX] Improve error message on failed lockBlock and exception handling on client…

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/BlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/BlockWorkerClient.java
@@ -72,8 +72,9 @@ public interface BlockWorkerClient extends Closeable {
    * @param blockId the ID of the block
    * @return the path of the block file locked
    * @throws IOException if a non-Alluxio exception occurs
+   * @throws AlluxioException if an Alluxio error occurs
    */
-  LockBlockResult lockBlock(final long blockId) throws IOException;
+  LockBlockResult lockBlock(final long blockId) throws IOException, AlluxioException;
 
   /**
    * Promotes block back to the top StorageTier.

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
@@ -13,8 +13,6 @@ package alluxio.client.block;
 
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.BlockDoesNotExistException;
-import alluxio.exception.ExceptionMessage;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.BufferUtils;
 import alluxio.wire.LockBlockResult;
@@ -65,9 +63,6 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
       mBlockWorkerClient = mCloser.register(mContext.createWorkerClient(workerNetAddress));
       LockBlockResult result = mBlockWorkerClient.lockBlock(blockId);
       mReader = mCloser.register(new LocalFileBlockReader(result.getBlockPath()));
-    } catch (BlockDoesNotExistException e) {
-      mCloser.close();
-      throw new IOException(ExceptionMessage.BLOCK_NOT_LOCALLY_AVAILABLE.getMessage(mBlockId), e);
     } catch (AlluxioException e) {
       mCloser.close();
       throw new IOException(e);

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockInStream.java
@@ -67,7 +67,7 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
       mReader = mCloser.register(new LocalFileBlockReader(result.getBlockPath()));
     } catch (BlockDoesNotExistException e) {
       mCloser.close();
-      throw new IOException(ExceptionMessage.BLOCK_NOT_LOCALLY_AVAILABLE.getMessage(mBlockId));
+      throw new IOException(ExceptionMessage.BLOCK_NOT_LOCALLY_AVAILABLE.getMessage(mBlockId), e);
     } catch (AlluxioException e) {
       mCloser.close();
       throw new IOException(e);

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -13,6 +13,8 @@ package alluxio.client.block;
 
 import alluxio.client.RemoteBlockReader;
 import alluxio.client.file.options.InStreamOptions;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.metrics.MetricsSystem;
 import alluxio.wire.LockBlockResult;
@@ -73,10 +75,13 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
     try {
       mBlockWorkerClient = mCloser.register(mContext.createWorkerClient(workerNetAddress));
       LockBlockResult result = mBlockWorkerClient.lockBlock(blockId);
-      if (result == null) {
-        throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId));
-      }
       mLockId = result.getLockId();
+    } catch (BlockDoesNotExistException e) {
+      mCloser.close();
+      throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId));
+    } catch (AlluxioException e) {
+      mCloser.close();
+      throw new IOException(e);
     } catch (IOException e) {
       mCloser.close();
       throw e;

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -78,7 +78,7 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
       mLockId = result.getLockId();
     } catch (BlockDoesNotExistException e) {
       mCloser.close();
-      throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId));
+      throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId), e);
     } catch (AlluxioException e) {
       mCloser.close();
       throw new IOException(e);

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockInStream.java
@@ -14,8 +14,6 @@ package alluxio.client.block;
 import alluxio.client.RemoteBlockReader;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.BlockDoesNotExistException;
-import alluxio.exception.ExceptionMessage;
 import alluxio.metrics.MetricsSystem;
 import alluxio.wire.LockBlockResult;
 import alluxio.wire.WorkerNetAddress;
@@ -76,9 +74,6 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
       mBlockWorkerClient = mCloser.register(mContext.createWorkerClient(workerNetAddress));
       LockBlockResult result = mBlockWorkerClient.lockBlock(blockId);
       mLockId = result.getLockId();
-    } catch (BlockDoesNotExistException e) {
-      mCloser.close();
-      throw new IOException(ExceptionMessage.BLOCK_UNAVAILABLE.getMessage(blockId), e);
     } catch (AlluxioException e) {
       mCloser.close();
       throw new IOException(e);

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -17,8 +17,8 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
-import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.metrics.MetricsSystem;
 import alluxio.thrift.AlluxioTException;
@@ -197,25 +197,17 @@ public final class RetryHandlingBlockWorkerClient
   }
 
   @Override
-  public LockBlockResult lockBlock(final long blockId) throws IOException {
+  public LockBlockResult lockBlock(final long blockId) throws IOException, AlluxioException {
     // TODO(jiri) Would be nice to have a helper method to execute this try-catch logic
-    try {
-      return retryRPC(
-          new RpcCallableThrowsAlluxioTException<LockBlockResult, BlockWorkerClientService
-              .Client>() {
-            @Override
-            public LockBlockResult call(BlockWorkerClientService.Client client)
-                throws AlluxioTException, TException {
-              return ThriftUtils.fromThrift(client.lockBlock(blockId, getSessionId()));
-            }
-          });
-    } catch (AlluxioException e) {
-      if (e instanceof FileDoesNotExistException) {
-        return null;
-      } else {
-        throw new IOException(e);
-      }
-    }
+    return retryRPC(
+        new RpcCallableThrowsAlluxioTException<LockBlockResult, BlockWorkerClientService
+            .Client>() {
+          @Override
+          public LockBlockResult call(BlockWorkerClientService.Client client)
+              throws AlluxioTException, TException {
+            return ThriftUtils.fromThrift(client.lockBlock(blockId, getSessionId()));
+          }
+        });
   }
 
   @Override

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -197,7 +197,6 @@ public final class RetryHandlingBlockWorkerClient
 
   @Override
   public LockBlockResult lockBlock(final long blockId) throws IOException, AlluxioException {
-    // TODO(jiri) Would be nice to have a helper method to execute this try-catch logic
     return retryRPC(
         new RpcCallableThrowsAlluxioTException<LockBlockResult, BlockWorkerClientService
             .Client>() {

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -17,7 +17,6 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.metrics.MetricsSystem;

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -32,8 +32,6 @@ public enum ExceptionMessage {
   PATH_INVALID("Path {0} is invalid"),
 
   // general block
-  BLOCK_NOT_LOCALLY_AVAILABLE("blockId {0,number,#} is not available on local machine"),
-  BLOCK_UNAVAILABLE("blockId {0,number,#} is not available in Alluxio"),
   CANNOT_REQUEST_SPACE("Not enough space left on worker {0} to store blockId {1,number,#}."),
   NO_LOCAL_WORKER("Local address {0} requested but there is no local worker"),
   NO_WORKER_AVAILABLE_ON_ADDRESS("No Alluxio worker available for address {0}"),

--- a/core/server/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -142,8 +142,7 @@ public final class TieredBlockStore implements BlockStore {
       return lockId;
     }
     mLockManager.unlockBlock(lockId);
-    throw new BlockDoesNotExistException(
-        ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_SESSION, blockId, sessionId);
+    throw new BlockDoesNotExistException(ExceptionMessage.NO_BLOCK_ID_FOUND, blockId);
   }
 
   @Override

--- a/core/server/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -138,8 +138,7 @@ public final class TieredBlockStoreTest {
   @Test
   public void lockNonExistingBlock() throws Exception {
     mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_SESSION
-        .getMessage(BLOCK_ID1, SESSION_ID1));
+    mThrown.expectMessage(ExceptionMessage.NO_BLOCK_ID_FOUND.getMessage(BLOCK_ID1));
 
     mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
   }

--- a/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
@@ -26,7 +26,6 @@ import alluxio.client.block.RetryHandlingBlockMasterClient;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.ConnectionFailedException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;

--- a/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/DataServerIntegrationTest.java
@@ -214,7 +214,7 @@ public class DataServerIntegrationTest {
   }
 
   private ByteBuffer readRemotely(RemoteBlockReader client, BlockInfo block, int length)
-      throws IOException, ConnectionFailedException {
+      throws IOException, AlluxioException {
     long lockId = mBlockWorkerClient.lockBlock(block.getBlockId()).getLockId();
     try {
       return client.readRemoteBlock(


### PR DESCRIPTION
Motivated by https://groups.google.com/forum/#!topic/alluxio-users/nddp3eEhrYA
where the error message like "no lock is found for blockId 16911433728 for sessionId 7814717572343933401" is confusing as it is in fact indicating block not stored in that worker any more

@calvinjia could you review this?