### PR TITLE
[SMALLFIX] Make shell method visibilities consistent

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -88,7 +88,7 @@ public abstract class AbstractShellCommand implements ShellCommand {
    *
    * @return the number of arguments
    */
-  abstract int getNumOfArgs();
+  protected abstract int getNumOfArgs();
 
   /**
    * Gets the supported Options of the command.

--- a/shell/src/main/java/alluxio/shell/command/CatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CatCommand.java
@@ -46,7 +46,7 @@ public final class CatCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
 
     if (status.isFolder()) {

--- a/shell/src/main/java/alluxio/shell/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CheckConsistencyCommand.java
@@ -35,7 +35,7 @@ public class CheckConsistencyCommand extends AbstractShellCommand {
   }
 
   @Override
-  int getNumOfArgs() {
+  protected int getNumOfArgs() {
     return 1;
   }
 

--- a/shell/src/main/java/alluxio/shell/command/DuCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/DuCommand.java
@@ -42,7 +42,7 @@ public final class DuCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     long sizeInBytes = getFileOrFolderSize(mFileSystem, path);
     System.out.println(path + " is " + sizeInBytes + " bytes");
   }

--- a/shell/src/main/java/alluxio/shell/command/FileInfoCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/FileInfoCommand.java
@@ -47,7 +47,7 @@ public final class FileInfoCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
 
     if (status.isFolder()) {

--- a/shell/src/main/java/alluxio/shell/command/FreeCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/FreeCommand.java
@@ -44,7 +44,7 @@ public final class FreeCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     FreeOptions options = FreeOptions.defaults().setRecursive(true);
     mFileSystem.free(path, options);
     System.out.println(path + " was successfully freed from memory.");

--- a/shell/src/main/java/alluxio/shell/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LoadCommand.java
@@ -49,7 +49,7 @@ public final class LoadCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     load(path);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/LocationCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LocationCommand.java
@@ -50,7 +50,7 @@ public final class LocationCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
 
     System.out.println(path + " with file id " + status.getFileId() + " is on nodes: ");

--- a/shell/src/main/java/alluxio/shell/command/PinCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/PinCommand.java
@@ -41,7 +41,7 @@ public final class PinCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     CommandUtils.setPinned(mFileSystem, path, true);
     System.out.println("File '" + path + "' was successfully pinned.");
   }

--- a/shell/src/main/java/alluxio/shell/command/ReportCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ReportCommand.java
@@ -43,7 +43,7 @@ public final class ReportCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     LineageFileSystem.get(FileSystemContext.INSTANCE, LineageContext.INSTANCE).reportLostFile(path);
     System.out.println(path + " has been reported as lost.");
   }

--- a/shell/src/main/java/alluxio/shell/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/RmCommand.java
@@ -54,7 +54,7 @@ public final class RmCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     // TODO(calvin): Remove explicit state checking.
     boolean recursive = cl.hasOption("R");
     if (!mFileSystem.exists(path)) {

--- a/shell/src/main/java/alluxio/shell/command/TailCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/TailCommand.java
@@ -49,7 +49,7 @@ public final class TailCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
 
     int numOfBytes = Constants.KB;

--- a/shell/src/main/java/alluxio/shell/command/UnpinCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/UnpinCommand.java
@@ -41,7 +41,7 @@ public final class UnpinCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
+  protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     CommandUtils.setPinned(mFileSystem, path, false);
     System.out.println("File '" + path + "' was successfully unpinned.");
   }

--- a/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
@@ -47,7 +47,8 @@ public abstract class WithWildCardPathCommand extends AbstractShellCommand {
    * @param cl the parsed command line object including options
    * @throws IOException if the command fails
    */
-  abstract void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException;
+  protected abstract void runCommand(AlluxioURI path, CommandLine cl)
+      throws AlluxioException, IOException;
 
   @Override
   protected int getNumOfArgs() {


### PR DESCRIPTION
We use protected everywhere else, no reason for just a few to be package-private