### PR TITLE
[ALLUXIO-2120] Reset client contexts when master address changes during initialization.

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -145,8 +145,6 @@ public final class AlluxioBlockStore {
     // But when there is no local worker or there are no local blocks, we prefer the first
     // location in blockInfo.locations that is nearest to memory tier.
     // Assuming if there is no local worker, there are no local blocks in blockInfo.locations.
-    // TODO(cc): Check mFileSystemContext.hasLocalWorker before finding for a local block when
-    // the TODO for hasLocalWorker is fixed.
     for (BlockLocation location : blockInfo.getLocations()) {
       WorkerNetAddress workerNetAddress = location.getWorkerAddress();
       if (workerNetAddress.getHost().equals(mLocalHostName)) {

--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -145,8 +145,8 @@ public final class AlluxioBlockStore {
     // But when there is no local worker or there are no local blocks, we prefer the first
     // location in blockInfo.locations that is nearest to memory tier.
     // Assuming if there is no local worker, there are no local blocks in blockInfo.locations.
-    // TODO(cc): Check mContext.hasLocalWorker before finding for a local block when the TODO
-    // for hasLocalWorker is fixed.
+    // TODO(cc): Check mFileSystemContext.hasLocalWorker before finding for a local block when
+    // the TODO for hasLocalWorker is fixed.
     for (BlockLocation location : blockInfo.getLocations()) {
       WorkerNetAddress workerNetAddress = location.getWorkerAddress();
       if (workerNetAddress.getHost().equals(mLocalHostName)) {

--- a/core/client/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
@@ -67,14 +67,14 @@ public final class UnknownLengthFileInStream extends FileInStream {
     if (mCurrentBlockInStream != null && mCurrentBlockInStream.remaining() == 0) {
       // Every byte was read from the input stream. Therefore, the read bytes is the length.
       // Complete the file with this new, known length.
-      FileSystemMasterClient masterClient = mContext.acquireMasterClient();
+      FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
       try {
         masterClient.completeFile(new AlluxioURI(mStatus.getPath()),
             CompleteFileOptions.defaults().setUfsLength(mPos));
       } catch (AlluxioException e) {
         throw new IOException(e);
       } finally {
-        mContext.releaseMasterClient(masterClient);
+        mFileSystemContext.releaseMasterClient(masterClient);
       }
     } else {
       LOG.warn("File with unknown length was closed before fully reading the input stream.");
@@ -106,7 +106,7 @@ public final class UnknownLengthFileInStream extends FileInStream {
   protected BlockInStream createUnderStoreBlockInStream(long blockStart, long length, String path)
       throws IOException {
     return new UnderStoreBlockInStream(blockStart, Constants.UNKNOWN_SIZE, length,
-        getUnderStoreStreamFactory(path, mContext));
+        getUnderStoreStreamFactory(path, mFileSystemContext));
   }
 
   @Override


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2120

Currently, when using hadoop compatible file system API, the client context is initialized only once. If during the first initialization, master address is invalid, then the invalid master address will be permanently used unless client JVM is restarted. A more user friendly behavior should be that if master address is reset to a different value, then the client context is reinitialized too.