### PR TITLE
[ALLUXIO-2021] Validate master address during initializing hadoop client.

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -426,13 +426,13 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     mUri = URI.create(mAlluxioHeader);
 
     if (sInitialized) {
-      assertSameClientURI();
+      checkMasterAddress();
       return;
     }
     synchronized (INIT_LOCK) {
       // If someone has initialized the object since the last check, return
       if (sInitialized) {
-        assertSameClientURI();
+        checkMasterAddress();
         return;
       }
 
@@ -458,7 +458,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
         sFileSystem = FileSystem.Factory.get();
         sInitialized = true;
       } catch (ConnectionFailedException | IOException e) {
-        LOG.error("Failed to connect to the provided master address {}: {}.", uri, e);
+        LOG.error("Failed to connect to the provided master address {}: {}.",
+            uri.toString(), e.toString());
         throw new IOException(e);
       } finally {
         FileSystemContext.INSTANCE.releaseMasterClient(client);
@@ -466,7 +467,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     }
   }
 
-  private void assertSameClientURI() throws IOException {
+  // Assures the mUri is the same as the master address in the current client context.
+  private void checkMasterAddress() throws IOException {
     InetSocketAddress masterAddress = ClientContext.getMasterAddress();
     boolean sameHost = masterAddress.getHostString().equals(mUri.getHost());
     boolean samePort = masterAddress.getPort() == mUri.getPort();

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -45,7 +45,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -291,7 +290,7 @@ public class AbstractFileSystemTest {
 
   private void mockFileSystemContextAndMasterClient() {
     mMockFileSystemContext = Mockito.mock(FileSystemContext.class);
-    Whitebox.setInternalState(FileSystemContext.class, "INSTANCE", mMockFileSystemContext);
+    AbstractFileSystem.setFileSystemContext(mMockFileSystemContext);
     mMockFileSystemMasterClient = Mockito.mock(FileSystemMasterClient.class);
     Mockito.when(mMockFileSystemContext.acquireMasterClient())
         .thenReturn(mMockFileSystemMasterClient);

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -152,6 +152,7 @@ public enum ExceptionMessage {
   UNKNOWN_LINEAGE_FILE_STATE("Unknown LineageFileState: {0}"),
 
   // client
+  DIFFERENT_MASTER_ADDRESS("Master address {0} is different from that in client context {1}"),
   INCOMPATIBLE_VERSION("{0} client version {1} is not compatible with server version {2}"),
 
   // configuration


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2021

Currently, the first master address user provided will be used to initialize the global client context, but if the address is wrong, the user has to restart the client JVM to reset a master address.

This PR validates the master address when initializing the hadoop compatible file system API by trying to connect to master RPC port, connection failure causes client initialization failure, so that a new master address can be set. Once a valid master address is set, further initialization with a different master address will fail.
