### PR TITLE
[SMALLFIX] Improvements to shell scripts.

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -21,15 +21,17 @@ BIN=$(cd "$( dirname "$0" )"; pwd)
 
 USAGE="Usage: alluxio-start.sh [-hNw] ACTION [MOPT] [-f]
 Where ACTION is one of:
-  all [MOPT]     \tStart master, proxy and all workers.
-  local [MOPT]   \tStart a master and worker locally.
+  all [MOPT]     \tStart master and all proxies and workers.
+  local [MOPT]   \tStart a master, proxy and worker locally.
   master         \tStart the master on this node.
   proxy          \tStart the proxy on this node.
+  proxies        \tStart proxies on worker nodes.
   safe           \tScript will run continuously and start the master if it's not running.
   worker [MOPT]  \tStart a worker on this node.
   workers [MOPT] \tStart workers on worker nodes.
   restart_worker \tRestart a failed worker on this node.
   restart_workers\tRestart any failed workers on worker nodes.
+
 MOPT (Mount Option) is one of:
   Mount    \tMount the configured RamFS. Notice: this will format the existing RamFS.
   SudoMount\tMount the configured RamFS using sudo.
@@ -79,7 +81,7 @@ is_ram_folder_mounted() {
 }
 
 check_mount_mode() {
-  case "$1" in
+  case $1 in
     Mount);;
     SudoMount);;
     NoMount)
@@ -197,6 +199,18 @@ restart_worker() {
   fi
 }
 
+restart_workers() {
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "restart_worker"
+}
+
+start_proxies() {
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "proxy"
+}
+
+start_workers() {
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" $1
+}
+
 run_safe() {
   while [ 1 ]
   do
@@ -271,16 +285,17 @@ main() {
   case "${ACTION}" in
     all)
       if [[ "${killonstart}" != "no" ]]; then
-        stop ${BIN}
+        stop
       fi
       start_master "${FORMAT}"
-      sleep 2
-      ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" "${MOPT}"
       start_proxy
+      sleep 2
+      start_workers "${MOPT}"
+      start_proxies
       ;;
     local)
       if [[ "${killonstart}" != "no" ]]; then
-        stop ${BIN}
+        stop
         sleep 1
       fi
       start_master "${FORMAT}"
@@ -294,20 +309,23 @@ main() {
     proxy)
       start_proxy
       ;;
-    worker)
-      start_worker "${MOPT}"
-      ;;
-    safe)
-      run_safe
-      ;;
-    workers)
-      ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "worker" "${MOPT}"
+    proxies)
+      start_proxies
       ;;
     restart_worker)
       restart_worker
       ;;
     restart_workers)
-      ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" restart_worker
+      restart_workers
+      ;;
+    safe)
+      run_safe
+      ;;
+    worker)
+      start_worker "${MOPT}"
+      ;;
+    workers)
+      start_workers "${MOPT}"
       ;;
     *)
     echo "Error: Invalid ACTION: ${ACTION}" >&2

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -22,7 +22,7 @@ BIN=$(cd "$( dirname "$0" )"; pwd)
 USAGE="Usage: alluxio-start.sh [-hNw] ACTION [MOPT] [-f]
 Where ACTION is one of:
   all [MOPT]     \tStart master and all proxies and workers.
-  local [MOPT]   \tStart a master, proxy and worker locally.
+  local [MOPT]   \tStart a master, proxy, and worker locally.
   master         \tStart the master on this node.
   proxy          \tStart the proxy on this node.
   proxies        \tStart proxies on worker nodes.

--- a/bin/alluxio-stop.sh
+++ b/bin/alluxio-stop.sh
@@ -19,51 +19,64 @@ BIN=$(cd "$( dirname "$0" )"; pwd)
 
 USAGE="Usage: alluxio-stop.sh [-h] [component]
 Where component is one of:
-  all     \tStop master, proxy and all workers.
+  all     \tStop master and all proxies and workers.
+  local   \tStop local master, proxy, and worker.
   master  \tStop local master.
   proxy   \tStop local proxy.
+  proxies \tStop all remote proxies.
   worker  \tStop local worker.
-  workers \tStop local worker and all remote workers.
+  workers \tStop all remote workers.
 
 -h  display this help."
 
-kill_master() {
-  ${LAUNCHER} ${BIN}/alluxio killAll alluxio.master.AlluxioMaster
+stop_master() {
+  ${LAUNCHER} "${BIN}/alluxio" "killAll" "alluxio.master.AlluxioMaster"
 }
 
-kill_proxy() {
-  ${LAUNCHER} ${BIN}/alluxio killAll alluxio.proxy.AlluxioProxy
+stop_proxy() {
+  ${LAUNCHER} "${BIN}/alluxio" "killAll" "alluxio.proxy.AlluxioProxy"
 }
 
-kill_worker() {
-  ${LAUNCHER} ${BIN}/alluxio killAll alluxio.worker.AlluxioWorker
+stop_worker() {
+  ${LAUNCHER} "${BIN}/alluxio" "killAll" "alluxio.worker.AlluxioWorker"
 }
 
-kill_remote_workers() {
-  ${LAUNCHER} ${BIN}/alluxio-workers.sh ${BIN}/alluxio killAll alluxio.worker.AlluxioWorker
+stop_remote_proxies() {
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio" "killAll" "alluxio.proxy.AlluxioProxy"
+}
+
+stop_remote_workers() {
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio" "killAll" "alluxio.worker.AlluxioWorker"
 }
 
 WHAT=${1:--h}
 
 case "${WHAT}" in
+  all)
+    stop_remote_proxies
+    stop_remote_workers
+    stop_proxy
+    stop_master
+    ;;
+  local)
+    stop_proxy
+    stop_worker
+    stop_master
+    ;;
   master)
-    kill_master
+    stop_master
     ;;
   proxy)
-    kill_proxy
+    stop_proxy
+    ;;
+  proxies)
+    stop_remote_proxies
     ;;
   worker)
-    kill_worker
+    stop_worker
     ;;
   workers)
-    kill_worker
-    kill_remote_workers
-    ;;
-  all)
-    kill_master
-    kill_worker
-    kill_remote_workers
-    kill_proxy
+    stop_remote_workers
     ;;
   -h)
     echo -e "${USAGE}"

--- a/bin/alluxio-stop.sh
+++ b/bin/alluxio-stop.sh
@@ -23,9 +23,9 @@ Where component is one of:
   local   \tStop local master, proxy, and worker.
   master  \tStop local master.
   proxy   \tStop local proxy.
-  proxies \tStop all remote proxies.
+  proxies \tStop proxies on worker nodes.
   worker  \tStop local worker.
-  workers \tStop all remote workers.
+  workers \tStop workers on worker nodes.
 
 -h  display this help."
 
@@ -41,11 +41,11 @@ stop_worker() {
   ${LAUNCHER} "${BIN}/alluxio" "killAll" "alluxio.worker.AlluxioWorker"
 }
 
-stop_remote_proxies() {
+stop_proxies() {
   ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio" "killAll" "alluxio.proxy.AlluxioProxy"
 }
 
-stop_remote_workers() {
+stop_workers() {
   ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio" "killAll" "alluxio.worker.AlluxioWorker"
 }
 
@@ -53,8 +53,8 @@ WHAT=${1:--h}
 
 case "${WHAT}" in
   all)
-    stop_remote_proxies
-    stop_remote_workers
+    stop_proxies
+    stop_workers
     stop_proxy
     stop_master
     ;;
@@ -70,13 +70,13 @@ case "${WHAT}" in
     stop_proxy
     ;;
   proxies)
-    stop_remote_proxies
+    stop_proxies
     ;;
   worker)
     stop_worker
     ;;
   workers)
-    stop_remote_workers
+    stop_workers
     ;;
   -h)
     echo -e "${USAGE}"

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -34,7 +34,7 @@ ALLUXIO_LOG_DIR="${BIN}/../logs"
 mkdir -p "${ALLUXIO_LOG_DIR}"
 ALLUXIO_TASK_LOG="${ALLUXIO_LOG_DIR}/task.log"
 
-echo "Executing the following command remotely on all workers: $@" >> ${ALLUXIO_TASK_LOG}
+echo "Executing the following command on all worker nodes: $@" >> ${ALLUXIO_TASK_LOG}
 
 for worker in $(echo ${HOSTLIST}); do
   echo "[${worker}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -34,19 +34,14 @@ ALLUXIO_LOG_DIR="${BIN}/../logs"
 mkdir -p "${ALLUXIO_LOG_DIR}"
 ALLUXIO_TASK_LOG="${ALLUXIO_LOG_DIR}/task.log"
 
-if [[ "$3" == "alluxio.worker.AlluxioWorker" ]]; then
-  WORKER_ACTION_TYPE="WORKERS"
-else
-  WORKER_ACTION_TYPE="MASTER"
-fi
+echo "Executing the following command remotely on all workers: $@" >> ${ALLUXIO_TASK_LOG}
 
 for worker in $(echo ${HOSTLIST}); do
-  echo "$(date +"%F %H:%M:%S,$(date +"%s%N" | cut -c 11- | cut -c 1-3)")
-   INFO ${WORKER_ACTION_TYPE}  Connecting to ${worker} as ${USER}..." >> ${ALLUXIO_TASK_LOG}
+  echo "[${worker}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}
   nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
-   $"${@// /\\ }" >> ${ALLUXIO_TASK_LOG} 2>&1&
+   $"${@// /\\ }" 2>&1 | while read line; do echo "[${worker}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
 done
 
-echo "Waiting for ${WORKER_ACTION_TYPE} tasks to finish..."
+echo "Waiting for tasks to finish..."
 wait
-echo "All ${WORKER_ACTION_TYPE} tasks finished, please analyze the log at ${ALLUXIO_TASK_LOG}."
+echo "All tasks finished, please analyze the log at ${ALLUXIO_TASK_LOG}."


### PR DESCRIPTION
This PR makes the following improvements to shell scripts:

- `bin/alluxio-start.sh proxies` is now supported
- `bin/alluxio-stop.sh local` is now supported
- `bin/alluxio-stop.sh proxies` is now supported

- `bin/alluxio-start.sh all` now correctly starts proxies
- `bin/alluxio-stop.sh *` stops services in the reverse order the corresponding `start` action started them

- removes brittle action type detection from `task.log`
- the `task.log` output lines of remote ssh execution are now tagged with hostname
