### PR TITLE
[SMALLFIX] Netty version upgrade

### DIFF
--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.28.Final</version>
+      <version>4.1.6.Final</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.28.Final</version>
+      <version>4.1.6.Final</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.28.Final</version>
+      <version>4.1.6.Final</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>


### PR DESCRIPTION
Upgrade netty from 4.0 to 4.1

New features in 4.1:
http://netty.io/wiki/new-and-noteworthy-in-4.1.html
The ones that are very relevant to us:
1. Easier and more precise buffer leak tracking
2. PooledByteBufAllocator as the default allocator
3. Globally unique channel ID