### PR TITLE
[ALLUXIO-2448] Use faster low-level Zookeeper API for inquire client

### DIFF
--- a/core/common/src/main/java/alluxio/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/MasterInquireClient.java
@@ -17,6 +17,7 @@ import alluxio.util.io.PathUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,11 +80,13 @@ public final class MasterInquireClient {
    * @return the address of the current leader master
    */
   public synchronized String getLeaderAddress() {
+    long startTime = System.currentTimeMillis();
     int tried = 0;
     try {
+      ZooKeeper zookeeper = mClient.getZookeeperClient().getZooKeeper();
       while (tried < mMaxTry) {
-        if (mClient.checkExists().forPath(mLeaderPath) != null) {
-          List<String> masters = mClient.getChildren().forPath(mLeaderPath);
+        if (zookeeper.exists(mLeaderPath, false) != null) {
+          List<String> masters = zookeeper.getChildren(mLeaderPath, null);
           LOG.info("Master addresses: {}", masters);
           if (masters.size() >= 1) {
             if (masters.size() == 1) {
@@ -93,8 +96,7 @@ public final class MasterInquireClient {
             long maxTime = 0;
             String leader = "";
             for (String master : masters) {
-              Stat stat = mClient.checkExists().forPath(
-                  PathUtils.concatPath(mLeaderPath, master));
+              Stat stat = zookeeper.exists(PathUtils.concatPath(mLeaderPath, master), null);
               if (stat != null && stat.getCtime() > maxTime) {
                 maxTime = stat.getCtime();
                 leader = master;
@@ -111,6 +113,8 @@ public final class MasterInquireClient {
     } catch (Exception e) {
       LOG.error("Error getting the leader master address from zookeeper. Zookeeper address: {}",
           mZookeeperAddress, e);
+    } finally {
+      LOG.debug("Finished getLeaderAddress() in {}ms", System.currentTimeMillis() - startTime);
     }
 
     return null;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2448

I found that the previous approach would always take over one second for the first `exists` RPC, while the low-level api would take less than 50 milliseconds. 

Docs on Zookeeper clients: http://curator.apache.org/curator-client/index.html