### PR TITLE
[SMALLFIX] Make persist shell command go though Alluxio worker

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -158,7 +158,7 @@ public final class FileSystemUtils {
           throw Throwables.propagate(e);
         }
       }
-    }, 20 * 60 * 1000 /* timeout in ms */, 1000 /* sleep interval in ms */);
+    }, 20 * Constants.MINUTE_MS /* timeout */, Constants.SECOND_MS /* sleep interval */);
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -15,28 +15,18 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
-import alluxio.client.ReadType;
 import alluxio.client.file.options.CheckConsistencyOptions;
-import alluxio.client.file.options.OpenFileOptions;
-import alluxio.client.file.options.SetAttributeOptions;
-import alluxio.collections.Pair;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
-import alluxio.security.authorization.Permission;
-import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.options.CreateOptions;
-import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 
-import com.google.common.io.Closer;
-import org.apache.commons.io.IOUtils;
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.List;
-import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -145,59 +135,29 @@ public final class FileSystemUtils {
    *
    * @param fs {@link FileSystem} to carry out Alluxio operations
    * @param uri the uri of the file to persist
-   * @param status the status info of the file
-   * @return the size of the file persisted
    * @throws IOException if an I/O error occurs
    * @throws FileDoesNotExistException if the given file does not exist
    * @throws AlluxioException if an unexpected Alluxio error occurs
    */
-  public static long persistFile(FileSystem fs, AlluxioURI uri, URIStatus status)
-      throws IOException, FileDoesNotExistException, AlluxioException {
-    // TODO(manugoyal) move this logic to the worker, as it deals with the under file system
-    Closer closer = Closer.create();
-    long ret;
+  public static void persistFile(final FileSystem fs, final AlluxioURI uri)
+      throws AlluxioException, IOException {
+    FileSystemContext context = FileSystemContext.INSTANCE;
+    FileSystemMasterClient client = context.acquireMasterClient();
     try {
-      OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);
-      FileInStream in = closer.register(fs.openFile(uri, options));
-      AlluxioURI dstPath = new AlluxioURI(status.getUfsPath());
-      UnderFileSystem ufs = UnderFileSystem.Factory.get(dstPath.toString());
-      // Create ancestor directories from top to the bottom. We cannot use recursive create parents
-      // here because the permission for the ancestors can be different.
-      Stack<Pair<String, MkdirsOptions>> ufsDirsToMakeWithOptions = new Stack<>();
-      AlluxioURI curAlluxioPath = uri.getParent();
-      AlluxioURI curUfsPath = dstPath.getParent();
-      // Stop at the Alluxio root because the mapped directory of Alluxio root in UFS may not exist.
-      while (!ufs.isDirectory(curUfsPath.toString()) && curAlluxioPath != null) {
-        URIStatus curDirStatus = fs.getStatus(curAlluxioPath);
-        Permission perm = new Permission(curDirStatus.getOwner(), curDirStatus.getGroup(),
-            (short) curDirStatus.getMode());
-        ufsDirsToMakeWithOptions.push(new Pair<>(curUfsPath.toString(),
-            MkdirsOptions.defaults().setCreateParent(false).setPermission(perm)));
-
-        curAlluxioPath = curAlluxioPath.getParent();
-        curUfsPath = curUfsPath.getParent();
-      }
-      while (!ufsDirsToMakeWithOptions.empty()) {
-        Pair<String, MkdirsOptions> ufsDirAndPerm = ufsDirsToMakeWithOptions.pop();
-        if (!ufs.mkdirs(ufsDirAndPerm.getFirst(), ufsDirAndPerm.getSecond())) {
-          throw new IOException("Failed to create " + ufsDirAndPerm.getFirst() + " with permission "
-              + ufsDirAndPerm.getSecond().toString());
+      client.scheduleAsyncPersist(uri);
+      CommonUtils.waitFor("Wait for the file to be persisted", new Function<Void, Boolean>() {
+        @Override
+        public Boolean apply(Void input) {
+          try {
+            return fs.getStatus(uri).isPersisted();
+          } catch (Exception e) {
+            throw Throwables.propagate(e);
+          }
         }
-      }
-      URIStatus uriStatus = fs.getStatus(uri);
-      Permission perm = new Permission(uriStatus.getOwner(), uriStatus.getGroup(),
-          (short) uriStatus.getMode());
-      OutputStream out = closer.register(ufs.create(dstPath.toString(),
-          CreateOptions.defaults().setPermission(perm)));
-      ret = IOUtils.copyLarge(in, out);
-    } catch (Exception e) {
-      throw closer.rethrow(e);
+      });
     } finally {
-      closer.close();
+      context.releaseMasterClient(client);
     }
-    // Tell the master to mark the file as persisted
-    fs.setAttribute(uri, SetAttributeOptions.defaults().setPersisted(true));
-    return ret;
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -146,19 +146,19 @@ public final class FileSystemUtils {
     FileSystemMasterClient client = context.acquireMasterClient();
     try {
       client.scheduleAsyncPersist(uri);
-      CommonUtils.waitFor("Wait for the file to be persisted", new Function<Void, Boolean>() {
-        @Override
-        public Boolean apply(Void input) {
-          try {
-            return fs.getStatus(uri).isPersisted();
-          } catch (Exception e) {
-            throw Throwables.propagate(e);
-          }
-        }
-      });
     } finally {
       context.releaseMasterClient(client);
     }
+    CommonUtils.waitFor("Wait for the file to be persisted", new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(Void input) {
+        try {
+          return fs.getStatus(uri).isPersisted();
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    }, 300 * 1000 /* timeout in ms */, 200 /* sleep interval in ms */);
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -158,7 +158,7 @@ public final class FileSystemUtils {
           throw Throwables.propagate(e);
         }
       }
-    }, 300 * 1000 /* timeout in ms */, 200 /* sleep interval in ms */);
+    }, 20 * 60 * 1000 /* timeout in ms */, 1000 /* sleep interval in ms */);
   }
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -41,6 +41,7 @@ public final class FileSystemUtils {
   // prevent instantiation
   private FileSystemUtils() {}
 
+  // TODO(chaomin): remove this unused util.
   /**
    * Shortcut for {@code waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS)}, i.e., wait for an
    * indefinite amount of time. Note that if a file is never completed, the thread will block

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -41,7 +41,7 @@ public final class FileSystemUtils {
   // prevent instantiation
   private FileSystemUtils() {}
 
-  // TODO(chaomin): remove this unused util.
+  // TODO(calvin): make this PublicApi as it meant to be user facing.
   /**
    * Shortcut for {@code waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS)}, i.e., wait for an
    * indefinite amount of time. Note that if a file is never completed, the thread will block

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -85,9 +85,11 @@ public final class SetAttributeOptions {
   }
 
   /**
+   * @deprecated the persisted attribute is deprecated since version 1.4 and will be removed in 2.0
    * @return the persisted value of the file; it denotes whether the file has been persisted to the
    *         under file system or not.
    */
+  @Deprecated
   public Boolean getPersisted() {
     return mPersisted;
   }
@@ -152,10 +154,12 @@ public final class SetAttributeOptions {
   }
 
   /**
+   * @deprecated the persisted attribute is deprecated since version 1.4 and will be removed in 2.0
    * @param persisted the persisted flag value to use; it specifies whether the file has been
    *        persisted in the under file system or not.
    * @return the updated options object
    */
+  @Deprecated
   public SetAttributeOptions setPersisted(boolean persisted) {
     LOG.warn("Setting the value of the persisted attribute is deprecated since version 1.4 and "
         + "will be removed in 2.0.");

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -31,12 +31,12 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class SetAttributeOptions {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private final Logger mLogger = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private Boolean mPinned;
   private Long mTtl;
   private TtlAction mTtlAction;
-  // Set attribute for persist will be deprecated in Alluxio 1.4 release.
+  // SetAttribute for persist will be deprecated in Alluxio 1.4 release.
   private Boolean mPersisted;
   private String mOwner;
   private String mGroup;
@@ -157,7 +157,7 @@ public final class SetAttributeOptions {
    * @return the updated options object
    */
   public SetAttributeOptions setPersisted(boolean persisted) {
-    LOG.info("DEPRECATED: set attribute for persist will be deprecated in Alluxio 1.4 release.");
+    mLogger.info("DEPRECATED: SetAttribute for persist will be deprecated in Alluxio 1.4 release.");
     mPersisted = persisted;
     return this;
   }

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -31,8 +31,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class SetAttributeOptions {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private Boolean mPinned;
   private Long mTtl;
   private TtlAction mTtlAction;
@@ -161,8 +159,6 @@ public final class SetAttributeOptions {
    */
   @Deprecated
   public SetAttributeOptions setPersisted(boolean persisted) {
-    LOG.warn("Setting the value of the persisted attribute is deprecated since version 1.4 and "
-        + "will be removed in 2.0.");
     mPersisted = persisted;
     return this;
   }

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -31,6 +31,7 @@ public final class SetAttributeOptions {
   private Boolean mPinned;
   private Long mTtl;
   private TtlAction mTtlAction;
+  // Set attribute for persist will be deprecated in Alluxio 1.4 release.
   private Boolean mPersisted;
   private String mOwner;
   private String mGroup;

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -157,7 +157,8 @@ public final class SetAttributeOptions {
    * @return the updated options object
    */
   public SetAttributeOptions setPersisted(boolean persisted) {
-    mLogger.info("DEPRECATED: SetAttribute for persist will be deprecated in Alluxio 1.4 release.");
+    mLogger.warn("Setting the value of the persisted attribute is deprecated since version 1.4 and "
+        + "will be removed in 2.0.");
     mPersisted = persisted;
     return this;
   }

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file.options;
 
+import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.security.authorization.Mode;
 import alluxio.thrift.SetAttributeTOptions;
@@ -18,6 +19,8 @@ import alluxio.wire.ThriftUtils;
 import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -28,6 +31,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class SetAttributeOptions {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private Boolean mPinned;
   private Long mTtl;
   private TtlAction mTtlAction;
@@ -152,6 +157,7 @@ public final class SetAttributeOptions {
    * @return the updated options object
    */
   public SetAttributeOptions setPersisted(boolean persisted) {
+    LOG.info("DEPRECATED: set attribute for persist will be deprecated in Alluxio 1.4 release.");
     mPersisted = persisted;
     return this;
   }

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.file.options;
 
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.security.authorization.Mode;
 import alluxio.thrift.SetAttributeTOptions;
@@ -19,8 +18,6 @@ import alluxio.wire.ThriftUtils;
 import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class SetAttributeOptions {
-  private final Logger mLogger = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private Boolean mPinned;
   private Long mTtl;
@@ -157,7 +157,7 @@ public final class SetAttributeOptions {
    * @return the updated options object
    */
   public SetAttributeOptions setPersisted(boolean persisted) {
-    mLogger.warn("Setting the value of the persisted attribute is deprecated since version 1.4 and "
+    LOG.warn("Setting the value of the persisted attribute is deprecated since version 1.4 and "
         + "will be removed in 2.0.");
     mPersisted = persisted;
     return this;

--- a/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
@@ -108,7 +108,7 @@ public class SetAttributeOptionsTest {
 
   @Test
   public void equalsTest() throws Exception {
-    CommonTestUtils.testEquals(SetAttributeOptions.class);
+    CommonTestUtils.testEquals(SetAttributeOptions.class, "mLogger");
   }
 
   @Test

--- a/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
@@ -108,7 +108,7 @@ public class SetAttributeOptionsTest {
 
   @Test
   public void equalsTest() throws Exception {
-    CommonTestUtils.testEquals(SetAttributeOptions.class, "mLogger");
+    CommonTestUtils.testEquals(SetAttributeOptions.class);
   }
 
   @Test

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -215,23 +215,6 @@ public final class CommonUtils {
   }
 
   /**
-   * Waits for a condition to be satisfied until a timeout occurs.
-   *
-   * @param description a description of what causes condition to evaluation to true
-   * @param condition the condition to wait on
-   * @param timeoutMs the number of milliseconds to wait before giving up and throwing an exception
-   */
-  public static void waitFor(String description, Function<Void, Boolean> condition, int timeoutMs) {
-    long start = System.currentTimeMillis();
-    while (!condition.apply(null)) {
-      if (System.currentTimeMillis() - start > timeoutMs) {
-        throw new RuntimeException("Timed out waiting for " + description);
-      }
-      CommonUtils.sleepMs(20);
-    }
-  }
-
-  /**
    * Waits indefinitely for a condition to be satisfied.
    *
    * @param description a description of what causes condition to evaluation to true
@@ -240,6 +223,36 @@ public final class CommonUtils {
   public static void waitFor(String description, Function<Void, Boolean> condition) {
     while (!condition.apply(null)) {
       CommonUtils.sleepMs(20);
+    }
+  }
+
+  /**
+   * Waits for a condition to be satisfied until a timeout occurs.
+   *
+   * @param description a description of what causes condition to evaluation to true
+   * @param condition the condition to wait on
+   * @param timeoutMs the number of milliseconds to wait before giving up and throwing an exception
+   */
+  public static void waitFor(String description, Function<Void, Boolean> condition, int timeoutMs) {
+    waitFor(description, condition, timeoutMs, 20);
+  }
+
+  /**
+   * Waits for a condition to be satisfied until a timeout occurs, with given sleep interval.
+   *
+   * @param description a description of what causes condition to evaluation to true
+   * @param condition the condition to wait on
+   * @param timeoutMs the number of milliseconds to wait before giving up and throwing an exception
+   * @param intervalMs the sleep interval in milliseconds
+   */
+  public static void waitFor(
+      String description, Function<Void, Boolean> condition, int timeoutMs, int intervalMs) {
+    long start = System.currentTimeMillis();
+    while (!condition.apply(null)) {
+      if (System.currentTimeMillis() - start > timeoutMs) {
+        throw new RuntimeException("Timed out waiting for " + description);
+      }
+      CommonUtils.sleepMs(intervalMs);
     }
   }
 

--- a/core/common/src/test/java/alluxio/CommonTestUtils.java
+++ b/core/common/src/test/java/alluxio/CommonTestUtils.java
@@ -20,6 +20,7 @@ import org.powermock.reflect.Whitebox;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -96,7 +97,7 @@ public final class CommonTestUtils {
     EqualsTester equalsTester = new EqualsTester();
     equalsTester.addEqualityGroup(createBaseObject(clazz), createBaseObject(clazz));
     // For each non-excluded field, create an object of the class with only that field changed.
-    for (Field field : getAllFields(clazz)) {
+    for (Field field : getNonStaticFields(clazz)) {
       if (excludedFieldsSet.contains(field.getName())) {
         continue;
       }
@@ -122,7 +123,7 @@ public final class CommonTestUtils {
       Constructor<T> constructor = clazz.getDeclaredConstructor();
       constructor.setAccessible(true);
       T instance = constructor.newInstance();
-      for (Field field : getAllFields(clazz)) {
+      for (Field field : getNonStaticFields(clazz)) {
         field.setAccessible(true);
         field.set(instance, getValuesForFieldType(field.getType()).get(0));
       }
@@ -169,13 +170,17 @@ public final class CommonTestUtils {
   }
 
   /**
-   * @param type the type to get the field for
-   * @return all fields of an object of the given type
+   * @param type the type to get the fields for
+   * @return all nonstatic fields of an object of the given type
    */
-  private static List<Field> getAllFields(Class<?> type) {
+  private static List<Field> getNonStaticFields(Class<?> type) {
     List<Field> fields = new ArrayList<>();
     for (Class<?> c = type; c != null; c = c.getSuperclass()) {
-      fields.addAll(Arrays.asList(c.getDeclaredFields()));
+      for (Field field : c.getDeclaredFields()) {
+        if (!Modifier.isStatic(field.getModifiers())) {
+          fields.add(field);
+        }
+      }
     }
     return fields;
   }

--- a/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -222,6 +222,7 @@ public final class FileDataManager {
    *
    * @param fileId the id of the file
    * @param blockIds the list of block ids
+   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    * @throws IOException if the file persistence fails
    */
   public void persistFile(long fileId, List<Long> blockIds) throws AlluxioException, IOException {
@@ -297,6 +298,7 @@ public final class FileDataManager {
    *
    * @param fileId the file id
    * @return the path for persistence
+   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    * @throws IOException if the folder creation fails
    */
   private String prepareUfsFilePath(long fileId) throws AlluxioException, IOException {

--- a/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -149,7 +149,7 @@ final class FileWorkerMasterSyncExecutor implements HeartbeatExecutor {
         LOG.info("persist file {} of blocks {}", mFileId, mBlockIds);
         try {
           mFileDataManager.persistFile(mFileId, mBlockIds);
-        } catch (IOException e) {
+        } catch (AlluxioException | IOException e) {
           LOG.error("Failed to persist file {}", mFileId, e);
         }
       }

--- a/shell/src/main/java/alluxio/shell/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/PersistCommand.java
@@ -93,8 +93,8 @@ public final class PersistCommand extends AbstractShellCommand {
     } else if (status.isPersisted()) {
       System.out.println(filePath + " is already persisted");
     } else {
-      long size = FileSystemUtils.persistFile(mFileSystem, filePath, status);
-      System.out.println("persisted file " + filePath + " with size " + size);
+      FileSystemUtils.persistFile(mFileSystem, filePath);
+      System.out.println("persisted file " + filePath);
     }
   }
 

--- a/shell/src/main/java/alluxio/shell/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/PersistCommand.java
@@ -94,7 +94,7 @@ public final class PersistCommand extends AbstractShellCommand {
       System.out.println(filePath + " is already persisted");
     } else {
       FileSystemUtils.persistFile(mFileSystem, filePath);
-      System.out.println("persisted file " + filePath);
+      System.out.println("persisted file " + filePath + " with size " + status.getLength());
     }
   }
 


### PR DESCRIPTION
Leverage `AsyncPersist` to remove the UFS dependency of persist shell command.

This PR fixes the ancestor permission propagation in AsyncPersist.
It also enables deprecation the Persist bit in `SetAttributeOptions`.