### PR TITLE
[SMALLFIX] Clean up temp alluxio-env.sh during tarball generation

### DIFF
--- a/dev/scripts/generate-tarball.sh
+++ b/dev/scripts/generate-tarball.sh
@@ -42,8 +42,10 @@ git reset --hard HEAD
 BUILD_LOG="${HOME}/logs/build.log"
 echo "Running build and logging to ${BUILD_LOG}"
 mvn -T 4C clean install -Dmaven.javadoc.skip=true -DskipTests -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Pmesos ${BUILD_OPTS} | tee ${BUILD_LOG} 2>&1
+# Temporarily create alluxio-env.sh so that we can call bin/alluxio version
 touch conf/alluxio-env.sh
 VERSION=$(bin/alluxio version)
+rm conf/alluxio-env.sh
 PREFIX=alluxio-${VERSION}
 
 cd ..


### PR DESCRIPTION
Previously the tarball would end up with an empty alluxio-env.sh file.