### PR TITLE
[SMALLFIX] Cleanup FileOutStream Integration tests

### DIFF
--- a/core/client/src/main/java/alluxio/client/WriteType.java
+++ b/core/client/src/main/java/alluxio/client/WriteType.java
@@ -92,15 +92,17 @@ public enum WriteType {
   }
 
   /**
-   * @return true if the write type is {@link #ASYNC_THROUGH}, false otherwise
+   * @return true if by this write type data will be persisted <em>asynchronously</em> to under
+   *         storage (e.g., {@link #ASYNC_THROUGH}), false otherwise
    */
   public boolean isAsync() {
     return mValue == ASYNC_THROUGH.mValue;
   }
 
   /**
-   * @return true if the write type is one of {@link #MUST_CACHE}, {@link #CACHE_THROUGH},
-   *         {@link #TRY_CACHE}, or {@link #ASYNC_THROUGH}
+   * @return true if by this write type data will be cached in Alluxio space (e.g.,
+   *         {@link #MUST_CACHE}, {@link #CACHE_THROUGH}, {@link #TRY_CACHE}, or
+   *         {@link #ASYNC_THROUGH}), false otherwise
    */
   public boolean isCache() {
     return (mValue == MUST_CACHE.mValue) || (mValue == CACHE_THROUGH.mValue)
@@ -108,7 +110,8 @@ public enum WriteType {
   }
 
   /**
-   * @return true if the write type is {@link #CACHE_THROUGH} or {@link #THROUGH}
+   * @return true if by this write type data will be persisted <em>synchronously</em> to under
+   *         storage (e.g., {@link #CACHE_THROUGH} or {@link #THROUGH}), false otherwise
    */
   public boolean isThrough() {
     return (mValue == CACHE_THROUGH.mValue) || (mValue == THROUGH.mValue);

--- a/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -132,6 +132,12 @@ public final class OutStreamOptions {
   }
 
   /**
+   * @return the write type
+   */
+  public WriteType getWriteType() {
+    return mWriteType;
+  }
+  /**
    * Sets the size of the block in bytes.
    *
    * @param blockSizeBytes the block size to use

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -280,33 +280,6 @@ public final class BufferUtils {
   }
 
   /**
-   * Gets a {@link ByteBuffer} containing an increasing sequence of integers starting at zero.
-   *
-   * @param len the target length of the sequence
-   * @return ByteBuffer containing an increasing sequence of integers
-   */
-  public static ByteBuffer getIncreasingIntBuffer(int len) {
-    return getIncreasingIntBuffer(0, len);
-  }
-
-  /**
-   * Gets a {@link ByteBuffer} containing an increasing sequence of integers starting at the given
-   * value.
-   *
-   * @param start the starting value to use
-   * @param len the target length of the sequence
-   * @return ByteBuffer containing an increasing sequence of integers
-   */
-  public static ByteBuffer getIncreasingIntBuffer(int start, int len) {
-    ByteBuffer ret = ByteBuffer.allocate(len * 4);
-    for (int k = 0; k < len; k++) {
-      ret.putInt(start + k);
-    }
-    ret.flip();
-    return ret;
-  }
-
-  /**
    * Writes buffer to the given file path.
    *
    * @param path file path to write the data

--- a/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
@@ -301,42 +301,6 @@ public class BufferUtilsTest {
   }
 
   /**
-   * Tests the {@link BufferUtils#getIncreasingIntBuffer(int, int)} method.
-   */
-  @Test
-  public void getIncreasingIntBuffer() {
-    class TestCase {
-      ByteBuffer mExpected;
-      int mLength;
-      int mStart;
-
-      public TestCase(ByteBuffer expected, int length, int start) {
-        mExpected = expected;
-        mLength = length;
-        mStart = start;
-      }
-    }
-
-    LinkedList<TestCase> testCases = new LinkedList<>();
-    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 0));
-    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 3));
-    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0, 0, 0, 0}), 1, 0));
-    testCases.add(new TestCase(ByteBuffer.wrap(
-        new byte[] {0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2}), 3, 0));
-    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0, 0, 0, 3}), 1, 3));
-    testCases.add(new TestCase(ByteBuffer.wrap(
-        new byte[] {0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5}), 3, 3));
-
-    for (TestCase testCase : testCases) {
-      ByteBuffer result = BufferUtils.getIncreasingIntBuffer(testCase.mStart, testCase.mLength);
-      Assert.assertEquals(testCase.mExpected.limit(), result.limit());
-      for (int k = 0; k < result.limit(); k++) {
-        Assert.assertEquals(testCase.mExpected.get(k), result.get(k));
-      }
-    }
-  }
-
-  /**
    * {@link BufferUtils#cleanDirectBuffer(ByteBuffer)} forces to unmap an unused direct buffer.
    * This test repeated allocates and de-allocates a direct buffer of size 16MB to make sure
    * cleanDirectBuffer is doing its job. The bufferArray is used to store references to the direct

--- a/tests/src/test/java/alluxio/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/IntegrationTestUtils.java
@@ -30,7 +30,6 @@ import java.util.Random;
  * Util methods for writing integration tests.
  */
 public final class IntegrationTestUtils {
-
   /**
    * Convenience method for calling
    * {@link #waitForPersist(LocalAlluxioClusterResource, AlluxioURI, int)} with a default timeout.

--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.IntegrationTestConstants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
@@ -21,6 +20,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.CreateFileOptions;
+import alluxio.client.file.options.OpenFileOptions;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;
 import alluxio.underfs.hdfs.LocalMiniDFSCluster;
@@ -31,8 +31,6 @@ import org.junit.Before;
 import org.junit.Rule;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract classes for all integration tests of {@link FileOutStream}.
@@ -42,14 +40,11 @@ public abstract class AbstractFileOutStreamIntegrationTest {
   protected static final int MAX_LEN = 255;
   protected static final int DELTA = 32;
   protected static final int BUFFER_BYTES = 100;
-  protected static final long WORKER_CAPACITY_BYTES = Constants.GB;
-  protected static final int QUOTA_UNIT_BYTES = 128;
-  protected static final int BLOCK_SIZE_BYTES = 128;
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
-          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES))
+          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
           .setProperty(PropertyKey.WORKER_DATA_SERVER_CLASS,
               IntegrationTestConstants.NETTY_DATA_SERVER)
           .build();
@@ -62,27 +57,76 @@ public abstract class AbstractFileOutStreamIntegrationTest {
   }
 
   /**
+   * Helper to write an Alluxio file with stream of bytes of increasing byte value.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   * @throws Exception if error occurs
+   */
+  protected void writeIncreasingBytesToFile(AlluxioURI filePath, int fileLen, CreateFileOptions op)
+      throws Exception {
+    FileOutStream os = mFileSystem.createFile(filePath, op);
+    for (int k = 0; k < fileLen; k++) {
+      os.write((byte) k);
+    }
+    os.close();
+  }
+
+  /**
+   * Helper to write an Alluxio file with increasing byte array.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   * @throws Exception if error occurs
+   */
+  protected void writeIncreasingByteArrayToFile(AlluxioURI filePath, int fileLen,
+      CreateFileOptions op) throws Exception {
+    FileOutStream os = mFileSystem.createFile(filePath, op);
+    os.write(BufferUtils.getIncreasingByteArray(fileLen));
+    os.close();
+  }
+
+  /**
+   * Helper to write an Alluxio file with two increasing byte arrays separately.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   * @throws Exception if error occurs
+   */
+  protected void writeTwoIncreasingByteArraysToFile(AlluxioURI filePath, int fileLen,
+      CreateFileOptions op) throws Exception {
+    FileOutStream os = mFileSystem.createFile(filePath, op);
+    os.write(BufferUtils.getIncreasingByteArray(0, fileLen / 2), 0, fileLen / 2);
+    os.write(BufferUtils.getIncreasingByteArray(fileLen / 2, fileLen / 2), 0, fileLen / 2);
+    os.close();
+  }
+
+  /**
    * Checks that we wrote the file correctly by reading it every possible way.
    *
    * @param filePath path of the tmp file
-   * @param underStorageType type of under storage write
+   * @param checkAlluxioStorage whether to check this file in Alluxio storage
+   * @param checkUnderStorage whether to check this file in under storage
    * @param fileLen length of the file
-   * @param increasingByteArrayLen expected length of increasing bytes written in the file
+   * @throws Exception if error occurs
    */
-  protected void checkWrite(AlluxioURI filePath, UnderStorageType underStorageType, int fileLen,
-      int increasingByteArrayLen) throws Exception {
-    for (CreateFileOptions op : getOptionSet()) {
-      URIStatus status = mFileSystem.getStatus(filePath);
+  protected void checkFile(AlluxioURI filePath, boolean checkAlluxioStorage,
+      boolean checkUnderStorage, int fileLen) throws Exception {
+    URIStatus status = mFileSystem.getStatus(filePath);
+    if (checkAlluxioStorage) {
       Assert.assertEquals(fileLen, status.getLength());
-      FileInStream is = mFileSystem.openFile(filePath, FileSystemTestUtils.toOpenFileOptions(op));
+      FileInStream is = mFileSystem.openFile(filePath,
+          OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE));
       byte[] res = new byte[(int) status.getLength()];
       Assert.assertEquals((int) status.getLength(), is.read(res));
-      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(increasingByteArrayLen, res));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(fileLen, res));
       is.close();
     }
 
-    if (underStorageType.isSyncPersist() || underStorageType.isAsyncPersist()) {
-      URIStatus status = mFileSystem.getStatus(filePath);
+    if (checkUnderStorage) {
       String checkpointPath = status.getUfsPath();
       UnderFileSystem ufs = UnderFileSystem.Factory.get(checkpointPath);
 
@@ -95,16 +139,8 @@ public abstract class AbstractFileOutStreamIntegrationTest {
       } else {
         Assert.assertEquals((int) status.getLength(), is.read(res));
       }
-      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(increasingByteArrayLen, res));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(fileLen, res));
       is.close();
     }
-  }
-
-  protected List<CreateFileOptions> getOptionSet() {
-    List<CreateFileOptions> ret = new ArrayList<>(3);
-    ret.add(CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH));
-    ret.add(CreateFileOptions.defaults().setWriteType(WriteType.MUST_CACHE));
-    ret.add(CreateFileOptions.defaults().setWriteType(WriteType.THROUGH));
-    return ret;
   }
 }

--- a/tests/src/test/java/alluxio/client/FileOutStreamAsyncWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileOutStreamAsyncWriteIntegrationTest.java
@@ -53,7 +53,7 @@ public final class FileOutStreamAsyncWriteIntegrationTest
     status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
-    checkWrite(filePath, UnderStorageType.ASYNC_PERSIST, length, length);
+    checkFile(filePath, true, true, length);
   }
 
   @Test
@@ -72,6 +72,6 @@ public final class FileOutStreamAsyncWriteIntegrationTest
     status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
-    checkWrite(filePath, UnderStorageType.ASYNC_PERSIST, 0, 0);
+    checkFile(filePath, true, true, 0);
   }
 }

--- a/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
@@ -21,73 +21,78 @@ import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration tests for {@link alluxio.client.file.FileOutStream}.
+ * Integration tests for {@link alluxio.client.file.FileOutStream}, parameterized by the write
+ * types.
  */
+@RunWith(Parameterized.class)
 public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamIntegrationTest {
   // TODO(binfan): Run tests with local writes enabled and disabled.
+
+  @Parameters
+  public static Object[] data() {
+    return new Object[] {
+        WriteType.ASYNC_THROUGH,
+        WriteType.CACHE_THROUGH,
+        WriteType.MUST_CACHE,
+        WriteType.THROUGH,
+    };
+  }
+
+  @Parameter
+  public WriteType mWriteType;
+
   /**
    * Tests {@link FileOutStream#write(int)}.
    */
   @Test
-  public void writeTest1() throws Exception {
+  public void writeBytes() throws Exception {
     String uniqPath = PathUtils.uniqPath();
-    for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
-      for (CreateFileOptions op : getOptionSet()) {
-        writeTest1Util(new AlluxioURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
-      }
+    for (int len = MIN_LEN; len <= MAX_LEN; len += DELTA) {
+      CreateFileOptions op = CreateFileOptions.defaults().setWriteType(mWriteType);
+      AlluxioURI filePath = new AlluxioURI(PathUtils.concatPath(uniqPath,
+          "file_" + len + "_" + mWriteType));
+      writeIncreasingBytesToFile(filePath, len, op);
+      checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+          mWriteType.getUnderStorageType().isSyncPersist(), len);
     }
-  }
-
-  private void writeTest1Util(AlluxioURI filePath, int len, CreateFileOptions op) throws Exception {
-    FileOutStream os = mFileSystem.createFile(filePath, op);
-    for (int k = 0; k < len; k++) {
-      os.write((byte) k);
-    }
-    os.close();
-    checkWrite(filePath, op.getWriteType().getUnderStorageType(), len, len);
   }
 
   /**
    * Tests {@link FileOutStream#write(byte[])}.
    */
   @Test
-  public void writeTest2() throws Exception {
+  public void writeByteArray() throws Exception {
     String uniqPath = PathUtils.uniqPath();
-    for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
-      for (CreateFileOptions op : getOptionSet()) {
-        writeTest2Util(new AlluxioURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
-      }
+    for (int len = MIN_LEN; len <= MAX_LEN; len += DELTA) {
+      CreateFileOptions op = CreateFileOptions.defaults().setWriteType(mWriteType);
+      AlluxioURI filePath = new AlluxioURI(PathUtils.concatPath(uniqPath,
+          "file_" + len + "_" + mWriteType));
+      writeIncreasingByteArrayToFile(filePath, len, op);
+      checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+          mWriteType.getUnderStorageType().isSyncPersist(), len);
     }
-  }
-
-  private void writeTest2Util(AlluxioURI filePath, int len, CreateFileOptions op) throws Exception {
-    FileOutStream os = mFileSystem.createFile(filePath, op);
-    os.write(BufferUtils.getIncreasingByteArray(len));
-    os.close();
-    checkWrite(filePath, op.getWriteType().getUnderStorageType(), len, len);
   }
 
   /**
    * Tests {@link FileOutStream#write(byte[], int, int)}.
    */
   @Test
-  public void writeTest3() throws Exception {
+  public void writeTwoByteArrays() throws Exception {
     String uniqPath = PathUtils.uniqPath();
-    for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
-      for (CreateFileOptions op : getOptionSet()) {
-        writeTest3Util(new AlluxioURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
-      }
+    for (int len = MIN_LEN; len <= MAX_LEN; len += DELTA) {
+      CreateFileOptions op = CreateFileOptions.defaults().setWriteType(mWriteType);
+      AlluxioURI filePath = new AlluxioURI(PathUtils.concatPath(uniqPath,
+          "file_" + len + "_" + mWriteType));
+      writeTwoIncreasingByteArraysToFile(filePath, len, op);
+      checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+          mWriteType.getUnderStorageType().isSyncPersist(), len);
     }
-  }
-
-  private void writeTest3Util(AlluxioURI filePath, int len, CreateFileOptions op) throws Exception {
-    FileOutStream os = mFileSystem.createFile(filePath, op);
-    os.write(BufferUtils.getIncreasingByteArray(0, len / 2), 0, len / 2);
-    os.write(BufferUtils.getIncreasingByteArray(len / 2, len / 2), 0, len / 2);
-    os.close();
-    checkWrite(filePath, op.getWriteType().getUnderStorageType(), len, len / 2 * 2);
   }
 
   /**
@@ -98,12 +103,13 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     final int length = 2;
     FileOutStream os = mFileSystem.createFile(filePath,
-        CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH)
+        CreateFileOptions.defaults().setWriteType(mWriteType)
             .setLocationPolicy(new LocalFirstPolicy()));
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
-    checkWrite(filePath, UnderStorageType.SYNC_PERSIST, length, length);
+    checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+        mWriteType.getUnderStorageType().isSyncPersist(), length);
   }
 
   /**
@@ -115,12 +121,13 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     final int length = 2;
     FileOutStream os = mFileSystem.createFile(filePath,
-            CreateFileOptions.defaults().setWriteType(WriteType.THROUGH));
+            CreateFileOptions.defaults().setWriteType(mWriteType));
     os.write((byte) 0);
     Thread.sleep(Configuration.getInt(PropertyKey.USER_HEARTBEAT_INTERVAL_MS) * 2);
     os.write((byte) 1);
     os.close();
-    checkWrite(filePath, UnderStorageType.SYNC_PERSIST, length, length);
+    checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+        mWriteType.getUnderStorageType().isSyncPersist(), length);
   }
 
   /**
@@ -132,7 +139,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
   public void outOfOrderWrite() throws Exception {
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     FileOutStream os = mFileSystem.createFile(filePath,
-            CreateFileOptions.defaults().setWriteType(WriteType.MUST_CACHE));
+            CreateFileOptions.defaults().setWriteType(mWriteType));
 
     // Write something small, so it is written into the buffer, and not directly to the file.
     os.write((byte) 0);
@@ -144,6 +151,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     os.write(BufferUtils.getIncreasingByteArray(1, length));
     os.close();
 
-    checkWrite(filePath, UnderStorageType.NO_PERSIST, length + 1, length + 1);
+    checkFile(filePath, mWriteType.getAlluxioStorageType().isStore(),
+        mWriteType.getUnderStorageType().isSyncPersist(), length + 1);
   }
 }


### PR DESCRIPTION
- javadoc improvement
- remove two unused util methods in `BufferUtils.java`
- refactor `AbstractFileOutStreamIntegrationTest.java` to parameterize different write types.