### PR TITLE
[ALLUXIO-2452] Added support for starting a Master node outside of Yarn

### DIFF
--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -138,6 +138,8 @@ Use the script `integration/bin/alluxio-yarn.sh` to start Alluxio. This script t
 For example, here we launch an Alluxio cluster with 3 worker nodes, where an HDFS temp directory is
 `hdfs://AlluxioMaster:9000/tmp/` and the master hostname is `AlluxioMaster`
 
+You may also start the Alluxio Master node separately from Yarn in which case the above startup will automatically detect the Master at the address provided and skip initialization of a new instance. This is useful if you have a particular host you'd like to run the Master on, which isn't part of your Yarn cluster, like an AWS EMR Master Instance.
+
 {% include Running-Alluxio-on-EC2-Yarn/three-arguments.md %}
 
 This script will launch an Alluxio Application Master on Yarn, which will then request containers for the Alluxio master and workers. You can also check `http://AlluxioMaster:8088` in the browser to

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -323,7 +323,7 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
       mMasterContainerNetAddress = address.getHostAddress();
       LOG.info("Found master already running on " + mMasterAddress);
     } else {
-      LOG.info("Configuring Master container.");
+      LOG.info("Configuring master container request.");
       Resource masterResource = Records.newRecord(Resource.class);
       masterResource.setMemory(mMasterMemInMB);
       masterResource.setVirtualCores(mMasterCpu);
@@ -418,24 +418,26 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
    */
   private boolean masterExists() {
 
-    // TODO(dan): derive port from Constant
+    String webPort = Configuration.get(PropertyKey.MASTER_WEB_PORT);
+    
     try {
-      URL myURL = new URL("http://" + mMasterAddress + ":" + "19999" + Constants.REST_API_PREFIX + "/master/version");
+      URL myURL = new URL("http://" + mMasterAddress + ":" + webPort + Constants.REST_API_PREFIX + "/master/version");
       LOG.debug("Checking for master at: " + myURL.toString());
       HttpURLConnection connection = (HttpURLConnection) myURL.openConnection();
       connection.setRequestMethod(HttpMethod.GET);
-
       int resCode = connection.getResponseCode();
       LOG.debug("Response code from master was: " + Integer.toString(resCode));
 
       if (resCode == HttpURLConnection.HTTP_OK) {
         connection.disconnect();
         return true;
+      } else {
+        connection.disconnect();
       }
     } catch (MalformedURLException e) {
       LOG.error("Malformed URL in attempt to check if master is running already", e);
     } catch (IOException e) {
-      LOG.error("Unable to open connection to master in attempt to check if already running", e);
+      LOG.debug("Unable to open connection to master in attempt to check if already running", e);
     }
 
     return false;

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -419,7 +419,7 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
   private boolean masterExists() {
 
     String webPort = Configuration.get(PropertyKey.MASTER_WEB_PORT);
-    
+
     try {
       URL myURL = new URL("http://" + mMasterAddress + ":" + webPort + Constants.REST_API_PREFIX + "/master/version");
       LOG.debug("Checking for master at: " + myURL.toString());

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -428,16 +428,12 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
       int resCode = connection.getResponseCode();
       LOG.debug("Response code from master was: " + Integer.toString(resCode));
 
-      if (resCode == HttpURLConnection.HTTP_OK) {
-        connection.disconnect();
-        return true;
-      } else {
-        connection.disconnect();
-      }
+      connection.disconnect();
+      return resCode == HttpURLConnection.HTTP_OK;
     } catch (MalformedURLException e) {
       LOG.error("Malformed URL in attempt to check if master is running already", e);
     } catch (IOException e) {
-      LOG.debug("Unable to open connection to master in attempt to check if already running", e);
+      LOG.debug("No existing master found", e);
     }
 
     return false;

--- a/integration/yarn/src/main/java/alluxio/yarn/Client.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/Client.java
@@ -129,7 +129,7 @@ public final class Client {
     mOptions.addOption("queue", true,
         "RM Queue in which this application is to be submitted. Default 'default'");
     mOptions.addOption("am_memory", true,
-        "Amount of memory in MB to request to run ApplicationMaster. Default 256");
+        "Amount of memory in MB to request to run ApplicationMaster. Default 1024");
     mOptions.addOption("am_vcores", true,
         "Amount of virtual cores to request to run ApplicationMaster. Default 1");
     mOptions.addOption("resource_path", true,
@@ -215,7 +215,7 @@ public final class Client {
     mAppName = cliParser.getOptionValue("appname", "Alluxio");
     mAmPriority = Integer.parseInt(cliParser.getOptionValue("priority", "0"));
     mAmQueue = cliParser.getOptionValue("queue", "default");
-    mAmMemoryInMB = Integer.parseInt(cliParser.getOptionValue("am_memory", "256"));
+    mAmMemoryInMB = Integer.parseInt(cliParser.getOptionValue("am_memory", "1024"));
     mAmVCores = Integer.parseInt(cliParser.getOptionValue("am_vcores", "1"));
     mNumWorkers = Integer.parseInt(cliParser.getOptionValue("num_workers", "1"));
     mMaxWorkersPerHost =


### PR DESCRIPTION
Adding support for starting a Master node outside of Yarn while keeping Worker nodes in Yarn. This update allows the ApplicationMaster to detect if a Master node is running on the given Alluxio Master Hostname and then skips provisioning one in Yarn if one is running.

This is useful for EMR users as it allows them to run Alluxio Master on the EMR Master Instance and then utilize all the Core Instances for Worker nodes.

JIRA Link: https://alluxio.atlassian.net/browse/ALLUXIO-2452