### PR TITLE
[SMALLFIX] Integration test cleanup

### DIFF
--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
-import alluxio.IntegrationTestConstants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileInStream;
@@ -45,8 +44,7 @@ public abstract class AbstractFileOutStreamIntegrationTest {
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
-          .setProperty(PropertyKey.WORKER_DATA_SERVER_CLASS,
-              IntegrationTestConstants.NETTY_DATA_SERVER).build();
+          .build();
 
   protected FileSystem mFileSystem = null;
 

--- a/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/lineage/LineageMasterIntegrationTest.java
@@ -13,7 +13,6 @@ package alluxio.master.lineage;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.IntegrationTestConstants;
 import alluxio.IntegrationTestUtils;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
@@ -68,8 +67,6 @@ public class LineageMasterIntegrationTest {
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES))
-          .setProperty(PropertyKey.WORKER_DATA_SERVER_CLASS,
-              IntegrationTestConstants.NETTY_DATA_SERVER)
           .setProperty(PropertyKey.USER_LINEAGE_ENABLED, "true")
           .setProperty(PropertyKey.MASTER_LINEAGE_RECOMPUTE_INTERVAL_MS,
               Integer.toString(RECOMPUTE_INTERVAL_MS))


### PR DESCRIPTION
`WORKER_DATA_SERVER_CLASS` by default is already set to `NETTY_DATA_SERVER`