### PR TITLE
[ALLUXIO-2461] Add -d option in ls command to list dir as plain file

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -63,6 +63,12 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .hasArg(false)
           .desc("force")
           .build();
+  protected static final Option LIST_DIR_AS_FILE_OPTION =
+      Option.builder("d")
+          .required(false)
+          .hasArg(false)
+          .desc("list directories as plain files")
+          .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -32,7 +32,8 @@ import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Displays information for all directories and files directly under the path specified in args.
+ * Displays information for the path specified in args. Depends on different options, this command
+ * can also display the information for all directly children under the path, or recursively.
  */
 @ThreadSafe
 public final class LsCommand extends WithWildCardPathCommand {
@@ -95,7 +96,10 @@ public final class LsCommand extends WithWildCardPathCommand {
 
   @Override
   protected Options getOptions() {
-    return new Options().addOption(RECURSIVE_OPTION).addOption(FORCE_OPTION);
+    return new Options()
+        .addOption(RECURSIVE_OPTION)
+        .addOption(FORCE_OPTION)
+        .addOption(LIST_DIR_AS_FILE_OPTION);
   }
 
   /**
@@ -103,11 +107,21 @@ public final class LsCommand extends WithWildCardPathCommand {
    *
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param recursive Whether list the path recursively
+   * @param dirAsFile list the directory status as a plain file
    * @throws AlluxioException when Alluxio exception occurs
    * @throws IOException when non-Alluxio exception occurs
    */
-  private void ls(AlluxioURI path, boolean recursive, boolean forceLoadMetadata)
+  private void ls(AlluxioURI path, boolean recursive, boolean forceLoadMetadata, boolean dirAsFile)
       throws AlluxioException, IOException {
+    if (dirAsFile) {
+      URIStatus status = mFileSystem.getStatus(path);
+      System.out.print(formatLsString(SecurityUtils.isSecurityEnabled(), status.isFolder(),
+          FormatUtils.formatMode((short) status.getMode(), status.isFolder()), status.getOwner(),
+          status.getGroup(), status.getLength(), status.getCreationTimeMs(),
+          100 == status.getInMemoryPercentage(), status.getPath()));
+      return;
+    }
+
     ListStatusOptions options = ListStatusOptions.defaults();
     if (forceLoadMetadata) {
       options.setLoadMetadataType(LoadMetadataType.Always);
@@ -120,7 +134,7 @@ public final class LsCommand extends WithWildCardPathCommand {
           100 == status.getInMemoryPercentage(), status.getPath()));
       if (recursive && status.isFolder()) {
         ls(new AlluxioURI(path.getScheme(), path.getAuthority(), status.getPath()), true,
-            forceLoadMetadata);
+            forceLoadMetadata, false);
       }
     }
   }
@@ -148,18 +162,19 @@ public final class LsCommand extends WithWildCardPathCommand {
 
   @Override
   public void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
-    ls(path, cl.hasOption("R"), cl.hasOption("f"));
+    ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"));
   }
 
   @Override
   public String getUsage() {
-    return "ls [-R] [-f] <path>";
+    return "ls [-R] [-f] [-d] <path>";
   }
 
   @Override
   public String getDescription() {
     return "Displays information for all files and directories directly under the specified path."
         + " Specify -R to display files and directories recursively."
-        + " Specify -f to force loading files in the directory.";
+        + " Specify -f to force loading files in the directory."
+        + " Specify -d to list directories as plain files.";
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -167,14 +167,14 @@ public final class LsCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "ls [-R] [-f] [-d] <path>";
+    return "ls [-R] [-d] [-f] <path>";
   }
 
   @Override
   public String getDescription() {
     return "Displays information for all files and directories directly under the specified path."
         + " Specify -R to display files and directories recursively."
-        + " Specify -f to force loading files in the directory."
-        + " Specify -d to list directories as plain files.";
+        + " Specify -d to list directories as plain files."
+        + " Specify -f to force loading files in the directory.";
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -119,6 +119,21 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   }
 
   /**
+   * Tests ls -d command on root directory when security is not enabled.
+   */
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
+  public void lsRootNoAcl() throws IOException, AlluxioException {
+    mFsShell.run("ls", "-d", "/");
+    URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/"));
+    String expected = "";
+    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.STATE_FOLDER);
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  /**
    * Tests ls command when security is enabled.
    */
   @Test

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -102,6 +102,23 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   }
 
   /**
+   * Tests ls -d command when security is not enabled.
+   */
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
+  public void lsDirectoryAsPlainFileNoAcl() throws IOException, AlluxioException {
+    URIStatus[] files = createFiles();
+    mFsShell.run("ls", "-d", "/testRoot");
+    URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/testRoot/"));
+    String expected = "";
+    expected += getLsNoAclResultStr("/testRoot", dirStatus.getCreationTimeMs(),
+        3 /* number of direct children under /testRoot/ dir */, LsCommand.STATE_FOLDER);
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  /**
    * Tests ls command when security is enabled.
    */
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2461

This makes it possible to `ls` the metadata for root dir `"/"`:
`./bin/alluxio fs ls -d / `