### PR TITLE
[SMALLFIX] Fix read performance regression for due to ObjectStore seek

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileInputStream.java
@@ -78,6 +78,9 @@ public final class ObjectUnderFileInputStream extends InputStream implements See
   @Override
   public void seek(long position) throws IOException {
     long currentPos = mInitPos + mStream.getCount();
+    if (position == currentPos) {
+      return;
+    }
     if (position > currentPos) {
       long toSkip = position - currentPos;
       if (toSkip != skip(toSkip)) {


### PR DESCRIPTION
Do not re-open stream when seek pos = current pos