### PR TITLE
[ALLUXIO-2021] Remove the hostname check

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -197,10 +197,10 @@ public final class FileSystemContext implements Closeable {
   }
 
   /**
-   * Resets the context. This method is hacky and not threadsafe. It is only used in
-   * {@link alluxio.hadoop.AbstractFileSystem} and tests to reset the default file system context.
+   * Resets the context. It is only used in {@link alluxio.hadoop.AbstractFileSystem} and
+   * tests to reset the default file system context.
    */
-  public void reset() {
+  public synchronized void reset() {
     close();
     init();
   }

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -438,24 +438,23 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     boolean masterAddIsSameAsDefault = checkMasterAddress();
 
     if (sInitialized) {
-      if (!masterAddIsSameAsDefault) {
-        throw new IOException(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
-            .getMessage(mUri.getHost() + ":" + mUri.getPort(),
-                FileSystemContext.INSTANCE.getMasterAddress()));
+      if (masterAddIsSameAsDefault) {
+        updateFileSystemAndContext();
+        return;
       }
-      updateFileSystemAndContext();
-      return;
     }
     synchronized (INIT_LOCK) {
       // If someone has initialized the object since the last check, return
       if (sInitialized) {
         if (!masterAddIsSameAsDefault) {
-          throw new IOException(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
+          LOG.warn(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
               .getMessage(mUri.getHost() + ":" + mUri.getPort(),
                   FileSystemContext.INSTANCE.getMasterAddress()));
+          sInitialized = false;
+        } else {
+          updateFileSystemAndContext();
+          return;
         }
-        updateFileSystemAndContext();
-        return;
       }
 
       initializeInternal(uri, conf);

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -437,23 +437,21 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
     boolean masterAddIsSameAsDefault = checkMasterAddress();
 
-    if (sInitialized) {
-      if (masterAddIsSameAsDefault) {
-        updateFileSystemAndContext();
-        return;
-      }
+    if (sInitialized && masterAddIsSameAsDefault) {
+      updateFileSystemAndContext();
+      return;
     }
     synchronized (INIT_LOCK) {
       // If someone has initialized the object since the last check, return
       if (sInitialized) {
-        if (!masterAddIsSameAsDefault) {
+        if (masterAddIsSameAsDefault) {
+          updateFileSystemAndContext();
+          return;
+        } else {
           LOG.warn(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
               .getMessage(mUri.getHost() + ":" + mUri.getPort(),
                   FileSystemContext.INSTANCE.getMasterAddress()));
           sInitialized = false;
-        } else {
-          updateFileSystemAndContext();
-          return;
         }
       }
 

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -23,7 +23,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.lineage.LineageContext;
 import alluxio.client.util.ClientTestUtils;
 import alluxio.exception.ConnectionFailedException;
-import alluxio.exception.ExceptionMessage;
 import alluxio.wire.FileInfo;
 
 import com.google.common.collect.Lists;
@@ -213,7 +212,7 @@ public class AbstractFileSystemTest {
   public void reinitializeWithDifferentURI() throws Exception {
     final org.apache.hadoop.conf.Configuration conf = getConf();
     String originalURI = "host1:1";
-    URI uri = URI.create(Constants.HEADER + "host1:1");
+    URI uri = URI.create(Constants.HEADER + originalURI);
     org.apache.hadoop.fs.FileSystem.get(uri, conf);
 
     Mockito.when(mMockFileSystemContext.getMasterAddress())
@@ -221,14 +220,16 @@ public class AbstractFileSystemTest {
 
     String[] newURIs = new String[]{"host2:1", "host1:2", "host2:2"};
     for (String newURI : newURIs) {
-      mExpectedException.expect(IOException.class);
-      mExpectedException.expectMessage(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
-          .getMessage(newURI, originalURI));
+      // mExpectedException.expect(IOException.class);
+      // mExpectedException.expectMessage(ExceptionMessage.DIFFERENT_MASTER_ADDRESS
+      //    .getMessage(newURI, originalURI));
 
       uri = URI.create(Constants.HEADER + newURI);
       org.apache.hadoop.fs.FileSystem.get(uri, conf);
-      // The above code should throw an exception.
-      Assert.fail("Initialization should throw an exception.");
+
+      // The above code should not throw an exception.
+      // TODO(cc): Remove or bring this check back.
+      // Assert.fail("Initialization should throw an exception.");
     }
   }
 

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -153,7 +153,7 @@ public enum ExceptionMessage {
   UNKNOWN_LINEAGE_FILE_STATE("Unknown LineageFileState: {0}"),
 
   // client
-  DIFFERENT_MASTER_ADDRESS("Master address {0} is different from that in client context {1}"),
+  DIFFERENT_MASTER_ADDRESS("Master address {0} is different from that in file system context {1}"),
   INCOMPATIBLE_VERSION("{0} client version {1} is not compatible with server version {2}"),
 
   // configuration


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2021

Remove a check added in https://github.com/Alluxio/alluxio/pull/4422 

When running hibench, i saw the following error.

java.io.IOException: Master address hibench-spark-Rl-peis-masters-1:19998 is different from that in client context hibench-spark-Rl-peis-masters-1/172.xx.xx.xx:19998
Failing this attempt. Failing the application.
16/12/24 06:35:14 INFO mapreduce.Job: Counters: 0
Exception in thread "main" java.io.IOException: Job failed!
	at org.apache.hadoop.mapred.JobClient.runJob(JobClient.java:865)
	at HiBench.BayesData.createBayesData(BayesData.java:137)
	at HiBench.BayesData.generate(BayesData.java:158)
	at HiBench.DataGen.run(DataGen.java:29)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
	at HiBench.DataGen.main(DataGen.java:45)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:221)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:136)