### PR TITLE
[ALLUXIO-2471] [branch-1.4] User UGI getShortUserName to get login user

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -532,9 +532,9 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   private Subject getHadoopSubject() {
     try {
       UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-      String username = ugi.getUserName();
+      String username = ugi.getShortUserName();
       if (username != null && !username.isEmpty()) {
-        User user = new User(ugi.getUserName());
+        User user = new User(ugi.getShortUserName());
         HashSet<Principal> principals = new HashSet<>();
         principals.add(user);
         return new Subject(false, principals, new HashSet<>(), new HashSet<>());

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -290,12 +290,8 @@ public class AbstractFileSystemTest {
 
     final org.apache.hadoop.conf.Configuration conf = getConf();
     URI uri = URI.create(Constants.HEADER + "host:1");
-    try {
-      org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
-      Assert.assertTrue(fs instanceof FileSystem);
-    } catch (IOException e) {
-      Assert.fail();
-    }
+    org.apache.hadoop.fs.FileSystem.get(uri, conf);
+    // FileSystem.get would have thrown an exception if the initialization failed.
   }
 
   @Test
@@ -304,12 +300,8 @@ public class AbstractFileSystemTest {
 
     final org.apache.hadoop.conf.Configuration conf = getConf();
     URI uri = URI.create(Constants.HEADER + "host:1");
-    try {
-      org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
-      Assert.assertTrue(fs instanceof FileSystem);
-    } catch (IOException e) {
-      Assert.fail();
-    }
+    org.apache.hadoop.fs.FileSystem.get(uri, conf);
+    // FileSystem.get would have thrown an exception if the initialization failed.
   }
 
   private org.apache.hadoop.conf.Configuration getConf() throws Exception {

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -290,7 +290,12 @@ public class AbstractFileSystemTest {
 
     final org.apache.hadoop.conf.Configuration conf = getConf();
     URI uri = URI.create(Constants.HEADER + "host:1");
-    org.apache.hadoop.fs.FileSystem.get(uri, conf);
+    try {
+      org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
+      Assert.assertTrue(fs instanceof FileSystem);
+    } catch (IOException e) {
+      Assert.fail();
+    }
   }
 
   @Test
@@ -299,7 +304,12 @@ public class AbstractFileSystemTest {
 
     final org.apache.hadoop.conf.Configuration conf = getConf();
     URI uri = URI.create(Constants.HEADER + "host:1");
-    org.apache.hadoop.fs.FileSystem.get(uri, conf);
+    try {
+      org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
+      Assert.assertTrue(fs instanceof FileSystem);
+    } catch (IOException e) {
+      Assert.fail();
+    }
   }
 
   private org.apache.hadoop.conf.Configuration getConf() throws Exception {

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -293,6 +293,15 @@ public class AbstractFileSystemTest {
     org.apache.hadoop.fs.FileSystem.get(uri, conf);
   }
 
+  @Test
+  public void initializeWithFullPrincipalUgi() throws Exception {
+    mockUserGroupInformation("testuser@ALLUXIO.COM");
+
+    final org.apache.hadoop.conf.Configuration conf = getConf();
+    URI uri = URI.create(Constants.HEADER + "host:1");
+    org.apache.hadoop.fs.FileSystem.get(uri, conf);
+  }
+
   private org.apache.hadoop.conf.Configuration getConf() throws Exception {
     org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     if (HadoopClientTestUtils.isHadoop1x()) {
@@ -324,6 +333,7 @@ public class AbstractFileSystemTest {
     final UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
     Mockito.when(UserGroupInformation.getCurrentUser()).thenReturn(ugi);
     Mockito.when(ugi.getUserName()).thenReturn(username);
+    Mockito.when(ugi.getShortUserName()).thenReturn(username.split("@")[0]);
   }
 
   private void assertFileInfoEqualsFileStatus(FileInfo info, FileStatus status) {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2471

We should use `ugi.getShortUserName` to get the user's login name, rather than the full principal name.