### PR TITLE
[SMALLFIX] S3A request timeout

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -81,6 +81,7 @@ public enum PropertyKey {
   UNDERFS_S3_UPLOAD_THREADS_MAX(Name.UNDERFS_S3_UPLOAD_THREADS_MAX, 20),
   UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS(Name.UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS, 60000),
   UNDERFS_S3A_INHERIT_ACL(Name.UNDERFS_S3A_INHERIT_ACL, true),
+  UNDERFS_S3A_REQUEST_TIMEOUT(Name.UNDERFS_S3A_REQUEST_TIMEOUT_MS, 60000),
   UNDERFS_S3A_SECURE_HTTP_ENABLED(Name.UNDERFS_S3A_SECURE_HTTP_ENABLED, false),
   UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED(Name.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED,
       false),
@@ -447,6 +448,8 @@ public enum PropertyKey {
     public static final String UNDERFS_S3A_INHERIT_ACL = "alluxio.underfs.s3a.inherit_acl";
     public static final String UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS =
         "alluxio.underfs.s3a.consistency.timeout.ms";
+    public static final String UNDERFS_S3A_REQUEST_TIMEOUT_MS =
+        "alluxio.underfs.s3a.request.timeout.ms";
     public static final String UNDERFS_S3A_SECURE_HTTP_ENABLED =
         "alluxio.underfs.s3a.secure.http.enabled";
     public static final String UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED =

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -30,6 +30,7 @@ alluxio.underfs.s3.admin.threads.max,20
 alluxio.underfs.s3.upload.threads.max,20
 alluxio.underfs.s3.disable.dns.buckets,false
 alluxio.underfs.s3a.consistency.timeout.ms,60000
+alluxio.underfs.s3a.request.timeout.ms,60000
 alluxio.underfs.s3a.secure.http.enabled,false
 alluxio.underfs.s3a.server.side.encryption.enabled,false
 alluxio.underfs.s3a.socket.timeout.ms,50000

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -89,6 +89,11 @@ alluxio.underfs.s3a.consistency.timeout.ms:
   The duration to wait for metadata consistency from the under storage. This is only used by
   internal Alluxio operations which should be successful, but may appear unsuccessful due to
   eventual consistency. The default value is 60000 milliseconds (1 minute).
+alluxio.underfs.s3a.request.timeout.ms:
+  The timeout for a single request to S3. Infinity if set to 0. Setting this property to a non-zero
+  value can improve performance by avoiding the long tail of requests to S3. For very slow
+  connections to S3, consider increasing this value or setting it to 0. The default value is 60000
+  milliseconds (1 minute).
 alluxio.underfs.s3a.secure.http.enabled:
   Whether or not to use HTTPS protocol when communicating with s3. The default value is false.
 alluxio.underfs.s3a.server.side.encryption.enabled:

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -148,6 +148,10 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     }
     clientConf.setMaxConnections(numThreads);
 
+    // Set client request timeout for all requests since multipart copy is used, and copy parts can
+    // only be set with the client configuration.
+    clientConf.setRequestTimeout(Configuration.getInt(PropertyKey.UNDERFS_S3A_REQUEST_TIMEOUT));
+
     AmazonS3Client amazonS3Client = new AmazonS3Client(credentials, clientConf);
     // Set a custom endpoint.
     if (Configuration.containsKey(PropertyKey.UNDERFS_S3_ENDPOINT)) {


### PR DESCRIPTION
Setting the request timeout can prevent stragglers from causing significant slowdowns.