### PR TITLE
[SMALLFIX] Fix mesos executors

### DIFF
--- a/core/server/src/main/java/alluxio/cli/Format.java
+++ b/core/server/src/main/java/alluxio/cli/Format.java
@@ -68,7 +68,6 @@ public final class Format {
    * Formats the Alluxio file system.
    *
    * @param args either {@code MASTER} or {@code WORKER}
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   public static void main(String[] args) {
     if (args.length != 1) {
@@ -84,6 +83,12 @@ public final class Format {
     System.exit(0);
   }
 
+  /**
+   * Formats the Alluxio file system.
+   *
+   * @param mode either {@code MASTER} or {@code WORKER}
+   * @throws IOException if a non-Alluxio related exception occurs
+   */
   public static void format(String mode) throws IOException {
     if ("MASTER".equalsIgnoreCase(mode)) {
       String masterJournal =

--- a/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
+++ b/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
@@ -23,11 +23,11 @@ import alluxio.client.file.FileSystem;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
+import alluxio.util.network.NetworkAddressUtils;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.IOUtils;
@@ -99,8 +99,7 @@ public final class AlluxioFrameworkIntegrationTest {
     try {
       startAlluxioFramework(env);
       LOG.info("Launched Alluxio cluster, waiting for worker to register with master");
-      String masterHostName =
-          Preconditions.checkNotNull(Configuration.get(PropertyKey.MASTER_HOSTNAME));
+      String masterHostName = NetworkAddressUtils.getLocalHostName();
       int masterPort = Configuration.getInt(PropertyKey.MASTER_RPC_PORT);
       InetSocketAddress masterAddress = new InetSocketAddress(masterHostName, masterPort);
       try (final BlockMasterClient client = new RetryHandlingBlockMasterClient(null,

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
@@ -75,8 +75,7 @@ public class AlluxioMasterExecutor implements Executor {
           Thread.currentThread().setContextClassLoader(
               UnderFileSystemRegistry.class.getClassLoader());
 
-          // TODO(jiri): Consider handling Format.main() failures gracefully.
-          Format.main(new String[] {"master"});
+          Format.format("master");
           AlluxioMaster.main(new String[] {});
 
           status =
@@ -85,7 +84,7 @@ public class AlluxioMasterExecutor implements Executor {
 
           driver.sendStatusUpdate(status);
         } catch (Exception e) {
-          e.printStackTrace();
+          LOG.error("Error starting Alluxio master", e);
         }
       }
     }.start();

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
@@ -76,7 +76,7 @@ public class AlluxioWorkerExecutor implements Executor {
               UnderFileSystemRegistry.class.getClassLoader());
 
           // TODO(jiri): Consider handling Format.main() failures gracefully.
-          Format.main(new String[] {"worker"});
+          Format.format("worker");
           AlluxioWorker.main(new String[] {});
 
           status =

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
@@ -75,7 +75,6 @@ public class AlluxioWorkerExecutor implements Executor {
           Thread.currentThread().setContextClassLoader(
               UnderFileSystemRegistry.class.getClassLoader());
 
-          // TODO(jiri): Consider handling Format.main() failures gracefully.
           Format.format("worker");
           AlluxioWorker.main(new String[] {});
 


### PR DESCRIPTION
Fixes regression introduced by #4250. We were calling `Format.main`, which would call `System.exit` even on success.