### PR TITLE
[DOCFIX]在调试向导中增加Alluxio远程调试章节

### DIFF
--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -19,6 +19,19 @@ Alluxio运行过程中可产生master、worker和client日志，这些日志存�
 
 master和worker日志对于理解Alluxio master节点和worker节点的运行过程是非常有帮助的，当Alluxio运行出现问题时，可以查阅日志发现问题产生原因。如果不清楚错误日志信息，可在[邮件列表](https://groups.google.com/forum/#!forum/alluxio-users)查找，错误日志信息有可能之前已经讨论过。
 
+## Alluxio远程调试
+
+Alluxio一般不在开发机上运行,这使得Alluxio的调试变得困难,我们通常会用"增加日志-编译-部署运行-查看日志"的方法来定位问题,而这种定位问题的效率比较低而且需要修改代码从新部署,这在有些时候是不允许的。
+
+使用java远程调试技术可以简单、不修改源码的方式，进行源码级调试。你需要增加jvm 远程调试参数，启动调试服务。增加远程调试参数的方法有很多，比较方便的一种方法是，在需要调试的节点上，修改alluxio-env.sh，增加如下配置属性。
+
+```properties
+ALLUXIO_MASTER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6600 $ALLUXIO_MASTER_JVM_OPTS"
+
+ALLUXIO_WORKER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6601 $ALLUXIO_WORKER_JVM_OPTS"
+```
+这样启动该节点上的master或者worker后，使用eclipse或intellij idea等java开发环境，新建java远程调试配置，设置调试主机名和端口号，然后启动调试连接。如果你设置了断点并且到达了断点处，开发环境会进入调试模式，可以读写当前现场的变量、调用栈、线程列表、表达式评估，也可以执行单步进入、单步跳过、恢复执行、挂起等调试控制。掌握这个技术使得日后的定位问题事半功倍，也会对调试过的代码上下文印象深刻。
+
 ## Alluxio部署常见问题
 
 #### 问题: 在本地机器上初次安装使用Alluxio失败，应该怎么办？

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -23,13 +23,14 @@ master和worker日志对于理解Alluxio master节点和worker节点的运行过
 
 Alluxio一般不在开发机上运行,这使得Alluxio的调试变得困难,我们通常会用"增加日志-编译-部署运行-查看日志"的方法来定位问题,而这种定位问题的效率比较低而且需要修改代码从新部署,这在有些时候是不允许的。
 
-使用java远程调试技术可以简单、不修改源码的方式，进行源码级调试。你需要增加jvm 远程调试参数，启动调试服务。增加远程调试参数的方法有很多，比较方便的一种方法是，在需要调试的节点上，修改alluxio-env.sh，增加如下配置属性。
+使用java远程调试技术可以简单、不修改源码的方式，进行源码级调试。你需要增加jvm 远程调试参数，启动调试服务。增加远程调试参数的方法有很多，比较方便的一种方法是，在需要调试的节点上，修改`alluxio-env.sh`，增加如下配置属性。
 
 ```properties
 ALLUXIO_MASTER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6600 $ALLUXIO_MASTER_JVM_OPTS"
 
 ALLUXIO_WORKER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6601 $ALLUXIO_WORKER_JVM_OPTS"
 ```
+
 这样启动该节点上的master或者worker后，使用eclipse或intellij idea等java开发环境，新建java远程调试配置，设置调试主机名和端口号，然后启动调试连接。如果你设置了断点并且到达了断点处，开发环境会进入调试模式，可以读写当前现场的变量、调用栈、线程列表、表达式评估，也可以执行单步进入、单步跳过、恢复执行、挂起等调试控制。掌握这个技术使得日后的定位问题事半功倍，也会对调试过的代码上下文印象深刻。
 
 ## Alluxio部署常见问题

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -26,9 +26,11 @@ Alluxio一般不在开发机上运行,这使得Alluxio的调试变得困难,我�
 使用java远程调试技术可以简单、不修改源码的方式，进行源码级调试。你需要增加jvm 远程调试参数，启动调试服务。增加远程调试参数的方法有很多，比较方便的一种方法是，在需要调试的节点上，修改`alluxio-env.sh`，增加如下配置属性。
 
 ```properties
-ALLUXIO_MASTER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6600 $ALLUXIO_MASTER_JVM_OPTS"
+ALLUXIO_MASTER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6600 $ALLUXIO_JAVA_OPTS"
 
-ALLUXIO_WORKER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6601 $ALLUXIO_WORKER_JVM_OPTS"
+ALLUXIO_WORKER_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6601 $ALLUXIO_JAVA_OPTS"
+
+ALLUXIO_PROXY_JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=6602 $ALLUXIO_JAVA_OPTS"
 ```
 
 这样启动该节点上的master或者worker后，使用eclipse或intellij idea等java开发环境，新建java远程调试配置，设置调试主机名和端口号，然后启动调试连接。如果你设置了断点并且到达了断点处，开发环境会进入调试模式，可以读写当前现场的变量、调用栈、线程列表、表达式评估，也可以执行单步进入、单步跳过、恢复执行、挂起等调试控制。掌握这个技术使得日后的定位问题事半功倍，也会对调试过的代码上下文印象深刻。


### PR DESCRIPTION
在google论坛Alluxio Developers中，我提出了名为“Just Debug it ! Debug it ! Remote Debug with alluxio (eclipse or Idea and others)”的主题，给出了远程调试alluxio的方法，开发者Bin Fan给予了回复，建议我把方法写在调试向导中，这样很多初学者会受益于此。