### PR TITLE
[SMALLFIX] [branch-1.4] Fix ufs capability test with object storage

### DIFF
--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -19,6 +19,7 @@ import alluxio.master.file.meta.options.MountInfo;
 import alluxio.metrics.MetricsSystem;
 import alluxio.rest.RestApiTest;
 import alluxio.rest.TestCase;
+import alluxio.util.CommonUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.wire.AlluxioMasterInfo;
@@ -167,7 +168,12 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
   @Test
   public void getUfsCapacity() throws Exception {
     Capacity ufsCapacity = getInfo(NO_PARAMS).getUfsCapacity();
-    Assert.assertTrue(ufsCapacity.getTotal() > 0);
+    if (CommonUtils.isUfsObjectStorage(mFileSystemMaster.getUfsAddress())) {
+      // Object storage ufs capability is always invalid.
+      Assert.assertEquals(-1, ufsCapacity.getTotal());
+    } else {
+      Assert.assertTrue(ufsCapacity.getTotal() > 0);
+    }
   }
 
   @Test

--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -169,7 +169,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
   public void getUfsCapacity() throws Exception {
     Capacity ufsCapacity = getInfo(NO_PARAMS).getUfsCapacity();
     if (CommonUtils.isUfsObjectStorage(mFileSystemMaster.getUfsAddress())) {
-      // Object storage ufs capability is always invalid.
+      // Object storage ufs capacity is always invalid.
       Assert.assertEquals(-1, ufsCapacity.getTotal());
     } else {
       Assert.assertTrue(ufsCapacity.getTotal() > 0);


### PR DESCRIPTION
It's expected to get invalid ufs capability for object storage.