### PR TITLE
[DOCFIX] Update ALLUXIO_MASTER_VERSION_SHORT in _config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ kramdown:
 # These allow the documentation to be updated with new releases of Alluxio.
 ALLUXIO_RELEASED_VERSION: 1.3.0
 # For example, "master" for the master branch, and 1.1 for 1.1.x releases and release candidates.
-ALLUXIO_MASTER_VERSION_SHORT: 1.4.0-SNAPSHOT
+ALLUXIO_MASTER_VERSION_SHORT: master
 # We must inline the version string (e.g., "1.4.0-SNAPSHOT") rather than using the macro defined above.
 # Otherwise the macro name remains in the output.
 ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/core/client/target/alluxio-core-client-1.4.0-SNAPSHOT-jar-with-dependencies.jar


### PR DESCRIPTION
In order for the docs to be rendered properly on alluxio.org, the `ALLUXIO_MASTER_VERSION_SHORT` must be set to the name of the branch (e.g., `master`, `branch-1.3`, etc.). 

This PR updates the variable to `master` on the master branch. 