### PR TITLE
[SMALLFIX] Deflake journal shutdown integration test

### DIFF
--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -51,7 +51,9 @@ public class JournalShutdownIntegrationTest {
   private static final long SHUTDOWN_TIME_MS = 15 * Constants.SECOND_MS;
   private static final String TEST_FILE_DIR = "/files/";
   private static final int TEST_NUM_MASTERS = 3;
-  private static final long TEST_TIME_MS = Constants.SECOND_MS;
+  // Period of time to run the file-creating client before shutting down the cluster. This must be
+  // long enough to guarantee that at least one file is created before the cluster is shut down.
+  private static final long TEST_TIME_MS = 3 * Constants.SECOND_MS;
 
   private ClientThread mCreateFileThread;
   /** Executor for running client threads. */

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -167,7 +167,6 @@ public class JournalShutdownIntegrationTest {
     return cluster;
   }
 
-
   /**
    * Starts a file-creating thread and runs it for some time, at least until it has created one
    * file.

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -51,9 +51,7 @@ public class JournalShutdownIntegrationTest {
   private static final long SHUTDOWN_TIME_MS = 15 * Constants.SECOND_MS;
   private static final String TEST_FILE_DIR = "/files/";
   private static final int TEST_NUM_MASTERS = 3;
-  // Period of time to run the file-creating client before shutting down the cluster. This must be
-  // long enough to guarantee that at least one file is created before the cluster is shut down.
-  private static final long TEST_TIME_MS = 3 * Constants.SECOND_MS;
+  private static final long TEST_TIME_MS = Constants.SECOND_MS;
 
   private ClientThread mCreateFileThread;
   /** Executor for running client threads. */
@@ -81,7 +79,7 @@ public class JournalShutdownIntegrationTest {
   @Test
   public void singleMasterJournalStopIntegration() throws Exception {
     LocalAlluxioCluster cluster = setupSingleMasterCluster();
-    CommonUtils.sleepMs(TEST_TIME_MS);
+    runCreateFileThread(cluster.getClient());
     // Shutdown the cluster
     cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
@@ -94,7 +92,7 @@ public class JournalShutdownIntegrationTest {
   @Test
   public void singleMasterJournalCrashIntegration() throws Exception {
     LocalAlluxioCluster cluster = setupSingleMasterCluster();
-    CommonUtils.sleepMs(TEST_TIME_MS);
+    runCreateFileThread(cluster.getClient());
     cluster.stopWorkers();
     // Crash the master
     cluster.getMaster().stop();
@@ -108,8 +106,7 @@ public class JournalShutdownIntegrationTest {
   @Test
   public void multiMasterJournalStopIntegration() throws Exception {
     MultiMasterLocalAlluxioCluster cluster = setupMultiMasterCluster();
-    // Run the test client thread for some time.
-    CommonUtils.sleepMs(TEST_TIME_MS);
+    runCreateFileThread(cluster.getClient());
     // Kill the leader one by one.
     for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {
       cluster.waitForNewMaster(60 * Constants.SECOND_MS);
@@ -158,8 +155,6 @@ public class JournalShutdownIntegrationTest {
         new MultiMasterLocalAlluxioCluster(TEST_NUM_MASTERS);
     cluster.initConfiguration();
     cluster.start();
-    mCreateFileThread = new ClientThread(0, cluster.getClient());
-    mExecutorsForClient.submit(mCreateFileThread);
     return cluster;
   }
 
@@ -169,9 +164,23 @@ public class JournalShutdownIntegrationTest {
     cluster.initConfiguration();
     Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
     cluster.start();
-    mCreateFileThread = new ClientThread(0, cluster.getClient());
-    mExecutorsForClient.submit(mCreateFileThread);
     return cluster;
+  }
+
+
+  /**
+   * Starts a file-creating thread and runs it for some time, at least until it has created one
+   * file.
+   *
+   * @param fs a file system client to use for creating files
+   */
+  private void runCreateFileThread(FileSystem fs) {
+    mCreateFileThread = new ClientThread(0, fs);
+    mExecutorsForClient.submit(mCreateFileThread);
+    CommonUtils.sleepMs(TEST_TIME_MS);
+    while (mCreateFileThread.getSuccessNum() == 0) {
+      CommonUtils.sleepMs(TEST_TIME_MS);
+    }
   }
 
   /**


### PR DESCRIPTION
We've seen some flakiness which could be caused by the test time
being too short, causing the cluster to shut down before any files
are written. This bumps the time to minimize the source of flakiness.