### PR TITLE
[SMALLFIX] Update Running-Alluxio-Fault-Tolerant.md

### DIFF
--- a/docs/en/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/en/Running-Alluxio-Fault-Tolerant.md
@@ -58,7 +58,7 @@ NameNode, as you will need to configure Alluxio below.
 
 ## Configuring Alluxio
 
-Once you have ZooKeeper and your shared filesystem running, you need to set up your `alluxio-env.sh`
+Once you have ZooKeeper and your shared filesystem running, you need to set up your `alluxio-site.properties`
 appropriately on each host.
 
 ### Externally Visible Address
@@ -71,7 +71,7 @@ other nodes will then be unable to reach your node.
 ### Configuring Fault Tolerant Alluxio
 
 In order to enable fault tolerance for Alluxio, additional configuration settings must be set for
-Alluxio masters, workers, and clients. In `conf/alluxio-env.sh`, these java options must be set:
+Alluxio masters, workers, and clients. In `conf/alluxio-site.properties`, these java options must be set:
 
 <table class="table">
 <tr><th>Property Name</th><th>Value</th><th>Meaning</th></tr>
@@ -101,9 +101,9 @@ details about setting configuration parameters can be found in
 ### Master Configuration
 
 In addition to the above configuration settings, Alluxio masters need additional configuration. For
-each master, the following variable must be set appropriately in `conf/alluxio-env.sh`:
+each master, the following variable must be set appropriately in `conf/alluxio-site.properties`:
 
-    ALLUXIO_MASTER_HOSTNAME=[externally visible address of this machine]
+    alluxio.master.hostname=[externally visible address of this machine]
 
 Also, specify the correct journal folder by setting `alluxio.master.journal.folder` appropriately in
 `conf/alluxio-site.properties`. For example, if you are using HDFS for the journal, you can add:
@@ -117,7 +117,7 @@ until the current master dies.
 ### Worker Configuration
 
 As long as the config parameters above are correctly set, the worker will be able to consult with
-ZooKeeper, and find the current leader master to connect to. Therefore, `ALLUXIO_MASTER_HOSTNAME`
+ZooKeeper, and find the current leader master to connect to. Therefore, the Alluxio master hostname
 does not have to be set for the workers.
 
 > Note: When running Alluxio in fault tolerant mode, it is possible that the default worker

--- a/docs/en/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/en/Running-Alluxio-Fault-Tolerant.md
@@ -117,7 +117,7 @@ until the current master dies.
 ### Worker Configuration
 
 As long as the config parameters above are correctly set, the worker will be able to consult with
-ZooKeeper, and find the current leader master to connect to. Therefore, the Alluxio master hostname
+ZooKeeper, and find the current leader master to connect to. Therefore, `alluxio.master.hostname`
 does not have to be set for the workers.
 
 > Note: When running Alluxio in fault tolerant mode, it is possible that the default worker


### PR DESCRIPTION
This updates the doc to recommend setting
alluxio.master.hostname in alluxio-site.properties
instead of ALLUXIO_MASTER_HOSTNAME in alluxio-env.sh.
This reflects our latest configuration story changes.