### PR TITLE
[DOCFIX] Glusterfs docfix

### DIFF
--- a/docs/_includes/Configuring-Alluxio-with-GlusterFS/bootstrapConf.md
+++ b/docs/_includes/Configuring-Alluxio-with-GlusterFS/bootstrapConf.md
@@ -1,3 +1,3 @@
 ```bash
-$ ./bin/alluxio bootstrapConf <ALLUXIO_MASTER_HOSTNAME> glusterfs 
+$ ./bin/alluxio bootstrapConf <ALLUXIO_MASTER_HOSTNAME>
 ```


### PR DESCRIPTION
The ufs parameter is no longer necessary.