### PR TITLE
[SMALLFIX] Add alluxio.master.hostname to alluxio-site.properties.template

### DIFF
--- a/conf/alluxio-site.properties.template
+++ b/conf/alluxio-site.properties.template
@@ -13,6 +13,7 @@
 # Details about all configuration properties http://www.alluxio.org/documentation/en/Configuration-Settings.html
 
 # Common properties
+# alluxio.master.hostname=localhost
 # alluxio.underfs.address=${alluxio.work.dir}/underFSStorage
 
 # Security properties


### PR DESCRIPTION
It becomes recommended in v1.4 to define `alluxio.master.hostname` in `alluxio-site.properties`. However, it is not in the template file.