### PR TITLE
[SMALLFIX] Fix loadMetadata performance

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/options/LoadMetadataOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/LoadMetadataOptions.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.file.options;
 
+import alluxio.underfs.UnderFileStatus;
+
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class LoadMetadataOptions {
   private boolean mCreateAncestors;
   private boolean mLoadDirectChildren;
+  private UnderFileStatus mUnderFileStatus;
 
   /**
    * @return the default {@link LoadMetadataOptions}
@@ -33,6 +36,14 @@ public final class LoadMetadataOptions {
   private LoadMetadataOptions() {
     mCreateAncestors = false;
     mLoadDirectChildren = false;
+    mUnderFileStatus = null;
+  }
+
+  /**
+   * @return null if unknown, else the status of UFS path for which loading metadata
+   */
+  public UnderFileStatus getUnderFileStatus() {
+    return mUnderFileStatus;
   }
 
   /**
@@ -75,6 +86,17 @@ public final class LoadMetadataOptions {
     return this;
   }
 
+  /**
+   * Sets the UFS status of path.
+   *
+   * @param status UFS status of path
+   * @return the updated object
+   */
+  public LoadMetadataOptions setUnderFileStatus(UnderFileStatus status) {
+    mUnderFileStatus = status;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -85,17 +107,19 @@ public final class LoadMetadataOptions {
     }
     LoadMetadataOptions that = (LoadMetadataOptions) o;
     return Objects.equal(mCreateAncestors, that.mCreateAncestors)
-        && Objects.equal(mLoadDirectChildren, that.mLoadDirectChildren);
+        && Objects.equal(mLoadDirectChildren, that.mLoadDirectChildren)
+        && Objects.equal(mUnderFileStatus, that.mUnderFileStatus);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mCreateAncestors, mLoadDirectChildren);
+    return Objects.hashCode(mCreateAncestors, mLoadDirectChildren, mUnderFileStatus);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("createAncestors", mCreateAncestors)
-        .add("loadDirectChildren", mLoadDirectChildren).toString();
+        .add("loadDirectChildren", mLoadDirectChildren)
+        .add("underFileStatus", mUnderFileStatus).toString();
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/options/LoadMetadataOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/LoadMetadataOptionsTest.java
@@ -17,6 +17,8 @@ import alluxio.underfs.UnderFileStatus;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Random;
+
 /**
  * Tests for the {@link LoadMetadataOptions} class.
  */
@@ -31,14 +33,17 @@ public class LoadMetadataOptionsTest {
 
   @Test
   public void fields() {
+    Random random = new Random();
+    boolean isCreateAncestors = random.nextBoolean();
+    boolean isLoadDirectChildren = random.nextBoolean();
+    boolean isDirectory = random.nextBoolean();
     LoadMetadataOptions options = LoadMetadataOptions.defaults();
-    options.setCreateAncestors(true);
-    Assert.assertEquals(false, options.isLoadDirectChildren());
-    options.setLoadDirectChildren(true);
-    options.setUnderFileStatus(new UnderFileStatus("dummy", true));
-    Assert.assertEquals(true, options.isCreateAncestors());
-    Assert.assertEquals(true, options.isLoadDirectChildren());
-    Assert.assertEquals(true, options.getUnderFileStatus().isDirectory());
+    options.setCreateAncestors(isCreateAncestors);
+    options.setLoadDirectChildren(isLoadDirectChildren);
+    options.setUnderFileStatus(new UnderFileStatus("dummy", isDirectory));
+    Assert.assertEquals(isCreateAncestors, options.isCreateAncestors());
+    Assert.assertEquals(isLoadDirectChildren, options.isLoadDirectChildren());
+    Assert.assertEquals(isDirectory, options.getUnderFileStatus().isDirectory());
   }
 
   @Test

--- a/core/server/src/test/java/alluxio/master/file/options/LoadMetadataOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/LoadMetadataOptionsTest.java
@@ -1,0 +1,48 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.options;
+
+import alluxio.CommonTestUtils;
+import alluxio.underfs.UnderFileStatus;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link LoadMetadataOptions} class.
+ */
+public class LoadMetadataOptionsTest {
+  @Test
+  public void defaults() {
+    LoadMetadataOptions options = LoadMetadataOptions.defaults();
+    Assert.assertEquals(false, options.isCreateAncestors());
+    Assert.assertEquals(false, options.isLoadDirectChildren());
+    Assert.assertEquals(null, options.getUnderFileStatus());
+  }
+
+  @Test
+  public void fields() {
+    LoadMetadataOptions options = LoadMetadataOptions.defaults();
+    options.setCreateAncestors(true);
+    Assert.assertEquals(false, options.isLoadDirectChildren());
+    options.setLoadDirectChildren(true);
+    options.setUnderFileStatus(new UnderFileStatus("dummy", true));
+    Assert.assertEquals(true, options.isCreateAncestors());
+    Assert.assertEquals(true, options.isLoadDirectChildren());
+    Assert.assertEquals(true, options.getUnderFileStatus().isDirectory());
+  }
+
+  @Test
+  public void equalsTest() throws Exception {
+    CommonTestUtils.testEquals(LoadMetadataOptions.class);
+  }
+}


### PR DESCRIPTION
When loading a directory from the UFS, the previous implementation makes many exists/isFile calls to the UFS. With the new UFS API these calls are unnecessary as the first listStatus on the parent directory now returns UnderFileStatus[] which contains the isFile/isDirectory bit.

This PR will majorly impact loadMetadata performance, potentially (3 x number of entries in directory) times fewer calls to UFS.