### PR TITLE
[DOCFIX] Tweak yarn ec2 docs

### DIFF
--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -123,7 +123,7 @@ but it makes the build run significantly faster.
 To customize Alluxio master and worker with specific properties (e.g., tiered storage setup on each
 worker), see [Configuration settings](Configuration-Settings.html). To ensure your configuration can be
 read by both the ApplicationMaster and Alluxio master/workers, put `alluxio-site.properties` under
-`~/.alluxio/` on each EC2 machine.
+`.alluxio` in the home folder of the user that the Alluxio masters/workers are running under on each EC2 machine.
 
 # Start Alluxio
 

--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -121,13 +121,13 @@ Note that adding `-DskipTests -Dfindbugs.skip -Dmaven.javadoc.skip -Dcheckstyle.
 but it makes the build run significantly faster.
 
 To customize Alluxio master and worker with specific properties (e.g., tiered storage setup on each
-worker), one can refer to [Configuration settings](Configuration-Settings.html) for more
-information. To ensure your configuration can be read by both the ApplicationMaster and Alluxio
-master/workers, put `alluxio-site.properties` under `~/.alluxio/` on each EC2 machine.
+worker), see [Configuration settings](Configuration-Settings.html). To ensure your configuration can be
+read by both the ApplicationMaster and Alluxio master/workers, put `alluxio-site.properties` under
+`~/.alluxio/` on each EC2 machine.
 
 # Start Alluxio
 
-If Yarn does not reside in HADOOP_HOME, you'll want to export the environment variable YARN_HOME to the base path of Yarn.
+If Yarn does not reside in HADOOP_HOME, set the environment variable YARN_HOME to the base path of Yarn.
 
 Use the script `integration/yarn/bin/alluxio-yarn.sh` to start Alluxio. This script takes three arguments:
 
@@ -151,11 +151,6 @@ From the output, we know the application ID to run Alluxio is
 **`application_1445469376652_0002`**. This application ID is needed to kill the application.
 
 # Test Alluxio
-
-When you know the IP of Alluxio master container, you can modify the `conf/alluxio-env.sh` to set
- up environment variable `ALLUXIO_MASTER_HOSTNAME` on each EC2 machine:
-
-{% include Running-Alluxio-on-EC2-Yarn/environment-variable.md %}
 
 You can run tests against Alluxio to check its health:
 

--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -123,7 +123,7 @@ but it makes the build run significantly faster.
 To customize Alluxio master and worker with specific properties (e.g., tiered storage setup on each
 worker), see [Configuration settings](Configuration-Settings.html). To ensure your configuration can be
 read by both the ApplicationMaster and Alluxio master/workers, put `alluxio-site.properties` under
-`.alluxio` in the home folder of the user that the Alluxio masters/workers are running under on each EC2 machine.
+`~/.alluxio`, as well as the home folders any users that will launch an Alluxio client or server.
 
 # Start Alluxio
 

--- a/docs/en/Running-Alluxio-on-EC2-Yarn.md
+++ b/docs/en/Running-Alluxio-on-EC2-Yarn.md
@@ -122,8 +122,8 @@ but it makes the build run significantly faster.
 
 To customize Alluxio master and worker with specific properties (e.g., tiered storage setup on each
 worker), see [Configuration settings](Configuration-Settings.html). To ensure your configuration can be
-read by both the ApplicationMaster and Alluxio master/workers, put `alluxio-site.properties` under
-`~/.alluxio`, as well as the home folders any users that will launch an Alluxio client or server.
+read by both the ApplicationMaster and Alluxio master/workers, put `alluxio-site.properties` in
+`~/.alluxio` under the home folders for any users that will launch an Alluxio client or server.
 
 # Start Alluxio
 


### PR DESCRIPTION
- A couple wording changes
- The master hostname is set deterministically, so we no longer need to search for it in the "Test Alluxio" section.