### PR TITLE
[ALLUXIO-2510]alluxio.user.network.netty.timeout.ms's default value is 30000

### DIFF
--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -18,7 +18,7 @@ alluxio.user.file.write.tier.default,0
 alluxio.user.heartbeat.interval.ms,1000
 alluxio.user.lineage.enabled,false
 alluxio.user.lineage.master.client.threads,10
-alluxio.user.network.netty.timeout.ms,3000
+alluxio.user.network.netty.timeout.ms,30000
 alluxio.user.network.netty.worker.threads,0
 alluxio.user.ufs.delegation.enabled,true
 alluxio.user.ufs.delegation.read.buffer.size.bytes,8MB


### PR DESCRIPTION
(https://alluxio.atlassian.net/browse/ALLUXIO-2510)
alluxio.user.network.netty.timeout.ms's default value is 30000