### PR TITLE
[SMALLFIX] REST API improvements

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/CreateDirectoryOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CreateDirectoryOptions.java
@@ -18,6 +18,8 @@ import alluxio.client.WriteType;
 import alluxio.security.authorization.Mode;
 import alluxio.thrift.CreateDirectoryTOptions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -27,6 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class CreateDirectoryOptions {
   private boolean mAllowExists;
   private Mode mMode; // null if creating the dir using system default mode

--- a/core/client/src/main/java/alluxio/client/file/options/CreateFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CreateFileOptions.java
@@ -26,6 +26,8 @@ import alluxio.wire.ThriftUtils;
 import alluxio.wire.TtlAction;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 
@@ -36,6 +38,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class CreateFileOptions {
   private boolean mRecursive;
   private FileWriteLocationPolicy mLocationPolicy;

--- a/core/client/src/main/java/alluxio/client/file/options/DeleteOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/DeleteOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class DeleteOptions {
   private boolean mRecursive;
 

--- a/core/client/src/main/java/alluxio/client/file/options/ExistsOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/ExistsOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class ExistsOptions {
   /**
    * @return the default {@link ExistsOptions}

--- a/core/client/src/main/java/alluxio/client/file/options/FreeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/FreeOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class FreeOptions {
   private boolean mRecursive;
 

--- a/core/client/src/main/java/alluxio/client/file/options/GetStatusOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/GetStatusOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class GetStatusOptions {
   /**
    * @return the default {@link GetStatusOptions}

--- a/core/client/src/main/java/alluxio/client/file/options/ListStatusOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/ListStatusOptions.java
@@ -15,6 +15,8 @@ import alluxio.annotation.PublicApi;
 import alluxio.thrift.ListStatusTOptions;
 import alluxio.wire.LoadMetadataType;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -24,6 +26,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class ListStatusOptions {
   private LoadMetadataType mLoadMetadataType;
 

--- a/core/client/src/main/java/alluxio/client/file/options/MountOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/MountOptions.java
@@ -14,6 +14,8 @@ package alluxio.client.file.options;
 import alluxio.annotation.PublicApi;
 import alluxio.thrift.MountTOptions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import java.util.Collections;
@@ -27,6 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class MountOptions {
   private boolean mReadOnly;
   private Map<String, String> mProperties;

--- a/core/client/src/main/java/alluxio/client/file/options/OpenFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/OpenFileOptions.java
@@ -19,6 +19,8 @@ import alluxio.client.file.policy.FileWriteLocationPolicy;
 import alluxio.util.CommonUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 
@@ -29,6 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class OpenFileOptions {
   private FileWriteLocationPolicy mLocationPolicy;
   private ReadType mReadType;

--- a/core/client/src/main/java/alluxio/client/file/options/RenameOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/RenameOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class RenameOptions {
   /**
    * @return the default {@link RenameOptions}

--- a/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -17,6 +17,8 @@ import alluxio.thrift.SetAttributeTOptions;
 import alluxio.wire.ThriftUtils;
 import alluxio.wire.TtlAction;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -27,6 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class SetAttributeOptions {
   private Boolean mPinned;
   private Long mTtl;

--- a/core/client/src/main/java/alluxio/client/file/options/UnmountOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/UnmountOptions.java
@@ -13,6 +13,8 @@ package alluxio.client.file.options;
 
 import alluxio.annotation.PublicApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -22,6 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
+@JsonInclude(Include.NON_EMPTY)
 public final class UnmountOptions {
   /**
    * @return the default {@link UnmountOptions}

--- a/core/common/src/main/java/alluxio/security/authorization/Mode.java
+++ b/core/common/src/main/java/alluxio/security/authorization/Mode.java
@@ -109,6 +109,8 @@ public final class Mode {
   private Bits mGroupBits;
   private Bits mOtherBits;
 
+  private Mode() {} // needed for JSON serialization and deserialization
+
   /**
    * Constructs an instance of {@link Mode} with the given {@link Bits}.
    *

--- a/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
@@ -31,7 +31,6 @@ import alluxio.rest.TestCase;
 import alluxio.rest.TestCaseOptions;
 import alluxio.security.authorization.Mode;
 import alluxio.wire.FileInfo;
-import alluxio.wire.TtlAction;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
@@ -22,13 +22,16 @@ import alluxio.client.file.options.ListStatusOptions;
 import alluxio.client.file.options.MountOptions;
 import alluxio.client.file.options.OpenFileOptions;
 import alluxio.client.file.options.RenameOptions;
+import alluxio.client.file.options.SetAttributeOptions;
 import alluxio.client.file.options.UnmountOptions;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.rest.RestApiTest;
 import alluxio.rest.TestCase;
 import alluxio.rest.TestCaseOptions;
+import alluxio.security.authorization.Mode;
 import alluxio.wire.FileInfo;
+import alluxio.wire.TtlAction;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -180,7 +183,9 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
     writeFile(uri, null);
     new TestCase(mHostname, mPort,
         PATHS_PREFIX + uri.toString() + "/" + PathsRestServiceHandler.SET_ATTRIBUTE, NO_PARAMS,
-        HttpMethod.POST, null, TestCaseOptions.defaults()).run();
+        HttpMethod.POST, null, TestCaseOptions.defaults()
+        .setBody(SetAttributeOptions.defaults().setMode(Mode.getDefault())))
+        .run();
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(uri);
     Assert.assertEquals(uri.toString(), fileInfo.getPath());
   }

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -140,8 +140,8 @@ public final class TestCase {
     }
 
     connection.connect();
-    Assert
-        .assertEquals(mEndpoint, Response.Status.OK.getStatusCode(), connection.getResponseCode());
+    Assert.assertEquals(connection.getResponseMessage(), Response.Status.OK.getStatusCode(),
+        connection.getResponseCode());
     return getResponse(connection);
   }
 


### PR DESCRIPTION
This PR fixes the following issues:
- adds JSON annotation to only serialize option fields that are set (affects tests only)
- provide private default constructor for `Mode`, which is needed for successful JSON deserialization
- improves the `SetAttribute` REST API test