### PR TITLE
[SMALLFIX] Increase the timeout for waiting for a new master.

### DIFF
--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -109,7 +109,7 @@ public class JournalShutdownIntegrationTest {
     runCreateFileThread(cluster.getClient());
     // Kill the leader one by one.
     for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {
-      cluster.waitForNewMaster(60 * Constants.SECOND_MS);
+      cluster.waitForNewMaster(120 * Constants.SECOND_MS);
       Assert.assertTrue(cluster.stopLeader());
     }
     cluster.stopFS();


### PR DESCRIPTION
Jenkins has been failing with timeout exceptions on this test. Increases the timeout to see if failures are just due to performance flakiness.