### PR TITLE
[ALLUXIO-2533]Update documentation of CACHE

### DIFF
--- a/docs/_data/table/cn/ReadType.yml
+++ b/docs/_data/table/cn/ReadType.yml
@@ -1,7 +1,9 @@
 CACHE_PROMOTE:
-  如果读取的数据在Worker上时，该数据被移动到Worker的最高层。如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中，用于每次完整地读取数据快。这是默认的读类型。
+  如果读取的数据在Worker上时，该数据被移动到Worker的最高层。如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。
+  如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内。
+  相反，一个数据块只有完全被读取时，才能被缓存。
 CACHE:
-  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内.
+  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内。
   相反，一个数据块只有完全被读取时，才能被缓存。
 NO_CACHE:
   不会创建副本。

--- a/docs/_data/table/cn/ReadType.yml
+++ b/docs/_data/table/cn/ReadType.yml
@@ -1,6 +1,7 @@
 CACHE_PROMOTE:
   如果读取的数据在Worker上时，该数据被移动到Worker的最高层。如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中，用于每次完整地读取数据快。这是默认的读类型。
 CACHE:
-  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中，用于每次完整地读取数据快。
+  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内.
+  相反，一个数据块只有完全被读取时，才能被缓存。
 NO_CACHE:
   不会创建副本。

--- a/docs/_data/table/cn/ReadType.yml
+++ b/docs/_data/table/cn/ReadType.yml
@@ -1,9 +1,9 @@
 CACHE_PROMOTE:
   如果读取的数据在Worker上时，该数据被移动到Worker的最高层。如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。
-  如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内。
+  如果`alluxio.user.file.cache.partially.read.block`设置为true,没有完全读取的数据块也会被*全部*存到Alluxio内。
   相反，一个数据块只有完全被读取时，才能被缓存。
 CACHE:
-  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。如果`alluxio.user.file.cache.partially.read.block`设置为true,如果设置这个变量为真, 没有完全读取的数据块也会被存到Alluxio内。
+  如果该数据不在本地Worker的Alluxio存储中，那么就将一个副本添加到本地Alluxio Worker中。如果`alluxio.user.file.cache.partially.read.block`设置为true,没有完全读取的数据块也会被*全部*存到Alluxio内。
   相反，一个数据块只有完全被读取时，才能被缓存。
 NO_CACHE:
   不会创建副本。

--- a/docs/_data/table/en/ReadType.yml
+++ b/docs/_data/table/en/ReadType.yml
@@ -1,7 +1,9 @@
 CACHE_PROMOTE:
   Data is moved to the highest tier in the worker where the data was read. If the data was not
-  in the Alluxio storage of the local worker, a replica will be added to the local Alluxio worker
-  for each completely read data block. This is the default read type.
+  in the Alluxio storage of the local worker, a replica will be added to the local Alluxio worker.
+  If `alluxio.user.file.cache.partially.read.block` is set to true, the entire block will be cached
+  by Alluxio space even if the client only reads a part of this block. Otherwise, a block will be
+  cached only if it is fully read.
 CACHE:
   If the data was not in the Alluxio storage of the local worker, a replica will be added to the
   local Alluxio worker. If `alluxio.user.file.cache.partially.read.block` is set to true, the

--- a/docs/_data/table/en/ReadType.yml
+++ b/docs/_data/table/en/ReadType.yml
@@ -4,6 +4,6 @@ CACHE_PROMOTE:
   for each completely read data block. This is the default read type.
 CACHE:
   If the data was not in the Alluxio storage of the local worker, a replica will be added to the
-  local Alluxio worker for each completely read data block.
+  local Alluxio worker.
 NO_CACHE:
   No replicas will be created.

--- a/docs/_data/table/en/ReadType.yml
+++ b/docs/_data/table/en/ReadType.yml
@@ -4,7 +4,8 @@ CACHE_PROMOTE:
   for each completely read data block. This is the default read type.
 CACHE:
   If the data was not in the Alluxio storage of the local worker, a replica will be added to the
-  local Alluxio worker. If `alluxio.user.file.cache.partially.read.block` is set to true, the entire
-  block will be cached by Alluxio space even if the client only reads a part of this block.
+  local Alluxio worker. If `alluxio.user.file.cache.partially.read.block` is set to true, the
+  entire block will be cached by Alluxio space even if the client only reads a part of this block.
+  Otherwise, a block will be cached only if it is fully read.
 NO_CACHE:
   No replicas will be created.

--- a/docs/_data/table/en/ReadType.yml
+++ b/docs/_data/table/en/ReadType.yml
@@ -4,6 +4,7 @@ CACHE_PROMOTE:
   for each completely read data block. This is the default read type.
 CACHE:
   If the data was not in the Alluxio storage of the local worker, a replica will be added to the
-  local Alluxio worker.
+  local Alluxio worker. If `alluxio.user.file.cache.partially.read.block` is set to true, the entire
+  block will be cached by Alluxio space even if the client only reads a part of this block.
 NO_CACHE:
   No replicas will be created.


### PR DESCRIPTION
(https://alluxio.atlassian.net/browse/ALLUXIO-2533)
The ` for each completely read data block` portion of CACHE description in the File System API documentation should be removed as it is no longer accurate.