### PR TITLE
[ALLUXIO-2542] Enable customize top tier

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -92,10 +92,10 @@ function mac_hfs_provision_sectors() {
 }
 
 function mount_ramfs_linux() {
-  TOTAL_MEM=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
-  if [[ ${TOTAL_MEM} -lt ${MEM_SIZE} ]]; then
-    echo "ERROR: Memory(${TOTAL_MEM}) is less than requested ramdisk size(${MEM_SIZE}). Please
-    reduce ALLUXIO_WORKER_MEMORY_SIZE" >&2
+  local total_mem=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
+  if [[ ${total_mem} -lt ${MEM_SIZE} ]]; then
+    echo "ERROR: Memory(${total_mem}) is less than requested ramdisk size(${MEM_SIZE}). Please
+    reduce alluxio.worker.memory.size in alluxio-site.properties" >&2
     exit 1
   fi
 
@@ -115,17 +115,17 @@ function mount_ramfs_linux() {
 
 function mount_ramfs_mac() {
   # Convert the memory size to number of sectors. Each sector is 512 Byte.
-  NUM_SECTORS=$(mac_hfs_provision_sectors ${MEM_SIZE} 512)
+  local num_sectors=$(mac_hfs_provision_sectors ${MEM_SIZE} 512)
 
   # Format the RAM FS
   # We may have a pre-existing RAM FS which we need to throw away
-  echo "Formatting RamFS: ${RAM_FOLDER} ${NUM_SECTORS} sectors (${MEM_SIZE})."
-  DEVICE=$(df -l | grep ${RAM_FOLDER} | cut -d " " -f 1)
-  if [[ -n "${DEVICE}" ]]; then
-    hdiutil detach -force ${DEVICE}
+  echo "Formatting RamFS: ${RAM_FOLDER} ${num_sectors} sectors (${MEM_SIZE})."
+  local device=$(df -l | grep ${RAM_FOLDER} | cut -d " " -f 1)
+  if [[ -n "${device}" ]]; then
+    hdiutil detach -force ${device}
   fi
   # Remove the "/Volumes/" part so we can get the name of the volume.
-  diskutil erasevolume HFS+ ${RAM_FOLDER/#\/Volumes\//} $(hdiutil attach -nomount ram://${NUM_SECTORS})
+  diskutil erasevolume HFS+ ${RAM_FOLDER/#\/Volumes\//} $(hdiutil attach -nomount ram://${num_sectors})
 }
 
 function mount_ramfs_local() {

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -37,7 +37,8 @@ MOPT (Mount Option) is one of:
   SudoMount\tMount the configured RamFS using sudo.
            \tNotice: this will format the existing RamFS.
   NoMount  \tDo not mount the configured RamFS.
-           \tNotice: Use NoMount (Linux only) to use tmpFS to avoid sudo requirement.
+           \tNotice: to avoid sudo requirement but use tmpFS in Linux,
+             one can set ALLUXIO_RAM_FOLDER=/dev/shm and use NoMount.
   SudoMount is assumed if MOPT is not specified.
 
 -f  format Journal, UnderFS Data and Workers Folder on master

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -69,8 +69,7 @@ is_ram_folder_mounted() {
   fi
 
   for fs in ${mounted_fs}; do
-    if [[ "${1}" == "${fs}" || \
-     "${1}" =~ ^"${fs}"\/.* ]]; then
+    if [[ "${1}" == "${fs}" || "${1}" =~ ^"${fs}"\/.* ]]; then
       return 0
     fi
   done
@@ -99,7 +98,7 @@ check_mount_mode() {
         fi
       fi
       if [[ "${ram_folder}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
-        echo "WARNING: Using tmpFS which is not guaranteed to be in memory."
+        echo "WARNING: Using tmpFS does not guarantee data to be stored in memory."
         echo "WARNING: Check vmstat for memory statistics (e.g. swapping)."
       fi
       ;;
@@ -119,7 +118,7 @@ do_mount() {
   MOUNT_FAILED=0
   case "$1" in
     Mount|SudoMount)
-      ${LAUNCHER} ${BIN}/alluxio-mount.sh $1
+      ${LAUNCHER} "${BIN}/alluxio-mount.sh" $1
       MOUNT_FAILED=$?
       ;;
     NoMount)

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -37,8 +37,8 @@ MOPT (Mount Option) is one of:
   SudoMount\tMount the configured RamFS using sudo.
            \tNotice: this will format the existing RamFS.
   NoMount  \tDo not mount the configured RamFS.
-           \tNotice: to avoid sudo requirement but use tmpFS in Linux,
-             one can set ALLUXIO_RAM_FOLDER=/dev/shm and use NoMount.
+           \tNotice: to avoid sudo requirement but using tmpFS in Linux,
+             set ALLUXIO_RAM_FOLDER=/dev/shm on each worker and use NoMount.
   SudoMount is assumed if MOPT is not specified.
 
 -f  format Journal, UnderFS Data and Workers Folder on master
@@ -83,13 +83,13 @@ check_mount_mode() {
     Mount);;
     SudoMount);;
     NoMount)
-      local folder_type=$(${BIN}/alluxio getConf alluxio.worker.tieredstore.level0.alias)
-      local ram_folder=$(${BIN}/alluxio getConf alluxio.worker.tieredstore.level0.dirs.path)
-      if [[ ${folder_type} != "MEM" ]]; then
+      local tier_alias=$(${BIN}/alluxio getConf alluxio.worker.tieredstore.level0.alias)
+      local tier_path=$(${BIN}/alluxio getConf alluxio.worker.tieredstore.level0.dirs.path)
+      if [[ ${tier_alias} != "MEM" ]]; then
         # if the top tier is not MEM, skip check
         return
       fi
-      is_ram_folder_mounted "${ram_folder}"
+      is_ram_folder_mounted "${tier_path}"
       if [[ $? -ne 0 ]]; then
         if [[ $(uname -s) == Darwin ]]; then
           # Assuming Mac OS X
@@ -98,7 +98,7 @@ check_mount_mode() {
           exit 1
         fi
       fi
-      if [[ "${ram_folder}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
+      if [[ "${tier_path}" =~ ^"/dev/shm"\/{0,1}$ ]]; then
         echo "WARNING: Using tmpFS does not guarantee data to be stored in memory."
         echo "WARNING: Check vmstat for memory statistics (e.g. swapping)."
       fi

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.sun.management.OperatingSystemMXBean;
 import io.netty.util.internal.chmv8.ConcurrentHashMapV8;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,37 +85,7 @@ public final class Configuration {
    */
   public static void defaultInit() {
     // Load default
-    Properties defaultProps = new Properties();
-    for (PropertyKey key : PropertyKey.values()) {
-      String value = key.getDefaultValue();
-      if (value != null) {
-        defaultProps.setProperty(key.toString(), value);
-      }
-    }
-    // Override runtime default
-    defaultProps.setProperty(PropertyKey.WORKER_NETWORK_NETTY_CHANNEL.toString(),
-        String.valueOf(ChannelType.defaultType()));
-    defaultProps.setProperty(PropertyKey.USER_NETWORK_NETTY_CHANNEL.toString(),
-        String.valueOf(ChannelType.defaultType()));
-    // Set ramdisk volume according to OS type
-    if (OSUtils.isLinux()) {
-      defaultProps
-          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH.toString(), "/mnt/ramdisk");
-    } else if (OSUtils.isMacOS()) {
-      defaultProps.setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH.toString(),
-          "/Volumes/ramdisk");
-    }
-    // Set a reasonable default for worker memory
-    try {
-      com.sun.management.OperatingSystemMXBean operatingSystemMXBean =
-          (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
-      long memSize = operatingSystemMXBean.getTotalPhysicalMemorySize();
-      defaultProps
-          .setProperty(PropertyKey.WORKER_MEMORY_SIZE.toString(), String.valueOf(memSize * 2 / 3));
-    } catch (Exception e) {
-      // The package com.sun.management may not be available on every platform.
-      // fallback to use the default value
-    }
+    Properties defaultProps = createDefaultProps();
 
     // Load system properties
     Properties systemProps = new Properties();
@@ -151,6 +122,46 @@ public final class Configuration {
 
     Preconditions.checkState(validate());
     checkConfigurationValues();
+  }
+
+  /**
+   * @return default properties
+   */
+  private static Properties createDefaultProps() {
+    Properties defaultProps = new Properties();
+    // Load compile-time default
+    for (PropertyKey key : PropertyKey.values()) {
+      String value = key.getDefaultValue();
+      if (value != null) {
+        defaultProps.setProperty(key.toString(), value);
+      }
+    }
+
+    // Load run-time default
+    defaultProps.setProperty(PropertyKey.WORKER_NETWORK_NETTY_CHANNEL.toString(),
+        String.valueOf(ChannelType.defaultType()));
+    defaultProps.setProperty(PropertyKey.USER_NETWORK_NETTY_CHANNEL.toString(),
+        String.valueOf(ChannelType.defaultType()));
+    // Set ramdisk volume according to OS type
+    if (OSUtils.isLinux()) {
+      defaultProps
+          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH.toString(), "/mnt/ramdisk");
+    } else if (OSUtils.isMacOS()) {
+      defaultProps.setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH.toString(),
+          "/Volumes/ramdisk");
+    }
+    // Set a reasonable default size for worker memory
+    try {
+      OperatingSystemMXBean operatingSystemMXBean =
+          (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+      long memSize = operatingSystemMXBean.getTotalPhysicalMemorySize();
+      defaultProps
+          .setProperty(PropertyKey.WORKER_MEMORY_SIZE.toString(), String.valueOf(memSize * 2 / 3));
+    } catch (Exception e) {
+      // The package com.sun.management may not be available on every platform.
+      // fallback to the compile-time default value
+    }
+    return defaultProps;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/OSUtils.java
+++ b/core/common/src/main/java/alluxio/util/OSUtils.java
@@ -44,6 +44,20 @@ public final class OSUtils {
   }
 
   /**
+   * @return true if current OS is MacOS
+   */
+  public static boolean isMacOS() {
+    return SystemUtils.IS_OS_MAC_OSX;
+  }
+
+  /**
+   * @return true if current OS is Linux
+   */
+  public static boolean isLinux() {
+    return SystemUtils.IS_OS_LINUX;
+  }
+
+  /**
    * @return true if current OS is AIX
    */
   public static boolean isAIX() {

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -50,19 +50,6 @@ if [[ -e "${ALLUXIO_CONF_DIR}/alluxio-env.sh" ]]; then
   . "${ALLUXIO_CONF_DIR}/alluxio-env.sh"
 fi
 
-# Determine reasonable defaults for worker memory and ramdisk folder
-if [[ $(uname -s) == Darwin ]]; then
-  # Assuming Mac OS X
-  DEFAULT_RAM_FOLDER="/Volumes/ramdisk"
-else
-  # Assuming Linux
-  DEFAULT_RAM_FOLDER="/mnt/ramdisk"
-fi
-# If ALLUXIO_RAM_FOLDER is explicitly set to the empty string, do not overwrite. This way a user
-# could set ALLUXIO_RAM_FOLDER="" to avoid using ramdisk at all. The ${X-Y} syntax will return $X
-# unless X is UNSET (not just empty), in which case it returns Y.
-ALLUXIO_RAM_FOLDER=${ALLUXIO_RAM_FOLDER-${DEFAULT_RAM_FOLDER}}
-
 if [[ -n "${ALLUXIO_MASTER_ADDRESS}" ]]; then
   echo "ALLUXIO_MASTER_ADDRESS is deprecated since version 1.1 and will be remove in version 2.0."
   echo "Please use \"ALLUXIO_MASTER_HOSTNAME\" instead."
@@ -78,6 +65,7 @@ if [[ -n "${ALLUXIO_LOGS_DIR}" ]]; then
 fi
 
 if [[ -n "${ALLUXIO_RAM_FOLDER}" ]]; then
+  ALLUXIO_JAVA_OPTS+=" -Dalluxio.worker.tieredstore.level0.alias=MEM"
   ALLUXIO_JAVA_OPTS+=" -Dalluxio.worker.tieredstore.level0.dirs.path=${ALLUXIO_RAM_FOLDER}"
 fi
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2542

This PR aims to add support to customize the top tier dir freely in `alluxio-site.properties` or using `ALLUXIO_RAM_FOLDER`. In addition, it simplifies the logic 

Specifically:
- Calculating the default ram folder based on OS in Java land rather than in Bash
- Calculating the default worker memory size based on total physical memory in Java land rather than in Bash
- If top tier is not MEM, allows `NoMount`
- Don't hardcode default ram folder to system properties --- this permits setting the folder in site properties.
