### PR TITLE
[SMALLFIX] Log warning when ufs creation fails

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
@@ -114,6 +114,7 @@ public final class UnderFileSystemRegistry {
         return factory.create(path, ufsConf);
       } catch (Exception e) {
         errors.add(e);
+        LOG.warn("Failed to create ufs", e);
       }
     }
 


### PR DESCRIPTION
The current thrown exception doesn't include a stack trace, which can
be extremely helpful for determining the root cause.