### PR TITLE
[SMALLFIX] Follow up to #4717

### DIFF
--- a/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -1618,7 +1618,8 @@ public final class FileSystemMaster extends AbstractMaster {
    * @param options method options
    * @return the id of the created directory
    * @throws InvalidPathException when the path is invalid, please see documentation on {@link
-   *         InodeTree#createPath(LockedInodePath, CreatePathOptions)}  for more details
+   *         InodeTree#createPath(LockedInodePath, alluxio.master.file.options.CreatePathOptions)}
+   *         for more details
    * @throws FileAlreadyExistsException when there is already a file at path
    * @throws IOException if a non-Alluxio related exception occurs
    * @throws AccessControlException if permission checking fails
@@ -1652,7 +1653,8 @@ public final class FileSystemMaster extends AbstractMaster {
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    * @throws InvalidPathException when the path is invalid, please see documentation on {@link
-   *         InodeTree#createPath(LockedInodePath, CreatePathOptions)} for more details
+   *         InodeTree#createPath(LockedInodePath, alluxio.master.file.options.CreatePathOptions)}
+   *         for more details
    * @throws AccessControlException if permission checking fails
    * @throws IOException if a non-Alluxio related exception occurs
    */
@@ -1673,7 +1675,8 @@ public final class FileSystemMaster extends AbstractMaster {
    * @return an {@link alluxio.master.file.meta.InodeTree.CreatePathResult} representing the
    *         modified inodes and created inodes during path creation
    * @throws InvalidPathException when the path is invalid, please see documentation on {@link
-   *         InodeTree#createPath(LockedInodePath, CreatePathOptions)} for more details
+   *         InodeTree#createPath(LockedInodePath, alluxio.master.file.options.CreatePathOptions)}
+   *         for more details
    * @throws FileAlreadyExistsException when there is already a file at path
    * @throws IOException if a non-Alluxio related exception occurs
    * @throws AccessControlException if permission checking fails
@@ -2374,10 +2377,7 @@ public final class FileSystemMaster extends AbstractMaster {
     if (resolution.getShared()) {
       mode.setOtherBits(mode.getOtherBits().or(mode.getOwnerBits()));
     }
-    // This file is loaded from UFS. By setting default mode to false, umask will not be
-    // applied to loaded mode.
-    createFileOptions =
-        createFileOptions.setOwner(ufsOwner).setGroup(ufsGroup).setMode(mode).setDefaultMode(false);
+    createFileOptions = createFileOptions.setOwner(ufsOwner).setGroup(ufsGroup).setMode(mode);
 
     try {
       createFileAndJournal(inodePath, createFileOptions, journalContext);
@@ -2424,11 +2424,8 @@ public final class FileSystemMaster extends AbstractMaster {
     if (resolution.getShared()) {
       mode.setOtherBits(mode.getOtherBits().or(mode.getOwnerBits()));
     }
-    // This directory is loaded from UFS. By setting default mode to false, umask will not be
-    // applied to loaded mode.
     createDirectoryOptions =
-        createDirectoryOptions.setOwner(ufsOwner).setGroup(ufsGroup).setMode(mode)
-            .setDefaultMode(false);
+        createDirectoryOptions.setOwner(ufsOwner).setGroup(ufsGroup).setMode(mode);
 
     try {
       createDirectoryAndJournal(inodePath, createDirectoryOptions, journalContext);

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -18,7 +18,6 @@ import alluxio.master.ProtobufUtils;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.proto.journal.File.InodeDirectoryEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
-import alluxio.security.authorization.Mode;
 import alluxio.wire.FileInfo;
 
 import com.google.common.collect.ImmutableSet;

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -230,10 +230,6 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   public static InodeDirectory create(long id, long parentId, String name,
       CreateDirectoryOptions options) {
-    Mode mode = new Mode(options.getMode());
-    if (options.isDefaultMode()) {
-      mode = Mode.defaults().applyDirectoryUMask();
-    }
     return new InodeDirectory(id)
         .setParentId(parentId)
         .setName(name)
@@ -241,7 +237,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
         .setTtlAction(options.getTtlAction())
         .setOwner(options.getOwner())
         .setGroup(options.getGroup())
-        .setMode(mode.toShort())
+        .setMode(options.getMode().toShort())
         .setMountPoint(options.isMountPoint());
   }
 

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -293,10 +293,6 @@ public final class InodeFile extends Inode<InodeFile> {
    */
   public static InodeFile create(long blockContainerId, long parentId, String name,
       long creationTimeMs, CreateFileOptions options) {
-    Mode mode = new Mode(options.getMode());
-    if (options.isDefaultMode()) {
-      mode = Mode.defaults().applyFileUMask();
-    }
     return new InodeFile(blockContainerId)
         .setBlockSizeBytes(options.getBlockSizeBytes())
         .setCreationTimeMs(creationTimeMs)
@@ -306,7 +302,7 @@ public final class InodeFile extends Inode<InodeFile> {
         .setParentId(parentId)
         .setOwner(options.getOwner())
         .setGroup(options.getGroup())
-        .setMode(mode.toShort())
+        .setMode(options.getMode().toShort())
         .setPersistenceState(options.isPersisted() ? PersistenceState.PERSISTED
             : PersistenceState.NOT_PERSISTED);
 

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -20,7 +20,6 @@ import alluxio.master.block.BlockId;
 import alluxio.master.file.options.CreateFileOptions;
 import alluxio.proto.journal.File.InodeFileEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
-import alluxio.security.authorization.Mode;
 import alluxio.wire.FileInfo;
 
 import com.google.common.base.Preconditions;

--- a/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -558,9 +558,7 @@ public class InodeTree implements JournalCheckpointStreamable {
         .setMountPoint(false)
         .setPersisted(options.isPersisted())
         .setOwner(options.getOwner())
-        .setGroup(options.getGroup())
-        .setMode(options.getMode())
-        .setDefaultMode(true);
+        .setGroup(options.getGroup());
     for (int k = pathIndex; k < (pathComponents.length - 1); k++) {
       InodeDirectory dir =
           InodeDirectory.create(mDirectoryIdGenerator.getNewDirectoryId(),

--- a/core/server/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -61,7 +61,7 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     if (options.isSetMode()) {
       mMode = new Mode(options.getMode());
     } else {
-      mMode = Mode.defaults().applyDirectoryUMask();
+      mMode.applyDirectoryUMask();
     }
   }
 

--- a/core/server/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -59,8 +59,9 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
       mGroup = SecurityUtils.getGroupFromThriftClient();
     }
     if (options.isSetMode()) {
-      mDefaultMode = false;
       mMode = new Mode(options.getMode());
+    } else {
+      mMode = Mode.defaults().applyDirectoryUMask();
     }
   }
 
@@ -69,6 +70,7 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     mAllowExists = false;
     mTtl = Constants.NO_TTL;
     mTtlAction = TtlAction.DELETE;
+    mMode.applyDirectoryUMask();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/master/file/options/CreateFileOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreateFileOptions.java
@@ -61,8 +61,9 @@ public final class CreateFileOptions extends CreatePathOptions<CreateFileOptions
       mGroup = SecurityUtils.getGroupFromThriftClient();
     }
     if (options.isSetMode()) {
-      mDefaultMode = false;
       mMode = new Mode(options.getMode());
+    } else {
+      mMode = Mode.defaults().applyFileUMask();
     }
   }
 
@@ -71,6 +72,7 @@ public final class CreateFileOptions extends CreatePathOptions<CreateFileOptions
     mBlockSizeBytes = Configuration.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
     mTtl = Constants.NO_TTL;
     mTtlAction = TtlAction.DELETE;
+    mMode.applyFileUMask();
   }
 
   /**

--- a/core/server/src/main/java/alluxio/master/file/options/CreateFileOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreateFileOptions.java
@@ -63,7 +63,7 @@ public final class CreateFileOptions extends CreatePathOptions<CreateFileOptions
     if (options.isSetMode()) {
       mMode = new Mode(options.getMode());
     } else {
-      mMode = Mode.defaults().applyFileUMask();
+      mMode.applyFileUMask();
     }
   }
 

--- a/core/server/src/main/java/alluxio/master/file/options/CreatePathOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreatePathOptions.java
@@ -33,18 +33,16 @@ public abstract class CreatePathOptions<T> {
   // TODO(peis): Rename this to mCreateAncestors.
   protected boolean mRecursive;
   protected boolean mMetadataLoad;
-  protected boolean mDefaultMode;
 
   protected CreatePathOptions() {
     mMountPoint = false;
     mOperationTimeMs = System.currentTimeMillis();
     mOwner = "";
     mGroup = "";
-    mMode = Mode.createFullAccess();
+    mMode = Mode.defaults();
     mPersisted = false;
     mRecursive = false;
     mMetadataLoad = false;
-    mDefaultMode = true;
   }
 
   protected abstract T getThis();
@@ -104,13 +102,6 @@ public abstract class CreatePathOptions<T> {
    */
   public boolean isMetadataLoad() {
     return mMetadataLoad;
-  }
-
-  /**
-   * @return the defaultMode flag; if true, the create path uses the default permission mode
-   */
-  public boolean isDefaultMode() {
-    return mDefaultMode;
   }
 
   /**
@@ -189,14 +180,6 @@ public abstract class CreatePathOptions<T> {
     return getThis();
   }
 
-  /**
-   * @param defaultMode the flag value to use; if true, the create path uses default permission mode
-   * @return the updated options object
-   */
-  public T setDefaultMode(boolean defaultMode) {
-    mDefaultMode = defaultMode;
-    return getThis();
-  }
 
   @Override
   public boolean equals(Object o) {
@@ -214,7 +197,6 @@ public abstract class CreatePathOptions<T> {
         && Objects.equal(mPersisted, that.mPersisted)
         && Objects.equal(mRecursive, that.mRecursive)
         && Objects.equal(mMetadataLoad, that.mMetadataLoad)
-        && Objects.equal(mDefaultMode, that.mDefaultMode)
         && mOperationTimeMs == that.mOperationTimeMs;
   }
 
@@ -222,7 +204,7 @@ public abstract class CreatePathOptions<T> {
   public int hashCode() {
     return Objects
         .hashCode(mMountPoint, mOwner, mGroup, mMode, mPersisted, mRecursive, mMetadataLoad,
-            mDefaultMode, mOperationTimeMs);
+            mOperationTimeMs);
   }
 
   protected Objects.ToStringHelper toStringHelper() {
@@ -234,7 +216,6 @@ public abstract class CreatePathOptions<T> {
         .add("mode", mMode)
         .add("persisted", mPersisted)
         .add("recursive", mRecursive)
-        .add("metadataLoad", mMetadataLoad)
-        .add("defaultMode", mDefaultMode);
+        .add("metadataLoad", mMetadataLoad);
   }
 }

--- a/core/server/src/main/java/alluxio/master/file/options/CreatePathOptions.java
+++ b/core/server/src/main/java/alluxio/master/file/options/CreatePathOptions.java
@@ -180,7 +180,6 @@ public abstract class CreatePathOptions<T> {
     return getThis();
   }
 
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -910,7 +910,7 @@ public final class PermissionCheckTest {
       if (i == permissions.size() - 1) {
         Inode<?> inode = InodeFile.create(i + 1, i, (i + 1) + "", CommonUtils.getCurrentMs(),
             CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setOwner(owner)
-                .setGroup(group).setMode(mode).setDefaultMode(false));
+                .setGroup(group).setMode(mode));
         inodes.add(inode);
       } else {
         Inode<?> inode = InodeDirectory.create(i + 1, i, (i + 1) + "",

--- a/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/AbstractInodeTest.java
@@ -26,7 +26,8 @@ import org.junit.rules.ExpectedException;
 public abstract class AbstractInodeTest {
   public static final String TEST_OWNER = "user1";
   public static final String TEST_GROUP = "group1";
-  public static final Mode TEST_MODE = new Mode((short) 0755);
+  public static final Mode TEST_DIR_MODE = new Mode((short) 0755);
+  public static final Mode TEST_FILE_MODE = new Mode((short) 0644);
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
@@ -38,12 +39,12 @@ public abstract class AbstractInodeTest {
   protected static InodeDirectory createInodeDirectory() {
     return InodeDirectory.create(1, 0, "test1",
         CreateDirectoryOptions.defaults().setOwner(TEST_OWNER).setGroup(TEST_GROUP)
-            .setMode(TEST_MODE));
+            .setMode(TEST_DIR_MODE));
   }
 
   protected InodeFile createInodeFile(long id) {
     return InodeFile.create(id, 1, "testFile" + id, 0,
         CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setOwner(TEST_OWNER)
-            .setGroup(TEST_GROUP).setMode(TEST_MODE));
+            .setGroup(TEST_GROUP).setMode(TEST_FILE_MODE));
   }
 }

--- a/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -57,7 +57,8 @@ public final class InodeTreeTest {
   private static final AlluxioURI NESTED_FILE_URI = new AlluxioURI("/nested/test/file");
   public static final String TEST_OWNER = "user1";
   public static final String TEST_GROUP = "group1";
-  public static final Mode TEST_MODE = new Mode((short) 0755);
+  public static final Mode TEST_DIR_MODE = new Mode((short) 0755);
+  public static final Mode TEST_FILE_MODE = new Mode((short) 0644);
   private static CreateFileOptions sFileOptions;
   private static CreateDirectoryOptions sDirectoryOptions;
   private static CreateFileOptions sNestedFileOptions;
@@ -89,7 +90,7 @@ public final class InodeTreeTest {
 
     Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
     Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup");
-    mTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_MODE);
+    mTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_DIR_MODE);
   }
 
   @After
@@ -104,16 +105,16 @@ public final class InodeTreeTest {
   public static void beforeClass() throws Exception {
     sFileOptions =
         CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB).setOwner(TEST_OWNER)
-            .setGroup(TEST_GROUP).setMode(TEST_MODE);
+            .setGroup(TEST_GROUP).setMode(TEST_FILE_MODE);
     sDirectoryOptions =
         CreateDirectoryOptions.defaults().setOwner(TEST_OWNER).setGroup(TEST_GROUP)
-            .setMode(TEST_MODE);
+            .setMode(TEST_DIR_MODE);
     sNestedFileOptions = CreateFileOptions.defaults().setBlockSizeBytes(Constants.KB)
         .setOwner(TEST_OWNER).setGroup(TEST_GROUP)
-        .setMode(TEST_MODE).setRecursive(true);
+        .setMode(TEST_FILE_MODE).setRecursive(true);
     sNestedDirectoryOptions =
         CreateDirectoryOptions.defaults().setOwner(TEST_OWNER).setGroup(TEST_GROUP)
-            .setMode(TEST_MODE).setRecursive(true);
+            .setMode(TEST_DIR_MODE).setRecursive(true);
   }
 
   /**
@@ -123,7 +124,7 @@ public final class InodeTreeTest {
   public void initializeRootTwice() throws Exception {
     Inode<?> root = getInodeByPath(mTree, new AlluxioURI("/"));
     // initializeRoot call does nothing
-    mTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_MODE);
+    mTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_DIR_MODE);
     Assert.assertEquals(TEST_OWNER, root.getOwner());
     Inode<?> newRoot = getInodeByPath(mTree, new AlluxioURI("/"));
     Assert.assertEquals(root, newRoot);
@@ -143,7 +144,7 @@ public final class InodeTreeTest {
     Assert.assertTrue(test.isDirectory());
     Assert.assertEquals("user1", test.getOwner());
     Assert.assertEquals("group1", test.getGroup());
-    Assert.assertEquals((short) 0755, test.getMode());
+    Assert.assertEquals(TEST_DIR_MODE.toShort(), test.getMode());
 
     // create nested directory
     createPath(mTree, NESTED_URI, sNestedDirectoryOptions);
@@ -154,7 +155,7 @@ public final class InodeTreeTest {
     Assert.assertTrue(test.isDirectory());
     Assert.assertEquals("user1", test.getOwner());
     Assert.assertEquals("group1", test.getGroup());
-    Assert.assertEquals((short) 0755, test.getMode());
+    Assert.assertEquals(TEST_DIR_MODE.toShort(), test.getMode());
   }
 
   /**
@@ -210,7 +211,7 @@ public final class InodeTreeTest {
     Assert.assertTrue(nestedFile.isFile());
     Assert.assertEquals("user1", nestedFile.getOwner());
     Assert.assertEquals("group1", nestedFile.getGroup());
-    Assert.assertEquals((short) 0644, nestedFile.getMode());
+    Assert.assertEquals(TEST_FILE_MODE.toShort(), nestedFile.getMode());
   }
 
   /**
@@ -226,7 +227,7 @@ public final class InodeTreeTest {
     // Need to use updated options to set the correct last mod time.
     CreateDirectoryOptions dirOptions =
         CreateDirectoryOptions.defaults().setOwner(TEST_OWNER).setGroup(TEST_GROUP)
-            .setMode(TEST_MODE).setRecursive(true);
+            .setMode(TEST_DIR_MODE).setRecursive(true);
 
     // create nested directory
     InodeTree.CreatePathResult createResult = createPath(mTree, NESTED_URI, dirOptions);

--- a/core/server/src/test/java/alluxio/master/file/options/CreateDirectoryOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/CreateDirectoryOptionsTest.java
@@ -39,6 +39,9 @@ public class CreateDirectoryOptionsTest {
     CreateDirectoryOptions options = CreateDirectoryOptions.defaults();
 
     Assert.assertEquals(false, options.isAllowExists());
+    Assert.assertEquals("", options.getOwner());
+    Assert.assertEquals("", options.getGroup());
+    Assert.assertEquals(Mode.defaults().applyDirectoryUMask(), options.getMode());
     Assert.assertFalse(options.isPersisted());
     Assert.assertFalse(options.isRecursive());
     Assert.assertEquals(Constants.NO_TTL, options.getTtl());

--- a/core/server/src/test/java/alluxio/master/file/options/CreateFileOptionsTest.java
+++ b/core/server/src/test/java/alluxio/master/file/options/CreateFileOptionsTest.java
@@ -42,7 +42,7 @@ public class CreateFileOptionsTest {
     Assert.assertEquals(64 * Constants.MB, options.getBlockSizeBytes());
     Assert.assertEquals("", options.getOwner());
     Assert.assertEquals("", options.getGroup());
-    Assert.assertEquals(Mode.createFullAccess(), options.getMode());
+    Assert.assertEquals(Mode.defaults().applyFileUMask(), options.getMode());
     Assert.assertFalse(options.isPersisted());
     Assert.assertFalse(options.isRecursive());
     Assert.assertEquals(Constants.NO_TTL, options.getTtl());


### PR DESCRIPTION
This PR is a follow up to #4717, removing the `mDefaultMode` field which is now no longer needed.