### PR TITLE
[DOCFIX] Fix the broken text in docs in Running-HBase-on-Alluxio.md

### DIFF
--- a/docs/cn/Running-HBase-on-Alluxio.md
+++ b/docs/cn/Running-HBase-on-Alluxio.md
@@ -22,7 +22,7 @@ Apache HBase可以通过通用文件系统包装类（可用于Hadoop文件系�
 
 需要添加以下3个属性到HBase安装的`conf`目录下的`hbase-site.xml`文件中(确保这些属性在所有HBase集群节点中都被配置好)：
 
-提示：无需在Alluxio中创建/base目录，HBase将会创建。
+提示：无需在Alluxio中创建/hbase目录，HBase将会创建。
 
 ```xml
 <property>


### PR DESCRIPTION
25行，创建/base目录，应该为创建/hbase目录。英文版是这样的。