### PR TITLE
[ALLUXIO-2552] Support symbolic permissions in chmod command

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -177,6 +177,12 @@ public enum ExceptionMessage {
   INVALID_SET_ACL_OPTIONS("Invalid set acl options: {0}, {1}, {2}"),
   PERMISSION_DENIED("Permission denied: {0}"),
   SECURITY_IS_NOT_ENABLED("Security is not enabled"),
+  INVALID_MODE("Invalid mode {0}"),
+  INVALID_MODE_SEGMENT("Invalid mode {0} - contains invalid segment {1}"),
+  INVALID_MODE_PERMISSIONS(
+      "Invalid mode {0} - contains invalid segment {1} which has invalid permissions {2}"),
+  INVALID_MODE_TARGETS(
+      "Invalid mode {0} - contains invalid segment {1} which has invalid targets {2}"),
 
   // yarn
   YARN_NOT_ENOUGH_HOSTS(

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -11,9 +11,9 @@
 
 package alluxio.security.authorization;
 
+import alluxio.exception.ExceptionMessage;
 import alluxio.security.authorization.Mode.Bits;
 
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -37,7 +37,9 @@ public final class ModeParser {
    * @return Mode
    */
   public Mode parse(String value) {
-    Preconditions.checkArgument(StringUtils.isNotBlank(value), "Invalid mode %s", value);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException(ExceptionMessage.INVALID_MODE.getMessage(value));
+    }
 
     try {
       return parseNumeric(value);
@@ -65,14 +67,18 @@ public final class ModeParser {
       // Must have targets=perm i.e. 2 parts
       // Targets must be in u, g, o and a
       // Permissions must be in r, w and x
-      Preconditions.checkArgument(specParts.length == 2,
-          "Invalid mode %s - contains invalid segment %s", value, spec);
-      Preconditions.checkArgument(StringUtils.containsOnly(specParts[0], VALID_TARGETS),
-          "Invalid mode %s - contains invalid segment %s which has invalid targets %s",
-          value, spec, specParts[0]);
-      Preconditions.checkArgument(StringUtils.containsOnly(specParts[1], VALID_PERMISSIONS),
-          "Invalid mode %s - contains invalid segment %s which has invalid permissions %s",
-          value, spec, specParts[1]);
+      if (specParts.length != 2) {
+        throw new IllegalArgumentException(ExceptionMessage.INVALID_MODE_SEGMENT
+            .getMessage(value, spec));
+      }
+      if (!StringUtils.containsOnly(specParts[0], VALID_TARGETS)) {
+        throw new IllegalArgumentException(ExceptionMessage.INVALID_MODE_TARGETS
+            .getMessage(value, spec, specParts[0]));
+      }
+      if (!StringUtils.containsOnly(specParts[1], VALID_PERMISSIONS)) {
+        throw new IllegalArgumentException(ExceptionMessage.INVALID_MODE_PERMISSIONS
+            .getMessage(value, spec, specParts[1]));
+      }
 
       // Build the permissions being specified
       Mode.Bits specBits = Bits.NONE;

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -1,0 +1,99 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import alluxio.security.authorization.Mode.Bits;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parser for {@code Mode} instances.
+ * @author rvesse
+ *
+ */
+public final class ModeParser {
+
+  /**
+   * Creates a new parser.
+   */
+  public ModeParser() {}
+
+  /**
+   * Parses the given value as a mode.
+   * @param value Value
+   * @return Mode
+   */
+  public Mode parse(String value) {
+    Preconditions.checkArgument(StringUtils.isBlank(value), "Invalid mode %s", value);
+
+    try {
+      return parseNumeric(value);
+    } catch (NumberFormatException e) {
+      // Treat as symbolic
+      return parseSymbolic(value);
+    }
+  }
+
+  private Mode parseNumeric(String value) {
+    short s = Short.parseShort(value);
+    return new Mode(s);
+  }
+
+  private Mode parseSymbolic(String value) {
+    Mode.Bits ownerBits = Bits.NONE;
+    Mode.Bits groupBits = Bits.NONE;
+    Mode.Bits otherBits = Bits.NONE;
+
+    String[] specs = value.split(",");
+    for (String spec : specs) {
+      String[] specParts = spec.split("=");
+      Preconditions.checkArgument(specParts.length == 2,
+          "Invalid mode %s - contains invalid segment %s", value, spec);
+
+      Mode.Bits specBits = Bits.NONE;
+      for (char permChar : specParts[1].toCharArray()) {
+        switch (permChar) {
+          case 'r':
+            specBits = specBits.or(Bits.READ);
+            break;
+          case 'w':
+            specBits = specBits.or(Bits.WRITE);
+            break;
+          case 'x':
+            specBits = specBits.or(Bits.EXECUTE);
+            break;
+          default:
+            // TODO(rvesse) Report error
+        }
+      }
+
+      for (char targetChar : specParts[0].toCharArray()) {
+        switch (targetChar) {
+          case 'u':
+            ownerBits = ownerBits.or(specBits);
+            break;
+          case 'g':
+            groupBits = groupBits.or(specBits);
+            break;
+          case 'o':
+            otherBits = otherBits.or(specBits);
+            break;
+          default:
+            // TODO(rvesse) Report error
+        }
+      }
+    }
+
+    return new Mode(ownerBits, groupBits, otherBits);
+  }
+}

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -14,9 +14,9 @@ package alluxio.security.authorization;
 import alluxio.exception.ExceptionMessage;
 import alluxio.security.authorization.Mode.Bits;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Parser for {@code Mode} instances.

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -14,6 +14,8 @@ package alluxio.security.authorization;
 import alluxio.exception.ExceptionMessage;
 import alluxio.security.authorization.Mode.Bits;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -21,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author rvesse
  *
  */
+@ThreadSafe
 public final class ModeParser {
 
   private static final char[] VALID_TARGETS = { 'u', 'g', 'o', 'a' };

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -34,7 +34,7 @@ public final class ModeParser {
    * @return Mode
    */
   public Mode parse(String value) {
-    Preconditions.checkArgument(StringUtils.isBlank(value), "Invalid mode %s", value);
+    Preconditions.checkArgument(StringUtils.isNotBlank(value), "Invalid mode %s", value);
 
     try {
       return parseNumeric(value);
@@ -45,7 +45,7 @@ public final class ModeParser {
   }
 
   private Mode parseNumeric(String value) {
-    short s = Short.parseShort(value);
+    short s = Short.parseShort(value, 8);
     return new Mode(s);
   }
 
@@ -54,7 +54,7 @@ public final class ModeParser {
     Mode.Bits groupBits = Bits.NONE;
     Mode.Bits otherBits = Bits.NONE;
 
-    String[] specs = value.split(",");
+    String[] specs = value.contains(",") ? value.split(",") : new String[] { value };
     for (String spec : specs) {
       String[] specParts = spec.split("=");
       Preconditions.checkArgument(specParts.length == 2,

--- a/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
@@ -1,0 +1,76 @@
+package alluxio.security.authorization;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests for the {@code ModeParser}.
+ * @author rvesse
+ *
+ */
+public final class ModeParserTest {
+
+  /**
+   * The exception expected to be thrown.
+   */
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+  
+  private final ModeParser parser = new ModeParser();
+  
+  @Test
+  public void numerics() {
+    Mode parsed = parser.parse("777");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
+
+    parsed = parser.parse("755");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
+    
+    parsed = parser.parse("644");
+    Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
+  }
+  
+  @Test
+  public void symbolics_separated() {
+    Mode parsed = parser.parse("u=rwx,g=rwx,o=rwx");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
+
+    parsed = parser.parse("u=rwx,g=rx,o=rx");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
+    
+    parsed = parser.parse("u=rw,g=r,o=r");
+    Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
+  }
+  
+  @Test
+  public void symbolics_combined() {
+    Mode parsed = parser.parse("ugo=rwx");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
+
+    parsed = parser.parse("u=rwx,go=rx");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
+    
+    parsed = parser.parse("u=rw,go=r");
+    Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
+  }
+}

--- a/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.security.authorization;
 
 import org.junit.Assert;
@@ -17,58 +28,58 @@ public final class ModeParserTest {
    */
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
-  
-  private final ModeParser parser = new ModeParser();
-  
+
+  private final ModeParser mParser = new ModeParser();
+
   @Test
   public void numerics() {
-    Mode parsed = parser.parse("777");
+    Mode parsed = mParser.parse("777");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
 
-    parsed = parser.parse("755");
+    parsed = mParser.parse("755");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
-    
-    parsed = parser.parse("644");
+
+    parsed = mParser.parse("644");
     Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
   }
-  
+
   @Test
   public void symbolics_separated() {
-    Mode parsed = parser.parse("u=rwx,g=rwx,o=rwx");
+    Mode parsed = mParser.parse("u=rwx,g=rwx,o=rwx");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
 
-    parsed = parser.parse("u=rwx,g=rx,o=rx");
+    parsed = mParser.parse("u=rwx,g=rx,o=rx");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
-    
-    parsed = parser.parse("u=rw,g=r,o=r");
+
+    parsed = mParser.parse("u=rw,g=r,o=r");
     Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
   }
-  
+
   @Test
   public void symbolics_combined() {
-    Mode parsed = parser.parse("ugo=rwx");
+    Mode parsed = mParser.parse("ugo=rwx");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
 
-    parsed = parser.parse("u=rwx,go=rx");
+    parsed = mParser.parse("u=rwx,go=rx");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ_EXECUTE, parsed.getOtherBits());
-    
-    parsed = parser.parse("u=rw,go=r");
+
+    parsed = mParser.parse("u=rw,go=r");
     Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());

--- a/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeParserTest.java
@@ -69,7 +69,12 @@ public final class ModeParserTest {
 
   @Test
   public void symbolics_combined() {
-    Mode parsed = mParser.parse("ugo=rwx");
+    Mode parsed = mParser.parse("a=rwx");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
+
+    parsed = mParser.parse("ugo=rwx");
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
@@ -83,5 +88,23 @@ public final class ModeParserTest {
     Assert.assertEquals(Mode.Bits.READ_WRITE, parsed.getOwnerBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getGroupBits());
     Assert.assertEquals(Mode.Bits.READ, parsed.getOtherBits());
+  }
+
+  @Test
+  public void symbolics_cumulative() {
+    Mode parsed = mParser.parse("u=r,u=w,u=x");
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getOtherBits());
+
+    parsed = mParser.parse("g=r,g=w,g=x");
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getOtherBits());
+
+    parsed = mParser.parse("o=r,o=w,o=x");
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getOwnerBits());
+    Assert.assertEquals(Mode.Bits.NONE, parsed.getGroupBits());
+    Assert.assertEquals(Mode.Bits.ALL, parsed.getOtherBits());
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
@@ -16,6 +16,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.options.SetAttributeOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.security.authorization.Mode;
+import alluxio.security.authorization.ModeParser;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -29,6 +30,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ChmodCommand extends AbstractShellCommand {
+  
+  private final ModeParser mParser = new ModeParser();
 
   /**
    * Creates a new instance of {@link ChmodCommand}.
@@ -65,7 +68,7 @@ public final class ChmodCommand extends AbstractShellCommand {
    */
   private void chmod(AlluxioURI path, String modeStr, boolean recursive) throws
       AlluxioException, IOException {
-    Mode mode = new Mode(Short.parseShort(modeStr, 8));
+    Mode mode = mParser.parse(modeStr);
     SetAttributeOptions options =
         SetAttributeOptions.defaults().setMode(mode).setRecursive(recursive);
     mFileSystem.setAttribute(path, options);

--- a/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ChmodCommand extends AbstractShellCommand {
-  
+
   private final ModeParser mParser = new ModeParser();
 
   /**

--- a/tests/src/test/java/alluxio/shell/command/ChmodCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChmodCommandTest.java
@@ -54,4 +54,16 @@ public final class ChmodCommandTest extends AbstractAlluxioShellTest {
     permission = mFileSystem.getStatus(new AlluxioURI("/testDir/testFile")).getMode();
     Assert.assertEquals((short) 0755, permission);
   }
+
+  @Test
+  public void chmodSymbolic() throws IOException, AlluxioException {
+    clearLoginUser();
+    FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
+    mFsShell.run("chmod", "a=rwx", "/testFile");
+    int permission = mFileSystem.getStatus(new AlluxioURI("/testFile")).getMode();
+    Assert.assertEquals((short) 0777, permission);
+    mFsShell.run("chmod", "u=rwx,go=rx", "/testFile");
+    permission = mFileSystem.getStatus(new AlluxioURI("/testFile")).getMode();
+    Assert.assertEquals((short) 0755, permission);
+  }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2552

This provides the initial support for specifying permissions in symbolic form when using the `chmod` command. This allows for specifying them more explicitly without users having to know how to convert them into the octal numeric form e.g.

    > alluxio fs chmod u=rw,go=r /example

Syntax is based upon the standard *nix symbolic syntax with some limitations, namely:

- The permissions `X`, `s`, and `t` are not supported since they make no sense in Alluxio
- Permissions cannot be specified in mutative form i.e. `g+w` or `u-x`

Supporting mutative permissions would require more substantial changes because permissions are always applied declaratively currently. The associated JIRA contains a description of a possible future enhancement to support this.

The functionality for parsing the symbolic form is provided in its own class so it can also be used by users if desired.  The `chmod` command is updated to use this to parse in the desired permissions. Unit test tests are provided as well as integration tests. I may still add some further test cases for the new functionality to this request.