### PR TITLE
[ALLUXIO-2556] Set classloader when entering Alluxio land from Hadoop Cli

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -422,6 +422,11 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Override
   public void initialize(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
+    // NOTE, we must switch the context classloader to the one provided by Hadoop configuration
+    // first before anything else. This ensures all Alluxio classes are loaded by the same
+    // classloader, given this class is already loaded by the Hadoop configuration classloader.
+    Thread.currentThread().setContextClassLoader(conf.getClassLoader());
+
     // When using zookeeper we get the leader master address from the alluxio.zookeeper.address
     // configuration property, so the user doesn't need to specify the authority.
     if (!Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {

--- a/core/common/src/main/java/alluxio/security/LoginUser.java
+++ b/core/common/src/main/java/alluxio/security/LoginUser.java
@@ -91,16 +91,15 @@ public final class LoginUser {
 
     Set<User> userSet = subject.getPrincipals(User.class);
     if (userSet.isEmpty()) {
-      String msg = String.format("Failed to login: No Alluxio User is found. Current login "
-          + "principals are %s.%n If you are running hadoop with Alluxio, please double check "
-          + "whether you have alluxio client jar included in HADOOP_CLASSPATH. Otherwise, you "
-          + "are expected to see this error.", subject.getPrincipals().toString());
-      throw new IOException(msg);
+      throw new IOException("Failed to login: No Alluxio User is found.");
     }
     if (userSet.size() > 1) {
-      String msg = String.format("Failed to login: More than one Alluxio User is found. Current "
-          + "login principals are %s.", subject.getPrincipals().toString());
-      throw new IOException(msg);
+      StringBuilder msg = new StringBuilder(
+          "Failed to login: More than one Alluxio Users are found:");
+      for (User user : userSet) {
+        msg.append(" ").append(user.toString());
+      }
+      throw new IOException(msg.toString());
     }
     return userSet.iterator().next();
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2556

This PR fixes a problem when a user is using Alluxio with `hadoop jar -libjars` without setting `HADOOP_CLASSPATH`. In this case, user may see login error like "Failed to login: no Alluxio user is found`. The root cause is two classloaders are introduced by hadoop jar
```java
      if(libjars!=null && libjars.length>0) {
        conf.setClassLoader(new URLClassLoader(libjars, conf.getClassLoader()));
        Thread.currentThread().setContextClassLoader(
            new URLClassLoader(libjars, 
                Thread.currentThread().getContextClassLoader()));
```
When Hadoop creates Alluxio FS, the first one is used to load Alluxio FS and related classes; while when entering Alluxio world, the second is used as context one. Having two classes causes confusion as a class is actually identified by the pair (className, classLoader). So when Alluxio security is turned on, authentication by JAAS will have trouble to recognize `alluxio.security.User` and causing failures like "Failed to login: no Alluxio user is found`.

This fix sets the classloader to be the one that has loaded Alluxio classes to context classloader to solve this problem. local tests verify the goal achieved.
