### PR TITLE
[ALLUXIO-2555] support thrift add timeout time

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -11,9 +11,10 @@
 
 package alluxio;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Configurations properties constants. Please check and update Configuration-Settings.md file when

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -11,10 +11,9 @@
 
 package alluxio;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Configurations properties constants. Please check and update Configuration-Settings.md file when
@@ -150,6 +149,7 @@ public enum PropertyKey {
   MASTER_WEB_HOSTNAME(Name.MASTER_WEB_HOSTNAME, null),
   MASTER_WEB_PORT(Name.MASTER_WEB_PORT, 19999),
   MASTER_WHITELIST(Name.MASTER_WHITELIST, "/"),
+  MASTER_CONNECTION_TIMEOUT_MS(Name.MASTER_CONNECTION_TIMEOUT_MS, 0),
   MASTER_WORKER_THREADS_MAX(Name.MASTER_WORKER_THREADS_MAX, 2048),
   MASTER_WORKER_THREADS_MIN(Name.MASTER_WORKER_THREADS_MIN, 512),
   MASTER_WORKER_TIMEOUT_MS(Name.MASTER_WORKER_TIMEOUT_MS, 300000),
@@ -555,6 +555,8 @@ public enum PropertyKey {
     public static final String MASTER_WEB_HOSTNAME = "alluxio.master.web.hostname";
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";
     public static final String MASTER_WHITELIST = "alluxio.master.whitelist";
+    public static final String MASTER_CONNECTION_TIMEOUT_MS =
+            "alluxio.master.connection.timeout.ms";
     public static final String MASTER_WORKER_THREADS_MAX = "alluxio.master.worker.threads.max";
     public static final String MASTER_WORKER_THREADS_MIN = "alluxio.master.worker.threads.min";
     public static final String MASTER_WORKER_TIMEOUT_MS = "alluxio.master.worker.timeout.ms";

--- a/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
@@ -49,12 +49,13 @@ import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * This class encapsulates the different master services that are configured to run.

--- a/docs/_data/table/cn/master-configuration.yml
+++ b/docs/_data/table/cn/master-configuration.yml
@@ -64,3 +64,5 @@ alluxio.master.keytab.file:
   Alluxio master的Kerberos密钥表文件。
 alluxio.master.principal:
   Alluxio master的Kerberos主体。
+alluxio.master.connection.timeout.ms
+  Alluxio master设置Thrift的超时时间（单位：毫秒），超过该时间关闭连接,默认值是0,表示无时间限制

--- a/docs/_data/table/cn/master-configuration.yml
+++ b/docs/_data/table/cn/master-configuration.yml
@@ -64,5 +64,5 @@ alluxio.master.keytab.file:
   Alluxio master的Kerberos密钥表文件。
 alluxio.master.principal:
   Alluxio master的Kerberos主体。
-alluxio.master.connection.timeout.ms
+alluxio.master.connection.timeout.ms:
   Alluxio master设置Thrift的超时时间（单位：毫秒），超过该时间关闭连接,默认值是0,表示无时间限制

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -76,5 +76,5 @@ alluxio.master.keytab.file:
   Kerberos keytab file for Alluxio master.
 alluxio.master.principal:
   Kerberos principal for Alluxio master.
-alluxio.master.connection.timeout.ms
+alluxio.master.connection.timeout.ms:
   Timeout (in milliseconds) between master and client，the default value is 0, that time is unlimited

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -76,3 +76,5 @@ alluxio.master.keytab.file:
   Kerberos keytab file for Alluxio master.
 alluxio.master.principal:
   Kerberos principal for Alluxio master.
+alluxio.master.connection.timeout.ms
+  Timeout (in milliseconds) between master and client，the default value is 0, that time is unlimited

--- a/docs/_data/table/master-configuration.csv
+++ b/docs/_data/table/master-configuration.csv
@@ -1,5 +1,6 @@
 propertyName,defaultValue
 alluxio.master.bind.host,0.0.0.0
+alluxio.master.connection.timeout.ms,0
 alluxio.master.heartbeat.interval.ms,1000
 alluxio.master.hostname,localhost
 alluxio.master.file.async.persist.handler,alluxio.master.file.async.DefaultAsyncPersistHandler


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2555

To solve the problem of network connection is not closed, when I use the Presto cluster connection, as a result of multi work open/load file, resulting in a lot of connection objects can not be released, increase configuration: `alluxio.master.connection.timeout.ms`
``` java
new TServerSocket(NetworkAddressUtils.getBindAddress(ServiceType.MASTER_RPC),
                  connectionTimeout);
```

