### PR TITLE
[ALLUXIO-2558] Proposed fix for ALLUXIO-2558

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -83,11 +83,10 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
         ThreadFactoryUtils.build("file-system-worker-heartbeat-%d", true)));
     mWorkerId = workerId;
     mSessions = new Sessions();
-    UnderFileSystem ufs =
-        UnderFileSystem.Factory.get(Configuration.get(PropertyKey.UNDERFS_ADDRESS));
-    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), ufs,
-        RateLimiter.create(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT)));
     mUnderFileSystemManager = new UnderFileSystemManager();
+    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), mUnderFileSystemManager,
+        RateLimiter.create(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT)));
+
 
     // Setup AbstractMasterClient
     mFileSystemMasterWorkerClient = new FileSystemMasterClient(

--- a/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -84,7 +84,7 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
     mSessions = new Sessions();
     mUnderFileSystemManager = new UnderFileSystemManager();
     mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker),
-        mUnderFileSystemManager, RateLimiter.create(
+        RateLimiter.create(
             Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT)));
 
     // Setup AbstractMasterClient

--- a/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -21,7 +21,6 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.thrift.FileSystemWorkerClientService;
-import alluxio.underfs.UnderFileSystem;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
@@ -84,9 +83,9 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
     mWorkerId = workerId;
     mSessions = new Sessions();
     mUnderFileSystemManager = new UnderFileSystemManager();
-    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker), mUnderFileSystemManager,
-        RateLimiter.create(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT)));
-
+    mFileDataManager = new FileDataManager(Preconditions.checkNotNull(blockWorker),
+        mUnderFileSystemManager, RateLimiter.create(
+            Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT)));
 
     // Setup AbstractMasterClient
     mFileSystemMasterWorkerClient = new FileSystemMasterClient(

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -260,11 +260,11 @@ public final class FileDataManager {
         BufferUtils.fastCopy(inputChannel, outputChannel);
         reader.close();
       }
-      
+
       outputStream.flush();
     } catch (BlockDoesNotExistException | InvalidWorkerStateException e) {
       errors.add(e);
-    } finally {     
+    } finally {
       // make sure all the locks are released
       for (long lockId : blockIdToLockId.values()) {
         try {
@@ -273,7 +273,7 @@ public final class FileDataManager {
           errors.add(e);
         }
       }
-      
+
       // Complete/cancel file as appropriate
       try {
         if (errors.isEmpty()) {

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -51,7 +51,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 // TODO(calvin): Consider whether the manager or the agents should contain the execution logic
 @ThreadSafe
-public class UnderFileSystemManager {
+public final class UnderFileSystemManager {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   // Input stream agent session index

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -51,7 +51,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 // TODO(calvin): Consider whether the manager or the agents should contain the execution logic
 @ThreadSafe
-public final class UnderFileSystemManager {
+public class UnderFileSystemManager {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   // Input stream agent session index

--- a/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -60,6 +60,7 @@ import java.util.List;
     FileSystem.Factory.class})
 public final class FileDataManagerTest {
   private UnderFileSystem mUfs;
+  private UnderFileSystemManager mUfsManager;
   private BlockWorker mBlockWorker;
   private MockRateLimiter mMockRateLimiter;
   private FileDataManager mManager;
@@ -68,15 +69,18 @@ public final class FileDataManagerTest {
   @Before
   public void before() throws Exception {
     mUfs = Mockito.mock(UnderFileSystem.class);
+    mUfsManager = Mockito.mock(UnderFileSystemManager.class);
     mBlockWorker = Mockito.mock(BlockWorker.class);
     mMockRateLimiter =
         new MockRateLimiter(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT));
-    mManager = new FileDataManager(mBlockWorker, mUfs, mMockRateLimiter.getGuavaRateLimiter());
+    mManager = new FileDataManager(mBlockWorker, mUfsManager,
+        mMockRateLimiter.getGuavaRateLimiter());
 
     mMockFileSystem = PowerMockito.mock(FileSystem.class);
     PowerMockito.mockStatic(FileSystem.Factory.class);
     Mockito.when(FileSystem.Factory.get()).thenReturn(mMockFileSystem);
     Mockito.when(mUfs.isDirectory(Mockito.anyString())).thenReturn(true);
+    Mockito.when(UnderFileSystem.Factory.get(Mockito.anyString())).thenReturn(mUfs);
   }
 
   @After
@@ -125,7 +129,8 @@ public final class FileDataManagerTest {
     Configuration.set(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT, "100");
     mMockRateLimiter =
         new MockRateLimiter(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT));
-    mManager = new FileDataManager(mBlockWorker, mUfs, mMockRateLimiter.getGuavaRateLimiter());
+    mManager = new FileDataManager(mBlockWorker, mUfsManager,
+        mMockRateLimiter.getGuavaRateLimiter());
 
     long fileId = 1;
     List<Long> blockIds = Lists.newArrayList(1L, 2L, 3L);

--- a/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -23,6 +23,8 @@ import alluxio.client.file.URIStatus;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemFactory;
+import alluxio.underfs.UnderFileSystemRegistry;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
@@ -60,7 +62,7 @@ import java.util.List;
     FileSystem.Factory.class})
 public final class FileDataManagerTest {
   private UnderFileSystem mUfs;
-  private UnderFileSystemManager mUfsManager;
+  private UnderFileSystemFactory mUfsFactory;
   private BlockWorker mBlockWorker;
   private MockRateLimiter mMockRateLimiter;
   private FileDataManager mManager;
@@ -69,23 +71,29 @@ public final class FileDataManagerTest {
   @Before
   public void before() throws Exception {
     mUfs = Mockito.mock(UnderFileSystem.class);
-    mUfsManager = Mockito.mock(UnderFileSystemManager.class);
     mBlockWorker = Mockito.mock(BlockWorker.class);
     mMockRateLimiter =
         new MockRateLimiter(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT));
-    mManager = new FileDataManager(mBlockWorker, mUfsManager,
-        mMockRateLimiter.getGuavaRateLimiter());
+    mManager = new FileDataManager(mBlockWorker, mMockRateLimiter.getGuavaRateLimiter());
 
     mMockFileSystem = PowerMockito.mock(FileSystem.class);
     PowerMockito.mockStatic(FileSystem.Factory.class);
     Mockito.when(FileSystem.Factory.get()).thenReturn(mMockFileSystem);
     Mockito.when(mUfs.isDirectory(Mockito.anyString())).thenReturn(true);
-    Mockito.when(UnderFileSystem.Factory.get(Mockito.anyString())).thenReturn(mUfs);
+
+    mUfsFactory = Mockito.mock(UnderFileSystemFactory.class);
+    Mockito.when(mUfsFactory.supportsPath(Mockito.anyString())).thenReturn(true);
+    Mockito.when(mUfsFactory.create(Mockito.anyString(), Mockito.anyObject()))
+      .thenReturn(mUfs);
+    UnderFileSystemRegistry.register(mUfsFactory);
   }
 
   @After
   public void after() throws IOException {
     ConfigurationTestUtils.resetConfiguration();
+    if (mUfsFactory != null) {
+      UnderFileSystemRegistry.unregister(mUfsFactory);
+    }
   }
 
   /**
@@ -129,8 +137,7 @@ public final class FileDataManagerTest {
     Configuration.set(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT, "100");
     mMockRateLimiter =
         new MockRateLimiter(Configuration.getBytes(PropertyKey.WORKER_FILE_PERSIST_RATE_LIMIT));
-    mManager = new FileDataManager(mBlockWorker, mUfsManager,
-        mMockRateLimiter.getGuavaRateLimiter());
+    mManager = new FileDataManager(mBlockWorker, mMockRateLimiter.getGuavaRateLimiter());
 
     long fileId = 1;
     List<Long> blockIds = Lists.newArrayList(1L, 2L, 3L);

--- a/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
@@ -34,6 +34,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public final class PersistMultipleMountsIntegrationTest
     extends AbstractFileOutStreamIntegrationTest {
+  private static final String MOUNT_PATH = "/mounted";
+
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();
 
@@ -51,7 +53,7 @@ public final class PersistMultipleMountsIntegrationTest
     mUfs = UnderFileSystem.Factory.get(mUfsRoot);
 
     mMountedUfsRoot = mTempFolder.getRoot().toURI().toString();
-    mFileSystem.mount(new AlluxioURI("/mounted"), new AlluxioURI(mMountedUfsRoot));
+    mFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
     mMountedUfs = UnderFileSystem.Factory.get(mMountedUfsRoot);
   }
 
@@ -84,7 +86,7 @@ public final class PersistMultipleMountsIntegrationTest
       return;
     }
     String path = PathUtils.uniqPath();
-    AlluxioURI filePath = new AlluxioURI("/mounted" + path);
+    AlluxioURI filePath = new AlluxioURI(MOUNT_PATH + path);
     FileOutStream os = mFileSystem.createFile(filePath,
         CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH));
     os.write((byte) 0);

--- a/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.options.CreateFileOptions;
+import alluxio.master.file.meta.PersistenceState;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.hdfs.HdfsUnderFileSystem;
+import alluxio.underfs.local.LocalUnderFileSystem;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration tests of file permission propagation for persist and async persist.
+ */
+public final class PersistMultipleMountsIntegrationTest
+    extends AbstractFileOutStreamIntegrationTest {
+  private String mUfsRoot;
+  private UnderFileSystem mUfs;
+
+  @Rule
+  public TemporaryFolder mTempFolder = new TemporaryFolder();
+  private String mMountedUfsRoot;
+  private UnderFileSystem mMountedUfs;
+
+  @Before
+  @Override
+  public void before() throws Exception {
+    super.before();
+
+    mUfsRoot = PathUtils.concatPath(Configuration.get(PropertyKey.UNDERFS_ADDRESS));
+    mUfs = UnderFileSystem.Factory.get(mUfsRoot);
+
+    mMountedUfsRoot = mTempFolder.getRoot().toURI().toString();
+    mFileSystem.mount(new AlluxioURI("/mounted"),
+        new AlluxioURI(mMountedUfsRoot));
+    mMountedUfs = UnderFileSystem.Factory.get(mMountedUfsRoot);
+  }
+
+  @Test
+  public void syncMultipleMountsDefaultPersist() throws Exception {
+    if (!(mUfs instanceof LocalUnderFileSystem) && !(mUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    String path = PathUtils.uniqPath();
+    AlluxioURI filePath = new AlluxioURI(path);
+    FileOutStream os = mFileSystem.createFile(filePath,
+        CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH));
+    os.write((byte) 0);
+    os.write((byte) 1);
+    os.close();
+
+    // Check the file is persisted
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertTrue(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));
+    Assert.assertFalse(mMountedUfs.exists(PathUtils.concatPath(mMountedUfsRoot, path)));
+  }
+
+  @Test
+  public void syncMultipleMountsMountedPersist() throws Exception {
+    if (!(mUfs instanceof LocalUnderFileSystem) && !(mUfs instanceof HdfsUnderFileSystem)) {
+      // Skip non-local and non-HDFS UFSs.
+      return;
+    }
+    String path = PathUtils.uniqPath();
+    AlluxioURI filePath = new AlluxioURI("/mounted" + path);
+    FileOutStream os = mFileSystem.createFile(filePath,
+        CreateFileOptions.defaults().setWriteType(WriteType.CACHE_THROUGH));
+    os.write((byte) 0);
+    os.write((byte) 1);
+    os.close();
+
+    // Check the file is persisted
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertFalse(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));
+    Assert.assertTrue(mMountedUfs.exists(PathUtils.concatPath(mMountedUfsRoot, path)));
+  }
+}

--- a/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/PersistMultipleMountsIntegrationTest.java
@@ -34,11 +34,11 @@ import org.junit.rules.TemporaryFolder;
  */
 public final class PersistMultipleMountsIntegrationTest
     extends AbstractFileOutStreamIntegrationTest {
-  private String mUfsRoot;
-  private UnderFileSystem mUfs;
-
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();
+
+  private String mUfsRoot;
+  private UnderFileSystem mUfs;
   private String mMountedUfsRoot;
   private UnderFileSystem mMountedUfs;
 
@@ -51,8 +51,7 @@ public final class PersistMultipleMountsIntegrationTest
     mUfs = UnderFileSystem.Factory.get(mUfsRoot);
 
     mMountedUfsRoot = mTempFolder.getRoot().toURI().toString();
-    mFileSystem.mount(new AlluxioURI("/mounted"),
-        new AlluxioURI(mMountedUfsRoot));
+    mFileSystem.mount(new AlluxioURI("/mounted"), new AlluxioURI(mMountedUfsRoot));
     mMountedUfs = UnderFileSystem.Factory.get(mMountedUfsRoot);
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2558

Since 1.4.0  moved persistence logic to the worker it is fundamentally broken when users Mount more than one under file system. This is because it takes a single instance of and under file system created from the default under file system Setting in the configuration. When multiple under file systems are mounted attempts to persist to non-default under filesystems will fail because they attempt to use the wrong under file system instance. This is one possible fix though I am not sure it is necessarily the correct one.

Have `FileDataManager` obtain `UnderFileSystem` instances as needed so it selects the
correct UFS to persist files to depending on the mount point under which
a file is located.