### PR TITLE
[SMALLFIX] Default to using /dev/shm for dockerized Alluxio worker

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -52,6 +52,7 @@ case ${service,,} in
     integration/docker/bin/alluxio-master.sh
     ;;
   worker)
+    export ALLUXIO_RAM_FOLDER=${ALLUXIO_RAM_FOLDER:-/dev/shm}
     bin/alluxio formatWorker
     integration/docker/bin/alluxio-worker.sh
     ;;

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -19,6 +19,10 @@ fi
 
 service=$1
 
+# Docker will set this tmpfs up by default. It's size is configurable through the
+# --shm-size argument to docker run
+export ALLUXIO_RAM_FOLDER=${ALLUXIO_RAM_FOLDER:-/dev/shm}
+
 home=/opt/$(ls /opt | grep alluxio)
 cd ${home}
 
@@ -52,7 +56,6 @@ case ${service,,} in
     integration/docker/bin/alluxio-master.sh
     ;;
   worker)
-    export ALLUXIO_RAM_FOLDER=${ALLUXIO_RAM_FOLDER:-/dev/shm}
     bin/alluxio formatWorker
     integration/docker/bin/alluxio-worker.sh
     ;;


### PR DESCRIPTION
When not mounting the ram folder from the host, it makes sense to use `/dev/shm` because Docker sets it up automatically and lets you configure it via `--shm-size`