### PR TITLE
[ALLUXIO-2548] Narrow down the use of sudo privileges

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -102,7 +102,7 @@ function mount_ramfs_linux() {
 
   echo "Formatting RamFS: ${TIER_PATH} (${MEM_SIZE})"
   if mount | grep ${TIER_PATH} > /dev/null; then
-    if [[ "${1}" == "SudoMount" ]]; then
+    if [[ "$1" == "SudoMount" ]]; then
       sudo umount -f ${TIER_PATH}
     else
       umount -f ${TIER_PATH}
@@ -115,7 +115,7 @@ function mount_ramfs_linux() {
     mkdir -p ${TIER_PATH}
   fi
 
-  if [[ "${1}" == "SudoMount" ]]; then
+  if [[ "$1" == "SudoMount" ]]; then
     sudo mount -t ramfs -o size=${MEM_SIZE} ramfs ${TIER_PATH}
   else
     mount -t ramfs -o size=${MEM_SIZE} ramfs ${TIER_PATH}
@@ -125,7 +125,7 @@ function mount_ramfs_linux() {
     exit 1
   fi
 
-  if [[ "${1}" == "SudoMount" ]]; then
+  if [[ "$1" == "SudoMount" ]]; then
     sudo chmod a+w ${TIER_PATH}
   else
     chmod a+w ${TIER_PATH}
@@ -169,9 +169,9 @@ function mount_ramfs_local() {
 }
 
 function main {
-  case "${1}" in
+  case "$1" in
     Mount|SudoMount)
-      case "${2}" in
+      case "$2" in
         ""|local)
           mount_ramfs_local $1
           ;;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2548

In case some one set limited sudo NOPASS access to mount/umount/chmod for OS user that starts Alluxio like the following  in `/etc/sudoers`
```
alluxio    ALL=(ALL) NOPASSWD: /bin/mount * ramfs /mnt/ramdisk, /bin/umount * /mnt/ramdisk, /bin/chmod * /mnt/ramdisk
```

This PR will remove the previous requirement of sudo privileges which is too broad.

Tested on linux.
