### PR TITLE
[ALLUXIO-2563] Improving Logger Names

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -16,7 +16,7 @@ log4j.rootLogger=INFO, ${alluxio.logger.type}
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) - %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Master
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -24,7 +24,7 @@ log4j.appender.MASTER_LOGGER.File=${alluxio.logs.dir}/master.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Proxy
 log4j.appender.PROXY_LOGGER=org.apache.log4j.RollingFileAppender
@@ -32,7 +32,7 @@ log4j.appender.PROXY_LOGGER.File=${alluxio.logs.dir}/proxy.log
 log4j.appender.PROXY_LOGGER.MaxFileSize=10MB
 log4j.appender.PROXY_LOGGER.MaxBackupIndex=100
 log4j.appender.PROXY_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Workers
 log4j.appender.WORKER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -40,7 +40,7 @@ log4j.appender.WORKER_LOGGER.File=${alluxio.logs.dir}/worker.log
 log4j.appender.WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for User
 log4j.appender.USER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -48,7 +48,7 @@ log4j.appender.USER_LOGGER.File=${alluxio.logs.dir}/user_${user.name}.log
 log4j.appender.USER_LOGGER.MaxFileSize=10MB
 log4j.appender.USER_LOGGER.MaxBackupIndex=10
 log4j.appender.USER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Fuse
 log4j.appender.FUSE_LOGGER=org.apache.log4j.RollingFileAppender
@@ -56,4 +56,4 @@ log4j.appender.FUSE_LOGGER.File=${alluxio.logs.dir}/fuse.log
 log4j.appender.FUSE_LOGGER.MaxFileSize=10MB
 log4j.appender.FUSE_LOGGER.MaxBackupIndex=10
 log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n

--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AlluxioBlockStore {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioBlockStore.class);
 
   private final FileSystemContext mContext;
   private String mLocalHostName;

--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.block;
 
-import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
@@ -12,7 +12,6 @@
 package alluxio.client.block;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
@@ -25,8 +24,6 @@ import alluxio.worker.block.io.LocalFileBlockWriter;
 
 import com.codahale.metrics.Counter;
 import com.google.common.io.Closer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/LocalBlockOutStream.java
@@ -40,7 +40,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class LocalBlockOutStream extends BufferedBlockOutStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private final Closer mCloser;
   private final BlockWorkerClient mBlockWorkerClient;
   private final LocalFileBlockWriter mWriter;

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockOutStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.block;
 
-import alluxio.Constants;
 import alluxio.client.RemoteBlockWriter;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
@@ -21,8 +20,6 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
 import com.google.common.io.Closer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 

--- a/core/client/src/main/java/alluxio/client/block/RemoteBlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/RemoteBlockOutStream.java
@@ -35,8 +35,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class RemoteBlockOutStream extends BufferedBlockOutStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private final RemoteBlockWriter mRemoteWriter;
   private final BlockWorkerClient mBlockWorkerClient;
   private final Closer mCloser;

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -13,7 +13,6 @@ package alluxio.client.block;
 
 import alluxio.AbstractThriftClient;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.exception.AlluxioException;

--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -57,7 +57,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class RetryHandlingBlockWorkerClient
     extends AbstractThriftClient<BlockWorkerClientService.Client> implements BlockWorkerClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RetryHandlingBlockWorkerClient.class);
+
   private static final ScheduledExecutorService HEARTBEAT_POOL = Executors.newScheduledThreadPool(
       Configuration.getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_THREADS),
       ThreadFactoryUtils.build("block-worker-heartbeat-%d", true));

--- a/core/client/src/main/java/alluxio/client/block/stream/BlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/BlockOutStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.block.stream;
 
-import alluxio.Constants;
 import alluxio.client.BoundedStream;
 import alluxio.client.Cancelable;
 import alluxio.client.block.BlockWorkerClient;
@@ -22,8 +21,6 @@ import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.io.Closer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;

--- a/core/client/src/main/java/alluxio/client/block/stream/BlockOutStream.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/BlockOutStream.java
@@ -37,8 +37,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class BlockOutStream extends FilterOutputStream implements BoundedStream, Cancelable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private final long mBlockId;
   private final long mBlockSize;
   private final Closer mCloser;

--- a/core/client/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
@@ -12,7 +12,6 @@
 package alluxio.client.block.stream;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystemContext;
 import alluxio.network.protocol.RPCProtoMessage;

--- a/core/client/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
@@ -62,7 +62,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class NettyPacketReader implements PacketReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyPacketReader.class);
+
   private static final boolean CANCEL_ENABLED =
       Configuration.getBoolean(PropertyKey.USER_NETWORK_NETTY_READER_CANCEL_ENABLED);
   private static final int MAX_PACKETS_IN_FLIGHT =

--- a/core/client/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -12,7 +12,6 @@
 package alluxio.client.block.stream;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystemContext;
 import alluxio.network.protocol.RPCProtoMessage;

--- a/core/client/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -57,7 +57,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class NettyPacketWriter implements PacketWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyPacketWriter.class);
 
   private static final long PACKET_SIZE =
       Configuration.getBytes(PropertyKey.USER_NETWORK_NETTY_WRITER_PACKET_SIZE_BYTES);

--- a/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -12,7 +12,6 @@
 package alluxio.client.file;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.file.options.CreateDirectoryOptions;
 import alluxio.client.file.options.CreateFileOptions;

--- a/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -53,7 +53,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 @ThreadSafe
 public class BaseFileSystem implements FileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BaseFileSystem.class);
+
   protected final FileSystemContext mFileSystemContext;
 
   /**

--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -60,7 +60,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class FileInStream extends InputStream implements BoundedStream, Seekable,
     PositionedReadable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileInStream.class);
 
   private static final boolean PACKET_STREAMING_ENABLED =
       Configuration.getBoolean(PropertyKey.USER_PACKET_STREAMING_ENABLED);

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -13,7 +13,6 @@ package alluxio.client.file;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.annotation.PublicApi;
 import alluxio.client.AbstractOutStream;

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -60,7 +60,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 @NotThreadSafe
 public class FileOutStream extends AbstractOutStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileOutStream.class);
 
   /** Used to manage closeable resources. */
   private final Closer mCloser;

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class FileSystemUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemUtils.class);
 
   // prevent instantiation
   private FileSystemUtils() {}

--- a/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
@@ -14,7 +14,6 @@ package alluxio.client.file;
 import alluxio.AbstractThriftClient;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.options.CancelUfsFileOptions;
 import alluxio.client.file.options.CloseUfsFileOptions;

--- a/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemWorkerClient.java
@@ -54,7 +54,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class FileSystemWorkerClient
     extends AbstractThriftClient<FileSystemWorkerClientService.Client> implements Closeable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemWorkerClient.class);
 
   private static final ScheduledExecutorService HEARTBEAT_POOL = Executors.newScheduledThreadPool(
       Configuration.getInt(PropertyKey.USER_FILE_WORKER_CLIENT_THREADS),

--- a/core/client/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class UnknownLengthFileInStream extends FileInStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(UnknownLengthFileInStream.class);
   /**
    * Since the file length is unknown, the actual length of the block is also unknown. Simply
    * using the maximum block size does not work well for allocation, since the maximum block size

--- a/core/client/src/main/java/alluxio/client/lineage/AbstractLineageClient.java
+++ b/core/client/src/main/java/alluxio/client/lineage/AbstractLineageClient.java
@@ -12,7 +12,6 @@
 package alluxio.client.lineage;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.lineage.options.CreateLineageOptions;
 import alluxio.client.lineage.options.DeleteLineageOptions;

--- a/core/client/src/main/java/alluxio/client/lineage/AbstractLineageClient.java
+++ b/core/client/src/main/java/alluxio/client/lineage/AbstractLineageClient.java
@@ -44,7 +44,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 @ThreadSafe
 public abstract class AbstractLineageClient implements LineageClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractLineageClient.class);
+
   protected LineageContext mContext;
 
   /**

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
@@ -12,16 +12,12 @@
 package alluxio.client.lineage;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.UnderFileSystemFileOutStream;
 import alluxio.client.file.options.OutStreamOptions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
@@ -34,8 +34,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public class LineageFileOutStream extends FileOutStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   /**
    * Creates a new file output stream when lineage is enabled.
    *

--- a/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
+++ b/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.netty;
 
-import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCResponse;

--- a/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
+++ b/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ClientHandler.class);
 
   /**
    * The interface for listeners to implement to receive callbacks when messages are received.

--- a/core/client/src/main/java/alluxio/client/netty/NettyClient.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyClient.java
@@ -12,7 +12,6 @@
 package alluxio.client.netty;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.network.ChannelType;
 import alluxio.network.protocol.RPCMessage;

--- a/core/client/src/main/java/alluxio/client/netty/NettyClient.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyClient.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class NettyClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyClient.class);
 
   /**  Share both the encoder and decoder with all the client pipelines. */
   private static final RPCMessageEncoder ENCODER = new RPCMessageEncoder();

--- a/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class NettyRemoteBlockReader implements RemoteBlockReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyRemoteBlockReader.class);
 
   private final FileSystemContext mContext;
   /** A reference to read response so we can explicitly release the resource after reading. */

--- a/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.netty;
 
-import alluxio.Constants;
 import alluxio.client.RemoteBlockReader;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.ExceptionMessage;

--- a/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockWriter.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class NettyRemoteBlockWriter implements RemoteBlockWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyRemoteBlockWriter.class);
 
   private FileSystemContext mContext;
   private boolean mOpen;

--- a/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyRemoteBlockWriter.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.netty;
 
-import alluxio.Constants;
 import alluxio.client.RemoteBlockWriter;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.ExceptionMessage;

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.netty;
 
-import alluxio.Constants;
 import alluxio.client.UnderFileSystemFileReader;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.ExceptionMessage;

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileReader.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class NettyUnderFileSystemFileReader implements UnderFileSystemFileReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyUnderFileSystemFileReader.class);
 
   private final FileSystemContext mContext;
 

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.netty;
 
-import alluxio.Constants;
 import alluxio.client.UnderFileSystemFileWriter;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.ExceptionMessage;

--- a/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
+++ b/core/client/src/main/java/alluxio/client/netty/NettyUnderFileSystemFileWriter.java
@@ -44,7 +44,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe
 public final class NettyUnderFileSystemFileWriter implements UnderFileSystemFileWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyUnderFileSystemFileWriter.class);
 
   private final FileSystemContext mContext;
 

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -72,8 +72,9 @@ import javax.security.auth.Subject;
  */
 @NotThreadSafe
 abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystem.class);
+
   public static final String FIRST_COM_PATH = "alluxio_dep/";
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   // Always tell Hadoop that we have 3x replication.
   private static final int BLOCK_REPLICATION_CONSTANT = 3;
   /** Lock for initializing the contexts, currently only one set of contexts is supported. */

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -13,7 +13,6 @@ package alluxio.hadoop;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;

--- a/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
@@ -38,8 +38,6 @@ import java.net.URISyntaxException;
  * {@link AbstractFileSystem} directly.
  */
 public class AlluxioFileSystem extends DelegateToFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   /**
    * This constructor has the signature needed by
    * {@link AbstractFileSystem#createFileSystem(URI, Configuration)}

--- a/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
@@ -16,8 +16,6 @@ import alluxio.PropertyKey;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;

--- a/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
@@ -12,7 +12,6 @@
 package alluxio.hadoop;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 
 import org.apache.hadoop.io.DefaultStringifier;

--- a/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/ConfUtils.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ConfUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ConfUtils.class);
 
   private ConfUtils() {} // Prevent instantiation.
 

--- a/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class HadoopUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopUtils.class);
 
   /**
    * Given a {@link Path} path, it returns the path component of its URI, which has the form

--- a/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -12,7 +12,6 @@
 package alluxio.hadoop;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 
 import org.apache.hadoop.conf.Configuration;

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -13,7 +13,6 @@ package alluxio.hadoop;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -46,7 +46,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class HdfsFileInputStream extends InputStream implements Seekable, PositionedReadable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsFileInputStream.class);
+
   private static final boolean PACKET_STREAMING_ENABLED =
       Configuration.getBoolean(PropertyKey.USER_PACKET_STREAMING_ENABLED);
 

--- a/core/client/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
+++ b/core/client/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
@@ -50,7 +50,8 @@ import java.util.concurrent.Future;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileSystemContext.class})
 public final class NettyPacketWriterTest {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyPacketWriterTest.class);
+
   private static final int PACKET_SIZE = 1024;
   private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(4,
       ThreadFactoryUtils.build("test-executor-%d", true));

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -69,7 +69,7 @@ import javax.security.auth.Subject;
  * Tests for {@link AbstractFileSystem}.
  */
 public class AbstractFileSystemTest {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystemTest.class);
 
   private FileSystemContext mMockFileSystemContext;
   private FileSystemContext mMockFileSystemContextCustomized;

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -45,8 +45,7 @@ import javax.security.auth.Subject;
 // TODO(peis): Consolidate this to ThriftClientPool.
 @ThreadSafe
 public abstract class AbstractClient implements Client {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractClient.class);
 
   /** The pattern of exception message when client and server transport frame sizes do not match. */
   private static final Pattern FRAME_SIZE_EXCEPTION_PATTERN =

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -15,8 +15,6 @@ import alluxio.util.network.NetworkAddressUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.List;

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -29,8 +29,6 @@ import javax.security.auth.Subject;
  */
 @ThreadSafe
 public abstract class AbstractMasterClient extends AbstractClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   /**
    * Identifies the Zookeeper path to use for discovering the master address. This should be null
    * if Zookeeper is not being used.

--- a/core/common/src/main/java/alluxio/AbstractThriftClient.java
+++ b/core/common/src/main/java/alluxio/AbstractThriftClient.java
@@ -32,8 +32,7 @@ import java.io.IOException;
  * @param <C> the Alluxio service type
  */
 public abstract class AbstractThriftClient<C extends AlluxioService.Client> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractThriftClient.class);
 
   private static final int BASE_SLEEP_MS =
       Configuration.getInt(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -61,7 +61,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class Configuration {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
 
   /** Regex string to find "${key}" for variable substitution. */
   private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -113,8 +113,6 @@ public final class Constants {
 
   public static final String REST_API_PREFIX = "/api/v1";
 
-  public static final String LOGGER_TYPE = PropertyKey.Name.LOGGER_TYPE;
-
   public static final String MASTER_COLUMN_FILE_PREFIX = "COL_";
   public static final String FORMAT_FILE_PREFIX = "_format_";
 

--- a/core/common/src/main/java/alluxio/LeaderSelectorClient.java
+++ b/core/common/src/main/java/alluxio/LeaderSelectorClient.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class LeaderSelectorClient implements Closeable, LeaderSelectorListener {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(LeaderSelectorClient.class);
 
   /** The election path in Zookeeper. */
   private final String mElectionPath;

--- a/core/common/src/main/java/alluxio/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/MasterInquireClient.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class MasterInquireClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MasterInquireClient.class);
 
   /** Map from key spliced by the address for Zookeeper and path of leader to created client. */
   private static HashMap<String, MasterInquireClient> sCreatedClients = new HashMap<>();

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -11,7 +11,6 @@
 
 package alluxio.heartbeat;
 
-import alluxio.Constants;
 import alluxio.security.LoginUser;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.CommonUtils;

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class HeartbeatThread implements Runnable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(HeartbeatThread.class);
 
   private final String mThreadName;
   private final HeartbeatExecutor mExecutor;

--- a/core/common/src/main/java/alluxio/heartbeat/SleepingTimer.java
+++ b/core/common/src/main/java/alluxio/heartbeat/SleepingTimer.java
@@ -41,7 +41,7 @@ public final class SleepingTimer implements HeartbeatTimer {
    * @param intervalMs the heartbeat interval
    */
   public SleepingTimer(String threadName, long intervalMs) {
-    this(threadName, intervalMs, LoggerFactory.getLogger(Constants.LOGGER_TYPE),
+    this(threadName, intervalMs, LoggerFactory.getLogger(SleepingTimer.class),
         new SystemClock(), new ThreadSleeper());
   }
 

--- a/core/common/src/main/java/alluxio/heartbeat/SleepingTimer.java
+++ b/core/common/src/main/java/alluxio/heartbeat/SleepingTimer.java
@@ -11,7 +11,6 @@
 
 package alluxio.heartbeat;
 
-import alluxio.Constants;
 import alluxio.clock.Clock;
 import alluxio.clock.SystemClock;
 import alluxio.time.Sleeper;

--- a/core/common/src/main/java/alluxio/job/CommandLineJob.java
+++ b/core/common/src/main/java/alluxio/job/CommandLineJob.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class CommandLineJob extends Job {
   private static final long serialVersionUID = 1655996721855899996L;
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CommandLineJob.class);
 
   private final String mCommand;
 

--- a/core/common/src/main/java/alluxio/job/CommandLineJob.java
+++ b/core/common/src/main/java/alluxio/job/CommandLineJob.java
@@ -11,7 +11,6 @@
 
 package alluxio.job;
 
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.wire.CommandLineJobInfo;
 import alluxio.wire.JobConfInfo;

--- a/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
@@ -11,8 +11,6 @@
 
 package alluxio.metrics;
 
-import alluxio.Constants;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.NotThreadSafe;
+
 /**
  * Configurations used by the metrics system.
  */

--- a/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsConfig.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class MetricsConfig {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private Properties mProperties;
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class MetricsSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsSystem.class);
 
   // Supported special instance names.
   public static final String MASTER_INSTANCE = "master";

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -12,7 +12,6 @@
 package alluxio.metrics;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.metrics.sink.Sink;
 import alluxio.util.network.NetworkAddressUtils;

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class NettyChannelPool extends DynamicResourcePool<Channel> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyChannelPool.class);
 
   private static final int NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE = 10;
   private static final ScheduledExecutorService GC_EXECUTOR =

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -12,6 +12,7 @@
 package alluxio.network.connection;
 
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.util.ThreadFactoryUtils;
 
@@ -19,6 +20,8 @@ import com.google.common.base.Throwables;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,6 +40,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class NettyChannelPool extends DynamicResourcePool<Channel> {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private static final int NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE = 10;
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(NETTY_CHANNEL_POOL_GC_THREADPOOL_SIZE,

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -12,7 +12,6 @@
 package alluxio.network.connection;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.util.ThreadFactoryUtils;
 

--- a/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
@@ -27,6 +27,8 @@ import org.apache.thrift.protocol.TMultiplexedProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -58,6 +60,8 @@ import javax.security.auth.Subject;
 @ThreadSafe
 public abstract class ThriftClientPool<T extends AlluxioService.Client>
     extends DynamicResourcePool<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private final TransportProvider mTransportProvider;
   private final String mServiceName;
   private final long mServiceVersion;

--- a/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/ThriftClientPool.java
@@ -60,7 +60,7 @@ import javax.security.auth.Subject;
 @ThreadSafe
 public abstract class ThriftClientPool<T extends AlluxioService.Client>
     extends DynamicResourcePool<T> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ThriftClientPool.class);
 
   private final TransportProvider mTransportProvider;
   private final String mServiceName;

--- a/core/common/src/main/java/alluxio/network/protocol/RPCMessageDecoder.java
+++ b/core/common/src/main/java/alluxio/network/protocol/RPCMessageDecoder.java
@@ -11,8 +11,6 @@
 
 package alluxio.network.protocol;
 
-import alluxio.Constants;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;

--- a/core/common/src/main/java/alluxio/network/protocol/RPCMessageDecoder.java
+++ b/core/common/src/main/java/alluxio/network/protocol/RPCMessageDecoder.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ChannelHandler.Sharable
 @ThreadSafe
 public final class RPCMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RPCMessageDecoder.class);
 
   /**
    * Constructs a new {@link RPCMessageDecoder}.

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public abstract class DynamicResourcePool<T> implements Pool<T> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicResourcePool.class);
 
   /**
    * A wrapper on the resource to include the last time at which it was used.

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public abstract class DynamicResourcePool<T> implements Pool<T> {
-  protected static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /**
    * A wrapper on the resource to include the last time at which it was used.

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -12,7 +12,6 @@
 package alluxio.security.group;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.annotation.PublicApi;
 import alluxio.util.CommonUtils;

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -36,7 +36,7 @@ public interface GroupMappingService {
    * Factory for creating a new instance.
    */
   class Factory {
-    private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+    private static final Logger LOG = LoggerFactory.getLogger(GroupMappingService.Factory.class);
 
     // TODO(chaomin): maintain a map from SECURITY_GROUP_MAPPING_CLASS name to cachedGroupMapping.
     // Currently the single global cached GroupMappingService assumes that there is no dynamic

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class AtomicFileOutputStream extends OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AtomicFileOutputStream.class);
 
   private AtomicFileOutputStreamCallback mUfs;
   private CreateOptions mOptions;

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs;
 
-import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.IdUtils;

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ObjectUnderFileSystem.class);
 
   /** Default maximum length for a single listing query. */
   private static final int DEFAULT_MAX_LISTING_CHUNK_LENGTH = 1000;

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -13,7 +13,6 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.underfs.options.CreateOptions;

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
@@ -11,8 +11,6 @@
 
 package alluxio.underfs;
 
-import alluxio.Constants;
-
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemRegistry.java
@@ -69,9 +69,10 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class UnderFileSystemRegistry {
+  private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemRegistry.class);
 
   private static final List<UnderFileSystemFactory> FACTORIES = new CopyOnWriteArrayList<>();
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private static boolean sInit = false;
 
   // prevent instantiation

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -11,7 +11,6 @@
 
 package alluxio.util;
 
-import alluxio.Constants;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 import alluxio.util.ShellUtils.ExitCodeException;

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -37,7 +37,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class CommonUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CommonUtils.class);
+
   private static final String ALPHANUM =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   private static final Random RANDOM = new Random();

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -12,7 +12,6 @@
 package alluxio.util;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.util.io.PathUtils;
 

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -29,7 +29,7 @@ import java.util.Properties;
  * Utilities for working with Alluxio configurations.
  */
 public final class ConfigurationUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationUtils.class);
 
   private ConfigurationUtils() {} // prevent instantiation
 

--- a/core/common/src/main/java/alluxio/util/IdUtils.java
+++ b/core/common/src/main/java/alluxio/util/IdUtils.java
@@ -27,12 +27,13 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class IdUtils {
-  private IdUtils() {} // prevent instantiation
+  private static final Logger LOG = LoggerFactory.getLogger(IdUtils.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   public static final long INVALID_FILE_ID = -1;
   public static final long INVALID_WORKER_ID = -1;
   private static SecureRandom sRandom = new SecureRandom();
+
+  private IdUtils() {} // prevent instantiation
 
   /**
    * Creates an id for a file based on the given id of the container.

--- a/core/common/src/main/java/alluxio/util/IdUtils.java
+++ b/core/common/src/main/java/alluxio/util/IdUtils.java
@@ -11,7 +11,6 @@
 
 package alluxio.util;
 
-import alluxio.Constants;
 import alluxio.master.block.BlockId;
 
 import org.slf4j.Logger;

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -29,8 +29,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ShellUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ShellUtils.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   /** a Unix command to set permission. */
   public static final String SET_PERMISSION_COMMAND = "chmod";
 

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -11,8 +11,6 @@
 
 package alluxio.util;
 
-import alluxio.Constants;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/common/src/main/java/alluxio/util/URIUtils.java
+++ b/core/common/src/main/java/alluxio/util/URIUtils.java
@@ -31,11 +31,10 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class URIUtils {
-  private URIUtils() {} // prevent instantiation
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   public static final char QUERY_SEPARATOR = '&';
   public static final char QUERY_KEY_VALUE_SEPARATOR = '=';
+
+  private URIUtils() {} // prevent instantiation
 
   /**
    * Generates a query string from a {@link Map <String, String>} of key/value pairs.

--- a/core/common/src/main/java/alluxio/util/URIUtils.java
+++ b/core/common/src/main/java/alluxio/util/URIUtils.java
@@ -11,11 +11,7 @@
 
 package alluxio.util;
 
-import alluxio.Constants;
-
 import com.google.common.base.Joiner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -33,7 +33,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class BufferUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BufferUtils.class);
+
   private static Method sCleanerCleanMethod;
   private static Method sByteBufferCleanerMethod;
 

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -11,8 +11,6 @@
 
 package alluxio.util.io;
 
-import alluxio.Constants;
-
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class FileUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileUtils.class);
 
   /**
    * Changes the local file's group.

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -12,7 +12,6 @@
 package alluxio.util.io;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.exception.InvalidPathException;
 
 import org.slf4j.Logger;

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -47,13 +47,14 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class NetworkAddressUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(NetworkAddressUtils.class);
+
   public static final String WILDCARD_ADDRESS = "0.0.0.0";
 
   /**
    * Checks if the underlying OS is Windows.
    */
   public static final boolean WINDOWS = OSUtils.isWindows();
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static String sLocalHost;
   private static String sLocalIP;

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -13,7 +13,6 @@ package alluxio.util.network;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.MasterInquireClient;
 import alluxio.PropertyKey;
 import alluxio.exception.PreconditionMessage;

--- a/core/common/src/main/java/alluxio/worker/DataServerMessage.java
+++ b/core/common/src/main/java/alluxio/worker/DataServerMessage.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker;
 
-import alluxio.Constants;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCResponse;
 

--- a/core/common/src/main/java/alluxio/worker/DataServerMessage.java
+++ b/core/common/src/main/java/alluxio/worker/DataServerMessage.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class DataServerMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DataServerMessage.class);
 
   // The size of the prefix of the header: frame length (long), messageType (int)
   private static final int HEADER_PREFIX_LENGTH = 12;

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -26,7 +26,7 @@ import java.util.UUID;
  * class initialization it deletes files and directories older than the maximum age.
  */
 public final class AlluxioTestDirectory {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioTestDirectory.class);
 
   private static final int MAX_FILE_AGE_HOURS = 1;
 

--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response;
  * Utilities for handling REST calls.
  */
 public final class RestUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RestUtils.class);
 
   /**
    * Calls the given {@link RestUtils.RestCallable} and handles any exceptions thrown.

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * Utilities for handling RPC calls.
  */
 public final class RpcUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RpcUtils.class);
 
   /**
    * Calls the given {@link RpcCallable} and handles any exceptions thrown.

--- a/core/server/common/src/main/java/alluxio/ServerUtils.java
+++ b/core/server/common/src/main/java/alluxio/ServerUtils.java
@@ -25,7 +25,7 @@ import java.util.ServiceLoader;
  * Utility methods for running server binaries.
  */
 public final class ServerUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ServerUtils.class);
 
   /**
    * Runs the given server.

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -35,7 +35,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class Format {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Format.class);
+
   private static final String USAGE = String.format("java -cp %s %s <MASTER/WORKER>",
       RuntimeConstants.ALLUXIO_JAR, Format.class.getCanonicalName());
 

--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1664)
 public abstract class AbstractMaster implements Master {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMaster.class);
 
   public static final long INVALID_FLUSH_COUNTER = -1;
   private static final long SHUTDOWN_TIMEOUT_MS = 10 * Constants.SECOND_MS;

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -12,13 +12,10 @@
 package alluxio.master.journal;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -32,8 +32,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AsyncJournalWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private final JournalWriter mJournalWriter;
   private final ConcurrentLinkedQueue<JournalEntry> mQueue;
   /** Represents the count of entries added to the journal queue. */

--- a/core/server/common/src/main/java/alluxio/master/journal/CheckpointManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/CheckpointManager.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * </pre>
  */
 public final class CheckpointManager {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointManager.class);
 
   /** The UFS where the journal is being written to. */
   private final UnderFileSystem mUfs;

--- a/core/server/common/src/main/java/alluxio/master/journal/CheckpointManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/CheckpointManager.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal;
 
-import alluxio.Constants;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.UnderFileSystemUtils;
 

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal;
 
-import alluxio.Constants;
 import alluxio.underfs.UnderFileSystem;
 
 import com.google.common.base.Preconditions;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class JournalReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(JournalReader.class);
 
   private final Journal mJournal;
   /** The UFS where the journal is being written to. */

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalTailer.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalTailer.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal;
 
-import alluxio.Constants;
 import alluxio.master.Master;
 import alluxio.proto.journal.Journal.JournalEntry;
 

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalTailer.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalTailer.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class JournalTailer {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(JournalTailer.class);
 
   /** The master to apply all the journal entries to. */
   private final Master mMaster;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalTailerThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalTailerThread.java
@@ -12,7 +12,6 @@
 package alluxio.master.journal;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.master.Master;
 import alluxio.util.CommonUtils;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalTailerThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalTailerThread.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class JournalTailerThread extends Thread {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(JournalTailerThread.class);
 
   /** The master to apply the journal entries to. */
   private final Master mMaster;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class JournalWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(JournalWriter.class);
 
   private final Journal mJournal;
   /** Absolute path to the directory storing all of the journal data. */

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
@@ -12,7 +12,6 @@
 package alluxio.master.journal;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.proto.journal.Journal.JournalEntry;

--- a/core/server/common/src/main/java/alluxio/master/journal/ProtoBufJournalFormatter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ProtoBufJournalFormatter.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ProtoBufJournalFormatter implements JournalFormatter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ProtoBufJournalFormatter.class);
 
   /**
    * Constructs a new {@link ProtoBufJournalFormatter}.

--- a/core/server/common/src/main/java/alluxio/master/journal/ProtoBufJournalFormatter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ProtoBufJournalFormatter.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal;
 
-import alluxio.Constants;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.proto.journal.Journal.JournalEntry;
 

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -13,7 +13,6 @@ package alluxio.web;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 
 import com.google.common.base.Preconditions;

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class WebServer {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(WebServer.class);
 
   private final Server mServer;
   private final String mServiceName;

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
@@ -11,7 +11,6 @@
 
 package alluxio.master;
 
-import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.ServerUtils;
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AlluxioMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioMaster.class);
 
   /**
    * Starts the Alluxio master.

--- a/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
@@ -62,7 +62,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class DefaultAlluxioMaster implements AlluxioMasterService {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultAlluxioMaster.class);
 
   /** Maximum number of threads to serve the rpc server. */
   private final int mMaxWorkerThreads;

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class FaultTolerantAlluxioMaster extends DefaultAlluxioMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FaultTolerantAlluxioMaster.class);
 
   /** The zookeeper client that handles selecting the leader. */
   private LeaderSelectorClient mLeaderSelectorClient = null;

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMaster.java
@@ -12,7 +12,6 @@
 package alluxio.master;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.LeaderSelectorClient;
 import alluxio.PropertyKey;
 import alluxio.master.journal.JournalFactory;

--- a/core/server/master/src/main/java/alluxio/master/MetaMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/MetaMasterClientServiceHandler.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * This class is a Thrift handler for meta master RPCs.
  */
 public final class MetaMasterClientServiceHandler implements MetaMasterClientService.Iface {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MetaMasterClientServiceHandler.class);
 
   private final AlluxioMasterService mAlluxioMaster;
 

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -78,7 +78,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1664)
 public final class BlockMaster extends AbstractMaster implements ContainerIdGenerable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockMaster.class);
   /**
    * The number of container ids to 'reserve' before having to journal container id state. This
    * allows the master to return container ids within the reservation, without having to write to

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterBlockInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterBlockInfo.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class MasterBlockInfo {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MasterBlockInfo.class);
 
   /** The id of the block. */
   private final long mBlockId;

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -39,7 +39,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class MasterWorkerInfo {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MasterWorkerInfo.class);
+
   /** Worker's address. */
   private final WorkerNetAddress mWorkerAddress;
   /** The id of the worker. */

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -140,7 +140,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1664)
 public final class FileSystemMaster extends AbstractMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemMaster.class);
 
   /**
    * Locking in the FileSystemMaster

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -13,7 +13,6 @@ package alluxio.master.file.async;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -42,7 +42,7 @@ public interface AsyncPersistHandler {
    */
   @ThreadSafe
   class Factory {
-    public static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+    public static final Logger LOG = LoggerFactory.getLogger(AsyncPersistHandler.Factory.class);
 
     private Factory() {} // prevent instantiation
 

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -44,7 +44,7 @@ import java.util.Set;
  * the corresponding worker polls.
  */
 public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultAsyncPersistHandler.class);
 
   private final FileSystemMasterView mFileSystemMasterView;
 

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.async;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -60,6 +60,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 // TODO(jiri): Make this class thread-safe.
 public class InodeTree implements JournalCheckpointStreamable {
+  private static final Logger LOG = LoggerFactory.getLogger(InodeTree.class);
+
   /** Value to be used for an inode with no parent. */
   public static final long NO_PARENT = -1;
 
@@ -88,7 +90,6 @@ public class InodeTree implements JournalCheckpointStreamable {
     WRITE_PARENT,
   }
 
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   /** Only the root inode should have the empty string as its name. */
   private static final String ROOT_INODE_NAME = "";
   /** Number of retries when trying to lock a path, from a given id. */

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -47,9 +47,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class MountTable implements JournalCheckpointStreamable {
-  public static final String ROOT = "/";
+  private static final Logger LOG = LoggerFactory.getLogger(MountTable.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  public static final String ROOT = "/";
 
   private final ReentrantReadWriteLock mLock;
   private final Lock mReadLock;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -71,7 +71,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class LineageMaster extends AbstractMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(LineageMaster.class);
 
   private final LineageStore mLineageStore;
   private final FileSystemMaster mFileSystemMaster;

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.checkpoint;
 
-import alluxio.Constants;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.file.meta.FileSystemMasterView;

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class CheckpointLatestPlanner implements CheckpointPlanner {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointLatestPlanner.class);
 
   /**
    * Creates a new instance of {@link CheckpointLatestPlanner}, which does not use the lineage store

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointSchedulingExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointSchedulingExecutor.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.checkpoint;
 
-import alluxio.Constants;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.lineage.LineageMaster;

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointSchedulingExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointSchedulingExecutor.java
@@ -27,7 +27,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class CheckpointSchedulingExecutor implements HeartbeatExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointSchedulingExecutor.class);
 
   private final LineageMaster mLineageMaster;
   private final FileSystemMaster mFileSystemMaster;

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.recompute;
 
-import alluxio.Constants;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class RecomputeExecutor implements HeartbeatExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RecomputeExecutor.class);
 
   private static final int DEFAULT_RECOMPUTE_LAUNCHER_POOL_SIZE = 10;
   private final RecomputePlanner mPlanner;

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class RecomputePlanner {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(RecomputePlanner.class);
 
   private final LineageStore mLineageStore;
   private final FileSystemMaster mFileSystemMaster;

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.recompute;
 
-import alluxio.Constants;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.LineageDoesNotExistException;
 import alluxio.master.file.FileSystemMaster;

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeDirectoryTest.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Unit tests for {@link InodeDirectory}.
  */
 public final class InodeDirectoryTest extends AbstractInodeTest {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(InodeDirectoryTest.class);
 
   /**
    * Tests the {@link InodeDirectory#addChild(Inode)} method.

--- a/core/server/proxy/src/main/java/alluxio/StreamCache.java
+++ b/core/server/proxy/src/main/java/alluxio/StreamCache.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class StreamCache {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(StreamCache.class);
 
   private static final RemovalListener<Integer, Closeable> CLOSER =
       new RemovalListener<Integer, Closeable>() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class AlluxioProxy {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioProxy.class);
 
   /**
    * Starts the Alluxio proxy.

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
@@ -12,7 +12,6 @@
 package alluxio.proxy;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.ServerUtils;

--- a/core/server/proxy/src/main/java/alluxio/proxy/DefaultAlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/DefaultAlluxioProxy.java
@@ -12,7 +12,6 @@
 package alluxio.proxy;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.util.CommonUtils;
 import alluxio.util.network.NetworkAddressUtils;

--- a/core/server/proxy/src/main/java/alluxio/proxy/DefaultAlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/DefaultAlluxioProxy.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class DefaultAlluxioProxy implements AlluxioProxyService {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultAlluxioProxy.class);
 
   /** The web server. */
   private WebServer mWebServer = null;

--- a/core/server/worker/src/main/java/alluxio/Sessions.java
+++ b/core/server/worker/src/main/java/alluxio/Sessions.java
@@ -27,14 +27,14 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class Sessions {
+  private static final Logger LOG = LoggerFactory.getLogger(Sessions.class);
+
   public static final int DATASERVER_SESSION_ID = -1;
   public static final int CHECKPOINT_SESSION_ID = -2;
   public static final int MIGRATE_DATA_SESSION_ID = -3;
   public static final int MASTER_COMMAND_SESSION_ID = -4;
   public static final int ACCESS_BLOCK_SESSION_ID = -5;
   public static final int KEYVALUE_SESSION_ID = -6;
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** Map from SessionId to {@link alluxio.SessionInfo} object. */
   private final Map<Long, SessionInfo> mSessions;

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
@@ -48,7 +48,9 @@ import javax.servlet.http.HttpServletResponse;
  */
 @ThreadSafe
 public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(WebInterfaceWorkerBlockInfoServlet.class);
+
   private static final long serialVersionUID = 4148506607369321012L;
   private final transient BlockWorker mBlockWorker;
 

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
@@ -12,7 +12,6 @@
 package alluxio.web;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -12,7 +12,6 @@
 package alluxio.worker;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.ServerUtils;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AlluxioWorker {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioWorker.class);
 
   /**
    * Starts the Alluxio worker.

--- a/core/server/worker/src/main/java/alluxio/worker/DefaultAlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/DefaultAlluxioWorker.java
@@ -57,7 +57,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class DefaultAlluxioWorker implements AlluxioWorkerService {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultAlluxioWorker.class);
 
   /** The worker serving blocks. */
   private BlockWorker mBlockWorker;

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -12,7 +12,6 @@
 package alluxio.worker;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.util.CommonUtils;
 

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -28,7 +28,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class SessionCleaner implements Runnable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SessionCleaner.class);
+
   /** The object which supports cleaning up sessions. */
   private final SessionCleanupCallback mSessionCleanupCallback;
   /** Milliseconds between each check. */

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class BlockLockManager {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockLockManager.class);
 
   /** The unique id of each lock. */
   private static final AtomicLong LOCK_ID_GEN = new AtomicLong(0);

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -22,8 +22,6 @@ import alluxio.thrift.Command;
 import alluxio.wire.WorkerNetAddress;
 
 import org.apache.thrift.TException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -40,7 +40,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class BlockMasterClient extends AbstractMasterClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private BlockMasterWorkerService.Client mClient = null;
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.Sessions;
 import alluxio.StorageTierAssoc;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -55,7 +55,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class BlockMasterSync implements HeartbeatExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockMasterSync.class);
+
   private static final int DEFAULT_BLOCK_REMOVER_POOL_SIZE = 10;
 
   /** The block worker responsible for interacting with Alluxio and UFS storage. */

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 // TODO(bin): consider how to better expose information to Evictor and Allocator.
 public final class BlockMetadataManager {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockMetadataManager.class);
 
   /** A list of managed {@link StorageTier}, in order from lowest tier ordinal to greatest. */
   private final List<StorageTier> mTiers;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block;
 
-import alluxio.Constants;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.exception.BlockAlreadyExistsException;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorkerClientServiceHandler.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public final class BlockWorkerClientServiceHandler implements BlockWorkerClientService.Iface {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockWorkerClientServiceHandler.class);
 
   /** Block Worker handle that carries out most of the operations. */
   private final BlockWorker mWorker;

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -72,7 +72,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public final class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultBlockWorker.class);
 
   /** Runnable responsible for heartbeating and registration with master. */
   private BlockMasterSync mBlockMasterSync;

--- a/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class PinListSync implements HeartbeatExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(PinListSync.class);
 
   /** Block worker handle responsible for interacting with Alluxio and UFS storage. */
   private final BlockWorker mBlockWorker;

--- a/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block;
 
-import alluxio.Constants;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.worker.file.FileSystemMasterClient;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -39,7 +39,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class SpaceReserver implements HeartbeatExecutor  {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SpaceReserver.class);
+
   private final BlockWorker mBlockWorker;
 
   /** Association between storage tier aliases and ordinals for the worker. */

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.PropertyKeyFormat;
 import alluxio.Sessions;

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -81,7 +81,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public final class TieredBlockStore implements BlockStore {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(TieredBlockStore.class);
+
   private static final int MAX_RETRIES =
           Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_RETRY);
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class AbstractEvictor extends AbstractBlockStoreEventListener implements Evictor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractEvictor.class);
   protected final Allocator mAllocator;
   protected BlockMetadataManagerView mManagerView;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block.evictor;
 
-import alluxio.Constants;
 import alluxio.Sessions;
 import alluxio.collections.Pair;
 import alluxio.exception.BlockDoesNotExistException;

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block.evictor;
 
-import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.worker.block.BlockMetadataManagerView;
 import alluxio.worker.block.BlockStoreLocation;

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class GreedyEvictor implements Evictor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(GreedyEvictor.class);
 
   /**
    * Creates a new instance of {@link GreedyEvictor}.

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
@@ -43,7 +43,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class StorageDir {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(StorageDir.class);
+
   private final long mCapacityBytes;
   /** A map from block id to block metadata. */
   private Map<Long, BlockMeta> mBlockIdToBlockMap;

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block.meta;
 
-import alluxio.Constants;
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block.meta;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.PropertyKeyFormat;
 import alluxio.WorkerStorageTierAssoc;

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class StorageTier {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(StorageTier.class);
 
   /** Alias value of this tier in tiered storage. */
   private final String mTierAlias;

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -13,7 +13,6 @@ package alluxio.worker.file;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.Sessions;
 import alluxio.client.file.FileSystem;

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -58,7 +58,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public final class FileDataManager {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileDataManager.class);
 
   private final UnderFileSystem mUfs;
 

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
@@ -41,8 +41,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class FileSystemMasterClient extends AbstractMasterClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private FileSystemMasterWorkerService.Client mClient = null;
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
@@ -23,8 +23,6 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.ThriftUtils;
 
 import org.apache.thrift.TException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -12,7 +12,6 @@
 package alluxio.worker.file;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.heartbeat.HeartbeatExecutor;

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileWorkerMasterSyncExecutor.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 final class FileWorkerMasterSyncExecutor implements HeartbeatExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(FileWorkerMasterSyncExecutor.class);
 
   /** Logic for managing async file persistence. */
   private final FileDataManager mFileDataManager;

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -52,7 +52,7 @@ import javax.annotation.concurrent.ThreadSafe;
 // TODO(calvin): Consider whether the manager or the agents should contain the execution logic
 @ThreadSafe
 public final class UnderFileSystemManager {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemManager.class);
 
   // Input stream agent session index
   private static final IndexDefinition<InputStreamAgent> INPUT_AGENT_SESSION_ID_INDEX =

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemManager.java
@@ -12,7 +12,6 @@
 package alluxio.worker.file;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.Seekable;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/BlockDataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/BlockDataServerHandler.java
@@ -12,7 +12,6 @@
 package alluxio.worker.netty;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/BlockDataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/BlockDataServerHandler.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class BlockDataServerHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BlockDataServerHandler.class);
 
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
   private final BlockWorker mWorker;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.Constants;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.network.protocol.databuffer.DataBuffer;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class DataServerBlockReadHandler extends DataServerReadHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DataServerBlockReadHandler.class);
 
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
   private final BlockWorker mWorker;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerHandler.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @ChannelHandler.Sharable
 @NotThreadSafe
 final class DataServerHandler extends SimpleChannelInboundHandler<RPCMessage> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DataServerHandler.class);
 
   /** Handler for any block store requests. */
   private final BlockDataServerHandler mBlockHandler;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.Constants;
 import alluxio.network.protocol.RPCBlockReadRequest;
 import alluxio.network.protocol.RPCBlockWriteRequest;
 import alluxio.network.protocol.RPCErrorResponse;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class DataServerReadHandler extends ChannelInboundHandlerAdapter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DataServerReadHandler.class);
 
   private static final long PACKET_SIZE =
       Configuration.getBytes(PropertyKey.WORKER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
@@ -12,7 +12,6 @@
 package alluxio.worker.netty;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCProtoMessage;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUFSFileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUFSFileReadHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.Constants;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.network.protocol.databuffer.DataBuffer;
@@ -22,8 +21,6 @@ import alluxio.worker.file.FileSystemWorker;
 import com.codahale.metrics.Counter;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUFSFileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUFSFileReadHandler.java
@@ -36,8 +36,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class DataServerUFSFileReadHandler extends DataServerReadHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
   private final FileSystemWorker mWorker;
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
@@ -55,7 +55,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DataServerWriteHandler.class);
 
   private static final int MAX_PACKETS_IN_FLIGHT =
       Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
@@ -12,7 +12,6 @@
 package alluxio.worker.netty;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCProtoMessage;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -12,7 +12,6 @@
 package alluxio.worker.netty;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.network.ChannelType;
 import alluxio.util.network.NettyUtils;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class NettyDataServer implements DataServer {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyDataServer.class);
 
   private final ServerBootstrap mBootstrap;
   private final ChannelFuture mChannelFuture;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.Constants;
 import alluxio.network.protocol.RPCFileReadRequest;
 import alluxio.network.protocol.RPCFileReadResponse;
 import alluxio.network.protocol.RPCFileWriteRequest;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/UnderFileSystemDataServerHandler.java
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class UnderFileSystemDataServerHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemDataServerHandler.class);
 
   /** Filesystem worker which handles file level operations for the worker. */
   private final FileSystemWorker mWorker;

--- a/docs/_includes/Contributing-to-Alluxio/slf4j.md
+++ b/docs/_includes/Contributing-to-Alluxio/slf4j.md
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory;
 
 public MyClass {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MyClass.class);
 
     public void someMethod() {
       LOG.info("Hello world");

--- a/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
+++ b/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
@@ -46,10 +46,11 @@ import java.util.Map.Entry;
  * running locally.
  */
 public final class AlluxioFrameworkIntegrationTest {
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFrameworkIntegrationTest.class);
+
   private static final String JDK_URL =
       "https://s3-us-west-2.amazonaws.com/alluxio-mesos/jdk-7u79-macosx-x64.tar.gz";
   private static final String JDK_PATH = "jdk1.7.0_79.jdk/Contents/Home";
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   @Parameter(names = {"-m", "--mesos"}, required = true,
       description = "Address for locally-running Mesos, e.g. localhost:5050")

--- a/examples/src/main/java/alluxio/cli/CliUtils.java
+++ b/examples/src/main/java/alluxio/cli/CliUtils.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
  * Utilities to run the examples.
  */
 public final class CliUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(CliUtils.class);
 
   private CliUtils() {} // prevent instantiation
 

--- a/examples/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/examples/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -161,11 +161,11 @@ public final class JournalCrashTest {
       mIsStopped = isStopped;
     }
   }
+  private static final Logger LOG = LoggerFactory.getLogger(JournalCrashTest.class);
 
   // The two Exit Codes are used to tell script if the test runs well.
   private static final int EXIT_FAILED = 1;
   private static final int EXIT_SUCCESS = 0;
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static CreateFileOptions sCreateFileOptions = null;
   private static List<ClientThread> sClientThreadList = null;

--- a/examples/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/examples/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -13,7 +13,6 @@ package alluxio.cli;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.client.WriteType;
@@ -161,6 +160,7 @@ public final class JournalCrashTest {
       mIsStopped = isStopped;
     }
   }
+
   private static final Logger LOG = LoggerFactory.getLogger(JournalCrashTest.class);
 
   // The two Exit Codes are used to tell script if the test runs well.

--- a/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
@@ -12,7 +12,6 @@
 package alluxio.examples;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.cli.CliUtils;
 import alluxio.client.file.FileInStream;

--- a/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
  * An example to show to how use Alluxio's API.
  */
 public class BasicCheckpoint implements Callable<Boolean> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BasicCheckpoint.class);
 
   private final String mFileFolder;
   private final int mNumFiles;

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -47,7 +47,7 @@ import java.util.concurrent.Callable;
  * </p>
  */
 public final class BasicNonByteBufferOperations implements Callable<Boolean> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BasicNonByteBufferOperations.class);
 
   private final AlluxioURI mFilePath;
   private final ReadType mReadType;

--- a/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicNonByteBufferOperations.java
@@ -12,7 +12,6 @@
 package alluxio.examples;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.AlluxioStorageType;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -12,7 +12,6 @@
 package alluxio.examples;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;

--- a/examples/src/main/java/alluxio/examples/BasicOperations.java
+++ b/examples/src/main/java/alluxio/examples/BasicOperations.java
@@ -39,7 +39,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class BasicOperations implements Callable<Boolean> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BasicOperations.class);
+
   private static final int NUMBERS = 20;
 
   private final AlluxioURI mFilePath;

--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -41,7 +41,7 @@ import java.nio.channels.FileChannel.MapMode;
  * Example to show the performance of Alluxio.
  */
 public final class Performance {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Performance.class);
 
   private static final int RESULT_ARRAY_SIZE = 64;
   private static final String FOLDER = "/mnt/ramdisk/";

--- a/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable;
  * read the store afterwards.
  */
 public final class KeyValueStoreOperations implements Callable<Boolean> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(KeyValueStoreOperations.class);
 
   private final int mPartitionLength = Constants.MB;
   private final int mNumKeyValuePairs = 10;

--- a/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Callable;
  * Tests whether two key-value stores contain the same set of key-value pairs.
  */
 public final class SameKeyValueStoresTest implements Callable<Boolean> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SameKeyValueStoresTest.class);
 
   private final AlluxioURI mStoreUri1;
   private final AlluxioURI mStoreUri2;

--- a/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
@@ -12,7 +12,6 @@
 package alluxio.examples.keyvalue;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.cli.CliUtils;
 import alluxio.client.keyvalue.KeyValueIterator;

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -12,7 +12,6 @@
 package alluxio.fuse;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 
@@ -37,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AlluxioFuse {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuse.class);
 
   // prevent instantiation
   private AlluxioFuse() {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -16,7 +16,6 @@ import static jnr.constants.platform.OpenFlags.O_WRONLY;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
@@ -58,7 +57,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 final class AlluxioFuseFileSystem extends FuseStubFS {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuseFileSystem.class);
+
   private static final int MAX_OPEN_FILES = Integer.MAX_VALUE;
   private static final long[] UID_AND_GID = AlluxioFuseUtils.getUidAndGid();
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -11,8 +11,6 @@
 
 package alluxio.fuse;
 
-import alluxio.Constants;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AlluxioFuseUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuseUtils.class);
 
   private AlluxioFuseUtils() {}
 

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
@@ -12,7 +12,6 @@
 package alluxio.mesos;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 
 import com.beust.jcommander.JCommander;

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class AlluxioFramework {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFramework.class);
 
   @Parameter(names = {"-m", "--mesos"}, description = "Mesos master location, e.g. localhost:5050")
   private String mMesosMaster;

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class AlluxioMasterExecutor implements Executor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioMasterExecutor.class);
 
   /**
    * Creates a new {@link AlluxioMasterExecutor}.

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
@@ -11,7 +11,6 @@
 
 package alluxio.mesos;
 
-import alluxio.Constants;
 import alluxio.cli.Format;
 import alluxio.master.AlluxioMaster;
 import alluxio.underfs.UnderFileSystemRegistry;

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Class for responding to Mesos offers to launch Alluxio on Mesos.
  */
 public class AlluxioScheduler implements Scheduler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioScheduler.class);
 
   private final String mRequiredMasterHostname;
 

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
@@ -11,7 +11,6 @@
 
 package alluxio.mesos;
 
-import alluxio.Constants;
 import alluxio.cli.Format;
 import alluxio.underfs.UnderFileSystemRegistry;
 import alluxio.worker.AlluxioWorker;

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class AlluxioWorkerExecutor implements Executor {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioWorkerExecutor.class);
 
   /**
    * Creates a new {@link AlluxioWorkerExecutor}.

--- a/integration/mesos/src/main/java/alluxio/mesos/OfferUtils.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/OfferUtils.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * Mesos framework offer utils.
  */
 public final class OfferUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(OfferUtils.class);
 
   private OfferUtils() {} // prevent instantiation
 

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -73,7 +73,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationMaster.class);
 
   /**
    * Resources needed by the master and worker containers. Yarn will copy these to the container

--- a/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
@@ -35,7 +35,8 @@ import java.util.concurrent.CountDownLatch;
  * A class for negotiating with YARN to allocate containers.
  */
 public final class ContainerAllocator {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerAllocator.class);
+
   private static final int MAX_WORKER_CONTAINER_REQUEST_ATTEMPTS = 20;
 
   private final String mContainerName;

--- a/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
@@ -11,7 +11,6 @@
 
 package alluxio.yarn;
 
-import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
 
 import com.google.common.collect.ConcurrentHashMultiset;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
@@ -34,8 +34,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class BaseKeyValuePartitionReader implements KeyValuePartitionReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private KeyValueWorkerClient mClient;
   private long mBlockId;
   private boolean mClosed;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.keyvalue;
 
-import alluxio.Constants;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.exception.AlluxioException;
 import alluxio.util.io.BufferUtils;
@@ -19,8 +18,6 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionWriter.java
@@ -18,8 +18,6 @@ import alluxio.client.AbstractOutStream;
 import alluxio.util.io.ByteIOUtils;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionWriter.java
@@ -40,8 +40,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class BaseKeyValuePartitionWriter implements KeyValuePartitionWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   /** Handle to write to the underlying file. */
   private final AbstractOutStream mFileOutStream;
   /** Number of key-value pairs added. */

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
@@ -12,7 +12,6 @@
 package alluxio.client.keyvalue;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.AlluxioException;
 import alluxio.thrift.PartitionInfo;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 class BaseKeyValueStoreReader implements KeyValueStoreReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BaseKeyValueStoreReader.class);
 
   private final InetSocketAddress mMasterAddress = FileSystemContext.INSTANCE.getMasterAddress();
   private final KeyValueMasterClient mMasterClient;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 class BaseKeyValueStoreWriter implements KeyValueStoreWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(BaseKeyValueStoreWriter.class);
 
   private final FileSystem mFileSystem = FileSystem.Factory.get();
   private final KeyValueMasterClient mMasterClient;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
@@ -12,7 +12,6 @@
 package alluxio.client.keyvalue;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.AlluxioException;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/ByteBufferKeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/ByteBufferKeyValuePartitionReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.keyvalue;
 
-import alluxio.Constants;
 import alluxio.exception.AlluxioException;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.ByteIOUtils;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/ByteBufferKeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/ByteBufferKeyValuePartitionReader.java
@@ -33,7 +33,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class ByteBufferKeyValuePartitionReader implements KeyValuePartitionReader {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ByteBufferKeyValuePartitionReader.class);
 
   private Index mIndex;
   private PayloadReader mPayloadReader;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
@@ -21,8 +21,6 @@ import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.WorkerNetAddress;
 
 import org.apache.thrift.TException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
@@ -38,8 +38,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class KeyValueWorkerClient extends AbstractClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private KeyValueWorkerClientService.Client mClient = null;
 
   /**

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
@@ -11,7 +11,6 @@
 
 package alluxio.hadoop.mapreduce;
 
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.keyvalue.KeyValueSystem;
 import alluxio.exception.AlluxioException;

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 @ThreadSafe
 public final class KeyValueOutputCommitter extends FileOutputCommitter {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(KeyValueOutputCommitter.class);
 
   private static final KeyValueSystem KEY_VALUE_SYSTEM = KeyValueSystem.Factory.create();
 

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -60,7 +60,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class KeyValueMaster extends AbstractMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private final FileSystemMaster mFileSystemMaster;
 
   /** Map from file id of a complete store to the list of partitions in this store. */

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -42,8 +42,6 @@ import alluxio.util.io.PathUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import org.apache.thrift.TProcessor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterFactory.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterFactory.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class KeyValueMasterFactory implements MasterFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(KeyValueMasterFactory.class);
 
   /**
    * Constructs a new {@link KeyValueMasterFactory}.

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
@@ -46,7 +46,8 @@ import javax.annotation.concurrent.ThreadSafe;
 // TODO(binfan): move logic outside and make this a simple wrapper.
 @ThreadSafe
 public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerClientService.Iface {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(KeyValueWorkerClientServiceHandler.class);
 
   /** BlockWorker handler for access block info. */
   private final BlockWorker mBlockWorker;

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerFactory.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerFactory.java
@@ -12,7 +12,6 @@
 package alluxio.worker.keyvalue;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.worker.Worker;
 import alluxio.worker.WorkerFactory;

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerFactory.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerFactory.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class KeyValueWorkerFactory implements WorkerFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(KeyValueWorkerFactory.class);
 
   /**
    * Constructs a new {@link KeyValueWorkerFactory}.

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class AbstractLocalAlluxioCluster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractLocalAlluxioCluster.class);
 
   private static final Random RANDOM_GENERATOR = new Random();
   private static final int DEFAULT_BLOCK_SIZE_BYTES = Constants.KB;

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class AbstractLocalAlluxioCluster {
-  protected static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static final Random RANDOM_GENERATOR = new Random();
   private static final int DEFAULT_BLOCK_SIZE_BYTES = Constants.KB;

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalAlluxioCluster.class);
 
   private LocalAlluxioMaster mMaster;
 

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -11,7 +11,6 @@
 
 package alluxio.master;
 
-import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.AlluxioWorkerService;

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -11,9 +11,13 @@
 
 package alluxio.master;
 
+import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.AlluxioWorkerService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -35,6 +39,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   private LocalAlluxioMaster mMaster;
 
   /**

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class LocalAlluxioMaster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalAlluxioMaster.class);
 
   private final String mHostname;
 

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -25,6 +25,8 @@ import alluxio.worker.AlluxioWorkerService;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import org.apache.curator.test.TestingServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,6 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCluster {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private TestingServer mCuratorServer = null;
   private int mNumOfMasters = 0;

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCluster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(MultiMasterLocalAlluxioCluster.class);
 
   private TestingServer mCuratorServer = null;
   private int mNumOfMasters = 0;

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -44,7 +44,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class AlluxioShell implements Closeable {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioShell.class);
+
   private static final Map<String, String[]> CMD_ALIAS = ImmutableMap.<String, String[]>builder()
       .put("lsr", new String[] {"ls", "-R"})
       .put("rmr", new String[] {"rm", "-R"})

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -12,7 +12,6 @@
 package alluxio.cli;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.shell.command.ShellCommand;

--- a/shell/src/main/java/alluxio/cli/ValidateConf.java
+++ b/shell/src/main/java/alluxio/cli/ValidateConf.java
@@ -12,7 +12,6 @@
 package alluxio.cli;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/shell/src/main/java/alluxio/cli/ValidateConf.java
+++ b/shell/src/main/java/alluxio/cli/ValidateConf.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ValidateConf {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(ValidateConf.class);
 
   /**
    * Console program that validates the configuration.

--- a/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
@@ -11,8 +11,6 @@
 
 package alluxio.hadoop.fs;
 
-import alluxio.Constants;
-
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.MapReduceBase;
 import org.apache.hadoop.mapred.OutputCollector;

--- a/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
@@ -40,10 +40,11 @@ import java.util.Iterator;
  * </ul>
  */
 public class AccumulatingReducer extends MapReduceBase implements Reducer<Text, Text, Text, Text> {
+  private static final Logger LOG = LoggerFactory.getLogger(AccumulatingReducer.class);
+
   static final String VALUE_TYPE_LONG = "l:";
   static final String VALUE_TYPE_FLOAT = "f:";
   static final String VALUE_TYPE_STRING = "s:";
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   protected String mHostname;
 

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -86,7 +86,8 @@ import java.util.StringTokenizer;
  */
 public class DFSIOIntegrationTest implements Tool {
   // Constants for DFSIOIntegrationTest
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(DFSIOIntegrationTest.class);
+
   private static final int DEFAULT_BUFFER_SIZE = 4096;
   private static final String BASE_FILE_NAME = "test_io_";
   private static final String DEFAULT_RES_FILE_NAME = "DFSIOIntegrationTest_results.log";

--- a/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.gcs;
 
-import alluxio.Constants;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;

--- a/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/gcs/GCSUnderStorageCluster.java
@@ -33,7 +33,8 @@ import java.util.UUID;
  * manual means.
  */
 public class GCSUnderStorageCluster extends UnderFileSystemCluster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(GCSUnderStorageCluster.class);
+
   private static final String INTEGRATION_GCS_BUCKET = "gcsBucket";
 
   private boolean mStarted;

--- a/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.s3;
 
-import alluxio.Constants;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemCluster;

--- a/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
+++ b/tests/src/test/java/alluxio/underfs/s3/S3UnderStorageCluster.java
@@ -33,7 +33,8 @@ import java.util.UUID;
  * manual means.
  */
 public class S3UnderStorageCluster extends UnderFileSystemCluster {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(S3UnderStorageCluster.class);
+
   private static final String INTEGRATION_S3_BUCKET = "s3Bucket";
 
   private boolean mStarted;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class GCSOutputStream extends OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(GCSOutputStream.class);
 
   /** Bucket name of the Alluxio GCS bucket. */
   private final String mBucketName;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.gcs;
 
-import alluxio.Constants;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class GCSUnderFileSystem extends ObjectUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(GCSUnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
   private static final String FOLDER_SUFFIX = "_$folder$";

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystemFactory.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class GCSUnderFileSystemFactory implements UnderFileSystemFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(GCSUnderFileSystemFactory.class);
 
   /**
    * Constructs a new {@link GCSUnderFileSystemFactory}.

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -13,7 +13,6 @@ package alluxio.underfs.hdfs;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -58,7 +58,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class HdfsUnderFileSystem extends BaseUnderFileSystem
     implements AtomicFileOutputStreamCallback {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsUnderFileSystem.class);
+
   private static final int MAX_TRY = 5;
   // TODO(hy): Add a sticky bit and narrow down the permission in hadoop 2.
   private static final FsPermission PERMISSION = new FsPermission((short) 0777)

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -13,7 +13,6 @@ package alluxio.underfs.local;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.security.authorization.Mode;

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -60,7 +60,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class LocalUnderFileSystem extends BaseUnderFileSystem
     implements AtomicFileOutputStreamCallback {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalUnderFileSystem.class);
 
   /**
    * Constructs a new {@link LocalUnderFileSystem}.

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class OSSOutputStream extends OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(OSSOutputStream.class);
 
   /** Bucket name of the Alluxio OSS bucket. */
   private final String mBucketName;

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.oss;
 
-import alluxio.Constants;
 import alluxio.util.io.PathUtils;
 
 import com.aliyun.oss.OSSClient;

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -44,7 +44,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class OSSUnderFileSystem extends ObjectUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(OSSUnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
   private static final String FOLDER_SUFFIX = "_$folder$";

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3OutputStream.java
@@ -44,7 +44,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class S3OutputStream extends OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(S3OutputStream.class);
 
   /** Bucket name of the Alluxio S3 bucket. */
   private final String mBucketName;

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3UnderFileSystem.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class S3UnderFileSystem extends ObjectUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(S3UnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
   private static final String FOLDER_SUFFIX = "_$folder$";

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -12,7 +12,6 @@
 package alluxio.underfs.s3a;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.util.io.PathUtils;
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class S3AOutputStream extends OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(S3AOutputStream.class);
 
   private static final boolean SSE_ENABLED =
       Configuration.getBoolean(PropertyKey.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED);

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -60,7 +60,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class S3AUnderFileSystem extends ObjectUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(S3AUnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
   private static final String FOLDER_SUFFIX = "_$folder$";

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
@@ -36,8 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class SwiftMockOutputStream extends OutputStream {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SwiftMockOutputStream.class);
 
   private final File mFile;
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.swift;
 
-import alluxio.Constants;
 import alluxio.util.io.PathUtils;
 
 import org.javaswift.joss.model.Account;

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
@@ -28,8 +28,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class SwiftOutputStream extends OutputStream {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SwiftOutputStream.class);
 
   private OutputStream mOutputStream;
   private HttpURLConnection mHttpCon;

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
@@ -11,8 +11,6 @@
 
 package alluxio.underfs.swift;
 
-import alluxio.Constants;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -53,7 +53,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SwiftUnderFileSystem.class);
 
   /** Regexp for Swift container ACL separator, including optional whitespaces. */
   private static final String ACL_SEPARATOR_REGEXP = "\\s*,\\s*";

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystemFactory.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class SwiftUnderFileSystemFactory implements UnderFileSystemFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SwiftUnderFileSystemFactory.class);
 
   /**
    * Constructs a new {@link SwiftUnderFileSystemFactory}.

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
@@ -11,7 +11,6 @@
 
 package alluxio.underfs.swift.http;
 
-import alluxio.Constants;
 import alluxio.underfs.swift.SwiftOutputStream;
 
 import org.javaswift.joss.model.Access;

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
@@ -31,7 +31,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class SwiftDirectClient {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  private static final Logger LOG = LoggerFactory.getLogger(SwiftDirectClient.class);
+
   private static final int HTTP_READ_TIMEOUT = 100 * 1000;
   private static final int HTTP_CHUNK_STREAMING = 8 * 1024 * 1024;
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2563

Previously our logger names were broken, defaulting to a hardcoded string. Instead of using the user defined logger category (before it was broken), we now use the class name in order to better filter the logs and remove the need for expensive log4j patterns.

Previous log message:
`2017-02-17 20:06:48,830 WARN  type (LocalUnderFileSystem.java:setOwner) - In order for Alluxio to set local files with the correct user and groups, Alluxio should be the local file system superusers.`

New log message:
`2017-02-17 20:07:40,012 WARN  LocalUnderFileSystem - In order for Alluxio to set local files with the correct user and groups, Alluxio should be the local file system superusers.`