### PR TITLE
[SMALLFIX] Use lazy unmount for Linux.

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -103,9 +103,9 @@ function mount_ramfs_linux() {
   echo "Formatting RamFS: ${TIER_PATH} (${MEM_SIZE})"
   if mount | grep ${TIER_PATH} > /dev/null; then
     if [[ "$1" == "SudoMount" ]]; then
-      sudo umount -f ${TIER_PATH}
+      sudo umount -l -f ${TIER_PATH}
     else
-      umount -f ${TIER_PATH}
+      umount -l -f ${TIER_PATH}
     fi
     if [[ $? -ne 0 ]]; then
       echo "ERROR: umount RamFS ${TIER_PATH} failed" >&2


### PR DESCRIPTION
Using the `-l` flag for `umount` on Linux is a solution for the `umount: /mnt/ramdisk: device is busy.` issue (see http://unix.stackexchange.com/questions/19918/umount-device-is-busy)