### PR TITLE
[SMALLFIX] Fix a  session heartbeat bug

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/block/RetryHandlingBlockWorkerClient.java
@@ -324,9 +324,13 @@ public final class RetryHandlingBlockWorkerClient
         client.sessionHeartbeat(mSessionId, null);
         Metrics.BLOCK_WORKER_HEATBEATS.inc();
         return;
-      } catch (AlluxioTException | ThriftIOException e) {
-        exception = e;
+      } catch (AlluxioTException e) {
+        AlluxioException ae = AlluxioException.fromThrift(e);
+        LOG.warn(ae.getMessage());
+        throw new IOException(ae);
+      } catch (ThriftIOException e) {
         LOG.warn(e.getMessage());
+        throw new IOException(e);
       } catch (TException e) {
         client.getOutputProtocol().getTransport().close();
         exception = e;

--- a/core/common/src/main/java/alluxio/retry/CountingRetry.java
+++ b/core/common/src/main/java/alluxio/retry/CountingRetry.java
@@ -30,7 +30,7 @@ public class CountingRetry implements RetryPolicy {
    * @param maxRetries max number of retries
    */
   public CountingRetry(int maxRetries) {
-    Preconditions.checkArgument(maxRetries > 0, "Max retries must be a positive number");
+    Preconditions.checkArgument(maxRetries >= 0, "Max retries must be a positive number");
     mMaxRetries = maxRetries;
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -339,6 +339,8 @@ public final class TieredBlockStore implements BlockStore {
     }
     for (TempBlockMeta tempBlockMeta : tempBlocksToRemove) {
       try {
+        LOG.warn("Clean up expired temporary block {} from session {}.", tempBlockMeta.getBlockId(),
+            sessionId);
         abortBlockInternal(sessionId, tempBlockMeta.getBlockId());
       } catch (Exception e) {
         LOG.error("Failed to cleanup tempBlock {} due to {}", tempBlockMeta.getBlockId(),


### PR DESCRIPTION
1. Add logging on worker side when a temp block is deleted because of expired session.
2. Reenables worker session heartbeat which was disabled accidentally in (PR#4800) 
3. Improve exception handling in sessionHeartbeat