### PR TITLE
[SMALLFIX] Propagate original exception when falling back to UFS read

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -604,7 +604,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
         return createUnderStoreBlockInStream(blockStart, getBlockSize(blockStart),
             mStatus.getUfsPath());
       } catch (IOException e2) {
-        LOG.debug("Failed to read from UFS after failing to read from Alluxio: {}", e2);
+        LOG.debug("Failed to read from UFS after failing to read from Alluxio", e2);
         // UFS read failed; throw the original exception
         throw e;
       }

--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -600,8 +600,14 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
         throw e;
       }
       long blockStart = BlockId.getSequenceNumber(blockId) * mBlockSize;
-      return createUnderStoreBlockInStream(blockStart, getBlockSize(blockStart),
-          mStatus.getUfsPath());
+      try {
+        return createUnderStoreBlockInStream(blockStart, getBlockSize(blockStart),
+            mStatus.getUfsPath());
+      } catch (IOException e2) {
+        LOG.debug("Failed to read from UFS after failing to read from Alluxio: {}", e2);
+        // UFS read failed; throw the original exception
+        throw e;
+      }
     }
   }
 


### PR DESCRIPTION
Especially with delegation enabled, it's confusing to receive exceptions complaining that the client can't talk directly to the UFS. With this change we will log the UFS exception for debugging purposes, and propagate the exception that caused us to attempt the direct UFS read in the first place.