### PR TITLE
[ALLUXIO-2545] Fix Security errors reported when running format locally

### DIFF
--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -26,6 +26,7 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
+import alluxio.util.SecurityUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -235,6 +236,15 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
     } else {
       return null;
     }
+  }
+
+  @Override
+  public boolean mkdirs(String path) throws IOException {
+    MkdirsOptions options = MkdirsOptions.defaults();
+    options.setOwner(SecurityUtils.getOwnerFromLoginModule());
+    options.setGroup(SecurityUtils.getGroupFromLoginModule());
+
+    return mkdirs(path, options);
   }
 
   @Override


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2545

2017-03-10 19:47:10,176 ERROR type (LocalUnderFileSystem.java:setOwner) - Fail to set owner for /data/Checkout/github-xiaochang/alluxio-1.4/journal/BlockMaster with user: , group: 

The default user and group provided to MkdirsOptions is "".

For version 1.4.0. it appears in log/user_xiaochang.log.
For version 1.5.0. it appears in the console output.

Fixed by overriding mkdirs from LocalUnderFileSystem.java to provide a default value from LoginModule. Don't know if it's appropriate or anything else not considered.


