### PR TITLE
[SMALLFIX]Correct the javadoc of getLostWorkersInfoList

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -301,7 +301,7 @@ public final class BlockMaster extends AbstractMaster implements ContainerIdGene
   }
 
   /**
-   * @return a set of {@link WorkerInfo}s of lost workers
+   * @return a list of {@link WorkerInfo}s of lost workers
    */
   public List<WorkerInfo> getLostWorkersInfoList() {
     List<WorkerInfo> ret = new ArrayList<>(mLostWorkers.size());


### PR DESCRIPTION
Return type has changed from `Set` to `List`, but javadoc still `Set`