### PR TITLE
[SMALLFIX]Fix javadoc checkstyle bug

### DIFF
--- a/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
+++ b/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
@@ -16,6 +16,7 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.ExecutorService;
 
 import javax.annotation.concurrent.NotThreadSafe;
+
 /**
  * This is the base class for all workers, and contains common functionality.
  */


### PR DESCRIPTION
before `class_def` should have a blank line.