### PR TITLE
[ALLUXIO-2587] Mark StreamCache as ThreadSafe and add concurrent test.

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/StreamCache.java
+++ b/core/server/proxy/src/main/java/alluxio/StreamCache.java
@@ -25,7 +25,7 @@ import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Cache for storing file input and output streams.
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * lookups of the stream. The streams are automatically closed when their cache entry is
  * invalidated or after being inactive for an extended period of time.
  */
-@NotThreadSafe
+@ThreadSafe
 public final class StreamCache {
   private static final Logger LOG = LoggerFactory.getLogger(StreamCache.class);
 
@@ -118,5 +118,12 @@ public final class StreamCache {
       return os;
     }
     return null;
+  }
+
+  /**
+   * @return total size of the cache for both input streams and output streams
+   */
+  public long size() {
+    return mInStreamCache.size() + mOutStreamCache.size();
   }
 }

--- a/core/server/proxy/src/test/java/alluxio/StreamCacheTest.java
+++ b/core/server/proxy/src/test/java/alluxio/StreamCacheTest.java
@@ -18,6 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class StreamCacheTest {
   @Test
   public void operations() throws Exception {
@@ -34,8 +37,51 @@ public class StreamCacheTest {
     Assert.assertSame(os, streamCache.invalidate(osId));
     Assert.assertNull(streamCache.invalidate(isId));
     Assert.assertNull(streamCache.invalidate(osId));
+    Assert.assertNull(streamCache.getInStream(isId));
+    Assert.assertNull(streamCache.getOutStream(osId));
     Mockito.verify(is).close();
     Mockito.verify(os).close();
+  }
+
+  @Test
+  public void concurrentOperations() throws Exception {
+    final StreamCache streamCache = new StreamCache(Constants.HOUR_MS);
+
+    class CacheTest<T> implements Runnable {
+      private T mStream;
+
+      CacheTest(T stream) {
+        mStream = stream;
+      }
+
+      @Override
+      public void run() {
+        int cacheID = 0;
+        if (mStream instanceof FileInStream) {
+          cacheID = streamCache.put((FileInStream) mStream);
+          Assert.assertSame(mStream, streamCache.getInStream(cacheID));
+        }
+        if (mStream instanceof FileOutStream) {
+          cacheID = streamCache.put((FileOutStream) mStream);
+          Assert.assertSame(mStream, streamCache.getOutStream(cacheID));
+        }
+        Assert.assertSame(mStream, streamCache.invalidate(cacheID));
+      }
+    }
+
+    final int numOps = 100;
+    final List<Thread> threads = new ArrayList<>();
+    for (int i = 0; i < numOps; i++) {
+      threads.add(new Thread(new CacheTest<>(Mockito.mock(FileInStream.class))));
+      threads.add(new Thread(new CacheTest<>(Mockito.mock(FileOutStream.class))));
+    }
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    for (Thread thread : threads) {
+      thread.join();
+    }
+    Assert.assertEquals(0, streamCache.size());
   }
 
   @Test
@@ -47,5 +93,21 @@ public class StreamCacheTest {
     streamCache.put(os);
     Mockito.verify(is).close();
     Mockito.verify(os).close();
+  }
+
+  @Test
+  public void size() throws Exception {
+    StreamCache streamCache = new StreamCache(Constants.HOUR_MS);
+    FileInStream is = Mockito.mock(FileInStream.class);
+    FileOutStream os = Mockito.mock(FileOutStream.class);
+    Assert.assertEquals(0, streamCache.size());
+    int isId = streamCache.put(is);
+    Assert.assertEquals(1, streamCache.size());
+    int osId = streamCache.put(os);
+    Assert.assertEquals(2, streamCache.size());
+    streamCache.invalidate(isId);
+    Assert.assertEquals(1, streamCache.size());
+    streamCache.invalidate(osId);
+    Assert.assertEquals(0, streamCache.size());
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2587

Adds concurrent test to StreamCache and mark it as @ThreadSafe.

Although the cached FileInStream and FileOutStream are not thread safe, but the StreamCache is thread safe, which means concurrent put, get, invalidate operations won't cause damage to StreamCache.