### PR TITLE
ALLUXIO­2590] Fix logging style in AlluxioBlockStore

### DIFF
--- a/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -153,7 +153,7 @@ public final class AlluxioBlockStore {
               .createLocalBlockInStream(mContext, blockId, blockInfo.getLength(), workerNetAddress,
                   options);
         } catch (IOException e) {
-          LOG.warn("Failed to open local stream for block " + blockId + ". " + e.getMessage());
+          LOG.warn("Failed to open local stream for block {}: {}", blockId, e.getMessage());
           // Getting a local stream failed, do not try again
           break;
         }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2590

Replaced
LOG.warn("Failed to open local stream for block " + blockId + ". " + e.getMessage());
with
LOG.warn("Failed to open local stream for block {}: {}", blockId, e.getMessage());