### PR TITLE
[SMALLFIX]Added a `worker Id` table column to the workers page.

### DIFF
--- a/core/server/common/src/main/webapp/workers.jsp
+++ b/core/server/common/src/main/webapp/workers.jsp
@@ -35,8 +35,8 @@
             <table class="table table-hover table-condensed">
               <thead>
                 <th>Node Name</th>
-                <th>Worker Id</th>
                 <% if ((Boolean) request.getAttribute("debug")) { %>
+                  <th>Worker Id</th>
                   <th>[D]Uptime</th>
                 <% } %>
                 <th>Last Heartbeat</th>
@@ -49,8 +49,8 @@
                 <% for (WebInterfaceWorkersServlet.NodeInfo nodeInfo : ((WebInterfaceWorkersServlet.NodeInfo[]) request.getAttribute("normalNodeInfos"))) { %>
                   <tr>
                     <th><a href="http://<%= nodeInfo.getHost() %>:<%= nodeInfo.getWebPort() %>"><%= nodeInfo.getHost() %></a></th>
-                    <th><%= nodeInfo.getWorkerId() %></th>
                     <% if ((Boolean) request.getAttribute("debug")) { %>
+                      <th><%= nodeInfo.getWorkerId() %></th>
                       <th><%= nodeInfo.getUptimeClockTime() %></th>
                     <% } %>
                     <th><%= nodeInfo.getLastHeartbeat() %></th>
@@ -94,6 +94,7 @@
               <thead>
                 <th>Node Name</th>
                 <% if ((Boolean) request.getAttribute("debug")) { %>
+                  <th>Worker Id</th>
                   <th>[D]Uptime</th>
                 <% } %>
                 <th>Last Heartbeat</th>
@@ -105,6 +106,7 @@
                   <tr>
                     <th><a href="http://<%= nodeInfo.getHost() %>:<%= nodeInfo.getWebPort() %>"><%= nodeInfo.getHost() %></a></th>
                     <% if ((Boolean) request.getAttribute("debug")) { %>
+                      <th><%= nodeInfo.getWorkerId() %></th>
                       <th><%= nodeInfo.getUptimeClockTime() %></th>
                     <% } %>
                     <th><%= nodeInfo.getLastHeartbeat() %></th>

--- a/core/server/common/src/main/webapp/workers.jsp
+++ b/core/server/common/src/main/webapp/workers.jsp
@@ -36,7 +36,7 @@
               <thead>
                 <th>Node Name</th>
                 <% if ((Boolean) request.getAttribute("debug")) { %>
-                  <th>Worker Id</th>
+                  <th>[D]Worker Id</th>
                   <th>[D]Uptime</th>
                 <% } %>
                 <th>Last Heartbeat</th>
@@ -94,7 +94,7 @@
               <thead>
                 <th>Node Name</th>
                 <% if ((Boolean) request.getAttribute("debug")) { %>
-                  <th>Worker Id</th>
+                  <th>[D]Worker Id</th>
                   <th>[D]Uptime</th>
                 <% } %>
                 <th>Last Heartbeat</th>

--- a/core/server/common/src/main/webapp/workers.jsp
+++ b/core/server/common/src/main/webapp/workers.jsp
@@ -35,6 +35,7 @@
             <table class="table table-hover table-condensed">
               <thead>
                 <th>Node Name</th>
+                <th>Worker Id</th>
                 <% if ((Boolean) request.getAttribute("debug")) { %>
                   <th>[D]Uptime</th>
                 <% } %>
@@ -48,6 +49,7 @@
                 <% for (WebInterfaceWorkersServlet.NodeInfo nodeInfo : ((WebInterfaceWorkersServlet.NodeInfo[]) request.getAttribute("normalNodeInfos"))) { %>
                   <tr>
                     <th><a href="http://<%= nodeInfo.getHost() %>:<%= nodeInfo.getWebPort() %>"><%= nodeInfo.getHost() %></a></th>
+                    <th><%= nodeInfo.getWorkerId() %></th>
                     <% if ((Boolean) request.getAttribute("debug")) { %>
                       <th><%= nodeInfo.getUptimeClockTime() %></th>
                     <% } %>

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceWorkersServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceWorkersServlet.java
@@ -49,6 +49,7 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
     private final int mFreePercent;
     private final int mUsedPercent;
     private final String mUptimeClockTime;
+    private final long mWorkerId;
 
     private NodeInfo(WorkerInfo workerInfo) {
       mHost = workerInfo.getAddress().getHost();
@@ -66,6 +67,7 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
       mUptimeClockTime =
           WebUtils.convertMsToShortClockTime(
               System.currentTimeMillis() - workerInfo.getStartTimeMs());
+      mWorkerId = workerInfo.getId();
     }
 
     /**
@@ -129,6 +131,13 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
      */
     public int getUsedSpacePercent() {
       return mUsedPercent;
+    }
+
+    /**
+     * @return the worker id
+     */
+    public long getWorkerId() {
+      return mWorkerId;
     }
 
     /**


### PR DESCRIPTION
Without worker id, we don't konw the workerid in the `master.log` means which worker.
Now we can find worker hostname from worker id in the workers page.