### PR TITLE
[SMALLFIX] Reduce log level of Zookeeper master lookup

### DIFF
--- a/core/common/src/main/java/alluxio/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/MasterInquireClient.java
@@ -99,7 +99,7 @@ public final class MasterInquireClient {
         ZooKeeper zookeeper = curatorClient.getZooKeeper();
         if (zookeeper.exists(mLeaderPath, false) != null) {
           List<String> masters = zookeeper.getChildren(mLeaderPath, null);
-          LOG.info("Master addresses: {}", masters);
+          LOG.debug("Master addresses: {}", masters);
           if (masters.size() >= 1) {
             if (masters.size() == 1) {
               return masters.get(0);
@@ -114,7 +114,7 @@ public final class MasterInquireClient {
                 leader = master;
               }
             }
-            LOG.info("The leader master: {}", leader);
+            LOG.debug("The leader master: {}", leader);
             return leader;
           }
         } else {


### PR DESCRIPTION
This lookup can happen very often, and the logs are only useful for debugging
purposes. The logged information can also be found by running the masterInfo
shell command or using the Zookeeper CLI.