### PR TITLE
[ALLUXIO-2527] Update setTtl documentation grammar

### DIFF
--- a/docs/_data/table/en/operation-command.yml
+++ b/docs/_data/table/en/operation-command.yml
@@ -73,7 +73,7 @@ rmr:
   Remove a file, or a directory with all the files and sub-directories that this directory
   contains.
 setTtl:
-  Set the TTL (time to live) in milliseconds to a file. Allowing to perform either "delete"
+  Set the TTL (time to live) in milliseconds to a file. Allow to perform either "delete"
   or "free" after expiry of ttl interval.
 tail:
   Print the last 1KB of the specified file to the console.


### PR DESCRIPTION
Fix the grammar of setTtl documentation in `docs/_data/table/en/operation-command.yml`.
https://alluxio.atlassian.net/browse/ALLUXIO-2527