### PR TITLE
[ALLUXIO-2490] change name of method 'setTtlForFileWithFreeOperationTest()'

### DIFF
--- a/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -769,7 +769,7 @@ public final class FileSystemMasterTest {
    * to 0.
    */
   @Test
-  public void setTtlForFileWithFreeOperationTest() throws Exception {
+  public void setTtlForFileWithFreeOperation() throws Exception {
     long blockId = createFileWithSingleBlock(NESTED_FILE_URI);
     Assert.assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2490
According to the Alluxio unit test style guide, test names should not contain the "Test" suffix.
Consequently, the FileSystemMasterTest#setTtlForFileWithFreeOperationTest() should be renamed to setTtlForFileWithFreeOperation().