### PR TITLE
[ALLUXIO-2615] modify the deprecated Throwables

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -158,7 +158,6 @@ public final class FileSystemUtils {
         } catch (Exception e) {
           Throwables.propagateIfPossible(e);
           throw new RuntimeException(e);
-          //throw Throwables.propagate(e);
         }
       }
     }, WaitForOptions.defaults().setTimeout(20 * Constants.MINUTE_MS)

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -156,7 +156,9 @@ public final class FileSystemUtils {
         try {
           return fs.getStatus(uri).isPersisted();
         } catch (Exception e) {
-          throw Throwables.propagate(e);
+          Throwables.propagateIfPossible(e);
+          throw new RuntimeException(e);
+          //throw Throwables.propagate(e);
         }
       }
     }, WaitForOptions.defaults().setTimeout(20 * Constants.MINUTE_MS)


### PR DESCRIPTION
[https://alluxio.atlassian.net/browse/ALLUXIO-2615](https://alluxio.atlassian.net/browse/ALLUXIO-2615)
## Deprecate Throwables.propagate with RuntimeException in FileSystemUtils.java

This JIRA modifies core/client/src/main/java/alluxio/client/file/FileSystemUtils.java to replace
```java
throw Throwables.propagate(e);
```
with
```java
Throwables.propagateIfPossible(e);
throw new RuntimeException(e);
```