### PR TITLE
[ALLUXIO-2633] fix copyToLocal command

### DIFF
--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -13,6 +13,7 @@ package alluxio;
 
 import alluxio.annotation.PublicApi;
 import alluxio.util.URIUtils;
+import alluxio.util.io.PathUtils;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -447,5 +448,19 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
       sb.append(mUri.getQuery());
     }
     return sb.toString();
+  }
+
+  /**
+   * Gets the path component of the {@link AlluxioURI}.
+   *
+   * @return the absolute path
+   */
+  public String getAbsolutePath() {
+    if (mUri.getAuthority() != null) {
+      return PathUtils.concatPath(System.getProperty("user.dir"),
+              mUri.getAuthority().equals(".") ? mUri.getPath() : mUri.getAuthority());
+    } else {
+      return mUri.getPath();
+    }
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -27,6 +27,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.shell.AlluxioShellUtils;
 import alluxio.util.io.PathUtils;
+import alluxio.PropertyKey.Name;
 
 import com.google.common.base.Joiner;
 import com.google.common.io.Closer;
@@ -554,7 +555,7 @@ public final class CpCommand extends AbstractShellCommand {
     File dstFile = new File(dstPath.getPath());
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
-    File tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);
+    File tmpDst = new File(Name.HOME + randomSuffix);
 
     try (Closer closer = Closer.create()) {
       OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -221,8 +221,7 @@ public final class CpCommand extends AbstractShellCommand {
         try {
           copy(new AlluxioURI(srcPath.getScheme(), srcPath.getAuthority(), status.getPath()),
               new AlluxioURI(dstPath.getScheme(), dstPath.getAuthority(),
-                  PathUtils
-                          .concatPath(dstPath.getPath(), status.getName())), recursive);
+                  PathUtils.concatPath(dstPath.getPath(), status.getName())), recursive);
         } catch (IOException e) {
           errorMessages.add(e.getMessage());
         }

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -555,7 +555,8 @@ public final class CpCommand extends AbstractShellCommand {
     File dstFile = new File(dstPath.getPath());
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
-    File tmpDst = new File(Name.HOME + randomSuffix);
+    File tmpDst = new File(PathUtils.concatPath( dstFile.getAbsolutePath(),
+            srcPath.getName() + randomSuffix));
 
     try (Closer closer = Closer.create()) {
       OpenFileOptions options = OpenFileOptions.defaults().setReadType(ReadType.NO_CACHE);

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -551,36 +551,18 @@ public final class CpCommand extends AbstractShellCommand {
    */
   private void copyFileToLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
-    File dstFile = new File(dstPath.getPath());
+    File dstFile = new File(dstPath.getAbsolutePath());
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
     File tmpDst;
     File outputFile;
-    String dstAbsolute = dstFile.getAbsolutePath();
-    String fileName;
-    if (dstPath.getPath().equals("")) {
-      // current directory
-      if (dstPath.getAuthority().equals(".")) {
-        fileName = srcPath.getName();
-      } else {
-        fileName = dstPath.getAuthority();
-      }
+    if (dstFile.isDirectory()) {
+      tmpDst = new File(PathUtils.concatPath(dstFile.getAbsolutePath(),
+              srcPath.getName() + randomSuffix));
+      outputFile = new File(PathUtils.concatPath(dstFile.getAbsolutePath()), srcPath.getName());
     } else {
-      fileName = dstPath.getName();
-    }
-
-    if (new File(dstAbsolute).exists()) {
-      if (new File(dstAbsolute).isFile()) {
-        tmpDst = new File(dstAbsolute + randomSuffix);
-        outputFile = new File(dstAbsolute);
-      } else {
-        tmpDst = new File(PathUtils.concatPath(dstFile.getAbsolutePath(),
-                fileName + randomSuffix));
-        outputFile = new File(PathUtils.concatPath(dstFile.getAbsolutePath(), fileName));
-      }
-    } else {
-      tmpDst = new File(dstFile.getParent(), fileName + randomSuffix);
-      outputFile = new File(dstFile.getParent(), fileName);
+      tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);
+      outputFile = new File(dstFile.getAbsolutePath());
     }
 
     try (Closer closer = Closer.create()) {

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -555,19 +555,33 @@ public final class CpCommand extends AbstractShellCommand {
     File dstFile = new File(dstPath.getPath());
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
-    File tmpDst, outputFile;
+    File tmpDst;
+    File outputFile;
     String dstAbsolute = dstFile.getAbsolutePath();
-    if (new File (dstAbsolute).exists()) {
+    String fileName;
+    if (dstPath.getPath().equals("")) {
+      // current directory
+      if (dstPath.getAuthority().equals(".")) {
+        fileName = srcPath.getName();
+      } else {
+        fileName = dstPath.getAuthority();
+      }
+    } else {
+      fileName = dstPath.getName();
+    }
+
+    if (new File(dstAbsolute).exists()) {
       if (new File(dstAbsolute).isFile()) {
         tmpDst = new File(dstAbsolute + randomSuffix);
         outputFile = new File(dstAbsolute);
       } else {
-        tmpDst = new File(PathUtils.concatPath(dstFile.getAbsolutePath(), srcPath.getName() + randomSuffix));
-        outputFile = new File(PathUtils.concatPath(dstFile.getAbsolutePath(),srcPath.getName()));
+        tmpDst = new File(PathUtils.concatPath(dstFile.getAbsolutePath(),
+                fileName + randomSuffix));
+        outputFile = new File(PathUtils.concatPath(dstFile.getAbsolutePath(), fileName));
       }
     } else {
-      tmpDst = new File(dstFile.getParent(), srcPath.getName() + randomSuffix);
-      outputFile = new File(dstFile.getParent(), srcPath.getName());
+      tmpDst = new File(dstFile.getParent(), fileName + randomSuffix);
+      outputFile = new File(dstFile.getParent(), fileName);
     }
 
     try (Closer closer = Closer.create()) {

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -221,7 +221,8 @@ public final class CpCommand extends AbstractShellCommand {
         try {
           copy(new AlluxioURI(srcPath.getScheme(), srcPath.getAuthority(), status.getPath()),
               new AlluxioURI(dstPath.getScheme(), dstPath.getAuthority(),
-                  PathUtils.concatPath(dstPath.getPath(), status.getName())), recursive);
+                  PathUtils
+                          .concatPath(dstPath.getPath(), status.getName())), recursive);
         } catch (IOException e) {
           errorMessages.add(e.getMessage());
         }
@@ -552,7 +553,6 @@ public final class CpCommand extends AbstractShellCommand {
   private void copyFileToLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
     File dstFile = new File(dstPath.getPath());
-    String fileName = srcPath.getName();
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
     File tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);
@@ -567,8 +567,8 @@ public final class CpCommand extends AbstractShellCommand {
         out.write(buf, 0, t);
         t = is.read(buf);
       }
-      File outputFile = new File(dstFile.getAbsolutePath() + "/" + fileName);
-      if (!tmpDst.renameTo(outputFile) {
+      File outputFile = new File(PathUtils.concatPath(dstFile.getAbsolutePath(),srcPath.getName()));
+      if (!tmpDst.renameTo(outputFile)) {
         throw new IOException(
             "Failed to rename " + tmpDst.getPath() + " to destination " + outputFile.getPath());
       }

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -552,6 +552,7 @@ public final class CpCommand extends AbstractShellCommand {
   private void copyFileToLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
     File dstFile = new File(dstPath.getPath());
+    String fileName = srcPath.getPath().substring(srcPath.getPath().lastIndexOf("/"));
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
     File tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);
@@ -566,11 +567,12 @@ public final class CpCommand extends AbstractShellCommand {
         out.write(buf, 0, t);
         t = is.read(buf);
       }
-      if (!tmpDst.renameTo(dstFile)) {
+      File outputFile = new File(dstFile.getAbsolutePath() + "/" + fileName));
+      if (!tmpDst.renameTo(outputFile) {
         throw new IOException(
-            "Failed to rename " + tmpDst.getPath() + " to destination " + dstPath);
+            "Failed to rename " + tmpDst.getPath() + " to destination " + outputFile.getPath());
       }
-      System.out.println("Copied " + srcPath + " to " + dstPath);
+      System.out.println("Copied " + srcPath + " to " + outputFile.getPath());
     } finally {
       tmpDst.delete();
     }

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -81,8 +81,7 @@ public final class CpCommand extends AbstractShellCommand {
     AlluxioURI dstPath = new AlluxioURI(args[1]);
     if ((dstPath.getScheme() == null || isAlluxio(dstPath.getScheme()))
         && isFile(srcPath.getScheme())) {
-      String path = srcPath.getPath();
-      List<File> srcFiles = AlluxioShellUtils.getFiles(path);
+      List<File> srcFiles = AlluxioShellUtils.getFiles(srcPath.getPath());
       if (srcFiles.size() == 0) {
         throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath));
       }

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -27,7 +27,6 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.shell.AlluxioShellUtils;
 import alluxio.util.io.PathUtils;
-import alluxio.PropertyKey.Name;
 
 import com.google.common.base.Joiner;
 import com.google.common.io.Closer;
@@ -42,7 +41,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -567,7 +567,7 @@ public final class CpCommand extends AbstractShellCommand {
         out.write(buf, 0, t);
         t = is.read(buf);
       }
-      File outputFile = new File(dstFile.getAbsolutePath() + "/" + fileName));
+      File outputFile = new File(dstFile.getAbsolutePath() + "/" + fileName);
       if (!tmpDst.renameTo(outputFile) {
         throw new IOException(
             "Failed to rename " + tmpDst.getPath() + " to destination " + outputFile.getPath());

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -552,7 +552,7 @@ public final class CpCommand extends AbstractShellCommand {
   private void copyFileToLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
     File dstFile = new File(dstPath.getPath());
-    String fileName = srcPath.getPath().substring(srcPath.getPath().lastIndexOf("/"));
+    String fileName = srcPath.getName();
     String randomSuffix =
         String.format(".%s_copyToLocal_", RandomStringUtils.randomAlphanumeric(8));
     File tmpDst = new File(dstFile.getAbsolutePath() + randomSuffix);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2633
bin/alluxio fs copyToLocal /LICENSE .
Failed to rename /Users/aja/alluxio/..WQnkYKkm_copyToLocal_ to destination .

By adding filename to the destination file can solve the problem. 