### PR TITLE
[ALLUXIO-2481]Remove unnecessary toString() in setProperty in KeyValuePartitionIntegrationTest.java

### DIFF
--- a/tests/src/test/java/alluxio/client/keyvalue/KeyValuePartitionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/keyvalue/KeyValuePartitionIntegrationTest.java
@@ -77,7 +77,7 @@ public final class KeyValuePartitionIntegrationTest {
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, Constants.GB)
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE)
           /* ensure key-value service is turned on */
-          .setProperty(PropertyKey.KEY_VALUE_ENABLED, "true")
+          .setProperty(PropertyKey.KEY_VALUE_ENABLED, true)
           .build();
 
   @BeforeClass


### PR DESCRIPTION
JIRA ticket:https://alluxio.atlassian.net/browse/ALLUXIO-2481

In alluxio/client/keyvalue/KeyValuePartitionIntegrationTest.java:
from
          .setProperty(PropertyKey.KEY_VALUE_ENABLED, "true")
to
          .setProperty(PropertyKey.KEY_VALUE_ENABLED, true)