### PR TITLE
[ALLUXIO-2470]Fix leaking resource in AbstractFileSystemTest

### DIFF
--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,6 +279,8 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
+
+    alluxioHadoopFs.close();
   }
 
   @Test

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,7 +279,6 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
-
     alluxioHadoopFs.close();
   }
 


### PR DESCRIPTION
JIRA ticket:https://alluxio.atlassian.net/browse/ALLUXIO-2470

In the listStatus method, we create a filesystem with
    FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
add
    alluxioHadoopFs.close();
at the end of the method