### PR TITLE
[ALLUXIO-2470]Fix leaking resource in AbstractFileSystemTest

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -128,7 +128,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
   @Override
   public void close() throws IOException {
-    if (mContext != FileSystemContext.INSTANCE) {
+    if (mContext != null && mContext != FileSystemContext.INSTANCE) {
       mContext.close();
     }
     super.close();

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,6 +279,8 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
+
+    alluxioHadoopFs.close();
   }
 
   @Test

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,7 +279,9 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
-    alluxioHadoopFs.close();
+    if(alluxioHadoopFs != null){
+      alluxioHadoopFs.close();
+    }
   }
 
   @Test

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,7 +279,6 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
-
     alluxioHadoopFs.close();
   }
 

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,7 +279,7 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
-    if(alluxioHadoopFs != null){
+    if (alluxioHadoopFs != null) {
       alluxioHadoopFs.close();
     }
   }

--- a/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -279,9 +279,7 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
-    if (alluxioHadoopFs != null) {
-      alluxioHadoopFs.close();
-    }
+    alluxioHadoopFs.close();
   }
 
   @Test


### PR DESCRIPTION
JIRA ticket:https://alluxio.atlassian.net/browse/ALLUXIO-2470

In the listStatus method, we create a filesystem with
FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
add
alluxioHadoopFs.close();
at the end of the method