### PR TITLE
[ALLUXIO-2581] Clean up comment style in CommonUtils

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -203,7 +203,7 @@ public final class CommonUtils {
     try {
       result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand(user));
     } catch (ExitCodeException e) {
-      // if we didn't get the group - just return empty list;
+      // if we didn't get the group - just return empty list
       LOG.warn("got exception trying to get groups for user " + user + ": " + e.getMessage());
       return groups;
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2581
Remove the semi-colon at the end of the comment.