### PR TITLE
[SMALLFIX] Alluxio format improvement

### DIFF
--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -82,7 +82,7 @@ public final class Format {
       LOG.error("Failed to format", e);
       System.exit(-1);
     }
-    LOG.info("Format completes");
+    LOG.info("Formatting complete");
     System.exit(0);
   }
 

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -116,8 +116,8 @@ public final class Format {
             try {
               formatFolder(name, dirWorkerDataFolder);
             } catch (IOException e) {
-              throw new RuntimeException(String.format("Failed to format worker data folder %s " +
-                  "due to %s", dirWorkerDataFolder, e.getMessage()));
+              throw new RuntimeException(String.format("Failed to format worker data folder %s "
+                  + "due to %s", dirWorkerDataFolder, e.getMessage()));
             }
           }
         }

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -55,12 +55,12 @@ public final class Format {
           failedToDelete = !ufs.deleteFile(childPath);
         }
         if (failedToDelete) {
-          LOG.info("Failed to delete {}", childPath);
+          LOG.error("Failed to delete {}", childPath);
           return false;
         }
       }
     } else if (!ufs.mkdirs(folder)) {
-      LOG.info("Failed to create {}:{}", name, folder);
+      LOG.error("Failed to create {}:{}", name, folder);
       return false;
     }
     return true;
@@ -82,6 +82,7 @@ public final class Format {
       LOG.error("Failed to format", e);
       System.exit(-1);
     }
+    LOG.info("Format completes");
     System.exit(0);
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsMutableJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsMutableJournal.java
@@ -46,6 +46,7 @@ public class UfsMutableJournal extends UfsJournal implements MutableJournal {
 
   @Override
   public void format() throws IOException {
+    LOG.info("Formatting {}", mLocation);
     UnderFileSystem ufs = UnderFileSystem.Factory.get(mLocation.toString());
     if (ufs.isDirectory(mLocation.toString())) {
       for (UnderFileStatus p : ufs.listStatus(mLocation.toString())) {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -31,6 +31,7 @@ import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -324,10 +325,10 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
   public void setOwner(String path, String user, String group) throws IOException {
     path = stripPath(path);
     try {
-      if (user != null) {
+      if (!Strings.isNullOrEmpty(user)) {
         FileUtils.changeLocalFileUser(path, user);
       }
-      if (group != null) {
+      if (!Strings.isNullOrEmpty(group)) {
         FileUtils.changeLocalFileGroup(path, group);
       }
     } catch (IOException e) {


### PR DESCRIPTION
- Print complete when format is done. otherwise it is hard to tell error or fine
- mkdir should not set owner /group when owner/group are empty string (default value for create dir Option. This is surfaced by running `alluxio format`. Previously you will see format error message like this:

```
$ bin/alluxio format
Executing the following command on all worker nodes and logging to /Users/binfan/tmp/alluxio/bin/../logs/task.log: /Users/binfan/tmp/alluxio/bin/alluxio formatWorker
Waiting for tasks to finish...
All tasks finished
Formatting Alluxio Master @ apc999
2017-03-22 11:11:43,624 INFO  Format - Formatting JOURNAL_FOLDER:/Users/binfan/tmp/alluxio/journal
2017-03-22 11:11:43,629 INFO  Format - Formatting BlockMaster_JOURNAL_FOLDER:/Users/binfan/tmp/alluxio/journal/BlockMaster
2017-03-22 11:11:43,638 ERROR LocalUnderFileSystem - Fail to set owner for /Users/binfan/tmp/alluxio/journal/BlockMaster with user: , group: 
2017-03-22 11:11:43,638 WARN  LocalUnderFileSystem - In order for Alluxio to set local files with the correct user and groups, Alluxio should be the local file system superusers.
2017-03-22 11:11:43,638 WARN  LocalUnderFileSystem - Failed to update the ufs dir ownership, default values will be used. java.nio.file.attribute.UserPrincipalNotFoundException
2017-03-22 11:11:43,639 INFO  Format - Formatting FileSystemMaster_JOURNAL_FOLDER:/Users/binfan/tmp/alluxio/journal/FileSystemMaster
2017-03-22 11:11:43,642 ERROR LocalUnderFileSystem - Fail to set owner for /Users/binfan/tmp/alluxio/journal/FileSystemMaster with user: , group: 
2017-03-22 11:11:43,642 WARN  LocalUnderFileSystem - In order for Alluxio to set local files with the correct user and groups, Alluxio should be the local file system superusers.
2017-03-22 11:11:43,642 WARN  LocalUnderFileSystem - Failed to update the ufs dir ownership, default values will be used. java.nio.file.attribute.UserPrincipalNotFoundException
2017-03-22 11:11:43,642 INFO  Format - Formatting LineageMaster_JOURNAL_FOLDER:/Users/binfan/tmp/alluxio/journal/LineageMaster
2017-03-22 11:11:43,645 ERROR LocalUnderFileSystem - Fail to set owner for /Users/binfan/tmp/alluxio/journal/LineageMaster with user: , group: 
2017-03-22 11:11:43,645 WARN  LocalUnderFileSystem - In order for Alluxio to set local files with the correct user and groups, Alluxio should be the local file system superusers.
2017-03-22 11:11:43,645 WARN  LocalUnderFileSystem - Failed to update the ufs dir ownership, default values will be used. java.nio.file.attribute.UserPrincipalNotFoundException
```
