### PR TITLE
[SMALLFIX] Remove unnecessary initialization of ALLUXIO_SHELL_JAVA_OPTS in bin/alluxio

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -196,7 +196,6 @@ function main {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 
   PARAMETER=""
-  ALLUXIO_SHELL_JAVA_OPTS=""
 
   case ${COMMAND} in
   "format")


### PR DESCRIPTION
This will prevent setting ALLUXIO_SHELL_JAVA_OPTS in shell to take effect