### PR TITLE
[ALLUXIO-2649] add double quote. Correctly dereference JAVA and JAVA_HOME

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -164,7 +164,7 @@ function runJavaClass {
           *) CLASS_ARGS+=" ${arg}"
       esac
   done
-  ${JAVA} -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} ${CLASS_ARGS}
+  "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} ${CLASS_ARGS}
 }
 
 function main {

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -146,7 +146,7 @@ start_master() {
   fi
 
   echo "Starting master @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
-  (nohup ${JAVA} -cp ${CLASSPATH} \
+  (nohup "${JAVA}" -cp ${CLASSPATH} \
    ${ALLUXIO_MASTER_JAVA_OPTS} \
    alluxio.master.AlluxioMaster > ${ALLUXIO_LOGS_DIR}/master.out 2>&1) &
 }
@@ -157,7 +157,7 @@ start_proxy() {
   fi
 
   echo "Starting proxy @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
-  (nohup ${JAVA} -cp ${CLASSPATH} \
+  (nohup "${JAVA}" -cp ${CLASSPATH} \
    ${ALLUXIO_PROXY_JAVA_OPTS} \
    alluxio.proxy.AlluxioProxy > ${ALLUXIO_LOGS_DIR}/proxy.out 2>&1) &
 }
@@ -174,7 +174,7 @@ start_worker() {
   fi
 
   echo "Starting worker @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
-  (nohup ${JAVA} -cp ${CLASSPATH} \
+  (nohup "${JAVA}" -cp ${CLASSPATH} \
    ${ALLUXIO_WORKER_JAVA_OPTS} \
    alluxio.worker.AlluxioWorker > ${ALLUXIO_LOGS_DIR}/worker.out 2>&1 ) &
 }
@@ -187,7 +187,7 @@ restart_worker() {
   RUN=$(ps -ef | grep "alluxio.worker.AlluxioWorker" | grep "java" | wc | cut -d" " -f7)
   if [[ ${RUN} -eq 0 ]]; then
     echo "Restarting worker @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
-    (nohup ${JAVA} -cp ${CLASSPATH} \
+    (nohup "${JAVA}" -cp ${CLASSPATH} \
      ${ALLUXIO_WORKER_JAVA_OPTS} \
      alluxio.worker.AlluxioWorker > ${ALLUXIO_LOGS_DIR}/worker.out 2>&1) &
   fi

--- a/integration/fuse/bin/alluxio-fuse.sh
+++ b/integration/fuse/bin/alluxio-fuse.sh
@@ -22,7 +22,7 @@ get_env () {
 }
 
 check_java_version () {
-  local java_mjr_vers=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F'.' '{print $1 $2}')
+  local java_mjr_vers=$("${JAVA}" -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F'.' '{print $1 $2}')
   if [[ ${java_mjr_vers} -lt 18 ]]; then
     echo "It seems you are running a version of Java which is older then Java8.
      Please, use Java8 to use alluxio-fuse" >&2
@@ -59,7 +59,7 @@ mount_fuse() {
   fi
   echo "Starting alluxio-fuse on local host."
   local mount_point=$1
-  (nohup ${JAVA} -cp ${ALLUXIO_FUSE_JAR} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
+  (nohup "${JAVA}" -cp ${ALLUXIO_FUSE_JAR} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
     alluxio.fuse.AlluxioFuse \
     -m ${mount_point} \
     -o big_writes > ${ALLUXIO_LOGS_DIR}/fuse.out 2>&1) &
@@ -86,7 +86,7 @@ umount_fuse () {
 }
 
 fuse_stat() {
-  local fuse_pid=$(${JAVA_HOME}/bin/jps | grep AlluxioFuse | awk -F' ' '{print $1}')
+  local fuse_pid=$("${JAVA_HOME}"/bin/jps | grep AlluxioFuse | awk -F' ' '{print $1}')
   if [[ -z ${fuse_pid} ]]; then
     if [[ $1 == "-v" ]]; then
       echo "AlluxioFuse: not running"


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2649
If there is a space in JAVA_HOME, bin/alluxio and bin/alluxio-start.sh will not work.
For example, many Mac users' JAVA_HOME is:
/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home

This is usually caused by running Oracle's official upgrade patch, for example from 1.6 to 1.8. Then your JAVA_HOME will be set like that.

This is not a unusually problem.For example, elasticsearch has this issue as well:
elastic/elasticsearch#6942

changed ${JAVA} to "${JAVA}" in some scripts to correctly dereference the variable