### PR TITLE
[ALLUXIO-2493] Remote one unnecessary 'Test' suffix

### DIFF
--- a/tests/src/test/java/alluxio/collections/IndexedSetConcurrencyTest.java
+++ b/tests/src/test/java/alluxio/collections/IndexedSetConcurrencyTest.java
@@ -378,7 +378,7 @@ public class IndexedSetConcurrencyTest {
   }
 
   @Test
-  public void concurrentAddTest() throws Exception {
+  public void concurrentAdd() throws Exception {
     List<Future<?>> futures = new ArrayList<>();
 
     // Add random number of each task type.


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2493
According to the Alluxio unit test style guide, test names should not contain the "Test" suffix.
Consequently, the IndexedSetConcurrencyTest#concurrentAddTest() should be renamed to concurrentAdd().