### PR TITLE
[ALLUXIO-2608] Deprecate Throwables.propagate with RuntimeException in RetryHandlingMetaMasterClient.java

### DIFF
--- a/core/client/src/main/java/alluxio/client/RetryHandlingMetaMasterClient.java
+++ b/core/client/src/main/java/alluxio/client/RetryHandlingMetaMasterClient.java
@@ -19,7 +19,6 @@ import alluxio.thrift.MetaMasterClientService;
 import alluxio.wire.MasterInfo;
 import alluxio.wire.MasterInfo.MasterInfoField;
 
-import com.google.common.base.Throwables;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
@@ -90,7 +89,7 @@ public final class RetryHandlingMetaMasterClient extends AbstractMasterClient
         }
       });
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2608
Deprecate Throwables.propagate with RuntimeException in RetryHandlingMetaMasterClient.java
