### PR TITLE
[SMALLFIX] Shade guice in presto profile

### DIFF
--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -177,26 +177,23 @@
       <!-- We are excluding guava, jackson-databind and jackson-core are in scope provided, as they are provided by Presto runtime. -->
       <dependencies>
         <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>2.6.6</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>com.google.inject</groupId>
           <artifactId>guice</artifactId>
-          <version>3.0</version>
-          <scope>provided</scope>
-        </dependency>
-        <dependency>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-          <version>2.6.6</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>

--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -188,6 +188,12 @@
           <scope>provided</scope>
         </dependency>
         <dependency>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+          <version>3.0</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
           <version>2.6.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>2.6.6</version>
-      </dependency>      
+      </dependency>
       <dependency>
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
@@ -219,7 +219,7 @@
         <groupId>com.qmino</groupId>
         <artifactId>miredot-annotations</artifactId>
         <version>1.4.0</version>
-      </dependency>      
+      </dependency>
       <dependency>
         <!-- using older version to match dependency version from Hadoop -->
         <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>2.6.6</version>
-      </dependency>
+      </dependency>      
       <dependency>
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
@@ -219,12 +219,19 @@
         <groupId>com.qmino</groupId>
         <artifactId>miredot-annotations</artifactId>
         <version>1.4.0</version>
-      </dependency>
+      </dependency>      
       <dependency>
         <!-- using older version to match dependency version from Hadoop -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>14.0.1</version>
+      </dependency>
+      <dependency>
+        <!-- using older version to match dependency version from Hadoop -->
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>3.0</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Guice from Hadoop dependency conflicts with Presto.
Checked with the latest presto 0.170