### PR TITLE
[SMALLFIX] Add s3a dependency to assembly jar.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-s3a</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-underfs-swift</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
Currently it is being implicitly included by the client dependency.