### PR TITLE
[ALLUXIO-2616] Deprecate Throwables.propagate with RuntimeException in RetryHandlingFileSystemWorkerClient.java

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/RetryHandlingFileSystemWorkerClient.java
+++ b/core/client/src/main/java/alluxio/client/file/RetryHandlingFileSystemWorkerClient.java
@@ -143,7 +143,8 @@ public final class RetryHandlingFileSystemWorkerClient
     try {
       return mClientPool.acquire();
     } catch (InterruptedException e) {
-      throw Throwables.propagate(e);
+      Throwables.propagateIfPossible(e);
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
[https://alluxio.atlassian.net/browse/ALLUXIO-2616](https://alluxio.atlassian.net/browse/ALLUXIO-2616)

Modify core/client/src/main/java/alluxio/client/file/RetryHandlingFileSystemWorkerClient.java to replace
```java
    throw Throwables.propagate(e);
```
with
```java
    Throwables.propagateIfPossible(e);
    throw new RuntimeException(e);
```