### PR TITLE
[ALLUXIO-2672] Better error message when journal write failed

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -108,6 +108,8 @@ public enum ExceptionMessage {
 
   // journal
   JOURNAL_WRITE_AFTER_CLOSE("Cannot write entry after closing the stream"),
+  JOURNAL_WRITE_FAILURE("Failed to write to journal file ({0}): {1}"),
+  JOURNAL_FLUSH_FAILURE("Failed to flush journal file ({0}): {1}"),
   UNEXPECTED_JOURNAL_ENTRY("Unexpected entry in journal: {0}"),
 
   // file

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
@@ -352,8 +352,8 @@ public final class UfsJournalWriter implements JournalWriter {
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
         throw new IOException(String
-            .format("Failed to write journal file %s. Please ensure there is enough space left",
-                mCurrentLog), e);
+            .format("Failed to write journal file %s. Please ensure there is enough space left: %s",
+                mCurrentLog, e.getMessage()), e);
       }
     }
 
@@ -388,8 +388,8 @@ public final class UfsJournalWriter implements JournalWriter {
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
         throw new IOException(String
-            .format("Failed to flush journal file %s. Please ensure there is enough space left",
-                mCurrentLog), e);
+            .format("Failed to flush journal file %s. Please ensure there is enough space left: %s",
+                mCurrentLog, e.getMessage()), e);
       }
       boolean overSize = mDataOutputStream.size() >= mMaxLogSize;
       if (overSize || !mUfs.supportsFlush()) {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
@@ -13,6 +13,7 @@ package alluxio.master.journal.ufs;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
+import alluxio.RuntimeConstants;
 import alluxio.exception.ExceptionMessage;
 import alluxio.master.journal.JournalFormatter;
 import alluxio.master.journal.JournalOutputStream;
@@ -351,9 +352,8 @@ public final class UfsJournalWriter implements JournalWriter {
             mDataOutputStream);
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
-        throw new IOException(String
-            .format("Failed to write journal file %s. Please ensure there is enough space left: %s",
-                mCurrentLog, e.getMessage()), e);
+        throw new IOException(ExceptionMessage.JOURNAL_WRITE_FAILURE.getMessageWithUrl(
+            RuntimeConstants.ALLUXIO_DEBUG_DOCS_URL, mCurrentLog, e.getMessage()), e);
       }
     }
 
@@ -387,9 +387,8 @@ public final class UfsJournalWriter implements JournalWriter {
         }
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
-        throw new IOException(String
-            .format("Failed to flush journal file %s. Please ensure there is enough space left: %s",
-                mCurrentLog, e.getMessage()), e);
+        throw new IOException(ExceptionMessage.JOURNAL_FLUSH_FAILURE.getMessageWithUrl(
+            RuntimeConstants.ALLUXIO_DEBUG_DOCS_URL, mCurrentLog, e.getMessage()), e);
       }
       boolean overSize = mDataOutputStream.size() >= mMaxLogSize;
       if (overSize || !mUfs.supportsFlush()) {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalWriter.java
@@ -351,7 +351,9 @@ public final class UfsJournalWriter implements JournalWriter {
             mDataOutputStream);
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
-        throw e;
+        throw new IOException(String
+            .format("Failed to write journal file %s. Please ensure there is enough space left",
+                mCurrentLog), e);
       }
     }
 
@@ -385,7 +387,9 @@ public final class UfsJournalWriter implements JournalWriter {
         }
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
-        throw e;
+        throw new IOException(String
+            .format("Failed to flush journal file %s. Please ensure there is enough space left",
+                mCurrentLog), e);
       }
       boolean overSize = mDataOutputStream.size() >= mMaxLogSize;
       if (overSize || !mUfs.supportsFlush()) {

--- a/docs/en/Debugging-Guide.md
+++ b/docs/en/Debugging-Guide.md
@@ -153,10 +153,10 @@ See [Configuration](Configuration-Settings.html#common-configuration) for more d
 #### Q: I'm writing a new file/directory to Alluxio and seeing journal errors in my application  
 
 A: When you see errors like "Failed to replace a bad datanode on the existing pipeline due to no more good datanodes being available to try",
-it is because that Alluxio master failed to write or update journal files which are stored in a HDFS directory according to 
-the property `alluxio.master.journal.folder`. There can be multiple reasons for this type of errors, typically because 
-some HDFS datanodes serving the journal files are under heavy load or running out of disk space. Please ensure the 
-HDFS deployment is available and healthy for Alluxio to write journals when the journal directory is set to be in HDFS.
+it is because Alluxio master failed to update journal files stored in a HDFS directory according to
+the property `alluxio.master.journal.folder` setting. There can be multiple reasons for this type of errors, typically because
+some HDFS datanodes serving the journal files are under heavy load or running out of disk space. Please ensure the
+HDFS deployment is connected and healthy for Alluxio to store journals when the journal directory is set to be in HDFS.
 
 
 ## Performance FAQ

--- a/docs/en/Debugging-Guide.md
+++ b/docs/en/Debugging-Guide.md
@@ -149,6 +149,16 @@ See [Command-Line-Interface](Command-Line-Interface.html) for more details.
 - Increase the capacity of workers by changing `alluxio.worker.memory.size` property.
 See [Configuration](Configuration-Settings.html#common-configuration) for more description.
 
+
+#### Q: I'm writing a new file/directory to Alluxio and seeing journal errors in my application  
+
+A: When you see errors like "Failed to replace a bad datanode on the existing pipeline due to no more good datanodes being available to try",
+it is because that Alluxio master failed to write or update journal files which are stored in a HDFS directory according to 
+the property `alluxio.master.journal.folder`. There can be multiple reasons for this type of errors, typically because 
+some HDFS datanodes serving the journal files are under heavy load or running out of disk space. Please ensure the 
+HDFS deployment is available and healthy for Alluxio to write journals when the journal directory is set to be in HDFS.
+
+
 ## Performance FAQ
 
 #### Q: I tested Alluxio/Spark against HDFS/Spark (running simple word count of GBs of files). There is no discernible performance difference. Why?


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2672

This is not a fix to ALLUXIO-2672 but just a slightly improvement in error messages users see.
Instead of showing error like this on client side (e.g., in Spark logs) which is not clear where is wrong, at least point out it is journal problem and likely due to insufficient space on the space to write journals.

```
2017-03-20 02:33:00,219 ERROR logger.type (RpcUtils.java:call) - Unexpected error running rpc
java.lang.RuntimeException: alluxio.exception.UnexpectedAlluxioException: java.lang.RuntimeException: java.io.IOException: Failed to replace a bad datanode on the existing pipeline due to no more good datanodes being available to try. (Nodes: current=[10.116.50.230:50010, 10.116.78.14:50010], original=[10.116.50.230:50010, 10.116.78.14:50010]). The current failed datanode replacement policy is DEFAULT, and a client may configure this via 'dfs.client.block.write.replace-datanode-on-failure.policy' in its configuration.
```