### PR TITLE
[SMALLFIX] Fix leaked masters

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultAlluxioMaster.java
@@ -34,7 +34,6 @@ import alluxio.web.WebServer;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import org.apache.thrift.TMultiplexedProcessor;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -260,9 +259,7 @@ public class DefaultAlluxioMaster implements AlluxioMasterService {
   protected void startMasters(boolean isLeader) {
     try {
       connectToUFS();
-      for (Master master : mRegistry.getMasters()) {
-        master.start(isLeader);
-      }
+      mRegistry.start(isLeader);
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
@@ -270,9 +267,7 @@ public class DefaultAlluxioMaster implements AlluxioMasterService {
 
   protected void stopMasters() {
     try {
-      for (Master master : Lists.reverse(mRegistry.getMasters())) {
-        master.stop();
-      }
+      mRegistry.stop();
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -28,7 +28,6 @@ import alluxio.exception.UnexpectedAlluxioException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
-import alluxio.master.Master;
 import alluxio.master.MasterRegistry;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.meta.PersistenceState;
@@ -1576,9 +1575,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster = new FileSystemMaster(mRegistry, factory,
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
 
-    for (Master master : mRegistry.getMasters()) {
-      master.start(true);
-    }
+    mRegistry.start(true);
 
     // set up workers
     mWorkerId1 = mBlockMaster.getWorkerId(
@@ -1596,8 +1593,6 @@ public final class FileSystemMasterTest {
   }
 
   private void stopServices() throws Exception {
-    for (Master master : mRegistry.getMasters()) {
-      master.stop();
-    }
+    mRegistry.stop();
   }
 }

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -127,7 +127,7 @@ public class JournalShutdownIntegrationTest {
     }
   }
 
-  private FileSystemMaster createFsMasterFromJournal() throws Exception {
+  private MasterRegistry createFsMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
   }
 
@@ -136,7 +136,8 @@ public class JournalShutdownIntegrationTest {
    */
   private void reproduceAndCheckState(int successFiles) throws Exception {
     Assert.assertNotEquals(successFiles, 0);
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
 
     int actualFiles =
         fsMaster.listStatus(new AlluxioURI(TEST_FILE_DIR), ListStatusOptions.defaults())
@@ -146,7 +147,7 @@ public class JournalShutdownIntegrationTest {
       Assert.assertTrue(
           fsMaster.getFileId(new AlluxioURI(TEST_FILE_DIR + f)) != IdUtils.INVALID_FILE_ID);
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   private MultiMasterLocalAlluxioCluster setupMultiMasterCluster() throws Exception {

--- a/tests/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/master/MasterTestUtils.java
@@ -48,13 +48,14 @@ public class MasterTestUtils {
   }
 
   /**
-   * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and
-   * returns the master registry containing that master.
+   * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and returns
+   * the master registry containing that master.
    *
    * @param isLeader whether to start as a leader
    * @return a master registry containing the created {@link FileSystemMaster} master
    */
-  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader) throws Exception {
+  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader)
+      throws Exception {
     String masterJournal = Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     MasterRegistry registry = new MasterRegistry();
     JournalFactory factory = new MutableJournal.Factory(new URI(masterJournal));

--- a/tests/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/master/MasterTestUtils.java
@@ -28,35 +28,40 @@ import java.net.URI;
 public class MasterTestUtils {
 
   /**
-   * Creates a new {@link FileSystemMaster} from journal.
+   * Creates a new leader {@link FileSystemMaster} from journal along with its dependencies, and
+   * returns the master registry containing that master.
    *
-   * @return a new {@link FileSystemMaster}
+   * @return a master registry containing the created {@link FileSystemMaster} master
    */
-  public static FileSystemMaster createLeaderFileSystemMasterFromJournal() throws Exception {
-    String masterJournal = Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
-    MasterRegistry registry = new MasterRegistry();
-    JournalFactory factory = new MutableJournal.Factory(new URI(masterJournal));
-    BlockMaster blockMaster = new BlockMaster(registry, factory);
-    FileSystemMaster fsMaster = new FileSystemMaster(registry, factory);
-    blockMaster.start(true);
-    fsMaster.start(true);
-    return fsMaster;
+  public static MasterRegistry createLeaderFileSystemMasterFromJournal() throws Exception {
+    return createFileSystemMasterFromJournal(true);
   }
 
   /**
-   * Creates a new standby {@link FileSystemMaster} from journal.
+   * Creates a new standby {@link FileSystemMaster} from journal along with its dependencies, and
+   * returns the master registry containing that master.
    *
-   * @return a new {@link FileSystemMaster}
+   * @return a master registry containing the created {@link FileSystemMaster} master
    */
-  public static FileSystemMaster createStandbyFileSystemMasterFromJournal() throws Exception {
+  public static MasterRegistry createStandbyFileSystemMasterFromJournal() throws Exception {
+    return createFileSystemMasterFromJournal(false);
+  }
+
+  /**
+   * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and
+   * returns the master registry containing that master.
+   *
+   * @param isLeader whether to start as a leader
+   * @return a master registry containing the created {@link FileSystemMaster} master
+   */
+  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader) throws Exception {
     String masterJournal = Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     MasterRegistry registry = new MasterRegistry();
     JournalFactory factory = new MutableJournal.Factory(new URI(masterJournal));
-    BlockMaster blockMaster = new BlockMaster(registry, factory);
-    FileSystemMaster fsMaster = new FileSystemMaster(registry, factory);
-    blockMaster.start(false);
-    fsMaster.start(false);
-    return fsMaster;
+    new BlockMaster(registry, factory);
+    new FileSystemMaster(registry, factory);
+    registry.start(isLeader);
+    return registry;
   }
 
   /**

--- a/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
+++ b/tests/src/test/java/alluxio/master/StartupConsistencyCheckTest.java
@@ -73,9 +73,11 @@ public class StartupConsistencyCheckTest {
   @Test
   public void consistent() throws Exception {
     mCluster.stopFS();
-    final FileSystemMaster master = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    MasterRegistry registry = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    FileSystemMaster master = registry.get(FileSystemMaster.class);
     MasterTestUtils.waitForStartupConsistencyCheck(master);
     Assert.assertTrue(master.getStartupConsistencyCheck().getInconsistentUris().isEmpty());
+    registry.stop();
   }
 
   /**
@@ -90,12 +92,15 @@ public class StartupConsistencyCheckTest {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(topLevelFileUfsPath);
     ufs.deleteFile(topLevelFileUfsPath);
     ufs.deleteDirectory(secondLevelDirUfsPath, DeleteOptions.defaults().setRecursive(true));
-    final FileSystemMaster master = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    MasterRegistry registry = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    FileSystemMaster master = registry.get(FileSystemMaster.class);
     MasterTestUtils.waitForStartupConsistencyCheck(master);
-    List expected = Lists.newArrayList(TOP_LEVEL_FILE, SECOND_LEVEL_DIR, THIRD_LEVEL_FILE);
-    List result = master.getStartupConsistencyCheck().getInconsistentUris();
+    List<AlluxioURI> expected =
+        Lists.newArrayList(TOP_LEVEL_FILE, SECOND_LEVEL_DIR, THIRD_LEVEL_FILE);
+    List<AlluxioURI> result = master.getStartupConsistencyCheck().getInconsistentUris();
     Collections.sort(expected);
     Collections.sort(result);
     Assert.assertEquals(expected, result);
+    registry.stop();
   }
 }

--- a/tests/src/test/java/alluxio/master/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/UfsJournalIntegrationTest.java
@@ -103,7 +103,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void addBlockTestUtil(URIStatus status) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
 
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
@@ -116,7 +117,7 @@ public class UfsJournalIntegrationTest {
     Assert.assertEquals(status.getBlockIds(), fsMasterInfo.getBlockIds());
     Assert.assertEquals(status.getBlockSizeBytes(), fsMasterInfo.getBlockSizeBytes());
     Assert.assertEquals(status.getLength(), fsMasterInfo.getLength());
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -164,7 +165,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void loadMetadataTestUtil(URIStatus status) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
 
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
@@ -173,7 +175,7 @@ public class UfsJournalIntegrationTest {
     Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/xyz")) != IdUtils.INVALID_FILE_ID);
     FileInfo fsMasterInfo = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/xyz")));
     Assert.assertEquals(status, new URIStatus(fsMasterInfo));
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -228,7 +230,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void deleteTestUtil() throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(5, fsMaster.listStatus(mRootUri,
@@ -239,19 +242,20 @@ public class UfsJournalIntegrationTest {
             fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
       }
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   @Test
   public void emptyImage() throws Exception {
     Assert.assertEquals(0, mFileSystem.listStatus(mRootUri).size());
     mLocalAlluxioCluster.stopFS();
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(0, fsMaster.listStatus(mRootUri,
         ListStatusOptions.defaults().setLoadMetadataType(LoadMetadataType.Never)).size());
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -273,7 +277,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void fileDirectoryTestUtil() throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(10, fsMaster.listStatus(mRootUri,
@@ -284,7 +289,7 @@ public class UfsJournalIntegrationTest {
             fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
       }
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -303,7 +308,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void fileTestUtil(URIStatus status) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(1, fsMaster.listStatus(mRootUri,
@@ -311,7 +317,7 @@ public class UfsJournalIntegrationTest {
     long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
     Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(status, new URIStatus(fsMaster.getFileInfo(fileId)));
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -345,7 +351,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void pinTestUtil(URIStatus directory, URIStatus file0, URIStatus file1) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
 
     FileInfo info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder")));
     Assert.assertEquals(directory, new URIStatus(info));
@@ -359,7 +366,7 @@ public class UfsJournalIntegrationTest {
     Assert.assertEquals(file1, new URIStatus(info));
     Assert.assertTrue(info.isPinned());
 
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -377,7 +384,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void directoryTestUtil(URIStatus status) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(1, fsMaster.listStatus(mRootUri,
@@ -385,7 +393,7 @@ public class UfsJournalIntegrationTest {
     long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
     Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(status, new URIStatus(fsMaster.getFileInfo(fileId)));
-    fsMaster.stop();
+    registry.stop();
   }
 
   @Test
@@ -418,13 +426,15 @@ public class UfsJournalIntegrationTest {
 
   private void persistDirectoryLaterTestUtil(Map<String, URIStatus> directoryStatuses)
       throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     for (Map.Entry<String, URIStatus> directoryStatus : directoryStatuses.entrySet()) {
       Assert.assertEquals(
           directoryStatus.getValue(),
           new URIStatus(fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI(directoryStatus
               .getKey())))));
     }
+    registry.stop();
   }
 
   /**
@@ -443,7 +453,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void manyFileTestUtil() throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(10, fsMaster.listStatus(mRootUri,
@@ -451,7 +462,7 @@ public class UfsJournalIntegrationTest {
     for (int k = 0; k < 10; k++) {
       Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -472,8 +483,8 @@ public class UfsJournalIntegrationTest {
     MasterTestUtils.createLeaderFileSystemMasterFromJournal().stop();
 
     // Start a standby master, which will replay the mount entry from the checkpoint.
-    final FileSystemMaster fsMaster = MasterTestUtils.createStandbyFileSystemMasterFromJournal();
-
+    MasterRegistry registry = MasterTestUtils.createStandbyFileSystemMasterFromJournal();
+    final FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     try {
       CommonUtils.waitFor("standby journal checkpoint replay", new Function<Void, Boolean>() {
         @Override
@@ -487,7 +498,7 @@ public class UfsJournalIntegrationTest {
         }
       }, WaitForOptions.defaults().setTimeout(60 * Constants.SECOND_MS));
     } finally {
-      fsMaster.stop();
+      registry.stop();
     }
   }
 
@@ -507,7 +518,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void multiEditLogTestUtil() throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(124, fsMaster.listStatus(mRootUri,
@@ -515,7 +527,7 @@ public class UfsJournalIntegrationTest {
     for (int k = 0; k < 124; k++) {
       Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   /**
@@ -540,7 +552,8 @@ public class UfsJournalIntegrationTest {
   }
 
   private void renameTestUtil() throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     long rootId = fsMaster.getFileId(mRootUri);
     Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
     Assert.assertEquals(10, fsMaster.listStatus(mRootUri,
@@ -551,7 +564,7 @@ public class UfsJournalIntegrationTest {
             fsMaster.getFileId(new AlluxioURI("/ii" + i + "/jj" + j)) != IdUtils.INVALID_FILE_ID);
       }
     }
-    fsMaster.stop();
+    registry.stop();
   }
 
   @Test
@@ -601,8 +614,10 @@ public class UfsJournalIntegrationTest {
       }
     }
     // We shouldn't lose track of the fact that the file is loaded into memory.
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     Assert.assertTrue(fsMaster.getInMemoryFiles().contains(file));
+    registry.stop();
   }
 
   @Test
@@ -626,8 +641,10 @@ public class UfsJournalIntegrationTest {
       }
     }
     // We shouldn't lose track of the fact that the file is loaded into memory.
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     Assert.assertTrue(fsMaster.getInMemoryFiles().contains(file));
+    registry.stop();
   }
 
   @Test
@@ -648,21 +665,22 @@ public class UfsJournalIntegrationTest {
       }
     }
     // We shouldn't lose track of the fact that the file is loaded into memory.
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     Assert.assertTrue(fsMaster.getInMemoryFiles().contains(file));
+    registry.stop();
   }
 
   private void aclTestUtil(URIStatus status, String user) throws Exception {
-    FileSystemMaster fsMaster = createFsMasterFromJournal();
-
+    MasterRegistry registry = createFsMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
     AuthenticatedClientUser.set(user);
     FileInfo info = fsMaster.getFileInfo(new AlluxioURI("/file"));
     Assert.assertEquals(status, new URIStatus(info));
-
-    fsMaster.stop();
+    registry.stop();
   }
 
-  private FileSystemMaster createFsMasterFromJournal() throws Exception {
+  private MasterRegistry createFsMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
   }
 

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -24,6 +24,7 @@ import alluxio.exception.InvalidPathException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
+import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.meta.InodeTree;
@@ -157,7 +158,7 @@ public class FileSystemMasterIntegrationTest {
     Assert.assertEquals(0644, (short) fileInfo.getMode());
   }
 
-  private FileSystemMaster createFileSystemMasterFromJournal() throws Exception {
+  private MasterRegistry createFileSystemMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
   }
 
@@ -172,12 +173,14 @@ public class FileSystemMasterIntegrationTest {
           new ConcurrentCreator(DEPTH, CONCURRENCY_DEPTH, ROOT_PATH);
       concurrentCreator.call();
 
-      FileSystemMaster fsMaster = createFileSystemMasterFromJournal();
+      MasterRegistry registry = createFileSystemMasterFromJournal();
+      FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
       for (FileInfo info : mFsMaster.listStatus(new AlluxioURI("/"),
           ListStatusOptions.defaults())) {
         AlluxioURI path = new AlluxioURI(info.getPath());
         Assert.assertEquals(mFsMaster.getFileId(path), fsMaster.getFileId(path));
       }
+      registry.stop();
       before();
     }
   }

--- a/tests/src/test/java/alluxio/security/ClusterInitializationTest.java
+++ b/tests/src/test/java/alluxio/security/ClusterInitializationTest.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.ExceptionMessage;
+import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.security.authentication.AuthType;
@@ -75,11 +76,13 @@ public class ClusterInitializationTest {
     LoginUserTestUtils.resetLoginUser(SUPER_USER);
 
     // user alluxio can recover master from journal
-    FileSystemMaster fileSystemMaster = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    MasterRegistry registry = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    FileSystemMaster fileSystemMaster = registry.get(FileSystemMaster.class);
 
     AuthenticatedClientUser.set(SUPER_USER);
     Assert.assertEquals(SUPER_USER,
         fileSystemMaster.getFileInfo(new AlluxioURI("/testFile")).getOwner());
+    registry.stop();
   }
 
   /**


### PR DESCRIPTION
We would often start `BlockMaster` and `FileSystemMaster`, but then only stop `FileSystemMaster`. This PR addresses this by moving masters start/stop logic to `MasterRegistry`