### PR TITLE
[ALLUXIO-2636]Convert semaphore to unfair

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -34,9 +34,8 @@ public final class ClientRWLock implements ReadWriteLock {
   private static final int MAX_AVAILABLE =
           Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
   /**
-   * Underlying Semaphore.
-   * Convert to non-fair lock for the accidental hold read lock forever and write lock request
-   * will blocked the all read lock following if we use fair lock.
+   * Uses the unfair lock to prevent a read lock that fails to release from locking the block
+   * forever and thus blocking all the subsequent write access.
    * See https://alluxio.atlassian.net/browse/ALLUXIO-2636.
    */
   private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, false);

--- a/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -33,7 +33,12 @@ public final class ClientRWLock implements ReadWriteLock {
   /** Total number of permits. This value decides the max number of concurrent readers. */
   private static final int MAX_AVAILABLE =
           Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
-  /** Underlying Semaphore. */
+  /**
+   * Underlying Semaphore.
+   * Convert to non-fair lock for the accidental hold read lock forever and write lock request
+   * will blocked the all read lock following if we use fair lock.
+   * See https://alluxio.atlassian.net/browse/ALLUXIO-2636.
+   */
   private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, false);
   /** Reference count. */
   private AtomicInteger mReferences = new AtomicInteger();

--- a/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -34,7 +34,7 @@ public final class ClientRWLock implements ReadWriteLock {
   private static final int MAX_AVAILABLE =
           Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
   /** Underlying Semaphore. */
-  private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, true);
+  private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, false);
   /** Reference count. */
   private AtomicInteger mReferences = new AtomicInteger();
 


### PR DESCRIPTION
If a thread read, then it hold the read lock and don't unlock, then another thread want to write lock, as we all know, this thread will never get the lock, but a third thread want to get the read lock, it also never get the lock if we set the semaphore to `fair`. So i set it to `unfair` to let other read thread get read lock.
(https://alluxio.atlassian.net/projects/ALLUXIO/issues/ALLUXIO-2636)