### PR TITLE
[ALLUXIO-2569]Add Shell Command 'bin/alluxio fs help'

### DIFF
--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -14,22 +14,19 @@ package alluxio.cli;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
+import alluxio.shell.AlluxioShellUtils;
 import alluxio.shell.command.ShellCommand;
-import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -83,33 +80,11 @@ public final class AlluxioShell implements Closeable {
    */
   public AlluxioShell() {
     mFileSystem = FileSystem.Factory.get();
-    loadCommands();
+    AlluxioShellUtils.loadCommands(mFileSystem, mCommands);
   }
 
   @Override
   public void close() throws IOException {
-  }
-
-  /**
-   * Uses reflection to get all the {@link ShellCommand} classes and store them in a map.
-   */
-  private void loadCommands() {
-    String pkgName = ShellCommand.class.getPackage().getName();
-    Reflections reflections = new Reflections(pkgName);
-    for (Class<? extends ShellCommand> cls : reflections.getSubTypesOf(ShellCommand.class)) {
-      // Only instantiate a concrete class
-      if (!Modifier.isAbstract(cls.getModifiers())) {
-        ShellCommand cmd;
-        try {
-          cmd = CommonUtils.createNewClassInstance(cls,
-              new Class[] { FileSystem.class },
-              new Object[] {mFileSystem });
-        } catch (Exception e) {
-          throw Throwables.propagate(e);
-        }
-        mCommands.put(cmd.getCommandName(), cmd);
-      }
-    }
   }
 
   /**

--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -221,11 +221,11 @@ public final class AlluxioShellUtils {
   }
 
   /**
-   * Gets all supported {@link ShellCommand} classes and stores them in a map.
+   * Gets all supported {@link ShellCommand} classes instances and load them into a map.
    * Provides a way to gain these commands information by their CommandName.
    *
    * @param fileSystem a FileSystem as each ShellCommand constructor's parameter
-   * @param commandsMap a HashMap that stores "key = commandName, value = commandInstance"
+   * @param commandsMap a Map which is used to store "key = commandName, value = commandInstance"
    *                    pairs
    */
   public static void loadCommands(FileSystem fileSystem, Map<String, ShellCommand> commandsMap) {

--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -19,16 +19,22 @@ import alluxio.cli.AlluxioShell;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
+import alluxio.shell.command.ShellCommand;
+import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import org.reflections.Reflections;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -212,6 +218,32 @@ public final class AlluxioShellUtils {
       }
     }
     return res;
+  }
+
+  /**
+   * Gets all supported {@link ShellCommand} classes and stores them in a map.
+   * Provides a way to gain these commands information by their CommandName.
+   *
+   * @param fileSystem a FileSystem as each ShellCommand constructor's parameter
+   * @param commandsMap a HashMap that stores "key = commandName, value = commandInstance"
+   *                    pairs
+   */
+  public static void loadCommands(FileSystem fileSystem, Map<String, ShellCommand> commandsMap) {
+    String pkgName = ShellCommand.class.getPackage().getName();
+    Reflections reflections = new Reflections(pkgName);
+    for (Class<? extends ShellCommand> cls : reflections.getSubTypesOf(ShellCommand.class)) {
+      // Only instantiate a concrete class
+      if (!Modifier.isAbstract(cls.getModifiers())) {
+        ShellCommand cmd;
+        try {
+          cmd = CommonUtils.createNewClassInstance(cls, new Class[] {FileSystem.class},
+              new Object[] {fileSystem});
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+        commandsMap.put(cmd.getCommandName(), cmd);
+      }
+    }
   }
 
   /**

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
- * "License"). You may not use this work except in compliance with the License, which is available
- * at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -81,6 +81,16 @@ public final class HelpCommand extends AbstractShellCommand {
   }
 
   @Override
+  public boolean validateArgs(String... args) {
+    boolean valid = args.length <= getNumOfArgs();
+    if (!valid) {
+      System.out.println(getCommandName() + " takes at most " + getNumOfArgs() + " arguments, "
+                           + " not " + args.length + "\n");
+    }
+    return valid;
+  }
+
+  @Override
   protected int getNumOfArgs() {
     return 1;
   }

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -1,0 +1,133 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell.command;
+
+import alluxio.client.file.FileSystem;
+import alluxio.exception.AlluxioException;
+import alluxio.util.CommonUtils;
+
+import com.google.common.base.Throwables;
+import org.apache.commons.cli.CommandLine;
+import org.reflections.Reflections;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Command for print help message for the given command.
+ * If there isn't given command, print help messages for all supported commands.
+ */
+@ThreadSafe
+public final class HelpCommand extends AbstractShellCommand {
+
+  /**
+   * @param fs the filesystem of Alluxio
+   */
+  public HelpCommand(FileSystem fs) {
+    super(fs);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "help";
+  }
+
+  @Override
+  public boolean validateArgs(String... args) {
+    boolean valid = args.length >= getNumOfArgs();
+    if (!valid) {
+      System.out.println(getCommandName() + " takes at least " + getNumOfArgs() + " arguments, "
+              + " not " + args.length + "\n");
+    }
+    return valid;
+  }
+
+  private final Map<String, ShellCommand> mCommands = new HashMap<>();
+
+  @Override
+  public void run(CommandLine cl) throws AlluxioException, IOException {
+    String[] args = cl.getArgs();
+    loadCommands();
+    SortedSet<String> sortedCmds = null;
+    boolean hasUnknownCommand = false;
+    if (args.length == 0) {
+      //print help messages for all supported commands.
+      sortedCmds = new TreeSet<>(mCommands.keySet());
+    } else {
+      sortedCmds = new TreeSet<>();
+      for (String cmd : args) {
+        if (mCommands.containsKey(cmd)) {
+          sortedCmds.add(cmd);
+        } else {
+          hasUnknownCommand = true;
+          System.out.println(cmd + " is an unknown command.");
+        }
+      }
+    }
+    if (hasUnknownCommand) {
+      System.out.println();
+    }
+    printUsage(sortedCmds);
+  }
+
+  private void loadCommands() {
+    String pkgName = ShellCommand.class.getPackage().getName();
+    Reflections reflections = new Reflections(pkgName);
+    for (Class<? extends ShellCommand> cls : reflections.getSubTypesOf(ShellCommand.class)) {
+      // Only instantiate a concrete class
+      if (!Modifier.isAbstract(cls.getModifiers())) {
+        ShellCommand cmd;
+        try {
+          cmd = CommonUtils.createNewClassInstance(cls,
+              new Class[] { FileSystem.class },
+              new Object[] {mFileSystem });
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+        mCommands.put(cmd.getCommandName(), cmd);
+      }
+    }
+  }
+
+  private void printUsage(SortedSet<String> sortedCmds) {
+    if (sortedCmds == null || sortedCmds.size() == 0) {
+      return;
+    }
+    for (String cmd : sortedCmds) {
+      System.out.format("%-60s%-95s%n", "       [" + mCommands.get(cmd).getUsage() + "]   ",
+          mCommands.get(cmd).getDescription());
+    }
+  }
+
+  @Override
+  public String getUsage() {
+    return "help <command>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Prints help message for the given command. "
+        + "If there isn't given command, prints help messages for all supported commands.";
+  }
+
+  @Override
+  protected int getNumOfArgs() {
+    return 0;
+  }
+
+}

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
- * (the "License"). You may not use this work except in compliance with the License, which is
- * available at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.
@@ -13,14 +13,11 @@ package alluxio.shell.command;
 
 import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
-import alluxio.util.CommonUtils;
+import alluxio.shell.AlluxioShellUtils;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.cli.CommandLine;
-import org.reflections.Reflections;
 
 import java.io.IOException;
-import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
@@ -29,8 +26,8 @@ import java.util.TreeSet;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Command for print help message for the given command.
- * If there isn't given command, print help messages for all supported commands.
+ * Command for print help message for the given command. If there isn't given command, print help
+ * messages for all supported commands.
  */
 @ThreadSafe
 public final class HelpCommand extends AbstractShellCommand {
@@ -47,71 +44,29 @@ public final class HelpCommand extends AbstractShellCommand {
     return "help";
   }
 
-  @Override
-  public boolean validateArgs(String... args) {
-    boolean valid = args.length >= getNumOfArgs();
-    if (!valid) {
-      System.out.println(getCommandName() + " takes at least " + getNumOfArgs() + " arguments, "
-              + " not " + args.length + "\n");
-    }
-    return valid;
-  }
-
   private final Map<String, ShellCommand> mCommands = new HashMap<>();
 
   @Override
   public void run(CommandLine cl) throws AlluxioException, IOException {
     String[] args = cl.getArgs();
-    loadCommands();
     SortedSet<String> sortedCmds = null;
-    boolean hasUnknownCommand = false;
+    AlluxioShellUtils.loadCommands(mFileSystem, mCommands);
     if (args.length == 0) {
-      //print help messages for all supported commands.
+      // print help messages for all supported commands.
       sortedCmds = new TreeSet<>(mCommands.keySet());
+      for (String cmd : sortedCmds) {
+        printCommandInfo(cmd);
+      }
+    } else if (mCommands.containsKey(args[0])) {
+      printCommandInfo(args[0]);
     } else {
-      sortedCmds = new TreeSet<>();
-      for (String cmd : args) {
-        if (mCommands.containsKey(cmd)) {
-          sortedCmds.add(cmd);
-        } else {
-          hasUnknownCommand = true;
-          System.out.println(cmd + " is an unknown command.");
-        }
-      }
-    }
-    if (hasUnknownCommand) {
-      System.out.println();
-    }
-    printUsage(sortedCmds);
-  }
-
-  private void loadCommands() {
-    String pkgName = ShellCommand.class.getPackage().getName();
-    Reflections reflections = new Reflections(pkgName);
-    for (Class<? extends ShellCommand> cls : reflections.getSubTypesOf(ShellCommand.class)) {
-      // Only instantiate a concrete class
-      if (!Modifier.isAbstract(cls.getModifiers())) {
-        ShellCommand cmd;
-        try {
-          cmd = CommonUtils.createNewClassInstance(cls,
-              new Class[] { FileSystem.class },
-              new Object[] {mFileSystem });
-        } catch (Exception e) {
-          throw Throwables.propagate(e);
-        }
-        mCommands.put(cmd.getCommandName(), cmd);
-      }
+      System.out.println(args[0] + " is an unknown command.");
     }
   }
 
-  private void printUsage(SortedSet<String> sortedCmds) {
-    if (sortedCmds == null || sortedCmds.size() == 0) {
-      return;
-    }
-    for (String cmd : sortedCmds) {
-      System.out.format("%-60s%-95s%n", "       [" + mCommands.get(cmd).getUsage() + "]   ",
-          mCommands.get(cmd).getDescription());
-    }
+  private void printCommandInfo(String commandName) {
+    System.out.format("%-60s%s%n", "       [" + mCommands.get(commandName).getUsage() + "]   ",
+        mCommands.get(commandName).getDescription());
   }
 
   @Override
@@ -127,7 +82,7 @@ public final class HelpCommand extends AbstractShellCommand {
 
   @Override
   protected int getNumOfArgs() {
-    return 0;
+    return 1;
   }
 
 }

--- a/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
@@ -20,6 +20,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.options.DeleteOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.master.LocalAlluxioCluster;
+import alluxio.shell.command.ShellCommand;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TException;
@@ -27,12 +28,17 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.reflections.Reflections;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Unit tests on {@link alluxio.shell.AlluxioShellUtils}.
@@ -253,6 +259,28 @@ public final class AlluxioShellUtilsTest {
 
     Assert.assertEquals(AlluxioShellUtils.match("/a/b/c", "*"), true);
     Assert.assertEquals(AlluxioShellUtils.match("/", "/*"), true);
+  }
+
+  @Test
+  public void loadCommands() {
+    Map<String, ShellCommand> map = new HashMap<>();
+    AlluxioShellUtils.loadCommands(mFileSystem, map);
+
+    String pkgName = ShellCommand.class.getPackage().getName();
+    Reflections reflections = new Reflections(pkgName);
+    Set<Class<? extends ShellCommand>> cmdSet = reflections.getSubTypesOf(ShellCommand.class);
+    for (Map.Entry<String, ShellCommand> entry : map.entrySet()) {
+      Assert.assertEquals(entry.getValue().getCommandName(), entry.getKey());
+      Assert.assertEquals(cmdSet.contains(entry.getValue().getClass()), true);
+    }
+
+    int expectSize = 0;
+    for (Class<? extends ShellCommand> cls : cmdSet) {
+      if (!Modifier.isAbstract(cls.getModifiers())) {
+        expectSize++;
+      }
+    }
+    Assert.assertEquals(expectSize, map.size());
   }
 }
 

--- a/tests/src/test/java/alluxio/shell/command/HelpCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/HelpCommandTest.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell.command;
+
+import alluxio.shell.AbstractAlluxioShellTest;
+import alluxio.shell.AlluxioShellUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Tests for help command.
+ */
+public final class HelpCommandTest extends AbstractAlluxioShellTest {
+
+  /**
+   * Tests help which given command doesn't exist.
+   */
+  @Test
+  public void helpNotExist() throws IOException {
+    mFsShell.run("help", "notExistTestCommand");
+    String expected = "notExistTestCommand is an unknown command.\n";
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  /**
+   * Tests help command with given command which exists.
+   */
+  @Test
+  public void help() throws IOException {
+    mFsShell.run("help", "help");
+    HelpCommand cmd = new HelpCommand(mFileSystem);
+    String expected = String.format("%-60s%s%n", "       [" + cmd.getUsage() + "]   ",
+            cmd.getDescription());
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  /**
+   * Tests help command without given command.
+   */
+  @Test
+  public void helpAllCommand() throws IOException {
+    mFsShell.run("help");
+    final Map<String, ShellCommand> commands = new HashMap<>();
+    String expected = "";
+    AlluxioShellUtils.loadCommands(mFileSystem, commands);
+    SortedSet<String> sortedCmds = new TreeSet<>(commands.keySet());
+    for (String cmd : sortedCmds) {
+      expected += String.format("%-60s%s%n", "       [" + commands.get(cmd).getUsage() + "]   ",
+              commands.get(cmd).getDescription());
+    }
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  /**
+   * Tests help command with redundant args.
+   */
+  @Test
+  public void helpRedundantArgs() throws IOException {
+    Assert.assertEquals(-1, mFsShell.run("help", "Cat", "Chmod"));
+  }
+}


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2569

Alluxio shell command "bin/alluxio fs" should provide a sub-command called "help", which works like the following:
For “bin/alluxio fs help <command>”, this will print help message for the given command.
For “bin/alluxio fs help”, this will print help messages for all supported commands.
To implement this feature, this "help" command should be a class "alluxio.shell.command.HelpCommand.java", inheriting "alluxio.shell.command.AbstractShellCommand". 