### PR TITLE
[SMALLFIX] Support enter debug mode use `-debug`

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -160,8 +160,13 @@ function runJavaClass {
   for arg in "$@"; do
       shift
       case "${arg}" in
-          -D*) ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
-          *) CLASS_ARGS+=" ${arg}"
+          -debug)
+              echo "debug mode!"
+              ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_SHELL_DEBUG_JAVA_OPTS}" ;;
+          -D*)
+              ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
+          *)
+              CLASS_ARGS+=" ${arg}"
       esac
   done
   "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} ${CLASS_ARGS}

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -161,8 +161,7 @@ function runJavaClass {
       shift
       case "${arg}" in
           -debug)
-              echo "debug mode!"
-              ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_SHELL_DEBUG_JAVA_OPTS}" ;;
+              ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
           -D*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)


### PR DESCRIPTION
example:
if you append append the `ALLUXIO_SHELL_DEBUG_JAVA_OPTS` in `alluxio-env.sh` as following:
```bash
ALLUXIO_SHELL_DEBUG_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5603"
```
then you can execute your shell command with -debug between the alluxio COMMAND and GENERIC_COMMAND_OPTIONS
```bash
$ alluxio fs -debug ls /
debug mode!
Listening for transport dt_socket at address: 5603
```