### PR TITLE
[ALLUXIO-2573] Add "-f" (format) option for Shell Command "bin/alluxio fs stat"

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -134,7 +134,8 @@ public final class StatCommand extends WithWildCardPathCommand {
         resp = status.getGroup();
         break;
       case 'u':
-        resp = status.getOwner();break;
+        resp = status.getOwner();
+        break;
       case 'y':
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         resp = sdf.format(new Date(status.getLastModificationTimeMs()));

--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -100,15 +100,15 @@ public final class StatCommand extends WithWildCardPathCommand {
         + "   \"%b\": Number of blocks allocated for file";
   }
 
-  private static final String formatRegex = "%([bgruyzNY])";
-  private static final Pattern frPattern = Pattern.compile(formatRegex);
+  private static final String FORMAT_REGEX = "%([bgruyzNY])";
+  private static final Pattern FORMAT_PATTERN = Pattern.compile(FORMAT_REGEX);
 
   private String formatOutput(CommandLine cl, URIStatus status) {
     String format = cl.getOptionValue('f');
     int formatLen = format.length();
 
     StringBuilder output = new StringBuilder();
-    Matcher m = frPattern.matcher(format);
+    Matcher m = FORMAT_PATTERN.matcher(format);
     for (int i = 0; i < formatLen;) {
       if (m.find(i)) {
         if (m.start() != i) {
@@ -144,7 +144,9 @@ public final class StatCommand extends WithWildCardPathCommand {
         return status.getName();
       case 'Y':
         return String.valueOf(status.getLastModificationTimeMs());
+      default:
+        assert false;
+        return "";
     }
-    return "";
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -62,20 +62,20 @@ public final class StatCommand extends WithWildCardPathCommand {
   @Override
   protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
-    if (status.isFolder()) {
-      System.out.println(path + " is a directory path.");
-      System.out.println(status);
+    if (cl.hasOption('f')) {
+      System.out.println(formatOutput(cl, status));
     } else {
-      System.out.println(path + " is a file path.");
-      if (cl.hasOption('f')) {
-        System.out.println(formatOutput(cl, status));
-      } else {
+      if (status.isFolder()) {
+        System.out.println(path + " is a directory path.");
         System.out.println(status);
-      }
-      System.out.println("Containing the following blocks: ");
-      AlluxioBlockStore blockStore = AlluxioBlockStore.create();
-      for (long blockId : status.getBlockIds()) {
-        System.out.println(blockStore.getInfo(blockId));
+      } else {
+        System.out.println(path + " is a file path.");
+        System.out.println(status);
+        System.out.println("Containing the following blocks: ");
+        AlluxioBlockStore blockStore = AlluxioBlockStore.create();
+        for (long blockId : status.getBlockIds()) {
+          System.out.println(blockStore.getInfo(blockId));
+        }
       }
     }
   }
@@ -99,7 +99,7 @@ public final class StatCommand extends WithWildCardPathCommand {
         + "   \"%b\": Number of blocks allocated for file";
   }
 
-  private static final String FORMAT_REGEX = "%([bgruyzNY])";
+  private static final String FORMAT_REGEX = "%([bguyzNY])";
   private static final Pattern FORMAT_PATTERN = Pattern.compile(FORMAT_REGEX);
 
   private String formatOutput(CommandLine cl, URIStatus status) {
@@ -127,7 +127,7 @@ public final class StatCommand extends WithWildCardPathCommand {
     char formatSpecifier = m.group(1).charAt(0);
     switch (formatSpecifier) {
       case 'b':
-        return String.valueOf(status.getFileBlockInfos().size());
+        return status.isFolder() ? "NA" : String.valueOf(status.getFileBlockInfos().size());
       case 'g':
         return status.getGroup();
       case 'u':
@@ -136,7 +136,7 @@ public final class StatCommand extends WithWildCardPathCommand {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         return sdf.format(new Date(status.getLastModificationTimeMs()));
       case 'z':
-        return String.valueOf(status.getLength());
+        return status.isFolder() ? "NA" : String.valueOf(status.getLength());
       case 'N':
         return status.getName();
       case 'Y':

--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -18,8 +18,14 @@ import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -43,6 +49,17 @@ public final class StatCommand extends WithWildCardPathCommand {
   }
 
   @Override
+  protected Options getOptions() {
+    return new Options().addOption(
+            Option.builder("f")
+                    .required(false)
+                    .hasArg(true)
+                    .desc("format")
+                    .build()
+    );
+  }
+
+  @Override
   protected void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(path);
     if (status.isFolder()) {
@@ -50,7 +67,11 @@ public final class StatCommand extends WithWildCardPathCommand {
       System.out.println(status);
     } else {
       System.out.println(path + " is a file path.");
-      System.out.println(status);
+      if (cl.hasOption('f')) {
+        System.out.println(formatOutput(cl, status));
+      } else {
+        System.out.println(status);
+      }
       System.out.println("Containing the following blocks: ");
       AlluxioBlockStore blockStore = AlluxioBlockStore.create();
       for (long blockId : status.getBlockIds()) {
@@ -61,11 +82,69 @@ public final class StatCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "stat <path>";
+    return "stat [-f <format>] <path>";
   }
 
   @Override
   public String getDescription() {
-    return "Displays info for the specified path both file and directory.";
+    return "Displays info for the specified path both file and directory."
+        + " Specify -f to display info in given format:"
+        + "   \"%N\": name of the file"
+        + "   \"%z\": size of file in bytes"
+        + "   \"%u\": owner"
+        + "   \"%g\": group name of owner"
+        + "   \"%r\": replication number"
+        + "   \"%y\" or \"%Y\": modification time."
+        + "     %y shows 'yyyy-MM-dd HH:mm:ss' (the UTC date),"
+        + "     %Y it shows milliseconds since January 1, 1970 UTC"
+        + "   \"%b\": Number of blocks allocated for file";
+  }
+
+  private static final String formatRegex = "%([bgruyzNY])";
+  private static final Pattern frPattern = Pattern.compile(formatRegex);
+
+  private String formatOutput(CommandLine cl, URIStatus status) {
+    String format = cl.getOptionValue('f');
+    int formatLen = format.length();
+
+    StringBuilder output = new StringBuilder();
+    Matcher m = frPattern.matcher(format);
+    for (int i = 0; i < formatLen;) {
+      if (m.find(i)) {
+        if (m.start() != i) {
+          output.append(format.substring(i, m.start()));
+        }
+        output.append(getField(m, status));
+        i = m.end();
+      } else {
+        output.append(format.substring(i));
+        break;
+      }
+    }
+    return output.toString();
+  }
+
+  private String getField(Matcher m, URIStatus status) {
+    char formatSpecifier = m.group(1).charAt(0);
+    switch (formatSpecifier) {
+      case 'b':
+        return String.valueOf(status.getFileBlockInfos().size());
+      case 'g':
+        return status.getGroup();
+//      case 'r':
+//        return status.
+      case 'u':
+        return status.getOwner();
+      case 'y':
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return sdf.format(new Date(status.getLastModificationTimeMs()));
+      case 'z':
+        return String.valueOf(status.getLength());
+      case 'N':
+        return status.getName();
+      case 'Y':
+        return String.valueOf(status.getLastModificationTimeMs());
+    }
+    return "";
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -53,7 +53,7 @@ public final class StatCommand extends WithWildCardPathCommand {
     return new Options().addOption(
             Option.builder("f")
                     .required(false)
-                    .hasArg(true)
+                    .hasArg()
                     .desc("format")
                     .build()
     );
@@ -89,14 +89,13 @@ public final class StatCommand extends WithWildCardPathCommand {
   public String getDescription() {
     return "Displays info for the specified path both file and directory."
         + " Specify -f to display info in given format:"
-        + "   \"%N\": name of the file"
-        + "   \"%z\": size of file in bytes"
-        + "   \"%u\": owner"
-        + "   \"%g\": group name of owner"
-        + "   \"%r\": replication number"
-        + "   \"%y\" or \"%Y\": modification time."
-        + "     %y shows 'yyyy-MM-dd HH:mm:ss' (the UTC date),"
-        + "     %Y it shows milliseconds since January 1, 1970 UTC"
+        + "   \"%N\": name of the file;"
+        + "   \"%z\": size of file in bytes;"
+        + "   \"%u\": owner;"
+        + "   \"%g\": group name of owner;"
+        + "   \"%y\" or \"%Y\": modification time,"
+            + " %y shows 'yyyy-MM-dd HH:mm:ss' (the UTC date),"
+            + " %Y it shows milliseconds since January 1, 1970 UTC;"
         + "   \"%b\": Number of blocks allocated for file";
   }
 
@@ -131,8 +130,6 @@ public final class StatCommand extends WithWildCardPathCommand {
         return String.valueOf(status.getFileBlockInfos().size());
       case 'g':
         return status.getGroup();
-//      case 'r':
-//        return status.
       case 'u':
         return status.getOwner();
       case 'y':

--- a/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
@@ -79,22 +79,21 @@ public final class StatCommandTest extends AbstractAlluxioShellTest {
   public void statFileFormat() throws IOException, AlluxioException {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
 
-    String format = "%N %z %u %g %y %b";
+    String format = "%N-%z";
     mFsShell.run("stat", "-f", format, testDir + "/foo/foobar1");
     String res1 = mOutput.toString();
-    Assert.assertTrue(res1.contains(testDir + "/foo"));
-    Assert.assertTrue(res1.contains("foobar1 10"));
-    Assert.assertTrue(res1.contains(testDir + "/foo/foobar1"));
-    Assert.assertFalse(res1.contains(testDir + "/bar"));
-    Assert.assertFalse(res1.contains(testDir + "/foobar4"));
-    Assert.assertFalse(res1.contains(testDir + "/bar/foobar3"));
+    String lineSeparator = System.getProperty("line.separator");
+    Assert.assertTrue(res1.equals("foobar1-10" + lineSeparator));
+  }
 
-//    mFsShell.run("stat", testDir + "/*/foo*");
-//    String res2 = mOutput.toString();
-//    res2 = res2.replace(res1, "");
-//    Assert.assertTrue(res2.contains(testDir + "/foo/foobar1"));
-//    Assert.assertTrue(res2.contains(testDir + "/foo/foobar2"));
-//    Assert.assertTrue(res2.contains(testDir + "/bar/foobar3"));
-//    Assert.assertFalse(res2.contains(testDir + "/foobar4"));
+  @Test
+  public void statDirectoryFormat() throws IOException, AlluxioException {
+    String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
+
+    String format = "%N-%z";
+    mFsShell.run("stat", "-f", format, testDir + "/foo");
+    String res1 = mOutput.toString();
+    String lineSeparator = System.getProperty("line.separator");
+    Assert.assertTrue(res1.equals("foo-NA" + lineSeparator));
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
@@ -79,21 +79,31 @@ public final class StatCommandTest extends AbstractAlluxioShellTest {
   public void statFileFormat() throws IOException, AlluxioException {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
 
-    String format = "%N-%z";
+    String format = "%N-%z-%b-%u-%g-%Y";
     mFsShell.run("stat", "-f", format, testDir + "/foo/foobar1");
     String res1 = mOutput.toString();
-    String lineSeparator = System.getProperty("line.separator");
-    Assert.assertTrue(res1.equals("foobar1-10" + lineSeparator));
+    Assert.assertTrue(res1.startsWith("foobar1-10-1-"));
+
+    format = "%N-%z-%b-%u-%g-%y";
+    mFsShell.run("stat", "-f", format, testDir + "/foo/foobar1");
+    String res2 = mOutput.toString();
+    res2 = res2.replace(res1, "");
+    Assert.assertTrue(res2.startsWith("foobar1-10-1-"));
   }
 
   @Test
   public void statDirectoryFormat() throws IOException, AlluxioException {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
 
-    String format = "%N-%z";
+    String format = "%N-%z-%b-%Y-%u-%g";
     mFsShell.run("stat", "-f", format, testDir + "/foo");
     String res1 = mOutput.toString();
-    String lineSeparator = System.getProperty("line.separator");
-    Assert.assertTrue(res1.equals("foo-NA" + lineSeparator));
+    Assert.assertTrue(res1.startsWith("foo-NA-NA-"));
+
+    format = "%N-%z-%b-%y-%u-%g";
+    mFsShell.run("stat", "-f", format, testDir + "/foo");
+    String res2 = mOutput.toString();
+    res2 = res2.replace(res1, "");
+    Assert.assertTrue(res2.startsWith("foo-NA-NA-"));
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/StatCommandTest.java
@@ -74,4 +74,27 @@ public final class StatCommandTest extends AbstractAlluxioShellTest {
     Assert.assertTrue(res2.contains(testDir + "/bar/foobar3"));
     Assert.assertFalse(res2.contains(testDir + "/foobar4"));
   }
+
+  @Test
+  public void statFileFormat() throws IOException, AlluxioException {
+    String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
+
+    String format = "%N %z %u %g %y %b";
+    mFsShell.run("stat", "-f", format, testDir + "/foo/foobar1");
+    String res1 = mOutput.toString();
+    Assert.assertTrue(res1.contains(testDir + "/foo"));
+    Assert.assertTrue(res1.contains("foobar1 10"));
+    Assert.assertTrue(res1.contains(testDir + "/foo/foobar1"));
+    Assert.assertFalse(res1.contains(testDir + "/bar"));
+    Assert.assertFalse(res1.contains(testDir + "/foobar4"));
+    Assert.assertFalse(res1.contains(testDir + "/bar/foobar3"));
+
+//    mFsShell.run("stat", testDir + "/*/foo*");
+//    String res2 = mOutput.toString();
+//    res2 = res2.replace(res1, "");
+//    Assert.assertTrue(res2.contains(testDir + "/foo/foobar1"));
+//    Assert.assertTrue(res2.contains(testDir + "/foo/foobar2"));
+//    Assert.assertTrue(res2.contains(testDir + "/bar/foobar3"));
+//    Assert.assertFalse(res2.contains(testDir + "/foobar4"));
+  }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2573
The stat shell command displays information about the file.
For “bin/alluxio fs stat -f <format> <path>”: prints the formatted stat info. e.g
Supported format symbol:
"%N": name of the file
"%z": size of file in bytes
"%u": owner
"%g": group name of owner
"%y" or "%Y": modification time. %y shows “yyyy-MM-dd HH:mm:ss” (the UTC date), for %Y it shows milliseconds since January 1, 1970 UTC
"%b": Number of blocks allocated for file