### PR TITLE
[ALLUXIO-2571]Add "-h" (HumanReadable) option for Shell Command “bin/alluxio fs ls”

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -83,10 +83,10 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .build();
   protected static final Option LIST_HUMAN_READABLE_OPTION =
       Option.builder("h")
-           .required(false)
-           .hasArg(false)
-           .desc("print human-readable format sizes")
-           .build();
+          .required(false)
+          .hasArg(false)
+          .desc("print human-readable format sizes")
+          .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -81,11 +81,11 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .hasArg(false)
           .desc("repair inconsistent files")
           .build();
-  protected static final Option LIST_RAW_SIZE_OPTION =
-      Option.builder("raw")
+  protected static final Option LIST_HUMAN_READABLE_OPTION =
+      Option.builder("h")
           .required(false)
           .hasArg(false)
-          .desc("print raw sizes.")
+          .desc("repair inconsistent files")
           .build();
 
   protected AbstractShellCommand(FileSystem fs) {

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -85,7 +85,7 @@ public abstract class AbstractShellCommand implements ShellCommand {
       Option.builder("h")
           .required(false)
           .hasArg(false)
-          .desc("repair inconsistent files")
+          .desc("print human-readable format sizes")
           .build();
 
   protected AbstractShellCommand(FileSystem fs) {

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -82,11 +82,11 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .desc("repair inconsistent files")
           .build();
   protected static final Option LIST_HUMAN_READABLE_OPTION =
-      Option.builder("h")
-          .required(false)
-          .hasArg(false)
-          .desc("print human-readable format sizes")
-          .build();
+          Option.builder("h")
+                  .required(false)
+                  .hasArg(false)
+                  .desc("print human-readable format sizes")
+                  .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -82,11 +82,11 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .desc("repair inconsistent files")
           .build();
   protected static final Option LIST_HUMAN_READABLE_OPTION =
-          Option.builder("h")
-                  .required(false)
-                  .hasArg(false)
-                  .desc("print human-readable format sizes")
-                  .build();
+      Option.builder("h")
+           .required(false)
+           .hasArg(false)
+           .desc("print human-readable format sizes")
+           .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -22,7 +22,6 @@ import alluxio.util.SecurityUtils;
 import alluxio.wire.LoadMetadataType;
 
 import org.apache.commons.cli.CommandLine;
-
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
@@ -176,7 +175,7 @@ public final class LsCommand extends WithWildCardPathCommand {
   @Override
   public void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
-            cl.hasOption("p"));
+        cl.hasOption("p"));
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -22,7 +22,7 @@ import alluxio.util.SecurityUtils;
 import alluxio.wire.LoadMetadataType;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
+
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
@@ -115,7 +115,6 @@ public final class LsCommand extends WithWildCardPathCommand {
         .addOption(LIST_HUMAN_READABLE_OPTION);
   }
 
-
   /**
    * Displays information for all directories and files directly under the path specified in args.
    *
@@ -177,7 +176,7 @@ public final class LsCommand extends WithWildCardPathCommand {
   @Override
   public void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
     ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
-        cl.hasOption("p"));
+            cl.hasOption("p"));
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -22,6 +22,7 @@ import alluxio.util.SecurityUtils;
 import alluxio.wire.LoadMetadataType;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public final class LsCommand extends WithWildCardPathCommand {
   /**
    * Formats the ls result string.
    *
-   * @param rawSize print raw sizes
+   * @param hSize print human-readable format sizes
    * @param acl whether security is enabled
    * @param isFolder whether this path is a file or a folder
    * @param permission permission string
@@ -56,7 +57,7 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param path path of the file or folder
    * @return the formatted string according to acl and isFolder
    */
-  public static String formatLsString(boolean rawSize, boolean acl, boolean isFolder, String
+  public static String formatLsString(boolean hSize, boolean acl, boolean isFolder, String
       permission,
       String userName, String groupName, long size, long createTimeMs, boolean inMemory,
       String path) {
@@ -66,7 +67,7 @@ public final class LsCommand extends WithWildCardPathCommand {
     } else {
       memoryState = inMemory ? STATE_FILE_IN_MEMORY : STATE_FILE_NOT_IN_MEMORY;
     }
-    String sizeStr = rawSize ? String.valueOf(size) : FormatUtils.getSizeFromBytes(size);
+    String sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     if (acl) {
       return String.format(Constants.LS_FORMAT, permission, userName, groupName,
           sizeStr, CommandUtils.convertMsToDate(createTimeMs),
@@ -77,8 +78,8 @@ public final class LsCommand extends WithWildCardPathCommand {
     }
   }
 
-  private void printLsString(URIStatus status, boolean rawSize) {
-    System.out.print(formatLsString(rawSize, SecurityUtils.isSecurityEnabled(),
+  private void printLsString(URIStatus status, boolean hSize) {
+    System.out.print(formatLsString(hSize, SecurityUtils.isSecurityEnabled(),
         status.isFolder(), FormatUtils.formatMode((short) status.getMode(), status.isFolder()),
         status.getOwner(), status.getGroup(), status.getLength(), status.getCreationTimeMs(),
         100 == status.getInMemoryPercentage(), status.getPath()));
@@ -111,8 +112,9 @@ public final class LsCommand extends WithWildCardPathCommand {
         .addOption(FORCE_OPTION)
         .addOption(LIST_DIR_AS_FILE_OPTION)
         .addOption(LIST_PINNED_FILES_OPTION)
-        .addOption(LIST_RAW_SIZE_OPTION);
+        .addOption(LIST_HUMAN_READABLE_OPTION);
   }
+
 
   /**
    * Displays information for all directories and files directly under the path specified in args.
@@ -120,19 +122,19 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param recursive Whether list the path recursively
    * @param dirAsFile list the directory status as a plain file
-   * @param rawSize print raw sizes
+   * @param hSize print human-readable format sizes
    * @throws AlluxioException when Alluxio exception occurs
    * @throws IOException when non-Alluxio exception occurs
    */
   private void ls(AlluxioURI path, boolean recursive, boolean forceLoadMetadata, boolean dirAsFile,
-                  boolean rawSize, boolean pinnedOnly)
+                  boolean hSize, boolean pinnedOnly)
       throws AlluxioException, IOException {
     if (dirAsFile) {
       URIStatus status = mFileSystem.getStatus(path);
       if (pinnedOnly && !status.isPinned()) {
         return;
       }
-      printLsString(status, rawSize);
+      printLsString(status, hSize);
       return;
     }
 
@@ -143,11 +145,11 @@ public final class LsCommand extends WithWildCardPathCommand {
     List<URIStatus> statuses = listStatusSortedByIncreasingCreationTime(path, options);
     for (URIStatus status : statuses) {
       if (!pinnedOnly || status.isPinned()) {
-        printLsString(status, rawSize);
+        printLsString(status, hSize);
       }
       if (recursive && status.isFolder()) {
         ls(new AlluxioURI(path.getScheme(), path.getAuthority(), status.getPath()), true,
-            forceLoadMetadata, false, rawSize, pinnedOnly);
+            forceLoadMetadata, false, hSize, pinnedOnly);
       }
     }
   }
@@ -174,13 +176,13 @@ public final class LsCommand extends WithWildCardPathCommand {
 
   @Override
   public void runCommand(AlluxioURI path, CommandLine cl) throws AlluxioException, IOException {
-    ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("raw"),
+    ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
         cl.hasOption("p"));
   }
 
   @Override
   public String getUsage() {
-    return "ls [-d|-f|-p|-R|-raw] <path>";
+    return "ls [-d|-f|-p|-R|-h] <path>";
   }
 
   @Override
@@ -190,6 +192,6 @@ public final class LsCommand extends WithWildCardPathCommand {
         + " Specify -f to force loading files in the directory."
         + " Specify -p to list all the pinned files."
         + " Specify -R to display files and directories recursively."
-        + " Specify -raw to print raw sizes.";
+        + " Specify -h to print human-readable format sizes.";
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -66,20 +66,6 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
         CommandUtils.convertMsToDate(createTime), fileType, path);
   }
 
-    // Helper function to format ls result without acl enabled.
-    private String getLsNoAclResultStr_h(AlluxioURI uri, int size, String fileType)
-            throws IOException, AlluxioException {
-        URIStatus status = mFileSystem.getStatus(uri);
-        return getLsNoAclResultStr_h(uri.getPath(), status.getCreationTimeMs(), size, fileType);
-    }
-
-    // Helper function to format ls result without acl enabled.
-    private String getLsNoAclResultStr_h(String path, long createTime, int size, String fileType)
-            throws IOException, AlluxioException {
-        return String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(size),
-                CommandUtils.convertMsToDate(createTime), fileType, path);
-    }
-
   // Helper function to create a set of files in the file system
   private URIStatus[] createFiles() throws IOException, AlluxioException {
     FileSystemTestUtils
@@ -127,12 +113,12 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
         URIStatus[] files = createFiles();
         mFsShell.run("ls", "-h", "/testRoot");
         String expected = "";
-        expected += getLsNoAclResultStr_h("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-                LsCommand.STATE_FILE_IN_MEMORY);
-        expected += getLsNoAclResultStr_h("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
-                LsCommand.STATE_FOLDER);
-        expected += getLsNoAclResultStr_h("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-                LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        expected += String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(10),
+                CommandUtils.convertMsToDate(files[0].getCreationTimeMs()), LsCommand.STATE_FILE_IN_MEMORY, "/testRoot/testFileA");
+        expected += String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(1),
+                CommandUtils.convertMsToDate(files[1].getCreationTimeMs()), LsCommand.STATE_FOLDER, "/testRoot/testDir");
+        expected += String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(30),
+                CommandUtils.convertMsToDate(files[3].getCreationTimeMs()), LsCommand.STATE_FILE_NOT_IN_MEMORY, "/testRoot/testFileC");
         Assert.assertEquals(expected, mOutput.toString());
     }
 

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -71,7 +71,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
       throws IOException, AlluxioException {
     String sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr,
-              CommandUtils.convertMsToDate(createTime), fileType, path);
+        CommandUtils.convertMsToDate(createTime), fileType, path);
   }
 
   // Helper function to create a set of files in the file system
@@ -115,19 +115,19 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
    */
   @Test
   @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
+      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsHumanReadable() throws IOException, AlluxioException {
     URIStatus[] files = createFiles();
     mFsShell.run("ls", "-h", "/testRoot");
     boolean hSize = true;
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), hSize, 10,
-            LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_MEMORY);
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), hSize, 1,
-            LsCommand.STATE_FOLDER);
+        LsCommand.STATE_FOLDER);
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), hSize, 30,
-            LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        LsCommand.STATE_FILE_NOT_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }
 

--- a/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/LsCommandTest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  */
 public final class LsCommandTest extends AbstractAlluxioShellTest {
   // Helper function to format ls result.
-  private String getLsResultStr(AlluxioURI uri, String size, String testUser, String testGroup)
+  private String getLsResultStr(AlluxioURI uri, int size, String testUser, String testGroup)
       throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
     return getLsResultStr(uri.getPath(), status.getCreationTimeMs(), size,
@@ -43,28 +43,42 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
   }
 
   // Helper function to format ls result.
-  private String getLsResultStr(String path, long createTime, String size, String fileType,
+  private String getLsResultStr(String path, long createTime, int size, String fileType,
       String testUser, String testGroup, int permission, boolean isDir)
       throws IOException, AlluxioException {
     return String
         .format(Constants.LS_FORMAT, FormatUtils.formatMode((short) permission, isDir),
-            testUser, testGroup, size,
+            testUser, testGroup, String.valueOf(size),
             CommandUtils.convertMsToDate(createTime), fileType, path);
   }
 
   // Helper function to format ls result without acl enabled.
-  private String getLsNoAclResultStr(AlluxioURI uri, String size, String fileType)
+  private String getLsNoAclResultStr(AlluxioURI uri, int size, String fileType)
       throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
     return getLsNoAclResultStr(uri.getPath(), status.getCreationTimeMs(), size, fileType);
   }
 
   // Helper function to format ls result without acl enabled.
-  private String getLsNoAclResultStr(String path, long createTime, String size, String fileType)
+  private String getLsNoAclResultStr(String path, long createTime, int size, String fileType)
       throws IOException, AlluxioException {
-    return String.format(Constants.LS_FORMAT_NO_ACL, size,
+    return String.format(Constants.LS_FORMAT_NO_ACL, String.valueOf(size),
         CommandUtils.convertMsToDate(createTime), fileType, path);
   }
+
+    // Helper function to format ls result without acl enabled.
+    private String getLsNoAclResultStr_h(AlluxioURI uri, int size, String fileType)
+            throws IOException, AlluxioException {
+        URIStatus status = mFileSystem.getStatus(uri);
+        return getLsNoAclResultStr_h(uri.getPath(), status.getCreationTimeMs(), size, fileType);
+    }
+
+    // Helper function to format ls result without acl enabled.
+    private String getLsNoAclResultStr_h(String path, long createTime, int size, String fileType)
+            throws IOException, AlluxioException {
+        return String.format(Constants.LS_FORMAT_NO_ACL, FormatUtils.getSizeFromBytes(size),
+                CommandUtils.convertMsToDate(createTime), fileType, path);
+    }
 
   // Helper function to create a set of files in the file system
   private URIStatus[] createFiles() throws IOException, AlluxioException {
@@ -93,14 +107,34 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     URIStatus[] files = createFiles();
     mFsShell.run("ls", "/testRoot");
     String expected = "";
-    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), String.valueOf(10),
+    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), String.valueOf(1),
+    expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
         LsCommand.STATE_FOLDER);
-    expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), String.valueOf(30),
+    expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         LsCommand.STATE_FILE_NOT_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }
+
+    /**
+     * Tests ls -h command when security is not enabled.
+     */
+    @Test
+    @LocalAlluxioClusterResource.Config(
+            confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+                    PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
+    public void lsHumanReadable() throws IOException, AlluxioException {
+        URIStatus[] files = createFiles();
+        mFsShell.run("ls", "-h", "/testRoot");
+        String expected = "";
+        expected += getLsNoAclResultStr_h("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
+                LsCommand.STATE_FILE_IN_MEMORY);
+        expected += getLsNoAclResultStr_h("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
+                LsCommand.STATE_FOLDER);
+        expected += getLsNoAclResultStr_h("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
+                LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        Assert.assertEquals(expected, mOutput.toString());
+    }
 
   /**
    * Tests ls -p command when security is not enabled.
@@ -117,31 +151,12 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
         SetAttributeOptions.defaults().setPinned(true));
     mFsShell.run("ls", "-pR",  "/testRoot");
     String expected = "";
-    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), String.valueOf(10),
+    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), String.valueOf(20),
+    expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
         LsCommand.STATE_FILE_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }
-    /**
-     * Tests ls -h command when security is not enabled.
-     */
-    @Test
-    @LocalAlluxioClusterResource.Config(
-            confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                    PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
-    public void lsHumanReadable() throws IOException, AlluxioException {
-        URIStatus[] files = createFiles();
-        mFsShell.run("ls", "-h", "/testRoot");
-        String expected = "";
-        expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), FormatUtils.getSizeFromBytes(10),
-                LsCommand.STATE_FILE_IN_MEMORY);
-        expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), FormatUtils.getSizeFromBytes(1),
-                LsCommand.STATE_FOLDER);
-        expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), FormatUtils.getSizeFromBytes(30),
-                LsCommand.STATE_FILE_NOT_IN_MEMORY);
-        Assert.assertEquals(expected, mOutput.toString());
-    }
 
   /**
    * Tests ls -d command when security is not enabled.
@@ -156,7 +171,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/testRoot/"));
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot", dirStatus.getCreationTimeMs(),
-            String.valueOf(3) /* number of direct children under /testRoot/ dir */, LsCommand.STATE_FOLDER);
+        3 /* number of direct children under /testRoot/ dir */, LsCommand.STATE_FOLDER);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -171,7 +186,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-d", "/");
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/"));
     String expected = "";
-    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), String.valueOf(0), LsCommand.STATE_FOLDER);
+    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.STATE_FOLDER);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -191,13 +206,13 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     URIStatus[] files = createFiles();
     mFsShell.run("ls", "/testRoot");
     String expected = "";
-    expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), String.valueOf(10),
+    expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[0].getMode(),
         files[0].isFolder());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), String.valueOf(1), LsCommand.STATE_FOLDER,
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
             testUser, testUser, files[1].getMode(), files[1].isFolder());
-    expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), String.valueOf(30),
+    expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         LsCommand.STATE_FILE_NOT_IN_MEMORY, testUser, testUser, files[3].getMode(),
         files[3].isFolder());
     Assert.assertEquals(expected, mOutput.toString());
@@ -214,22 +229,22 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
 
     String expect = "";
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), String.valueOf(30),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), String.valueOf(10),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), String.valueOf(20),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
         LsCommand.STATE_FILE_IN_MEMORY);
     mFsShell.run("ls", testDir + "/*/foo*");
     Assert.assertEquals(expect, mOutput.toString());
 
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), String.valueOf(30),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), String.valueOf(10),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), String.valueOf(20),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), String.valueOf(40),
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40,
         LsCommand.STATE_FILE_IN_MEMORY);
     mFsShell.run("ls", testDir + "/*");
     Assert.assertEquals(expect, mOutput.toString());
@@ -253,16 +268,16 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem);
 
     String expect = "";
-    expect += getLsResultStr(new AlluxioURI(testDir + "/bar/foobar3"), String.valueOf(30), testUser, testUser);
-    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar1"), String.valueOf(10), testUser, testUser);
-    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar2"), String.valueOf(20), testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30, testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10, testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20, testUser, testUser);
     mFsShell.run("ls", testDir + "/*/foo*");
     Assert.assertEquals(expect, mOutput.toString());
 
-    expect += getLsResultStr(new AlluxioURI(testDir + "/bar/foobar3"), String.valueOf(30), testUser, testUser);
-    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar1"), String.valueOf(10), testUser, testUser);
-    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar2"), String.valueOf(20), testUser, testUser);
-    expect += getLsResultStr(new AlluxioURI(testDir + "/foobar4"), String.valueOf(40), testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30, testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10, testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20, testUser, testUser);
+    expect += getLsResultStr(new AlluxioURI(testDir + "/foobar4"), 40, testUser, testUser);
     mFsShell.run("ls", testDir + "/*");
     Assert.assertEquals(expect, mOutput.toString());
   }
@@ -279,13 +294,13 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     mFsShell.run("lsr", "/testRoot");
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
-    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), String.valueOf(10),
+    expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), String.valueOf(1),
+    expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
         LsCommand.STATE_FOLDER);
-    expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), String.valueOf(20),
+    expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
         LsCommand.STATE_FILE_IN_MEMORY);
-    expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), String.valueOf(30),
+    expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         LsCommand.STATE_FILE_NOT_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }
@@ -309,16 +324,16 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     mFsShell.run("lsr", "/testRoot");
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
-    expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), String.valueOf(10),
+    expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[0].getMode(),
         files[0].isFolder());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), String.valueOf(1), LsCommand.STATE_FOLDER,
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
             testUser, testUser, files[1].getMode(), files[1].isFolder());
-    expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), String.valueOf(20),
+    expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
         LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[2].getMode(),
         files[2].isFolder());
-    expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), String.valueOf(30),
+    expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         LsCommand.STATE_FILE_NOT_IN_MEMORY, testUser, testUser, files[3].getMode(),
         files[3].isFolder());
     Assert.assertEquals(expected, mOutput.toString());
@@ -336,7 +351,7 @@ public final class LsCommandTest extends AbstractAlluxioShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, fileName, WriteType.MUST_CACHE, 10);
     URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
     mFsShell.run("ls", "/");
-    String expected = getLsNoAclResultStr(fileName, file.getCreationTimeMs(), String.valueOf(10),
+    String expected = getLsNoAclResultStr(fileName, file.getCreationTimeMs(), 10,
         LsCommand.STATE_FILE_IN_MEMORY);
     Assert.assertEquals(expected, mOutput.toString());
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2571

Currently "bin/alluxio fs ls <path>" command works like normal "ls" command on Linux shell, it shows the information of files or directories, including the size of a file.
This JIRA aims to add a “-h” option like linux "ls" command by which user can specify the format of file sizes in a human-readable fashion (eg 1K instead of 1024). To be more specific 
when used with the -l option, the size part of ls output use unit suffixes: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte and Petabyte, like "204B", "35K", "1M", "23G" depends on the actual file size. Right now, this is enabled by default and you have to use -raw option to show the raw size. This JIRA aims to switch this by displaying the size in raw bytes by default, and only shows human-readable when "-h" is specified.