### PR TITLE
[ALLUXIO-2591] Fix logging style in BaseFileSystem

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -85,7 +85,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.createDirectory(path, options);
-      LOG.debug("Created directory " + path.getPath());
+      LOG.debug("Created directory {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -105,7 +105,7 @@ public class BaseFileSystem implements FileSystem {
     try {
       masterClient.createFile(path, options);
       status = masterClient.getStatus(path);
-      LOG.debug("Created file " + path.getPath());
+      LOG.debug("Created file {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -126,7 +126,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.delete(path, options);
-      LOG.debug("Deleted file " + path.getName());
+      LOG.debug("Deleted {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -165,7 +165,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.free(path, options);
-      LOG.debug("Freed file " + path.getPath());
+      LOG.debug("Freed {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -234,7 +234,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.loadMetadata(path, options);
-      LOG.debug("loaded metadata {} with options {}", path.getParent(), options);
+      LOG.debug("Loaded metadata {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -290,7 +290,7 @@ public class BaseFileSystem implements FileSystem {
     try {
       // TODO(calvin): Update this code on the master side.
       masterClient.rename(src, dst);
-      LOG.debug("Renamed file " + src.getPath() + " to " + dst.getPath());
+      LOG.debug("Renamed {} to {}, options: {}", src.getPath(), dst.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -308,7 +308,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.setAttribute(path, options);
-      LOG.debug("Set attributes for path {} with options {}", path.getPath(), options);
+      LOG.debug("Set attributes for {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }
@@ -325,7 +325,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFileSystemContext.acquireMasterClient();
     try {
       masterClient.unmount(path);
-      LOG.info("Unmount " + path);
+      LOG.debug("Unmounted {}, options: {}", path.getPath(), options);
     } finally {
       mFileSystemContext.releaseMasterClient(masterClient);
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2591
All the replacements is done,**EXCEPT** 
`LOG.info("Mount " + ufsPath.toString() + " to " + alluxioPath.getPath());`
 TO
 `¨LOG.debug("Mounted {} to {}, options: {}", ufsPath.toString(), alluxioPath.getPath(), options);¨`
There is a problem with this replacement that  it may lead to a mistake reported by maven described as

> error: Line is longer than 100 characters (found 101)

please check the correctness of the code for this replacement.