### PR TITLE
[ALLUXIO-2694] Specify null variable in ClientHandler.java precondition check

### DIFF
--- a/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
+++ b/core/client/src/main/java/alluxio/client/netty/ClientHandler.java
@@ -69,7 +69,7 @@ public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage>
    * @return the current handler
    */
   public ClientHandler addListener(ResponseListener listener) {
-    mListeners.add(Preconditions.checkNotNull(listener));
+    mListeners.add(Preconditions.checkNotNull(listener, "listener"));
     return this;
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2694
Currently we use
mAddress = Preconditions.checkNotNull(address);
If this precondition fails, it will throw a NullPointerException with no message. We should add a second argument so that the exception will include the name of the variable that is null:
mAddress = Preconditions.checkNotNull(address, "address");