### PR TITLE
[ALLUXIO-2592]Fix logging style in AbstractFileSystem

### DIFF
--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -249,7 +249,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       mFileSystem.delete(uri, options);
       return true;
     } catch (InvalidPathException | FileDoesNotExistException e) {
-      LOG.error("delete failed: {}", e.getMessage());
+      LOG.warn("delete failed: {}", e.getMessage());
       return false;
     } catch (AlluxioException e) {
       throw new IOException(e);
@@ -656,7 +656,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     try {
       mFileSystem.rename(srcPath, dstPath);
     } catch (FileDoesNotExistException e) {
-      LOG.error("Failed to rename {} to {}", src, dst);
+      LOG.warn("rename failed: {}", e.getMessage());
       return false;
     } catch (AlluxioException e) {
       ensureExists(srcPath);
@@ -664,14 +664,14 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       try {
         dstStatus = mFileSystem.getStatus(dstPath);
       } catch (IOException | AlluxioException e2) {
-        LOG.error("Failed to rename {} to {}", src, dst);
+        LOG.warn("rename failed: {}", e.getMessage());
         return false;
       }
       // If the destination is an existing folder, try to move the src into the folder
       if (dstStatus != null && dstStatus.isFolder()) {
         dstPath = dstPath.join(srcPath.getName());
       } else {
-        LOG.error("Failed to rename {} to {}", src, dst);
+        LOG.warn("rename failed: {}", e.getMessage());
         return false;
       }
       try {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2592
Replace all occurrences of
  LOG.error("delete failed: {}", e.getMessage());
  LOG.error("Failed to rename {} to {}", src, dst);
with
  LOG.warn("delete failed: {}", e.getMessage());
  LOG.warn("rename failed: {}", e.getMessage());