### PR TITLE
[ALLUXIO-2797] Use precondition check chaining in FileInfo

### DIFF
--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -268,8 +268,7 @@ public final class FileInfo implements Serializable {
    * @return the file information
    */
   public FileInfo setName(String name) {
-    Preconditions.checkNotNull(name);
-    mName = name;
+    mName = Preconditions.checkNotNull(name);
     return this;
   }
 


### PR DESCRIPTION
The preconditions check in setName(String name) can be chained to save a statement.