### PR TITLE
[ALLUXIO-2708] Specify null variable in CommandLineJobInfo.java precondition check

### DIFF
--- a/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
+++ b/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
@@ -66,7 +66,7 @@ public final class CommandLineJobInfo implements Serializable {
    * @return the lineage command-line job information
    */
   public CommandLineJobInfo setCommand(String command) {
-    Preconditions.checkNotNull(command);
+    Preconditions.checkNotNull(command, "command");
     mCommand = command;
     return this;
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2708
Currently we use
Preconditions.checkNotNull(command); 
If this precondition fails, it will throw a NullPointerException with no message. We should add a second argument so that the exception will include the name of the variable that is null:
Preconditions.checkNotNull(command, "command"); 