### PR TITLE
[ALLUXIO-2704] Specify null variable in PlainSaslServerCallbackHandler.java precondition check

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerCallbackHandler.java
+++ b/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerCallbackHandler.java
@@ -39,7 +39,8 @@ public final class PlainSaslServerCallbackHandler implements CallbackHandler {
    */
   public PlainSaslServerCallbackHandler(AuthenticationProvider authenticationProvider,
       Runnable callback) {
-    mAuthenticationProvider = Preconditions.checkNotNull(authenticationProvider);
+    mAuthenticationProvider = Preconditions.checkNotNull(authenticationProvider,
+                                                         "authenticationProvider");
     mCallback = callback;
   }
 

--- a/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerCallbackHandler.java
+++ b/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerCallbackHandler.java
@@ -40,7 +40,7 @@ public final class PlainSaslServerCallbackHandler implements CallbackHandler {
   public PlainSaslServerCallbackHandler(AuthenticationProvider authenticationProvider,
       Runnable callback) {
     mAuthenticationProvider = Preconditions.checkNotNull(authenticationProvider,
-                                                         "authenticationProvider");
+        "authenticationProvider");
     mCallback = callback;
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2704
Add a second argument so that the exception will include the name of the variable that is null.