### PR TITLE
[ALLUXIO-2720] Deprecate Throwables.propagate with RuntimeException in ClientTestUtils.java

### DIFF
--- a/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -17,7 +17,6 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.lineage.LineageContext;
 import alluxio.hadoop.HadoopClientTestUtils;
 
-import com.google.common.base.Throwables;
 
 /**
  * Utility methods for the client tests.
@@ -42,7 +41,7 @@ public final class ClientTestUtils {
       HadoopClientTestUtils.resetHadoopClientContext();
       resetContexts();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -17,7 +17,6 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.lineage.LineageContext;
 import alluxio.hadoop.HadoopClientTestUtils;
 
-
 /**
  * Utility methods for the client tests.
  */


### PR DESCRIPTION
[ALLUXIO-2720]Deprecate Throwables.propagate with RuntimeException in ClientTestUtils.java
https://alluxio.atlassian.net/browse/ALLUXIO-2720