### PR TITLE
[ALLUXIO-2743] Support specifying Mount Options for each Mount Point (part2)

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -156,19 +156,18 @@ function copyDir {
 }
 
 function runJavaClass {
-  CLASS_ARGS=""
+  CLASS_ARGS=()
   for arg in "$@"; do
-      shift
       case "${arg}" in
           -debug)
               ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
           -D*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
-              CLASS_ARGS+=" ${arg}"
+              CLASS_ARGS+=("${arg}")
       esac
   done
-  "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} ${CLASS_ARGS}
+  "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
 }
 
 function main {

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -36,27 +36,6 @@ public abstract class AbstractShellCommand implements ShellCommand {
             .hasArg(false)
             .desc("recursive")
             .build();
-  protected static final Option READONLY_OPTION =
-      Option.builder("readonly")
-          .required(false)
-          .hasArg(false)
-          .desc("readonly")
-          .build();
-  protected static final Option MOUNT_SHARED_OPTION =
-      Option.builder("shared")
-          .required(false)
-          .hasArg(false)
-          .desc("shared")
-          .build();
-
-  // TODO(gpang): Investigate property=value style of cmdline options. They didn't seem to
-  // support spaces in values.
-  protected static final Option PROPERTY_FILE_OPTION =
-      Option.builder("P")
-          .required(false)
-          .numberOfArgs(1)
-          .desc("properties file name")
-          .build();
   protected static final Option FORCE_OPTION =
       Option.builder("f")
           .required(false)

--- a/shell/src/main/java/alluxio/shell/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/MountCommand.java
@@ -34,6 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class MountCommand extends AbstractShellCommand {
+  /** the pattern to parse key=value as argument of --option. */
   private static final Pattern OPTION_PATTERN = Pattern.compile("(.*)=(.*)");
 
   private static final Option READONLY_OPTION =
@@ -89,8 +90,12 @@ public final class MountCommand extends AbstractShellCommand {
     AlluxioURI ufsPath = new AlluxioURI(args[1]);
     MountOptions options = MountOptions.defaults();
 
-    options.setReadOnly(cl.hasOption(READONLY_OPTION.getLongOpt()));
-    options.setShared(cl.hasOption(SHARED_OPTION.getLongOpt()));
+    if (cl.hasOption(READONLY_OPTION.getLongOpt())) {
+      options.setReadOnly(true);
+    }
+    if (cl.hasOption(SHARED_OPTION.getLongOpt())) {
+      options.setShared(true);
+    }
     if (cl.hasOption(OPTION_OPTION.getLongOpt())) {
       Map<String, String> properties = new HashMap<>();
       String[] optionValues = cl.getOptionValues("option");

--- a/shell/src/main/java/alluxio/shell/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/MountCommand.java
@@ -39,21 +39,21 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class MountCommand extends AbstractShellCommand {
   private static final Pattern OPTION_PATTERN = Pattern.compile("(.*)=(.*)");
 
-  private static final Option MOUNT_READONLY_OPTION =
+  private static final Option READONLY_OPTION =
       Option.builder()
           .longOpt("readonly")
           .required(false)
           .hasArg(false)
           .desc("readonly")
           .build();
-  private static final Option MOUNT_SHARED_OPTION =
+  private static final Option SHARED_OPTION =
       Option.builder()
           .longOpt("shared")
           .required(false)
           .hasArg(false)
           .desc("shared")
           .build();
-  private static final Option MOUNT_OPTION_OPTION =
+  private static final Option OPTION_OPTION =
       Option.builder()
           .longOpt("option")
           .required(false)
@@ -88,8 +88,8 @@ public final class MountCommand extends AbstractShellCommand {
 
   @Override
   protected Options getOptions() {
-    return new Options().addOption(PROPERTY_FILE_OPTION).addOption(MOUNT_READONLY_OPTION)
-        .addOption(MOUNT_SHARED_OPTION).addOption(MOUNT_OPTION_OPTION);
+    return new Options().addOption(PROPERTY_FILE_OPTION).addOption(READONLY_OPTION)
+        .addOption(SHARED_OPTION).addOption(OPTION_OPTION);
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/MountCommand.java
@@ -44,21 +44,22 @@ public final class MountCommand extends AbstractShellCommand {
           .longOpt("readonly")
           .required(false)
           .hasArg(false)
-          .desc("readonly")
+          .desc("mount point is readonly in Alluxio")
           .build();
   private static final Option SHARED_OPTION =
       Option.builder()
           .longOpt("shared")
           .required(false)
           .hasArg(false)
-          .desc("shared")
+          .desc("mount point is shared")
           .build();
   private static final Option OPTION_OPTION =
       Option.builder()
           .longOpt("option")
+          .argName("key=value")
           .required(false)
           .hasArg(true)
-          .desc("option")
+          .desc("options associated with this mount point")
           .build();
   // TODO(gpang): Investigate property=value style of cmdline options. They didn't seem to
   // support spaces in values.

--- a/shell/src/main/java/alluxio/shell/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/MountCommand.java
@@ -130,7 +130,7 @@ public final class MountCommand extends AbstractShellCommand {
 
     if (cl.hasOption("option")) {
       Map<String, String> properties = new HashMap<>();
-      String optionValues[] = cl.getOptionValues("option");
+      String[] optionValues = cl.getOptionValues("option");
       for (String option : optionValues) {
         Matcher matcher = OPTION_PATTERN.matcher(option);
         Preconditions.checkArgument(matcher.matches(), "Unrecognized property %s", option);

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -79,11 +79,19 @@ public final class MountCommandTest extends AbstractAlluxioShellTest {
   }
 
   @Test
-  public void mountWithSpaceQuotedOption() throws Exception {
+  public void mountWithSpaceInOptionValues() throws Exception {
     AlluxioURI mountPoint = new AlluxioURI("/mnt");
     String ufsPath = mFolder.getRoot().getAbsolutePath();
     Assert.assertEquals(0, mFsShell
         .run("mount", "--option", "key=\" value with spaces\"", mountPoint.toString(), ufsPath));
+  }
+
+  @Test
+  public void mountWithEqualsInOptionValues() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(0,
+        mFsShell.run("mount", "--option", "key=k=v", mountPoint.toString(), ufsPath));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -63,9 +63,27 @@ public final class MountCommandTest extends AbstractAlluxioShellTest {
     Assert.assertEquals(-1, mFsShell.run("mount"));
     // ufs missing
     Assert.assertEquals(-1, mFsShell.run("mount", mountPoint.toString()));
+    // extra arg
+    Assert.assertEquals(-1, mFsShell.run("mount", mountPoint.toString(), ufsPath, "extraArg"));
     // --option with wrong argument format
     Assert.assertEquals(-1,
-        mFsShell.run("mount", "--option wrongArgFormat", mountPoint.toString(), ufsPath));
+        mFsShell.run("mount", "--option", "wrongArgFormat", mountPoint.toString(), ufsPath));
+  }
+
+  @Test
+  public void mountWithMultipleOptions() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(0, mFsShell
+        .run("mount", "--option", "k1=v1", "--option", "k2=v2", mountPoint.toString(), ufsPath));
+  }
+
+  @Test
+  public void mountWithSpaceQuotedOption() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(0, mFsShell
+        .run("mount", "--option", "key=\" value with spaces\"", mountPoint.toString(), ufsPath));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -87,6 +87,15 @@ public final class MountCommandTest extends AbstractAlluxioShellTest {
   }
 
   @Test
+  public void mountWithQuotesInOptionValues() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(0, mFsShell
+        .run("mount", "--option", "key=valueWith\"Quotes\"", mountPoint.toString(), ufsPath));
+  }
+
+
+  @Test
   public void mountWithEqualsInOptionValues() throws Exception {
     AlluxioURI mountPoint = new AlluxioURI("/mnt");
     String ufsPath = mFolder.getRoot().getAbsolutePath();

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -1,0 +1,81 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell.command;
+
+import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.client.file.options.CreateDirectoryOptions;
+import alluxio.shell.AbstractAlluxioShellTest;
+import alluxio.util.io.BufferUtils;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Tests for mount command.
+ */
+public final class MountCommandTest extends AbstractAlluxioShellTest {
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  private void checkMountPoint(AlluxioURI mountPoint, String ufsPath) throws Exception {
+    // File in UFS can be read in Alluxio
+    AlluxioURI testFile = mountPoint.join("testFile");
+    generateRelativeFileContent(PathUtils.concatPath(ufsPath, "testFile"),
+        BufferUtils.getIncreasingByteArray(10));
+    Assert.assertTrue(fileExists(testFile));
+    // Dir in Alluxio can be persisted to UFS
+    AlluxioURI testDir = mountPoint.join("testDir");
+    mFileSystem.createDirectory(testDir,
+        CreateDirectoryOptions.defaults().setWriteType(WriteType.CACHE_THROUGH));
+    Assert.assertTrue(fileExists(testDir));
+    Assert.assertTrue(Files.exists(Paths.get(ufsPath, "testDir")));
+  }
+
+  @Test
+  public void mount() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+
+    Assert.assertEquals(0, mFsShell.run("mount", mountPoint.toString(), ufsPath));
+    checkMountPoint(mountPoint, ufsPath);
+  }
+
+  @Test
+  public void mountToRootFailed() throws Exception {
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(-1, mFsShell.run("mount", "/", ufsPath));
+  }
+
+  @Test
+  public void mountToExistingMountPointFailed() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath1 = mFolder.newFolder().getAbsolutePath();
+    String ufsPath2 = mFolder.newFolder().getAbsolutePath();
+    Assert.assertEquals(0, mFsShell.run("mount", mountPoint.toString(), ufsPath1));
+    Assert.assertEquals(-1, mFsShell.run("mount", mountPoint.toString(), ufsPath2));
+  }
+
+  @Test
+  public void mountTwiceFailed() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    Assert.assertEquals(0, mFsShell.run("mount", mountPoint.toString(), ufsPath));
+    Assert.assertEquals(-1, mFsShell.run("mount", mountPoint.toString(), ufsPath));
+  }
+}

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -94,7 +94,6 @@ public final class MountCommandTest extends AbstractAlluxioShellTest {
         .run("mount", "--option", "key=valueWith\"Quotes\"", mountPoint.toString(), ufsPath));
   }
 
-
   @Test
   public void mountWithEqualsInOptionValues() throws Exception {
     AlluxioURI mountPoint = new AlluxioURI("/mnt");

--- a/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/MountCommandTest.java
@@ -51,9 +51,21 @@ public final class MountCommandTest extends AbstractAlluxioShellTest {
   public void mount() throws Exception {
     AlluxioURI mountPoint = new AlluxioURI("/mnt");
     String ufsPath = mFolder.getRoot().getAbsolutePath();
-
     Assert.assertEquals(0, mFsShell.run("mount", mountPoint.toString(), ufsPath));
     checkMountPoint(mountPoint, ufsPath);
+  }
+
+  @Test
+  public void mountWithWrongArgs() throws Exception {
+    AlluxioURI mountPoint = new AlluxioURI("/mnt");
+    String ufsPath = mFolder.getRoot().getAbsolutePath();
+    // alluxio, ufs path missing
+    Assert.assertEquals(-1, mFsShell.run("mount"));
+    // ufs missing
+    Assert.assertEquals(-1, mFsShell.run("mount", mountPoint.toString()));
+    // --option with wrong argument format
+    Assert.assertEquals(-1,
+        mFsShell.run("mount", "--option wrongArgFormat", mountPoint.toString(), ufsPath));
   }
 
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2743

This PR includes:
- Add support in mount command to take `--option` and remove `-P` since we have `--option` supported
- Fix the issue that args with space could not be passed to alluxio shell
- Add integration tests of mount command