### PR TITLE
[ALLUXIO-2700] Specify null variable in DataByteArrayChannel.java precondition check

### DIFF
--- a/core/common/src/main/java/alluxio/network/protocol/databuffer/DataByteArrayChannel.java
+++ b/core/common/src/main/java/alluxio/network/protocol/databuffer/DataByteArrayChannel.java
@@ -31,7 +31,7 @@ public final class DataByteArrayChannel implements DataBuffer {
    * @param length the length of the data
    */
   public DataByteArrayChannel(byte[] byteArray, long offset, long length) {
-    mByteArray = Preconditions.checkNotNull(byteArray);
+    mByteArray = Preconditions.checkNotNull(byteArray, "byteArray");
     mOffset = offset;
     mLength = length;
   }


### PR DESCRIPTION
[https://alluxio.atlassian.net/browse/ALLUXIO-2700](url)
Currently we use
mByteArray = Preconditions.checkNotNull(byteArray);
If this precondition fails, it will throw a NullPointerException with no message. We should add a second argument so that the exception will include the name of the variable that is null:
mByteArray = Preconditions.checkNotNull(byteArray, "byteArray");