### PR TITLE
[SMALLFIX] Improve shell command output

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -333,8 +333,7 @@ public final class CommonUtils {
    */
   public static String stripLeadingAndTrailingQuotes(String str) {
     int length = str.length();
-    if (length > 1 && str.startsWith("\"") && str.endsWith("\"")
-        && str.substring(1, length - 1).indexOf('"') == -1) {
+    if (length > 1 && str.startsWith("\"") && str.endsWith("\"")) {
       str = str.substring(1, length - 1);
     }
     return str;

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -325,6 +325,22 @@ public final class CommonUtils {
   }
 
   /**
+   * Strips the leading and trailing quotes from the given string.
+   * E.g. return 'alluxio' for input '"alluxio"'.
+   *
+   * @param str The string to strip
+   * @return The string without the leading and trailing quotes
+   */
+  public static String stripLeadingAndTrailingQuotes(String str) {
+    int length = str.length();
+    if (length > 1 && str.startsWith("\"") && str.endsWith("\"")
+        && str.substring(1, length - 1).indexOf('"') == -1) {
+      str = str.substring(1, length - 1);
+    }
+    return str;
+  }
+
+  /**
    * Gets the value with a given key from a static key/value mapping in string format. E.g. with
    * mapping "id1=user1;id2=user2", it returns "user1" with key "id1". It returns null if the given
    * key does not exist in the mapping.

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -312,6 +312,22 @@ public class CommonUtilsTest {
   }
 
   @Test
+  public void stripLeadingAndTrailingQuotes() throws Exception {
+    Assert.assertEquals("", CommonUtils.stripLeadingAndTrailingQuotes(""));
+    Assert.assertEquals("\"", CommonUtils.stripLeadingAndTrailingQuotes("\""));
+    Assert.assertEquals("", CommonUtils.stripLeadingAndTrailingQuotes("\"\""));
+    Assert.assertEquals("\"", CommonUtils.stripLeadingAndTrailingQuotes("\"\"\""));
+    Assert.assertEquals("\"\"", CommonUtils.stripLeadingAndTrailingQuotes("\"\"\"\""));
+    Assert.assertEquals("noquote", CommonUtils.stripLeadingAndTrailingQuotes("noquote"));
+    Assert.assertEquals(
+        "\"singlequote", CommonUtils.stripLeadingAndTrailingQuotes("\"singlequote"));
+    Assert.assertEquals(
+        "singlequote\"", CommonUtils.stripLeadingAndTrailingQuotes("singlequote\""));
+    Assert.assertEquals("quoted", CommonUtils.stripLeadingAndTrailingQuotes("\"quoted\""));
+    Assert.assertEquals("\"quoted\"", CommonUtils.stripLeadingAndTrailingQuotes("\"\"quoted\"\""));
+  }
+
+  @Test
   public void getValueFromStaticMapping() throws Exception {
     String mapping = "k=v; a=a; alice=bob; id1=userA; foo=bar";
     Assert.assertEquals("v",     CommonUtils.getValueFromStaticMapping(mapping, "k"));

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -105,11 +105,10 @@ public final class AlluxioShell implements Closeable {
    * Prints usage for all shell commands.
    */
   private void printUsage() {
-    System.out.println("Usage: java AlluxioShell");
+    System.err.println("Usage: alluxio fs [generic options]");
     SortedSet<String> sortedCmds = new TreeSet<>(mCommands.keySet());
     for (String cmd : sortedCmds) {
-      System.out.format("%-60s%-95s%n", "       [" + mCommands.get(cmd).getUsage() + "]   ",
-          mCommands.get(cmd).getDescription());
+      System.err.format("%-60s%n", "       [" + mCommands.get(cmd).getUsage() + "]");
     }
   }
 
@@ -132,14 +131,14 @@ public final class AlluxioShell implements Closeable {
     if (command == null) { // Unknown command (we didn't find the cmd in our dict)
       String[] replacementCmd = getReplacementCmd(cmd);
       if (replacementCmd == null) {
-        System.out.println(cmd + " is an unknown command.\n");
+        System.err.println(cmd + " is an unknown command.\n");
         printUsage();
         return -1;
       }
       // Handle command alias, and print out WARNING message for deprecated cmd.
       String deprecatedMsg = "WARNING: " + cmd + " is deprecated. Please use "
                              + StringUtils.join(replacementCmd, " ") + " instead.";
-      System.out.println(deprecatedMsg);
+      System.err.println(deprecatedMsg);
       LOG.warn(deprecatedMsg);
 
       String[] replacementArgv = (String[]) ArrayUtils.addAll(replacementCmd,
@@ -150,7 +149,7 @@ public final class AlluxioShell implements Closeable {
     String[] args = Arrays.copyOfRange(argv, 1, argv.length);
     CommandLine cmdline = command.parseAndValidateArgs(args);
     if (cmdline == null) {
-      printUsage();
+      System.err.println("Usage: " + command.getUsage());
       return -1;
     }
 
@@ -158,7 +157,7 @@ public final class AlluxioShell implements Closeable {
     try {
       return command.run(cmdline);
     } catch (Exception e) {
-      System.out.println(e.getMessage());
+      System.err.println(e.getMessage());
       LOG.error("Error running " + StringUtils.join(argv, " "), e);
       return -1;
     }

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -105,10 +105,10 @@ public final class AlluxioShell implements Closeable {
    * Prints usage for all shell commands.
    */
   private void printUsage() {
-    System.err.println("Usage: alluxio fs [generic options]");
+    System.out.println("Usage: alluxio fs [generic options]");
     SortedSet<String> sortedCmds = new TreeSet<>(mCommands.keySet());
     for (String cmd : sortedCmds) {
-      System.err.format("%-60s%n", "       [" + mCommands.get(cmd).getUsage() + "]");
+      System.out.format("%-60s%n", "       [" + mCommands.get(cmd).getUsage() + "]");
     }
   }
 
@@ -131,14 +131,14 @@ public final class AlluxioShell implements Closeable {
     if (command == null) { // Unknown command (we didn't find the cmd in our dict)
       String[] replacementCmd = getReplacementCmd(cmd);
       if (replacementCmd == null) {
-        System.err.println(cmd + " is an unknown command.\n");
+        System.out.println(cmd + " is an unknown command.\n");
         printUsage();
         return -1;
       }
       // Handle command alias, and print out WARNING message for deprecated cmd.
       String deprecatedMsg = "WARNING: " + cmd + " is deprecated. Please use "
                              + StringUtils.join(replacementCmd, " ") + " instead.";
-      System.err.println(deprecatedMsg);
+      System.out.println(deprecatedMsg);
       LOG.warn(deprecatedMsg);
 
       String[] replacementArgv = (String[]) ArrayUtils.addAll(replacementCmd,
@@ -149,7 +149,7 @@ public final class AlluxioShell implements Closeable {
     String[] args = Arrays.copyOfRange(argv, 1, argv.length);
     CommandLine cmdline = command.parseAndValidateArgs(args);
     if (cmdline == null) {
-      System.err.println("Usage: " + command.getUsage());
+      System.out.println("Usage: " + command.getUsage());
       return -1;
     }
 
@@ -157,7 +157,7 @@ public final class AlluxioShell implements Closeable {
     try {
       return command.run(cmdline);
     } catch (Exception e) {
-      System.err.println(e.getMessage());
+      System.out.println(e.getMessage());
       LOG.error("Error running " + StringUtils.join(argv, " "), e);
       return -1;
     }

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -72,7 +71,7 @@ public final class AlluxioShell implements Closeable {
     System.exit(ret);
   }
 
-  private final Map<String, ShellCommand> mCommands = new HashMap<>();
+  private final Map<String, ShellCommand> mCommands;
   private final FileSystem mFileSystem;
 
   /**
@@ -80,7 +79,7 @@ public final class AlluxioShell implements Closeable {
    */
   public AlluxioShell() {
     mFileSystem = FileSystem.Factory.get();
-    AlluxioShellUtils.loadCommands(mFileSystem, mCommands);
+    mCommands = AlluxioShellUtils.loadCommands(mFileSystem);
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -225,8 +225,8 @@ public final class AlluxioShellUtils {
    * Gets all supported {@link ShellCommand} classes instances and load them into a map.
    * Provides a way to gain these commands information by their CommandName.
    *
-   * @param fileSystem a FileSystem as each ShellCommand constructor's parameter
-   * @return a map mapping from commandName to commandInstance
+   * @param fileSystem the {@link FileSystem} instance to construct the command
+   * @return a mapping from command name to command instance
    */
   public static Map<String, ShellCommand> loadCommands(FileSystem fileSystem) {
     Map<String, ShellCommand> commandsMap = new HashMap<>();

--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -32,6 +32,7 @@ import org.reflections.Reflections;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -225,10 +226,10 @@ public final class AlluxioShellUtils {
    * Provides a way to gain these commands information by their CommandName.
    *
    * @param fileSystem a FileSystem as each ShellCommand constructor's parameter
-   * @param commandsMap a Map which is used to store "key = commandName, value = commandInstance"
-   *                    pairs
+   * @return a map mapping from commandName to commandInstance
    */
-  public static void loadCommands(FileSystem fileSystem, Map<String, ShellCommand> commandsMap) {
+  public static Map<String, ShellCommand> loadCommands(FileSystem fileSystem) {
+    Map<String, ShellCommand> commandsMap = new HashMap<>();
     String pkgName = ShellCommand.class.getPackage().getName();
     Reflections reflections = new Reflections(pkgName);
     for (Class<? extends ShellCommand> cls : reflections.getSubTypesOf(ShellCommand.class)) {
@@ -244,6 +245,7 @@ public final class AlluxioShellUtils {
         commandsMap.put(cmd.getCommandName(), cmd);
       }
     }
+    return commandsMap;
   }
 
   /**

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -114,12 +114,8 @@ public abstract class AbstractShellCommand implements ShellCommand {
    */
   protected abstract int getNumOfArgs();
 
-  /**
-   * Gets the supported Options of the command.
-   *
-   * @return the Options
-   */
-  protected Options getOptions() {
+  @Override
+  public Options getOptions() {
     return new Options();
   }
 
@@ -130,10 +126,9 @@ public abstract class AbstractShellCommand implements ShellCommand {
     CommandLine cmd;
 
     try {
-      cmd = parser.parse(opts, args, true /* stopAtNonOption */);
+      cmd = parser.parse(opts, args);
     } catch (ParseException e) {
-      // TODO(ifcharming): improve the error message when an unregistered option appears
-      System.err.println("Unable to parse input args: " + e.getMessage());
+      System.err.println(String.format("%s: %s", getCommandName(), e.getMessage()));
       return null;
     }
 

--- a/shell/src/main/java/alluxio/shell/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CheckConsistencyCommand.java
@@ -44,7 +44,7 @@ public class CheckConsistencyCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(FIX_INCONSISTENT_FILES);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/ChgrpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChgrpCommand.java
@@ -49,7 +49,7 @@ public final class ChgrpCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
@@ -53,7 +53,7 @@ public final class ChmodCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -49,7 +49,7 @@ public final class ChownCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -70,7 +70,7 @@ public final class CpCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/FreeCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/FreeCommand.java
@@ -40,7 +40,7 @@ public final class FreeCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(FORCE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/HeadCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HeadCommand.java
@@ -89,7 +89,7 @@ public final class HeadCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     Option bytesOption =
         Option.builder("c").required(false).numberOfArgs(1).desc("user specified option").build();
     return new Options().addOption(bytesOption);

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -53,7 +53,7 @@ public final class HelpCommand extends AbstractShellCommand {
     String[] args = cl.getArgs();
     SortedSet<String> sortedCmds = null;
     AlluxioShellUtils.loadCommands(mFileSystem, mCommands);
-    try (PrintWriter pw = new PrintWriter(System.err)) {
+    try (PrintWriter pw = new PrintWriter(System.out)) {
       if (args.length == 0) {
         // print help messages for all supported commands.
         sortedCmds = new TreeSet<>(mCommands.keySet());

--- a/shell/src/main/java/alluxio/shell/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/HelpCommand.java
@@ -16,8 +16,10 @@ import alluxio.exception.AlluxioException;
 import alluxio.shell.AlluxioShellUtils;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.HelpFormatter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
@@ -51,23 +53,34 @@ public final class HelpCommand extends AbstractShellCommand {
     String[] args = cl.getArgs();
     SortedSet<String> sortedCmds = null;
     AlluxioShellUtils.loadCommands(mFileSystem, mCommands);
-    if (args.length == 0) {
-      // print help messages for all supported commands.
-      sortedCmds = new TreeSet<>(mCommands.keySet());
-      for (String cmd : sortedCmds) {
-        printCommandInfo(cmd);
+    try (PrintWriter pw = new PrintWriter(System.err)) {
+      if (args.length == 0) {
+        // print help messages for all supported commands.
+        sortedCmds = new TreeSet<>(mCommands.keySet());
+        for (String cmd : sortedCmds) {
+          printCommandInfo(cmd, pw);
+          pw.println();
+        }
+      } else if (mCommands.containsKey(args[0])) {
+        printCommandInfo(args[0], pw);
+      } else {
+        pw.println(args[0] + " is an unknown command.");
       }
-    } else if (mCommands.containsKey(args[0])) {
-      printCommandInfo(args[0]);
-    } else {
-      System.out.println(args[0] + " is an unknown command.");
+      return 0;
     }
-    return 0;
   }
 
-  private void printCommandInfo(String commandName) {
-    System.out.format("%-60s%s%n", "       [" + mCommands.get(commandName).getUsage() + "]   ",
-        mCommands.get(commandName).getDescription());
+  private void printCommandInfo(String commandName, PrintWriter pw) {
+    ShellCommand command = mCommands.get(commandName);
+    String description = String.format("%s: %s", commandName, command.getDescription());
+    HelpFormatter help = new HelpFormatter();
+    int width = help.getWidth();
+    help.printWrapped(pw, width, description);
+    help.printUsage(pw, width, command.getUsage());
+    if (command.getOptions().getOptions().size() > 0) {
+      help.printOptions(pw, width, command.getOptions(), help.getLeftPadding(),
+          help.getDescPadding());
+    }
   }
 
   @Override
@@ -85,8 +98,9 @@ public final class HelpCommand extends AbstractShellCommand {
   public boolean validateArgs(String... args) {
     boolean valid = args.length <= getNumOfArgs();
     if (!valid) {
-      System.out.println(getCommandName() + " takes at most " + getNumOfArgs() + " arguments, "
-                           + " not " + args.length + "\n");
+      System.out.println(
+          getCommandName() + " takes at most " + getNumOfArgs() + " arguments, " + " not "
+              + args.length + "\n");
     }
     return valid;
   }

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -105,7 +105,7 @@ public final class LsCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options()
         .addOption(RECURSIVE_OPTION)
         .addOption(FORCE_OPTION)

--- a/shell/src/main/java/alluxio/shell/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/MountCommand.java
@@ -52,7 +52,7 @@ public final class MountCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(PROPERTY_FILE_OPTION).addOption(READONLY_OPTION)
         .addOption(MOUNT_SHARED_OPTION);
   }

--- a/shell/src/main/java/alluxio/shell/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/RmCommand.java
@@ -49,7 +49,7 @@ public final class RmCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/SetTtlCommand.java
@@ -57,7 +57,7 @@ public final class SetTtlCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(TTL_ACTION_OPTION);
   }
 

--- a/shell/src/main/java/alluxio/shell/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/SetTtlCommand.java
@@ -14,6 +14,7 @@ package alluxio.shell.command;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
+import alluxio.util.CommonUtils;
 import alluxio.wire.TtlAction;
 
 import com.google.common.base.Preconditions;
@@ -80,7 +81,7 @@ public final class SetTtlCommand extends AbstractShellCommand {
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     String[] args = cl.getArgs();
-    long ttlMs = Long.parseLong(args[1]);
+    long ttlMs = Long.parseLong(CommonUtils.stripLeadingAndTrailingQuotes(args[1]));
     Preconditions.checkArgument(ttlMs >= 0, "TTL value must be >= 0");
     AlluxioURI path = new AlluxioURI(args[0]);
     CommandUtils.setTtl(mFileSystem, path, ttlMs, mAction);

--- a/shell/src/main/java/alluxio/shell/command/ShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ShellCommand.java
@@ -32,9 +32,7 @@ public interface ShellCommand {
   String getCommandName();
 
   /**
-   * Gets the supported Options of the command.
-   *
-   * @return the Options
+   * @return the supported {@link Options} of the command
    */
   Options getOptions();
 

--- a/shell/src/main/java/alluxio/shell/command/ShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ShellCommand.java
@@ -15,6 +15,7 @@ import alluxio.cli.AlluxioShell;
 import alluxio.exception.AlluxioException;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 
 import java.io.IOException;
 
@@ -29,6 +30,13 @@ public interface ShellCommand {
    * @return the command name
    */
   String getCommandName();
+
+  /**
+   * Gets the supported Options of the command.
+   *
+   * @return the Options
+   */
+  Options getOptions();
 
   /**
    * Parses and validates the arguments.

--- a/shell/src/main/java/alluxio/shell/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/StatCommand.java
@@ -50,7 +50,7 @@ public final class StatCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options().addOption(
         Option.builder("f")
             .required(false)

--- a/shell/src/main/java/alluxio/shell/command/TailCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/TailCommand.java
@@ -89,7 +89,7 @@ public final class TailCommand extends WithWildCardPathCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     Option bytesOption =
         Option.builder("c").required(false).numberOfArgs(1).desc("user specified option").build();
     return new Options().addOption(bytesOption);

--- a/shell/src/main/java/alluxio/shell/command/TestCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/TestCommand.java
@@ -79,7 +79,7 @@ public final class TestCommand extends AbstractShellCommand {
   }
 
   @Override
-  protected Options getOptions() {
+  public Options getOptions() {
     return new Options()
         .addOption(DIR_OPTION)
         .addOption(FILE_OPTION)

--- a/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/shell/AlluxioShellUtilsTest.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -263,8 +262,7 @@ public final class AlluxioShellUtilsTest {
 
   @Test
   public void loadCommands() {
-    Map<String, ShellCommand> map = new HashMap<>();
-    AlluxioShellUtils.loadCommands(mFileSystem, map);
+    Map<String, ShellCommand> map = AlluxioShellUtils.loadCommands(mFileSystem);
 
     String pkgName = ShellCommand.class.getPackage().getName();
     Reflections reflections = new Reflections(pkgName);

--- a/tests/src/test/java/alluxio/shell/command/SetTtlCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/SetTtlCommandTest.java
@@ -103,7 +103,7 @@ public final class SetTtlCommandTest extends AbstractAlluxioShellTest {
   @Test
   public void setTtlNegative() throws IOException {
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 1);
-    mFsShell.run("setTtl", "/testFile", "-1");
+    mFsShell.run("setTtl", "/testFile", "\"-1\"");
     Assert.assertTrue(mOutput.toString().contains("TTL value must be >= 0"));
   }
 }


### PR DESCRIPTION
Various change on shell side to improve its output. This PR is motivated when I was working on https://github.com/Alluxio/alluxio/pull/5166 to add a new opt in mount cmd where I found various issues with current shell command.

- Fix the issue that unknown options was treated as an arg, rather than throwing error about unrecognized option. @ifcharming , I saw you change in https://github.com/Alluxio/alluxio/pull/2604, do you have particular reason to set `stopAtNonOption` in this PR, will my PR here break anything you fixed?
This is the output after this PR. Previously it will treat `--wrongOpt` a path to ls.
```bash
$ bin/alluxio fs ls --wrongOpt
ls: Unrecognized option: --wrongOpt
Usage: ls [-d|-f|-p|-R|-h] <path>
```
- Fix the output of `bin/alluxio fs` to be cleaner. Previously we also put command description in the output, which makes the output too big.
```bash
Usage: alluxio fs [generic options]
       [cat <path>]                                         
       [checkConsistency [-r] <Alluxio path>]               
       [checksum <Alluxio path>]                            
       [chgrp [-R] <group> <path>]                          
       [chmod [-R] <mode> <path>]                           
       [chown [-R] <owner> <path>]                          
       [copyFromLocal <src> <remoteDst>]                    
       [copyToLocal <src> <localDst>]
       ...
```
- Fix the output of `bin/alluxio fs help <cmd>` for (1) wrapped width and (2) with detailed per-opt usage info. Now it looks like:
```bash
ls: Displays information for all files and directories directly under the
specified path. Specify -d to list directories as plain files. Specify -f
to force loading files in the directory. Specify -p to list all the pinned
files. Specify -R to display files and directories recursively. Specify -h
to print human-readable format sizes.
usage: ls [-d|-f|-p|-R|-h] <path>
 -d   list directories as plain files
 -f   force
 -h   print human-readable format sizes
 -p   list all pinned files
 -R   recursive
```
- ~~All shell help-related message is redirect to `System.err` rather than `System.out`~~  Reverted this change --- creating a lot test failure as we assert on system out. Will have separate PR for this.



