### PR TITLE
[SMALLFIX] Set Alluxio CLASSPATH correctly when starting Fuse connection

### DIFF
--- a/integration/fuse/bin/alluxio-fuse.sh
+++ b/integration/fuse/bin/alluxio-fuse.sh
@@ -19,6 +19,7 @@ get_env () {
 
   ALLUXIO_FUSE_JAR=${SCRIPT_DIR}/../target/alluxio-integration-fuse-${VERSION}-jar-with-dependencies.jar
   FUSE_MAX_WRITE=131072
+  CLASSPATH=${CLASSPATH}:${ALLUXIO_FUSE_JAR}
 }
 
 check_java_version () {
@@ -59,7 +60,7 @@ mount_fuse() {
   fi
   echo "Starting alluxio-fuse on local host."
   local mount_point=$1
-  (nohup "${JAVA}" -cp ${ALLUXIO_FUSE_JAR} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
+  (nohup "${JAVA}" -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
     alluxio.fuse.AlluxioFuse \
     -m ${mount_point} \
     -o big_writes > ${ALLUXIO_LOGS_DIR}/fuse.out 2>&1) &

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -16,7 +16,6 @@ import static jnr.constants.platform.OpenFlags.O_WRONLY;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
@@ -86,15 +85,6 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
   AlluxioFuseFileSystem(FileSystem fs, AlluxioFuseOptions opts) {
     super();
     mFileSystem = fs;
-    // TODO(andrew): get rid of the MASTER_ADDRESS property key
-    if (Configuration.containsKey(PropertyKey.MASTER_HOSTNAME)) {
-      String masterHostname = Configuration.get(PropertyKey.MASTER_HOSTNAME);
-      String masterPort = Configuration.get(PropertyKey.MASTER_RPC_PORT);
-      boolean useZk = Boolean.parseBoolean(Configuration.get(PropertyKey.ZOOKEEPER_ENABLED));
-      String masterAddress =
-          (useZk ? Constants.HEADER_FT : Constants.HEADER) + masterHostname + ":" + masterPort;
-      Configuration.set(PropertyKey.MASTER_ADDRESS, masterAddress);
-    }
     mAlluxioMaster = Configuration.get(PropertyKey.MASTER_ADDRESS);
     mAlluxioRootPath = Paths.get(opts.getAlluxioRoot());
     mNextOpenFileId = 0L;

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -16,6 +16,7 @@ import static jnr.constants.platform.OpenFlags.O_WRONLY;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
@@ -85,6 +86,15 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
   AlluxioFuseFileSystem(FileSystem fs, AlluxioFuseOptions opts) {
     super();
     mFileSystem = fs;
+    // TODO(andrew): get rid of the MASTER_ADDRESS property key
+    if (Configuration.containsKey(PropertyKey.MASTER_HOSTNAME)) {
+      String masterHostname = Configuration.get(PropertyKey.MASTER_HOSTNAME);
+      String masterPort = Configuration.get(PropertyKey.MASTER_RPC_PORT);
+      boolean useZk = Boolean.parseBoolean(Configuration.get(PropertyKey.ZOOKEEPER_ENABLED));
+      String masterAddress =
+          (useZk ? Constants.HEADER_FT : Constants.HEADER) + masterHostname + ":" + masterPort;
+      Configuration.set(PropertyKey.MASTER_ADDRESS, masterAddress);
+    }
     mAlluxioMaster = Configuration.get(PropertyKey.MASTER_ADDRESS);
     mAlluxioRootPath = Paths.get(opts.getAlluxioRoot());
     mNextOpenFileId = 0L;


### PR DESCRIPTION
Infer MASTER_ADDRESS from MASTER_HOSTNAME and MASTER_RPC_PORT. 