### PR TITLE
[SMALLFIX] Disable secondary master in the integration tests 

### DIFF
--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -112,7 +112,8 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
   protected void startMaster() throws Exception {
     mMaster = LocalAlluxioMaster.create(mWorkDirectory);
     mMaster.start();
-    mMaster.startSecondary();
+    // TODO(peis): Reenable this. This is slowing down the tests.
+    // mMaster.startSecondary();
   }
 
   @Override


### PR DESCRIPTION
It slows down the tests. Disable for now.