### PR TITLE
[SMALLFIX] Remove boilerplate @throws javadoc

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -222,6 +222,7 @@
     <module name="JavadocMethod">
       <property name="id" value="ProductionScope"/>
       <property name="scope" value="public"/>
+      <property name="allowMissingThrowsTags" value="true"/>
     </module>
     <!-- Checks Javadoc comments for public class and interface definitions. Only applies to
          production code -->

--- a/core/client/src/main/java/alluxio/client/AbstractOutStream.java
+++ b/core/client/src/main/java/alluxio/client/AbstractOutStream.java
@@ -42,8 +42,6 @@ public abstract class AbstractOutStream extends OutputStream implements Cancelab
 
   /**
    * Aborts the output stream.
-   *
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void cancel() throws IOException {}

--- a/core/client/src/main/java/alluxio/client/Cancelable.java
+++ b/core/client/src/main/java/alluxio/client/Cancelable.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 public interface Cancelable {
    /**
     * Cancels an operation.
-    *
-    * @throws IOException if an I/O error occurs
     */
   void cancel() throws IOException;
 }

--- a/core/client/src/main/java/alluxio/client/PositionedReadable.java
+++ b/core/client/src/main/java/alluxio/client/PositionedReadable.java
@@ -32,7 +32,6 @@ public interface PositionedReadable {
    * @param offset offset in the buffer
    * @param length number of bytes to read
    * @return actual number of bytes read; -1 means "EOF";
-   * @throws IOException if an I/O error occurs
    */
   int positionedRead(long position, byte[] buffer, int offset, int length) throws IOException;
 }

--- a/core/client/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileInStream.java
@@ -654,7 +654,6 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    *
    * @param pos The position to seek to. It is guaranteed to be valid (pos >= 0 && pos != mPos &&
    *            pos <= mFileLength)
-   * @throws IOException if an I/O error occurs
    */
   private void seekInternal(long pos) throws IOException {
     closeOrCancelCacheStream();
@@ -674,7 +673,6 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    *
    * @param pos The position to seek to. It is guaranteed to be valid (pos >= 0 && pos != mPos &&
    *            pos <= mFileLength).
-   * @throws IOException if an I/O error occurs
    */
   private void seekInternalWithCachingPartiallyReadBlock(long pos) throws IOException {
     // Precompute this because mPos will be updated several times in this function.

--- a/core/client/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/file/FileOutStream.java
@@ -81,7 +81,6 @@ public class FileOutStream extends AbstractOutStream {
    * @param path the file path
    * @param options the client options
    * @param context the file system context
-   * @throws IOException if an I/O error occurs
    */
   public FileOutStream(AlluxioURI path, OutStreamOptions options, FileSystemContext context)
       throws IOException {
@@ -302,8 +301,6 @@ public class FileOutStream extends AbstractOutStream {
 
   /**
    * Schedules the async persistence of the current file.
-   *
-   * @throws IOException if an I/O error occurs
    */
   protected void scheduleAsyncPersist() throws IOException {
     try (CloseableResource<FileSystemMasterClient> masterClient = mContext

--- a/core/client/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystem.java
@@ -77,8 +77,6 @@ public interface FileSystem {
    * @param path the path of the directory to create in Alluxio space
    * @throws FileAlreadyExistsException if there is already a file or directory at the given path
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void createDirectory(AlluxioURI path)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException;
@@ -90,8 +88,6 @@ public interface FileSystem {
    * @param options options to associate with this operation
    * @throws FileAlreadyExistsException if there is already a file or directory at the given path
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void createDirectory(AlluxioURI path, CreateDirectoryOptions options)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException;
@@ -103,8 +99,6 @@ public interface FileSystem {
    * @return a {@link FileOutStream} which will write data to the newly created file
    * @throws FileAlreadyExistsException if there is already a file at the given path
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   FileOutStream createFile(AlluxioURI path)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException;
@@ -117,8 +111,6 @@ public interface FileSystem {
    * @return a {@link FileOutStream} which will write data to the newly created file
    * @throws FileAlreadyExistsException if there is already a file at the given path
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   FileOutStream createFile(AlluxioURI path, CreateFileOptions options)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException;
@@ -129,8 +121,6 @@ public interface FileSystem {
    * @param path the path to delete in Alluxio space
    * @throws FileDoesNotExistException if the given path does not exist
    * @throws DirectoryNotEmptyException if recursive is false and the path is a nonempty directory
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void delete(AlluxioURI path)
       throws DirectoryNotEmptyException, FileDoesNotExistException, IOException, AlluxioException;
@@ -142,8 +132,6 @@ public interface FileSystem {
    * @param options options to associate with this operation
    * @throws FileDoesNotExistException if the given path does not exist
    * @throws DirectoryNotEmptyException if recursive is false and the path is a nonempty directory
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void delete(AlluxioURI path, DeleteOptions options)
       throws DirectoryNotEmptyException, FileDoesNotExistException, IOException, AlluxioException;
@@ -154,8 +142,6 @@ public interface FileSystem {
    * @param path the path in question
    * @return true if the path exists, false otherwise
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   boolean exists(AlluxioURI path) throws InvalidPathException, IOException, AlluxioException;
 
@@ -166,8 +152,6 @@ public interface FileSystem {
    * @param options options to associate with this operation
    * @return true if the path exists, false otherwise
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   boolean exists(AlluxioURI path, ExistsOptions options)
       throws InvalidPathException, IOException, AlluxioException;
@@ -177,8 +161,6 @@ public interface FileSystem {
    *
    * @param path the path to free in Alluxio space
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void free(AlluxioURI path) throws FileDoesNotExistException, IOException, AlluxioException;
 
@@ -189,8 +171,6 @@ public interface FileSystem {
    * @param path the path to free in Alluxio space
    * @param options options to associate with this operation
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void free(AlluxioURI path, FreeOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -201,8 +181,6 @@ public interface FileSystem {
    * @param path the path to obtain information about
    * @return the {@link URIStatus} of the file
    * @throws FileDoesNotExistException if the path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   URIStatus getStatus(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -214,8 +192,6 @@ public interface FileSystem {
    * @param options options to associate with this operation
    * @return the {@link URIStatus} of the file
    * @throws FileDoesNotExistException if the path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   URIStatus getStatus(AlluxioURI path, GetStatusOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -227,8 +203,6 @@ public interface FileSystem {
    * @return a list of {@link URIStatus}s containing information about the files and directories
    *         which are children of the given path
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   List<URIStatus> listStatus(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -242,8 +216,6 @@ public interface FileSystem {
    * @return a list of {@link URIStatus}s containing information about the files and directories
    *         which are children of the given path
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   List<URIStatus> listStatus(AlluxioURI path, ListStatusOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -254,8 +226,6 @@ public interface FileSystem {
    *
    * @param path the path for which to load metadata from UFS
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    * @deprecated since version 1.1 and will be removed in version 2.0
    */
   @Deprecated
@@ -268,8 +238,6 @@ public interface FileSystem {
    * @param path the path for which to load metadata from UFS
    * @param options options to associate with this operation
    * @throws FileDoesNotExistException if the given path does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    * @deprecated since version 1.1 and will be removed in version 2.0
    */
   @Deprecated
@@ -282,8 +250,6 @@ public interface FileSystem {
    *
    * @param alluxioPath an Alluxio path to mount the data to
    * @param ufsPath a UFS path to mount the data from
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath) throws IOException, AlluxioException;
 
@@ -296,8 +262,6 @@ public interface FileSystem {
    * @param alluxioPath an Alluxio path to mount the data to
    * @param ufsPath a UFS path to mount the data from
    * @param options options to associate with this operation
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountOptions options)
       throws IOException, AlluxioException;
@@ -308,8 +272,6 @@ public interface FileSystem {
    * @param path the file to read from
    * @return a {@link FileInStream} for the given path
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   FileInStream openFile(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -321,8 +283,6 @@ public interface FileSystem {
    * @param options options to associate with this operation
    * @return a {@link FileInStream} for the given path
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   FileInStream openFile(AlluxioURI path, OpenFileOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -334,8 +294,6 @@ public interface FileSystem {
    * @param src the path of the source, this must already exist
    * @param dst the path of the destination, this path should not exist
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void rename(AlluxioURI src, AlluxioURI dst)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -348,8 +306,6 @@ public interface FileSystem {
    * @param dst the path of the destination, this path should not exist
    * @param options options to associate with this operation
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void rename(AlluxioURI src, AlluxioURI dst, RenameOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -360,8 +316,6 @@ public interface FileSystem {
    *
    * @param path the path to set attributes for
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void setAttribute(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -372,8 +326,6 @@ public interface FileSystem {
    * @param path the path to set attributes for
    * @param options options to associate with this operation
    * @throws FileDoesNotExistException if the given file does not exist
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void setAttribute(AlluxioURI path, SetAttributeOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
@@ -382,8 +334,6 @@ public interface FileSystem {
    * Convenience method for {@link #unmount(AlluxioURI, UnmountOptions)} with default options.
    *
    * @param path an Alluxio path, this must be a mount point
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void unmount(AlluxioURI path) throws IOException, AlluxioException;
 
@@ -394,8 +344,6 @@ public interface FileSystem {
    *
    * @param path an Alluxio path, this must be a mount point
    * @param options options to associate with this operation
-   * @throws IOException if an IO exception occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   void unmount(AlluxioURI path, UnmountOptions options) throws IOException, AlluxioException;
 }

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -51,7 +51,6 @@ public final class FileSystemUtils {
    * @param uri the URI of the file on which the thread should wait
    * @return true if the file is complete when this method returns and false if the method timed out
    *         before the file was complete.
-   * @throws IOException if an I/O error occurs
    * @throws AlluxioException if an Alluxio Exception occurs
    * @throws InterruptedException if the thread receives an interrupt while waiting for file
    *         completion
@@ -88,8 +87,6 @@ public final class FileSystemUtils {
    * @param tunit the @{link TimeUnit} instance describing the {@code timeout} parameter
    * @return true if the file is complete when this method returns and false if the method timed out
    *         before the file was complete.
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio exception occurs
    * @throws InterruptedException if the thread receives an interrupt while waiting for file
    *         completion
    */

--- a/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -51,7 +51,6 @@ public final class FileSystemUtils {
    * @param uri the URI of the file on which the thread should wait
    * @return true if the file is complete when this method returns and false if the method timed out
    *         before the file was complete.
-   * @throws AlluxioException if an Alluxio Exception occurs
    * @throws InterruptedException if the thread receives an interrupt while waiting for file
    *         completion
    * @see #waitCompleted(FileSystem, AlluxioURI, long, TimeUnit)

--- a/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
@@ -18,8 +18,6 @@ import alluxio.util.SecurityUtils;
 
 import com.google.common.base.Objects;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -37,13 +35,12 @@ public final class CompleteUfsFileOptions {
    * default file mode.
    *
    * @return the default {@link CompleteUfsFileOptions}
-   * @throws IOException if failed to set owner from login module
    */
-  public static CompleteUfsFileOptions defaults() throws IOException {
+  public static CompleteUfsFileOptions defaults() {
     return new CompleteUfsFileOptions();
   }
 
-  private CompleteUfsFileOptions() throws IOException {
+  private CompleteUfsFileOptions() {
     mOwner = SecurityUtils.getOwnerFromLoginModule();
     mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();

--- a/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
@@ -18,8 +18,6 @@ import alluxio.util.SecurityUtils;
 
 import com.google.common.base.Objects;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -37,13 +35,12 @@ public final class CreateUfsFileOptions {
    * default file mode.
    *
    * @return the default {@link CreateUfsFileOptions}
-   * @throws IOException if failed to set owner from login module
    */
-  public static CreateUfsFileOptions defaults() throws IOException {
+  public static CreateUfsFileOptions defaults() {
     return new CreateUfsFileOptions();
   }
 
-  private CreateUfsFileOptions() throws IOException {
+  private CreateUfsFileOptions() {
     mOwner = SecurityUtils.getOwnerFromLoginModule();
     mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();

--- a/core/client/src/main/java/alluxio/client/lineage/AlluxioLineage.java
+++ b/core/client/src/main/java/alluxio/client/lineage/AlluxioLineage.java
@@ -75,8 +75,6 @@ public final class AlluxioLineage extends AbstractLineageClient {
    * @return the lineage id
    * @throws FileDoesNotExistException an input file does not exist in Alluxio storage, nor is added
    *         as an output file of an existing lineage
-   * @throws AlluxioException if an unexpected alluxio error occurs
-   * @throws IOException if an I/O error occurs
    */
   public long createLineage(List<AlluxioURI> inputFiles, List<AlluxioURI> outputFiles, Job job)
       throws FileDoesNotExistException, AlluxioException, IOException {
@@ -88,10 +86,8 @@ public final class AlluxioLineage extends AbstractLineageClient {
    *
    * @param lineageId the id of the lineage
    * @return true if the lineage deletion is successful, false otherwise
-   * @throws IOException if an I/O error occurs
    * @throws LineageDoesNotExistException if the lineage does not exist
    * @throws LineageDeletionException if the deletion is cascade but the lineage has children
-   * @throws AlluxioException if an unexpected alluxio error occurs
    */
   public boolean deleteLineage(long lineageId)
       throws IOException, LineageDoesNotExistException, LineageDeletionException, AlluxioException {
@@ -103,7 +99,6 @@ public final class AlluxioLineage extends AbstractLineageClient {
    * options.
    *
    * @return the information about lineages
-   * @throws IOException if an I/O error occurs
    */
   public List<LineageInfo> getLineageInfoList() throws IOException {
     return getLineageInfoList(GetLineageInfoListOptions.defaults());

--- a/core/client/src/main/java/alluxio/client/lineage/DummyFileOutputStream.java
+++ b/core/client/src/main/java/alluxio/client/lineage/DummyFileOutputStream.java
@@ -32,7 +32,6 @@ public final class DummyFileOutputStream extends FileOutStream {
    *
    * @param path the path of the file
    * @param options the set of options specific to this operation
-   * @throws IOException if an I/O error occurs
    */
   public DummyFileOutputStream(AlluxioURI path, OutStreamOptions options) throws IOException {
     super(path, options, FileSystemContext.INSTANCE);

--- a/core/client/src/main/java/alluxio/client/lineage/LineageClient.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageClient.java
@@ -41,10 +41,8 @@ interface LineageClient {
    * @param job the job that takes the listed input file and computes the output file
    * @param options the method options
    * @return the lineage id
-   * @throws IOException if an I/O error occurs
    * @throws FileDoesNotExistException an input file does not exist in Alluxio storage, nor is added
    *         as an output file of an existing lineage
-   * @throws AlluxioException if an unexpected alluxio error occurs
    */
   long createLineage(List<AlluxioURI> inputFiles, List<AlluxioURI> outputFiles, Job job,
       CreateLineageOptions options) throws FileDoesNotExistException, IOException, AlluxioException;
@@ -54,7 +52,6 @@ interface LineageClient {
    *
    * @param options method options
    * @return the information about lineages
-   * @throws IOException if an I/O error occurs
    */
   List<LineageInfo> getLineageInfoList(GetLineageInfoListOptions options) throws IOException;
 
@@ -67,10 +64,8 @@ interface LineageClient {
    * @param lineageId the id of the lineage
    * @param options method options
    * @return true if the lineage deletion is successful, false otherwise
-   * @throws IOException if an I/O error occurs
    * @throws LineageDeletionException if the deletion is cascade but the lineage has children
    * @throws LineageDoesNotExistException if the lineage does not exist
-   * @throws AlluxioException if an unexpected alluxio error occurs
    */
   boolean deleteLineage(long lineageId, DeleteLineageOptions options)
       throws IOException, LineageDoesNotExistException, LineageDeletionException, AlluxioException;

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileOutStream.java
@@ -35,7 +35,6 @@ public class LineageFileOutStream extends FileOutStream {
    * @param context file system context
    * @param path the path of the file
    * @param options the set of options specific to this operation
-   * @throws IOException if an I/O error occurs
    */
   public LineageFileOutStream(FileSystemContext context, AlluxioURI path, OutStreamOptions options)
       throws IOException {

--- a/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
+++ b/core/client/src/main/java/alluxio/client/lineage/LineageFileSystem.java
@@ -60,8 +60,6 @@ public final class LineageFileSystem extends BaseFileSystem {
    * @param options the set of options specific to this operation
    * @return the id of the reinitialized file when the file is lost or not completed, -1 otherwise
    * @throws LineageDoesNotExistException if the lineage does not exist
-   * @throws IOException if the recreation fails
-   * @throws AlluxioException if an unexpected AlluxioException occurs
    */
   private long reinitializeFile(AlluxioURI path, CreateFileOptions options)
       throws LineageDoesNotExistException, IOException, AlluxioException {
@@ -87,8 +85,6 @@ public final class LineageFileSystem extends BaseFileSystem {
    * @param path the Alluxio path of the file
    * @param options the set of options specific to this operation
    * @return an output stream to write the file
-   * @throws IOException if a non-Alluxio exception occurs
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   @Override
   public FileOutStream createFile(AlluxioURI path, CreateFileOptions options)
@@ -110,9 +106,7 @@ public final class LineageFileSystem extends BaseFileSystem {
    * Reports a file as lost.
    *
    * @param path the path to the lost file
-   * @throws IOException if a non-Alluxio exception occurs
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AlluxioException if an Alluxio exception occurs
    */
   public void reportLostFile(AlluxioURI path)
       throws IOException, FileDoesNotExistException, AlluxioException {

--- a/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -145,7 +145,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param blockSize block size in bytes
    * @param progress queryable progress
    * @return an {@link FSDataOutputStream} created at the indicated path of a file
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public FSDataOutputStream create(Path path, FsPermission permission, boolean overwrite,
@@ -198,7 +197,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param replication required block replication for the file
    * @param blockSize the size in bytes of the buffer to be used
    * @param progress queryable progress
-   * @throws IOException if an I/O error occurs
    * @see #setPermission(Path, FsPermission)
    * @deprecated API only for 0.20-append
    */
@@ -217,7 +215,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    *
    * @param path path to delete
    * @return true if one or more files/directories were deleted; false otherwise
-   * @throws IOException if an I/O error occurs
    * @deprecated Use {@link #delete(Path, boolean)} instead.
    */
   @Override
@@ -232,7 +229,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param path path to delete
    * @param recursive if true, will attempt to delete all children of the path
    * @return true if one or more files/directories were deleted; false otherwise
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public boolean delete(Path path, boolean recursive) throws IOException {
@@ -337,7 +333,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param path path to set owner or group
    * @param username username to be set
    * @param groupname groupname to be set
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void setOwner(Path path, final String username, final String groupname)
@@ -368,7 +363,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    *
    * @param path path to set permission
    * @param permission permission set to path
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void setPermission(Path path, FsPermission permission) throws IOException {
@@ -477,7 +471,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    *
    * @param uri the uri
    * @param conf the hadoop conf
-   * @throws IOException if an I/O error occurs
    */
   void initializeInternal(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system. These
@@ -599,7 +592,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param path path to create
    * @param permission permissions to grant the created folder
    * @return true if the indicated folder is created successfully or already exists
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public boolean mkdirs(Path path, FsPermission permission) throws IOException {
@@ -625,7 +617,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @param path the file name to open
    * @param bufferSize stream buffer size in bytes, currently unused
    * @return an {@link FSDataInputStream} at the indicated path of a file
-   * @throws IOException if an I/O error occurs
    */
   // TODO(calvin): Consider respecting the buffer size option
   @Override
@@ -697,7 +688,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * in {@link IOException}.
    *
    * @param path the path to look up
-   * @throws IOException if an Alluxio exception occurs
    */
   private void ensureExists(AlluxioURI path) throws IOException {
     try {

--- a/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
+++ b/core/client/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
@@ -43,7 +43,6 @@ public class AlluxioFileSystem extends DelegateToFileSystem {
    *
    * @param uri the uri for this Alluxio filesystem
    * @param conf Hadoop configuration
-   * @throws IOException if an I/O error occurs
    * @throws URISyntaxException if <code>uri</code> has syntax error
    */
   AlluxioFileSystem(final URI uri, final Configuration conf)

--- a/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -55,7 +55,6 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
    * @param context the file system context
    * @param uri the Alluxio file URI
    * @param stats filesystem statistics
-   * @throws IOException if an I/O error occurs
    */
   public HdfsFileInputStream(FileSystemContext context, AlluxioURI uri,
       org.apache.hadoop.fs.FileSystem.Statistics stats) throws IOException {
@@ -169,7 +168,6 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
    * location. Can't seek past the end of the file.
    *
    * @param pos the position to seek to
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void seek(long pos) throws IOException {
@@ -207,7 +205,6 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
    *
    * @param n the number of bytes to be skipped
    * @return the actual number of bytes skipped
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public long skip(long n) throws IOException {

--- a/core/client/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
+++ b/core/client/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
@@ -149,7 +149,6 @@ public final class NettyPacketReaderTest {
    * @param offset the offset
    * @param length the length
    * @return the packet reader instance
-   * @throws Exception if it fails to create the packet reader
    */
   private PacketReader create(long offset, long length) throws Exception {
     PacketReader reader = mFactory.create(offset, length);

--- a/core/client/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
+++ b/core/client/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
@@ -163,7 +163,6 @@ public final class NettyPacketWriterTest {
    *
    * @param length the length
    * @return the packet writer instance
-   * @throws Exception if it fails to create the packet writer
    */
   private PacketWriter create(long length) throws Exception {
     PacketWriter writer =

--- a/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -541,7 +541,6 @@ public class FileInStreamTest {
    * streams and that the correct bytes are read from the {@link FileInStream}.
    *
    * @param dataRead the bytes to read
-   * @throws Exception when reading from the stream fails
    */
   private void testReadBuffer(int dataRead) throws Exception {
     byte[] buffer = new byte[dataRead];

--- a/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -73,9 +73,6 @@ public class FileInStreamTest {
 
   /**
    * Sets up the context and streams before a test runs.
-   *
-   * @throws AlluxioException when the worker ufs operations fail
-   * @throws IOException when the read and write streams fail
    */
   @Before
   public void before() throws Exception {

--- a/core/common/src/main/java/alluxio/LeaderSelectorClient.java
+++ b/core/common/src/main/java/alluxio/LeaderSelectorClient.java
@@ -138,8 +138,6 @@ public final class LeaderSelectorClient implements Closeable, LeaderSelectorList
 
   /**
    * Starts the leader selection.
-   *
-   * @throws IOException if an error occurs during leader selection
    */
   public void start() throws IOException {
     mLeaderSelector.start();

--- a/core/common/src/main/java/alluxio/Seekable.java
+++ b/core/common/src/main/java/alluxio/Seekable.java
@@ -24,7 +24,6 @@ public interface Seekable {
    * the start of the stream. Seeking to a position before the current read position is supported.
    *
    * @param pos the position to seek to, it must be between 0 and the end of the stream - 1
-   * @throws IOException if the seek fails due to an error accessing the stream at the position
    */
   void seek(long pos) throws IOException;
 }

--- a/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
+++ b/core/common/src/main/java/alluxio/network/connection/NettyChannelPool.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -81,7 +80,6 @@ public final class NettyChannelPool extends DynamicResourcePool<Channel> {
    * Creates a netty channel instance.
    *
    * @return the channel created
-   * @throws IOException if it fails to create a channel
    */
   @Override
   protected Channel createNewResource() {

--- a/core/common/src/main/java/alluxio/resource/Pool.java
+++ b/core/common/src/main/java/alluxio/resource/Pool.java
@@ -23,7 +23,6 @@ public interface Pool<T> {
    * Acquires a resource from the pool.
    *
    * @return the acquired resource which should not be null
-   * @throws Exception if it fails
    */
   T acquire() throws Exception;
 
@@ -33,7 +32,6 @@ public interface Pool<T> {
    * @param time time it takes before timeout if no resource is available
    * @param unit the unit of the time
    * @return the acquired resource which should not be null
-   * @throws Exception if it fails
    */
   T acquire(long time, TimeUnit unit) throws Exception;
 

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -50,7 +50,6 @@ public final class AuthenticatedClientUser {
    * Gets the {@link User} from the {@link ThreadLocal} variable.
    *
    * @return the client user, null if the user is not present
-   * @throws IOException if authentication is not enabled
    */
   // TODO(peis): Fail early if the user is not able to be set to avoid returning null.
   public static User get() throws IOException {

--- a/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
@@ -111,7 +111,6 @@ public class CachedGroupMapping implements GroupMappingService {
    *
    * @param user user name
    * @return the list of groups that the user belongs to
-   * @throws IOException if failed to get groups
    */
   public List<String> getGroups(String user) throws IOException {
     if (!mCacheEnabled) {

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -77,7 +77,6 @@ public interface GroupMappingService {
    *
    * @param user user's name
    * @return group memberships of user
-   * @throws IOException if can't get user's groups
    */
   List<String> getGroups(String user) throws IOException;
 }

--- a/core/common/src/main/java/alluxio/security/group/provider/IdentityUserGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/IdentityUserGroupsMapping.java
@@ -15,7 +15,6 @@ import alluxio.security.group.GroupMappingService;
 
 import com.google.common.collect.Lists;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -34,10 +33,9 @@ public final class IdentityUserGroupsMapping implements GroupMappingService {
    *
    * @param user get groups for this user
    * @return list of groups for a given user
-   * @throws IOException when trying to create a new list
    */
   @Override
-  public List<String> getGroups(String user) throws IOException {
+  public List<String> getGroups(String user) {
     return Lists.newArrayList(user);
   }
 }

--- a/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
@@ -35,7 +35,6 @@ public final class ShellBasedUnixGroupsMapping implements GroupMappingService {
    *
    * @param user get groups for this user
    * @return list of groups for a given user
-   * @throws IOException when getting the UNIX groups
    */
   @Override
   public List<String> getGroups(String user) throws IOException {

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -45,7 +45,6 @@ public class AtomicFileOutputStream extends OutputStream {
    * @param path path being written to
    * @param ufs the calling {@link UnderFileSystem}
    * @param options create options for destination file
-   * @throws IOException when a non Alluxio error occurs
    */
   public AtomicFileOutputStream(String path, AtomicFileOutputStreamCallback ufs,
       CreateOptions options) throws IOException {

--- a/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStreamCallback.java
+++ b/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStreamCallback.java
@@ -28,7 +28,6 @@ public interface AtomicFileOutputStreamCallback extends UnderFileSystem {
    * @param path the file name
    * @param options the options for create
    * @return A {@code OutputStream} object
-   * @throws IOException if a non-Alluxio error occurs
    */
   OutputStream createDirect(String path, CreateOptions options) throws IOException;
 }

--- a/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
@@ -111,7 +111,6 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
    * @param startPos start position in bytes (inclusive)
    * @param endPos end position in bytes (exclusive)
    * @return a new {@link InputStream}
-   * @throws IOException when a non-Alluxio error occurs
    */
   protected abstract InputStream createStream(long startPos, long endPos) throws IOException;
 

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileInputStream.java
@@ -46,7 +46,6 @@ public final class ObjectUnderFileInputStream extends InputStream implements See
    * @param ufs Object UFS for input stream
    * @param key key in the underlying object store
    * @param options to open to stream
-   * @throws IOException when a non-Alluxio error occurs
    */
   public ObjectUnderFileInputStream(ObjectUnderFileSystem ufs, String key, OpenOptions options)
       throws IOException {
@@ -100,7 +99,6 @@ public final class ObjectUnderFileInputStream extends InputStream implements See
    * Open a new stream.
    *
    * @param options for opening a stream
-   * @throws IOException if a non-Alluxio error occurs
    */
   private void openStream(OpenOptions options) throws IOException {
     if (mStream != null) {

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -121,7 +121,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
      *
      * @return null if listing did not find anything or is done, otherwise return new
      * {@link ObjectListingChunk} for the next chunk
-     * @throws IOException if a non-alluxio error occurs
      */
     ObjectListingChunk getNextChunk() throws IOException;
   }
@@ -198,7 +197,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    *
    * @param path the file name
    * @return the default Alluxio user block size
-   * @throws IOException this implementation will not throw this exception, but subclasses may
    */
   @Override
   public long getBlockSizeByte(String path) throws IOException {
@@ -395,7 +393,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * Creates an {@link OutputStream} for object uploads.
    *
    * @param key ufs key including scheme and bucket
-   * @throws IOException if failed to create stream
    * @return new OutputStream
    */
   protected abstract OutputStream createObject(String key) throws IOException;
@@ -493,7 +490,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param child the key of the child
    * @param parent the key of the parent
    * @return the child key with the parent prefix removed
-   * @throws IOException if parent prefix is invalid
    */
   protected String getChildName(String child, String parent) throws IOException {
     if (child.startsWith(parent)) {
@@ -515,7 +511,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param key pseudo-directory key excluding header and bucket
    * @param recursive whether to request immediate children only, or all descendants
    * @return chunked object listing, or null if key is not found
-   * @throws IOException if a non-Alluxio error occurs
    */
   protected abstract ObjectListingChunk getObjectListingChunk(String key, boolean recursive)
       throws IOException;
@@ -526,7 +521,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param path of pseudo-directory
    * @param recursive whether to request immediate children only, or all descendants
    * @return chunked object listing, or null if the path does not exist as a pseudo-directory
-   * @throws IOException when a non-Alluxio error occurs
    */
   protected ObjectListingChunk getObjectListingChunkAndCreateNonEmpty(String path,
       boolean recursive) throws IOException {
@@ -557,7 +551,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param path the key to list
    * @param options for listing
    * @return an array of the file and folder names in this directory
-   * @throws IOException if an I/O error occurs
    */
   protected UnderFileStatus[] listInternal(String path, ListOptions options) throws IOException {
     ObjectListingChunk chunk = getObjectListingChunkAndCreateNonEmpty(path, options.isRecursive());
@@ -659,7 +652,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    *
    * @param key the key to open
    * @return an {@link InputStream} to read from key
-   * @throws IOException if a non-Alluxio error occurs
    */
   protected abstract InputStream openObject(String key, OpenOptions options) throws IOException;
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -199,8 +199,6 @@ public interface UnderFileSystem {
 
   /**
    * Closes this under file system.
-   *
-   * @throws IOException if a non-Alluxio error occurs
    */
   void close() throws IOException;
 
@@ -210,7 +208,6 @@ public interface UnderFileSystem {
    *
    * The default implementation is a no-op. This should be overridden if a subclass needs
    * additional functionality.
-   * @throws IOException if an error occurs during configuration
    */
   void configureProperties() throws IOException;
 
@@ -222,7 +219,6 @@ public interface UnderFileSystem {
    * </p>
    *
    * @param hostname the host that wants to connect to the under file system
-   * @throws IOException if a non-Alluxio error occurs
    */
   void connectFromMaster(String hostname) throws IOException;
 
@@ -234,7 +230,6 @@ public interface UnderFileSystem {
    * </p>
    *
    * @param hostname the host that wants to connect to the under file system
-   * @throws IOException if a non-Alluxio error occurs
    */
   void connectFromWorker(String hostname) throws IOException;
 
@@ -244,7 +239,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return A {@code OutputStream} object
-   * @throws IOException if a non-Alluxio error occurs
    */
   OutputStream create(String path) throws IOException;
 
@@ -256,7 +250,6 @@ public interface UnderFileSystem {
    * @param path the file name
    * @param options the options for create
    * @return A {@code OutputStream} object
-   * @throws IOException if a non-Alluxio error occurs
    */
   OutputStream create(String path, CreateOptions options) throws IOException;
 
@@ -266,7 +259,6 @@ public interface UnderFileSystem {
    *
    * @param path of the directory to delete
    * @return true if directory was found and deleted, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean deleteDirectory(String path) throws IOException;
 
@@ -276,7 +268,6 @@ public interface UnderFileSystem {
    * @param path of the directory to delete
    * @param options for directory delete semantics
    * @return true if directory was found and deleted, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean deleteDirectory(String path, DeleteOptions options) throws IOException;
 
@@ -285,7 +276,6 @@ public interface UnderFileSystem {
    *
    * @param path of the file to delete
    * @return true if file was found and deleted, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean deleteFile(String path) throws IOException;
 
@@ -294,7 +284,6 @@ public interface UnderFileSystem {
    *
    * @param path the absolute path
    * @return true if the path exists, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean exists(String path) throws IOException;
 
@@ -303,7 +292,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return the block size in bytes
-   * @throws IOException if a non-Alluxio error occurs
    */
   long getBlockSizeByte(String path) throws IOException;
 
@@ -319,7 +307,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return The list of locations
-   * @throws IOException if a non-Alluxio error occurs
    */
   List<String> getFileLocations(String path) throws IOException;
 
@@ -329,7 +316,6 @@ public interface UnderFileSystem {
    * @param path the file name
    * @param options method options
    * @return The list of locations
-   * @throws IOException if a non-Alluxio error occurs
    */
   List<String> getFileLocations(String path, FileLocationOptions options) throws IOException;
 
@@ -338,7 +324,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return the file size in bytes
-   * @throws IOException if a non-Alluxio error occurs
    */
   long getFileSize(String path) throws IOException;
 
@@ -347,7 +332,6 @@ public interface UnderFileSystem {
    *
    * @param path the path of the file
    * @return the group of the file
-   * @throws IOException if a non-Alluxio error occurs
    */
   String getGroup(String path) throws IOException;
 
@@ -357,7 +341,6 @@ public interface UnderFileSystem {
    *
    * @param path the path of the file
    * @return the mode of the file
-   * @throws IOException if a non-Alluxio error occurs
    */
   short getMode(String path) throws IOException;
 
@@ -366,7 +349,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return modification time in milliseconds
-   * @throws IOException if a non-Alluxio error occurs
    */
   long getModificationTimeMs(String path) throws IOException;
 
@@ -375,7 +357,6 @@ public interface UnderFileSystem {
    *
    * @param path the path of the file
    * @return the owner of the file
-   * @throws IOException if a non-Alluxio error occurs
    */
   String getOwner(String path) throws IOException;
 
@@ -391,7 +372,6 @@ public interface UnderFileSystem {
    * @param path the path to query
    * @param type the type of queries
    * @return The space in bytes
-   * @throws IOException if a non-Alluxio error occurs
    */
   long getSpace(String path, SpaceType type) throws IOException;
 
@@ -409,7 +389,6 @@ public interface UnderFileSystem {
    *
    * @param path the absolute directory path
    * @return true if the path exists and is a directory, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean isDirectory(String path) throws IOException;
 
@@ -418,7 +397,6 @@ public interface UnderFileSystem {
    *
    * @param path the absolute file path
    * @return true if the path exists and is a file, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean isFile(String path) throws IOException;
 
@@ -440,7 +418,6 @@ public interface UnderFileSystem {
    * @return An array with the statuses of the files and directories in the directory denoted by
    *         this abstract pathname. The array will be empty if the directory is empty. Returns
    *         {@code null} if this abstract pathname does not denote a directory.
-   * @throws IOException if a non-Alluxio error occurs
    */
   UnderFileStatus[] listStatus(String path) throws IOException;
 
@@ -463,7 +440,6 @@ public interface UnderFileSystem {
    * @return An array of statuses naming the files and directories in the directory denoted by this
    *         abstract pathname. The array will be empty if the directory is empty. Returns
    *         {@code null} if this abstract pathname does not denote a directory.
-   * @throws IOException if a non-Alluxio error occurs
    */
   UnderFileStatus[] listStatus(String path, ListOptions options) throws IOException;
 
@@ -473,7 +449,6 @@ public interface UnderFileSystem {
    *
    * @param path the folder to create
    * @return {@code true} if and only if the directory was created; {@code false} otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean mkdirs(String path) throws IOException;
 
@@ -484,7 +459,6 @@ public interface UnderFileSystem {
    * @param path the folder to create
    * @param options the options for mkdirs
    * @return {@code true} if and only if the directory was created; {@code false} otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean mkdirs(String path, MkdirsOptions options) throws IOException;
 
@@ -493,7 +467,6 @@ public interface UnderFileSystem {
    *
    * @param path the file name
    * @return The {@code InputStream} object
-   * @throws IOException if a non-Alluxio error occurs
    */
   InputStream open(String path) throws IOException;
 
@@ -503,7 +476,6 @@ public interface UnderFileSystem {
    * @param path the file name
    * @param options to open input stream
    * @return The {@code InputStream} object
-   * @throws IOException if a non-Alluxio error occurs
    */
   InputStream open(String path, OpenOptions options) throws IOException;
 
@@ -513,7 +485,6 @@ public interface UnderFileSystem {
    * @param src the source directory path
    * @param dst the destination directory path
    * @return true if succeed, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean renameDirectory(String src, String dst) throws IOException;
 
@@ -523,7 +494,6 @@ public interface UnderFileSystem {
    * @param src the source file path
    * @param dst the destination file path
    * @return true if succeed, false otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   boolean renameFile(String src, String dst) throws IOException;
 
@@ -555,7 +525,6 @@ public interface UnderFileSystem {
    * @param path the path of the file
    * @param owner the new owner to set, unchanged if null
    * @param group the new group to set, unchanged if null
-   * @throws IOException if a non-Alluxio error occurs
    */
   void setOwner(String path, String owner, String group) throws IOException;
 
@@ -571,7 +540,6 @@ public interface UnderFileSystem {
    *
    * @param path the path of the file
    * @param mode the mode to set in short format, e.g. 0777
-   * @throws IOException if a non-Alluxio error occurs
    */
   void setMode(String path, short mode) throws IOException;
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -580,7 +580,6 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
      * Executes the call.
      *
      * @return the result of the call
-     * @throws IOException if an error occurs during the external communication
      */
     T call() throws IOException;
   }
@@ -591,7 +590,6 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
    * @param callable the callable to invoke
    * @param <T> the return type
    * @return the result of the callable
-   * @throws IOException if an error occurs when invoking the operation on the underlying storage
    */
   private <T> T call(UfsCallable<T> callable) throws IOException {
     LOG.debug("Enter: {}", callable);

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -203,7 +203,6 @@ public final class CommonUtils {
    *
    * @param user user name
    * @return the groups list that the {@code user} belongs to. The primary group is returned first
-   * @throws IOException if encounter any error when running the command
    */
   public static List<String> getUnixGroups(String user) throws IOException {
     String result;
@@ -282,7 +281,6 @@ public final class CommonUtils {
    *
    * @param userName Alluxio user name
    * @return primary group name
-   * @throws IOException if getting group failed
    */
   public static String getPrimaryGroupName(String userName) throws IOException {
     List<String> groups = getGroups(userName);
@@ -294,7 +292,6 @@ public final class CommonUtils {
    *
    * @param userName Alluxio user name
    * @return the group list of the user
-   * @throws IOException if getting group list failed
    */
   public static List<String> getGroups(String userName) throws IOException {
     GroupMappingService groupMappingService = GroupMappingService.Factory.get();

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -65,10 +65,7 @@ public final class ShellUtils {
     mCommand = execString.clone();
   }
 
-  /** Checks to see if a command needs to be executed and execute command.
-   *
-   * @throws IOException if command ran failed
-   */
+  /** Checks to see if a command needs to be executed and execute command. */
   protected void run() throws IOException {
     mExitCode = 0; // reset for next run
     runCommand();
@@ -76,8 +73,6 @@ public final class ShellUtils {
 
   /**
    * Runs a command.
-   *
-   * @throws IOException if command ran failed
    */
   private void runCommand() throws IOException {
     ProcessBuilder builder = new ProcessBuilder(getExecString());
@@ -208,7 +203,6 @@ public final class ShellUtils {
    *
    * @param cmd shell command to execute
    * @return the output of the executed command
-   * @throws IOException if command ran failed
    */
   public static String execCommand(String... cmd) throws IOException {
     ShellUtils exec = new ShellUtils(cmd);

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -35,7 +35,6 @@ public final class UnderFileSystemUtils {
    * Deletes the directory at the given path if it exists.
    *
    * @param path path to the directory
-   * @throws IOException if the directory cannot be deleted
    */
   public static void deleteDirIfExists(final String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(path);
@@ -50,7 +49,6 @@ public final class UnderFileSystemUtils {
    * Attempts to create the directory if it does not already exist.
    *
    * @param path path to the directory
-   * @throws IOException if the directory cannot be created
    */
   public static void mkdirIfNotExists(final String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(path);
@@ -66,7 +64,6 @@ public final class UnderFileSystemUtils {
    * Creates an empty file.
    *
    * @param path path to the file
-   * @throws IOException if the file cannot be created
    */
   public static void touch(final String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(path);

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -284,7 +284,6 @@ public final class BufferUtils {
    *
    * @param path file path to write the data
    * @param buffer raw data
-   * @throws IOException if the operation fails
    */
   public static void writeBufferToFile(String path, byte[] buffer) throws IOException {
     try (FileOutputStream os = new FileOutputStream(path)) {
@@ -297,7 +296,6 @@ public final class BufferUtils {
    *
    * @param src the source channel
    * @param dest the destination channel
-   * @throws IOException if the copy fails
    */
   public static void fastCopy(final ReadableByteChannel src, final WritableByteChannel dest)
       throws IOException {

--- a/core/common/src/main/java/alluxio/util/io/ByteIOUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/ByteIOUtils.java
@@ -129,8 +129,6 @@ public final class ByteIOUtils {
    *
    * @param out output stream
    * @param v byte value to write
-   * @throws IOException if an I/O error occurs; in particular, an {@code IOException} may be
-   *         thrown if the output stream has been closed.
    */
   public static void writeByte(OutputStream out, byte v) throws IOException {
     out.write(v);
@@ -154,8 +152,6 @@ public final class ByteIOUtils {
    *
    * @param out output stream
    * @param v short value to write
-   * @throws IOException if an I/O error occurs; in particular, an {@code IOException} may be
-   *         thrown if the output stream has been closed.
    */
   public static void writeShort(OutputStream out, short v) throws IOException {
     out.write((byte) (0xff & (v >> 8)));
@@ -196,8 +192,6 @@ public final class ByteIOUtils {
    *
    * @param out output stream
    * @param v integer value to write
-   * @throws IOException if an I/O error occurs; in particular, an {@code IOException} may be
-   *         thrown if the output stream has been closed.
    */
   public static void writeInt(OutputStream out, int v) throws IOException {
     out.write((byte) (0xff & (v >> 24)));
@@ -230,8 +224,6 @@ public final class ByteIOUtils {
    *
    * @param out output stream
    * @param v long value to write
-   * @throws IOException if an I/O error occurs; in particular, an {@code IOException} may be
-   *         thrown if the output stream has been closed.
    */
   public static void writeLong(OutputStream out, long v) throws IOException {
     out.write((byte) (0xff & (v >> 56)));

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -54,7 +54,6 @@ public final class FileUtils {
    *
    * @param path that will change owner
    * @param group the new group
-   * @throws IOException if the group is unable to be changed
    */
   public static void changeLocalFileGroup(String path, String group) throws IOException {
     UserPrincipalLookupService lookupService =
@@ -71,7 +70,6 @@ public final class FileUtils {
    *
    * @param filePath that will change permission
    * @param perms the permission, e.g. "rwxr--r--"
-   * @throws IOException when fails to change permission
    */
   public static void changeLocalFilePermission(String filePath, String perms) throws IOException {
     Files.setPosixFilePermissions(Paths.get(filePath), PosixFilePermissions.fromString(perms));
@@ -81,7 +79,6 @@ public final class FileUtils {
    * Changes local file's permission to be "rwxrwxrwx".
    *
    * @param filePath that will change permission
-   * @throws IOException when fails to change file's permission to "rwxrwxrwx"
    */
   public static void changeLocalFileToFullPermission(String filePath) throws IOException {
     changeLocalFilePermission(filePath, "rwxrwxrwx");
@@ -92,7 +89,6 @@ public final class FileUtils {
    *
    * @param filePath the file path
    * @return the owner of the local file
-   * @throws IOException when fails to get the owner
    */
   public static String getLocalFileOwner(String filePath) throws IOException {
     PosixFileAttributes attr =
@@ -105,7 +101,6 @@ public final class FileUtils {
    *
    * @param filePath the file path
    * @return the group of the local file
-   * @throws IOException when fails to get the group
    */
   public static String getLocalFileGroup(String filePath) throws IOException {
     PosixFileAttributes attr =
@@ -118,7 +113,6 @@ public final class FileUtils {
    *
    * @param filePath the file path
    * @return the file mode in short, e.g. 0777
-   * @throws IOException when fails to get the permission
    */
   public static short getLocalFileMode(String filePath) throws IOException {
     Set<PosixFilePermission> permission =
@@ -137,7 +131,6 @@ public final class FileUtils {
    *
    * @param path that will change owner
    * @param user the new user
-   * @throws IOException if the group is unable to be changed
    */
   public static void changeLocalFileUser(String path, String user) throws IOException {
     UserPrincipalLookupService lookupService =
@@ -181,8 +174,6 @@ public final class FileUtils {
    * permissions.
    *
    * @param path the path of the block
-   * @throws IOException when fails to create block path and parent directories with appropriate
-   *         permissions.
    */
   public static void createBlockPath(String path) throws IOException {
     try {
@@ -204,7 +195,6 @@ public final class FileUtils {
    *
    * @param srcPath pathname string of source file
    * @param dstPath pathname string of destination file
-   * @throws IOException when fails to move
    */
   public static void move(String srcPath, String dstPath) throws IOException {
     com.google.common.io.Files.move(new File(srcPath), new File(dstPath));
@@ -217,7 +207,6 @@ public final class FileUtils {
    * solution.
    *
    * @param path pathname string of file or directory
-   * @throws IOException when fails to delete
    */
   public static void delete(String path) throws IOException {
     File file = new File(path);
@@ -230,7 +219,6 @@ public final class FileUtils {
    * Deletes a path recursively.
    *
    * @param path pathname to be deleted
-   * @throws IOException when fails to delete
    */
   public static void deletePathRecursively(String path) throws IOException {
     Path root = Paths.get(path);
@@ -260,7 +248,6 @@ public final class FileUtils {
    * Also, appropriate directory permissions (777 + StickyBit, namely "drwxrwxrwt") are set.
    *
    * @param path storage directory path to create
-   * @throws IOException when fails to create storage directory path
    */
   public static void createStorageDirPath(String path) throws IOException {
     File dir = new File(path);
@@ -284,7 +271,6 @@ public final class FileUtils {
    * Creates an empty file and its intermediate directories if necessary.
    *
    * @param filePath pathname string of the file to create
-   * @throws IOException if an I/O error occurred or file already exists
    */
   public static void createFile(String filePath) throws IOException {
     File file = new File(filePath);
@@ -298,7 +284,6 @@ public final class FileUtils {
    * Creates an empty directory and its intermediate directories if necessary.
    *
    * @param path path of the directory to create
-   * @throws IOException if an I/O error occurred or directory already exists
    */
   public static void createDir(String path) throws IOException {
     new File(path).mkdirs();

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -441,7 +441,6 @@ public final class NetworkAddressUtils {
    * @param timeoutMs Timeout in milliseconds to use for checking that a possible local IP is
    *        reachable
    * @return a {@code boolean} indicating if the given address is externally resolvable address
-   * @throws IOException if the address resolution fails
    */
   private static boolean isValidAddress(InetAddress address, int timeoutMs) throws IOException {
     return !address.isAnyLocalAddress() && !address.isLinkLocalAddress()
@@ -548,7 +547,6 @@ public final class NetworkAddressUtils {
    *
    * @param address socket address to parse
    * @return InetSocketAddress of the String
-   * @throws IOException if the socket address is invalid
    */
   public static InetSocketAddress parseInetSocketAddress(String address) throws IOException {
     if (address == null) {

--- a/core/common/src/main/java/alluxio/worker/DataServerMessage.java
+++ b/core/common/src/main/java/alluxio/worker/DataServerMessage.java
@@ -326,7 +326,6 @@ public final class DataServerMessage {
    *
    * @param socketChannel The socket channel to receive from
    * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
-   * @throws IOException when a non-Alluxio related exception occurs
    */
   public int recv(SocketChannel socketChannel) throws IOException {
     isSend(false);
@@ -402,7 +401,6 @@ public final class DataServerMessage {
    * Sends this message to the specified socket channel. Make sure this is a send message.
    *
    * @param socketChannel The socket channel to send to
-   * @throws IOException when a non-Alluxio related exception occurs
    */
   public void send(SocketChannel socketChannel) throws IOException {
     Preconditions.checkNotNull(socketChannel, "socketChannel");

--- a/core/common/src/main/java/alluxio/worker/block/io/BlockWriter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/BlockWriter.java
@@ -15,7 +15,6 @@ import alluxio.QuietlyCloseable;
 
 import io.netty.buffer.ByteBuf;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
 
@@ -30,7 +29,6 @@ public interface BlockWriter extends QuietlyCloseable {
    *
    * @param inputBuf {@link ByteBuffer} that input data is stored in
    * @return the size of data that was appended in bytes
-   * @throws IOException if the operation fails
    */
   long append(ByteBuffer inputBuf);
 
@@ -46,7 +44,6 @@ public interface BlockWriter extends QuietlyCloseable {
    * This is only called in the netty data server.
    *
    * @param buf the byte buffer to hold the data
-   * @throws IOException if any I/O errors occur
    */
   void transferFrom(ByteBuf buf);
 

--- a/core/common/src/test/java/alluxio/security/LoginUserTestUtils.java
+++ b/core/common/src/test/java/alluxio/security/LoginUserTestUtils.java
@@ -13,8 +13,6 @@ package alluxio.security;
 
 import org.powermock.reflect.Whitebox;
 
-import java.io.IOException;
-
 /**
  * Utility methods for the tests using {@link LoginUser}.
  */
@@ -35,9 +33,8 @@ public final class LoginUserTestUtils {
    * Resets the {@link LoginUser} and re-login with new user.
    *
    * @param user the new user
-   * @throws IOException if login fails
    */
-  public static void resetLoginUser(String user) throws IOException {
+  public static void resetLoginUser(String user) {
     synchronized (LoginUser.class) {
       Whitebox.setInternalState(LoginUser.class, "sLoginUser", new User(user));
     }

--- a/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
@@ -42,8 +42,6 @@ public final class PlainSaslServerCallbackHandlerTest {
 
   /**
    * Sets up the configuration and callback handler before running a test.
-   *
-   * @throws Exception thrown if the authentication provider cannot be set up
    */
   @Before
   public void before() throws Exception {
@@ -65,8 +63,6 @@ public final class PlainSaslServerCallbackHandlerTest {
 
   /**
    * Tests that the authentication callbacks matches.
-   *
-   * @throws Exception thrown if the handler fails
    */
   @Test
   public void authenticateNameMatch() throws Exception {

--- a/core/common/src/test/java/alluxio/wire/BlockInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/BlockInfoTest.java
@@ -23,8 +23,6 @@ public class BlockInfoTest {
 
   /**
    * Test to convert between a BlockInfo type and a json type.
-   *
-   * @throws Exception if an error occurs during convert between BlockInfo type and json type
    */
   @Test
   public void json() throws Exception {

--- a/core/common/src/test/java/alluxio/wire/CapacityTest.java
+++ b/core/common/src/test/java/alluxio/wire/CapacityTest.java
@@ -23,8 +23,6 @@ public class CapacityTest {
 
   /**
    * Test to convert between a Capacity type and a json type.
-   *
-   * @throws Exception if an error occurs during conversion between Capacity type and json type
    */
   @Test
   public void json() throws Exception {

--- a/core/common/src/test/java/alluxio/wire/JobConfInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/JobConfInfoTest.java
@@ -23,8 +23,6 @@ public class JobConfInfoTest {
 
   /**
    * Test to convert between a JobConfInfo type and a json type.
-   *
-   * @throws Exception if an error occurs during convert between JobConfInfo type and json type
    */
   @Test
   public void json() throws Exception {

--- a/core/protobuf/src/main/java/alluxio/util/proto/ProtoUtils.java
+++ b/core/protobuf/src/main/java/alluxio/util/proto/ProtoUtils.java
@@ -31,7 +31,6 @@ public final class ProtoUtils {
    * @param firstByte first byte in the input stream
    * @param input input stream
    * @return an int value read from the input stream
-   * @throws IOException if the proto message being parsed is invalid
    */
   public static int readRawVarint32(int firstByte, InputStream input) throws IOException {
     return CodedInputStream.readRawVarint32(firstByte, input);

--- a/core/server/common/src/main/java/alluxio/Process.java
+++ b/core/server/common/src/main/java/alluxio/Process.java
@@ -20,15 +20,11 @@ public interface Process {
    * Starts the Alluxio process. This call blocks until the process is stopped via
    * {@link #stop()}. The {@link #waitForReady()} method can be used to make sure that the
    * process is ready to serve requests.
-   *
-   * @throws Exception if the process fails to start
    */
   void start() throws Exception;
 
   /**
    * Stops the Alluxio process, blocking until the action is completed.
-   *
-   * @throws Exception if the process fails to stop
    */
   void stop() throws Exception;
 

--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -123,7 +123,6 @@ public class Registry<T extends Server<U>, U> {
    * If a {@link Server} fails to start, already-started {@link Server}s will be stopped.
    *
    * @param options the start options
-   * @throws IOException if an IO error occurs
    */
   public void start(U options) throws IOException {
     List<T> servers = new ArrayList<>();
@@ -143,8 +142,6 @@ public class Registry<T extends Server<U>, U> {
   /**
    * Stops all {@link Server}s in reverse dependency order. If A depends on B, B is stopped
    * before A.
-   *
-   * @throws IOException if an IO error occurs
    */
   public void stop() throws IOException {
     for (T server : Lists.reverse(getServers())) {

--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -65,7 +65,6 @@ public final class RestUtils {
      * The REST endpoint implementation.
      *
      * @return the return value from the callable
-     * @throws Exception if an exception occurs
      */
     T call() throws Exception;
   }

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -128,7 +128,6 @@ public final class RpcUtils {
      * The RPC implementation.
      *
      * @return the return value from the RPC
-     * @throws AlluxioException if an expected exception occurs in the Alluxio system
      */
     T call() throws AlluxioException;
   }
@@ -143,7 +142,6 @@ public final class RpcUtils {
      * The RPC implementation.
      *
      * @return the return value from the RPC
-     * @throws AlluxioException if an expected exception occurs in the Alluxio system
      */
     T call() throws AlluxioException, IOException;
   }

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -144,7 +144,6 @@ public final class RpcUtils {
      *
      * @return the return value from the RPC
      * @throws AlluxioException if an expected exception occurs in the Alluxio system
-     * @throws IOException if an exception is thrown when interacting with the underlying system
      */
     T call() throws AlluxioException, IOException;
   }

--- a/core/server/common/src/main/java/alluxio/Server.java
+++ b/core/server/common/src/main/java/alluxio/Server.java
@@ -43,15 +43,12 @@ public interface Server<T> {
    * Starts the Alluxio server.
    *
    * @param options the start options
-   * @throws IOException if the server fails to start
    */
   void start(T options) throws IOException;
 
   /**
    * Stops the Alluxio server. Here, anything created or started in {@link #start(T)} should be
    * cleaned up and shutdown.
-   *
-   * @throws IOException if the server fails to stop
    */
   void stop() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -102,7 +102,6 @@ public final class Format {
    * Formats the Alluxio file system.
    *
    * @param mode either {@code MASTER} or {@code WORKER}
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   public static void format(Mode mode) throws IOException {
     switch (mode) {

--- a/core/server/common/src/main/java/alluxio/master/Master.java
+++ b/core/server/common/src/main/java/alluxio/master/Master.java
@@ -26,7 +26,6 @@ public interface Master extends JournalEntryIterable, Server<Boolean> {
    * entries.
    *
    * @param entry the entry to process to update the state of the master
-   * @throws IOException if I/O error occurs
    */
   void processJournalEntry(JournalEntry entry) throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -102,7 +102,6 @@ public final class AsyncJournalWriter {
    * counter is already flushed, this is essentially a no-op.
    *
    * @param targetCounter the counter to flush
-   * @throws IOException if an error occurs in flushing the journal
    */
   public void flush(final long targetCounter) throws IOException {
     if (targetCounter <= mFlushCounter.get()) {

--- a/core/server/common/src/main/java/alluxio/master/journal/Journal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/Journal.java
@@ -63,7 +63,6 @@ public interface Journal {
   /**
    * @param options the options to create the writer
    * @return the {@link JournalWriter} for this journal
-   * @throws IOException if an I/O error occurs
    */
   JournalWriter getWriter(JournalWriterOptions options) throws IOException;
 
@@ -71,20 +70,16 @@ public interface Journal {
    * Gets the log sequence number of the last journal entry written to checkpoint + 1.
    *
    * @return the next sequence number to checkpoint
-   * @throws IOException if an I/O error occur
    */
   long getNextSequenceNumberToCheckpoint() throws IOException;
 
   /**
    * @return whether the journal has been formatted
-   * @throws IOException if an I/O error occurs
    */
   boolean isFormatted() throws IOException;
 
   /**
    * Formats the journal.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void format() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalFileParser.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalFileParser.java
@@ -47,7 +47,6 @@ public interface JournalFileParser extends Closeable {
    * is no more entry left.
    *
    * @return the journal entry, null if no more entry left
-   * @throws IOException if any I/O errors occur
    */
   JournalEntry next() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalReader.java
@@ -28,7 +28,6 @@ public interface JournalReader extends Closeable {
    * Reads an entry from the journal. Return null if there is no more entry left.
    *
    * @return the journal entry, null if no more entry left
-   * @throws IOException if it failed to read an entry due to an I/O error
    * @throws InvalidJournalEntryException if the journal entry is invalid (e.g. corrupted entry)
    */
   JournalEntry read() throws IOException, InvalidJournalEntryException;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
@@ -98,8 +98,6 @@ public final class JournalUpgrader {
 
     /**
      * Upgrades journal from v0 to v1.
-     *
-     * @throws IOException if any I/O errors occur
      */
     void upgrade() throws IOException {
       if (!mUfs.exists(mCheckpointV0.toString())) {

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalWriter.java
@@ -25,21 +25,16 @@ public interface JournalWriter extends Closeable {
    * is persisted.
    *
    * @param entry the journal entry to write
-   * @throws IOException if an error occurs writing the entry
    */
   void write(JournalEntry entry) throws IOException;
 
   /**
    * Flushes all the entries written to the underlying storage.
-   *
-   * @throws IOException if an error occurs preventing the stream from being flushed
    */
   void flush() throws IOException;
 
   /**
    * Cancels the current journal writer.
-   *
-   * @throws IOException if any I/O errors occur
    */
   void cancel() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
@@ -63,7 +63,6 @@ final class UfsJournalCheckpointWriter implements JournalWriter {
    *
    * @param journal the handle to the journal
    * @param options the options to create the journal writer
-   * @throws IOException if any I/O errors occur
    */
   UfsJournalCheckpointWriter(UfsJournal journal, JournalWriterOptions options)
       throws IOException {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -99,8 +99,6 @@ final class UfsJournalLogWriter implements JournalWriter {
     /**
      * Closes the stream by committing the log. The implementation must be idempotent as this
      * close can fail and be retried.
-     *
-     * @throws IOException if it fails to close
      */
     @Override
     public void close() throws IOException {
@@ -141,7 +139,6 @@ final class UfsJournalLogWriter implements JournalWriter {
    *
    * @param journal the handle to the journal
    * @param options the options to create the journal log writer
-   * @throws IOException if any I/O exceptions occur
    */
   UfsJournalLogWriter(UfsJournal journal, JournalWriterOptions options) throws IOException {
     mJournal = Preconditions.checkNotNull(journal);
@@ -179,8 +176,6 @@ final class UfsJournalLogWriter implements JournalWriter {
   /**
    * Closes the current journal output stream and creates a new one.
    * The implementation must be idempotent so that it can work when retrying during failures.
-   *
-   * @throws IOException if an IO exception occurs during the log rotation
    */
   private void maybeRotateLog() throws IOException {
     if (!mRotateLogForNextWrite) {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -149,7 +149,6 @@ final class UfsJournalReader implements JournalReader {
    * The real read implementation that reads a journal entry from a journal file.
    *
    * @return the journal entry, null if no journal entry is found
-   * @throws IOException if any I/O errors occur
    * @throws InvalidJournalEntryException if the journal entry found is invalid
    */
   private Journal.JournalEntry readInternal() throws IOException, InvalidJournalEntryException {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
@@ -81,7 +81,6 @@ final class UfsJournalSnapshot {
    * Creates a snapshot of the journal.
    *
    * @return the journal snapshot
-   * @throws IOException if any I/O errors occur
    */
   static UfsJournalSnapshot getSnapshot(UfsJournal journal) throws IOException {
     // Checkpoints.
@@ -124,7 +123,6 @@ final class UfsJournalSnapshot {
    * Gets the current log (the incomplete log) that is being written to.
    *
    * @return the current log
-   * @throws IOException if any I/O errors occur
    */
   static UfsJournalFile getCurrentLog(UfsJournal journal) throws IOException {
     List<UfsJournalFile> logs = new ArrayList<>();
@@ -150,7 +148,6 @@ final class UfsJournalSnapshot {
    * Gets the first journal log sequence number that is not yet checkpointed.
    *
    * @return the first journal log sequence number that is not yet checkpointed
-   * @throws IOException if any I/O errors occur
    */
   static long getNextLogSequenceNumberToCheckpoint(UfsJournal journal) throws IOException {
     List<UfsJournalFile> checkpoints = new ArrayList<>();

--- a/core/server/common/src/main/java/alluxio/master/journalv0/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/AsyncJournalWriter.java
@@ -101,7 +101,6 @@ public final class AsyncJournalWriter {
    * counter is already flushed, this is essentially a no-op.
    *
    * @param targetCounter the counter to flush
-   * @throws IOException if an error occurs in flushing the journal
    */
   public void flush(final long targetCounter) throws IOException {
     if (targetCounter <= mFlushCounter.get()) {

--- a/core/server/common/src/main/java/alluxio/master/journalv0/Journal.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/Journal.java
@@ -75,7 +75,6 @@ public interface Journal {
 
   /**
    * @return whether the journal has been formatted
-   * @throws IOException if an I/O error occurs
    */
   boolean isFormatted() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalCheckpointStreamable.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalCheckpointStreamable.java
@@ -21,7 +21,6 @@ public interface JournalCheckpointStreamable {
    * Writes to the journal, in a streaming fashion, via the {@link JournalOutputStream}.
    *
    * @param outputStream the output stream to write to for the journal checkpoint
-   * @throws IOException if an I/O error occurs
    */
   void streamToJournalCheckpoint(JournalOutputStream outputStream) throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalFormatter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalFormatter.java
@@ -55,7 +55,6 @@ public interface JournalFormatter {
    *
    * @param entry The journal entry to serialize
    * @param outputStream the output stream to serialize the entry to
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   void serialize(JournalEntry entry, OutputStream outputStream) throws IOException;
 
@@ -66,7 +65,6 @@ public interface JournalFormatter {
    * @param inputStream The input stream to deserialize
    * @return a {@link JournalInputStream} for reading all the journal entries in the given input
    *         stream.
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   JournalInputStream deserialize(InputStream inputStream) throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalInputStream.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalInputStream.java
@@ -23,14 +23,11 @@ public interface JournalInputStream extends AutoCloseable {
    * Reads the next journal entry.
    *
    * @return the next {@link JournalEntry} in the stream, or null if the are no more entries
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   JournalEntry read() throws IOException;
 
   /**
    * Closes the stream.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void close() throws IOException;
 

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalOutputStream.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalOutputStream.java
@@ -24,21 +24,16 @@ public interface JournalOutputStream extends AutoCloseable {
    * Writes a {@link JournalEntry} to the journal.
    *
    * @param entry the entry to write to the journal
-   * @throws IOException if an I/O error occurs
    */
   void write(JournalEntry entry) throws IOException;
 
   /**
    * Closes the stream.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void close() throws IOException;
 
   /**
    * Flushes the stream.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void flush() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalReader.java
@@ -39,21 +39,17 @@ public interface JournalReader {
    * calling {@link #getNextInputStream()}.
    *
    * @return the {@link JournalInputStream} for the journal checkpoint
-   * @throws IOException if the checkpoint cannot be read, or was already read
    */
   JournalInputStream getCheckpointInputStream() throws IOException;
 
   /**
    * @return the input stream for the next completed log. Will return null if the next
    *         completed log does not exist yet.
-   * @throws IOException if the reader is no longer valid or when trying to get an input stream
-   *                     before a checkpoint was read
    */
   JournalInputStream getNextInputStream() throws IOException;
 
   /**
    * @return the last modified time of the checkpoint in ms
-   * @throws IOException if the checkpoint does not exist
    */
   long getCheckpointLastModifiedTimeMs() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalTool.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalTool.java
@@ -60,7 +60,6 @@ public final class JournalTool {
    * alluxio.master.journal.JournalTool < journal/FileSystemMaster/log.out}.
    *
    * @param args arguments passed to the tool
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   public static void main(String[] args) throws IOException {
     if (!parseInputArgs(args)) {

--- a/core/server/common/src/main/java/alluxio/master/journalv0/JournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/JournalWriter.java
@@ -30,8 +30,6 @@ public interface JournalWriter {
 
   /**
    * Marks all logs as completed.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void completeLogs() throws IOException;
 
@@ -43,7 +41,6 @@ public interface JournalWriter {
    *        number will be used to determine the next sequence numbers for the subsequent journal
    *        entries.
    * @return the output stream for the journal checkpoint
-   * @throws IOException if an I/O error occurs
    */
   JournalOutputStream getCheckpointOutputStream(long latestSequenceNumber) throws IOException;
 
@@ -52,14 +49,11 @@ public interface JournalWriter {
    * afterward to ensure the entry is persisted.
    *
    * @param entry the journal entry to write
-   * @throws IOException if an error occurs writing the entry or if the checkpoint is not closed
    */
   void write(JournalEntry entry) throws IOException;
 
   /**
    * Flushes the current log stream. Otherwise this operation is a no-op.
-   *
-   * @throws IOException if an error occurs preventing the stream from being flushed
    */
   void flush() throws IOException;
 
@@ -70,8 +64,6 @@ public interface JournalWriter {
 
   /**
    * Closes the journal.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void close() throws IOException;
 
@@ -82,16 +74,12 @@ public interface JournalWriter {
 
   /**
    * Deletes all of the completed logs.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void deleteCompletedLogs() throws IOException;
 
   /**
    * Marks the current log as completed. If successful, the current log will no longer exist. The
    * current log must be closed before this call.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void completeCurrentLog() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journalv0/MutableJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/MutableJournal.java
@@ -65,8 +65,6 @@ public interface MutableJournal extends Journal {
 
   /**
    * Formats the journal.
-   *
-   * @throws IOException if an I/O error occurs
    */
   void format() throws IOException;
 

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
@@ -225,7 +225,6 @@ public final class UfsJournalWriter implements JournalWriter {
      * number to the passed in entry.
      *
      * @param entry an entry to write to the journal checkpoint file
-     * @throws IOException if an I/O error occurs
      */
     @Override
     public synchronized void write(JournalEntry entry) throws IOException {
@@ -245,8 +244,6 @@ public final class UfsJournalWriter implements JournalWriter {
      * already reflects that state.
      *
      * The current log file (if it exists) will be closed and marked as complete.
-     *
-     * @throws IOException if an I/O error occurs
      */
     @Override
     public synchronized void close() throws IOException {
@@ -315,7 +312,6 @@ public final class UfsJournalWriter implements JournalWriter {
      * @param journalFormatter the journal formatter to use when writing journal entries
      * @param journalWriter the journal writer to use to get journal entry sequence numbers and
      *        complete the log when it needs to be rotated
-     * @throws IOException if the ufs can't create an outstream to logPath
      */
     public EntryOutputStream(UnderFileSystem ufs, URI log, JournalFormatter journalFormatter,
         UfsJournalWriter journalWriter) throws IOException {
@@ -335,7 +331,6 @@ public final class UfsJournalWriter implements JournalWriter {
      * sequence number to the passed in entry.
      *
      * @param entry an entry to write to the journal checkpoint file
-     * @throws IOException if an I/O error occurs
      */
     @Override
     public synchronized void write(JournalEntry entry) throws IOException {
@@ -406,8 +401,6 @@ public final class UfsJournalWriter implements JournalWriter {
 
     /**
      * Completes the current log and rotates in a new log.
-     *
-     * @throws IOException if an IO exception occurs during the log rotation
      */
     private void rotateLog() throws IOException {
       mDataOutputStream.close();

--- a/core/server/common/src/main/java/alluxio/web/WebInterfaceBrowseLogsServlet.java
+++ b/core/server/common/src/main/java/alluxio/web/WebInterfaceBrowseLogsServlet.java
@@ -63,7 +63,6 @@ public final class WebInterfaceBrowseLogsServlet extends HttpServlet {
    * @param file the local file to display
    * @param request the {@link HttpServletRequest} object
    * @param offset where the file starts to display
-   * @throws IOException if an I/O error occurs
    */
   private void displayLocalFile(File file, HttpServletRequest request, long offset)
       throws IOException {
@@ -101,7 +100,6 @@ public final class WebInterfaceBrowseLogsServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/core/server/common/src/main/java/alluxio/web/WebInterfaceDownloadLocalServlet.java
+++ b/core/server/common/src/main/java/alluxio/web/WebInterfaceDownloadLocalServlet.java
@@ -48,7 +48,6 @@ public final class WebInterfaceDownloadLocalServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -82,7 +81,6 @@ public final class WebInterfaceDownloadLocalServlet extends HttpServlet {
    * @param file the local log file to download
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
-   * @throws IOException if an I/O error occurs
    */
   private void downloadLogFile(File file, HttpServletRequest request, HttpServletResponse response)
       throws IOException {

--- a/core/server/common/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
+++ b/core/server/common/src/main/java/alluxio/web/WebInterfaceHeaderServlet.java
@@ -43,7 +43,6 @@ public final class WebInterfaceHeaderServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -154,8 +154,6 @@ public abstract class WebServer {
 
   /**
    * Shuts down the web server.
-   *
-   * @throws Exception if the underlying jetty server throws an exception
    */
   public void stop() throws Exception {
     // close all connectors and release all binding ports

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -311,8 +311,6 @@ public class AlluxioMasterProcess implements MasterProcess {
   /**
    * Stops serving, trying stop RPC server and web ui server and letting {@link MetricsSystem} stop
    * all the sinks.
-   *
-   * @throws Exception if the underlying jetty server throws an exception
    */
   protected void stopServing() throws Exception {
     if (mThriftServer != null) {

--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -93,8 +93,6 @@ public final class AlluxioSecondaryMaster implements Process {
 
   /**
    * Connects to the UFS.
-   *
-   * @throws IOException if any I/O errors occur
    */
   private void connectToUFS() throws IOException {
     String ufsAddress = Configuration.get(PropertyKey.UNDERFS_ADDRESS);

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -34,8 +34,6 @@ final class MasterUtils {
 
   /**
    * Checks whether the journal has been formatted.
-   *
-   * @throws IOException if the journal has not been formatted
    */
   public static void checkJournalFormatted() throws IOException {
     Journal.Factory factory = new Journal.Factory(getJournalLocation());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -56,6 +56,7 @@ import alluxio.master.file.options.CheckConsistencyOptions;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
+import alluxio.master.file.options.CreatePathOptions;
 import alluxio.master.file.options.DeleteOptions;
 import alluxio.master.file.options.FreeOptions;
 import alluxio.master.file.options.ListStatusOptions;
@@ -489,7 +490,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    *
    * @return a list of paths in Alluxio which are not consistent with the under storage
    * @throws InterruptedException if the thread is interrupted during execution
-   * @throws IOException if an error occurs interacting with the under storage
    */
   private List<AlluxioURI> startupCheckConsistency(final ExecutorService service)
       throws InterruptedException, IOException {
@@ -520,7 +520,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
        * READ locked only during the consistency check of the children files.
        *
        * @return a list of inconsistent uris
-       * @throws IOException if an error occurs interacting with the under storage
        */
       @Override
       public List<AlluxioURI> call() throws IOException {
@@ -955,7 +954,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if the creation fails
    */
   private void createFileAndJournal(LockedInodePath inodePath, CreateFileOptions options,
       JournalContext journalContext)
@@ -972,7 +970,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws InvalidPathException if an invalid path is encountered
    * @throws FileAlreadyExistsException if the file already exists
    * @throws BlockInfoException if invalid block information is encountered
-   * @throws IOException if an I/O error occurs
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    */
@@ -1074,7 +1071,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param journalContext the journal context
    * @throws InvalidPathException if the path is invalid
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws IOException if an I/O error occurs
    * @throws DirectoryNotEmptyException if recursive is false and the file is a nonempty directory
    */
   private void deleteAndJournal(LockedInodePath inodePath, DeleteOptions deleteOptions,
@@ -1108,7 +1104,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param deleteOptions the method optitions
    * @param journalContext the journal context
    * @throws FileDoesNotExistException if a non-existent file is encountered
-   * @throws IOException if an I/O error is encountered
    * @throws InvalidPathException if the specified path is the root
    * @throws DirectoryNotEmptyException if recursive is false and the file is a nonempty directory
    */
@@ -1413,7 +1408,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    *         InodeTree#createPath(LockedInodePath, CreatePathOptions, JournalContext)}
    *         for more details
    * @throws AccessControlException if permission checking fails
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   private void createDirectoryAndJournal(LockedInodePath inodePath, CreateDirectoryOptions options,
       JournalContext journalContext)
@@ -1435,7 +1429,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    *         InodeTree#createPath(LockedInodePath, CreatePathOptions, JournalContext)}
    *         for more details
    * @throws FileAlreadyExistsException when there is already a file at path
-   * @throws IOException if a non-Alluxio related exception occurs
    * @throws AccessControlException if permission checking fails
    */
   private InodeTree.CreatePathResult createDirectoryInternal(LockedInodePath inodePath,
@@ -1495,7 +1488,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws InvalidPathException if an invalid path is encountered
    * @throws FileDoesNotExistException if a non-existent file is encountered
    * @throws FileAlreadyExistsException if the file already exists
-   * @throws IOException if an I/O error occurs
    */
   private void renameAndJournal(LockedInodePath srcInodePath, LockedInodePath dstInodePath,
       RenameOptions options, JournalContext journalContext)
@@ -1575,7 +1567,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param journalContext the journal context
    * @throws FileDoesNotExistException if a non-existent file is encountered
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if an I/O error is encountered
    */
   private void renameInternal(LockedInodePath srcInodePath, LockedInodePath dstInodePath,
       boolean replayed, RenameOptions options, JournalContext journalContext)
@@ -1935,7 +1926,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws FileAlreadyCompletedException if the file is already completed
    * @throws InvalidFileSizeException if invalid file size is encountered
    * @throws AccessControlException if permission checking fails
-   * @throws IOException if an I/O error occurs
    */
   private void loadMetadataAndJournal(LockedInodePath inodePath, LoadMetadataOptions options,
       JournalContext journalContext)
@@ -1999,7 +1989,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws AccessControlException if permission checking fails or permission setting fails
    * @throws FileAlreadyCompletedException if the file is already completed
    * @throws InvalidFileSizeException if invalid file size is encountered
-   * @throws IOException if an I/O error occurs
    */
   private void loadFileMetadataAndJournal(LockedInodePath inodePath,
       MountTable.Resolution resolution, LoadMetadataOptions options, JournalContext journalContext)
@@ -2046,7 +2035,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param options the load metadata options
    * @param journalContext the journal context
    * @throws InvalidPathException if invalid path is encountered
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the path does not exist
    */
@@ -2142,7 +2130,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws InvalidPathException if an invalid path is encountered
    * @throws FileAlreadyExistsException if the path to be mounted to already exists
    * @throws FileDoesNotExistException if the parent of the path to be mounted to does not exist
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if the permission check fails
    */
   private void mountAndJournal(LockedInodePath inodePath, AlluxioURI ufsPath, MountOptions options,
@@ -2189,7 +2176,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param entry the entry to use
    * @throws FileAlreadyExistsException if the mount point already exists
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if an I/O exception occurs
    */
   private void mountFromEntry(AddMountPointEntry entry)
       throws FileAlreadyExistsException, InvalidPathException, IOException {
@@ -2211,7 +2197,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param options the mount options (may be updated)
    * @throws FileAlreadyExistsException if the mount point already exists
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if an I/O exception occurs
    */
   private void mountInternal(LockedInodePath inodePath, AlluxioURI ufsPath, boolean replayed,
       MountOptions options) throws FileAlreadyExistsException, InvalidPathException, IOException {
@@ -2267,7 +2252,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param journalContext the journal context
    * @throws InvalidPathException if the given path is not a mount point
    * @throws FileDoesNotExistException if the path to be mounted does not exist
-   * @throws IOException if an I/O error occurs
    */
   private void unmountAndJournal(LockedInodePath inodePath, JournalContext journalContext)
       throws InvalidPathException, FileDoesNotExistException, IOException {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -56,7 +56,6 @@ import alluxio.master.file.options.CheckConsistencyOptions;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
-import alluxio.master.file.options.CreatePathOptions;
 import alluxio.master.file.options.DeleteOptions;
 import alluxio.master.file.options.FreeOptions;
 import alluxio.master.file.options.ListStatusOptions;
@@ -1404,9 +1403,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws FileAlreadyExistsException when there is already a file at path
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
-   * @throws InvalidPathException when the path is invalid, please see documentation on {@link
-   *         InodeTree#createPath(LockedInodePath, CreatePathOptions, JournalContext)}
-   *         for more details
+   * @throws InvalidPathException when the path is invalid
    * @throws AccessControlException if permission checking fails
    */
   private void createDirectoryAndJournal(LockedInodePath inodePath, CreateDirectoryOptions options,
@@ -1425,9 +1422,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param journalContext the journal context
    * @return an {@link alluxio.master.file.meta.InodeTree.CreatePathResult} representing the
    *         modified inodes and created inodes during path creation
-   * @throws InvalidPathException when the path is invalid, please see documentation on {@link
-   *         InodeTree#createPath(LockedInodePath, CreatePathOptions, JournalContext)}
-   *         for more details
+   * @throws InvalidPathException when the path is invalid
    * @throws FileAlreadyExistsException when there is already a file at path
    * @throws AccessControlException if permission checking fails
    */

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2423,7 +2423,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    *
    * @param inodePath the {@link LockedInodePath} of the file for persistence
    * @param journalContext the journal context
-   * @throws AlluxioException if scheduling fails
    */
   private void scheduleAsyncPersistenceAndJournal(LockedInodePath inodePath,
       JournalContext journalContext) throws AlluxioException {
@@ -2439,7 +2438,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   /**
    * @param inodePath the {@link LockedInodePath} of the file to persist
-   * @throws AlluxioException if scheduling fails
    */
   private void scheduleAsyncPersistenceInternal(LockedInodePath inodePath) throws AlluxioException {
     inodePath.getInode().setPersistenceState(PersistenceState.TO_BE_PERSISTED);

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -139,7 +139,6 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if the permission checking fails
    * @throws FileDoesNotExistException if the path does not exist
    * @throws InvalidPathException if the path is invalid
-   * @throws IOException if an error occurs interacting with the under storage
    */
   List<AlluxioURI> checkConsistency(AlluxioURI path, CheckConsistencyOptions options)
       throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException;
@@ -173,7 +172,6 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if an invalid path is encountered
    * @throws FileAlreadyExistsException if the file already exists
    * @throws BlockInfoException if an invalid block information is encountered
-   * @throws IOException if the creation fails
    * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    * option is false
@@ -236,7 +234,6 @@ public interface FileSystemMaster extends Master {
    * @param options method options
    * @throws DirectoryNotEmptyException if recursive is false and the file is a nonempty directory
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
@@ -274,7 +271,6 @@ public interface FileSystemMaster extends Master {
    * @return the id of the created directory
    * @throws InvalidPathException when the path is invalid
    * @throws FileAlreadyExistsException when there is already a file at path
-   * @throws IOException if a non-Alluxio related exception occurs
    * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
@@ -294,7 +290,6 @@ public interface FileSystemMaster extends Master {
    * @param options method options
    * @throws FileDoesNotExistException if a non-existent file is encountered
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if permission checking fails
    * @throws FileAlreadyExistsException if the file already exists
    */
@@ -379,7 +374,6 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if invalid path is encountered
    * @throws InvalidFileSizeException if invalid file size is encountered
    * @throws FileAlreadyCompletedException if the file is already completed
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if permission checking fails
    */
   long loadMetadata(AlluxioURI path, LoadMetadataOptions options)
@@ -398,7 +392,6 @@ public interface FileSystemMaster extends Master {
    * @throws FileAlreadyExistsException if the path to be mounted to already exists
    * @throws FileDoesNotExistException if the parent of the path to be mounted to does not exist
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if the permission check fails
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountOptions options)
@@ -414,7 +407,6 @@ public interface FileSystemMaster extends Master {
    * @param alluxioPath the Alluxio path to unmount, must be a mount point
    * @throws FileDoesNotExistException if the path to be mounted does not exist
    * @throws InvalidPathException if the given path is not a mount point
-   * @throws IOException if an I/O error occurs
    * @throws AccessControlException if the permission check fails
    */
   void unmount(AlluxioURI alluxioPath)

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -447,7 +447,6 @@ public interface FileSystemMaster extends Master {
    * Schedules a file for async persistence.
    *
    * @param path the path of the file for persistence
-   * @throws AlluxioException if scheduling fails
    */
   void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
 

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -69,7 +69,6 @@ public interface AsyncPersistHandler {
    * Schedules a file for async persistence.
    *
    * @param path the path to the file
-   * @throws AlluxioException if the scheduling fails
    */
   void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -481,7 +481,6 @@ public class InodeTree implements JournalEntryIterable {
    * @throws InvalidPathException when path is invalid, for example, (1) when there is nonexistent
    *         necessary parent directories and recursive is false, (2) when one of the necessary
    *         parent directories is actually a file
-   * @throws IOException if creating the path fails
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    */
@@ -984,7 +983,6 @@ public class InodeTree implements JournalEntryIterable {
    *
    * @param dir the {@link InodeDirectory} to persist
    * @param journalContext the journal context
-   * @throws IOException if the file fails to persist
    * @throws InvalidPathException if the path for the inode is invalid
    * @throws FileDoesNotExistException if the path for the inode is invalid
    */

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -20,8 +20,6 @@ import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -45,9 +43,8 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
    * transport.
    *
    * @param options the {@link CreateDirectoryTOptions} to use
-   * @throws IOException if it failed to retrieve users or groups from thrift transport
    */
-  public CreateDirectoryOptions(CreateDirectoryTOptions options) throws IOException {
+  public CreateDirectoryOptions(CreateDirectoryTOptions options) {
     super();
     mAllowExists = options.isAllowExists();
     mPersisted = options.isPersisted();

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateFileOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateFileOptions.java
@@ -22,8 +22,6 @@ import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -48,9 +46,8 @@ public final class CreateFileOptions extends CreatePathOptions<CreateFileOptions
    * of permission is constructed with the username obtained from thrift transport.
    *
    * @param options the {@link CreateFileTOptions} to use
-   * @throws IOException if it failed to retrieve users or groups from thrift transport
    */
-  public CreateFileOptions(CreateFileTOptions options) throws IOException {
+  public CreateFileOptions(CreateFileTOptions options) {
     super();
     mBlockSizeBytes = options.getBlockSizeBytes();
     mPersisted = options.isPersisted();

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -182,7 +182,6 @@ public final class LineageMaster extends AbstractMaster {
    * @throws InvalidPathException if the path to the input file is invalid
    * @throws FileAlreadyExistsException if the output file already exists
    * @throws BlockInfoException if fails to create the output file
-   * @throws IOException if the creation of a file fails
    * @throws AccessControlException if the permission check fails
    * @throws FileDoesNotExistException if any of the input files do not exist
    */

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
@@ -75,7 +75,6 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param offset where the file starts to display
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws IOException if an I/O error occurs
    * @throws InvalidPathException if an invalid path is encountered
    * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
@@ -129,7 +128,6 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
@@ -76,7 +76,6 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
    * @param offset where the file starts to display
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   private void displayFile(AlluxioURI path, HttpServletRequest request, long offset)
       throws FileDoesNotExistException, InvalidPathException, IOException, AlluxioException {

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
@@ -59,7 +59,6 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
    * @param request The {@link HttpServletRequest} object
    * @param response The {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceDownloadServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceDownloadServlet.java
@@ -62,7 +62,6 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -101,9 +100,7 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws IOException if an I/O error occurs
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   private void downloadFile(AlluxioURI path, HttpServletRequest request,
       HttpServletResponse response) throws FileDoesNotExistException, IOException,

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -120,7 +120,6 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -165,7 +164,6 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
    * Populates key, value pairs for UI display.
    *
    * @param request The {@link HttpServletRequest} object
-   * @throws IOException if an I/O error occurs
    */
   private void populateValues(HttpServletRequest request) throws IOException {
     BlockMaster blockMaster = mMasterProcess.getMaster(BlockMaster.class);

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceMasterMetricsServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceMasterMetricsServlet.java
@@ -49,7 +49,6 @@ public final class WebInterfaceMasterMetricsServlet extends WebInterfaceAbstract
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -69,7 +68,6 @@ public final class WebInterfaceMasterMetricsServlet extends WebInterfaceAbstract
    * Populates key, value pairs for UI display.
    *
    * @param request The {@link HttpServletRequest} object
-   * @throws IOException if an I/O error occurs
    */
   private void populateValues(HttpServletRequest request) throws IOException {
     MetricRegistry mr = MetricsSystem.METRIC_REGISTRY;

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceMemoryServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceMemoryServlet.java
@@ -59,7 +59,6 @@ public final class WebInterfaceMemoryServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceWorkersServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceWorkersServlet.java
@@ -192,7 +192,6 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -222,7 +221,6 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
    * Populates key, value pairs for UI display.
    *
    * @param request the {@link HttpServletRequest} object
-   * @throws IOException if an I/O error occurs
    */
   private void populateValues(HttpServletRequest request) throws IOException {
     request.setAttribute("debug", Configuration.getBoolean(PropertyKey.DEBUG));

--- a/core/server/master/src/test/java/alluxio/master/lineage/recompute/TestRecomputeExecutor.java
+++ b/core/server/master/src/test/java/alluxio/master/lineage/recompute/TestRecomputeExecutor.java
@@ -30,8 +30,6 @@ public final class TestRecomputeExecutor {
 
   /**
    * Tests recompute executor creates a recompute plan and launches the recompute job at heartbeat.
-   *
-   * @throws Exception if anything wrong happens
    */
   @Test
   public void recomputeLauncher() throws Exception {

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerBlockInfoServlet.java
@@ -68,7 +68,6 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -184,8 +183,6 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
    *
    * @param fileId the file id of the file
    * @return the {@link UIFileInfo} object of the file
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio exception is thrown
    */
   private UIFileInfo getUiFileInfo(long fileId) throws IOException, AlluxioException {
     return getUiFileInfo(new URIStatus(mBlockWorker.getFileInfo(fileId)));
@@ -196,8 +193,6 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
    *
    * @param filePath the path of the file
    * @return the {@link UIFileInfo} object of the file
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio exception is thrown
    */
   private UIFileInfo getUiFileInfo(AlluxioURI filePath) throws IOException, AlluxioException {
     return getUiFileInfo(FileSystem.Factory.get().getStatus(filePath));

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerGeneralServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerGeneralServlet.java
@@ -204,7 +204,6 @@ public final class WebInterfaceWorkerGeneralServlet extends HttpServlet {
    * Populates key, value pairs for UI display.
    *
    * @param request the {@link HttpServletRequest} object
-   * @throws IOException if an I/O error occurs
    */
   private void populateValues(HttpServletRequest request) throws IOException {
     request.setAttribute("workerInfo", mUiWorkerInfo);

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerMetricsServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerMetricsServlet.java
@@ -46,7 +46,6 @@ public final class WebInterfaceWorkerMetricsServlet extends WebInterfaceAbstract
    * @param request the {@link HttpServletRequest} object
    * @param response the {@link HttpServletResponse} object
    * @throws ServletException if the target resource throws this exception
-   * @throws IOException if the target resource throws this exception
    */
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -66,7 +65,6 @@ public final class WebInterfaceWorkerMetricsServlet extends WebInterfaceAbstract
    * Populates key, value pairs for UI display.
    *
    * @param request The {@link HttpServletRequest} object
-   * @throws IOException if an I/O error occurs
    */
   private void populateValues(HttpServletRequest request) throws IOException {
     MetricRegistry mr = MetricsSystem.METRIC_REGISTRY;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -160,7 +160,6 @@ public final class BlockMasterSync implements HeartbeatExecutor {
    * This call will block until the command is complete.
    *
    * @param cmd the command to execute
-   * @throws Exception if an error occurs when executing the command
    */
   // TODO(calvin): Evaluate the necessity of each command.
   private void handleMasterCommand(Command cmd) throws Exception {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -108,7 +108,6 @@ public final class BlockMasterSync implements HeartbeatExecutor {
    * Registers with the Alluxio master. This should be called before the continuous heartbeat thread
    * begins.
    *
-   * @throws IOException when workerId cannot be found
    * @throws ConnectionFailedException if network connection failed
    */
   private void registerWithMaster() {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -88,7 +88,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockAlreadyExistsException if block id already exists, either temporary or committed,
    *         or block in eviction plan already exists
    * @throws WorkerOutOfSpaceException if this Store has no more space than the initialBlockSize
-   * @throws IOException if blocks in eviction plan fail to be moved or deleted
    */
   TempBlockMeta createBlock(long sessionId, long blockId, BlockStoreLocation location,
       long initialBlockSize) throws BlockAlreadyExistsException, WorkerOutOfSpaceException,
@@ -142,7 +141,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
    * @throws InvalidWorkerStateException if block id does not belong to session id
-   * @throws IOException if the block can not be moved from temporary path to committed path
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
   void commitBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
@@ -159,7 +157,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
    * @throws InvalidWorkerStateException if block id does not belong to session id
-   * @throws IOException if temporary block can not be deleted
    */
   void abortBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       BlockDoesNotExistException, InvalidWorkerStateException, IOException;
@@ -174,8 +171,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockDoesNotExistException if block id can not be found, or some block in eviction plan
    *         cannot be found
    * @throws WorkerOutOfSpaceException if requested space can not be satisfied
-   * @throws IOException if blocks in {@link alluxio.worker.block.evictor.EvictionPlan} fail to be
-   *         moved or deleted on file system
    */
   void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException;
@@ -190,7 +185,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockDoesNotExistException if the block can not be found
    * @throws BlockAlreadyExistsException if a committed block with the same ID exists
    * @throws InvalidWorkerStateException if the worker state is invalid
-   * @throws IOException if block can not be created
    */
   BlockWriter getBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
@@ -209,7 +203,6 @@ interface BlockStore extends SessionCleanable {
    * @throws BlockDoesNotExistException if lockId is not found
    * @throws InvalidWorkerStateException if session id or block id is not the same as that in the
    *         LockRecord of lockId
-   * @throws IOException if block can not be read
    */
   BlockReader getBlockReader(long sessionId, long blockId, long lockId)
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException;
@@ -227,7 +220,6 @@ interface BlockStore extends SessionCleanable {
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
-   * @throws IOException if block cannot be moved from current location to newLocation
    */
   void moveBlock(long sessionId, long blockId, BlockStoreLocation newLocation)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
@@ -247,7 +239,6 @@ interface BlockStore extends SessionCleanable {
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
-   * @throws IOException if block cannot be moved from current location to newLocation
    */
   void moveBlock(long sessionId, long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) throws BlockDoesNotExistException,
@@ -261,7 +252,6 @@ interface BlockStore extends SessionCleanable {
    * @param blockId the id of an existing block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws BlockDoesNotExistException if block can not be found
-   * @throws IOException if block cannot be removed from current path
    */
   void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException,
       BlockDoesNotExistException, IOException;
@@ -274,7 +264,6 @@ interface BlockStore extends SessionCleanable {
    * @param location the location of the block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws BlockDoesNotExistException if block can not be found
-   * @throws IOException if block cannot be removed from current path
    */
   void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException;
@@ -331,8 +320,6 @@ interface BlockStore extends SessionCleanable {
    * @param location the location to free space
    * @throws WorkerOutOfSpaceException if there is not enough space
    * @throws BlockDoesNotExistException if blocks in {@link EvictionPlan} can not be found
-   * @throws IOException if blocks in {@link EvictionPlan} fail to be moved or deleted on file
-   *         system
    */
   void freeSpace(long sessionId, long availableBytes, BlockStoreLocation location)
       throws WorkerOutOfSpaceException, BlockDoesNotExistException, IOException;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -54,7 +54,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block cannot be found
    * @throws InvalidWorkerStateException if blockId does not belong to sessionId
-   * @throws IOException if temporary block cannot be deleted
    */
   void abortBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       BlockDoesNotExistException, InvalidWorkerStateException, IOException;
@@ -80,7 +79,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block cannot be found
    * @throws InvalidWorkerStateException if blockId does not belong to sessionId
-   * @throws IOException if the block cannot be moved from temporary path to committed path
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
   void commitBlock(long sessionId, long blockId)
@@ -100,7 +98,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockAlreadyExistsException if blockId already exists, either temporary or committed,
    *         or block in eviction plan already exists
    * @throws WorkerOutOfSpaceException if this Store has no more space than the initialBlockSize
-   * @throws IOException if blocks in eviction plan fail to be moved or deleted
    */
   String createBlock(long sessionId, long blockId, String tierAlias, long initialBytes)
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
@@ -117,7 +114,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockAlreadyExistsException if blockId already exists, either temporary or committed,
    *         or block in eviction plan already exists
    * @throws WorkerOutOfSpaceException if this Store has no more space than the initialBlockSize
-   * @throws IOException if blocks in eviction plan fail to be moved or deleted
    */
   void createBlockRemote(long sessionId, long blockId, String tierAlias, long initialBytes)
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
@@ -130,7 +126,6 @@ public interface BlockWorker extends Worker {
    * @param tierAlias the alias of the tier to free space
    * @throws WorkerOutOfSpaceException if there is not enough space
    * @throws BlockDoesNotExistException if blocks can not be found
-   * @throws IOException if blocks fail to be moved or deleted on file system
    * @throws BlockAlreadyExistsException if blocks to move already exists in destination location
    * @throws InvalidWorkerStateException if blocks to move/evict is uncommitted
    */
@@ -151,7 +146,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockDoesNotExistException if the block cannot be found
    * @throws BlockAlreadyExistsException if a committed block with the same ID exists
    * @throws InvalidWorkerStateException if the worker state is invalid
-   * @throws IOException if block cannot be created
    */
   BlockWriter getTempBlockWriterRemote(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
@@ -252,7 +246,6 @@ public interface BlockWorker extends Worker {
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
-   * @throws IOException if block cannot be moved from current location to newLocation
    */
   void moveBlock(long sessionId, long blockId, String tierAlias)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
@@ -284,7 +277,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockDoesNotExistException if lockId is not found
    * @throws InvalidWorkerStateException if sessionId or blockId is not the same as that in the
    *         LockRecord of lockId
-   * @throws IOException if block cannot be read
    */
   BlockReader readBlockRemote(long sessionId, long blockId, long lockId)
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException;
@@ -298,7 +290,6 @@ public interface BlockWorker extends Worker {
    * @param noCache if set, do not try to cache the block in the Alluxio worker
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the block does not exist in the UFS block store
-   * @throws IOException if any I/O related errors occur
    */
   BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean noCache)
       throws BlockDoesNotExistException, IOException;
@@ -310,7 +301,6 @@ public interface BlockWorker extends Worker {
    * @param blockId the id of the block to be freed
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws BlockDoesNotExistException if block cannot be found
-   * @throws IOException if block cannot be removed from current path
    */
   void removeBlock(long sessionId, long blockId)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException;
@@ -325,8 +315,6 @@ public interface BlockWorker extends Worker {
    * @throws BlockDoesNotExistException if blockId can not be found, or some block in eviction plan
    *         cannot be found
    * @throws WorkerOutOfSpaceException if requested space can not be satisfied
-   * @throws IOException if blocks in {@link alluxio.worker.block.evictor.EvictionPlan} fail to be
-   *         moved or deleted on file system
    */
   void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException;
@@ -368,7 +356,6 @@ public interface BlockWorker extends Worker {
    *
    * @param fileId the file id
    * @return the file info
-   * @throws IOException if an I/O error occurs
    */
   FileInfo getFileInfo(long fileId) throws IOException;
 
@@ -397,7 +384,6 @@ public interface BlockWorker extends Worker {
    *         because the block exists in the Alluxio block store
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    *         {@link UnderFileSystemBlockStore}
-   * @throws IOException if any I/O related errors occur
    * @throws WorkerOutOfSpaceException the the worker does not have enough space to commit the block
    */
   void closeUfsBlock(long sessionId, long blockId)

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -457,7 +457,6 @@ public final class TieredBlockStore implements BlockStore {
    * @throws BlockDoesNotExistException if block id can not be found in temporary blocks
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws InvalidWorkerStateException if block id is not owned by session id
-   * @throws IOException if I/O errors occur when deleting the block file
    */
   private void abortBlockInternal(long sessionId, long blockId) throws BlockDoesNotExistException,
       BlockAlreadyExistsException, InvalidWorkerStateException, IOException {
@@ -490,7 +489,6 @@ public final class TieredBlockStore implements BlockStore {
    * @throws BlockDoesNotExistException if block id can not be found in temporary blocks
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws InvalidWorkerStateException if block id is not owned by session id
-   * @throws IOException if I/O errors occur when deleting the block file
    */
   private BlockStoreLocation commitBlockInternal(long sessionId, long blockId)
       throws BlockAlreadyExistsException, InvalidWorkerStateException, BlockDoesNotExistException,
@@ -610,7 +608,6 @@ public final class TieredBlockStore implements BlockStore {
    * @param availableBytes amount of space in bytes to free
    * @param location location of space
    * @throws WorkerOutOfSpaceException if it is impossible to achieve the free requirement
-   * @throws IOException if I/O errors occur when removing or moving block files
    */
   private void freeSpaceInternal(long sessionId, long availableBytes, BlockStoreLocation location)
       throws WorkerOutOfSpaceException, IOException {
@@ -713,7 +710,6 @@ public final class TieredBlockStore implements BlockStore {
    * @throws BlockDoesNotExistException if block is not found
    * @throws BlockAlreadyExistsException if a block with same Id already exists in new location
    * @throws InvalidWorkerStateException if the block to move is a temp block
-   * @throws IOException if I/O errors occur when moving block file
    */
   private MoveBlockResult moveBlockInternal(long sessionId, long blockId,
       BlockStoreLocation oldLocation, BlockStoreLocation newLocation)
@@ -789,7 +785,6 @@ public final class TieredBlockStore implements BlockStore {
    * @param location the source location of the block
    * @throws InvalidWorkerStateException if the block to remove is a temp block
    * @throws BlockDoesNotExistException if this block can not be found
-   * @throws IOException if I/O errors occur when removing this block file
    */
   private void removeBlockInternal(long sessionId, long blockId, BlockStoreLocation location)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
@@ -829,7 +824,6 @@ public final class TieredBlockStore implements BlockStore {
    * directory has the sticky bit so only the worker user can delete or rename files it creates.
    *
    * @param blockPath the block path to create
-   * @throws IOException if the file cannot be created in the tiered storage folder
    */
   // TODO(peis): Consider using domain socket to avoid setting the permission to 777.
   private static void createBlockFile(String blockPath) throws IOException {

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -88,7 +88,6 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    * @param localBlockStore the Local block store
    * @return the block reader
    * @throws BlockDoesNotExistException if the UFS block does not exist in the UFS block store
-   * @throws IOException if an I/O related error occur
    */
   public static UnderFileSystemBlockReader create(UnderFileSystemBlockMeta blockMeta, long offset,
       boolean noCache, BlockStore localBlockStore)
@@ -120,7 +119,6 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    *
    * @param offset the position within the block to start the read
    * @throws BlockDoesNotExistException if the UFS block does not exist in the UFS block store
-   * @throws IOException if an I/O related error occur
    */
   private void init(long offset) throws BlockDoesNotExistException, IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(mBlockMeta.getUnderFileSystemPath());

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -130,7 +130,6 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
    *
    * @param sessionId the session ID
    * @param blockId the block ID
-   * @throws IOException if it fails to clean up
    */
   public void closeReaderOrWriter(long sessionId, long blockId) throws IOException {
     BlockInfo blockInfo;
@@ -209,7 +208,6 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    * {@link UnderFileSystemBlockStore}
-   * @throws IOException if any I/O errors occur
    */
   public BlockReader getBlockReader(final long sessionId, long blockId, long offset,
       boolean noCache) throws BlockDoesNotExistException, IOException {
@@ -365,8 +363,6 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
 
     /**
      * Closes the block reader or writer.
-     *
-     * @throws IOException if it fails to close block reader or writer
      */
     public synchronized void closeReaderOrWriter() throws IOException {
       if (mBlockReader != null) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
@@ -83,7 +83,6 @@ public final class StorageDir {
    * @param dirPath filesystem path of this dir for actual storage
    * @return the new created {@link StorageDir}
    * @throws BlockAlreadyExistsException when metadata of existing committed blocks already exists
-   * @throws IOException if the storage directory cannot be created with the appropriate permissions
    * @throws WorkerOutOfSpaceException when metadata can not be added due to limited left space
    */
   public static StorageDir newStorageDir(StorageTier tier, int dirIndex, long capacityBytes,
@@ -101,7 +100,6 @@ public final class StorageDir {
    * {dir}/{blockId}. other paths will be deleted.
    *
    * @throws BlockAlreadyExistsException when metadata of existing committed blocks already exists
-   * @throws IOException if the storage directory cannot be created with the appropriate permissions
    * @throws WorkerOutOfSpaceException when metadata can not be added due to limited left space
    */
   private void initializeMeta() throws BlockAlreadyExistsException, IOException,

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -103,7 +103,6 @@ public final class StorageTier {
    * @param tierAlias the tier alias
    * @return a new storage tier
    * @throws BlockAlreadyExistsException if the tier already exists
-   * @throws IOException if an I/O error occurred
    * @throws WorkerOutOfSpaceException if there is not enough space available
    */
   public static StorageTier newStorageTier(String tierAlias)

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -153,7 +153,6 @@ public final class FileDataManager {
    *
    * @param fileId the file id
    * @return true if the file exists in under storage system, false otherwise
-   * @throws IOException an I/O exception occurs
    */
   private synchronized boolean fileExistsInUfs(long fileId) throws IOException {
     FileInfo fileInfo = mBlockWorker.getFileInfo(fileId);
@@ -168,7 +167,6 @@ public final class FileDataManager {
    *
    * @param fileId the id of the file
    * @param blockIds the ids of the file's blocks
-   * @throws IOException when an I/O exception occurs
    */
   public void lockBlocks(long fileId, List<Long> blockIds) throws IOException {
     Map<Long, Long> blockIdToLockId = new HashMap<>();
@@ -214,8 +212,6 @@ public final class FileDataManager {
    *
    * @param fileId the id of the file
    * @param blockIds the list of block ids
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
-   * @throws IOException if the file persistence fails
    */
   public void persistFile(long fileId, List<Long> blockIds) throws AlluxioException, IOException {
     Map<Long, Long> blockIdToLockId;
@@ -292,8 +288,6 @@ public final class FileDataManager {
    *
    * @param fileId the file id
    * @return the path for persistence
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
-   * @throws IOException if the folder creation fails
    */
   private String prepareUfsFilePath(long fileId) throws AlluxioException, IOException {
     FileInfo fileInfo = mBlockWorker.getFileInfo(fileId);

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
@@ -39,8 +39,6 @@ public final class UnderFileSystemUtils {
    * @param ufsPath path in the under file system
    * @param fs file system master client
    * @param ufs the under file system
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
-   * @throws IOException if folder creation fails
    */
   public static void prepareFilePath(AlluxioURI alluxioPath, String ufsPath, FileSystem fs,
       UnderFileSystem ufs) throws AlluxioException, IOException {

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
@@ -55,7 +55,6 @@ final class DataServerBlockReadHandler extends DataServerReadHandler {
      * Creates an instance of {@link BlockReadRequestInternal}.
      *
      * @param request the block read request
-     * @throws Exception if it fails to create the object
      */
     BlockReadRequestInternal(Protocol.ReadRequest request) throws Exception {
       super(request.getId(), request.getOffset(), request.getOffset() + request.getLength());

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
@@ -95,7 +95,6 @@ public final class DataServerBlockWriteHandler extends DataServerWriteHandler {
    * Initializes the handler if necessary.
    *
    * @param msg the block write request
-   * @throws Exception if it fails to initialize
    */
   protected void initializeRequest(RPCProtoMessage msg) throws Exception {
     super.initializeRequest(msg);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
@@ -327,7 +327,6 @@ abstract class DataServerReadHandler extends ChannelInboundHandlerAdapter {
    * @param channel the netty channel
    * @param len The length, in bytes, of the data to read from the block
    * @return a {@link DataBuffer} representing the data
-   * @throws IOException if an I/O error occurs when reading the data
    */
   protected abstract DataBuffer getDataBuffer(Channel channel, long offset, int len)
       throws IOException;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
@@ -316,7 +316,6 @@ abstract class DataServerReadHandler extends ChannelInboundHandlerAdapter {
    * Initializes the handler for the given block read request.
    *
    * @param request the block read request
-   * @throws Exception if it fails to initialize
    */
   protected abstract void initializeRequest(Protocol.ReadRequest request) throws Exception;
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
@@ -51,7 +51,6 @@ final class DataServerUfsBlockReadHandler extends DataServerReadHandler {
      * Creates an instance of {@link UfsBlockReadRequestInternal}.
      *
      * @param request the block read request
-     * @throws Exception if it fails to create the object
      */
     UfsBlockReadRequestInternal(Protocol.ReadRequest request) throws Exception {
       super(request.getId(), request.getOffset(), request.getOffset() + request.getLength());

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsFileWriteHandler.java
@@ -91,7 +91,6 @@ final class DataServerUfsFileWriteHandler extends DataServerWriteHandler {
    * Initializes the handler if necessary.
    *
    * @param msg the block write request
-   * @throws Exception if it fails to initialize
    */
   @Override
   protected void initializeRequest(RPCProtoMessage msg) throws Exception {

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
@@ -146,8 +146,6 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Cancels the request.
-     *
-     * @throws IOException if I/O errors occur
      */
     abstract void cancel() throws IOException;
   }
@@ -359,8 +357,6 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Completes this write.
-     *
-     * @throws IOException if I/O related errors occur
      */
     private void complete() throws IOException {
       if (mRequest != null) {
@@ -372,8 +368,6 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Cancels this write.
-     *
-     * @throws IOException if I/O related errors occur
      */
     private void cancel() throws IOException {
       if (mRequest != null) {

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
@@ -460,7 +460,6 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
    * Initializes the handler if necessary.
    *
    * @param msg the block write request
-   * @throws Exception if it fails to initialize
    */
   protected void initializeRequest(RPCProtoMessage msg) throws Exception {
     Preconditions.checkState(mRequest == null);
@@ -473,7 +472,6 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
    *
    * @param buf the buffer
    * @param pos the pos
-   * @throws Exception if it fails to write the buffer
    */
   protected abstract void writeBuf(ByteBuf buf, long pos) throws Exception;
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -28,7 +28,6 @@ import com.google.common.primitives.Ints;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
-import java.io.IOException;
 import java.util.Collections;
 
 /**
@@ -173,7 +172,6 @@ public final class TieredBlockStoreTestUtils {
    * @param baseDir the directory path as prefix for all the paths in the array 'dirs'
    * @param dirs 1-D array of directory paths
    * @return new joined and created paths array
-   * @throws IOException when error happens during creating temporary folder
    */
   private static String[] createDirHierarchy(String baseDir, final String[] dirs) throws Exception {
     if (baseDir == null) {

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -60,7 +60,6 @@ public final class TieredBlockStoreTestUtils {
    * @param tierCapacity like {@link #TIER_CAPACITY_BYTES}, should be in the same dimension with
    *        tierPath, each element is the capacity of the corresponding dir in tierPath
    * @param workerDataFolder when specified it sets up the alluxio.worker.data.folder property
-   * @throws Exception when error happens during creating temporary folder
    */
   public static void setupConfWithMultiTier(String baseDir, int[] tierOrdinal, String[] tierAlias,
       String[][] tierPath, long[][] tierCapacity, String workerDataFolder) throws Exception {
@@ -106,7 +105,6 @@ public final class TieredBlockStoreTestUtils {
    *        into `baseDir/tierPath`
    * @param tierCapacity capacity of this tier
    * @param workerDataFolder when specified it sets up the alluxio.worker.data.folder property
-   * @throws Exception when error happens during creating temporary folder
    */
   public static void setupConfWithSingleTier(String baseDir, int tierOrdinal, String tierAlias,
       String[] tierPath, long[] tierCapacity, String workerDataFolder) throws Exception {
@@ -152,7 +150,6 @@ public final class TieredBlockStoreTestUtils {
    * @param baseDir the directory path as prefix for all the paths in the array 'dirs'
    * @param dirs 2-D array of directory paths
    * @return new joined and created paths array
-   * @throws Exception when error happens during creating temporary folder
    */
   private static String[][] createDirHierarchy(String baseDir, final String[][] dirs)
       throws Exception {
@@ -191,7 +188,6 @@ public final class TieredBlockStoreTestUtils {
    * @param baseDir the directory path as prefix for paths of directories in the tiered storage; the
    *        directory needs to exist before calling this method
    * @return the created metadata manager
-   * @throws Exception when error happens during creating temporary folder
    */
   public static BlockMetadataManager defaultMetadataManager(String baseDir) throws Exception {
     setupDefaultConf(baseDir);
@@ -204,7 +200,6 @@ public final class TieredBlockStoreTestUtils {
    * @param baseDir the directory path as prefix for paths of directories in the tiered storage; the
    *        directory needs to exist before calling this method
    * @return the created metadata manager view
-   * @throws Exception when error happens during creating temporary folder
    */
   public static BlockMetadataManagerView defaultMetadataManagerView(String baseDir)
       throws Exception {
@@ -220,7 +215,6 @@ public final class TieredBlockStoreTestUtils {
    *
    * @param baseDir the directory path as prefix for paths of directories in the tiered storage; the
    *        directory needs to exist before calling this method
-   * @throws Exception when error happens during creating temporary folder
    */
   public static void setupDefaultConf(String baseDir) throws Exception {
     setupConfWithMultiTier(baseDir, TIER_ORDINAL, TIER_ALIAS, TIER_PATH, TIER_CAPACITY_BYTES,
@@ -236,7 +230,6 @@ public final class TieredBlockStoreTestUtils {
    * @param dir the {@link StorageDir} the block resides in
    * @param meta the metadata manager to update meta of the block
    * @param evictor the evictor to be informed of the new block
-   * @throws Exception when fail to cache
    */
   public static void cache(long sessionId, long blockId, long bytes, StorageDir dir,
       BlockMetadataManager meta, Evictor evictor) throws Exception {
@@ -261,7 +254,6 @@ public final class TieredBlockStoreTestUtils {
    * @param bytes size of the block in bytes
    * @param blockStore block store that the block is written into
    * @param location the location where the block resides
-   * @throws Exception when fail to cache
    */
   public static void cache(long sessionId, long blockId, long bytes, BlockStore blockStore,
       BlockStoreLocation location) throws Exception {
@@ -286,7 +278,6 @@ public final class TieredBlockStoreTestUtils {
    * @param dirIndex index of directory in the tierLevel the block resides in
    * @param meta the metadata manager to update meta of the block
    * @param evictor the evictor to be informed of the new block
-   * @throws Exception when fail to cache
    */
   public static void cache(long sessionId, long blockId, long bytes, int tierLevel, int dirIndex,
       BlockMetadataManager meta, Evictor evictor) throws Exception {
@@ -302,7 +293,6 @@ public final class TieredBlockStoreTestUtils {
    * @param bytes size of the block in bytes
    * @param dir the {@link StorageDir} the block resides in
    * @return the temp block meta
-   * @throws Exception when fail to create this block
    */
   public static TempBlockMeta createTempBlock(long sessionId, long blockId, long bytes,
       StorageDir dir) throws Exception {

--- a/core/server/worker/src/test/java/alluxio/worker/block/evictor/EvictorTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/evictor/EvictorTestUtils.java
@@ -179,7 +179,6 @@ public class EvictorTestUtils {
    * @param bytesToBeAvailable the requested bytes to be available
    * @param plan the eviction plan, should not be null
    * @param metaManager the metadata manager
-   * @throws Exception when fail
    */
   public static void assertEvictionPlanValid(long bytesToBeAvailable, EvictionPlan plan,
       BlockMetadataManager metaManager) throws Exception {

--- a/core/server/worker/src/test/java/alluxio/worker/netty/DataServerReadHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/DataServerReadHandlerTest.java
@@ -142,7 +142,6 @@ public abstract class DataServerReadHandlerTest {
    * @param length the length of the file
    * @param start the start position to compute the checksum
    * @param end the last position to compute the checksum
-   * @throws Exception if it fails to populate the input file
    * @return the checksum
    */
   protected long populateInputFile(long length, long start, long end) throws Exception {
@@ -256,7 +255,6 @@ public abstract class DataServerReadHandlerTest {
    * Mocks the reader (block reader or UFS file reader).
    *
    * @param start the start pos of the reader
-   * @throws Exception if it fails to mock the reader
    */
   protected abstract void mockReader(long start) throws Exception;
 }

--- a/core/server/worker/src/test/java/alluxio/worker/netty/DataServerWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/DataServerWriteHandlerTest.java
@@ -127,7 +127,6 @@ public abstract class DataServerWriteHandlerTest {
    * Checks the file content matches expectation (file length and file checksum).
    *
    * @param size the file size in bytes
-   * @throws IOException if it fails to check the file content
    */
   protected void checkFileContent(long size) throws IOException {
     RandomAccessFile file = new RandomAccessFile(mFile, "r");

--- a/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
+++ b/examples/src/main/java/alluxio/cli/AlluxioFrameworkIntegrationTest.java
@@ -207,7 +207,6 @@ public final class AlluxioFrameworkIntegrationTest {
 
   /**
    * @param args arguments
-   * @throws Exception if an exception occurs
    */
   public static void main(String[] args) throws Exception {
     AlluxioFrameworkIntegrationTest test = new AlluxioFrameworkIntegrationTest();

--- a/examples/src/main/java/alluxio/cli/MiniBenchmark.java
+++ b/examples/src/main/java/alluxio/cli/MiniBenchmark.java
@@ -59,7 +59,6 @@ public final class MiniBenchmark {
 
   /**
    * @param args there are no arguments needed
-   * @throws Exception if error occurs during tests
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 3) {
@@ -91,7 +90,6 @@ public final class MiniBenchmark {
    *
    * @param fileSize the file size
    * @param iterations the number of iterations to run
-   * @throws Exception if it fails to read
    */
   private static void readFile(long fileSize, int iterations) throws Exception {
     FileSystem fileSystem = FileSystem.Factory.get();
@@ -112,7 +110,6 @@ public final class MiniBenchmark {
    *
    * @param fileSize the file size
    * @param iterations number of iterations
-   * @throws Exception if it fails to write
    */
   private static void writeFile(long fileSize, int iterations) throws Exception {
     FileSystem fileSystem = FileSystem.Factory.get();

--- a/examples/src/main/java/alluxio/cli/TestRunner.java
+++ b/examples/src/main/java/alluxio/cli/TestRunner.java
@@ -80,7 +80,6 @@ public final class TestRunner {
    * Console program that validates the configuration.
    *
    * @param args there are no arguments needed
-   * @throws Exception if error occurs during tests
    */
   public static void main(String[] args) throws Exception {
     TestRunner runner = new TestRunner();

--- a/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/alluxio/examples/BasicCheckpoint.java
@@ -92,7 +92,6 @@ public class BasicCheckpoint implements Callable<Boolean> {
    * Usage: {@code java -cp <ALLUXIO-VERSION> alluxio.examples.BasicCheckpoint <FileFolder> <Files>}
    *
    * @param args the folder for the files and the files to use
-   * @throws IOException if the example fails to run
    */
   public static void main(String[] args) throws IOException {
     if (args.length != 2) {

--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -64,9 +64,6 @@ public final class Performance {
 
   /**
    * Creates the files for this example.
-   *
-   * @throws AlluxioException if creating a file fails
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   public static void createFiles() throws AlluxioException, IOException {
     final long startTimeMs = CommonUtils.getCurrentMs();
@@ -140,8 +137,6 @@ public final class Performance {
 
     /**
      * Copies a partition in memory.
-     *
-     * @throws IOException if a non-Alluxio related exception occurs
      */
     public void memoryCopyPartition() throws IOException {
       if (sDebugMode) {
@@ -226,7 +221,6 @@ public final class Performance {
      * @param left the id of the worker on the left
      * @param right the id of the worker on the right
      * @param buf the buffer to write
-     * @throws IOException if a non-Alluxio related exception occurs
      */
     public AlluxioWriterWorker(int id, int left, int right, ByteBuffer buf) throws IOException {
       super(id, left, right, buf);
@@ -235,9 +229,6 @@ public final class Performance {
 
     /**
      * Writes a partition.
-     *
-     * @throws IOException if a non-Alluxio related exception occurs
-     * @throws AlluxioException if the write stream cannot be retrieved
      */
     public void writePartition()
             throws IOException, AlluxioException {
@@ -282,7 +273,6 @@ public final class Performance {
      * @param left the id of the worker on the left
      * @param right the id of the worker on the right
      * @param buf the buffer to read
-     * @throws IOException if a non-Alluxio related exception occurs
      */
     public AlluxioReadWorker(int id, int left, int right, ByteBuffer buf) throws IOException {
       super(id, left, right, buf);
@@ -291,9 +281,6 @@ public final class Performance {
 
     /**
      * Reads a partition.
-     *
-     * @throws IOException if a non-Alluxio related exception occurs
-     * @throws AlluxioException if the file cannot be opened or the stream cannot be retrieved
      */
     public void readPartition() throws IOException, AlluxioException {
       if (sDebugMode) {
@@ -384,7 +371,6 @@ public final class Performance {
      * @param buf the buffer
      * @param write indicates if data is written to HDFS
      * @param msg the message to write
-     * @throws IOException if a non-Alluxio related exception occurs
      */
     public HdfsWorker(int id, int left, int right, ByteBuffer buf, boolean write, String msg)
         throws IOException {
@@ -411,8 +397,6 @@ public final class Performance {
 
     /**
      * Creates IO utilization.
-     *
-     * @throws IOException if a non-Alluxio related exception occurs
      */
     public void io() throws IOException {
       if (sDebugMode) {
@@ -591,7 +575,6 @@ public final class Performance {
    * <TestCaseNumber> <BaseFileNumber>}
    *
    * @param args the arguments for this example
-   * @throws Exception if the example fails
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 9) {

--- a/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreOperations.java
@@ -47,7 +47,6 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
 
   /**
    * @param storeUri URI of the key-value store to write to, should not exist before
-   * @throws Exception if the instance fails to be created
    */
   public KeyValueStoreOperations(AlluxioURI storeUri) throws Exception {
     mStoreUri = storeUri;
@@ -123,7 +122,6 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
    * Starts in a command like {@code java -cp ALLUXIO_JAR CLASS_NAME <key-value store URI>}.
    *
    * @param args one argument, specifying the URI of the store to be created
-   * @throws Exception if unexpected errors happen
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 1) {

--- a/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreQuickStart.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/KeyValueStoreQuickStart.java
@@ -28,7 +28,6 @@ public final class KeyValueStoreQuickStart {
    * The main program.
    *
    * @param args one argument which is the path of the new key-value store
-   * @throws Exception if any exception happens
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 1) {

--- a/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/SameKeyValueStoresTest.java
@@ -39,7 +39,6 @@ public final class SameKeyValueStoresTest implements Callable<Boolean> {
   /**
    * @param storeUri1 the URI of the first key-value store
    * @param storeUri2 the URI of the second key-value store
-   * @throws Exception if the instance fails to be created
    */
   public SameKeyValueStoresTest(AlluxioURI storeUri1, AlluxioURI storeUri2) throws Exception {
     mStoreUri1 = storeUri1;
@@ -93,7 +92,6 @@ public final class SameKeyValueStoresTest implements Callable<Boolean> {
    * {@code java -cp ALLUXIO_JAR CLASS_NAME <key-value store URI 1> <key-value store URI 2>}.
    *
    * @param args two arguments, specifying the URIs of the stores to be compared
-   * @throws Exception if unexpected errors happen
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 2) {

--- a/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/ShowKeyValueStore.java
@@ -51,7 +51,6 @@ public final class ShowKeyValueStore {
    * @param args two parameters, the first is the key-value store URI, the second is the scope of
    *    the store to be shown ("key" to show only keys, "value" to show only values, and "all" to
    *    show both keys and values)
-   * @throws Exception if any exception happens
    */
   public static void main(String[] args) throws Exception {
     if (args.length != 2) {

--- a/examples/src/main/java/alluxio/examples/keyvalue/hadoop/CloneStoreMapReduce.java
+++ b/examples/src/main/java/alluxio/examples/keyvalue/hadoop/CloneStoreMapReduce.java
@@ -77,7 +77,6 @@ public final class CloneStoreMapReduce {
   /**
    * @param args two parameters, the first is the input key-value store path, the second is the
    *    output key-value store path
-   * @throws Exception if any exception happens
    */
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();

--- a/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
@@ -61,8 +61,6 @@ final class OpenFileEntry implements Closeable {
 
   /**
    * Closes the underlying open streams.
-   *
-   * @throws IOException if the {@link FileInStream} cannot be closed
    */
   @Override
   public void close() throws IOException {

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
@@ -108,7 +108,6 @@ public class AlluxioFramework {
    * Starts the Alluxio framework.
    *
    * @param args command-line arguments
-   * @throws Exception if the Alluxio framework encounters an unrecoverable error
    */
   public static void main(String[] args) throws Exception {
     AlluxioFramework framework = new AlluxioFramework();

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioMasterExecutor.java
@@ -111,7 +111,6 @@ public class AlluxioMasterExecutor implements Executor {
    * Starts the Alluxio master executor.
    *
    * @param args command-line arguments
-   * @throws Exception if the executor encounters an unrecoverable error
    */
   public static void main(String[] args) throws Exception {
     MesosExecutorDriver driver = new MesosExecutorDriver(new AlluxioMasterExecutor());

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioWorkerExecutor.java
@@ -110,7 +110,6 @@ public class AlluxioWorkerExecutor implements Executor {
    * Starts the Alluxio worker executor.
    *
    * @param args command-line arguments
-   * @throws Exception if the executor encounters an unrecoverable error
    */
   public static void main(String[] args) throws Exception {
     MesosExecutorDriver driver = new MesosExecutorDriver(new AlluxioWorkerExecutor());

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -220,7 +220,6 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
    * Run the application master.
    *
    * @param cliParser client arguments parser
-   * @throws Exception
    */
   private static void runApplicationMaster(final CommandLine cliParser) throws Exception {
     int numWorkers = Integer.parseInt(cliParser.getOptionValue("num_workers", "1"));
@@ -310,8 +309,6 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
 
   /**
    * Submits requests for containers until the master and all workers are launched.
-   *
-   * @throws Exception if an error occurs while requesting or launching containers
    */
   public void requestAndLaunchContainers() throws Exception {
 

--- a/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ApplicationMaster.java
@@ -50,6 +50,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -58,13 +62,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.MalformedURLException;
-import java.net.InetAddress;
 
-import javax.ws.rs.HttpMethod;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.ws.rs.HttpMethod;
 
 /**
  * Actual owner of Alluxio running on Yarn. The YARN ResourceManager will launch this
@@ -276,9 +276,6 @@ public final class ApplicationMaster implements AMRMClientAsync.CallbackHandler 
 
   /**
    * Starts the application master.
-   *
-   * @throws IOException if registering the application master fails due to an IO error
-   * @throws YarnException if registering the application master fails due to an internal Yarn error
    */
   public void start() throws IOException, YarnException {
     if (UserGroupInformation.isSecurityEnabled()) {

--- a/integration/yarn/src/main/java/alluxio/yarn/Client.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/Client.java
@@ -12,9 +12,9 @@
 package alluxio.yarn;
 
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.ExceptionMessage;
-import alluxio.Constants;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.yarn.YarnUtils.YarnContainerType;
@@ -45,9 +45,9 @@ import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.client.ClientRMProxy;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.YarnClientApplication;
-import org.apache.hadoop.yarn.client.ClientRMProxy;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Apps;
@@ -174,9 +174,6 @@ public final class Client {
 
   /**
    * Main run function for the client.
-   *
-   * @throws IOException if errors occur from ResourceManager
-   * @throws YarnException if errors occur from ResourceManager
    */
   public void run() throws IOException, YarnException {
     submitApplication();
@@ -423,9 +420,6 @@ public final class Client {
 
   /**
    * Monitor the submitted application until app is running, finished, killed or failed.
-   *
-   * @throws YarnException if errors occur when obtaining application report from ResourceManager
-   * @throws IOException if errors occur when obtaining application report from ResourceManager
    */
   private void monitorApplication() throws YarnException, IOException {
     while (true) {

--- a/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/ContainerAllocator.java
@@ -101,7 +101,6 @@ public final class ContainerAllocator {
    * Allocates the containers specified by the constructor.
    *
    * @return the allocated containers
-   * @throws Exception if an error occurs
    */
   public List<Container> allocateContainers() throws Exception {
     for (int attempt = 0; attempt < MAX_WORKER_CONTAINER_REQUEST_ATTEMPTS; attempt++) {

--- a/integration/yarn/src/main/java/alluxio/yarn/YarnUtils.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/YarnUtils.java
@@ -63,8 +63,6 @@ public final class YarnUtils {
    *
    * @param yarnClient the client to use to look up node information
    * @return the set of host names
-   * @throws YarnException if an error occurs within YARN
-   * @throws IOException if an error occurs in YARN's underlying IO
    */
   public static Set<String> getNodeHosts(YarnClient yarnClient) throws YarnException, IOException {
     ImmutableSet.Builder<String> nodeHosts = ImmutableSet.builder();
@@ -79,7 +77,6 @@ public final class YarnUtils {
    *
    * @param yarnConf YARN configuration
    * @param resource the path to a resource file on HDFS
-   * @throws IOException if the file can not be found on HDFS
    * @return the created local resource
    */
   public static LocalResource createLocalResourceOfFile(YarnConfiguration yarnConf,

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValuePartitionReader.java
@@ -40,8 +40,6 @@ final class BaseKeyValuePartitionReader implements KeyValuePartitionReader {
    * Constructs {@link BaseKeyValuePartitionReader} given a block id.
    *
    * @param blockId blockId of the key-value file to read from
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
-   * @throws IOException if a non-Alluxio exception occurs
    */
   BaseKeyValuePartitionReader(long blockId) throws AlluxioException, IOException {
     mBlockId = blockId;
@@ -82,8 +80,6 @@ final class BaseKeyValuePartitionReader implements KeyValuePartitionReader {
    *
    * @param key the key to lookup
    * @return the value of this key
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   private ByteBuffer getInternal(ByteBuffer key) throws IOException, AlluxioException {
     Preconditions.checkState(!mClosed, "Can not query a reader closed");
@@ -99,9 +95,6 @@ final class BaseKeyValuePartitionReader implements KeyValuePartitionReader {
 
     /**
      * Gets the first key-value pair and constructs a new key-value partition iterator.
-     *
-     * @throws IOException if a non-Alluxio error happens when getting the first key-value pair
-     * @throws AlluxioException if an Alluxio error happens when getting the first key-value pair
      */
     public Iterator() throws IOException, AlluxioException {
       mNextKey = nextKey(null);

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
@@ -171,9 +171,6 @@ class BaseKeyValueStoreWriter implements KeyValueStoreWriter {
 
   /**
    * Completes the current partition.
-   *
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   private void completePartition() throws IOException, AlluxioException {
     if (mWriter == null) {

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/Index.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/Index.java
@@ -28,7 +28,6 @@ public interface Index {
    * @param value bytes of value
    * @param writer writer to store key-value payload
    * @return true on success, false otherwise (e.g., unresolvable hash collision)
-   * @throws IOException if errors happen when writer writes key/value
    */
   boolean put(byte[] key, byte[] value, PayloadWriter writer) throws IOException;
 
@@ -38,7 +37,6 @@ public interface Index {
    * @param key bytes of key
    * @param reader reader to access key-value payload
    * @return ByteBuffer of value, or null if not found
-   * @throws IOException if a non-Alluxio related exception occurs
    */
   ByteBuffer get(ByteBuffer key, PayloadReader reader) throws IOException;
 

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueIterable.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueIterable.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 public interface KeyValueIterable {
   /**
    * @return a {@link KeyValueIterator} for iterating over key-value pairs in the store
-   * @throws IOException if a non-Alluxio error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   KeyValueIterator iterator() throws IOException, AlluxioException;
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueIterator.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueIterator.java
@@ -30,8 +30,6 @@ public interface KeyValueIterator {
    * Throws a {@link java.util.NoSuchElementException} if there are no more pairs.
    *
    * @return the next key-value pair in the iteration
-   * @throws IOException if a non-Alluxio exception occurs
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   KeyValuePair next() throws IOException, AlluxioException;
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionReader.java
@@ -40,8 +40,6 @@ public interface KeyValuePartitionReader extends Closeable, KeyValueIterable {
      *
      * @param uri Alluxio URI of the key-value partition to use as input
      * @return an instance of a {@link KeyValuePartitionReader}
-     * @throws IOException if a non-Alluxio exception occurs
-     * @throws AlluxioException if an unexpected Alluxio exception is thrown
      */
     public static KeyValuePartitionReader create(AlluxioURI uri)
         throws AlluxioException, IOException {
@@ -60,8 +58,6 @@ public interface KeyValuePartitionReader extends Closeable, KeyValueIterable {
      *
      * @param blockId blockId the key-value partition to use as input
      * @return an instance of a {@link KeyValuePartitionReader}
-     * @throws IOException if a non-Alluxio exception occurs
-     * @throws AlluxioException if an unexpected Alluxio exception is thrown
      */
     public static KeyValuePartitionReader create(long blockId)
         throws AlluxioException, IOException {
@@ -75,8 +71,6 @@ public interface KeyValuePartitionReader extends Closeable, KeyValueIterable {
    *
    * @param key key to get, cannot be null
    * @return bytes of the value if found, null otherwise
-   * @throws IOException if a non-Alluxio exception occurs
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   byte[] get(byte[] key) throws IOException, AlluxioException;
 
@@ -87,15 +81,11 @@ public interface KeyValuePartitionReader extends Closeable, KeyValueIterable {
    *
    * @param key key to get, cannot be null
    * @return bytes of the value if found, null otherwise
-   * @throws IOException if a non-Alluxio exception occurs
-   * @throws AlluxioException if an unexpected Alluxio exception is thrown
    */
   ByteBuffer get(ByteBuffer key) throws IOException, AlluxioException;
 
   /**
    * @return the number of key-value pairs in the partition
-   * @throws IOException if a non-Alluxio error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   int size() throws IOException, AlluxioException;
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionWriter.java
@@ -43,8 +43,6 @@ public interface KeyValuePartitionWriter extends Closeable, Cancelable {
      *
      * @param uri URI of the key-value partition file to write to
      * @return an instance of a {@link KeyValuePartitionWriter}
-     * @throws IOException if a non-Alluxio exception occurs
-     * @throws AlluxioException if an unexpected Alluxio exception is thrown
      */
     public static KeyValuePartitionWriter create(AlluxioURI uri)
         throws AlluxioException, IOException {
@@ -62,7 +60,6 @@ public interface KeyValuePartitionWriter extends Closeable, Cancelable {
    *
    * @param key key to put, cannot be null
    * @param value value to put, cannot be null
-   * @throws IOException if a non-Alluxio exception occurs
    */
   void put(byte[] key, byte[] value) throws IOException;
 

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreIterator.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreIterator.java
@@ -36,9 +36,6 @@ public final class KeyValueStoreIterator implements KeyValueIterator {
 
   /**
    * @param partitions the partitions to use
-   * @throws IOException if a non-Alluxio related exception occurs
-   * @throws AlluxioException if a {@link KeyValuePartitionReader} cannot be created or iterated
-   *         over
    */
   public KeyValueStoreIterator(List<PartitionInfo> partitions)
       throws IOException, AlluxioException {

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreReader.java
@@ -30,8 +30,6 @@ public interface KeyValueStoreReader extends Closeable, KeyValueIterable {
    *
    * @param key key to get, cannot be null
    * @return value associated with the given key, or null if not found
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   byte[] get(byte[] key) throws IOException, AlluxioException;
 
@@ -40,15 +38,11 @@ public interface KeyValueStoreReader extends Closeable, KeyValueIterable {
    *
    * @param key key to get, cannot be null
    * @return value associated with the given key, or null if not found
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   ByteBuffer get(ByteBuffer key) throws IOException, AlluxioException;
 
   /**
    * @return the number of key-value pairs in the store
-   * @throws IOException if a non-Alluxio error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   int size() throws IOException, AlluxioException;
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreWriter.java
@@ -29,8 +29,6 @@ public interface KeyValueStoreWriter extends Closeable, Cancelable {
    *
    * @param key key to put, cannot be null
    * @param value value to put, cannot be null
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   void put(byte[] key, byte[] value) throws IOException, AlluxioException;
 
@@ -39,8 +37,6 @@ public interface KeyValueStoreWriter extends Closeable, Cancelable {
    *
    * @param key key to put, cannot be null
    * @param value value to put, cannot be null
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   void put(ByteBuffer key, ByteBuffer value) throws IOException, AlluxioException;
 

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueSystem.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueSystem.java
@@ -49,8 +49,6 @@ public interface KeyValueSystem {
    *
    * @param uri {@link AlluxioURI} to the store
    * @return {@link BaseKeyValueStoreReader} instance
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   KeyValueStoreReader openStore(AlluxioURI uri) throws IOException, AlluxioException;
 
@@ -59,8 +57,6 @@ public interface KeyValueSystem {
    *
    * @param uri {@link AlluxioURI} to the store
    * @return {@link BaseKeyValueStoreWriter} instance
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if Alluxio error occurs
    */
   KeyValueStoreWriter createStore(AlluxioURI uri) throws IOException, AlluxioException;
 
@@ -69,8 +65,6 @@ public interface KeyValueSystem {
    *
    * @param oldUri the old {@link AlluxioURI} to the store
    * @param newUri the new {@link AlluxioURI} to the store
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if other Alluxio error occurs
    */
   void renameStore(AlluxioURI oldUri, AlluxioURI newUri) throws IOException, AlluxioException;
 
@@ -78,10 +72,8 @@ public interface KeyValueSystem {
    * Deletes a completed key-value store.
    *
    * @param uri {@link AlluxioURI} to the store
-   * @throws IOException if non-Alluxio error occurs
    * @throws InvalidPathException if the uri exists but is not a key-value store
    * @throws FileDoesNotExistException if the uri does not exist
-   * @throws AlluxioException if other Alluxio error occurs
    */
   void deleteStore(AlluxioURI uri)
       throws IOException, InvalidPathException, FileDoesNotExistException, AlluxioException;
@@ -94,8 +86,6 @@ public interface KeyValueSystem {
    *
    * @param fromUri the {@link AlluxioURI} to the store to be merged
    * @param toUri the {@link AlluxioURI} to the store to be merged to
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if other Alluxio error occurs
    */
   void mergeStore(AlluxioURI fromUri, AlluxioURI toUri) throws IOException, AlluxioException;
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueWorkerClient.java
@@ -73,8 +73,6 @@ public final class KeyValueWorkerClient extends AbstractClient {
    * @param blockId The id of the block
    * @param key the key to get the value for
    * @return ByteBuffer of value, or null if not found
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   public synchronized ByteBuffer get(final long blockId, final ByteBuffer key)
       throws IOException, AlluxioException {
@@ -96,8 +94,6 @@ public final class KeyValueWorkerClient extends AbstractClient {
    * @param key the current key
    * @param numKeys maximum number of next keys to fetch
    * @return the next batch of keys
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an Alluxio error occurs
    */
   public synchronized List<ByteBuffer> getNextKeys(final long blockId, final ByteBuffer key,
       final int numKeys) throws IOException, AlluxioException {
@@ -112,8 +108,6 @@ public final class KeyValueWorkerClient extends AbstractClient {
   /**
    * @param blockId the id of the partition
    * @return the number of key-value pairs in the partition
-   * @throws IOException if a non-Alluxio related exception occurs
-   * @throws AlluxioException if an exception in Alluxio occurs
    */
   public synchronized int getSize(final long blockId) throws IOException, AlluxioException {
     return retryRPC(new RpcCallable<Integer>() {

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/PayloadWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/PayloadWriter.java
@@ -25,7 +25,6 @@ public interface PayloadWriter {
    * @param key bytes of key
    * @param value bytes of value
    * @return the offset of this key-value pair in payload buffer
-   * @throws IOException if error occurs writing the key and value to payload buffer
    */
   int insert(byte[] key, byte[] value) throws IOException;
 }

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueInputFormat.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueInputFormat.java
@@ -56,7 +56,6 @@ public final class KeyValueInputFormat extends InputFormat<BytesWritable, BytesW
    *
    * @param jobContext MapReduce job configuration
    * @return list of {@link InputSplit}s, each split is a partition
-   * @throws IOException if information about the partition cannot be retrieved
    */
   @Override
   public List<InputSplit> getSplits(JobContext jobContext) throws IOException {

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputCommitter.java
@@ -45,7 +45,6 @@ public final class KeyValueOutputCommitter extends FileOutputCommitter {
    *
    * @param outputPath the job's output path, or null if the output committer is a noop
    * @param taskContext the task's context
-   * @throws IOException if the construction fails
    */
   public KeyValueOutputCommitter(Path outputPath, TaskAttemptContext taskContext)
       throws IOException {
@@ -55,7 +54,6 @@ public final class KeyValueOutputCommitter extends FileOutputCommitter {
   /**
    * @param taskContext MapReduce task configuration
    * @return true if the task output directory exists, otherwise false
-   * @throws IOException if fails to determine whether the output directory exists
    */
   @Override
   public boolean needsTaskCommit(TaskAttemptContext taskContext) throws IOException {

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputFormat.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueOutputFormat.java
@@ -93,7 +93,6 @@ public final class KeyValueOutputFormat extends FileOutputFormat<BytesWritable, 
   /**
    * @param taskContext MapReduce task configuration
    * @return a {@link KeyValueOutputCommitter}
-   * @throws IOException when committer fails to be created
    */
   @Override
   public OutputCommitter getOutputCommitter(TaskAttemptContext taskContext) throws IOException {

--- a/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueRecordWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/hadoop/mapreduce/KeyValueRecordWriter.java
@@ -36,7 +36,6 @@ final class KeyValueRecordWriter extends RecordWriter<BytesWritable, BytesWritab
    * Constructs a new {@link KeyValueRecordWriter}.
    *
    * @param storeUri the URI for the temporary key-value store to be created by this record writer
-   * @throws IOException when instance creation fails
    */
   public KeyValueRecordWriter(AlluxioURI storeUri) throws IOException {
     try {

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -269,10 +269,8 @@ public final class KeyValueMaster extends AbstractMaster {
    * Deletes a completed key-value store.
    *
    * @param uri {@link AlluxioURI} to the store
-   * @throws IOException if non-Alluxio error occurs
    * @throws InvalidPathException if the uri exists but is not a key-value store
    * @throws FileDoesNotExistException if the uri does not exist
-   * @throws AlluxioException if other Alluxio error occurs
    */
   public synchronized void deleteStore(AlluxioURI uri)
       throws IOException, InvalidPathException, FileDoesNotExistException, AlluxioException {
@@ -314,8 +312,6 @@ public final class KeyValueMaster extends AbstractMaster {
    *
    * @param oldUri the old {@link AlluxioURI} to the store
    * @param newUri the {@link AlluxioURI} to the store
-   * @throws IOException if non-Alluxio error occurs
-   * @throws AlluxioException if other Alluxio error occurs
    */
   public synchronized void renameStore(AlluxioURI oldUri, AlluxioURI newUri)
       throws IOException, AlluxioException {
@@ -351,10 +347,8 @@ public final class KeyValueMaster extends AbstractMaster {
    *
    * @param fromUri the {@link AlluxioURI} to the store to be merged
    * @param toUri the {@link AlluxioURI} to the store to be merged to
-   * @throws IOException if non-Alluxio error occurs
    * @throws InvalidPathException if the uri exists but is not a key-value store
    * @throws FileDoesNotExistException if the uri does not exist
-   * @throws AlluxioException if other Alluxio error occurs
    */
   public synchronized void mergeStore(AlluxioURI fromUri, AlluxioURI toUri)
       throws IOException, FileDoesNotExistException, InvalidPathException, AlluxioException {

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
@@ -97,7 +97,6 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
    * @param blockId Block Id
    * @param keyBuffer bytes of key
    * @return key found in the key-value block or null if not found
-   * @throws IOException if read operation failed
    * @throws BlockDoesNotExistException if the worker is not serving this block
    */
   private ByteBuffer getInternal(long blockId, ByteBuffer keyBuffer)

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -78,8 +78,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Starts both master and a worker using the configurations in test conf respectively.
-   *
-   * @throws Exception if the operation fails
    */
   public void start() throws Exception {
     // Disable HDFS client caching to avoid file system close() affecting other clients
@@ -98,15 +96,11 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Configures and starts the master(s).
-   *
-   * @throws Exception if the operation fails
    */
   protected abstract void startMasters() throws Exception;
 
   /**
    * Configures and starts the proxy.
-   *
-   * @throws Exception if the operation fails
    */
   private void startProxy() throws Exception {
     mProxyProcess = ProxyProcess.Factory.create();
@@ -130,8 +124,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Configures and starts the worker(s).
-   *
-   * @throws Exception if the operation fails
    */
   protected void startWorkers() throws Exception {
     mWorkers = new ArrayList<>();
@@ -212,8 +204,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Stops both the alluxio and underfs service threads.
-   *
-   * @throws Exception when the operation fails
    */
   public void stop() throws Exception {
     stopFS();
@@ -225,8 +215,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Stops the alluxio filesystem's service thread only.
-   *
-   * @throws Exception when the operation fails
    */
   public void stopFS() throws Exception {
     LOG.info("stop Alluxio filesystem");
@@ -237,8 +225,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Cleans up the underfs cluster test folder only.
-   *
-   * @throws Exception when the operation fails
    */
   protected void stopUFS() throws Exception {
     LOG.info("stop under storage system");
@@ -249,15 +235,11 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Stops the masters.
-   *
-   * @throws Exception when operation fails
    */
   protected abstract void stopMasters() throws Exception;
 
   /**
    * Stops the proxy.
-   *
-   * @throws Exception when operation fails
    */
   protected void stopProxy() throws Exception {
     mProxyProcess.stop();
@@ -265,8 +247,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Stops the workers.
-   *
-   * @throws Exception when operation fails
    */
   public void stopWorkers() throws Exception {
     for (WorkerProcess worker : mWorkers) {

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -166,8 +166,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Sets up corresponding directories for tests.
-   *
-   * @throws IOException when creating or deleting dirs failed
    */
   protected void setupTest() throws IOException {
     String underfsAddress = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
@@ -282,8 +280,6 @@ public abstract class AbstractLocalAlluxioCluster {
 
   /**
    * Creates a default {@link Configuration} for testing.
-   *
-   * @throws IOException when the operation fails
    */
   public void initConfiguration() throws IOException {
     setAlluxioWorkDirectory();
@@ -377,7 +373,6 @@ public abstract class AbstractLocalAlluxioCluster {
    * Returns a {@link FileSystem} client.
    *
    * @return a {@link FileSystem} client
-   * @throws IOException when the operation fails
    */
   public abstract FileSystem getClient() throws IOException;
 

--- a/minicluster/src/main/java/alluxio/master/ClientPool.java
+++ b/minicluster/src/main/java/alluxio/master/ClientPool.java
@@ -39,7 +39,6 @@ public final class ClientPool implements Closeable {
    * closed directly, but can be closed by calling {@link #close()} on this object.
    *
    * @return a {@link FileSystem} client
-   * @throws IOException when the operation fails
    */
   public FileSystem getClient() throws IOException {
     final FileSystem fs = FileSystem.Factory.get();

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -144,8 +144,6 @@ public final class LocalAlluxioMaster {
 
   /**
    * Stops the master and cleans up client connections.
-   *
-   * @throws Exception when the operation fails
    */
   public void stop() throws Exception {
     clearClients();

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -65,7 +65,6 @@ public final class LocalAlluxioMaster {
   /**
    * Creates a new local Alluxio master with an isolated work directory and port.
    *
-   * @throws IOException when unable to do file operation or listen on port
    * @return an instance of Alluxio master
    */
   public static LocalAlluxioMaster create() throws IOException {
@@ -83,7 +82,6 @@ public final class LocalAlluxioMaster {
    *
    * @param workDirectory Alluxio work directory, this method will create it if it doesn't exist yet
    * @return the created Alluxio master
-   * @throws IOException when unable to do file operation or listen on port
    */
   public static LocalAlluxioMaster create(final String workDirectory) throws IOException {
     UnderFileSystemUtils.mkdirIfNotExists(workDirectory);
@@ -167,8 +165,6 @@ public final class LocalAlluxioMaster {
 
   /**
    * Clears all the clients.
-   *
-   * @throws IOException if the client pool cannot be closed
    */
   public void clearClients() throws IOException {
     mClientPool.close();
@@ -206,7 +202,6 @@ public final class LocalAlluxioMaster {
 
   /**
    * @return the client from the pool
-   * @throws IOException if the client cannot be retrieved
    */
   public FileSystem getClient() throws IOException {
     return mClientPool.getClient();

--- a/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
+++ b/minicluster/src/main/java/alluxio/underfs/UnderFileSystemCluster.java
@@ -70,7 +70,6 @@ public abstract class UnderFileSystemCluster {
    * Creates an underfs test bed and register the shutdown hook.
    *
    * @param baseDir base directory
-   * @throws IOException when the operation fails
    * @return an instance of the UnderFileSystemCluster class
    */
   public static synchronized UnderFileSystemCluster get(String baseDir)
@@ -135,8 +134,6 @@ public abstract class UnderFileSystemCluster {
    * system for the next test round instead of turning on/off it from time to time. This function is
    * expected to be called either before or after each test case which avoids certain overhead from
    * the bootstrap.
-   *
-   * @throws IOException when the operation fails
    */
   public void cleanup() throws IOException {
     if (isStarted()) {
@@ -166,8 +163,6 @@ public abstract class UnderFileSystemCluster {
   /**
    * Adds a shutdown hook. The {@link #shutdown()} phase will be automatically called while the
    * process exists.
-   *
-   * @throws IOException when the operation fails
    */
   public void registerJVMOnExistHook() throws IOException {
     Runtime.getRuntime().addShutdownHook(new ShutdownHook(this));
@@ -175,15 +170,11 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * Stops the underfs cluster system.
-   *
-   * @throws IOException when the operation fails
    */
   public abstract void shutdown() throws IOException;
 
   /**
    * Starts the underfs cluster system.
-   *
-   * @throws IOException when the operation fails
    */
   public abstract void start() throws IOException;
 }

--- a/shell/src/main/java/alluxio/cli/AlluxioShell.java
+++ b/shell/src/main/java/alluxio/cli/AlluxioShell.java
@@ -50,7 +50,6 @@ public final class AlluxioShell implements Closeable {
    * Main method, starts a new AlluxioShell.
    *
    * @param argv [] Array of arguments given by the user's input from the terminal
-   * @throws IOException if closing the shell fails
    */
   public static void main(String[] argv) throws IOException {
     int ret;

--- a/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
+++ b/shell/src/main/java/alluxio/shell/AlluxioShellUtils.java
@@ -54,7 +54,6 @@ public final class AlluxioShellUtils {
    *
    * @param path the path to obtain the local path from
    * @return the local path in string format
-   * @throws IOException if the given path is not valid
    */
   public static String getFilePath(String path) throws IOException {
     path = validatePath(path);
@@ -74,7 +73,6 @@ public final class AlluxioShellUtils {
    * @return the verified path in a form like alluxio://host:port/dir. If only the "/dir" or "dir"
    *         part is provided, the host and port are retrieved from property,
    *         alluxio.master.hostname and alluxio.master.port, respectively.
-   * @throws IOException if the given path is not valid
    */
   public static String validatePath(String path) throws IOException {
     if (path.startsWith(Constants.HEADER) || path.startsWith(Constants.HEADER_FT)) {
@@ -102,8 +100,6 @@ public final class AlluxioShellUtils {
    * @param alluxioClient the client used to fetch information of Alluxio files
    * @param inputURI the input URI (could contain wildcards)
    * @return a list of {@link AlluxioURI}s that matches the inputURI
-   * @throws IOException if any filesystem errors are encountered when expanding paths with
-   *                     wildcards
    */
   public static List<AlluxioURI> getAlluxioURIs(FileSystem alluxioClient, AlluxioURI inputURI)
       throws IOException {
@@ -131,8 +127,6 @@ public final class AlluxioShellUtils {
    * @param parentDir the {@link AlluxioURI} of the directory in which we are searching matched
    *                  files
    * @return a list of {@link AlluxioURI}s of the files that match the inputURI in parentDir
-   * @throws IOException if any filesystem errors are encountered when expanding paths with
-   *                     wildcards
    */
   private static List<AlluxioURI> getAlluxioURIs(FileSystem alluxioClient, AlluxioURI inputURI,
       AlluxioURI parentDir) throws IOException {

--- a/shell/src/main/java/alluxio/shell/command/ChecksumCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChecksumCommand.java
@@ -69,8 +69,6 @@ public final class ChecksumCommand extends AbstractShellCommand {
    *
    * @param filePath The {@link AlluxioURI} path of the file calculate MD5 checksum on
    * @return A string representation of the file's MD5 checksum
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private String calculateChecksum(AlluxioURI filePath)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/ChgrpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChgrpCommand.java
@@ -59,8 +59,6 @@ public final class ChgrpCommand extends AbstractShellCommand {
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param group The group to be updated to the file or directory
    * @param recursive Whether change the group recursively
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void chgrp(AlluxioURI path, String group, boolean recursive)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChmodCommand.java
@@ -63,8 +63,6 @@ public final class ChmodCommand extends AbstractShellCommand {
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param modeStr The new permission to be updated to the file or directory
    * @param recursive Whether change the permission recursively
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void chmod(AlluxioURI path, String modeStr, boolean recursive) throws
       AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -59,8 +59,6 @@ public final class ChownCommand extends AbstractShellCommand {
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param owner The owner to be updated to the file or directory
    * @param recursive Whether change the owner recursively
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void chown(AlluxioURI path, String owner, boolean recursive)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/CommandUtils.java
+++ b/shell/src/main/java/alluxio/shell/command/CommandUtils.java
@@ -47,8 +47,6 @@ public final class CommandUtils {
    *        created file should be kept around before it is automatically deleted, irrespective of
    *        whether the file is pinned; {@link Constants#NO_TTL} means to unset the TTL value
    * @param ttlAction Action to perform on Ttl expiry
-   * @throws AlluxioException when an Alluxio exception occurs
-   * @throws IOException when a non-Alluxio exception occurs
    */
   public static void setTtl(FileSystem fs, AlluxioURI path, long ttlMs,
       TtlAction ttlAction) throws AlluxioException, IOException {
@@ -74,8 +72,6 @@ public final class CommandUtils {
    * @param fs The {@link FileSystem} client
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param pinned the state to be set
-   * @throws AlluxioException when an Alluxio exception occurs
-   * @throws IOException when a non-Alluxio exception occurs
    */
   public static void setPinned(FileSystem fs, AlluxioURI path, boolean pinned)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/CpCommand.java
@@ -132,8 +132,6 @@ public final class CpCommand extends AbstractShellCommand {
    * @param srcPaths a list of files or directories in the Alluxio filesystem
    * @param dstPath the destination in the Alluxio filesystem
    * @param recursive indicates whether directories should be copied recursively
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyWildcard(List<AlluxioURI> srcPaths, AlluxioURI dstPath, boolean recursive)
       throws AlluxioException, IOException {
@@ -171,8 +169,6 @@ public final class CpCommand extends AbstractShellCommand {
    * @param srcPath the source {@link AlluxioURI} (could be a file or a directory)
    * @param dstPath the {@link AlluxioURI} of the destination path in the Alluxio filesystem
    * @param recursive indicates whether directories should be copied recursively
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copy(AlluxioURI srcPath, AlluxioURI dstPath, boolean recursive)
       throws AlluxioException, IOException {
@@ -239,8 +235,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath the source {@link AlluxioURI} (has to be a file)
    * @param dstPath the destination path in the Alluxio filesystem
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyFile(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
@@ -260,8 +254,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath the {@link AlluxioURI} of the source directory in the local filesystem
    * @param dstPath the {@link AlluxioURI} of the destination
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyFromLocalDir(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
@@ -307,8 +299,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPaths a list of files or directories in the local filesystem
    * @param dstPath the {@link AlluxioURI} of the destination
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyFromLocalWildcard(List<AlluxioURI> srcPaths, AlluxioURI dstPath)
       throws AlluxioException, IOException {
@@ -344,8 +334,6 @@ public final class CpCommand extends AbstractShellCommand {
    * destination directory already exists.
    *
    * @param dstPath the {@link AlluxioURI} of the destination directory which will be created
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void createDstDir(AlluxioURI dstPath) throws AlluxioException, IOException {
     try {
@@ -366,8 +354,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath the {@link AlluxioURI} of the source in the local filesystem
    * @param dstPath the {@link AlluxioURI} of the destination
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyFromLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
@@ -386,8 +372,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath the {@link AlluxioURI} of the source file in the local filesystem
    * @param dstPath the {@link AlluxioURI} of the destination
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyPath(AlluxioURI srcPath, AlluxioURI dstPath) throws AlluxioException,
       IOException {
@@ -461,8 +445,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPaths the list of files in the Alluxio filesystem
    * @param dstPath the {@link AlluxioURI} of the destination directory in the local filesystem
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyWildcardToLocal(List<AlluxioURI> srcPaths, AlluxioURI dstPath)
       throws AlluxioException, IOException {
@@ -497,8 +479,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath the source {@link AlluxioURI} (could be a file or a directory)
    * @param dstPath the {@link AlluxioURI} of the destination in the local filesystem
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyToLocal(AlluxioURI srcPath, AlluxioURI dstPath) throws AlluxioException,
       IOException {
@@ -547,8 +527,6 @@ public final class CpCommand extends AbstractShellCommand {
    *
    * @param srcPath The source {@link AlluxioURI} (has to be a file)
    * @param dstPath The {@link AlluxioURI} of the destination in the local filesystem
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void copyFileToLocal(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/DuCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/DuCommand.java
@@ -53,8 +53,6 @@ public final class DuCommand extends WithWildCardPathCommand {
    * @param fs a {@link FileSystem}
    * @param path a {@link AlluxioURI} denoting the path
    * @return total size of the specified path in byte
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private long getFileOrFolderSize(FileSystem fs, AlluxioURI path)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LoadCommand.java
@@ -57,8 +57,6 @@ public final class LoadCommand extends WithWildCardPathCommand {
    * Loads a file or directory in Alluxio space, makes it resident in memory.
    *
    * @param filePath The {@link AlluxioURI} path to load into Alluxio memory
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void load(AlluxioURI filePath) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(filePath);

--- a/shell/src/main/java/alluxio/shell/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/LsCommand.java
@@ -121,8 +121,6 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param recursive Whether list the path recursively
    * @param dirAsFile list the directory status as a plain file
    * @param hSize print human-readable format sizes
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void ls(AlluxioURI path, boolean recursive, boolean forceLoadMetadata, boolean dirAsFile,
                   boolean hSize, boolean pinnedOnly)

--- a/shell/src/main/java/alluxio/shell/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/PersistCommand.java
@@ -72,8 +72,6 @@ public final class PersistCommand extends AbstractShellCommand {
    * Persists a file or directory currently stored only in Alluxio to the UnderFileSystem.
    *
    * @param filePath the {@link AlluxioURI} path to persist to the UnderFileSystem
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    */
   private void persist(AlluxioURI filePath) throws AlluxioException, IOException {
     URIStatus status = mFileSystem.getStatus(filePath);

--- a/shell/src/main/java/alluxio/shell/command/ShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ShellCommand.java
@@ -48,8 +48,6 @@ public interface ShellCommand {
    * Runs the command.
    *
    * @param cl the parsed command line for the arguments
-   * @throws AlluxioException when Alluxio exception occurs
-   * @throws IOException when non-Alluxio exception occurs
    * @return the result of running the command
    */
   int run(CommandLine cl) throws AlluxioException, IOException;

--- a/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/WithWildCardPathCommand.java
@@ -45,7 +45,6 @@ public abstract class WithWildCardPathCommand extends AbstractShellCommand {
    *
    * @param path the expanded input path
    * @param cl the parsed command line object including options
-   * @throws IOException if the command fails
    */
   protected abstract void runCommand(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException;

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -73,7 +73,6 @@ public final class FileSystemAclIntegrationTest {
    * Deletes files in the given filesystem.
    *
    * @param fs given filesystem
-   * @throws IOException
    */
   public static void cleanup(org.apache.hadoop.fs.FileSystem fs) throws IOException {
     FileStatus[] statuses = fs.listStatus(new Path("/"));

--- a/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemRenameIntegrationTest.java
@@ -51,7 +51,6 @@ public final class FileSystemRenameIntegrationTest {
    * Deletes files in the given filesystem.
    *
    * @param fs given filesystem
-   * @throws IOException
    */
   public static void cleanup(org.apache.hadoop.fs.FileSystem fs) throws IOException {
     FileStatus[] statuses = fs.listStatus(new Path("/"));

--- a/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/AccumulatingReducer.java
@@ -65,7 +65,6 @@ public class AccumulatingReducer extends MapReduceBase implements Reducer<Text, 
    * @param values the values to accumulates
    * @param output collect the result of accumulating
    * @param reporter to report progress and update status information
-   * @throws IOException
    */
   public void reduce(Text key, Iterator<Text> values, OutputCollector<Text, Text> output,
       Reporter reporter) throws IOException {

--- a/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/fs/DFSIOIntegrationTest.java
@@ -13,8 +13,8 @@ package alluxio.hadoop.fs;
 
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
-import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.hadoop.FileSystem;
+import alluxio.hadoop.HadoopConfigurationUtils;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
@@ -242,7 +242,6 @@ public class DFSIOIntegrationTest implements Tool {
 
   /**
    * Writes into files, then calculates and collects the write test statistics.
-   * @throws Exception if has error
    */
   public static void writeTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =

--- a/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterCreateTest.java
+++ b/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterCreateTest.java
@@ -247,7 +247,6 @@ public class ConcurrentFileSystemMasterCreateTest {
    * @param useSinglePath if true, threads will only use a single path
    * @param createFiles if true, will create files at the bottom of the tree, directories otherwise
    * @param listParentDir if true, will list the parent dir to load the metadata
-   * @throws Exception if an error occurs
    */
   private void runLoadMetadata(WriteType writeType, boolean useSinglePath, boolean createFiles,
       boolean listParentDir) throws Exception {

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -189,8 +189,6 @@ public class FileSystemMasterIntegrationTest {
 
   /**
    * Tests concurrent delete of files.
-   *
-   * @throws Exception if an error occurs during creating or deleting files
    */
   @Test
   public void concurrentDelete() throws Exception {
@@ -208,8 +206,6 @@ public class FileSystemMasterIntegrationTest {
 
   /**
    * Tests concurrent free of files.
-   *
-   * @throws Exception if an error occurs during creating or freeing files
    */
   @Test
   public void concurrentFree() throws Exception {
@@ -224,8 +220,6 @@ public class FileSystemMasterIntegrationTest {
 
   /**
    * Tests concurrent rename of files.
-   *
-   * @throws Exception if an error occurs during creating or renaming files
    */
   @Test
   public void concurrentRename() throws Exception {
@@ -749,7 +743,6 @@ public class FileSystemMasterIntegrationTest {
      * files in one directory by multiple concurrent threads.
      *
      * @return null
-     * @throws Exception if an exception occurs
      */
     @Override
     public Void call() throws Exception {
@@ -764,7 +757,6 @@ public class FileSystemMasterIntegrationTest {
      * @param depth the depth of files to be created in one directory
      * @param concurrencyDepth the concurrency depth of files to be created in one directory
      * @param path the directory of files to be created in
-     * @throws Exception if an exception occurs
      */
     public void exec(int depth, int concurrencyDepth, AlluxioURI path) throws Exception {
       if (depth < 1) {
@@ -848,7 +840,6 @@ public class FileSystemMasterIntegrationTest {
      * @param depth the depth of files to be freed in one directory
      * @param concurrencyDepth the concurrency depth of files to be freed in one directory
      * @param path the directory of files to be freed in
-     * @throws Exception if an exception occurs
      */
     public void exec(int depth, int concurrencyDepth, AlluxioURI path) throws Exception {
       if (depth < 1) {
@@ -922,7 +913,6 @@ public class FileSystemMasterIntegrationTest {
      * @param depth the depth of files to be deleted in one directory
      * @param concurrencyDepth the concurrency depth of files to be deleted in one directory
      * @param path the directory of files to be deleted in
-     * @throws Exception if an exception occurs
      */
     public void exec(int depth, int concurrencyDepth, AlluxioURI path) throws Exception {
       if (depth < 1) {

--- a/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
@@ -466,8 +466,6 @@ public class UfsJournalIntegrationTest {
 
   /**
    * Tests the situation where a checkpoint mount entry is replayed by a standby master.
-   *
-   * @throws Exception on error
    */
   @Test
   public void mountEntryCheckpoint() throws Exception {

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -96,7 +96,6 @@ public final class TestCase {
 
   /**
    * @return The URL which is created
-   * @throws Exception
    */
   public URL createURL() throws Exception {
     StringBuilder sb = new StringBuilder();
@@ -111,7 +110,6 @@ public final class TestCase {
   /**
    * @param connection the HttpURLConnection
    * @return the String from the InputStream of HttpURLConnection
-   * @throws Exception
    */
   public String getResponse(HttpURLConnection connection) throws Exception {
     StringBuilder sb = new StringBuilder();

--- a/tests/src/test/java/alluxio/security/MasterClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/security/MasterClientAuthenticationIntegrationTest.java
@@ -100,7 +100,6 @@ public final class MasterClientAuthenticationIntegrationTest {
    * successfully to the Master, it can successfully create file or not.
    *
    * @param filename the name of the file
-   * @throws Exception if a {@link FileSystemMasterClient} operation fails
    */
   private void authenticationOperationTest(String filename) throws Exception {
     FileSystemMasterClient masterClient = FileSystemMasterClient.Factory

--- a/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
+++ b/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
@@ -116,7 +116,6 @@ public abstract class AbstractAlluxioShellTest {
    * @param path the file path
    * @param toWrite the file content
    * @return the created file instance
-   * @throws IOException if error happens during writing to file
    * @throws FileNotFoundException if file not found
    */
   protected File generateFileContent(String path, byte[] toWrite) throws IOException,
@@ -135,7 +134,6 @@ public abstract class AbstractAlluxioShellTest {
    * @param path the file path
    * @param toWrite the file content
    * @return the created file instance
-   * @throws IOException if error happens during writing to file
    * @throws FileNotFoundException if file not found
    */
   protected File generateRelativeFileContent(String path, byte[] toWrite) throws IOException,
@@ -215,7 +213,6 @@ public abstract class AbstractAlluxioShellTest {
    * Clears the {@link alluxio.security.LoginUser} and logs in with new user.
    *
    * @param user the new user
-   * @throws IOException if login fails
    */
   protected void clearAndLogin(String user) throws IOException {
     LoginUserTestUtils.resetLoginUser(user);
@@ -227,8 +224,6 @@ public abstract class AbstractAlluxioShellTest {
    * @param uri the path of the file to read
    * @param length the length of content to read
    * @return the content that has been read
-   * @throws IOException if an I/O error occurs
-   * @throws AlluxioException if an unexpected exception is thrown
    */
   protected byte[] readContent(AlluxioURI uri, int length) throws IOException, AlluxioException {
     try (FileInStream tfis = mFileSystem

--- a/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -862,7 +862,6 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
    *
    * @param testFile path of file to create
    * @return the number of copies of TEST_BYTES made
-   * @throws IOException if a non-Alluxio error occurs
    */
   private int prepareMultiBlockFile(String testFile) throws IOException {
     OutputStream outputStream = mUfs.create(testFile);
@@ -883,7 +882,6 @@ public final class UnderStorageSystemInterfaceIntegrationTest {
    * through Alluxio). No breadcrumbs are created for directories.
    *
    * @param ufs the {@link ObjectUnderFileSystem} to test
-   * @throws IOException if a non-Alluxio error occurs
    * @return configuration for the pre-populated objects
    */
   private ObjectStorePreConfig prepareObjectStore(ObjectUnderFileSystem ufs) throws IOException {

--- a/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/tests/src/test/java/alluxio/underfs/hdfs/LocalMiniDFSCluster.java
@@ -77,7 +77,6 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
    *
    * @param path the directory path to be created
    * @return {@code true} if and only if the directory was created; {@code false} otherwise
-   * @throws IOException if a non-Alluxio error occurs
    */
   public static boolean mkdirs(String path) throws IOException {
     UnderFileSystem ufs = UnderFileSystem.Factory.get(path);

--- a/tests/src/test/java/alluxio/worker/block/meta/SpecificTierWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/block/meta/SpecificTierWriteIntegrationTest.java
@@ -88,7 +88,6 @@ public class SpecificTierWriteIntegrationTest {
    * @param memBytes the expected number of bytes used in the MEM tier
    * @param ssdBytes the expected number of bytes used in the SSD tier
    * @param hddBytes the expected number of bytes used in the HDD tier
-   * @throws Exception when an error occurs
    */
   private void writeFileAndCheckUsage(int writeTier, long memBytes, long ssdBytes, long hddBytes)
       throws Exception {

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
@@ -113,7 +113,6 @@ public final class GCSInputStream extends InputStream {
    *
    * @param n number of bytes to skip
    * @return the number of bytes skipped
-   * @throws IOException if an error occurs when requesting from GCS
    */
   @Override
   public long skip(long n) throws IOException {

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
@@ -69,7 +69,6 @@ public final class GCSOutputStream extends OutputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the JetS3t client
-   * @throws IOException when a non-Alluxio related error occurs
    */
   public GCSOutputStream(String bucketName, String key, GoogleStorageService client)
       throws IOException {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -488,7 +488,6 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
    * @param path file or directory path
    * @param recursive whether to delete path recursively
    * @return true, if succeed
-   * @throws IOException when a non-alluxio error occurs
    */
   private boolean delete(String path, boolean recursive) throws IOException {
     IOException te = null;
@@ -510,7 +509,6 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
    *
    * @param path the pathname to list
    * @return {@code null} if the path is not a directory
-   * @throws IOException
    */
   private FileStatus[] listStatusInternal(String path) throws IOException {
     FileStatus[] files;
@@ -532,7 +530,6 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
    * @param src path of source file or directory
    * @param dst path of destination file or directory
    * @return true if rename succeeds
-   * @throws IOException
    */
   private boolean rename(String src, String dst) throws IOException {
     IOException te = null;

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -393,7 +393,6 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
    * @param src path of source file or directory
    * @param dst path of destination file or directory
    * @return true if rename succeeds
-   * @throws IOException
    */
   private boolean rename(String src, String dst) throws IOException {
     src = stripPath(src);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -49,7 +49,6 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the client for OSS
-   * @throws IOException if an I/O error occurs
    */
   OSSInputStream(String bucketName, String key, OSSClient client) throws IOException {
     this(bucketName, key, client, 0L);
@@ -62,7 +61,6 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for OSS
    * @param position the position to begin reading from
-   * @throws IOException if an I/O error occurs
    */
   OSSInputStream(String bucketName, String key, OSSClient client, long position)
       throws IOException {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
@@ -67,7 +67,6 @@ public final class OSSOutputStream extends OutputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the client for OSS
-   * @throws IOException if an I/O error occurs
    */
   public OSSOutputStream(String bucketName, String key, OSSClient client) throws IOException {
     Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(),
@@ -97,7 +96,6 @@ public final class OSSOutputStream extends OutputStream {
    * file.
    *
    * @param b the bytes to write
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void write(int b) throws IOException {
@@ -109,7 +107,6 @@ public final class OSSOutputStream extends OutputStream {
    * local file.
    *
    * @param b the byte array
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void write(byte[] b) throws IOException {
@@ -123,7 +120,6 @@ public final class OSSOutputStream extends OutputStream {
    * @param b the byte array
    * @param off the start offset in the data
    * @param len the number of bytes to write
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
@@ -133,8 +129,6 @@ public final class OSSOutputStream extends OutputStream {
   /**
    * Flushes this output stream and forces any buffered output bytes to be written out. Before
    * close, the data are flushed to local file.
-   *
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void flush() throws IOException {
@@ -144,8 +138,6 @@ public final class OSSOutputStream extends OutputStream {
   /**
    * Closes this output stream. When an output stream is closed, the local temporary file is
    * uploaded to OSS Service. Once the file is uploaded, the temporary file is deleted.
-   *
-   * @throws IOException if an I/O error occurs
    */
   @Override
   public void close() throws IOException {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -61,7 +61,6 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    *
    * @param uri the {@link AlluxioURI} for this UFS
    * @return the created {@link OSSUnderFileSystem} instance
-   * @throws Exception when a connection to GCS could not be created
    */
   public static OSSUnderFileSystem createInstance(AlluxioURI uri) throws Exception {
     String bucketName = UnderFileSystemUtils.getBucketName(uri);

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
@@ -32,7 +32,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.security.DigestOutputStream;
 
 /**
@@ -52,8 +51,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Sets the properties and configuration before each test runs.
-   *
-   * @throws Exception when the {@link HttpURLConnection#getOutputStream()} throws exception
    */
   @Before
   public void before() throws Exception {
@@ -64,8 +61,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Tests to ensure IOException is thrown if {@link FileOutputStream()} throws an IOException.
-   *
-   * @throws Exception when the IOException is not thrown
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -81,8 +76,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Tests to ensure {@link OSSOutputStream#write(int)} calls {@link OutputStream#write(int)}.
-   *
-   * @throws Exception when {@link OutputStream#write(int)} is not called
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -100,8 +93,6 @@ public class OSSOutputStreamTest {
   /**
    * Tests to ensure {@link OSSOutputStream#write(byte[], int, int)} calls
    * {@link OutputStream#write(byte[], int, int)} .
-   *
-   * @throws Exception when {@link OutputStream#write(byte[], int, int)} is not called
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -119,8 +110,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Tests to ensure {@link OSSOutputStream#write(byte[])} calls {@link OutputStream#write(byte[])}.
-   *
-   * @throws Exception when {@link OutputStream#write(byte[])} is not called
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -140,8 +129,6 @@ public class OSSOutputStreamTest {
    * Tests to ensure IOException is thrown if
    * {@link OSSClient#putObject(String, String, InputStream, ObjectMetadata)} throws an
    * OSSException.
-   *
-   * @throws Exception when the IOException is thrown
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -162,9 +149,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Tests to ensure {@link File#delete()} is called when close the stream.
-   *
-   * @throws Exception when {@link OSSClient#putObject(String, String, InputStream, ObjectMetadata)}
-   *         throws an OSSException
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)
@@ -182,8 +166,6 @@ public class OSSOutputStreamTest {
 
   /**
    * Tests to ensure {@link OSSOutputStream#flush()} calls {@link OutputStream#flush()}.
-   *
-   * @throws Exception when flush is not called
    */
   @Test
   @PrepareForTest(OSSOutputStream.class)

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3InputStream.java
@@ -112,7 +112,6 @@ public class S3InputStream extends InputStream {
    *
    * @param n number of bytes to skip
    * @return the number of bytes skipped
-   * @throws IOException if an error occurs when requesting from S3
    */
   @Override
   public long skip(long n) throws IOException {

--- a/underfs/s3/src/main/java/alluxio/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/alluxio/underfs/s3/S3OutputStream.java
@@ -83,7 +83,6 @@ public class S3OutputStream extends OutputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the JetS3t client
-   * @throws IOException when a non-Alluxio related error occurs
    */
   public S3OutputStream(String bucketName, String key, S3Service client) throws IOException {
     Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(), "Bucket name must "

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -84,7 +84,6 @@ public class S3AOutputStream extends OutputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param manager the transfer manager to upload the file with
-   * @throws IOException when a non-Alluxio related error occurs
    */
   public S3AOutputStream(String bucketName, String key, TransferManager manager)
       throws IOException {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
@@ -16,7 +16,6 @@ import alluxio.util.io.PathUtils;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
 import org.javaswift.joss.model.StoredObject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +55,6 @@ public class SwiftMockOutputStream extends OutputStream {
    * @param account simulated Swift account
    * @param containerName container name
    * @param objectName name of file or folder to write
-   * @throws IOException if an I/O error occurs
    */
   public SwiftMockOutputStream(Account account, String containerName, String objectName)
       throws IOException {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
@@ -35,7 +35,6 @@ public class SwiftOutputStream extends OutputStream {
    * Creates a new instance of {@link SwiftOutputStream}.
    *
    * @param httpCon connection to Swift
-   * @throws IOException if an I/O error occurs
    */
   public SwiftOutputStream(HttpURLConnection httpCon) throws IOException {
     try {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/http/SwiftDirectClient.java
@@ -45,7 +45,6 @@ public class SwiftDirectClient {
    *
    * @param access JOSS access object
    * @param objectName name of the object to create
-   * @throws IOException if an I/O error occurs
    * @return SwiftOutputStream that will be used to upload data to Swift
    */
   public static SwiftOutputStream put(Access access, String objectName) throws IOException {


### PR DESCRIPTION
This PR removes javadoc descriptions for almost all instances of `IOException`, `AlluxioException`, and `Exception`. These exceptions are too general for anything useful to be said about them. Specific descriptions are fragile and can easily become outdated as implementations change. It's better to save vertical space.