### PR TITLE
[SMALLFIX] Access control exception cleanup

### DIFF
--- a/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
@@ -44,8 +44,13 @@ public final class CompleteUfsFileOptions {
   }
 
   private CompleteUfsFileOptions() throws IOException {
-    mOwner = SecurityUtils.getOwnerFromLoginModule();
-    mGroup = SecurityUtils.getGroupFromLoginModule();
+    if (SecurityUtils.isSecurityEnabled()) {
+      mOwner = SecurityUtils.getOwnerFromLoginModule();
+      mGroup = SecurityUtils.getGroupFromLoginModule();
+    } else {
+      mOwner = "";
+      mGroup = "";
+    }
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
@@ -18,8 +18,6 @@ import alluxio.util.SecurityUtils;
 
 import com.google.common.base.Objects;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -37,20 +35,14 @@ public final class CompleteUfsFileOptions {
    * default file mode.
    *
    * @return the default {@link CompleteUfsFileOptions}
-   * @throws IOException if failed to set owner from login module
    */
-  public static CompleteUfsFileOptions defaults() throws IOException {
+  public static CompleteUfsFileOptions defaults() {
     return new CompleteUfsFileOptions();
   }
 
-  private CompleteUfsFileOptions() throws IOException {
-    if (SecurityUtils.isSecurityEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromLoginModule();
-      mGroup = SecurityUtils.getGroupFromLoginModule();
-    } else {
-      mOwner = "";
-      mGroup = "";
-    }
+  private CompleteUfsFileOptions() {
+    mOwner = SecurityUtils.getOwnerFromLoginModule();
+    mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
@@ -41,13 +41,8 @@ public final class CompleteUfsFileOptions {
   }
 
   private CompleteUfsFileOptions() {
-    if (SecurityUtils.isSecurityEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromLoginModule();
-      mGroup = SecurityUtils.getGroupFromLoginModule();
-    } else {
-      mOwner = "";
-      mGroup = "";
-    }
+    mOwner = SecurityUtils.getOwnerFromLoginModule();
+    mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CompleteUfsFileOptions.java
@@ -41,8 +41,13 @@ public final class CompleteUfsFileOptions {
   }
 
   private CompleteUfsFileOptions() {
-    mOwner = SecurityUtils.getOwnerFromLoginModule();
-    mGroup = SecurityUtils.getGroupFromLoginModule();
+    if (SecurityUtils.isSecurityEnabled()) {
+      mOwner = SecurityUtils.getOwnerFromLoginModule();
+      mGroup = SecurityUtils.getGroupFromLoginModule();
+    } else {
+      mOwner = "";
+      mGroup = "";
+    }
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
@@ -44,8 +44,13 @@ public final class CreateUfsFileOptions {
   }
 
   private CreateUfsFileOptions() throws IOException {
-    mOwner = SecurityUtils.getOwnerFromLoginModule();
-    mGroup = SecurityUtils.getGroupFromLoginModule();
+    if (SecurityUtils.isSecurityEnabled()) {
+      mOwner = SecurityUtils.getOwnerFromLoginModule();
+      mGroup = SecurityUtils.getGroupFromLoginModule();
+    } else {
+      mOwner = "";
+      mGroup = "";
+    }
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/CreateUfsFileOptions.java
@@ -44,13 +44,8 @@ public final class CreateUfsFileOptions {
   }
 
   private CreateUfsFileOptions() throws IOException {
-    if (SecurityUtils.isSecurityEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromLoginModule();
-      mGroup = SecurityUtils.getGroupFromLoginModule();
-    } else {
-      mOwner = "";
-      mGroup = "";
-    }
+    mOwner = SecurityUtils.getOwnerFromLoginModule();
+    mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();
     // TODO(chaomin): set permission based on the alluxio file. Not needed for now since the
     // file is always created with default permission.

--- a/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -67,13 +67,8 @@ public final class OutStreamOptions {
     }
     mWriteTier = Configuration.getInt(PropertyKey.USER_FILE_WRITE_TIER_DEFAULT);
     mWriteType = Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
-    if (SecurityUtils.isSecurityEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromLoginModule();
-      mGroup = SecurityUtils.getGroupFromLoginModule();
-    } else {
-      mOwner = "";
-      mGroup = "";
-    }
+    mOwner = SecurityUtils.getOwnerFromLoginModule();
+    mGroup = SecurityUtils.getGroupFromLoginModule();
     mMode = Mode.defaults().applyFileUMask();
   }
 

--- a/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -67,8 +67,13 @@ public final class OutStreamOptions {
     }
     mWriteTier = Configuration.getInt(PropertyKey.USER_FILE_WRITE_TIER_DEFAULT);
     mWriteType = Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
-    mOwner = SecurityUtils.getOwnerFromLoginModule();
-    mGroup = SecurityUtils.getGroupFromLoginModule();
+    if (SecurityUtils.isSecurityEnabled()) {
+      mOwner = SecurityUtils.getOwnerFromLoginModule();
+      mGroup = SecurityUtils.getGroupFromLoginModule();
+    } else {
+      mOwner = "";
+      mGroup = "";
+    }
     mMode = Mode.defaults().applyFileUMask();
   }
 

--- a/core/client/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
+++ b/core/client/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
@@ -52,7 +52,7 @@ public class OutStreamOptionsTest {
     public FakeUserGroupsMapping() {}
 
     @Override
-    public List<String> getGroups(String user) throws IOException {
+    public List<String> getGroups(String user) {
       return Lists.newArrayList("test_group");
     }
   }

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -189,7 +189,7 @@ public enum ExceptionMessage {
 
   // security
   AUTHENTICATION_IS_NOT_ENABLED("Authentication is not enabled"),
-  AUTHORIZED_CLIENT_USER_IS_NULL("The client user is not authorized so as to be null in server"),
+  FAILED_TO_GET_GROUPS("Failed to get groups for user {0}"),
   INVALID_SET_ACL_OPTIONS("Invalid set acl options: {0}, {1}, {2}"),
   INVALID_MODE("Invalid mode {0}"),
   INVALID_MODE_SEGMENT("Invalid mode {0} - contains invalid segment {1}"),
@@ -197,6 +197,7 @@ public enum ExceptionMessage {
       "Invalid mode {0} - contains invalid segment {1} which has invalid permissions {2}"),
   INVALID_MODE_TARGETS(
       "Invalid mode {0} - contains invalid segment {1} which has invalid targets {2}"),
+  NO_CLIENT_USER("Failed to determine client user"),
   PERMISSION_DENIED("Permission denied: {0}"),
   SECURITY_IS_NOT_ENABLED("Security is not enabled"),
 

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -20,8 +20,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -63,12 +61,8 @@ public final class HeartbeatThread implements Runnable {
 
   @Override
   public void run() {
-    try {
-      if (SecurityUtils.isSecurityEnabled() && AuthenticatedClientUser.get() == null) {
-        AuthenticatedClientUser.set(LoginUser.get().getName());
-      }
-    } catch (IOException e) {
-      LOG.error("Failed to set AuthenticatedClientUser in HeartbeatThread.");
+    if (SecurityUtils.isSecurityEnabled() && AuthenticatedClientUser.get() == null) {
+      AuthenticatedClientUser.set(LoginUser.get().getName());
     }
 
     // set the thread name

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -45,7 +45,8 @@ public final class AuthenticatedClientUser {
   }
 
   /**
-   * Gets the {@link User} from the {@link ThreadLocal} variable.
+   * Gets the {@link User} from the {@link ThreadLocal} variable. An exception will be thrown if
+   * authentication is disabled.
    *
    * @return the client user, or null if no client user is set
    */
@@ -58,7 +59,7 @@ public final class AuthenticatedClientUser {
 
   /**
    * Gets the user name from the {@link ThreadLocal} variable. An exception will be thrown if no
-   * client user has been set.
+   * client user has been set, or authentication is disabled.
    *
    * @return the client user's name
    */

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -63,7 +63,7 @@ public final class AuthenticatedClientUser {
    *
    * @return the client user's name
    */
-  public static String getClientUser() {
+  public static String getName() {
     User user = get();
     if (user == null) {
       throw new UnauthenticatedException(ExceptionMessage.NO_CLIENT_USER.getMessage());

--- a/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
@@ -13,6 +13,7 @@ package alluxio.security.group;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
+import alluxio.exception.status.UnavailableException;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -25,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -119,8 +119,7 @@ public class CachedGroupMapping implements GroupMappingService {
     try {
       return mCache.get(user);
     } catch (ExecutionException e) {
-      LOG.warn("Failed to get groups for user {}: {}", user, e.getMessage());
-      return new ArrayList<>();
+      throw new UnavailableException(e);
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
@@ -22,8 +22,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -39,8 +37,6 @@ import java.util.concurrent.TimeUnit;
  * implementation depends on {@link GroupMappingService}.
  */
 public class CachedGroupMapping implements GroupMappingService {
-  private static final Logger LOG = LoggerFactory.getLogger(CachedGroupMapping.class);
-
   /** The underlying implementation of GroupMappingService. */
   private final GroupMappingService mService;
   /** Whether the cache is enabled. Set timeout to non-positive value to disable cache. */

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -79,5 +79,5 @@ public interface GroupMappingService {
    * @return group memberships of user
    * @throws IOException if can't get user's groups
    */
-  List<String> getGroups(String user) throws IOException;
+  List<String> getGroups(String user);
 }

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -19,7 +19,6 @@ import alluxio.util.CommonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -77,7 +76,6 @@ public interface GroupMappingService {
    *
    * @param user user's name
    * @return group memberships of user
-   * @throws IOException if can't get user's groups
    */
   List<String> getGroups(String user);
 }

--- a/core/common/src/main/java/alluxio/security/group/provider/IdentityUserGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/IdentityUserGroupsMapping.java
@@ -15,7 +15,6 @@ import alluxio.security.group.GroupMappingService;
 
 import com.google.common.collect.Lists;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -34,10 +33,9 @@ public final class IdentityUserGroupsMapping implements GroupMappingService {
    *
    * @param user get groups for this user
    * @return list of groups for a given user
-   * @throws IOException when trying to create a new list
    */
   @Override
-  public List<String> getGroups(String user) throws IOException {
+  public List<String> getGroups(String user) {
     return Lists.newArrayList(user);
   }
 }

--- a/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
@@ -38,7 +38,7 @@ public final class ShellBasedUnixGroupsMapping implements GroupMappingService {
    * @throws IOException when getting the UNIX groups
    */
   @Override
-  public List<String> getGroups(String user) throws IOException {
+  public List<String> getGroups(String user) {
     List<String> groups = CommonUtils.getUnixGroups(user);
     // remove duplicated primary group
     return new ArrayList<>(new LinkedHashSet<>(groups));

--- a/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/provider/ShellBasedUnixGroupsMapping.java
@@ -14,7 +14,6 @@ package alluxio.security.group.provider;
 import alluxio.security.group.GroupMappingService;
 import alluxio.util.CommonUtils;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -35,7 +34,6 @@ public final class ShellBasedUnixGroupsMapping implements GroupMappingService {
    *
    * @param user get groups for this user
    * @return list of groups for a given user
-   * @throws IOException when getting the UNIX groups
    */
   @Override
   public List<String> getGroups(String user) {

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -14,7 +14,6 @@ package alluxio.util;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
-import alluxio.util.ShellUtils.ExitCodeException;
 
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
@@ -198,19 +197,20 @@ public final class CommonUtils {
   }
 
   /**
-   * Gets the current user's group list from Unix by running the command 'groups' NOTE. For
-   * non-existing user it will return EMPTY list. This method may return duplicate groups.
+   * Gets the current user's group list from Unix by running the command 'groups'.
+   *
+   * If a user's groups can't be determined for any reason, this method returns an empty list. This
+   * method may return duplicate groups.
    *
    * @param user user name
    * @return the groups list that the {@code user} belongs to. The primary group is returned first
-   * @throws IOException if encounter any error when running the command
    */
-  public static List<String> getUnixGroups(String user) throws IOException {
+  public static List<String> getUnixGroups(String user) {
     String result;
     List<String> groups = new ArrayList<>();
     try {
       result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand(user));
-    } catch (ExitCodeException e) {
+    } catch (IOException e) {
       // if we didn't get the group - just return empty list
       LOG.warn("got exception trying to get groups for user " + user + ": " + e.getMessage());
       return groups;
@@ -282,21 +282,19 @@ public final class CommonUtils {
    *
    * @param userName Alluxio user name
    * @return primary group name
-   * @throws IOException if getting group failed
    */
-  public static String getPrimaryGroupName(String userName) throws IOException {
+  public static String getPrimaryGroupName(String userName) {
     List<String> groups = getGroups(userName);
     return (groups != null && groups.size() > 0) ? groups.get(0) : "";
   }
 
   /**
-   * Using {@link CachedGroupMapping} to get the group list of a user.
+   * Uses {@link CachedGroupMapping} to get the group list of a user.
    *
    * @param userName Alluxio user name
    * @return the group list of the user
-   * @throws IOException if getting group list failed
    */
-  public static List<String> getGroups(String userName) throws IOException {
+  public static List<String> getGroups(String userName) {
     GroupMappingService groupMappingService = GroupMappingService.Factory.get();
     return groupMappingService.getGroups(userName);
   }

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -200,8 +200,8 @@ public final class CommonUtils {
   /**
    * Gets the current user's group list from Unix by running the command 'groups'.
    *
-   * If a user's groups can't be determined for any reason, this method returns an empty list. This
-   * method may return duplicate groups.
+   * This method returns an empty list if the user does not exist. This method may return duplicate
+   * groups.
    *
    * @param user user name
    * @return the groups list that the {@code user} belongs to. The primary group is returned first

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -14,6 +14,7 @@ package alluxio.util;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
+import alluxio.util.ShellUtils.ExitCodeException;
 
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
@@ -210,10 +211,12 @@ public final class CommonUtils {
     List<String> groups = new ArrayList<>();
     try {
       result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand(user));
-    } catch (IOException e) {
+    } catch (ExitCodeException e) {
       // if we didn't get the group - just return empty list
       LOG.warn("got exception trying to get groups for user " + user + ": " + e.getMessage());
       return groups;
+    } catch (IOException e) {
+      throw AlluxioStatusException.fromIOException(e);
     }
 
     StringTokenizer tokenizer = new StringTokenizer(result, ShellUtils.TOKEN_SEPARATOR_REGEX);

--- a/core/common/src/main/java/alluxio/util/SecurityUtils.java
+++ b/core/common/src/main/java/alluxio/util/SecurityUtils.java
@@ -15,11 +15,8 @@ import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.security.LoginUser;
-import alluxio.security.User;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
-
-import java.io.IOException;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -71,46 +68,23 @@ public final class SecurityUtils {
   }
 
   /**
-   * @return the owner fetched from the Thrift client, or empty string if the fetch fails or
-   *         authentication is disabled
+   * @return the owner fetched from the Thrift client
    */
   public static String getOwnerFromThriftClient() {
-    try {
-      User user = AuthenticatedClientUser.get();
-      if (user == null) {
-        return "";
-      }
-      return user.getName();
-    } catch (IOException e) {
-      return "";
-    }
+    return AuthenticatedClientUser.getClientUser();
   }
 
   /**
-   * @return the group fetched from the login module, or empty string if the fetch fails or
-   *         authentication is disabled
+   * @return the group fetched from the login module
    */
   public static String getGroupFromLoginModule() {
-    try {
-      return CommonUtils.getPrimaryGroupName(LoginUser.get().getName());
-    } catch (IOException | UnsupportedOperationException e) {
-      return "";
-    }
+    return CommonUtils.getPrimaryGroupName(LoginUser.get().getName());
   }
 
   /**
-   * @return the group fetched from the Thrift client, or empty string if the fetch fails or
-   *         authentication is disabled
+   * @return the group fetched from the Thrift client
    */
   public static String getGroupFromThriftClient() {
-    try {
-      User user = AuthenticatedClientUser.get();
-      if (user == null) {
-        return "";
-      }
-      return CommonUtils.getPrimaryGroupName(user.getName());
-    } catch (IOException e) {
-      return "";
-    }
+    return CommonUtils.getPrimaryGroupName(AuthenticatedClientUser.get().getName());
   }
 }

--- a/core/common/src/main/java/alluxio/util/SecurityUtils.java
+++ b/core/common/src/main/java/alluxio/util/SecurityUtils.java
@@ -13,7 +13,6 @@ package alluxio.util;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.exception.status.UnauthenticatedException;
 import alluxio.security.LoginUser;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
@@ -56,15 +55,10 @@ public final class SecurityUtils {
   }
 
   /**
-   * @return the owner fetched from the login module, or empty string if the fetch fails or
-   *         authentication is disabled
+   * @return the owner fetched from the login module
    */
   public static String getOwnerFromLoginModule() {
-    try {
-      return LoginUser.get().getName();
-    } catch (UnauthenticatedException | UnsupportedOperationException e) {
-      return "";
-    }
+    return LoginUser.get().getName();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/SecurityUtils.java
+++ b/core/common/src/main/java/alluxio/util/SecurityUtils.java
@@ -55,30 +55,42 @@ public final class SecurityUtils {
   }
 
   /**
-   * @return the owner fetched from the login module
+   * @return the owner fetched from the login module, or empty string if authentication is disabled
    */
   public static String getOwnerFromLoginModule() {
+    if (SecurityUtils.isSecurityEnabled()) {
+      return "";
+    }
     return LoginUser.get().getName();
   }
 
   /**
-   * @return the owner fetched from the Thrift client
+   * @return the owner fetched from the Thrift client, or empty string if authentication is disabled
    */
   public static String getOwnerFromThriftClient() {
+    if (SecurityUtils.isSecurityEnabled()) {
+      return "";
+    }
     return AuthenticatedClientUser.getClientUser();
   }
 
   /**
-   * @return the group fetched from the login module
+   * @return the group fetched from the login module, or empty string if authentication is disabled
    */
   public static String getGroupFromLoginModule() {
+    if (SecurityUtils.isSecurityEnabled()) {
+      return "";
+    }
     return CommonUtils.getPrimaryGroupName(LoginUser.get().getName());
   }
 
   /**
-   * @return the group fetched from the Thrift client
+   * @return the group fetched from the Thrift client, or empty string if authentication is disabled
    */
   public static String getGroupFromThriftClient() {
+    if (SecurityUtils.isSecurityEnabled()) {
+      return "";
+    }
     return CommonUtils.getPrimaryGroupName(AuthenticatedClientUser.get().getName());
   }
 }

--- a/core/common/src/main/java/alluxio/util/SecurityUtils.java
+++ b/core/common/src/main/java/alluxio/util/SecurityUtils.java
@@ -71,7 +71,7 @@ public final class SecurityUtils {
     if (SecurityUtils.isSecurityEnabled()) {
       return "";
     }
-    return AuthenticatedClientUser.getClientUser();
+    return AuthenticatedClientUser.getName();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
@@ -31,15 +31,8 @@ public final class SecurityUtilsTest {
     ConfigurationTestUtils.resetConfiguration();
   }
 
-  /**
-   * Tests the {@link SecurityUtils#getOwnerFromThriftClient()} ()} method.
-   */
   @Test
   public void getOwnerFromThriftClient() throws Exception {
-    // When security is not enabled, user and group are not set
-    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
-    Assert.assertEquals("", SecurityUtils.getOwnerFromThriftClient());
-
     Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
         IdentityUserGroupsMapping.class.getName());
@@ -47,15 +40,8 @@ public final class SecurityUtilsTest {
     Assert.assertEquals("test_client_user", SecurityUtils.getOwnerFromThriftClient());
   }
 
-  /**
-   * Tests the {@link SecurityUtils#getGroupFromThriftClient()} ()} method.
-   */
   @Test
   public void getGroupFromThriftClient() throws Exception {
-    // When security is not enabled, user and group are not set
-    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
-    Assert.assertEquals("", SecurityUtils.getGroupFromThriftClient());
-
     Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
         IdentityUserGroupsMapping.class.getName());
@@ -63,15 +49,8 @@ public final class SecurityUtilsTest {
     Assert.assertEquals("test_client_user", SecurityUtils.getGroupFromThriftClient());
   }
 
-  /**
-   * Tests the {@link SecurityUtils#getOwnerFromLoginModule()} method.
-   */
   @Test
   public void getOwnerFromLoginModule() throws Exception {
-    // When security is not enabled, user and group are not set
-    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
-    Assert.assertEquals("", SecurityUtils.getOwnerFromLoginModule());
-
     // When authentication is enabled, user and group are inferred from login module
     Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, "test_login_user");
@@ -80,15 +59,8 @@ public final class SecurityUtilsTest {
     Assert.assertEquals("test_login_user", SecurityUtils.getOwnerFromLoginModule());
   }
 
-  /**
-   * Tests the {@link SecurityUtils#getGroupFromLoginModule()} method.
-   */
   @Test
-  public void getGroupFromLoginModuleError() throws Exception {
-    // When security is not enabled, user and group are not set
-    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName());
-    Assert.assertEquals("", SecurityUtils.getGroupFromLoginModule());
-
+  public void getGroupFromLoginModule() throws Exception {
     // When authentication is enabled, user and group are inferred from login module
     Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
     Configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, "test_login_user");

--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
 import javax.ws.rs.core.Response;
 
 /**
@@ -42,12 +40,6 @@ public final class RestUtils {
       if (SecurityUtils.isSecurityEnabled() && AuthenticatedClientUser.get() == null) {
         AuthenticatedClientUser.set(LoginUser.get().getName());
       }
-    } catch (IOException e) {
-      LOG.error("Failed to set AuthenticatedClientUser in REST service handler.", e);
-      return createErrorResponse(e.getMessage());
-    }
-
-    try {
       return createResponse(callable.call());
     } catch (Exception e) {
       LOG.error("Unexpected error invoking rest endpoint", e);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -438,8 +438,13 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // Only initialize root when isPrimary because when initializing root, BlockMaster needs to
       // write journal entry, if it is not primary, BlockMaster won't have a writable journal.
       // If it is secondary, it should be able to load the inode tree from primary's checkpoint.
-      mInodeTree.initializeRoot(SecurityUtils.getOwnerFromLoginModule(),
-          SecurityUtils.getGroupFromLoginModule(), Mode.createFullAccess().applyDirectoryUMask());
+      String owner = "";
+      String group = "";
+      if (SecurityUtils.isSecurityEnabled()) {
+        owner = SecurityUtils.getOwnerFromLoginModule();
+        group = SecurityUtils.getGroupFromLoginModule();
+      }
+      mInodeTree.initializeRoot(owner, group, Mode.createFullAccess().applyDirectoryUMask());
       String defaultUFS = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
       try {
         mMountTable.add(new AlluxioURI(MountTable.ROOT), new AlluxioURI(defaultUFS),

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -56,6 +56,7 @@ import alluxio.master.file.options.CheckConsistencyOptions;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
+import alluxio.master.file.options.CreatePathOptions;
 import alluxio.master.file.options.DeleteOptions;
 import alluxio.master.file.options.FreeOptions;
 import alluxio.master.file.options.ListStatusOptions;
@@ -753,7 +754,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   @Override
   public List<AlluxioURI> checkConsistency(AlluxioURI path, CheckConsistencyOptions options)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException {
+      throws FileDoesNotExistException, InvalidPathException, IOException {
     List<AlluxioURI> inconsistentUris = new ArrayList<>();
     try (LockedInodePath parent = mInodeTree.lockInodePath(path, InodeTree.LockMode.READ)) {
       mPermissionChecker.checkPermission(Mode.Bits.READ, parent);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -438,13 +438,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // Only initialize root when isPrimary because when initializing root, BlockMaster needs to
       // write journal entry, if it is not primary, BlockMaster won't have a writable journal.
       // If it is secondary, it should be able to load the inode tree from primary's checkpoint.
-      String owner = "";
-      String group = "";
-      if (SecurityUtils.isSecurityEnabled()) {
-        owner = SecurityUtils.getOwnerFromLoginModule();
-        group = SecurityUtils.getGroupFromLoginModule();
-      }
-      mInodeTree.initializeRoot(owner, group, Mode.createFullAccess().applyDirectoryUMask());
+      mInodeTree.initializeRoot(SecurityUtils.getOwnerFromLoginModule(),
+          SecurityUtils.getGroupFromLoginModule(), Mode.createFullAccess().applyDirectoryUMask());
       String defaultUFS = Configuration.get(PropertyKey.UNDERFS_ADDRESS);
       try {
         mMountTable.add(new AlluxioURI(MountTable.ROOT), new AlluxioURI(defaultUFS),

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -12,7 +12,6 @@
 package alluxio.master.file;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.DirectoryNotEmptyException;
@@ -65,9 +64,8 @@ public interface FileSystemMaster extends Master {
    *
    * @param path the path to get the file id for
    * @return the file id for a given path, or -1 if there is no file at that path
-   * @throws AccessControlException if permission checking fails
    */
-  long getFileId(AlluxioURI path) throws AccessControlException;
+  long getFileId(AlluxioURI path);
 
   /**
    * Returns the {@link FileInfo} for a given file id. This method is not user-facing but supposed
@@ -76,11 +74,9 @@ public interface FileSystemMaster extends Master {
    * @param fileId the file id to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given file
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission denied
    */
   // TODO(binfan): Add permission checking for internal APIs
-  FileInfo getFileInfo(long fileId)
-      throws FileDoesNotExistException, AccessControlException;
+  FileInfo getFileInfo(long fileId) throws FileDoesNotExistException;
 
   /**
    * Returns the {@link FileInfo} for a given path.
@@ -91,11 +87,9 @@ public interface FileSystemMaster extends Master {
    * @return the {@link FileInfo} for the given file id
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the file path is not valid
-   * @throws AccessControlException if permission checking fails
    */
   // TODO(peis): Add an option not to load metadata.
-  FileInfo getFileInfo(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+  FileInfo getFileInfo(AlluxioURI path) throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * Returns the persistence state for a file id. This method is used by the lineage master.
@@ -118,12 +112,11 @@ public interface FileSystemMaster extends Master {
    * @param path the path to get the {@link FileInfo} list for
    * @param listStatusOptions the {@link alluxio.master.file.options.ListStatusOptions}
    * @return the list of {@link FileInfo}s
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the path is invalid
    */
   List<FileInfo> listStatus(AlluxioURI path, ListStatusOptions listStatusOptions)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException;
+      throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * @return a read-only view of the file system master
@@ -136,13 +129,12 @@ public interface FileSystemMaster extends Master {
    * @param path the root of the subtree to check
    * @param options the options to use for the checkConsistency method
    * @return a list of paths in Alluxio which are not consistent with the under storage
-   * @throws AccessControlException if the permission checking fails
    * @throws FileDoesNotExistException if the path does not exist
    * @throws InvalidPathException if the path is invalid
    * @throws IOException if an error occurs interacting with the under storage
    */
   List<AlluxioURI> checkConsistency(AlluxioURI path, CheckConsistencyOptions options)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException;
+      throws FileDoesNotExistException, InvalidPathException, IOException;
 
   /**
    * Completes a file. After a file is completed, it cannot be written to.
@@ -156,11 +148,10 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if an invalid path is encountered
    * @throws InvalidFileSizeException if an invalid file size is encountered
    * @throws FileAlreadyCompletedException if the file is already completed
-   * @throws AccessControlException if permission checking fails
    */
   void completeFile(AlluxioURI path, CompleteFileOptions options)
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
-      InvalidFileSizeException, FileAlreadyCompletedException, AccessControlException;
+      InvalidFileSizeException, FileAlreadyCompletedException;
 
   /**
    * Creates a file (not a directory) for a given path.
@@ -174,13 +165,11 @@ public interface FileSystemMaster extends Master {
    * @throws FileAlreadyExistsException if the file already exists
    * @throws BlockInfoException if an invalid block information is encountered
    * @throws IOException if the creation fails
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    * option is false
    */
-  long createFile(AlluxioURI path, CreateFileOptions options)
-      throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
-      BlockInfoException, IOException, FileDoesNotExistException;
+  long createFile(AlluxioURI path, CreateFileOptions options) throws InvalidPathException,
+      FileAlreadyExistsException, BlockInfoException, IOException, FileDoesNotExistException;
 
   /**
    * Reinitializes the blocks of an existing open file.
@@ -207,10 +196,8 @@ public interface FileSystemMaster extends Master {
    * @return the next block id for the given file
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the given path is not valid
-   * @throws AccessControlException if permission checking fails
    */
-  long getNewBlockIdForFile(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+  long getNewBlockIdForFile(AlluxioURI path) throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * @return a copy of the current mount table
@@ -237,12 +224,10 @@ public interface FileSystemMaster extends Master {
    * @throws DirectoryNotEmptyException if recursive is false and the file is a nonempty directory
    * @throws FileDoesNotExistException if the file does not exist
    * @throws IOException if an I/O error occurs
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   void delete(AlluxioURI path, DeleteOptions options) throws IOException,
-      FileDoesNotExistException, DirectoryNotEmptyException, InvalidPathException,
-      AccessControlException;
+      FileDoesNotExistException, DirectoryNotEmptyException, InvalidPathException;
 
   /**
    * Gets the {@link FileBlockInfo} for all blocks of a file. If path is a directory, an exception
@@ -254,10 +239,9 @@ public interface FileSystemMaster extends Master {
    * @return a list of {@link FileBlockInfo} for all the blocks of the given path
    * @throws FileDoesNotExistException if the file does not exist or path is a directory
    * @throws InvalidPathException if the path of the given file is invalid
-   * @throws AccessControlException if permission checking fails
    */
   List<FileBlockInfo> getFileBlockInfoList(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * @return absolute paths of all in memory files
@@ -275,13 +259,11 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException when the path is invalid
    * @throws FileAlreadyExistsException when there is already a file at path
    * @throws IOException if a non-Alluxio related exception occurs
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    */
-  long createDirectory(AlluxioURI path, CreateDirectoryOptions options)
-      throws InvalidPathException, FileAlreadyExistsException, IOException, AccessControlException,
-      FileDoesNotExistException;
+  long createDirectory(AlluxioURI path, CreateDirectoryOptions options) throws InvalidPathException,
+      FileAlreadyExistsException, IOException, FileDoesNotExistException;
 
   /**
    * Renames a file to a destination.
@@ -295,12 +277,11 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if a non-existent file is encountered
    * @throws InvalidPathException if an invalid path is encountered
    * @throws IOException if an I/O error occurs
-   * @throws AccessControlException if permission checking fails
    * @throws FileAlreadyExistsException if the file already exists
    */
   void rename(AlluxioURI srcPath, AlluxioURI dstPath, RenameOptions options)
       throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException, AccessControlException;
+      IOException;
 
   /**
    * Frees or evicts all of the blocks of the file from alluxio storage. If the given file is a
@@ -311,7 +292,6 @@ public interface FileSystemMaster extends Master {
    * @param path the path to free
    * @param options options to free
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the given path is invalid
    * @throws UnexpectedAlluxioException if the file or directory can not be freed
    */
@@ -320,8 +300,7 @@ public interface FileSystemMaster extends Master {
   // clients of earlier versions prior to 1.5. If a new exception is added, it will be converted
   // into RuntimeException on the client.
   void free(AlluxioURI path, FreeOptions options)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      UnexpectedAlluxioException;
+      throws FileDoesNotExistException, InvalidPathException, UnexpectedAlluxioException;
 
   /**
    * Gets the path of a file with the given id.
@@ -380,11 +359,10 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidFileSizeException if invalid file size is encountered
    * @throws FileAlreadyCompletedException if the file is already completed
    * @throws IOException if an I/O error occurs
-   * @throws AccessControlException if permission checking fails
    */
   long loadMetadata(AlluxioURI path, LoadMetadataOptions options)
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
-      InvalidFileSizeException, FileAlreadyCompletedException, IOException, AccessControlException;
+      InvalidFileSizeException, FileAlreadyCompletedException, IOException;
 
   /**
    * Mounts a UFS path onto an Alluxio path.
@@ -399,11 +377,10 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if the parent of the path to be mounted to does not exist
    * @throws InvalidPathException if an invalid path is encountered
    * @throws IOException if an I/O error occurs
-   * @throws AccessControlException if the permission check fails
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountOptions options)
       throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException, AccessControlException;
+      IOException;
 
   /**
    * Unmounts a UFS path previously mounted onto an Alluxio path.
@@ -415,25 +392,22 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if the path to be mounted does not exist
    * @throws InvalidPathException if the given path is not a mount point
    * @throws IOException if an I/O error occurs
-   * @throws AccessControlException if the permission check fails
    */
   void unmount(AlluxioURI alluxioPath)
-      throws FileDoesNotExistException, InvalidPathException, IOException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, IOException;
 
   /**
    * Resets a file. It first free the whole file, and then reinitializes it.
    *
    * @param fileId the id of the file
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid for the id of the file
    * @throws UnexpectedAlluxioException if the file or directory can not be freed
    */
   // Currently used by Lineage Master
   // TODO(binfan): Add permission checking for internal APIs
   void resetFile(long fileId)
-      throws UnexpectedAlluxioException, FileDoesNotExistException, InvalidPathException,
-      AccessControlException;
+      throws UnexpectedAlluxioException, FileDoesNotExistException, InvalidPathException;
 
   /**
    * Sets the file attribute.
@@ -445,11 +419,10 @@ public interface FileSystemMaster extends Master {
    * @param path the path to set attribute for
    * @param options attributes to be set, see {@link SetAttributeOptions}
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the given path is invalid
    */
   void setAttribute(AlluxioURI path, SetAttributeOptions options)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException;
+      throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * Schedules a file for async persistence.
@@ -469,10 +442,9 @@ public interface FileSystemMaster extends Master {
    * @return the command for persisting the blocks of a file
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the file path corresponding to the file id is invalid
-   * @throws AccessControlException if permission checking fails
    */
   FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException;
 
   /**
    * @return a list of {@link WorkerInfo} objects representing the workers in Alluxio

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -86,7 +86,7 @@ public final class PermissionChecker {
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser();
+    String user = AuthenticatedClientUser.getName();
     List<String> groups = CommonUtils.getGroups(user);
 
     // remove the last element if all components of the path exist, since we only check the parent.
@@ -114,7 +114,7 @@ public final class PermissionChecker {
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser();
+    String user = AuthenticatedClientUser.getName();
     List<String> groups = CommonUtils.getGroups(user);
 
     checkInodeList(user, groups, bits, inodePath.getUri().getPath(), inodeList, false);
@@ -134,7 +134,7 @@ public final class PermissionChecker {
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser();
+    String user = AuthenticatedClientUser.getName();
     List<String> groups = CommonUtils.getGroups(user);
     return getPermissionInternal(user, groups, inodePath.getUri().getPath(), inodeList);
   }
@@ -175,7 +175,7 @@ public final class PermissionChecker {
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser();
+    String user = AuthenticatedClientUser.getName();
     List<String> groups = CommonUtils.getGroups(user);
 
     if (isPrivilegedUser(user, groups)) {
@@ -190,7 +190,7 @@ public final class PermissionChecker {
    */
   private void checkSuperUser() {
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser();
+    String user = AuthenticatedClientUser.getName();
     List<String> groups = CommonUtils.getGroups(user);
     if (!isPrivilegedUser(user, groups)) {
       throw new PermissionDeniedException(ExceptionMessage.PERMISSION_DENIED

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -13,7 +13,6 @@ package alluxio.master.file;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
@@ -69,11 +68,10 @@ public final class PermissionChecker {
    *
    * @param bits bits that capture the action {@link Mode.Bits} by user
    * @param inodePath the path to check permission on
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   public void checkParentPermission(Mode.Bits bits, LockedInodePath inodePath)
-      throws AccessControlException, InvalidPathException {
+      throws InvalidPathException {
     if (!mPermissionCheckEnabled) {
       return;
     }
@@ -147,11 +145,10 @@ public final class PermissionChecker {
    * @param inodePath the path to check permission on
    * @param superuserRequired indicates whether it requires to be the superuser
    * @param ownerRequired indicates whether it requires to be the owner of this path
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   public void checkSetAttributePermission(LockedInodePath inodePath, boolean superuserRequired,
-      boolean ownerRequired) throws AccessControlException, InvalidPathException {
+      boolean ownerRequired) throws InvalidPathException {
     if (!mPermissionCheckEnabled) {
       return;
     }
@@ -171,11 +168,10 @@ public final class PermissionChecker {
    * Checks whether the client user is the owner of the path.
    *
    * @param inodePath path to be checked on
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   private void checkOwner(LockedInodePath inodePath)
-      throws AccessControlException, InvalidPathException {
+      throws InvalidPathException {
     // collects inodes info on the path
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
@@ -192,15 +188,13 @@ public final class PermissionChecker {
 
   /**
    * Checks whether the user is a super user or in super group.
-   *
-   * @throws AccessControlException if the user is not a super user
    */
-  private void checkSuperUser() throws AccessControlException {
+  private void checkSuperUser() {
     // collects user and groups
     String user = AuthenticatedClientUser.getClientUser();
     List<String> groups = CommonUtils.getGroups(user);
     if (!isPrivilegedUser(user, groups)) {
-      throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
+      throw new PermissionDeniedException(ExceptionMessage.PERMISSION_DENIED
           .getMessage(user + " is not a super user or in super group"));
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -17,6 +17,7 @@ import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.LockedInodePath;
@@ -26,8 +27,8 @@ import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 
-import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -88,7 +89,7 @@ public final class PermissionChecker {
 
     // collects user and groups
     String user = AuthenticatedClientUser.getClientUser();
-    List<String> groups = getGroups(user);
+    List<String> groups = CommonUtils.getGroups(user);
 
     // remove the last element if all components of the path exist, since we only check the parent.
     if (inodePath.fullPathExists()) {
@@ -103,11 +104,10 @@ public final class PermissionChecker {
    *
    * @param bits bits that capture the action {@link Mode.Bits} by user
    * @param inodePath the path to check permission on
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   public void checkPermission(Mode.Bits bits, LockedInodePath inodePath)
-      throws AccessControlException, InvalidPathException {
+      throws InvalidPathException {
     if (!mPermissionCheckEnabled) {
       return;
     }
@@ -117,7 +117,7 @@ public final class PermissionChecker {
 
     // collects user and groups
     String user = AuthenticatedClientUser.getClientUser();
-    List<String> groups = getGroups(user);
+    List<String> groups = CommonUtils.getGroups(user);
 
     checkInodeList(user, groups, bits, inodePath.getUri().getPath(), inodeList, false);
   }
@@ -136,13 +136,9 @@ public final class PermissionChecker {
     List<Inode<?>> inodeList = inodePath.getInodeList();
 
     // collects user and groups
-    try {
-      String user = AuthenticatedClientUser.getClientUser();
-      List<String> groups = getGroups(user);
-      return getPermissionInternal(user, groups, inodePath.getUri().getPath(), inodeList);
-    } catch (AccessControlException e) {
-      return Mode.Bits.NONE;
-    }
+    String user = AuthenticatedClientUser.getClientUser();
+    List<String> groups = CommonUtils.getGroups(user);
+    return getPermissionInternal(user, groups, inodePath.getUri().getPath(), inodeList);
   }
 
   /**
@@ -172,20 +168,6 @@ public final class PermissionChecker {
   }
 
   /**
-   * @param user the user to get groups for
-   * @return the groups for the given user
-   * @throws AccessControlException if the group service information cannot be accessed
-   */
-  private List<String> getGroups(String user) throws AccessControlException {
-    try {
-      return CommonUtils.getGroups(user);
-    } catch (IOException e) {
-      throw new AccessControlException(
-          ExceptionMessage.PERMISSION_DENIED.getMessage(e.getMessage()));
-    }
-  }
-
-  /**
    * Checks whether the client user is the owner of the path.
    *
    * @param inodePath path to be checked on
@@ -199,7 +181,7 @@ public final class PermissionChecker {
 
     // collects user and groups
     String user = AuthenticatedClientUser.getClientUser();
-    List<String> groups = getGroups(user);
+    List<String> groups = CommonUtils.getGroups(user);
 
     if (isPrivilegedUser(user, groups)) {
       return;
@@ -216,7 +198,7 @@ public final class PermissionChecker {
   private void checkSuperUser() throws AccessControlException {
     // collects user and groups
     String user = AuthenticatedClientUser.getClientUser();
-    List<String> groups = getGroups(user);
+    List<String> groups = CommonUtils.getGroups(user);
     if (!isPrivilegedUser(user, groups)) {
       throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
           .getMessage(user + " is not a super user or in super group"));
@@ -235,10 +217,9 @@ public final class PermissionChecker {
    * @param path the path to check permission on
    * @param inodeList file info list of all the inodes retrieved by traversing the path
    * @param checkIsOwner indicates whether to check the user is the owner of the path
-   * @throws AccessControlException if permission checking fails
    */
   private void checkInodeList(String user, List<String> groups, Mode.Bits bits,
-      String path, List<Inode<?>> inodeList, boolean checkIsOwner) throws AccessControlException {
+      String path, List<Inode<?>> inodeList, boolean checkIsOwner) {
     int size = inodeList.size();
     Preconditions
         .checkArgument(size > 0, PreconditionMessage.EMPTY_FILE_INFO_LIST_FOR_PERMISSION_CHECK);
@@ -258,7 +239,7 @@ public final class PermissionChecker {
       if (inode == null || user.equals(inode.getOwner())) {
         return;
       }
-      throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
+      throw new PermissionDeniedException(ExceptionMessage.PERMISSION_DENIED
           .getMessage("user=" + user + " is not the owner of path=" + path));
     }
     checkInode(user, groups, inode, bits, path);
@@ -272,10 +253,9 @@ public final class PermissionChecker {
    * @param inode whose attributes used for permission check logic
    * @param bits requested {@link Mode.Bits} by user
    * @param path the path to check permission on
-   * @throws AccessControlException if permission checking fails
    */
   private void checkInode(String user, List<String> groups, Inode<?> inode, Mode.Bits bits,
-      String path) throws AccessControlException {
+      String path) {
     if (inode == null) {
       return;
     }
@@ -294,8 +274,8 @@ public final class PermissionChecker {
       return;
     }
 
-    throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
-        .getMessage(toExceptionMessage(user, bits, path, inode)));
+    throw new PermissionDeniedException(
+        ExceptionMessage.PERMISSION_DENIED.getMessage(toExceptionMessage(user, bits, path, inode)));
   }
 
   /**
@@ -304,30 +284,20 @@ public final class PermissionChecker {
    * @param user the user
    * @param groups the groups this user belongs to
    * @param path the inode path
-   * @param inodeList the list of inodes in the path
+   * @param inodeList the list of inodes in the path, must not be empty
    * @return the permission
    */
   private Mode.Bits getPermissionInternal(String user, List<String> groups, String path,
       List<Inode<?>> inodeList) {
-    int size = inodeList.size();
-    Preconditions
-        .checkArgument(size > 0, PreconditionMessage.EMPTY_FILE_INFO_LIST_FOR_PERMISSION_CHECK);
+    Preconditions.checkArgument(!inodeList.isEmpty(),
+        PreconditionMessage.EMPTY_FILE_INFO_LIST_FOR_PERMISSION_CHECK);
 
     // bypass checking permission for super user or super group of Alluxio file system.
     if (isPrivilegedUser(user, groups)) {
       return Mode.Bits.ALL;
     }
 
-    // traverses from root to the parent dir to all inodes included by this path are executable
-    for (int i = 0; i < size - 1; i++) {
-      try {
-        checkInode(user, groups, inodeList.get(i), Mode.Bits.EXECUTE, path);
-      } catch (AccessControlException e) {
-        return Mode.Bits.NONE;
-      }
-    }
-
-    Inode inode = inodeList.get(inodeList.size() - 1);
+    Inode<?> inode = Iterables.getLast(inodeList);
     if (inode == null) {
       return Mode.Bits.NONE;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -170,8 +170,7 @@ public final class PermissionChecker {
    * @param inodePath path to be checked on
    * @throws InvalidPathException if the path is invalid
    */
-  private void checkOwner(LockedInodePath inodePath)
-      throws InvalidPathException {
+  private void checkOwner(LockedInodePath inodePath) throws InvalidPathException {
     // collects inodes info on the path
     List<Inode<?>> inodeList = inodePath.getInodeList();
 

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -14,7 +14,6 @@ package alluxio.master.file.async;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
@@ -80,8 +79,7 @@ public interface AsyncPersistHandler {
    * @return the list of files for persistence
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the path is invalid
-   * @throws AccessControlException if permission checking fails
    */
   List<PersistFile> pollFilesToPersist(long workerId)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException;
 }

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -146,11 +146,10 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
    * @return the list of files
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the path is invalid
-   * @throws AccessControlException if permission checking fails
    */
   @Override
   public synchronized List<PersistFile> pollFilesToPersist(long workerId)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException {
     List<PersistFile> filesToPersist = new ArrayList<>();
     List<Long> fileIdsToPersist = new ArrayList<>();
 

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.async;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
@@ -83,11 +82,9 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
    * @param path the path to the file
    * @return the id of the storing worker
    * @throws FileDoesNotExistException when the file does not exist on any worker
-   * @throws AccessControlException if permission checking fails
    */
   // TODO(calvin): Propagate the exceptions in certain cases
-  private long getWorkerStoringFile(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException {
+  private long getWorkerStoringFile(AlluxioURI path) throws FileDoesNotExistException {
     long fileId = mFileSystemMasterView.getFileId(path);
     if (mFileSystemMasterView.getFileInfo(fileId).getLength() == 0) {
       // if file is empty, return any worker

--- a/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
@@ -60,10 +60,8 @@ public final class FileSystemMasterView {
    * @param fileId the file id to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given file id
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission denied
    */
-  public synchronized FileInfo getFileInfo(long fileId)
-      throws FileDoesNotExistException, AccessControlException {
+  public synchronized FileInfo getFileInfo(long fileId) throws FileDoesNotExistException {
     return mFileSystemMaster.getFileInfo(fileId);
   }
 
@@ -93,10 +91,9 @@ public final class FileSystemMasterView {
    * @return a list of {@link FileBlockInfo} for all the blocks of the given file
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if the path of the given file is invalid
-   * @throws AccessControlException if permission checking fails
    */
   public synchronized List<FileBlockInfo> getFileBlockInfoList(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException {
     return mFileSystemMaster.getFileBlockInfoList(path);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.file.FileSystemMaster;
@@ -78,11 +77,9 @@ public final class FileSystemMasterView {
    *
    * @param path the path to get the file id for
    * @return the file id for a given path, or -1 if there is no file at that path
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if file does not exist
    */
-  public synchronized long getFileId(AlluxioURI path)
-      throws AccessControlException, FileDoesNotExistException {
+  public synchronized long getFileId(AlluxioURI path) throws FileDoesNotExistException {
     return mFileSystemMaster.getFileId(path);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -17,13 +17,13 @@ import alluxio.collections.ConcurrentHashSet;
 import alluxio.collections.FieldIndex;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.UniqueFieldIndex;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.block.ContainerIdGenerable;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
@@ -920,10 +920,8 @@ public class InodeTree implements JournalEntryIterable {
    * represents the root inode, the tree is "reset", and all state is cleared.
    *
    * @param entry the journal entry representing an inode
-   * @throws AccessControlException when owner of mRoot is not the owner of root journal entry
    */
-  public void addInodeDirectoryFromJournal(InodeDirectoryEntry entry)
-      throws AccessControlException {
+  public void addInodeDirectoryFromJournal(InodeDirectoryEntry entry) {
     InodeDirectory directory = InodeDirectory.fromJournalEntry(entry);
     if (directory.getName().equals(ROOT_INODE_NAME)) {
       // This is the root inode. Clear all the state, and set the root.
@@ -933,7 +931,7 @@ public class InodeTree implements JournalEntryIterable {
       if (SecurityUtils.isSecurityEnabled() && mRoot != null && !directory.getOwner().isEmpty()
           && !mRoot.getOwner().equals(directory.getOwner())) {
         // user is not the owner of journal root entry
-        throw new AccessControlException(
+        throw new PermissionDeniedException(
             ExceptionMessage.PERMISSION_DENIED.getMessage("Unauthorized user on root"));
       }
       mInodes.clear();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -12,10 +12,10 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.file.options.MountOptions;
 import alluxio.master.journal.JournalEntryIterable;
@@ -291,16 +291,16 @@ public final class MountTable implements JournalEntryIterable {
    *
    * @param alluxioUri an Alluxio path URI
    * @throws InvalidPathException if the Alluxio path is invalid
-   * @throws AccessControlException if the Alluxio path is under a readonly mount point
    */
   public void checkUnderWritableMountPoint(AlluxioURI alluxioUri)
-      throws InvalidPathException, AccessControlException {
+      throws InvalidPathException {
     try (LockResource r = new LockResource(mReadLock)) {
       // This will re-acquire the read lock, but that is allowed.
       String mountPoint = getMountPoint(alluxioUri);
       MountInfo mountInfo = mMountTable.get(mountPoint);
       if (mountInfo.getOptions().isReadOnly()) {
-        throw new AccessControlException(ExceptionMessage.MOUNT_READONLY, alluxioUri, mountPoint);
+        throw new PermissionDeniedException(
+            ExceptionMessage.MOUNT_READONLY.getMessage(alluxioUri, mountPoint));
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -54,10 +54,8 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     mRecursive = options.isRecursive();
     mTtl = options.getTtl();
     mTtlAction = ThriftUtils.fromThrift(options.getTtlAction());
-    if (SecurityUtils.isAuthenticationEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromThriftClient();
-      mGroup = SecurityUtils.getGroupFromThriftClient();
-    }
+    mOwner = SecurityUtils.getOwnerFromThriftClient();
+    mGroup = SecurityUtils.getGroupFromThriftClient();
     if (options.isSetMode()) {
       mMode = new Mode(options.getMode());
     } else {

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateFileOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateFileOptions.java
@@ -57,10 +57,8 @@ public final class CreateFileOptions extends CreatePathOptions<CreateFileOptions
     mRecursive = options.isRecursive();
     mTtl = options.getTtl();
     mTtlAction = ThriftUtils.fromThrift(options.getTtlAction());
-    if (SecurityUtils.isAuthenticationEnabled()) {
-      mOwner = SecurityUtils.getOwnerFromThriftClient();
-      mGroup = SecurityUtils.getGroupFromThriftClient();
-    }
+    mOwner = SecurityUtils.getOwnerFromThriftClient();
+    mGroup = SecurityUtils.getGroupFromThriftClient();
     if (options.isSetMode()) {
       mMode = new Mode(options.getMode());
     } else {

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -17,7 +17,6 @@ import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.Server;
 import alluxio.clock.SystemClock;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
@@ -183,12 +182,11 @@ public final class LineageMaster extends AbstractMaster {
    * @throws FileAlreadyExistsException if the output file already exists
    * @throws BlockInfoException if fails to create the output file
    * @throws IOException if the creation of a file fails
-   * @throws AccessControlException if the permission check fails
    * @throws FileDoesNotExistException if any of the input files do not exist
    */
   public synchronized long createLineage(List<AlluxioURI> inputFiles, List<AlluxioURI> outputFiles,
       Job job) throws InvalidPathException, FileAlreadyExistsException, BlockInfoException,
-      IOException, AccessControlException, FileDoesNotExistException {
+      IOException, FileDoesNotExistException {
     List<Long> inputAlluxioFiles = new ArrayList<>();
     for (AlluxioURI inputFile : inputFiles) {
       long fileId;
@@ -277,13 +275,11 @@ public final class LineageMaster extends AbstractMaster {
    * @return the id of the reinitialized file when the file is lost or not completed, -1 otherwise
    * @throws InvalidPathException the file path is invalid
    * @throws LineageDoesNotExistException when the file does not exist
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the path does not exist
    */
   public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl,
       TtlAction ttlAction)
-      throws InvalidPathException, LineageDoesNotExistException, AccessControlException,
-      FileDoesNotExistException {
+          throws InvalidPathException, LineageDoesNotExistException, FileDoesNotExistException {
     long fileId = mFileSystemMaster.getFileId(new AlluxioURI(path));
     FileInfo fileInfo;
     try {
@@ -364,11 +360,10 @@ public final class LineageMaster extends AbstractMaster {
    *
    * @param path the path to the file
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   public synchronized void reportLostFile(String path) throws FileDoesNotExistException,
-      AccessControlException, InvalidPathException {
+      InvalidPathException {
     long fileId = mFileSystemMaster.getFileId(new AlluxioURI(path));
     mFileSystemMaster.reportLostFile(fileId);
   }

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.checkpoint;
 
-import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.lineage.meta.Lineage;
@@ -57,7 +56,7 @@ public final class CheckpointLatestPlanner implements CheckpointPlanner {
             || LineageStateUtils.isInCheckpointing(lineage, fileSystemMasterView)) {
           continue;
         }
-      } catch (FileDoesNotExistException | AccessControlException e) {
+      } catch (FileDoesNotExistException e) {
         LOG.error("The lineage file does not exist", e);
         continue;
       }

--- a/core/server/master/src/main/java/alluxio/master/lineage/meta/LineageStateUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/meta/LineageStateUtils.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.meta;
 
-import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.file.meta.PersistenceState;
@@ -36,10 +35,9 @@ public final class LineageStateUtils {
    * @param fileSystemMasterView the view of the file system master where the output file lies
    * @return true if all the output files of the given lineage are completed, false otherwise
    * @throws FileDoesNotExistException if the file does not exist
-   * @throws AccessControlException if permission denied
    */
   public static boolean isCompleted(Lineage lineage, FileSystemMasterView fileSystemMasterView)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException {
     for (long outputFile : lineage.getOutputFiles()) {
       FileInfo fileInfo = fileSystemMasterView.getFileInfo(outputFile);
       if (!fileInfo.isCompleted()) {

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -112,7 +112,7 @@ public final class RecomputeExecutor implements HeartbeatExecutor {
               LOG.error("the lost file {} does not exist", fileId, e);
             } catch (InvalidPathException e) {
               LOG.error("the lost file {} is invalid", fileId, e);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
               LOG.error("failed to reset {}", fileId, e);
             }
           }

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.lineage.recompute;
 
-import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.UnexpectedAlluxioException;
@@ -113,8 +112,8 @@ public final class RecomputeExecutor implements HeartbeatExecutor {
               LOG.error("the lost file {} does not exist", fileId, e);
             } catch (InvalidPathException e) {
               LOG.error("the lost file {} is invalid", fileId, e);
-            } catch (AccessControlException e) {
-              LOG.error("the lost file {} cannot be accessed", fileId, e);
+            } catch (Exception e) {
+              LOG.error("failed to reset {}", fileId, e);
             }
           }
         } catch (FileDoesNotExistException e) {

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
@@ -20,10 +20,10 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.OpenFileOptions;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.MasterProcess;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.FileSystemMaster;
@@ -211,8 +211,8 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
           "Error: File " + currentPath + " is not available " + e.getMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (AccessControlException e) {
-      request.setAttribute("invalidPathError",
+    } catch (PermissionDeniedException e) {
+      request.setAttribute("PermissionDeniedException",
           "Error: File " + currentPath + " cannot be accessed " + e.getMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
@@ -244,8 +244,8 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
         request.setAttribute("InvalidPathException",
             "Error: invalid path " + e.getMessage());
         getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
-      } catch (AccessControlException e) {
-        request.setAttribute("AccessControlException",
+      } catch (PermissionDeniedException e) {
+        request.setAttribute("PermissionDeniedException",
             "Error: File " + currentPath + " cannot be accessed " + e.getMessage());
         getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
         return;
@@ -294,10 +294,9 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
    * @param request the {@link HttpServletRequest} object
    * @throws FileDoesNotExistException if the file does not exist
    * @throws InvalidPathException if an invalid path is encountered
-   * @throws AccessControlException if permission checking fails
    */
   private void setPathDirectories(AlluxioURI path, HttpServletRequest request)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException {
     FileSystemMaster fileSystemMaster = mMasterProcess.getMaster(FileSystemMaster.class);
     if (path.isRoot()) {
       request.setAttribute("pathInfos", new UIFileInfo[0]);

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceMemoryServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceMemoryServlet.java
@@ -14,8 +14,8 @@ package alluxio.web;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.MasterProcess;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.security.LoginUser;
@@ -90,7 +90,7 @@ public final class WebInterfaceMemoryServlet extends HttpServlet {
             "Error: File does not exist " + e.getLocalizedMessage());
         getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
         return;
-      } catch (AccessControlException e) {
+      } catch (PermissionDeniedException e) {
         request.setAttribute("permissionError",
             "Error: File " + file + " cannot be accessed " + e.getMessage());
         getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -17,7 +17,6 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.LoginUserRule;
 import alluxio.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.status.PermissionDeniedException;
@@ -804,7 +803,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void setOwnerFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(TEST_USER_2.getUser() + " is not a super user or in super group");
     verifySetAcl(TEST_USER_2, TEST_FILE_URI, TEST_USER_1.getUser(), null, (short) -1, false);
   }
@@ -883,7 +882,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void setAclFailByNotSuperUser() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(TEST_USER_2.getUser() + " is not a super user or in super group");
 
     verifySetAcl(TEST_USER_2, TEST_FILE_URI, TEST_USER_1.getUser(), TEST_USER_1.getGroup(),

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -20,6 +20,7 @@ import alluxio.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.MasterRegistry;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
@@ -62,7 +63,6 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -163,7 +163,7 @@ public final class PermissionCheckTest {
     }
 
     @Override
-    public List<String> getGroups(String user) throws IOException {
+    public List<String> getGroups(String user) {
       if (mUserGroups.containsKey(user)) {
         return Lists.newArrayList(mUserGroups.get(user).split(","));
       }
@@ -287,7 +287,7 @@ public final class PermissionCheckTest {
    */
   @Test
   public void createUnderRootFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED
         .getMessage(toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, "/file1", "/")));
     // create "/file1" for user1
@@ -302,7 +302,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void createFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_URI + "/file1",
             "testDir")));
@@ -340,7 +340,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void mkdirUnderRootByUser() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED
         .getMessage(toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, "/dir1", "/")));
 
@@ -356,7 +356,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void mkdirFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_URI + "/dir1",
             "testDir")));
@@ -396,7 +396,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void renameUnderRootFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, TEST_FILE_URI, "/")));
 
@@ -423,7 +423,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void renameFailBySrc() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_FILE_URI, "testDir")));
 
@@ -433,7 +433,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void renameFailByDst() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, "/fileRenamed", "/")));
 
@@ -461,7 +461,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void deleteUnderRootFailed() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED
         .getMessage(toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, TEST_DIR_URI, "/")));
 
@@ -487,7 +487,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void deleteUnderRootFailOnDir() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED
         .getMessage(toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_URI, "/")));
 
@@ -497,7 +497,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void deleteUnderRootFailOnFile() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, TEST_FILE_URI, "/")));
 
@@ -513,7 +513,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void deleteFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_FILE_URI, "testDir")));
 
@@ -542,7 +542,7 @@ public final class PermissionCheckTest {
   public void readFileIdFail() throws Exception {
     String file = createUnreadableFileOrDir(true);
 
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, file, "onlyReadByUser1")));
     verifyGetFileId(TEST_USER_2, file);
@@ -552,7 +552,7 @@ public final class PermissionCheckTest {
   public void readFileInfoFail() throws Exception {
     String file = createUnreadableFileOrDir(true);
 
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, file, "onlyReadByUser1")));
     verifyGetFileInfoOrList(TEST_USER_2, file, true);
@@ -562,7 +562,7 @@ public final class PermissionCheckTest {
   public void readDirIdFail() throws Exception {
     String dir = createUnreadableFileOrDir(false);
 
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, dir, "onlyReadByUser1")));
     verifyGetFileId(TEST_USER_2, dir);
@@ -572,7 +572,7 @@ public final class PermissionCheckTest {
   public void readDirInfoFail() throws Exception {
     String dir = createUnreadableFileOrDir(false);
 
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, dir, "onlyReadByUser1")));
     try (Closeable r = new AuthenticatedUserRule(TEST_USER_2.getUser()).toResource()) {
@@ -590,7 +590,7 @@ public final class PermissionCheckTest {
       verifyCreateDirectory(TEST_USER_1, dir, false);
       verifyRead(TEST_USER_1, dir, false);
 
-      mThrown.expect(AccessControlException.class);
+      mThrown.expect(PermissionDeniedException.class);
       mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
           toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.EXECUTE, dir, "notExecuteDir")));
       verifyGetFileInfoOrList(TEST_USER_2, dir, false);
@@ -672,7 +672,7 @@ public final class PermissionCheckTest {
       verifyCreateFile(TEST_USER_1, file, false);
       SetAttributeOptions expect = getNonDefaultSetState();
 
-      mThrown.expect(AccessControlException.class);
+      mThrown.expect(PermissionDeniedException.class);
       mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
           toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, file, "testState1")));
       verifySetState(TEST_USER_2, file, expect);
@@ -719,7 +719,7 @@ public final class PermissionCheckTest {
       verifyCreateFile(TEST_USER_1, file, false);
       CompleteFileOptions expect = getNonDefaultCompleteFileOptions();
 
-      mThrown.expect(AccessControlException.class);
+      mThrown.expect(PermissionDeniedException.class);
       mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
           toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, file, "testComplete1")));
       verifyCompleteFile(TEST_USER_2, file, expect);
@@ -765,7 +765,7 @@ public final class PermissionCheckTest {
       String file = PathUtils.concatPath(TEST_DIR_URI, "testComplete1");
       verifyCreateFile(TEST_USER_1, file, false);
 
-      mThrown.expect(AccessControlException.class);
+      mThrown.expect(PermissionDeniedException.class);
       mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
           toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, file, "testComplete1")));
       verifyFree(TEST_USER_2, file, false);
@@ -780,7 +780,7 @@ public final class PermissionCheckTest {
       String file = PathUtils.concatPath(TEST_DIR_URI + "/testComplete1");
       verifyCreateFile(TEST_USER_1, file, false);
 
-      mThrown.expect(AccessControlException.class);
+      mThrown.expect(PermissionDeniedException.class);
       mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
           toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.READ, file, "testComplete1")));
       verifyFree(TEST_USER_2, file, false);
@@ -830,7 +830,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void setGroupFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         "user=" + TEST_USER_1.getUser() + " is not the owner of path=" + TEST_FILE_URI));
 
@@ -860,7 +860,7 @@ public final class PermissionCheckTest {
 
   @Test
   public void setPermissionFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         "user=" + TEST_USER_1.getUser() + " is not the owner of path=" + TEST_FILE_URI));
 

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -16,9 +16,9 @@ import alluxio.Configuration;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.MasterRegistry;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
@@ -49,7 +49,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -148,7 +147,7 @@ public final class PermissionCheckerTest {
     }
 
     @Override
-    public List<String> getGroups(String user) throws IOException {
+    public List<String> getGroups(String user) {
       if (mUserGroups.containsKey(user)) {
         return Lists.newArrayList(mUserGroups.get(user).split(","));
       }
@@ -279,7 +278,7 @@ public final class PermissionCheckerTest {
 
   @Test
   public void selfCheckFailByOtherGroup() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_FILE_URI,
             "file")));
@@ -290,7 +289,7 @@ public final class PermissionCheckerTest {
 
   @Test
   public void selfCheckFailBySameGroup() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_3.getUser(), Mode.Bits.WRITE, TEST_DIR_FILE_URI,
             "file")));
@@ -315,7 +314,7 @@ public final class PermissionCheckerTest {
 
   @Test
   public void parentCheckFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_DIR_FILE_URI,
             "testDir")));
@@ -330,7 +329,7 @@ public final class PermissionCheckerTest {
 
   @Test
   public void ancestorCheckFail() throws Exception {
-    mThrown.expect(AccessControlException.class);
+    mThrown.expect(PermissionDeniedException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
         toExceptionMessage(TEST_USER_2.getUser(), Mode.Bits.WRITE, TEST_NOT_EXIST_URI,
             "testDir")));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -12,10 +12,10 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.file.options.MountOptions;
 
@@ -193,7 +193,7 @@ public final class MountTableTest {
     try {
       mMountTable.checkUnderWritableMountPoint(alluxioUri);
       Assert.fail("Readonly mount point should not be writable.");
-    } catch (AccessControlException e) {
+    } catch (PermissionDeniedException e) {
       // Exception expected
       Assert.assertEquals(ExceptionMessage.MOUNT_READONLY.getMessage(alluxioUri, mountPath),
           e.getMessage());
@@ -204,7 +204,7 @@ public final class MountTableTest {
       alluxioUri = new AlluxioURI("alluxio://localhost:1234" + path);
       mMountTable.checkUnderWritableMountPoint(alluxioUri);
       Assert.fail("Readonly mount point should not be writable.");
-    } catch (AccessControlException e) {
+    } catch (PermissionDeniedException e) {
       // Exception expected
       Assert.assertEquals(ExceptionMessage.MOUNT_READONLY.getMessage(alluxioUri, mountPath),
           e.getMessage());
@@ -223,7 +223,7 @@ public final class MountTableTest {
 
     try {
       mMountTable.checkUnderWritableMountPoint(alluxioUri);
-    } catch (AccessControlException e) {
+    } catch (PermissionDeniedException e) {
       Assert.fail("Default mount point should be writable.");
     }
 
@@ -231,7 +231,7 @@ public final class MountTableTest {
       String path = mountPath + "/sub/directory";
       alluxioUri = new AlluxioURI("alluxio://localhost:1234" + path);
       mMountTable.checkUnderWritableMountPoint(alluxioUri);
-    } catch (AccessControlException e) {
+    } catch (PermissionDeniedException e) {
       Assert.fail("Default mount point should be writable.");
     }
   }

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.Server;
 import alluxio.clock.SystemClock;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
@@ -146,12 +145,11 @@ public final class KeyValueMaster extends AbstractMaster {
    *
    * @param path URI of the key-value store
    * @param info information of this completed partition
-   * @throws AccessControlException if permission checking fails
    * @throws FileDoesNotExistException if the key-value store URI does not exists
    * @throws InvalidPathException if the path is invalid
    */
   public synchronized void completePartition(AlluxioURI path, PartitionInfo info)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+      throws FileDoesNotExistException, InvalidPathException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -190,10 +188,9 @@ public final class KeyValueMaster extends AbstractMaster {
    * @param path URI of the key-value store
    * @throws FileDoesNotExistException if the key-value store URI does not exists
    * @throws InvalidPathException if the path is not valid
-   * @throws AccessControlException if permission checking fails
    */
   public synchronized void completeStore(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -226,10 +223,9 @@ public final class KeyValueMaster extends AbstractMaster {
    * @param path URI of the key-value store
    * @throws FileAlreadyExistsException if a key-value store URI exists
    * @throws InvalidPathException if the given path is invalid
-   * @throws AccessControlException if permission checking fails
    */
   public synchronized void createStore(AlluxioURI path)
-      throws FileAlreadyExistsException, InvalidPathException, AccessControlException {
+      throws FileAlreadyExistsException, InvalidPathException {
     try {
       // Create this dir
       mFileSystemMaster
@@ -294,8 +290,7 @@ public final class KeyValueMaster extends AbstractMaster {
     mCompleteStoreToPartitions.remove(fileId);
   }
 
-  private long getFileId(AlluxioURI uri)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+  private long getFileId(AlluxioURI uri) throws FileDoesNotExistException, InvalidPathException {
     long fileId = mFileSystemMaster.getFileId(uri);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
@@ -392,11 +387,10 @@ public final class KeyValueMaster extends AbstractMaster {
    * @param path URI of the key-value store
    * @return a list of partition information
    * @throws FileDoesNotExistException if the key-value store URI does not exists
-   * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   public synchronized List<PartitionInfo> getPartitionInfo(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException {
+      throws FileDoesNotExistException, InvalidPathException {
     long fileId = getFileId(path);
     List<PartitionInfo> partitions = mCompleteStoreToPartitions.get(fileId);
     if (partitions == null) {

--- a/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
@@ -51,7 +51,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
@@ -637,7 +636,7 @@ public class UfsJournalIntegrationTest {
     }
 
     @Override
-    public List<String> getGroups(String user) throws IOException {
+    public List<String> getGroups(String user) {
       if (mUserGroups.containsKey(user)) {
         return Lists.newArrayList(mUserGroups.get(user).split(","));
       }


### PR DESCRIPTION
- Use the PermissionDenied status exception over AccessControlException
- Improve some error messages
- Throw exceptions instead of returning empty strings when authentication is disabled but user/group are looked up