### PR TITLE
[SMALLFIX] Some improvements to mini benchmark 

### DIFF
--- a/examples/src/main/java/alluxio/cli/MiniBenchmark.java
+++ b/examples/src/main/java/alluxio/cli/MiniBenchmark.java
@@ -169,8 +169,9 @@ public final class MiniBenchmark {
       executorService.shutdown();
       Preconditions.checkState(executorService.awaitTermination(1, TimeUnit.HOURS));
       double time = runtime.get() * 1.0 / sConcurrency / Constants.SECOND_NANO;
-      System.out.printf("Iteration: %d; Duration: %f seconds; Aggregated throughput: %f GB/second.%n",
-          i, time, sConcurrency * 1.0 * sFileSize / time / Constants.GB);
+      System.out
+          .printf("Iteration: %d; Duration: %f seconds; Aggregated throughput: %f GB/second.%n", i,
+              time, sConcurrency * 1.0 * sFileSize / time / Constants.GB);
     }
   }
 

--- a/examples/src/main/java/alluxio/cli/MiniBenchmark.java
+++ b/examples/src/main/java/alluxio/cli/MiniBenchmark.java
@@ -31,10 +31,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -127,11 +129,11 @@ public final class MiniBenchmark {
 
     CommonUtils.warmUpLoop();
 
-    long start = System.nanoTime();
-
     for (int i = 0; i < sIterations; ++i) {
       final AtomicInteger count = new AtomicInteger(0);
+      final CyclicBarrier barrier = new CyclicBarrier(sConcurrency);
       ExecutorService executorService = Executors.newFixedThreadPool(sConcurrency);
+      final AtomicLong runtime = new AtomicLong(0);
       for (int j = 0; j < sConcurrency; ++j) {
         switch (sType) {
           case READ:
@@ -139,7 +141,7 @@ public final class MiniBenchmark {
               @Override
               public void run() {
                 try {
-                  readFile(count.addAndGet(1));
+                  readFile(barrier, runtime, count.addAndGet(1));
                 } catch (Exception e) {
                   LOG.error("Failed to read file.", e);
                   System.exit(-1);
@@ -152,7 +154,7 @@ public final class MiniBenchmark {
               @Override
               public void run() {
                 try {
-                  writeFile(count.addAndGet(1));
+                  writeFile(barrier, runtime, count.addAndGet(1));
                 } catch (Exception e) {
                   LOG.error("Failed to write file.", e);
                   System.exit(-1);
@@ -166,9 +168,10 @@ public final class MiniBenchmark {
       }
       executorService.shutdown();
       Preconditions.checkState(executorService.awaitTermination(1, TimeUnit.HOURS));
+      double time = runtime.get() * 1.0 / sConcurrency / Constants.SECOND_NANO;
+      System.out.printf("Iteration: %d; Duration: %f seconds; Aggregated throughput: %f GB/second.%n",
+          i, time, sConcurrency * 1.0 * sFileSize / time / Constants.GB);
     }
-    System.out.printf("Runtime: %f seconds.%n",
-        (System.nanoTime() - start) * 1.0 / Constants.SECOND_NANO);
   }
 
   /**
@@ -177,14 +180,18 @@ public final class MiniBenchmark {
    * @param count the count to determine the filename
    * @throws Exception if it fails to read
    */
-  private static void readFile(int count) throws Exception {
+  private static void readFile(CyclicBarrier barrier, AtomicLong runTime, int count)
+      throws Exception {
     FileSystem fileSystem = FileSystem.Factory.get();
     byte[] buffer = new byte[(int) Math.min(sFileSize, 4 * Constants.MB)];
 
+    barrier.await();
+    long startTime = System.nanoTime();
     try (FileInStream inStream = fileSystem.openFile(filename(count))) {
       while (inStream.read(buffer) != -1) {
       }
     }
+    runTime.addAndGet(System.nanoTime() - startTime);
   }
 
   /**
@@ -193,7 +200,8 @@ public final class MiniBenchmark {
    * @param count the count to determine the filename
    * @throws Exception if it fails to write
    */
-  private static void writeFile(int count) throws Exception {
+  private static void writeFile(CyclicBarrier barrier, AtomicLong runtime, int count)
+      throws Exception {
     FileSystem fileSystem = FileSystem.Factory.get();
     byte[] buffer = new byte[(int) Math.min(sFileSize, 4 * Constants.MB)];
     Arrays.fill(buffer, (byte) 'a');
@@ -203,6 +211,8 @@ public final class MiniBenchmark {
       fileSystem.delete(path);
     }
 
+    barrier.await();
+    long startTime = System.nanoTime();
     long bytesWritten = 0;
     try (FileOutStream outStream = fileSystem.createFile(path)) {
       while (bytesWritten < sFileSize) {
@@ -210,6 +220,7 @@ public final class MiniBenchmark {
         bytesWritten += buffer.length;
       }
     }
+    runtime.addAndGet(System.nanoTime() - startTime);
   }
 
   private static AlluxioURI filename(int count) {


### PR DESCRIPTION
Count runtime more accurately.
Separate results from different iterations as the runtime can vary from iteration to iteration.