### PR TITLE
[SMALLFIX] Temporarily ignore flaky MasterFaultToleranceIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Ignore("https://alluxio.atlassian.net/browse/ALLUXIO-2818")
 public class MasterFaultToleranceIntegrationTest {
   // Fail if the cluster doesn't come up after this amount of time.
   private static final int CLUSTER_WAIT_TIMEOUT_MS = 120 * Constants.SECOND_MS;


### PR DESCRIPTION
This has been failing a lot of builds and pull request builds lately. Lets ignore it until we have it fixed