### PR TITLE
[SMALLFIX] Clean up session info test.

### DIFF
--- a/core/server/worker/src/test/java/alluxio/SessionInfoTest.java
+++ b/core/server/worker/src/test/java/alluxio/SessionInfoTest.java
@@ -12,7 +12,6 @@
 package alluxio;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -22,16 +21,7 @@ public final class SessionInfoTest {
   private static final int MIN_LEN = 1;
   private static final int MAX_LEN = 1000;
   private static final int DELTA = 50;
-
-  private int mSessionTimeoutMs;
-
-  /**
-   * Sets up the configuration for Alluxio before a test runs.
-   */
-  @Before
-  public final void before() {
-    mSessionTimeoutMs = Configuration.getInt(PropertyKey.WORKER_SESSION_TIMEOUT_MS);
-  }
+  private static final int SESSION_TIMEOUT_MS = 1000;
 
   /**
    * Tests the {@link SessionInfo#SessionInfo(long, int)} constructor.
@@ -39,7 +29,7 @@ public final class SessionInfoTest {
   @Test
   public void constructor() {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
-      SessionInfo tSessionInfo = new SessionInfo(k, mSessionTimeoutMs);
+      SessionInfo tSessionInfo = new SessionInfo(k, SESSION_TIMEOUT_MS);
       Assert.assertEquals(k, tSessionInfo.getSessionId());
     }
   }
@@ -51,7 +41,7 @@ public final class SessionInfoTest {
   @Test(expected = RuntimeException.class)
   public void constructorWithException() {
     for (int k = 0; k >= -1000; k -= DELTA) {
-      SessionInfo tSessionInfo = new SessionInfo(k, mSessionTimeoutMs);
+      SessionInfo tSessionInfo = new SessionInfo(k, SESSION_TIMEOUT_MS);
       Assert.assertEquals(k, tSessionInfo.getSessionId());
       Assert.fail("SessionId " + k + " should be invalid.");
     }
@@ -63,7 +53,7 @@ public final class SessionInfoTest {
   @Test
   public void getSessionId() {
     for (int k = MIN_LEN; k < MAX_LEN; k += 66) {
-      SessionInfo tSessionInfo = new SessionInfo(k, mSessionTimeoutMs);
+      SessionInfo tSessionInfo = new SessionInfo(k, SESSION_TIMEOUT_MS);
       Assert.assertEquals(k, tSessionInfo.getSessionId());
     }
   }
@@ -73,7 +63,7 @@ public final class SessionInfoTest {
    */
   @Test
   public void timeout() {
-    SessionInfo tSessionInfo = new SessionInfo(1, mSessionTimeoutMs);
+    SessionInfo tSessionInfo = new SessionInfo(1, SESSION_TIMEOUT_MS);
     Assert.assertFalse(tSessionInfo.timeout());
   }
 }


### PR DESCRIPTION
Unnecessarily uses configuration.