### PR TITLE
[SMALLFIX] Fix typo in alluxio-mount.sh

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -88,7 +88,7 @@ function mount_ramfs_linux() {
 
 function mount_ramfs_mac() {
   # Convert the memory size to number of sectors. Each sector is 512 Byte.
-  local num_sectors=$(${bin}/alluxio runClass alluxio.util.HFSUtils ${MEM_SIZE} 512)
+  local num_sectors=$(${BIN}/alluxio runClass alluxio.util.HFSUtils ${MEM_SIZE} 512)
 
   # Format the RAM FS
   # We may have a pre-existing RAM FS which we need to throw away


### PR DESCRIPTION
Fix the typo 

@LuQQiu  it should be `${BIN}` rather than `${bin}` in your previous PR, as a lot of shell (e.g., BASH)  are case sensitive