### PR TITLE
[SMALLFIX] Add 10s timeout for the wait for ready method.

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -21,6 +21,7 @@ import alluxio.metrics.sink.MetricsServlet;
 import alluxio.security.authentication.TransportProvider;
 import alluxio.thrift.MetaMasterClientService;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.web.MasterWebServer;
@@ -178,7 +179,7 @@ public class AlluxioMasterProcess implements MasterProcess {
         return mThriftServer != null && mThriftServer.isServing()
             && mWebServer != null && mWebServer.getServer().isRunning();
       }
-    });
+    }, WaitForOptions.defaults().setTimeout(10000));
   }
 
   @Override

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
@@ -15,6 +15,7 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.web.ProxyWebServer;
@@ -117,7 +118,7 @@ public final class AlluxioProxyProcess implements ProxyProcess {
           return false;
         }
       }
-    });
+    }, WaitForOptions.defaults().setTimeout(10000));
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -23,6 +23,7 @@ import alluxio.security.authentication.TransportProvider;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.WorkerUfsManager;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.web.WebServer;
@@ -329,7 +330,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
         return mThriftServer.isServing() && mRegistry.get(BlockWorker.class).getWorkerId() != null
             && mWebServer.getServer().isRunning();
       }
-    });
+    }, WaitForOptions.defaults().setTimeout(10000));
   }
 
   @Override


### PR DESCRIPTION
Prevents integration tests from waiting indefinitely when a cluster resource is being created.