### PR TITLE
[ALLUXIO-2813] Move session logic to netty

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockOutStream.java
@@ -78,10 +78,9 @@ public class BlockOutStream extends FilterOutputStream implements BoundedStream,
       WorkerNetAddress workerNetAddress, FileSystemContext context, OutStreamOptions options) {
     Closer closer = Closer.create();
     try {
-      BlockWorkerClient client = closer.register(context.createBlockWorkerClient(workerNetAddress));
-      PacketOutStream outStream = closer.register(PacketOutStream
-          .createNettyPacketOutStream(context, workerNetAddress, client.getSessionId(), blockId,
-              blockSize, Protocol.RequestType.ALLUXIO_BLOCK, options));
+      PacketOutStream outStream =
+          closer.register(PacketOutStream.createNettyPacketOutStream(context, workerNetAddress,
+              blockId, blockSize, Protocol.RequestType.ALLUXIO_BLOCK, options));
       return new BlockOutStream(outStream, closer, options);
     } catch (RuntimeException e) {
       CommonUtils.closeQuietly(closer);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -111,15 +111,14 @@ public final class NettyPacketWriter implements PacketWriter {
    * @param address the data server address
    * @param id the block ID or UFS file ID
    * @param length the length of the block or file to write, set to Long.MAX_VALUE if unknown
-   * @param sessionId the session ID
    * @param tier the target tier
    * @param type the request type (block or UFS file)
    * @param packetSize the packet size
    */
   public NettyPacketWriter(FileSystemContext context, final WorkerNetAddress address, long id,
-      long length, long sessionId, int tier, Protocol.RequestType type, long packetSize) {
-    this(context, address, length, Protocol.WriteRequest.newBuilder().setId(id)
-        .setSessionId(sessionId).setTier(tier).setType(type).buildPartial(), packetSize);
+      long length, int tier, Protocol.RequestType type, long packetSize) {
+    this(context, address, length, Protocol.WriteRequest.newBuilder().setId(id).setTier(tier)
+        .setType(type).buildPartial(), packetSize);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/PacketOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/PacketOutStream.java
@@ -72,7 +72,6 @@ public class PacketOutStream extends OutputStream implements BoundedStream, Quie
    *
    * @param context the file system context
    * @param address the netty data server address
-   * @param sessionId the session ID
    * @param id the ID (block ID or UFS file ID)
    * @param length the block or file length
    * @param type the request type (either block write or UFS file write)
@@ -80,12 +79,13 @@ public class PacketOutStream extends OutputStream implements BoundedStream, Quie
    * @return the {@link PacketOutStream} created
    */
   public static PacketOutStream createNettyPacketOutStream(FileSystemContext context,
-      WorkerNetAddress address, long sessionId, long id, long length,
-      Protocol.RequestType type, OutStreamOptions options) {
+      WorkerNetAddress address, long id, long length, Protocol.RequestType type,
+      OutStreamOptions options) {
     long packetSize =
         Configuration.getBytes(PropertyKey.USER_NETWORK_NETTY_WRITER_PACKET_SIZE_BYTES);
-    PacketWriter packetWriter = new NettyPacketWriter(
-        context, address, id, length, sessionId, options.getWriteTier(), type, packetSize);
+    PacketWriter packetWriter =
+        new NettyPacketWriter(context, address, id, length, options.getWriteTier(), type,
+            packetSize);
     return new PacketOutStream(packetWriter, length);
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
@@ -52,7 +52,7 @@ public final class UnderFileSystemFileOutStream extends FilterOutputStream {
   public UnderFileSystemFileOutStream(FileSystemContext context, WorkerNetAddress address,
       OutStreamOptions options) {
     super(PacketOutStream.createNettyPacketOutStream(context, address, Long.MAX_VALUE,
-        Protocol.WriteRequest.newBuilder().setSessionId(-1).setTier(TIER_UNUSED)
+        Protocol.WriteRequest.newBuilder().setTier(TIER_UNUSED)
             .setType(Protocol.RequestType.UFS_FILE).setMountId(options.getMountId())
             .setUfsPath(options.getUfsPath()).setOwner(options.getOwner())
             .setGroup(options.getGroup()).setMode(options.getMode().toShort()).buildPartial(),

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
@@ -58,7 +58,6 @@ public final class NettyPacketWriterTest {
 
   private static final Random RANDOM = new Random();
   private static final long BLOCK_ID = 1L;
-  private static final long SESSION_ID = 2L;
   private static final int TIER = 0;
 
   private FileSystemContext mContext;
@@ -166,7 +165,7 @@ public final class NettyPacketWriterTest {
    */
   private PacketWriter create(long length) throws Exception {
     PacketWriter writer =
-        new NettyPacketWriter(mContext, mAddress, BLOCK_ID, length, SESSION_ID, TIER,
+        new NettyPacketWriter(mContext, mAddress, BLOCK_ID, length, TIER,
             Protocol.RequestType.ALLUXIO_BLOCK, PACKET_SIZE);
     mChannel.finishChannelCreation();
     return writer;

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -1336,15 +1336,15 @@ public final class Protocol {
      */
     long getOffset();
 
-    // optional int64 session_id = 4;
+    // optional int64 session_id_deprecated = 4;
     /**
-     * <code>optional int64 session_id = 4;</code>
+     * <code>optional int64 session_id_deprecated = 4;</code>
      */
-    boolean hasSessionId();
+    boolean hasSessionIdDeprecated();
     /**
-     * <code>optional int64 session_id = 4;</code>
+     * <code>optional int64 session_id_deprecated = 4;</code>
      */
-    long getSessionId();
+    long getSessionIdDeprecated();
 
     // optional int32 tier = 5;
     /**
@@ -1540,7 +1540,7 @@ public final class Protocol {
             }
             case 32: {
               bitField0_ |= 0x00000008;
-              sessionId_ = input.readInt64();
+              sessionIdDeprecated_ = input.readInt64();
               break;
             }
             case 40: {
@@ -1679,20 +1679,20 @@ public final class Protocol {
       return offset_;
     }
 
-    // optional int64 session_id = 4;
-    public static final int SESSION_ID_FIELD_NUMBER = 4;
-    private long sessionId_;
+    // optional int64 session_id_deprecated = 4;
+    public static final int SESSION_ID_DEPRECATED_FIELD_NUMBER = 4;
+    private long sessionIdDeprecated_;
     /**
-     * <code>optional int64 session_id = 4;</code>
+     * <code>optional int64 session_id_deprecated = 4;</code>
      */
-    public boolean hasSessionId() {
+    public boolean hasSessionIdDeprecated() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional int64 session_id = 4;</code>
+     * <code>optional int64 session_id_deprecated = 4;</code>
      */
-    public long getSessionId() {
-      return sessionId_;
+    public long getSessionIdDeprecated() {
+      return sessionIdDeprecated_;
     }
 
     // optional int32 tier = 5;
@@ -1928,7 +1928,7 @@ public final class Protocol {
       type_ = alluxio.proto.dataserver.Protocol.RequestType.ALLUXIO_BLOCK;
       id_ = 0L;
       offset_ = 0L;
-      sessionId_ = 0L;
+      sessionIdDeprecated_ = 0L;
       tier_ = 0;
       eof_ = false;
       cancel_ = false;
@@ -1960,7 +1960,7 @@ public final class Protocol {
         output.writeInt64(3, offset_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeInt64(4, sessionId_);
+        output.writeInt64(4, sessionIdDeprecated_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeInt32(5, tier_);
@@ -2009,7 +2009,7 @@ public final class Protocol {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(4, sessionId_);
+          .computeInt64Size(4, sessionIdDeprecated_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
@@ -2170,7 +2170,7 @@ public final class Protocol {
         bitField0_ = (bitField0_ & ~0x00000002);
         offset_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000004);
-        sessionId_ = 0L;
+        sessionIdDeprecated_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000008);
         tier_ = 0;
         bitField0_ = (bitField0_ & ~0x00000010);
@@ -2231,7 +2231,7 @@ public final class Protocol {
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
           to_bitField0_ |= 0x00000008;
         }
-        result.sessionId_ = sessionId_;
+        result.sessionIdDeprecated_ = sessionIdDeprecated_;
         if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
           to_bitField0_ |= 0x00000010;
         }
@@ -2289,8 +2289,8 @@ public final class Protocol {
         if (other.hasOffset()) {
           setOffset(other.getOffset());
         }
-        if (other.hasSessionId()) {
-          setSessionId(other.getSessionId());
+        if (other.hasSessionIdDeprecated()) {
+          setSessionIdDeprecated(other.getSessionIdDeprecated());
         }
         if (other.hasTier()) {
           setTier(other.getTier());
@@ -2467,35 +2467,35 @@ public final class Protocol {
         return this;
       }
 
-      // optional int64 session_id = 4;
-      private long sessionId_ ;
+      // optional int64 session_id_deprecated = 4;
+      private long sessionIdDeprecated_ ;
       /**
-       * <code>optional int64 session_id = 4;</code>
+       * <code>optional int64 session_id_deprecated = 4;</code>
        */
-      public boolean hasSessionId() {
+      public boolean hasSessionIdDeprecated() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
-       * <code>optional int64 session_id = 4;</code>
+       * <code>optional int64 session_id_deprecated = 4;</code>
        */
-      public long getSessionId() {
-        return sessionId_;
+      public long getSessionIdDeprecated() {
+        return sessionIdDeprecated_;
       }
       /**
-       * <code>optional int64 session_id = 4;</code>
+       * <code>optional int64 session_id_deprecated = 4;</code>
        */
-      public Builder setSessionId(long value) {
+      public Builder setSessionIdDeprecated(long value) {
         bitField0_ |= 0x00000008;
-        sessionId_ = value;
+        sessionIdDeprecated_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int64 session_id = 4;</code>
+       * <code>optional int64 session_id_deprecated = 4;</code>
        */
-      public Builder clearSessionId() {
+      public Builder clearSessionIdDeprecated() {
         bitField0_ = (bitField0_ & ~0x00000008);
-        sessionId_ = 0L;
+        sessionIdDeprecated_ = 0L;
         onChanged();
         return this;
       }
@@ -7145,27 +7145,28 @@ public final class Protocol {
       "tType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\016\n\006len" +
       "gth\030\004 \001(\003\022\016\n\006cancel\030\005 \001(\010\022\017\n\007lock_id\030\006 \001" +
       "(\003\022\022\n\nsession_id\030\007 \001(\003\022\020\n\010no_cache\030\010 \001(\010" +
-      "\022\023\n\013packet_size\030\t \001(\003\"\356\001\n\014WriteRequest\0223" +
+      "\022\023\n\013packet_size\030\t \001(\003\"\371\001\n\014WriteRequest\0223" +
       "\n\004type\030\001 \001(\0162%.alluxio.proto.dataserver." +
       "RequestType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022" +
-      "\022\n\nsession_id\030\004 \001(\003\022\014\n\004tier\030\005 \001(\005\022\013\n\003eof",
-      "\030\006 \001(\010\022\016\n\006cancel\030\007 \001(\010\022\020\n\010ufs_path\030\010 \001(\t" +
-      "\022\r\n\005owner\030\t \001(\t\022\r\n\005group\030\n \001(\t\022\014\n\004mode\030\013" +
-      " \001(\005\022\020\n\010mount_id\030\014 \001(\003\"J\n\010Response\022-\n\006st" +
-      "atus\030\001 \001(\0162\035.alluxio.proto.status.PStatu" +
-      "s\022\017\n\007message\030\002 \001(\t\"\013\n\tHeartbeat\"=\n\025Local" +
-      "BlockOpenRequest\022\020\n\010block_id\030\001 \001(\003\022\022\n\nse" +
-      "ssion_id\030\002 \001(\003\"&\n\026LocalBlockOpenResponse" +
-      "\022\014\n\004path\030\001 \001(\t\">\n\026LocalBlockCloseRequest" +
-      "\022\020\n\010block_id\030\001 \001(\003\022\022\n\nsession_id\030\002 \001(\003\"\203" +
-      "\001\n\027LocalBlockCreateRequest\022\020\n\010block_id\030\001",
-      " \001(\003\022\022\n\nsession_id\030\002 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030" +
-      "\n\020space_to_reserve\030\004 \001(\003\022\032\n\022only_reserve" +
-      "_space\030\005 \001(\010\"(\n\030LocalBlockCreateResponse" +
-      "\022\014\n\004path\030\001 \001(\t\"Q\n\031LocalBlockCompleteRequ" +
-      "est\022\020\n\010block_id\030\001 \001(\003\022\022\n\nsession_id\030\002 \001(" +
-      "\003\022\016\n\006cancel\030\003 \001(\010*=\n\013RequestType\022\021\n\rALLU" +
-      "XIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\r\n\tUFS_BLOCK\020\002"
+      "\035\n\025session_id_deprecated\030\004 \001(\003\022\014\n\004tier\030\005",
+      " \001(\005\022\013\n\003eof\030\006 \001(\010\022\016\n\006cancel\030\007 \001(\010\022\020\n\010ufs" +
+      "_path\030\010 \001(\t\022\r\n\005owner\030\t \001(\t\022\r\n\005group\030\n \001(" +
+      "\t\022\014\n\004mode\030\013 \001(\005\022\020\n\010mount_id\030\014 \001(\003\"J\n\010Res" +
+      "ponse\022-\n\006status\030\001 \001(\0162\035.alluxio.proto.st" +
+      "atus.PStatus\022\017\n\007message\030\002 \001(\t\"\013\n\tHeartbe" +
+      "at\"=\n\025LocalBlockOpenRequest\022\020\n\010block_id\030" +
+      "\001 \001(\003\022\022\n\nsession_id\030\002 \001(\003\"&\n\026LocalBlockO" +
+      "penResponse\022\014\n\004path\030\001 \001(\t\">\n\026LocalBlockC" +
+      "loseRequest\022\020\n\010block_id\030\001 \001(\003\022\022\n\nsession" +
+      "_id\030\002 \001(\003\"\203\001\n\027LocalBlockCreateRequest\022\020\n",
+      "\010block_id\030\001 \001(\003\022\022\n\nsession_id\030\002 \001(\003\022\014\n\004t" +
+      "ier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n\022o" +
+      "nly_reserve_space\030\005 \001(\010\"(\n\030LocalBlockCre" +
+      "ateResponse\022\014\n\004path\030\001 \001(\t\"Q\n\031LocalBlockC" +
+      "ompleteRequest\022\020\n\010block_id\030\001 \001(\003\022\022\n\nsess" +
+      "ion_id\030\002 \001(\003\022\016\n\006cancel\030\003 \001(\010*=\n\013RequestT" +
+      "ype\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\r\n\t" +
+      "UFS_BLOCK\020\002"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -7183,7 +7184,7 @@ public final class Protocol {
           internal_static_alluxio_proto_dataserver_WriteRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_dataserver_WriteRequest_descriptor,
-              new java.lang.String[] { "Type", "Id", "Offset", "SessionId", "Tier", "Eof", "Cancel", "UfsPath", "Owner", "Group", "Mode", "MountId", });
+              new java.lang.String[] { "Type", "Id", "Offset", "SessionIdDeprecated", "Tier", "Eof", "Cancel", "UfsPath", "Owner", "Group", "Mode", "MountId", });
           internal_static_alluxio_proto_dataserver_Response_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_alluxio_proto_dataserver_Response_fieldAccessorTable = new

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -38,7 +38,7 @@ message WriteRequest {
   // The block ID or UFS file ID.
   optional int64 id = 2;
   optional int64 offset = 3;
-  optional int64 session_id = 4;
+  optional int64 session_id_deprecated = 4;
 
   // This is only applicable for block write.
   optional int32 tier = 5;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -17,6 +17,7 @@ import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.UfsBlockAccessTokenUnavailableException;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.wire.FileInfo;
+import alluxio.worker.SessionCleanable;
 import alluxio.worker.Worker;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * A block worker in the Alluxio system.
  */
-public interface BlockWorker extends Worker {
+public interface BlockWorker extends Worker, SessionCleanable {
   /**
    * @return the worker data service bind host
    */

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -471,6 +471,12 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
     mUnderFileSystemBlockStore.releaseAccess(sessionId, blockId);
   }
 
+  @Override
+  public void cleanupSession(long sessionId) {
+    mBlockStore.cleanupSession(sessionId);
+    mUnderFileSystemBlockStore.cleanupSession(sessionId);
+  }
+
   /**
    * This class contains some metrics related to the block worker.
    * This class is public because the metric names are referenced in

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
@@ -53,27 +53,28 @@ public final class DataServerBlockWriteHandler extends DataServerWriteHandler {
     BlockWriteRequestInternal(Protocol.WriteRequest request) throws Exception {
       super(request.getId(), request.getSessionId());
       Preconditions.checkState(request.getOffset() == 0);
-      mWorker.createBlockRemote(request.getSessionId(), request.getId(),
-          mStorageTierAssoc.getAlias(request.getTier()), FILE_BUFFER_SIZE);
+      mWorker.createBlockRemote(mSessionId, mId, mStorageTierAssoc.getAlias(request.getTier()),
+          FILE_BUFFER_SIZE);
       mBytesReserved = FILE_BUFFER_SIZE;
-      mBlockWriter = mWorker.getTempBlockWriterRemote(request.getSessionId(), request.getId());
+      mBlockWriter = mWorker.getTempBlockWriterRemote(mSessionId, mId);
     }
 
     @Override
     public void close() throws IOException {
       mBlockWriter.close();
       try {
-        mWorker.commitBlock(mRequest.mSessionId, mRequest.mId);
+        mWorker.commitBlock(mSessionId, mId);
       } catch (Exception e) {
         throw CommonUtils.castToIOException(e);
       }
+      mWorker.cleanupSession(mSessionId);
     }
 
     @Override
     void cancel() throws IOException {
       mBlockWriter.close();
       try {
-        mWorker.abortBlock(mRequest.mSessionId, mRequest.mId);
+        mWorker.abortBlock(mSessionId, mId);
       } catch (Exception e) {
         throw CommonUtils.castToIOException(e);
       }

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockWriteHandler.java
@@ -51,7 +51,7 @@ public final class DataServerBlockWriteHandler extends DataServerWriteHandler {
     final BlockWriter mBlockWriter;
 
     BlockWriteRequestInternal(Protocol.WriteRequest request) throws Exception {
-      super(request.getId(), request.getSessionId());
+      super(request.getId());
       Preconditions.checkState(request.getOffset() == 0);
       mWorker.createBlockRemote(mSessionId, mId, mStorageTierAssoc.getAlias(request.getTier()),
           FILE_BUFFER_SIZE);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerReadHandler.java
@@ -146,12 +146,14 @@ abstract class DataServerReadHandler extends ChannelInboundHandlerAdapter {
     final long mStart;
     final long mEnd;
     final long mPacketSize;
+    final long mSessionId;
 
-    ReadRequestInternal(long id, long start, long end, long packetSize) {
+    ReadRequestInternal(long id, long start, long end, long packetSize, long sessionId) {
       mId = id;
       mStart = start;
       mEnd = end;
       mPacketSize = packetSize;
+      mSessionId = sessionId;
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
@@ -68,7 +68,8 @@ final class DataServerUfsBlockReadHandler extends DataServerReadHandler {
           LOG.warn("Failed to close block reader for block {}.", mId);
         }
       }
-      mWorker.cleanupSession(mSessionId);
+      // Add this back when the commit block logic is moved to Netty
+      // mWorker.cleanupSession(mSessionId);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsBlockReadHandler.java
@@ -54,9 +54,8 @@ final class DataServerUfsBlockReadHandler extends DataServerReadHandler {
      */
     UfsBlockReadRequestInternal(Protocol.ReadRequest request) throws Exception {
       super(request.getId(), request.getOffset(), request.getOffset() + request.getLength(),
-          request.getPacketSize());
-      mBlockReader =
-          mWorker.readUfsBlock(request.getSessionId(), mId, mStart, request.getNoCache());
+          request.getPacketSize(), request.getSessionId());
+      mBlockReader = mWorker.readUfsBlock(mSessionId, mId, mStart, request.getNoCache());
       // Note that we do not need to seek to offset since the block worker is created at the offset.
     }
 
@@ -69,6 +68,7 @@ final class DataServerUfsBlockReadHandler extends DataServerReadHandler {
           LOG.warn("Failed to close block reader for block {}.", mId);
         }
       }
+      mWorker.cleanupSession(mSessionId);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerUfsFileWriteHandler.java
@@ -41,7 +41,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class DataServerUfsFileWriteHandler extends DataServerWriteHandler {
-  private static final long UNUSED_SESSION_ID = -1;
   private final UfsManager mUfsManager;
 
   private class FileWriteRequestInternal extends WriteRequestInternal {
@@ -50,7 +49,7 @@ final class DataServerUfsFileWriteHandler extends DataServerWriteHandler {
     private final OutputStream mOutputStream;
 
     FileWriteRequestInternal(Protocol.WriteRequest request) throws Exception {
-      super(request.getId(), UNUSED_SESSION_ID);
+      super(request.getId());
       mUfsPath = request.getUfsPath();
       mUnderFileSystem = mUfsManager.get(request.getMountId());
       mOutputStream =

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerWriteHandler.java
@@ -21,6 +21,7 @@ import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.resource.LockResource;
+import alluxio.util.IdUtils;
 import alluxio.util.network.NettyUtils;
 
 import com.google.common.base.Preconditions;
@@ -137,11 +138,12 @@ abstract class DataServerWriteHandler extends ChannelInboundHandlerAdapter {
   abstract class WriteRequestInternal implements Closeable {
     /** This ID can either be block ID or temp UFS file ID. */
     final long mId;
+    /** The session id associated with all temporary resources of this request. */
     final long mSessionId;
 
-    WriteRequestInternal(long id, long sessionId) {
+    WriteRequestInternal(long id) {
       mId = id;
-      mSessionId = sessionId;
+      mSessionId = IdUtils.getRandomNonNegativeLong();
     }
 
     /**

--- a/core/server/worker/src/test/java/alluxio/worker/netty/DataServerBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/DataServerBlockWriteHandlerTest.java
@@ -80,7 +80,7 @@ public final class DataServerBlockWriteHandlerTest extends DataServerWriteHandle
   @Override
   protected RPCProtoMessage buildWriteRequest(long offset, int len) {
     Protocol.WriteRequest writeRequest =
-        Protocol.WriteRequest.newBuilder().setId(1L).setOffset(offset).setSessionId(1L)
+        Protocol.WriteRequest.newBuilder().setId(1L).setOffset(offset)
             .setType(Protocol.RequestType.ALLUXIO_BLOCK).build();
     DataBuffer buffer = null;
     if (len > 0) {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2813

Changes the session heartbeat logic to use netty instead of thrift. Now we assume the entirety of read or write operations (including any metadata operations) are concluded before `InternalRequest#close` is called. `InternalRequest#close` will clean up any lingering temporary state.

This currently won't work for reads w/ caching since the cache logic is outside of the netty data path.