### PR TITLE
[SMALLFIX] Correctly clean up aborted writes

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/PacketOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/PacketOutStream.java
@@ -173,13 +173,6 @@ public class PacketOutStream extends OutputStream implements BoundedStream, Quie
     for (PacketWriter packetWriter : mPacketWriters) {
       packetWriter.flush();
     }
-
-    // Release the channel used in the packet writer early. This is required to avoid holding the
-    // netty channel unnecessarily because the block out streams are closed after all the blocks
-    // are written.
-    if (remaining() == 0) {
-      close();
-    }
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/AbstractFileOutStreamIntegrationTest.java
@@ -40,11 +40,13 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   protected static final int MAX_LEN = 255;
   protected static final int DELTA = 32;
   protected static final int BUFFER_BYTES = 100;
+  protected static final int BLOCK_SIZE_BYTES = 1000;
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
+          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
           .build();
 
   protected FileSystem mFileSystem = null;

--- a/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
@@ -17,14 +17,20 @@ import alluxio.PropertyKey;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.policy.LocalFirstPolicy;
+import alluxio.master.file.FileSystemMaster;
+import alluxio.util.CommonUtils;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
+import alluxio.wire.WorkerInfo;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+
+import java.util.List;
 
 /**
  * Integration tests for {@link alluxio.client.file.FileOutStream}, parameterized by the write
@@ -172,6 +178,28 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
       checkFileInUnderStorage(filePath, length + 1);
+    }
+  }
+
+  /**
+   * Tests canceling after multiple blocks have been written correctly leaves cleans up temporary
+   * worker resources.
+   */
+  @Test
+  public void abortWrite() throws Exception {
+    AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
+    try (FileOutStream os =
+        mFileSystem.createFile(path, CreateFileOptions.defaults().setWriteType(mWriteType))) {
+      os.write(BufferUtils.getIncreasingByteArray(0, BLOCK_SIZE_BYTES * 3 + 1));
+      os.cancel();
+    }
+    long gracePeriod = Configuration.getLong(PropertyKey.MASTER_HEARTBEAT_INTERVAL_MS) * 2;
+    CommonUtils.sleepMs(gracePeriod);
+    List<WorkerInfo> workers =
+        mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
+            .getMaster(FileSystemMaster.class).getFileSystemMasterView().getWorkerInfoList();
+    for (WorkerInfo worker : workers) {
+      Assert.assertEquals(0, worker.getUsedBytes());
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
@@ -182,11 +182,11 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
   }
 
   /**
-   * Tests canceling after multiple blocks have been written correctly leaves cleans up temporary
-   * worker resources.
+   * Tests canceling after multiple blocks have been written correctly cleans up temporary worker
+   * resources.
    */
   @Test
-  public void abortWrite() throws Exception {
+  public void cancelWrite() throws Exception {
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
     try (FileOutStream os =
         mFileSystem.createFile(path, CreateFileOptions.defaults().setWriteType(mWriteType))) {


### PR DESCRIPTION
Since the control path is tied to the channel, we cannot close the channel (commit blocks) until the entire file is ready.