### PR TITLE
[ALLUXIO-2813] Move promote logic to data path

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -82,7 +82,8 @@ public class BlockInStream extends FilterInputStream implements BoundedStream, S
   public static BlockInStream createNettyBlockInStream(long blockId, long blockSize,
       WorkerNetAddress workerNetAddress, FileSystemContext context,
       Protocol.OpenUfsBlockOptions openUfsBlockOptions, InStreamOptions options) {
-    Protocol.ReadRequest.Builder builder = Protocol.ReadRequest.newBuilder().setBlockId(blockId);
+    Protocol.ReadRequest.Builder builder = Protocol.ReadRequest.newBuilder().setBlockId(blockId)
+        .setPromote(options.getAlluxioStorageType().isPromote());
     if (openUfsBlockOptions != null) {
       builder.setOpenUfsBlockOptions(openUfsBlockOptions);
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
@@ -108,19 +108,21 @@ public final class LocalFilePacketReader implements PacketReader {
      * @param address the worker address
      * @param blockId the block ID
      * @param packetSize the packet size
+     * @param promote whether or not to promote the block
      */
     public Factory(FileSystemContext context, WorkerNetAddress address, long blockId,
-        long packetSize) {
+        long packetSize, boolean promote) {
       mContext = context;
       mAddress = address;
       mBlockId = blockId;
       mPacketSize = packetSize;
 
       mChannel = context.acquireNettyChannel(address);
-      ProtoMessage message = NettyRPC
-          .call(NettyRPCContext.defaults().setChannel(mChannel).setTimeout(READ_TIMEOUT_MS),
-              new ProtoMessage(
-                  Protocol.LocalBlockOpenRequest.newBuilder().setBlockId(mBlockId).build()));
+      ProtoMessage message =
+          NettyRPC.call(
+              NettyRPCContext.defaults().setChannel(mChannel).setTimeout(READ_TIMEOUT_MS),
+              new ProtoMessage(Protocol.LocalBlockOpenRequest.newBuilder().setBlockId(mBlockId)
+                  .setPromote(promote).build()));
       Preconditions.checkState(message.isLocalBlockOpenResponse());
       mPath = message.asLocalBlockOpenResponse().getPath();
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/PacketInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/PacketInStream.java
@@ -67,12 +67,10 @@ public class PacketInStream extends InputStream implements BoundedStream, Seekab
    * @return the {@link PacketInStream} created
    */
   public static PacketInStream createLocalPacketInStream(FileSystemContext context,
-      WorkerNetAddress address, long blockId, long length,
-      InStreamOptions options) {
+      WorkerNetAddress address, long blockId, long length, InStreamOptions options) {
     long packetSize = Configuration.getBytes(PropertyKey.USER_LOCAL_READER_PACKET_SIZE_BYTES);
-    return new PacketInStream(
-        new LocalFilePacketReader.Factory(context, address, blockId, packetSize),
-        blockId, length);
+    return new PacketInStream(new LocalFilePacketReader.Factory(context, address, blockId,
+        packetSize, options.getAlluxioStorageType().isPromote()), blockId, length);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -603,14 +603,6 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    * @return the block in stream
    */
   private BlockInStream getBlockInStream(long blockId) {
-    if (mAlluxioStorageType.isPromote()) {
-      try {
-        mBlockStore.promote(blockId);
-      } catch (Exception e) {
-        // Failed to promote.
-        LOG.warn("Promotion of block with ID {} failed with error {}.", blockId, e.getMessage());
-      }
-    }
     Protocol.OpenUfsBlockOptions openUfsBlockOptions = null;
     if (mStatus.isPersisted()) {
       long blockStart = BlockId.getSequenceNumber(blockId) * mBlockSize;

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -411,21 +411,6 @@ public class FileInStreamTest {
   }
 
   /**
-   * Tests that we promote blocks when they are read.
-   */
-  @Test
-  public void testPromote() throws IOException {
-    Mockito.verify(mBlockStore, Mockito.times(0)).promote(0);
-    mTestStream.read();
-    Mockito.verify(mBlockStore).promote(0);
-    mTestStream.read();
-    Mockito.verify(mBlockStore).promote(0);
-    Mockito.verify(mBlockStore, Mockito.times(0)).promote(1);
-    mTestStream.read(new byte[(int) BLOCK_LENGTH]);
-    Mockito.verify(mBlockStore).promote(1);
-  }
-
-  /**
    * Tests that {@link IOException}s thrown by the {@link AlluxioBlockStore} are properly
    * propagated.
    */

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -5196,12 +5196,22 @@ public final class Protocol {
      * <code>optional int64 block_id = 1;</code>
      */
     long getBlockId();
+
+    // optional int64 promote = 3;
+    /**
+     * <code>optional int64 promote = 3;</code>
+     */
+    boolean hasPromote();
+    /**
+     * <code>optional int64 promote = 3;</code>
+     */
+    long getPromote();
   }
   /**
    * Protobuf type {@code alluxio.proto.dataserver.LocalBlockOpenRequest}
    *
    * <pre>
-   * next available id: 3
+   * next available id: 4
    * </pre>
    */
   public static final class LocalBlockOpenRequest extends
@@ -5255,6 +5265,11 @@ public final class Protocol {
             case 8: {
               bitField0_ |= 0x00000001;
               blockId_ = input.readInt64();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000002;
+              promote_ = input.readInt64();
               break;
             }
           }
@@ -5313,8 +5328,25 @@ public final class Protocol {
       return blockId_;
     }
 
+    // optional int64 promote = 3;
+    public static final int PROMOTE_FIELD_NUMBER = 3;
+    private long promote_;
+    /**
+     * <code>optional int64 promote = 3;</code>
+     */
+    public boolean hasPromote() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional int64 promote = 3;</code>
+     */
+    public long getPromote() {
+      return promote_;
+    }
+
     private void initFields() {
       blockId_ = 0L;
+      promote_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -5331,6 +5363,9 @@ public final class Protocol {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt64(1, blockId_);
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(3, promote_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -5343,6 +5378,10 @@ public final class Protocol {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(1, blockId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, promote_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5426,7 +5465,7 @@ public final class Protocol {
      * Protobuf type {@code alluxio.proto.dataserver.LocalBlockOpenRequest}
      *
      * <pre>
-     * next available id: 3
+     * next available id: 4
      * </pre>
      */
     public static final class Builder extends
@@ -5466,6 +5505,8 @@ public final class Protocol {
         super.clear();
         blockId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000001);
+        promote_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -5498,6 +5539,10 @@ public final class Protocol {
           to_bitField0_ |= 0x00000001;
         }
         result.blockId_ = blockId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.promote_ = promote_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -5516,6 +5561,9 @@ public final class Protocol {
         if (other == alluxio.proto.dataserver.Protocol.LocalBlockOpenRequest.getDefaultInstance()) return this;
         if (other.hasBlockId()) {
           setBlockId(other.getBlockId());
+        }
+        if (other.hasPromote()) {
+          setPromote(other.getPromote());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -5573,6 +5621,39 @@ public final class Protocol {
       public Builder clearBlockId() {
         bitField0_ = (bitField0_ & ~0x00000001);
         blockId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // optional int64 promote = 3;
+      private long promote_ ;
+      /**
+       * <code>optional int64 promote = 3;</code>
+       */
+      public boolean hasPromote() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional int64 promote = 3;</code>
+       */
+      public long getPromote() {
+        return promote_;
+      }
+      /**
+       * <code>optional int64 promote = 3;</code>
+       */
+      public Builder setPromote(long value) {
+        bitField0_ |= 0x00000002;
+        promote_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 promote = 3;</code>
+       */
+      public Builder clearPromote() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        promote_ = 0L;
         onChanged();
         return this;
       }
@@ -8203,17 +8284,17 @@ public final class Protocol {
       "Status\022\017\n\007message\030\002 \001(\t\"i\n\014ReadResponse\022" +
       "9\n\004type\030\001 \001(\0162+.alluxio.proto.dataserver" +
       ".ReadResponse.Type\"\036\n\004Type\022\026\n\022UFS_READ_H",
-      "EARTBEAT\020\001\"\013\n\tHeartbeat\")\n\025LocalBlockOpe" +
-      "nRequest\022\020\n\010block_id\030\001 \001(\003\"&\n\026LocalBlock" +
-      "OpenResponse\022\014\n\004path\030\001 \001(\t\"*\n\026LocalBlock" +
-      "CloseRequest\022\020\n\010block_id\030\001 \001(\003\"o\n\027LocalB" +
-      "lockCreateRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n\004t" +
-      "ier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n\022o" +
-      "nly_reserve_space\030\005 \001(\010\"(\n\030LocalBlockCre" +
-      "ateResponse\022\014\n\004path\030\001 \001(\t\"=\n\031LocalBlockC" +
-      "ompleteRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006canc" +
-      "el\030\003 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLOCK",
-      "\020\000\022\014\n\010UFS_FILE\020\001"
+      "EARTBEAT\020\001\"\013\n\tHeartbeat\":\n\025LocalBlockOpe" +
+      "nRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promote\030\003 " +
+      "\001(\003\"&\n\026LocalBlockOpenResponse\022\014\n\004path\030\001 " +
+      "\001(\t\"*\n\026LocalBlockCloseRequest\022\020\n\010block_i" +
+      "d\030\001 \001(\003\"o\n\027LocalBlockCreateRequest\022\020\n\010bl" +
+      "ock_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to_r" +
+      "eserve\030\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001(\010" +
+      "\"(\n\030LocalBlockCreateResponse\022\014\n\004path\030\001 \001" +
+      "(\t\"=\n\031LocalBlockCompleteRequest\022\020\n\010block" +
+      "_id\030\001 \001(\003\022\016\n\006cancel\030\003 \001(\010*.\n\013RequestType",
+      "\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8261,7 +8342,7 @@ public final class Protocol {
           internal_static_alluxio_proto_dataserver_LocalBlockOpenRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_dataserver_LocalBlockOpenRequest_descriptor,
-              new java.lang.String[] { "BlockId", });
+              new java.lang.String[] { "BlockId", "Promote", });
           internal_static_alluxio_proto_dataserver_LocalBlockOpenResponse_descriptor =
             getDescriptor().getMessageTypes().get(7);
           internal_static_alluxio_proto_dataserver_LocalBlockOpenResponse_fieldAccessorTable = new

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -95,6 +95,101 @@ public final class Protocol {
     // @@protoc_insertion_point(enum_scope:alluxio.proto.dataserver.RequestType)
   }
 
+  /**
+   * Protobuf enum {@code alluxio.proto.dataserver.ReadType}
+   *
+   * <pre>
+   * The read type.
+   * </pre>
+   */
+  public enum ReadType
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>NO_CACHE = 0;</code>
+     */
+    NO_CACHE(0, 0),
+    /**
+     * <code>CACHE = 1;</code>
+     */
+    CACHE(1, 1),
+    /**
+     * <code>CACHE_PROMOTE = 2;</code>
+     */
+    CACHE_PROMOTE(2, 2),
+    ;
+
+    /**
+     * <code>NO_CACHE = 0;</code>
+     */
+    public static final int NO_CACHE_VALUE = 0;
+    /**
+     * <code>CACHE = 1;</code>
+     */
+    public static final int CACHE_VALUE = 1;
+    /**
+     * <code>CACHE_PROMOTE = 2;</code>
+     */
+    public static final int CACHE_PROMOTE_VALUE = 2;
+
+
+    public final int getNumber() { return value; }
+
+    public static ReadType valueOf(int value) {
+      switch (value) {
+        case 0: return NO_CACHE;
+        case 1: return CACHE;
+        case 2: return CACHE_PROMOTE;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<ReadType>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<ReadType>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<ReadType>() {
+            public ReadType findValueByNumber(int number) {
+              return ReadType.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return alluxio.proto.dataserver.Protocol.getDescriptor().getEnumTypes().get(1);
+    }
+
+    private static final ReadType[] VALUES = values();
+
+    public static ReadType valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private ReadType(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:alluxio.proto.dataserver.ReadType)
+  }
+
   public interface ReadRequestOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -146,6 +241,24 @@ public final class Protocol {
      */
     boolean getCancel();
 
+    // optional .alluxio.proto.dataserver.ReadType read_type = 7;
+    /**
+     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     *
+     * <pre>
+     * The read type associated with this request
+     * </pre>
+     */
+    boolean hasReadType();
+    /**
+     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     *
+     * <pre>
+     * The read type associated with this request
+     * </pre>
+     */
+    alluxio.proto.dataserver.Protocol.ReadType getReadType();
+
     // optional int64 packet_size = 5;
     /**
      * <code>optional int64 packet_size = 5;</code>
@@ -195,7 +308,7 @@ public final class Protocol {
    *
    * <pre>
    * The read request.
-   * next available id: 7
+   * next available id: 8
    * </pre>
    */
   public static final class ReadRequest extends
@@ -267,13 +380,13 @@ public final class Protocol {
               break;
             }
             case 40: {
-              bitField0_ |= 0x00000010;
+              bitField0_ |= 0x00000020;
               packetSize_ = input.readInt64();
               break;
             }
             case 50: {
               alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+              if (((bitField0_ & 0x00000040) == 0x00000040)) {
                 subBuilder = openUfsBlockOptions_.toBuilder();
               }
               openUfsBlockOptions_ = input.readMessage(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.PARSER, extensionRegistry);
@@ -281,7 +394,18 @@ public final class Protocol {
                 subBuilder.mergeFrom(openUfsBlockOptions_);
                 openUfsBlockOptions_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00000020;
+              bitField0_ |= 0x00000040;
+              break;
+            }
+            case 56: {
+              int rawValue = input.readEnum();
+              alluxio.proto.dataserver.Protocol.ReadType value = alluxio.proto.dataserver.Protocol.ReadType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(7, rawValue);
+              } else {
+                bitField0_ |= 0x00000010;
+                readType_ = value;
+              }
               break;
             }
           }
@@ -396,6 +520,30 @@ public final class Protocol {
       return cancel_;
     }
 
+    // optional .alluxio.proto.dataserver.ReadType read_type = 7;
+    public static final int READ_TYPE_FIELD_NUMBER = 7;
+    private alluxio.proto.dataserver.Protocol.ReadType readType_;
+    /**
+     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     *
+     * <pre>
+     * The read type associated with this request
+     * </pre>
+     */
+    public boolean hasReadType() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     *
+     * <pre>
+     * The read type associated with this request
+     * </pre>
+     */
+    public alluxio.proto.dataserver.Protocol.ReadType getReadType() {
+      return readType_;
+    }
+
     // optional int64 packet_size = 5;
     public static final int PACKET_SIZE_FIELD_NUMBER = 5;
     private long packetSize_;
@@ -407,7 +555,7 @@ public final class Protocol {
      * </pre>
      */
     public boolean hasPacketSize() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <code>optional int64 packet_size = 5;</code>
@@ -431,7 +579,7 @@ public final class Protocol {
      * </pre>
      */
     public boolean hasOpenUfsBlockOptions() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
      * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
@@ -459,6 +607,7 @@ public final class Protocol {
       offset_ = 0L;
       length_ = 0L;
       cancel_ = false;
+      readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
       packetSize_ = 0L;
       openUfsBlockOptions_ = alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance();
     }
@@ -486,11 +635,14 @@ public final class Protocol {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeBool(4, cancel_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeInt64(5, packetSize_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeMessage(6, openUfsBlockOptions_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeEnum(7, readType_.getNumber());
       }
       getUnknownFields().writeTo(output);
     }
@@ -517,13 +669,17 @@ public final class Protocol {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(4, cancel_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(5, packetSize_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, openUfsBlockOptions_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(7, readType_.getNumber());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -608,7 +764,7 @@ public final class Protocol {
      *
      * <pre>
      * The read request.
-     * next available id: 7
+     * next available id: 8
      * </pre>
      */
     public static final class Builder extends
@@ -655,14 +811,16 @@ public final class Protocol {
         bitField0_ = (bitField0_ & ~0x00000004);
         cancel_ = false;
         bitField0_ = (bitField0_ & ~0x00000008);
-        packetSize_ = 0L;
+        readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
         bitField0_ = (bitField0_ & ~0x00000010);
+        packetSize_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
         if (openUfsBlockOptionsBuilder_ == null) {
           openUfsBlockOptions_ = alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance();
         } else {
           openUfsBlockOptionsBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -710,9 +868,13 @@ public final class Protocol {
         if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
           to_bitField0_ |= 0x00000010;
         }
-        result.packetSize_ = packetSize_;
+        result.readType_ = readType_;
         if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
           to_bitField0_ |= 0x00000020;
+        }
+        result.packetSize_ = packetSize_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
         }
         if (openUfsBlockOptionsBuilder_ == null) {
           result.openUfsBlockOptions_ = openUfsBlockOptions_;
@@ -746,6 +908,9 @@ public final class Protocol {
         }
         if (other.hasCancel()) {
           setCancel(other.getCancel());
+        }
+        if (other.hasReadType()) {
+          setReadType(other.getReadType());
         }
         if (other.hasPacketSize()) {
           setPacketSize(other.getPacketSize());
@@ -928,6 +1093,58 @@ public final class Protocol {
         return this;
       }
 
+      // optional .alluxio.proto.dataserver.ReadType read_type = 7;
+      private alluxio.proto.dataserver.Protocol.ReadType readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+      /**
+       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       *
+       * <pre>
+       * The read type associated with this request
+       * </pre>
+       */
+      public boolean hasReadType() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       *
+       * <pre>
+       * The read type associated with this request
+       * </pre>
+       */
+      public alluxio.proto.dataserver.Protocol.ReadType getReadType() {
+        return readType_;
+      }
+      /**
+       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       *
+       * <pre>
+       * The read type associated with this request
+       * </pre>
+       */
+      public Builder setReadType(alluxio.proto.dataserver.Protocol.ReadType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000010;
+        readType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       *
+       * <pre>
+       * The read type associated with this request
+       * </pre>
+       */
+      public Builder clearReadType() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+        onChanged();
+        return this;
+      }
+
       // optional int64 packet_size = 5;
       private long packetSize_ ;
       /**
@@ -938,7 +1155,7 @@ public final class Protocol {
        * </pre>
        */
       public boolean hasPacketSize() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
        * <code>optional int64 packet_size = 5;</code>
@@ -958,7 +1175,7 @@ public final class Protocol {
        * </pre>
        */
       public Builder setPacketSize(long value) {
-        bitField0_ |= 0x00000010;
+        bitField0_ |= 0x00000020;
         packetSize_ = value;
         onChanged();
         return this;
@@ -971,7 +1188,7 @@ public final class Protocol {
        * </pre>
        */
       public Builder clearPacketSize() {
-        bitField0_ = (bitField0_ & ~0x00000010);
+        bitField0_ = (bitField0_ & ~0x00000020);
         packetSize_ = 0L;
         onChanged();
         return this;
@@ -989,7 +1206,7 @@ public final class Protocol {
        * </pre>
        */
       public boolean hasOpenUfsBlockOptions() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000040) == 0x00000040);
       }
       /**
        * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
@@ -1022,7 +1239,7 @@ public final class Protocol {
         } else {
           openUfsBlockOptionsBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         return this;
       }
       /**
@@ -1040,7 +1257,7 @@ public final class Protocol {
         } else {
           openUfsBlockOptionsBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         return this;
       }
       /**
@@ -1052,7 +1269,7 @@ public final class Protocol {
        */
       public Builder mergeOpenUfsBlockOptions(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions value) {
         if (openUfsBlockOptionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+          if (((bitField0_ & 0x00000040) == 0x00000040) &&
               openUfsBlockOptions_ != alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance()) {
             openUfsBlockOptions_ =
               alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.newBuilder(openUfsBlockOptions_).mergeFrom(value).buildPartial();
@@ -1063,7 +1280,7 @@ public final class Protocol {
         } else {
           openUfsBlockOptionsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         return this;
       }
       /**
@@ -1080,7 +1297,7 @@ public final class Protocol {
         } else {
           openUfsBlockOptionsBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
       /**
@@ -1091,7 +1308,7 @@ public final class Protocol {
        * </pre>
        */
       public alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder getOpenUfsBlockOptionsBuilder() {
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         onChanged();
         return getOpenUfsBlockOptionsFieldBuilder().getBuilder();
       }
@@ -8071,35 +8288,38 @@ public final class Protocol {
   static {
     java.lang.String[] descriptorData = {
       "\n\016protocol.proto\022\030alluxio.proto.dataserv" +
-      "er\032\014status.proto\"\263\001\n\013ReadRequest\022\020\n\010bloc" +
+      "er\032\014status.proto\"\352\001\n\013ReadRequest\022\020\n\010bloc" +
       "k_id\030\001 \001(\003\022\016\n\006offset\030\002 \001(\003\022\016\n\006length\030\003 \001" +
-      "(\003\022\016\n\006cancel\030\004 \001(\010\022\023\n\013packet_size\030\005 \001(\003\022" +
-      "M\n\026open_ufs_block_options\030\006 \001(\0132-.alluxi" +
-      "o.proto.dataserver.OpenUfsBlockOptions\"\224" +
-      "\001\n\023OpenUfsBlockOptions\022\017\n\007ufsPath\030\001 \001(\t\022" +
-      "\026\n\016offset_in_file\030\002 \001(\003\022\022\n\nblock_size\030\003 " +
-      "\001(\003\022\035\n\025maxUfsReadConcurrency\030\004 \001(\005\022\017\n\007mo" +
-      "untId\030\005 \001(\003\022\020\n\010no_cache\030\006 \001(\010\"\332\001\n\014WriteR",
-      "equest\0223\n\004type\030\001 \001(\0162%.alluxio.proto.dat" +
-      "aserver.RequestType\022\n\n\002id\030\002 \001(\003\022\016\n\006offse" +
-      "t\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\013\n\003eof\030\005 \001(\010\022\016\n\006ca" +
-      "ncel\030\006 \001(\010\022\020\n\010ufs_path\030\007 \001(\t\022\r\n\005owner\030\010 " +
-      "\001(\t\022\r\n\005group\030\t \001(\t\022\014\n\004mode\030\n \001(\005\022\020\n\010moun" +
-      "t_id\030\013 \001(\003\"J\n\010Response\022-\n\006status\030\001 \001(\0162\035" +
-      ".alluxio.proto.status.PStatus\022\017\n\007message" +
-      "\030\002 \001(\t\"i\n\014ReadResponse\0229\n\004type\030\001 \001(\0162+.a" +
-      "lluxio.proto.dataserver.ReadResponse.Typ" +
-      "e\"\036\n\004Type\022\026\n\022UFS_READ_HEARTBEAT\020\001\"\013\n\tHea",
-      "rtbeat\")\n\025LocalBlockOpenRequest\022\020\n\010block" +
-      "_id\030\001 \001(\003\"&\n\026LocalBlockOpenResponse\022\014\n\004p" +
-      "ath\030\001 \001(\t\"*\n\026LocalBlockCloseRequest\022\020\n\010b" +
-      "lock_id\030\001 \001(\003\"o\n\027LocalBlockCreateRequest" +
-      "\022\020\n\010block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020spac" +
-      "e_to_reserve\030\004 \001(\003\022\032\n\022only_reserve_space" +
-      "\030\005 \001(\010\"(\n\030LocalBlockCreateResponse\022\014\n\004pa" +
-      "th\030\001 \001(\t\"=\n\031LocalBlockCompleteRequest\022\020\n" +
-      "\010block_id\030\001 \001(\003\022\016\n\006cancel\030\003 \001(\010*.\n\013Reque" +
-      "stType\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001"
+      "(\003\022\016\n\006cancel\030\004 \001(\010\0225\n\tread_type\030\007 \001(\0162\"." +
+      "alluxio.proto.dataserver.ReadType\022\023\n\013pac" +
+      "ket_size\030\005 \001(\003\022M\n\026open_ufs_block_options" +
+      "\030\006 \001(\0132-.alluxio.proto.dataserver.OpenUf" +
+      "sBlockOptions\"\224\001\n\023OpenUfsBlockOptions\022\017\n" +
+      "\007ufsPath\030\001 \001(\t\022\026\n\016offset_in_file\030\002 \001(\003\022\022" +
+      "\n\nblock_size\030\003 \001(\003\022\035\n\025maxUfsReadConcurre",
+      "ncy\030\004 \001(\005\022\017\n\007mountId\030\005 \001(\003\022\020\n\010no_cache\030\006" +
+      " \001(\010\"\332\001\n\014WriteRequest\0223\n\004type\030\001 \001(\0162%.al" +
+      "luxio.proto.dataserver.RequestType\022\n\n\002id" +
+      "\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\013\n\003" +
+      "eof\030\005 \001(\010\022\016\n\006cancel\030\006 \001(\010\022\020\n\010ufs_path\030\007 " +
+      "\001(\t\022\r\n\005owner\030\010 \001(\t\022\r\n\005group\030\t \001(\t\022\014\n\004mod" +
+      "e\030\n \001(\005\022\020\n\010mount_id\030\013 \001(\003\"J\n\010Response\022-\n" +
+      "\006status\030\001 \001(\0162\035.alluxio.proto.status.PSt" +
+      "atus\022\017\n\007message\030\002 \001(\t\"i\n\014ReadResponse\0229\n" +
+      "\004type\030\001 \001(\0162+.alluxio.proto.dataserver.R",
+      "eadResponse.Type\"\036\n\004Type\022\026\n\022UFS_READ_HEA" +
+      "RTBEAT\020\001\"\013\n\tHeartbeat\")\n\025LocalBlockOpenR" +
+      "equest\022\020\n\010block_id\030\001 \001(\003\"&\n\026LocalBlockOp" +
+      "enResponse\022\014\n\004path\030\001 \001(\t\"*\n\026LocalBlockCl" +
+      "oseRequest\022\020\n\010block_id\030\001 \001(\003\"o\n\027LocalBlo" +
+      "ckCreateRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n\004tie" +
+      "r\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n\022onl" +
+      "y_reserve_space\030\005 \001(\010\"(\n\030LocalBlockCreat" +
+      "eResponse\022\014\n\004path\030\001 \001(\t\"=\n\031LocalBlockCom" +
+      "pleteRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006cancel",
+      "\030\003 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLOCK\020\000" +
+      "\022\014\n\010UFS_FILE\020\001*6\n\010ReadType\022\014\n\010NO_CACHE\020\000" +
+      "\022\t\n\005CACHE\020\001\022\021\n\rCACHE_PROMOTE\020\002"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8111,7 +8331,7 @@ public final class Protocol {
           internal_static_alluxio_proto_dataserver_ReadRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_dataserver_ReadRequest_descriptor,
-              new java.lang.String[] { "BlockId", "Offset", "Length", "Cancel", "PacketSize", "OpenUfsBlockOptions", });
+              new java.lang.String[] { "BlockId", "Offset", "Length", "Cancel", "ReadType", "PacketSize", "OpenUfsBlockOptions", });
           internal_static_alluxio_proto_dataserver_OpenUfsBlockOptions_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_alluxio_proto_dataserver_OpenUfsBlockOptions_fieldAccessorTable = new

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -5197,15 +5197,15 @@ public final class Protocol {
      */
     long getBlockId();
 
-    // optional int64 promote = 3;
+    // optional bool promote = 3;
     /**
-     * <code>optional int64 promote = 3;</code>
+     * <code>optional bool promote = 3;</code>
      */
     boolean hasPromote();
     /**
-     * <code>optional int64 promote = 3;</code>
+     * <code>optional bool promote = 3;</code>
      */
-    long getPromote();
+    boolean getPromote();
   }
   /**
    * Protobuf type {@code alluxio.proto.dataserver.LocalBlockOpenRequest}
@@ -5269,7 +5269,7 @@ public final class Protocol {
             }
             case 24: {
               bitField0_ |= 0x00000002;
-              promote_ = input.readInt64();
+              promote_ = input.readBool();
               break;
             }
           }
@@ -5328,25 +5328,25 @@ public final class Protocol {
       return blockId_;
     }
 
-    // optional int64 promote = 3;
+    // optional bool promote = 3;
     public static final int PROMOTE_FIELD_NUMBER = 3;
-    private long promote_;
+    private boolean promote_;
     /**
-     * <code>optional int64 promote = 3;</code>
+     * <code>optional bool promote = 3;</code>
      */
     public boolean hasPromote() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional int64 promote = 3;</code>
+     * <code>optional bool promote = 3;</code>
      */
-    public long getPromote() {
+    public boolean getPromote() {
       return promote_;
     }
 
     private void initFields() {
       blockId_ = 0L;
-      promote_ = 0L;
+      promote_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -5364,7 +5364,7 @@ public final class Protocol {
         output.writeInt64(1, blockId_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeInt64(3, promote_);
+        output.writeBool(3, promote_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -5381,7 +5381,7 @@ public final class Protocol {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(3, promote_);
+          .computeBoolSize(3, promote_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5505,7 +5505,7 @@ public final class Protocol {
         super.clear();
         blockId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000001);
-        promote_ = 0L;
+        promote_ = false;
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
@@ -5625,35 +5625,35 @@ public final class Protocol {
         return this;
       }
 
-      // optional int64 promote = 3;
-      private long promote_ ;
+      // optional bool promote = 3;
+      private boolean promote_ ;
       /**
-       * <code>optional int64 promote = 3;</code>
+       * <code>optional bool promote = 3;</code>
        */
       public boolean hasPromote() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional int64 promote = 3;</code>
+       * <code>optional bool promote = 3;</code>
        */
-      public long getPromote() {
+      public boolean getPromote() {
         return promote_;
       }
       /**
-       * <code>optional int64 promote = 3;</code>
+       * <code>optional bool promote = 3;</code>
        */
-      public Builder setPromote(long value) {
+      public Builder setPromote(boolean value) {
         bitField0_ |= 0x00000002;
         promote_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int64 promote = 3;</code>
+       * <code>optional bool promote = 3;</code>
        */
       public Builder clearPromote() {
         bitField0_ = (bitField0_ & ~0x00000002);
-        promote_ = 0L;
+        promote_ = false;
         onChanged();
         return this;
       }
@@ -8286,7 +8286,7 @@ public final class Protocol {
       ".ReadResponse.Type\"\036\n\004Type\022\026\n\022UFS_READ_H",
       "EARTBEAT\020\001\"\013\n\tHeartbeat\":\n\025LocalBlockOpe" +
       "nRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promote\030\003 " +
-      "\001(\003\"&\n\026LocalBlockOpenResponse\022\014\n\004path\030\001 " +
+      "\001(\010\"&\n\026LocalBlockOpenResponse\022\014\n\004path\030\001 " +
       "\001(\t\"*\n\026LocalBlockCloseRequest\022\020\n\010block_i" +
       "d\030\001 \001(\003\"o\n\027LocalBlockCreateRequest\022\020\n\010bl" +
       "ock_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to_r" +

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -5726,13 +5726,13 @@ public final class Protocol {
      */
     long getBlockId();
 
-    // optional bool promote = 3;
+    // optional bool promote = 2;
     /**
-     * <code>optional bool promote = 3;</code>
+     * <code>optional bool promote = 2;</code>
      */
     boolean hasPromote();
     /**
-     * <code>optional bool promote = 3;</code>
+     * <code>optional bool promote = 2;</code>
      */
     boolean getPromote();
   }
@@ -5740,7 +5740,7 @@ public final class Protocol {
    * Protobuf type {@code alluxio.proto.dataserver.LocalBlockOpenRequest}
    *
    * <pre>
-   * next available id: 4
+   * next available id: 3
    * </pre>
    */
   public static final class LocalBlockOpenRequest extends
@@ -5796,7 +5796,7 @@ public final class Protocol {
               blockId_ = input.readInt64();
               break;
             }
-            case 24: {
+            case 16: {
               bitField0_ |= 0x00000002;
               promote_ = input.readBool();
               break;
@@ -5857,17 +5857,17 @@ public final class Protocol {
       return blockId_;
     }
 
-    // optional bool promote = 3;
-    public static final int PROMOTE_FIELD_NUMBER = 3;
+    // optional bool promote = 2;
+    public static final int PROMOTE_FIELD_NUMBER = 2;
     private boolean promote_;
     /**
-     * <code>optional bool promote = 3;</code>
+     * <code>optional bool promote = 2;</code>
      */
     public boolean hasPromote() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bool promote = 3;</code>
+     * <code>optional bool promote = 2;</code>
      */
     public boolean getPromote() {
       return promote_;
@@ -5893,7 +5893,7 @@ public final class Protocol {
         output.writeInt64(1, blockId_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBool(3, promote_);
+        output.writeBool(2, promote_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -5910,7 +5910,7 @@ public final class Protocol {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(3, promote_);
+          .computeBoolSize(2, promote_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5994,7 +5994,7 @@ public final class Protocol {
      * Protobuf type {@code alluxio.proto.dataserver.LocalBlockOpenRequest}
      *
      * <pre>
-     * next available id: 4
+     * next available id: 3
      * </pre>
      */
     public static final class Builder extends
@@ -6154,22 +6154,22 @@ public final class Protocol {
         return this;
       }
 
-      // optional bool promote = 3;
+      // optional bool promote = 2;
       private boolean promote_ ;
       /**
-       * <code>optional bool promote = 3;</code>
+       * <code>optional bool promote = 2;</code>
        */
       public boolean hasPromote() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional bool promote = 3;</code>
+       * <code>optional bool promote = 2;</code>
        */
       public boolean getPromote() {
         return promote_;
       }
       /**
-       * <code>optional bool promote = 3;</code>
+       * <code>optional bool promote = 2;</code>
        */
       public Builder setPromote(boolean value) {
         bitField0_ |= 0x00000002;
@@ -6178,7 +6178,7 @@ public final class Protocol {
         return this;
       }
       /**
-       * <code>optional bool promote = 3;</code>
+       * <code>optional bool promote = 2;</code>
        */
       public Builder clearPromote() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -6694,7 +6694,7 @@ public final class Protocol {
    * Protobuf type {@code alluxio.proto.dataserver.LocalBlockCloseRequest}
    *
    * <pre>
-   * next available id: 3
+   * next available id: 2
    * </pre>
    */
   public static final class LocalBlockCloseRequest extends
@@ -6919,7 +6919,7 @@ public final class Protocol {
      * Protobuf type {@code alluxio.proto.dataserver.LocalBlockCloseRequest}
      *
      * <pre>
-     * next available id: 3
+     * next available id: 2
      * </pre>
      */
     public static final class Builder extends
@@ -8252,13 +8252,13 @@ public final class Protocol {
      */
     long getBlockId();
 
-    // optional bool cancel = 3;
+    // optional bool cancel = 2;
     /**
-     * <code>optional bool cancel = 3;</code>
+     * <code>optional bool cancel = 2;</code>
      */
     boolean hasCancel();
     /**
-     * <code>optional bool cancel = 3;</code>
+     * <code>optional bool cancel = 2;</code>
      */
     boolean getCancel();
   }
@@ -8266,7 +8266,7 @@ public final class Protocol {
    * Protobuf type {@code alluxio.proto.dataserver.LocalBlockCompleteRequest}
    *
    * <pre>
-   * next available id: 4
+   * next available id: 3
    * </pre>
    */
   public static final class LocalBlockCompleteRequest extends
@@ -8322,7 +8322,7 @@ public final class Protocol {
               blockId_ = input.readInt64();
               break;
             }
-            case 24: {
+            case 16: {
               bitField0_ |= 0x00000002;
               cancel_ = input.readBool();
               break;
@@ -8383,17 +8383,17 @@ public final class Protocol {
       return blockId_;
     }
 
-    // optional bool cancel = 3;
-    public static final int CANCEL_FIELD_NUMBER = 3;
+    // optional bool cancel = 2;
+    public static final int CANCEL_FIELD_NUMBER = 2;
     private boolean cancel_;
     /**
-     * <code>optional bool cancel = 3;</code>
+     * <code>optional bool cancel = 2;</code>
      */
     public boolean hasCancel() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bool cancel = 3;</code>
+     * <code>optional bool cancel = 2;</code>
      */
     public boolean getCancel() {
       return cancel_;
@@ -8419,7 +8419,7 @@ public final class Protocol {
         output.writeInt64(1, blockId_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBool(3, cancel_);
+        output.writeBool(2, cancel_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -8436,7 +8436,7 @@ public final class Protocol {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(3, cancel_);
+          .computeBoolSize(2, cancel_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -8520,7 +8520,7 @@ public final class Protocol {
      * Protobuf type {@code alluxio.proto.dataserver.LocalBlockCompleteRequest}
      *
      * <pre>
-     * next available id: 4
+     * next available id: 3
      * </pre>
      */
     public static final class Builder extends
@@ -8680,22 +8680,22 @@ public final class Protocol {
         return this;
       }
 
-      // optional bool cancel = 3;
+      // optional bool cancel = 2;
       private boolean cancel_ ;
       /**
-       * <code>optional bool cancel = 3;</code>
+       * <code>optional bool cancel = 2;</code>
        */
       public boolean hasCancel() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional bool cancel = 3;</code>
+       * <code>optional bool cancel = 2;</code>
        */
       public boolean getCancel() {
         return cancel_;
       }
       /**
-       * <code>optional bool cancel = 3;</code>
+       * <code>optional bool cancel = 2;</code>
        */
       public Builder setCancel(boolean value) {
         bitField0_ |= 0x00000002;
@@ -8704,7 +8704,7 @@ public final class Protocol {
         return this;
       }
       /**
-       * <code>optional bool cancel = 3;</code>
+       * <code>optional bool cancel = 2;</code>
        */
       public Builder clearCancel() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -8822,7 +8822,7 @@ public final class Protocol {
       ".alluxio.proto.dataserver.ReadResponse.T" +
       "ype\"\036\n\004Type\022\026\n\022UFS_READ_HEARTBEAT\020\001\"\013\n\tH" +
       "eartbeat\":\n\025LocalBlockOpenRequest\022\020\n\010blo" +
-      "ck_id\030\001 \001(\003\022\017\n\007promote\030\003 \001(\010\"&\n\026LocalBlo" +
+      "ck_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"&\n\026LocalBlo" +
       "ckOpenResponse\022\014\n\004path\030\001 \001(\t\"*\n\026LocalBlo" +
       "ckCloseRequest\022\020\n\010block_id\030\001 \001(\003\"o\n\027Loca" +
       "lBlockCreateRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n" +
@@ -8830,7 +8830,7 @@ public final class Protocol {
       "\022only_reserve_space\030\005 \001(\010\"(\n\030LocalBlockC",
       "reateResponse\022\014\n\004path\030\001 \001(\t\"=\n\031LocalBloc" +
       "kCompleteRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006ca" +
-      "ncel\030\003 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLO" +
+      "ncel\030\002 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLO" +
       "CK\020\000\022\014\n\010UFS_FILE\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =

--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -95,101 +95,6 @@ public final class Protocol {
     // @@protoc_insertion_point(enum_scope:alluxio.proto.dataserver.RequestType)
   }
 
-  /**
-   * Protobuf enum {@code alluxio.proto.dataserver.ReadType}
-   *
-   * <pre>
-   * The read type.
-   * </pre>
-   */
-  public enum ReadType
-      implements com.google.protobuf.ProtocolMessageEnum {
-    /**
-     * <code>NO_CACHE = 0;</code>
-     */
-    NO_CACHE(0, 0),
-    /**
-     * <code>CACHE = 1;</code>
-     */
-    CACHE(1, 1),
-    /**
-     * <code>CACHE_PROMOTE = 2;</code>
-     */
-    CACHE_PROMOTE(2, 2),
-    ;
-
-    /**
-     * <code>NO_CACHE = 0;</code>
-     */
-    public static final int NO_CACHE_VALUE = 0;
-    /**
-     * <code>CACHE = 1;</code>
-     */
-    public static final int CACHE_VALUE = 1;
-    /**
-     * <code>CACHE_PROMOTE = 2;</code>
-     */
-    public static final int CACHE_PROMOTE_VALUE = 2;
-
-
-    public final int getNumber() { return value; }
-
-    public static ReadType valueOf(int value) {
-      switch (value) {
-        case 0: return NO_CACHE;
-        case 1: return CACHE;
-        case 2: return CACHE_PROMOTE;
-        default: return null;
-      }
-    }
-
-    public static com.google.protobuf.Internal.EnumLiteMap<ReadType>
-        internalGetValueMap() {
-      return internalValueMap;
-    }
-    private static com.google.protobuf.Internal.EnumLiteMap<ReadType>
-        internalValueMap =
-          new com.google.protobuf.Internal.EnumLiteMap<ReadType>() {
-            public ReadType findValueByNumber(int number) {
-              return ReadType.valueOf(number);
-            }
-          };
-
-    public final com.google.protobuf.Descriptors.EnumValueDescriptor
-        getValueDescriptor() {
-      return getDescriptor().getValues().get(index);
-    }
-    public final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptorForType() {
-      return getDescriptor();
-    }
-    public static final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptor() {
-      return alluxio.proto.dataserver.Protocol.getDescriptor().getEnumTypes().get(1);
-    }
-
-    private static final ReadType[] VALUES = values();
-
-    public static ReadType valueOf(
-        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-      if (desc.getType() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "EnumValueDescriptor is not for this type.");
-      }
-      return VALUES[desc.getIndex()];
-    }
-
-    private final int index;
-    private final int value;
-
-    private ReadType(int index, int value) {
-      this.index = index;
-      this.value = value;
-    }
-
-    // @@protoc_insertion_point(enum_scope:alluxio.proto.dataserver.ReadType)
-  }
-
   public interface ReadRequestOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -241,23 +146,23 @@ public final class Protocol {
      */
     boolean getCancel();
 
-    // optional .alluxio.proto.dataserver.ReadType read_type = 7;
+    // optional bool promote = 7;
     /**
-     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     * <code>optional bool promote = 7;</code>
      *
      * <pre>
-     * The read type associated with this request
+     * Whether the block should be promoted before reading
      * </pre>
      */
-    boolean hasReadType();
+    boolean hasPromote();
     /**
-     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     * <code>optional bool promote = 7;</code>
      *
      * <pre>
-     * The read type associated with this request
+     * Whether the block should be promoted before reading
      * </pre>
      */
-    alluxio.proto.dataserver.Protocol.ReadType getReadType();
+    boolean getPromote();
 
     // optional int64 packet_size = 5;
     /**
@@ -398,14 +303,8 @@ public final class Protocol {
               break;
             }
             case 56: {
-              int rawValue = input.readEnum();
-              alluxio.proto.dataserver.Protocol.ReadType value = alluxio.proto.dataserver.Protocol.ReadType.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(7, rawValue);
-              } else {
-                bitField0_ |= 0x00000010;
-                readType_ = value;
-              }
+              bitField0_ |= 0x00000010;
+              promote_ = input.readBool();
               break;
             }
           }
@@ -520,28 +419,28 @@ public final class Protocol {
       return cancel_;
     }
 
-    // optional .alluxio.proto.dataserver.ReadType read_type = 7;
-    public static final int READ_TYPE_FIELD_NUMBER = 7;
-    private alluxio.proto.dataserver.Protocol.ReadType readType_;
+    // optional bool promote = 7;
+    public static final int PROMOTE_FIELD_NUMBER = 7;
+    private boolean promote_;
     /**
-     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     * <code>optional bool promote = 7;</code>
      *
      * <pre>
-     * The read type associated with this request
+     * Whether the block should be promoted before reading
      * </pre>
      */
-    public boolean hasReadType() {
+    public boolean hasPromote() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+     * <code>optional bool promote = 7;</code>
      *
      * <pre>
-     * The read type associated with this request
+     * Whether the block should be promoted before reading
      * </pre>
      */
-    public alluxio.proto.dataserver.Protocol.ReadType getReadType() {
-      return readType_;
+    public boolean getPromote() {
+      return promote_;
     }
 
     // optional int64 packet_size = 5;
@@ -607,7 +506,7 @@ public final class Protocol {
       offset_ = 0L;
       length_ = 0L;
       cancel_ = false;
-      readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+      promote_ = false;
       packetSize_ = 0L;
       openUfsBlockOptions_ = alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance();
     }
@@ -642,7 +541,7 @@ public final class Protocol {
         output.writeMessage(6, openUfsBlockOptions_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeEnum(7, readType_.getNumber());
+        output.writeBool(7, promote_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -679,7 +578,7 @@ public final class Protocol {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(7, readType_.getNumber());
+          .computeBoolSize(7, promote_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -811,7 +710,7 @@ public final class Protocol {
         bitField0_ = (bitField0_ & ~0x00000004);
         cancel_ = false;
         bitField0_ = (bitField0_ & ~0x00000008);
-        readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+        promote_ = false;
         bitField0_ = (bitField0_ & ~0x00000010);
         packetSize_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000020);
@@ -868,7 +767,7 @@ public final class Protocol {
         if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
           to_bitField0_ |= 0x00000010;
         }
-        result.readType_ = readType_;
+        result.promote_ = promote_;
         if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
           to_bitField0_ |= 0x00000020;
         }
@@ -909,8 +808,8 @@ public final class Protocol {
         if (other.hasCancel()) {
           setCancel(other.getCancel());
         }
-        if (other.hasReadType()) {
-          setReadType(other.getReadType());
+        if (other.hasPromote()) {
+          setPromote(other.getPromote());
         }
         if (other.hasPacketSize()) {
           setPacketSize(other.getPacketSize());
@@ -1093,54 +992,51 @@ public final class Protocol {
         return this;
       }
 
-      // optional .alluxio.proto.dataserver.ReadType read_type = 7;
-      private alluxio.proto.dataserver.Protocol.ReadType readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+      // optional bool promote = 7;
+      private boolean promote_ ;
       /**
-       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       * <code>optional bool promote = 7;</code>
        *
        * <pre>
-       * The read type associated with this request
+       * Whether the block should be promoted before reading
        * </pre>
        */
-      public boolean hasReadType() {
+      public boolean hasPromote() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
-       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       * <code>optional bool promote = 7;</code>
        *
        * <pre>
-       * The read type associated with this request
+       * Whether the block should be promoted before reading
        * </pre>
        */
-      public alluxio.proto.dataserver.Protocol.ReadType getReadType() {
-        return readType_;
+      public boolean getPromote() {
+        return promote_;
       }
       /**
-       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       * <code>optional bool promote = 7;</code>
        *
        * <pre>
-       * The read type associated with this request
+       * Whether the block should be promoted before reading
        * </pre>
        */
-      public Builder setReadType(alluxio.proto.dataserver.Protocol.ReadType value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
+      public Builder setPromote(boolean value) {
         bitField0_ |= 0x00000010;
-        readType_ = value;
+        promote_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional .alluxio.proto.dataserver.ReadType read_type = 7;</code>
+       * <code>optional bool promote = 7;</code>
        *
        * <pre>
-       * The read type associated with this request
+       * Whether the block should be promoted before reading
        * </pre>
        */
-      public Builder clearReadType() {
+      public Builder clearPromote() {
         bitField0_ = (bitField0_ & ~0x00000010);
-        readType_ = alluxio.proto.dataserver.Protocol.ReadType.NO_CACHE;
+        promote_ = false;
         onChanged();
         return this;
       }
@@ -8288,38 +8184,36 @@ public final class Protocol {
   static {
     java.lang.String[] descriptorData = {
       "\n\016protocol.proto\022\030alluxio.proto.dataserv" +
-      "er\032\014status.proto\"\352\001\n\013ReadRequest\022\020\n\010bloc" +
+      "er\032\014status.proto\"\304\001\n\013ReadRequest\022\020\n\010bloc" +
       "k_id\030\001 \001(\003\022\016\n\006offset\030\002 \001(\003\022\016\n\006length\030\003 \001" +
-      "(\003\022\016\n\006cancel\030\004 \001(\010\0225\n\tread_type\030\007 \001(\0162\"." +
-      "alluxio.proto.dataserver.ReadType\022\023\n\013pac" +
-      "ket_size\030\005 \001(\003\022M\n\026open_ufs_block_options" +
-      "\030\006 \001(\0132-.alluxio.proto.dataserver.OpenUf" +
-      "sBlockOptions\"\224\001\n\023OpenUfsBlockOptions\022\017\n" +
-      "\007ufsPath\030\001 \001(\t\022\026\n\016offset_in_file\030\002 \001(\003\022\022" +
-      "\n\nblock_size\030\003 \001(\003\022\035\n\025maxUfsReadConcurre",
-      "ncy\030\004 \001(\005\022\017\n\007mountId\030\005 \001(\003\022\020\n\010no_cache\030\006" +
-      " \001(\010\"\332\001\n\014WriteRequest\0223\n\004type\030\001 \001(\0162%.al" +
-      "luxio.proto.dataserver.RequestType\022\n\n\002id" +
-      "\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\013\n\003" +
-      "eof\030\005 \001(\010\022\016\n\006cancel\030\006 \001(\010\022\020\n\010ufs_path\030\007 " +
-      "\001(\t\022\r\n\005owner\030\010 \001(\t\022\r\n\005group\030\t \001(\t\022\014\n\004mod" +
-      "e\030\n \001(\005\022\020\n\010mount_id\030\013 \001(\003\"J\n\010Response\022-\n" +
-      "\006status\030\001 \001(\0162\035.alluxio.proto.status.PSt" +
-      "atus\022\017\n\007message\030\002 \001(\t\"i\n\014ReadResponse\0229\n" +
-      "\004type\030\001 \001(\0162+.alluxio.proto.dataserver.R",
-      "eadResponse.Type\"\036\n\004Type\022\026\n\022UFS_READ_HEA" +
-      "RTBEAT\020\001\"\013\n\tHeartbeat\")\n\025LocalBlockOpenR" +
-      "equest\022\020\n\010block_id\030\001 \001(\003\"&\n\026LocalBlockOp" +
-      "enResponse\022\014\n\004path\030\001 \001(\t\"*\n\026LocalBlockCl" +
-      "oseRequest\022\020\n\010block_id\030\001 \001(\003\"o\n\027LocalBlo" +
-      "ckCreateRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n\004tie" +
-      "r\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n\022onl" +
-      "y_reserve_space\030\005 \001(\010\"(\n\030LocalBlockCreat" +
-      "eResponse\022\014\n\004path\030\001 \001(\t\"=\n\031LocalBlockCom" +
-      "pleteRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006cancel",
-      "\030\003 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLOCK\020\000" +
-      "\022\014\n\010UFS_FILE\020\001*6\n\010ReadType\022\014\n\010NO_CACHE\020\000" +
-      "\022\t\n\005CACHE\020\001\022\021\n\rCACHE_PROMOTE\020\002"
+      "(\003\022\016\n\006cancel\030\004 \001(\010\022\017\n\007promote\030\007 \001(\010\022\023\n\013p" +
+      "acket_size\030\005 \001(\003\022M\n\026open_ufs_block_optio" +
+      "ns\030\006 \001(\0132-.alluxio.proto.dataserver.Open" +
+      "UfsBlockOptions\"\224\001\n\023OpenUfsBlockOptions\022" +
+      "\017\n\007ufsPath\030\001 \001(\t\022\026\n\016offset_in_file\030\002 \001(\003" +
+      "\022\022\n\nblock_size\030\003 \001(\003\022\035\n\025maxUfsReadConcur" +
+      "rency\030\004 \001(\005\022\017\n\007mountId\030\005 \001(\003\022\020\n\010no_cache",
+      "\030\006 \001(\010\"\332\001\n\014WriteRequest\0223\n\004type\030\001 \001(\0162%." +
+      "alluxio.proto.dataserver.RequestType\022\n\n\002" +
+      "id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\013" +
+      "\n\003eof\030\005 \001(\010\022\016\n\006cancel\030\006 \001(\010\022\020\n\010ufs_path\030" +
+      "\007 \001(\t\022\r\n\005owner\030\010 \001(\t\022\r\n\005group\030\t \001(\t\022\014\n\004m" +
+      "ode\030\n \001(\005\022\020\n\010mount_id\030\013 \001(\003\"J\n\010Response\022" +
+      "-\n\006status\030\001 \001(\0162\035.alluxio.proto.status.P" +
+      "Status\022\017\n\007message\030\002 \001(\t\"i\n\014ReadResponse\022" +
+      "9\n\004type\030\001 \001(\0162+.alluxio.proto.dataserver" +
+      ".ReadResponse.Type\"\036\n\004Type\022\026\n\022UFS_READ_H",
+      "EARTBEAT\020\001\"\013\n\tHeartbeat\")\n\025LocalBlockOpe" +
+      "nRequest\022\020\n\010block_id\030\001 \001(\003\"&\n\026LocalBlock" +
+      "OpenResponse\022\014\n\004path\030\001 \001(\t\"*\n\026LocalBlock" +
+      "CloseRequest\022\020\n\010block_id\030\001 \001(\003\"o\n\027LocalB" +
+      "lockCreateRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n\004t" +
+      "ier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n\022o" +
+      "nly_reserve_space\030\005 \001(\010\"(\n\030LocalBlockCre" +
+      "ateResponse\022\014\n\004path\030\001 \001(\t\"=\n\031LocalBlockC" +
+      "ompleteRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006canc" +
+      "el\030\003 \001(\010*.\n\013RequestType\022\021\n\rALLUXIO_BLOCK",
+      "\020\000\022\014\n\010UFS_FILE\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8331,7 +8225,7 @@ public final class Protocol {
           internal_static_alluxio_proto_dataserver_ReadRequest_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_dataserver_ReadRequest_descriptor,
-              new java.lang.String[] { "BlockId", "Offset", "Length", "Cancel", "ReadType", "PacketSize", "OpenUfsBlockOptions", });
+              new java.lang.String[] { "BlockId", "Offset", "Length", "Cancel", "Promote", "PacketSize", "OpenUfsBlockOptions", });
           internal_static_alluxio_proto_dataserver_OpenUfsBlockOptions_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_alluxio_proto_dataserver_OpenUfsBlockOptions_fieldAccessorTable = new

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -96,10 +96,10 @@ message Heartbeat {
 
 // Netty RPCs. Every RPC needs to define a request type and optionally a response type (default to Response).
 
-// next available id: 4
+// next available id: 3
 message LocalBlockOpenRequest {
   optional int64 block_id = 1;
-  optional bool promote = 3;
+  optional bool promote = 2;
 }
 
 // next available id: 2
@@ -107,7 +107,7 @@ message LocalBlockOpenResponse {
   optional string path = 1;
 }
 
-// next available id: 3
+// next available id: 2
 message LocalBlockCloseRequest {
   optional int64 block_id = 1;
 }
@@ -126,8 +126,8 @@ message LocalBlockCreateResponse {
   optional string path = 1;
 }
 
-// next available id: 4
+// next available id: 3
 message LocalBlockCompleteRequest {
   optional int64 block_id = 1;
-  optional bool cancel = 3;
+  optional bool cancel = 2;
 }

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -11,14 +11,23 @@ enum RequestType {
   UFS_FILE = 1;
 }
 
+// The read type.
+enum ReadType {
+  NO_CACHE = 0;
+  CACHE = 1;
+  CACHE_PROMOTE = 2;
+}
+
 // The read request.
-// next available id: 7
+// next available id: 8
 message ReadRequest {
   optional int64 block_id = 1;
   optional int64 offset = 2;
   optional int64 length = 3;
   // If set, this request is to cancel the reading request for the id.
   optional bool cancel = 4;
+  // The read type associated with this request
+  optional ReadType read_type = 7;
 
   // If set, the server should send packets in the specified packet size.
   optional int64 packet_size = 5;

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -11,13 +11,6 @@ enum RequestType {
   UFS_FILE = 1;
 }
 
-// The read type.
-enum ReadType {
-  NO_CACHE = 0;
-  CACHE = 1;
-  CACHE_PROMOTE = 2;
-}
-
 // The read request.
 // next available id: 8
 message ReadRequest {
@@ -26,8 +19,8 @@ message ReadRequest {
   optional int64 length = 3;
   // If set, this request is to cancel the reading request for the id.
   optional bool cancel = 4;
-  // The read type associated with this request
-  optional ReadType read_type = 7;
+  // Whether the block should be promoted before reading
+  optional bool promote = 7;
 
   // If set, the server should send packets in the specified packet size.
   optional int64 packet_size = 5;

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -93,7 +93,7 @@ message Heartbeat {
 // next available id: 4
 message LocalBlockOpenRequest {
   optional int64 block_id = 1;
-  optional int64 promote = 3;
+  optional bool promote = 3;
 }
 
 // next available id: 2

--- a/core/protobuf/src/proto/dataserver/protocol.proto
+++ b/core/protobuf/src/proto/dataserver/protocol.proto
@@ -90,9 +90,10 @@ message Heartbeat {
 
 // Netty RPCs. Every RPC needs to define a request type and optionally a response type (default to Response).
 
-// next available id: 3
+// next available id: 4
 message LocalBlockOpenRequest {
   optional int64 block_id = 1;
+  optional int64 promote = 3;
 }
 
 // next available id: 2

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerBlockReadHandler.java
@@ -71,7 +71,7 @@ final class DataServerBlockReadHandler extends DataServerReadHandler {
   private final class BlockReadRequestInternal extends ReadRequestInternal {
     BlockReader mBlockReader;
     final Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
-    final Protocol.ReadType mReadType;
+    final boolean mPromote;
 
     /**
      * Creates an instance of {@link BlockReadRequestInternal}.
@@ -87,7 +87,7 @@ final class DataServerBlockReadHandler extends DataServerReadHandler {
       } else {
         mOpenUfsBlockOptions = null;
       }
-      mReadType = request.getReadType();
+      mPromote = request.getPromote();
       // Note that we do not need to seek to offset since the block worker is created at the offset.
     }
 
@@ -96,13 +96,6 @@ final class DataServerBlockReadHandler extends DataServerReadHandler {
      */
     boolean isPersisted() {
       return mOpenUfsBlockOptions != null && mOpenUfsBlockOptions.hasUfsPath();
-    }
-
-    /**
-     * @return true if the block should be promoted before reading
-     */
-    boolean isPromote() {
-      return mReadType == Protocol.ReadType.CACHE_PROMOTE;
     }
 
     @Override
@@ -190,7 +183,7 @@ final class DataServerBlockReadHandler extends DataServerReadHandler {
       }
       if (lockId != BlockLockManager.INVALID_LOCK_ID) {
         try {
-          if (request.isPromote()) {
+          if (request.mPromote) {
             mWorker.moveBlock(request.mSessionId, request.mId, mStorageTierAssoc.getAlias(0));
           }
           request.mBlockReader = mWorker.readBlockRemote(request.mSessionId, request.mId, lockId);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerShortCircuitReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerShortCircuitReadHandler.java
@@ -99,7 +99,10 @@ class DataServerShortCircuitReadHandler extends ChannelInboundHandlerAdapter {
     ctx.fireChannelUnregistered();
   }
 
-  class BlockOpenRequestHandler implements Runnable {
+  /**
+   * Runnable for handling the expensive open block call logic.
+   */
+  final class BlockOpenRequestHandler implements Runnable {
     Protocol.LocalBlockOpenRequest mRequest;
     ChannelHandlerContext mContext;
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/DataServerShortCircuitReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/DataServerShortCircuitReadHandler.java
@@ -12,6 +12,8 @@
 package alluxio.worker.netty;
 
 import alluxio.RpcUtils;
+import alluxio.StorageTierAssoc;
+import alluxio.WorkerStorageTierAssoc;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
@@ -29,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Netty handler that handles short circuit read requests.
@@ -38,8 +41,11 @@ class DataServerShortCircuitReadHandler extends ChannelInboundHandlerAdapter {
   private static final Logger LOG =
       LoggerFactory.getLogger(DataServerShortCircuitReadHandler.class);
 
+  /** Executor service for block opens. */
+  private final ExecutorService mBlockOpenExecutor;
+  private final StorageTierAssoc mStorageTierAssoc = new WorkerStorageTierAssoc();
   /** The block worker. */
-  private final BlockWorker mBlockWorker;
+  private final BlockWorker mWorker;
   /** The lock Id of the block being read. */
   private long mLockId;
   private long mSessionId;
@@ -49,8 +55,9 @@ class DataServerShortCircuitReadHandler extends ChannelInboundHandlerAdapter {
    *
    * @param blockWorker the block worker
    */
-  DataServerShortCircuitReadHandler(BlockWorker blockWorker) {
-    mBlockWorker = blockWorker;
+  DataServerShortCircuitReadHandler(ExecutorService service, BlockWorker blockWorker) {
+    mBlockOpenExecutor = service;
+    mWorker = blockWorker;
     mLockId = BlockLockManager.INVALID_LOCK_ID;
   }
 
@@ -83,64 +90,88 @@ class DataServerShortCircuitReadHandler extends ChannelInboundHandlerAdapter {
   public void channelUnregistered(ChannelHandlerContext ctx) {
     if (mLockId != BlockLockManager.INVALID_LOCK_ID) {
       try {
-        mBlockWorker.unlockBlock(mLockId);
+        mWorker.unlockBlock(mLockId);
       } catch (BlockDoesNotExistException e) {
         LOG.warn("Failed to unlock lock {} with error {}.", mLockId, e.getMessage());
       }
-      mBlockWorker.cleanupSession(mSessionId);
+      mWorker.cleanupSession(mSessionId);
     }
     ctx.fireChannelUnregistered();
   }
 
+  class BlockOpenRequestHandler implements Runnable {
+    Protocol.LocalBlockOpenRequest mRequest;
+    ChannelHandlerContext mContext;
+
+    private BlockOpenRequestHandler(ChannelHandlerContext ctx, Protocol.LocalBlockOpenRequest req) {
+      mContext = ctx;
+      mRequest = req;
+    }
+
+    @Override
+    public void run() {
+      RpcUtils.nettyRPCAndLog(LOG, new RpcUtils.NettyRPCCallable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          // It is a no-op to lock the same block multiple times within the same channel.
+          if (mLockId == BlockLockManager.INVALID_LOCK_ID) {
+            mSessionId = IdUtils.getRandomNonNegativeLong();
+            // TODO(calvin): Update the locking logic so this can be done better
+            if (mRequest.getPromote()) {
+              try {
+                mWorker.moveBlock(mSessionId, mRequest.getBlockId(), mStorageTierAssoc.getAlias(0));
+              } catch (Exception e) {
+                LOG.warn("Failed to promote block {}: {}", mRequest.getBlockId(), e.getMessage());
+              }
+            }
+            mLockId = mWorker.lockBlock(mSessionId, mRequest.getBlockId());
+            mWorker.accessBlock(mSessionId, mRequest.getBlockId());
+          } else {
+            LOG.warn("Lock block {} without releasing previous block lock {}.",
+                mRequest.getBlockId(), mLockId);
+            throw new InvalidWorkerStateException(
+                ExceptionMessage.LOCK_NOT_RELEASED.getMessage(mLockId));
+          }
+          Protocol.LocalBlockOpenResponse response = Protocol.LocalBlockOpenResponse.newBuilder()
+              .setPath(mWorker.readBlock(mSessionId, mRequest.getBlockId(), mLockId))
+              .build();
+          mContext.writeAndFlush(new RPCProtoMessage(new ProtoMessage(response)));
+
+          return null;
+        }
+
+        @Override
+        public void exceptionCaught(Throwable e) {
+          if (mLockId != BlockLockManager.INVALID_LOCK_ID) {
+            try {
+              mWorker.unlockBlock(mLockId);
+            } catch (BlockDoesNotExistException ee) {
+              LOG.error("Failed to unlock block {}.", mRequest.getBlockId(), e);
+            }
+            mLockId = BlockLockManager.INVALID_LOCK_ID;
+          }
+          mContext.writeAndFlush(RPCProtoMessage.createResponse(AlluxioStatusException.from(e)));
+        }
+
+        @Override
+        public String toString() {
+          return String.format("Open block: %s", mRequest.toString());
+        }
+      });
+    }
+  }
+
   /**
-   * Handles {@link Protocol.LocalBlockOpenRequest}. No exceptions should be thrown.
+   * Handles {@link Protocol.LocalBlockOpenRequest}. Since the open can be expensive, the work is
+   * delegated to a threadpool. No exceptions should be thrown.
    *
    * @param ctx the channel handler context
    * @param request the local block open request
    */
   private void handleBlockOpenRequest(final ChannelHandlerContext ctx,
       final Protocol.LocalBlockOpenRequest request) {
-    RpcUtils.nettyRPCAndLog(LOG, new RpcUtils.NettyRPCCallable<Void>() {
-
-      @Override
-      public Void call() throws Exception {
-        // It is a no-op to lock the same block multiple times within the same channel.
-        if (mLockId == BlockLockManager.INVALID_LOCK_ID) {
-          mSessionId = IdUtils.getRandomNonNegativeLong();
-          mLockId = mBlockWorker.lockBlock(mSessionId, request.getBlockId());
-          mBlockWorker.accessBlock(mSessionId, request.getBlockId());
-        } else {
-          LOG.warn("Lock block {} without releasing previous block lock {}.", request.getBlockId(),
-              mLockId);
-          throw new InvalidWorkerStateException(
-              ExceptionMessage.LOCK_NOT_RELEASED.getMessage(mLockId));
-        }
-        Protocol.LocalBlockOpenResponse response = Protocol.LocalBlockOpenResponse.newBuilder()
-            .setPath(mBlockWorker.readBlock(mSessionId, request.getBlockId(), mLockId))
-            .build();
-        ctx.writeAndFlush(new RPCProtoMessage(new ProtoMessage(response)));
-
-        return null;
-      }
-
-      @Override
-      public void exceptionCaught(Throwable e) {
-        if (mLockId != BlockLockManager.INVALID_LOCK_ID) {
-          try {
-            mBlockWorker.unlockBlock(mLockId);
-          } catch (BlockDoesNotExistException ee) {
-            LOG.error("Failed to unlock block {}.", request.getBlockId(), e);
-          }
-          mLockId = BlockLockManager.INVALID_LOCK_ID;
-        }
-        ctx.writeAndFlush(RPCProtoMessage.createResponse(AlluxioStatusException.from(e)));
-      }
-
-      @Override
-      public String toString() {
-        return String.format("Open block: %s", request.toString());
-      }
-    });
+    BlockOpenRequestHandler handler = new BlockOpenRequestHandler(ctx, request);
+    mBlockOpenExecutor.submit(handler);
   }
 
   /**
@@ -156,7 +187,7 @@ class DataServerShortCircuitReadHandler extends ChannelInboundHandlerAdapter {
       @Override
       public Void call() throws Exception {
         if (mLockId != BlockLockManager.INVALID_LOCK_ID) {
-          mBlockWorker.unlockBlock(mLockId);
+          mWorker.unlockBlock(mLockId);
           mLockId = BlockLockManager.INVALID_LOCK_ID;
         } else {
           LOG.warn("Close a closed block {}.", request.getBlockId());

--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
@@ -53,7 +53,7 @@ final class NettyExecutors {
       new ThreadPoolExecutor(THREADS_MIN,
           Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(),
-          ThreadFactoryUtils.build("BlockPromoteExecutor-%d", true));
+          ThreadFactoryUtils.build("BlockOpenExecutor-%d", true));
 
   /**
    * Private constructor.

--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
@@ -49,6 +49,12 @@ final class NettyExecutors {
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(),
           ThreadFactoryUtils.build("FilePacketWriterExecutor-%d", true));
 
+  public static final ExecutorService BLOCK_OPEN_EXECUTOR =
+      new ThreadPoolExecutor(THREADS_MIN,
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX),
+          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(),
+          ThreadFactoryUtils.build("BlockPromoteExecutor-%d", true));
+
   /**
    * Private constructor.
    */

--- a/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -68,7 +68,8 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
     pipeline.addLast("dataServerBlockWriteHandler", new DataServerBlockWriteHandler(
         NettyExecutors.BLOCK_WRITER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class)));
     pipeline.addLast("dataServerShortCircuitReadHandler",
-        new DataServerShortCircuitReadHandler(mWorkerProcess.getWorker(BlockWorker.class)));
+        new DataServerShortCircuitReadHandler(NettyExecutors.BLOCK_OPEN_EXECUTOR,
+            mWorkerProcess.getWorker(BlockWorker.class)));
     pipeline.addLast("dataServerShortCircuitWriteHandler",
         new DataServerShortCircuitWriteHandler(mWorkerProcess.getWorker(BlockWorker.class)));
 

--- a/tests/src/test/java/alluxio/worker/block/meta/TierPromoteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/block/meta/TierPromoteIntegrationTest.java
@@ -33,26 +33,20 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@RunWith(Parameterized.class)
 public class TierPromoteIntegrationTest extends BaseIntegrationTest {
   private static final int CAPACITY_BYTES = Constants.KB;
   private static final String BLOCK_SIZE_BYTES = "1KB";
 
   @Rule
-  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource.Builder()
-          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
-          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BLOCK_SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
-          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
-          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
-          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
-              Files.createTempDir().getAbsolutePath())
-          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(1),
-              Files.createTempDir().getAbsolutePath())
-          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(1),
-              String.valueOf(CAPACITY_BYTES)).build();
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource;
 
   @ClassRule
   public static ManuallyScheduleHeartbeat sManuallySchedule =
@@ -65,49 +59,38 @@ public class TierPromoteIntegrationTest extends BaseIntegrationTest {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }
 
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = { PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false"})
-  public void promoteBlock() throws Exception {
-    final int size = CAPACITY_BYTES / 2;
-    AlluxioURI path1 = new AlluxioURI(PathUtils.uniqPath());
-    AlluxioURI path2 = new AlluxioURI(PathUtils.uniqPath());
-    AlluxioURI path3 = new AlluxioURI(PathUtils.uniqPath());
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    List<Object[]> list = new ArrayList<>();
+    list.add(new Object[] { /* short circuit enabled */ "true" });
+    list.add(new Object[] { /* short circuit enabled */ "false"});
+    return list;
+  }
 
-    // Write three files, first file should be in ssd, the others should be in memory
-    FileOutStream os1 = mFileSystem.createFile(path1);
-    os1.write(BufferUtils.getIncreasingByteArray(size));
-    os1.close();
-    FileOutStream os2 = mFileSystem.createFile(path2);
-    os2.write(BufferUtils.getIncreasingByteArray(size));
-    os2.close();
-    FileOutStream os3 = mFileSystem.createFile(path3);
-    os3.write(BufferUtils.getIncreasingByteArray(size));
-    os3.close();
-
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-
-    // Not in memory but in Alluxio storage
-    Assert.assertEquals(0, mFileSystem.getStatus(path1).getInMemoryPercentage());
-    Assert.assertFalse(mFileSystem.getStatus(path1).getFileBlockInfos().isEmpty());
-
-    // After reading with CACHE_PROMOTE, the file should be in memory
-    FileInStream in = mFileSystem.openFile(path1, OpenFileOptions.defaults().setReadType(ReadType
-        .CACHE_PROMOTE));
-    byte[] buf = new byte[size];
-    while (in.read(buf) != -1) {
-      // read the entire file
-    }
-    in.close();
-
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-
-    // In memory
-    Assert.assertEquals(100, mFileSystem.getStatus(path1).getInMemoryPercentage());
+  /**
+   * Constructor.
+   *
+   * @param shortCircuitEnabled whether to enable the short circuit data paths
+   */
+  public TierPromoteIntegrationTest(String shortCircuitEnabled) {
+    mLocalAlluxioClusterResource = new LocalAlluxioClusterResource.Builder()
+        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
+        .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
+        .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BLOCK_SIZE_BYTES)
+        .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
+        .setProperty(PropertyKey.USER_SHORT_CIRCUIT_ENABLED, shortCircuitEnabled)
+        .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
+        .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
+        .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
+            Files.createTempDir().getAbsolutePath())
+        .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(1),
+            Files.createTempDir().getAbsolutePath())
+        .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(1),
+            String.valueOf(CAPACITY_BYTES)).build();
   }
 
   @Test
-  public void promoteBlockShortCircuit() throws Exception {
+  public void promoteBlock() throws Exception {
     final int size = CAPACITY_BYTES / 2;
     AlluxioURI path1 = new AlluxioURI(PathUtils.uniqPath());
     AlluxioURI path2 = new AlluxioURI(PathUtils.uniqPath());

--- a/tests/src/test/java/alluxio/worker/block/meta/TierPromoteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/worker/block/meta/TierPromoteIntegrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.meta;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.LocalAlluxioClusterResource;
+import alluxio.PropertyKey;
+import alluxio.BaseIntegrationTest;
+import alluxio.client.ReadType;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.options.OpenFileOptions;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.HeartbeatScheduler;
+import alluxio.heartbeat.ManuallyScheduleHeartbeat;
+import alluxio.util.io.BufferUtils;
+import alluxio.util.io.PathUtils;
+
+import com.google.common.io.Files;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TierPromoteIntegrationTest extends BaseIntegrationTest {
+  private static final int CAPACITY_BYTES = Constants.KB;
+  private static final String BLOCK_SIZE_BYTES = "1KB";
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
+          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
+          .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BLOCK_SIZE_BYTES)
+          .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
+          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
+              Files.createTempDir().getAbsolutePath())
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(1),
+              Files.createTempDir().getAbsolutePath())
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(1),
+              String.valueOf(CAPACITY_BYTES)).build();
+
+  @ClassRule
+  public static ManuallyScheduleHeartbeat sManuallySchedule =
+      new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+  private FileSystem mFileSystem = null;
+
+  @Before
+  public final void before() throws Exception {
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = { PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false"})
+  public void promoteBlock() throws Exception {
+    final int size = CAPACITY_BYTES / 2;
+    AlluxioURI path1 = new AlluxioURI(PathUtils.uniqPath());
+    AlluxioURI path2 = new AlluxioURI(PathUtils.uniqPath());
+    AlluxioURI path3 = new AlluxioURI(PathUtils.uniqPath());
+
+    // Write three files, first file should be in ssd, the others should be in memory
+    FileOutStream os1 = mFileSystem.createFile(path1);
+    os1.write(BufferUtils.getIncreasingByteArray(size));
+    os1.close();
+    FileOutStream os2 = mFileSystem.createFile(path2);
+    os2.write(BufferUtils.getIncreasingByteArray(size));
+    os2.close();
+    FileOutStream os3 = mFileSystem.createFile(path3);
+    os3.write(BufferUtils.getIncreasingByteArray(size));
+    os3.close();
+
+    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+    // Not in memory but in Alluxio storage
+    Assert.assertEquals(0, mFileSystem.getStatus(path1).getInMemoryPercentage());
+    Assert.assertFalse(mFileSystem.getStatus(path1).getFileBlockInfos().isEmpty());
+
+    // After reading with CACHE_PROMOTE, the file should be in memory
+    FileInStream in = mFileSystem.openFile(path1, OpenFileOptions.defaults().setReadType(ReadType
+        .CACHE_PROMOTE));
+    byte[] buf = new byte[size];
+    while (in.read(buf) != -1) {
+      // read the entire file
+    }
+    in.close();
+
+    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+    // In memory
+    Assert.assertEquals(100, mFileSystem.getStatus(path1).getInMemoryPercentage());
+  }
+
+  @Test
+  public void promoteBlockShortCircuit() throws Exception {
+    final int size = CAPACITY_BYTES / 2;
+    AlluxioURI path1 = new AlluxioURI(PathUtils.uniqPath());
+    AlluxioURI path2 = new AlluxioURI(PathUtils.uniqPath());
+    AlluxioURI path3 = new AlluxioURI(PathUtils.uniqPath());
+
+    // Write three files, first file should be in ssd, the others should be in memory
+    FileOutStream os1 = mFileSystem.createFile(path1);
+    os1.write(BufferUtils.getIncreasingByteArray(size));
+    os1.close();
+    FileOutStream os2 = mFileSystem.createFile(path2);
+    os2.write(BufferUtils.getIncreasingByteArray(size));
+    os2.close();
+    FileOutStream os3 = mFileSystem.createFile(path3);
+    os3.write(BufferUtils.getIncreasingByteArray(size));
+    os3.close();
+
+    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+    // Not in memory but in Alluxio storage
+    Assert.assertEquals(0, mFileSystem.getStatus(path1).getInMemoryPercentage());
+    Assert.assertFalse(mFileSystem.getStatus(path1).getFileBlockInfos().isEmpty());
+
+    // After reading with CACHE_PROMOTE, the file should be in memory
+    FileInStream in = mFileSystem.openFile(path1, OpenFileOptions.defaults().setReadType(ReadType
+        .CACHE_PROMOTE));
+    byte[] buf = new byte[size];
+    while (in.read(buf) != -1) {
+      // read the entire file
+    }
+    in.close();
+
+    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+    // In memory
+    Assert.assertEquals(100, mFileSystem.getStatus(path1).getInMemoryPercentage());
+  }
+}


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2813

A few things which I think are suboptimal atm

1. Passing a boolean instead of ReadType. If we go with read type we may be able to save more metadata fields, but I think it should be part of a separate refactor.
2. Worker side lock logic. The worker side logic currently assumes locks are held by possibly remote clients which makes locking awkward when we move things to netty (in the same JVM).
3. Threadpool/runnable in short circuit reader. As a developer the code there seems unintuitive.