### PR TITLE
[SMALLFIX] Remove hadoop-client dependency in servers

### DIFF
--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -41,10 +41,6 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-annotations</artifactId>
     </dependency>

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -23,7 +23,6 @@ import alluxio.underfs.options.CreateOptions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,13 +205,6 @@ final class UfsJournalLogWriter implements JournalWriter {
     DataOutputStream outputStream = mJournalOutputStream.mOutputStream;
     try {
       outputStream.flush();
-      if (outputStream instanceof FSDataOutputStream) {
-        // The output stream directly created by {@link UnderFileSystem} may be
-        // {@link FSDataOutputStream}, which means the under filesystem is HDFS, but
-        // {@link DataOutputStream#flush} won't flush the data to HDFS, so we need to call
-        // {@link FSDataOutputStream#sync} to actually flush data to HDFS.
-        ((FSDataOutputStream) outputStream).sync();
-      }
     } catch (IOException e) {
       mRotateLogForNextWrite = true;
       throw new IOException(ExceptionMessage.JOURNAL_FLUSH_FAILURE

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
@@ -24,7 +24,6 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.util.UnderFileSystemUtils;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -373,13 +372,6 @@ public final class UfsJournalWriter implements JournalWriter {
       }
       try {
         mDataOutputStream.flush();
-        if (mRawOutputStream instanceof FSDataOutputStream) {
-          // The output stream directly created by {@link UnderFileSystem} may be
-          // {@link FSDataOutputStream}, which means the under filesystem is HDFS, but
-          // {@link DataOutputStream#flush} won't flush the data to HDFS, so we need to call
-          // {@link FSDataOutputStream#sync} to actually flush data to HDFS.
-          ((FSDataOutputStream) mRawOutputStream).sync();
-        }
       } catch (IOException e) {
         mRotateLogForNextWrite = true;
         throw new IOException(ExceptionMessage.JOURNAL_FLUSH_FAILURE.getMessageWithUrl(

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileInputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileInputStream.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * HDFS implementation for {@link UnderFileInputStream}.
+ * Input stream implementation for {@link HdfsUnderFileSystem}.
  */
 @NotThreadSafe
 public class HdfsUnderFileInputStream extends FilterInputStream implements Seekable {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
@@ -1,0 +1,65 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Output stream implementation for {@link HdfsUnderFileSystem}. This class is just a wrapper on top
+ * of an underlying {@link FSDataOutputStream}, except all calls to {@link #flush()} will be
+ * converted to {@link FSDataOutputStream#sync()}. This is currently safe because all invocations of
+ * flush intend the functionality to be sync.
+ */
+@NotThreadSafe
+public class HdfsUnderFileOutputStream extends OutputStream {
+  /** Underlying output stream. */
+  final FSDataOutputStream mOut;
+
+  /**
+   * Basic constructor.
+   *
+   * @param out underlying stream to wrap
+   */
+  public HdfsUnderFileOutputStream(FSDataOutputStream out) {
+    mOut = out;
+  }
+
+  @Override
+  public void close() throws IOException {
+    mOut.close();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    // TODO(calvin): This functionality should be restricted to select output streams.
+    mOut.sync();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    mOut.write(b);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    mOut.write(b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    mOut.write(b, off, len);
+  }
+}

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -170,8 +170,8 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
     while (retryPolicy.attemptRetry()) {
       try {
         // TODO(chaomin): support creating HDFS files with specified block size and replication.
-        return FileSystem.create(mFileSystem, new Path(path),
-            new FsPermission(options.getMode().toShort()));
+        return new HdfsUnderFileOutputStream(FileSystem.create(mFileSystem, new Path(path),
+            new FsPermission(options.getMode().toShort())));
       } catch (IOException e) {
         LOG.warn("Retry count {} : {} ", retryPolicy.getRetryCount(), e.getMessage());
         te = e;


### PR DESCRIPTION
We only use the dependency to call a special output stream API which can be isolated to the ufs module.