### PR TITLE
[ALLUXIO-2838] Add delete shell with alluxioOnly Option

### DIFF
--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -12,13 +12,7 @@
 package alluxio.shell.command;
 
 import alluxio.client.file.FileSystem;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -66,14 +60,13 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .hasArg(false)
           .desc("print human-readable format sizes")
           .build();
+  protected static final Option DELETE_ALLUXIO_ONLY =
+      Option.builder("alluxioOnly")
+          .required(false)
+          .hasArg(false)
+          .desc("delete alluxio space only")
+          .build();
 
-  protected static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
-  protected static final Option REMOVE_UNCHECKED_OPTION =
-      Option.builder(REMOVE_UNCHECKED_OPTION_CHAR)
-            .required(false)
-            .hasArg(false)
-            .desc("remove directories without checking UFS contents are in sync")
-            .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -76,9 +76,9 @@ public abstract class AbstractShellCommand implements ShellCommand {
   protected static final Option REMOVE_UNCHECKED_OPTION =
       Option.builder(REMOVE_UNCHECKED_OPTION_CHAR)
           .required(false)
-  		    .hasArg(false)
-  		    .desc("remove directories without checking UFS contents are in sync")
-  		    .build();
+          .hasArg(false)
+          .desc("remove directories without checking UFS contents are in sync")
+          .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -12,7 +12,12 @@
 package alluxio.shell.command;
 
 import alluxio.client.file.FileSystem;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -67,6 +72,13 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .desc("delete alluxio space only")
           .build();
 
+	protected static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
+	protected static final Option REMOVE_UNCHECKED_OPTION =
+			Option.builder(REMOVE_UNCHECKED_OPTION_CHAR)
+					.required(false)
+					.hasArg(false)
+					.desc("remove directories without checking UFS contents are in sync")
+					.build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/AbstractShellCommand.java
@@ -12,6 +12,7 @@
 package alluxio.shell.command;
 
 import alluxio.client.file.FileSystem;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -71,14 +72,13 @@ public abstract class AbstractShellCommand implements ShellCommand {
           .hasArg(false)
           .desc("delete alluxio space only")
           .build();
-
-	protected static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
-	protected static final Option REMOVE_UNCHECKED_OPTION =
-			Option.builder(REMOVE_UNCHECKED_OPTION_CHAR)
-					.required(false)
-					.hasArg(false)
-					.desc("remove directories without checking UFS contents are in sync")
-					.build();
+  protected static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
+  protected static final Option REMOVE_UNCHECKED_OPTION =
+      Option.builder(REMOVE_UNCHECKED_OPTION_CHAR)
+          .required(false)
+  		    .hasArg(false)
+  		    .desc("remove directories without checking UFS contents are in sync")
+  		    .build();
 
   protected AbstractShellCommand(FileSystem fs) {
     mFileSystem = fs;

--- a/shell/src/main/java/alluxio/shell/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/RmCommand.java
@@ -17,13 +17,11 @@ import alluxio.client.file.options.DeleteOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import java.io.IOException;
-
 import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
 
 /**
  * Removes the file specified by argv.
@@ -50,7 +48,7 @@ public final class RmCommand extends WithWildCardPathCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(RECURSIVE_OPTION).addOption(REMOVE_UNCHECKED_OPTION);
+    return new Options().addOption(RECURSIVE_OPTION).addOption(DELETE_ALLUXIO_ONLY);
   }
 
   @Override
@@ -65,21 +63,25 @@ public final class RmCommand extends WithWildCardPathCommand {
           path.getPath() + " is a directory, to remove it, please use \"rm -R <path>\"");
     }
 
-    DeleteOptions options = DeleteOptions.defaults().setRecursive(recursive);
-    if (cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)) {
-      options.setUnchecked(true);
-    }
+    boolean isAlluxioOnly = cl.hasOption("alluxioOnly");
+    //System.out.println("isAlluxioOnly: " + isAlluxioOnly);
+    DeleteOptions options = DeleteOptions.defaults().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly);
     mFileSystem.delete(path, options);
-    System.out.println(path + " has been removed");
+    if (!isAlluxioOnly) {
+      System.out.println(path + " has been removed in Alluxion space and Ufs space");
+    }else {
+      System.out.println(path + " just been removed in Alluxio Space, but Ufs space still exists");
+    }
   }
 
   @Override
   public String getUsage() {
-    return "rm [-R] <path>";
+    return "rm [-R] [-alluxioOnly] <path>";
   }
 
   @Override
   public String getDescription() {
-    return "Removes the specified file. Specify -R to remove file or directory recursively.";
+    return "Removes the specified file. Specify -R to remove file or directory recursively." +
+        "Specify -alluxioOnly just remove block data and metadata in Alluxio space";
   }
 }

--- a/shell/src/main/java/alluxio/shell/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/RmCommand.java
@@ -70,7 +70,7 @@ public final class RmCommand extends WithWildCardPathCommand {
         .setRecursive(recursive).setAlluxioOnly(isAlluxioOnly);
     mFileSystem.delete(path, options);
     if (!isAlluxioOnly) {
-      System.out.println(path + " has been removed in Alluxion space and Ufs space");
+      System.out.println(path + " has been removed");
     } else {
       System.out.println(path + " just been removed in Alluxio Space, but Ufs space still exists");
     }

--- a/shell/src/main/java/alluxio/shell/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/RmCommand.java
@@ -17,6 +17,7 @@ import alluxio.client.file.options.DeleteOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
@@ -65,11 +66,12 @@ public final class RmCommand extends WithWildCardPathCommand {
 
     boolean isAlluxioOnly = cl.hasOption("alluxioOnly");
     //System.out.println("isAlluxioOnly: " + isAlluxioOnly);
-    DeleteOptions options = DeleteOptions.defaults().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly);
+    DeleteOptions options = DeleteOptions.defaults()
+        .setRecursive(recursive).setAlluxioOnly(isAlluxioOnly);
     mFileSystem.delete(path, options);
     if (!isAlluxioOnly) {
       System.out.println(path + " has been removed in Alluxion space and Ufs space");
-    }else {
+    } else {
       System.out.println(path + " just been removed in Alluxio Space, but Ufs space still exists");
     }
   }
@@ -81,7 +83,7 @@ public final class RmCommand extends WithWildCardPathCommand {
 
   @Override
   public String getDescription() {
-    return "Removes the specified file. Specify -R to remove file or directory recursively." +
-        "Specify -alluxioOnly just remove block data and metadata in Alluxio space";
+    return "Removes the specified file. Specify -R to remove file or directory recursively."
+        + "Specify -alluxioOnly just remove block data and metadata in Alluxio space";
   }
 }


### PR DESCRIPTION
use delete -alluxioOnly to delete metadata and block data just in alluxio space, and not to delete in ufs space if ufs mounted
Addresses: https://alluxio.atlassian.net/browse/ALLUXIO-2838