### PR TITLE
[SMALLFIX] Minor issues w/ Object UFS

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -372,7 +372,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     }
     LOG.error("Error fetching directory status, assuming directory does not exist");
     throw new FileNotFoundException(path);
-}
+  }
 
   // Not supported
   @Override

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -365,9 +365,13 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public UfsDirectoryStatus getDirectoryStatus(String path) throws IOException {
-    ObjectPermissions permissions = getPermissions();
-    return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
-        permissions.getMode());
+    if (isDirectory(path)) {
+      ObjectPermissions permissions = getPermissions();
+      return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
+          permissions.getMode());
+    }
+    LOG.error("Error fetching directory status, assuming directory does not exist");
+    throw new FileNotFoundException(path);
 }
 
   // Not supported

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -87,12 +87,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * Information about a single object in object UFS.
    */
   protected class ObjectStatus {
+    private static final long INVALID_CONTENT_LENGTH = -1L;
+    private static final long INVALID_MODIFIED_TIME = -1L;
+
     private final long mContentLength;
     private final long mLastModifiedTimeMs;
     private final String mName;
-
-    private static final long INVALID_CONTENT_LENGTH = -1L;
-    private static final long INVALID_MODIFIED_TIME = -1L;
 
     public ObjectStatus(String name, long contentLength, long lastModifiedTimeMs) {
       mContentLength = contentLength;
@@ -370,7 +370,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
           permissions.getMode());
     }
-    LOG.error("Error fetching directory status, assuming directory does not exist");
+    LOG.warn("Error fetching directory status, assuming directory %s does not exist", path);
     throw new FileNotFoundException(path);
   }
 
@@ -403,7 +403,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       return new UfsFileStatus(path, details.getContentLength(), details.getLastModifiedTimeMs(),
           permissions.getOwner(), permissions.getGroup(), permissions.getMode());
     } else {
-      LOG.error("Error fetching file status, assuming file does not exist");
+      LOG.warn("Error fetching file status, assuming file %s does not exist", path);
       throw new FileNotFoundException(path);
     }
   }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -87,13 +87,22 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * Information about a single object in object UFS.
    */
   protected class ObjectStatus {
-    final long mContentLength;
-    final long mLastModifiedTimeMs;
-    final String mName;
+    private final long mContentLength;
+    private final long mLastModifiedTimeMs;
+    private final String mName;
+
+    private static final long INVALID_CONTENT_LENGTH = -1L;
+    private static final long INVALID_MODIFIED_TIME = -1L;
 
     public ObjectStatus(String name, long contentLength, long lastModifiedTimeMs) {
       mContentLength = contentLength;
       mLastModifiedTimeMs = lastModifiedTimeMs;
+      mName = name;
+    }
+
+    public ObjectStatus(String name) {
+      mContentLength = INVALID_CONTENT_LENGTH;
+      mLastModifiedTimeMs = INVALID_MODIFIED_TIME;
       mName = name;
     }
 
@@ -356,17 +365,10 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public UfsDirectoryStatus getDirectoryStatus(String path) throws IOException {
-    String keyAsFolder = convertToFolderName(stripPrefixIfPresent(path));
-    ObjectStatus details = getObjectStatus(keyAsFolder);
-    if (details != null) {
-      ObjectPermissions permissions = getPermissions();
-      return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
-          permissions.getMode());
-    } else {
-      LOG.error("Error fetching directory status, assuming directory does not exist");
-      throw new FileNotFoundException(path);
-    }
-  }
+    ObjectPermissions permissions = getPermissions();
+    return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
+        permissions.getMode());
+}
 
   // Not supported
   @Override

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -370,7 +370,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
           permissions.getMode());
     }
-    LOG.warn("Error fetching directory status, assuming directory %s does not exist", path);
+    LOG.warn("Error fetching directory status, assuming directory {} does not exist", path);
     throw new FileNotFoundException(path);
   }
 
@@ -403,7 +403,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       return new UfsFileStatus(path, details.getContentLength(), details.getLastModifiedTimeMs(),
           permissions.getOwner(), permissions.getGroup(), permissions.getMode());
     } else {
-      LOG.warn("Error fetching file status, assuming file %s does not exist", path);
+      LOG.warn("Error fetching file status, assuming file {} does not exist", path);
       throw new FileNotFoundException(path);
     }
   }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -304,8 +304,12 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
       int i = 0;
       ObjectStatus[] res = new ObjectStatus[objects.size()];
       for (DirectoryOrObject object : objects) {
-        res[i++] = new ObjectStatus(object.getName(), object.getAsObject().getContentLength(),
-            object.getAsObject().getLastModifiedAsDate().getTime());
+        if (object.isObject()) {
+          res[i++] = new ObjectStatus(object.getName(), object.getAsObject().getContentLength(),
+              object.getAsObject().getLastModifiedAsDate().getTime());
+        } else {
+          res[i++] = new ObjectStatus(object.getName());
+        }
       }
       return res;
     }


### PR DESCRIPTION
- `ObjectUnderFileSystem:getDirectoryStatus` updated to work correctly for pseudo-directory with no breadcrumb
- JOSS Swift library does not return size and last modified for pseudo-directory objects => populating `ObjectStatus` with invalid values