### PR TITLE
[SMALLFIX] Update S3A directory suffix

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -135,6 +135,8 @@ public class PropertyKey {
       create(Name.UNDERFS_S3_UPLOAD_THREADS_MAX, 20);
   public static final PropertyKey UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS =
       create(Name.UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS, 60000);
+  public static final PropertyKey UNDERFS_S3A_DIRECTORY_SUFFIX =
+      create(Name.UNDERFS_S3A_DIRECTORY_SUFFIX, "/");
   public static final PropertyKey UNDERFS_S3A_INHERIT_ACL =
       create(Name.UNDERFS_S3A_INHERIT_ACL, true);
   public static final PropertyKey UNDERFS_S3A_REQUEST_TIMEOUT =
@@ -757,6 +759,8 @@ public class PropertyKey {
     public static final String UNDERFS_S3A_INHERIT_ACL = "alluxio.underfs.s3a.inherit_acl";
     public static final String UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS =
         "alluxio.underfs.s3a.consistency.timeout.ms";
+    public static final String UNDERFS_S3A_DIRECTORY_SUFFIX =
+        "alluxio.underfs.s3a.directory.suffix";
     public static final String UNDERFS_S3A_REQUEST_TIMEOUT_MS =
         "alluxio.underfs.s3a.request.timeout.ms";
     public static final String UNDERFS_S3A_SECURE_HTTP_ENABLED =

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -32,6 +32,7 @@ alluxio.underfs.s3.admin.threads.max,20
 alluxio.underfs.s3.upload.threads.max,20
 alluxio.underfs.s3.disable.dns.buckets,false
 alluxio.underfs.s3a.consistency.timeout.ms,60000
+alluxio.underfs.s3a.directory.suffix,"/"
 alluxio.underfs.s3a.request.timeout.ms,60000
 alluxio.underfs.s3a.secure.http.enabled,false
 alluxio.underfs.s3a.server.side.encryption.enabled,false

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -95,6 +95,9 @@ alluxio.underfs.s3a.consistency.timeout.ms:
   The duration to wait for metadata consistency from the under storage. This is only used by
   internal Alluxio operations which should be successful, but may appear unsuccessful due to
   eventual consistency. The default value is 60000 milliseconds (1 minute).
+alluxio.underfs.s3a.directory.suffix:
+  Directories are represented in S3 as zero-byte objects named with the specified suffix. The
+  default value is "/".
 alluxio.underfs.s3a.request.timeout.ms:
   The timeout for a single request to S3. Infinity if set to 0. Setting this property to a non-zero
   value can improve performance by avoiding the long tail of requests to S3. For very slow

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -68,7 +68,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(S3AUnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
-  private static final String FOLDER_SUFFIX = "_$folder$";
+  private static final String FOLDER_SUFFIX = "/";
 
   /** Static hash for a directory's empty contents. */
   private static final String DIR_HASH;

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -67,9 +67,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(S3AUnderFileSystem.class);
 
-  /** Suffix for an empty file to flag it as a directory. */
-  private static final String FOLDER_SUFFIX = "/";
-
   /** Static hash for a directory's empty contents. */
   private static final String DIR_HASH;
 
@@ -333,7 +330,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   protected String getFolderSuffix() {
-    return FOLDER_SUFFIX;
+    return mUfsConf.getValue(PropertyKey.UNDERFS_S3A_DIRECTORY_SUFFIX);
   }
 
   @Override


### PR DESCRIPTION
Update the suffix for pseudo-directories in S3A to path separator.

Caveats when migrating from older versions:
- 1.4.0 directory breadcrumbs will show up as files
- `isDirectory` will not recognize 1.4.0 empty directories
- `deleteDirectory` will not delete 1.4.0 empty directories. Also performance could be impacted as `UfsSyncChecker` may falsely detect nested directory breadcrumbs as un-synced files