### PR TITLE
[ALLUXIO-2559] Check that ramfs/tmpfs is big enough

### DIFF
--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -97,8 +97,8 @@ public final class ModeParser {
             specBits = specBits.or(Bits.EXECUTE);
             break;
           default:
-            throw new IllegalStateException("Unknown permission character: " + permChar);
             // Should never get here as already checked for invalid targets
+            throw new IllegalStateException("Unknown permission character: " + permChar);
         }
       }
 

--- a/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ModeParser.java
@@ -97,6 +97,7 @@ public final class ModeParser {
             specBits = specBits.or(Bits.EXECUTE);
             break;
           default:
+            throw new IllegalStateException("Unknown permission character: " + permChar);
             // Should never get here as already checked for invalid targets
         }
       }
@@ -120,6 +121,7 @@ public final class ModeParser {
             break;
           default:
             // Should never get here as already checked for invalid targets
+            throw new IllegalStateException("Unknown target character: " + targetChar);
         }
       }
     }

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -450,6 +450,9 @@ public final class CommonUtils {
           result.get();
         } catch (ExecutionException e) {
           Throwables.propagateIfPossible(e.getCause());
+          if (!(e instanceof Exception)) {
+            throw new RuntimeException(e);
+          }
           throw (Exception) e.getCause();
         } catch (CancellationException e) {
           throw new TimeoutException("Timed out running callable");

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -449,11 +449,12 @@ public final class CommonUtils {
         try {
           result.get();
         } catch (ExecutionException e) {
-          Throwables.propagateIfPossible(e.getCause());
-          if (!(e instanceof Exception)) {
-            throw new RuntimeException(e);
+          Throwable cause = e.getCause();
+          Throwables.propagateIfPossible(cause);
+          if (cause instanceof Exception) {
+            throw (Exception) cause;
           }
-          throw (Exception) e.getCause();
+          throw new RuntimeException(cause);
         } catch (CancellationException e) {
           throw new TimeoutException("Timed out running callable");
         }

--- a/core/common/src/main/java/alluxio/util/FormatUtils.java
+++ b/core/common/src/main/java/alluxio/util/FormatUtils.java
@@ -17,8 +17,8 @@ import alluxio.security.authorization.Mode;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Locale;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -181,15 +181,15 @@ public final class FormatUtils {
     end = end.toLowerCase();
     if (end.isEmpty() || end.equals("b")) {
       return (long) (ret + alpha);
-    } else if (end.equals("kb")) {
+    } else if (end.equals("kb") || end.equals("k")) {
       return (long) (ret * Constants.KB + alpha);
-    } else if (end.equals("mb")) {
+    } else if (end.equals("mb") || end.equals("m")) {
       return (long) (ret * Constants.MB + alpha);
-    } else if (end.equals("gb")) {
+    } else if (end.equals("gb") || end.equals("g")) {
       return (long) (ret * Constants.GB + alpha);
-    } else if (end.equals("tb")) {
+    } else if (end.equals("tb") || end.equals("t")) {
       return (long) (ret * Constants.TB + alpha);
-    } else if (end.equals("pb")) {
+    } else if (end.equals("pb") || end.equals("p")) {
       // When parsing petabyte values, we can't multiply with doubles and longs, since that will
       // lose presicion with such high numbers. Therefore we use a BigDecimal.
       BigDecimal pBDecimal = new BigDecimal(Constants.PB);

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -142,15 +142,14 @@ public final class ShellUtils {
      * @throws ExitCodeException if the command returns a non-zero exit code
      */
     private String run() throws ExitCodeException, IOException {
-      Process mProcess = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
+      Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
 
       BufferedReader inReader =
-          new BufferedReader(new InputStreamReader(mProcess.getInputStream(),
+          new BufferedReader(new InputStreamReader(process.getInputStream(),
               Charset.defaultCharset()));
 
-      // read input streams as this would free up the buffers
       try {
-        // read from the input stream buffer
+        // read the output of the command
         StringBuilder output = new StringBuilder();
         String line = inReader.readLine();
         while (line != null) {
@@ -159,7 +158,7 @@ public final class ShellUtils {
           line = inReader.readLine();
         }
         // wait for the process to finish and check the exit code
-        int exitCode = mProcess.waitFor();
+        int exitCode = process.waitFor();
         if (exitCode != 0) {
           throw new ExitCodeException(exitCode, output.toString());
         }
@@ -177,14 +176,14 @@ public final class ShellUtils {
           // drain that fd!! it may block, OOM, or cause bizarre behavior
           // see: https://bugs.openjdk.java.net/browse/JDK-8024521
           // issue is fixed in build 7u60
-          InputStream stdout = mProcess.getInputStream();
+          InputStream stdout = process.getInputStream();
           synchronized (stdout) {
             inReader.close();
           }
         } catch (IOException e) {
           LOG.warn("Error while closing the input stream", e);
         }
-        mProcess.destroy();
+        process.destroy();
       }
     }
   }

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -128,7 +128,7 @@ public final class ShellUtils {
   }
 
   @NotThreadSafe
-  private final static class Command {
+  private static final class Command {
     private String[] mCommand;
 
     private Command(String[] execString) {

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -68,7 +68,7 @@ public final class ShellUtils {
   /**
    * Gets system mount information. This method should only be attempted on Unix systems.
    *
-   * @return system mount information.
+   * @return system mount information
    */
   public static List<UnixMountInfo> getUnixMountInfo() throws IOException {
     Preconditions.checkState(OSUtils.isLinux() || OSUtils.isMacOS());
@@ -128,7 +128,7 @@ public final class ShellUtils {
   }
 
   @NotThreadSafe
-  private static class Command {
+  private final static class Command {
     private String[] mCommand;
 
     private Command(String[] execString) {
@@ -236,4 +236,6 @@ public final class ShellUtils {
   public static String execCommand(String... cmd) throws IOException {
     return new Command(cmd).run();
   }
+
+  private ShellUtils() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/util/UnixMountInfo.java
+++ b/core/common/src/main/java/alluxio/util/UnixMountInfo.java
@@ -87,6 +87,7 @@ public final class UnixMountInfo {
         .toString();
   }
 
+  /** Builder for {@link UnixMountInfo}. */
   public static class Builder {
     private String mDeviceSpec;
     private String mMountPoint;
@@ -141,7 +142,7 @@ public final class UnixMountInfo {
   }
 
   /** Unix mount info options. */
-  public static class Options {
+  public final static class Options {
     private final Long mSize;
 
     private Options(Long size) {

--- a/core/common/src/main/java/alluxio/util/UnixMountInfo.java
+++ b/core/common/src/main/java/alluxio/util/UnixMountInfo.java
@@ -1,0 +1,206 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import com.google.common.base.Objects;
+
+/**
+ * Class representing an entry in a Unix /etc/fstab file.
+ */
+public final class UnixMountInfo {
+  private final String mDeviceSpec;
+  private final String mMountPoint;
+  private final String mFsType;
+  private final Options mOptions;
+
+  private UnixMountInfo(String deviceSpec, String mountPoint, String fsType, Options options) {
+    mDeviceSpec = deviceSpec;
+    mMountPoint = mountPoint;
+    mFsType = fsType;
+    mOptions = options;
+  }
+
+  /**
+   * @return the device spec, or null if it couldn't be determined
+   */
+  public String getDeviceSpec() {
+    return mDeviceSpec;
+  }
+
+  /**
+   * @return the mount point, or null if it couldn't be determined
+   */
+  public String getMountPoint() {
+    return mMountPoint;
+  }
+
+  /**
+   * @return the filesystem type, or null if it couldn't be determined
+   */
+  public String getFsType() {
+    return mFsType;
+  }
+
+  /**
+   * @return the mount options
+   */
+  public Options getOptions() {
+    return mOptions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UnixMountInfo)) {
+      return false;
+    }
+    UnixMountInfo that = (UnixMountInfo) o;
+    return Objects.equal(mDeviceSpec, that.mDeviceSpec)
+        && Objects.equal(mMountPoint, that.mMountPoint)
+        && Objects.equal(mFsType, that.mFsType)
+        && Objects.equal(mOptions, that.mOptions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mDeviceSpec, mMountPoint, mFsType, mOptions);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("deviceSpec", mDeviceSpec)
+        .add("mountPoint", mMountPoint)
+        .add("fsType", mFsType)
+        .add("options", mOptions)
+        .toString();
+  }
+
+  public static class Builder {
+    private String mDeviceSpec;
+    private String mMountPoint;
+    private String mFsType;
+    private Options mOptions;
+
+    /** Constructs a new Unix mount info builder. */
+    public Builder() {}
+
+    /**
+     * @param deviceSpec the device spec to set
+     * @return the builder
+     */
+    public Builder setDeviceSpec(String deviceSpec) {
+      mDeviceSpec = deviceSpec;
+      return this;
+    }
+
+    /**
+     * @param mountPoint the mount point to set
+     * @return the builder
+     */
+    public Builder setMountPoint(String mountPoint) {
+      mMountPoint = mountPoint;
+      return this;
+    }
+
+    /**
+     * @param fsType the fs type to set
+     * @return the builder
+     */
+    public Builder setFsType(String fsType) {
+      mFsType = fsType;
+      return this;
+    }
+
+    /**
+     * @param options the mount info options to set
+     * @return the builder
+     */
+    public Builder setOptions(Options options) {
+      mOptions = options;
+      return this;
+    }
+
+    /**
+     * @return the built Unix mount info
+     */
+    public UnixMountInfo build() {
+      return new UnixMountInfo(mDeviceSpec, mMountPoint, mFsType, mOptions);
+    }
+  }
+
+  /** Unix mount info options. */
+  public static class Options {
+    private final Long mSize;
+
+    private Options(Long size) {
+      mSize = size;
+    }
+
+    /**
+     * @return the mount point size, or null if it couldn't be determined
+     */
+    public Long getSize() {
+      return mSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Options)) {
+        return false;
+      }
+      Options that = (Options) o;
+      return Objects.equal(mSize, that.mSize);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mSize);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+          .add("size", mSize)
+          .toString();
+    }
+
+    /** Builder for Unix mount info options. */
+    public static class Builder {
+      private Long mSize;
+
+      /** Constructs a new unix mount info options builder. */
+      public Builder() {}
+
+      /**
+       * @param size the mount size to set
+       * @return the builder
+       */
+      public Builder setSize(Long size) {
+        mSize = size;
+        return this;
+      }
+
+      /**
+       * @return the built Unix mount info options
+       */
+      public Options build() {
+        return new Options(mSize);
+      }
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/util/UnixMountInfo.java
+++ b/core/common/src/main/java/alluxio/util/UnixMountInfo.java
@@ -12,41 +12,42 @@
 package alluxio.util;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 
 /**
  * Class representing an entry in a Unix /etc/fstab file.
  */
 public final class UnixMountInfo {
-  private final String mDeviceSpec;
-  private final String mMountPoint;
-  private final String mFsType;
-  private final Options mOptions;
+  private final Optional<String> mDeviceSpec;
+  private final Optional<String> mMountPoint;
+  private final Optional<String> mFsType;
+  private final Options mMountOptions;
 
   private UnixMountInfo(String deviceSpec, String mountPoint, String fsType, Options options) {
-    mDeviceSpec = deviceSpec;
-    mMountPoint = mountPoint;
-    mFsType = fsType;
-    mOptions = options;
+    mDeviceSpec = Optional.fromNullable(deviceSpec);
+    mMountPoint = Optional.fromNullable(mountPoint);
+    mFsType = Optional.fromNullable(fsType);
+    mMountOptions = options;
   }
 
   /**
-   * @return the device spec, or null if it couldn't be determined
+   * @return the device spec
    */
-  public String getDeviceSpec() {
+  public Optional<String> getDeviceSpec() {
     return mDeviceSpec;
   }
 
   /**
-   * @return the mount point, or null if it couldn't be determined
+   * @return the mount point
    */
-  public String getMountPoint() {
+  public Optional<String> getMountPoint() {
     return mMountPoint;
   }
 
   /**
-   * @return the filesystem type, or null if it couldn't be determined
+   * @return the filesystem type
    */
-  public String getFsType() {
+  public Optional<String> getFsType() {
     return mFsType;
   }
 
@@ -54,7 +55,7 @@ public final class UnixMountInfo {
    * @return the mount options
    */
   public Options getOptions() {
-    return mOptions;
+    return mMountOptions;
   }
 
   @Override
@@ -69,12 +70,12 @@ public final class UnixMountInfo {
     return Objects.equal(mDeviceSpec, that.mDeviceSpec)
         && Objects.equal(mMountPoint, that.mMountPoint)
         && Objects.equal(mFsType, that.mFsType)
-        && Objects.equal(mOptions, that.mOptions);
+        && Objects.equal(mMountOptions, that.mMountOptions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mDeviceSpec, mMountPoint, mFsType, mOptions);
+    return Objects.hashCode(mDeviceSpec, mMountPoint, mFsType, mMountOptions);
   }
 
   @Override
@@ -83,7 +84,7 @@ public final class UnixMountInfo {
         .add("deviceSpec", mDeviceSpec)
         .add("mountPoint", mMountPoint)
         .add("fsType", mFsType)
-        .add("options", mOptions)
+        .add("options", mMountOptions)
         .toString();
   }
 
@@ -143,16 +144,16 @@ public final class UnixMountInfo {
 
   /** Unix mount info options. */
   public static final class Options {
-    private final Long mSize;
+    private final Optional<Long> mSize;
 
     private Options(Long size) {
-      mSize = size;
+      mSize = Optional.fromNullable(size);
     }
 
     /**
-     * @return the mount point size, or null if it couldn't be determined
+     * @return the mount point size
      */
-    public Long getSize() {
+    public Optional<Long> getSize() {
       return mSize;
     }
 

--- a/core/common/src/main/java/alluxio/util/UnixMountInfo.java
+++ b/core/common/src/main/java/alluxio/util/UnixMountInfo.java
@@ -142,7 +142,7 @@ public final class UnixMountInfo {
   }
 
   /** Unix mount info options. */
-  public final static class Options {
+  public static final class Options {
     private final Long mSize;
 
     private Options(Long size) {

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.util;
 
+import alluxio.Constants;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 
@@ -29,6 +30,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests the {@link CommonUtils} class.
@@ -339,5 +345,107 @@ public class CommonUtilsTest {
     Assert.assertEquals(null,    CommonUtils.getValueFromStaticMapping(mapping, "/"));
     Assert.assertEquals(null,    CommonUtils.getValueFromStaticMapping(mapping, "v"));
     Assert.assertEquals(null,    CommonUtils.getValueFromStaticMapping(mapping, "nonexist"));
+  }
+
+  @Test
+  public void invokeAllSuccess() throws Exception {
+    int numTasks = 5;
+    final CyclicBarrier b = new CyclicBarrier(numTasks);
+    final AtomicInteger completed = new AtomicInteger();
+    List<Callable<Void>> tasks = new ArrayList<>();
+    for (int i = 0; i < numTasks; i++) {
+      tasks.add(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          b.await();
+          completed.incrementAndGet();
+          return null;
+        }
+      });
+    }
+    CommonUtils.invokeAll(tasks, 10, TimeUnit.SECONDS);
+    Assert.assertEquals(numTasks, completed.get());
+  }
+
+  @Test
+  public void invokeAllHang() throws Exception {
+    int numTasks = 5;
+    List<Callable<Void>> tasks = new ArrayList<>();
+    for (int i = 0; i < numTasks; i++) {
+      tasks.add(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          Thread.sleep(10 * Constants.SECOND_MS);
+          return null;
+        }
+      });
+    }
+    try {
+      CommonUtils.invokeAll(tasks, 50, TimeUnit.MILLISECONDS);
+      Assert.fail("Expected a timeout exception");
+    } catch (TimeoutException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void invokeAllPropagatesException() throws Exception {
+    int numTasks = 5;
+    final AtomicInteger id = new AtomicInteger();
+    List<Callable<Void>> tasks = new ArrayList<>();
+    final Exception testException = new Exception("test message");
+    for (int i = 0; i < numTasks; i++) {
+      tasks.add(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          int myId = id.incrementAndGet();
+          // The 3rd task throws an exception
+          if (myId == 3) {
+            throw testException;
+          }
+          return null;
+        }
+      });
+    }
+    try {
+      CommonUtils.invokeAll(tasks, 2, TimeUnit.SECONDS);
+      Assert.fail("Expected an exception to be thrown");
+    } catch (Exception e) {
+      Assert.assertSame(testException, e);
+    }
+  }
+
+
+  /**
+   * Tests that when one task throws an exception and other tasks time out, the exception is
+   * propagated.
+   */
+  @Test
+  public void invokeAllPropagatesExceptionWithTimeout() throws Exception {
+    int numTasks = 5;
+    final AtomicInteger id = new AtomicInteger();
+    List<Callable<Void>> tasks = new ArrayList<>();
+    final Exception testException = new Exception("test message");
+    for (int i = 0; i < numTasks; i++) {
+      tasks.add(new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          int myId = id.incrementAndGet();
+          // The 3rd task throws an exception, other tasks sleep.
+          if (myId == 3) {
+            throw testException;
+          } else {
+            Thread.sleep(10 * Constants.SECOND_MS);
+          }
+          return null;
+        }
+      });
+    }
+    try {
+      CommonUtils.invokeAll(tasks, 50, TimeUnit.MILLISECONDS);
+      Assert.fail("Expected an exception to be thrown");
+    } catch (Exception e) {
+      Assert.assertSame(testException, e);
+    }
   }
 }

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -415,7 +415,6 @@ public class CommonUtilsTest {
     }
   }
 
-
   /**
    * Tests that when one task throws an exception and other tasks time out, the exception is
    * propagated.

--- a/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
@@ -213,24 +213,32 @@ public final class FormatUtilsTest {
       Assert.assertEquals(k * Constants.KB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "Kb"));
       Assert.assertEquals(k * Constants.KB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "KB"));
       Assert.assertEquals(k * Constants.KB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "kB"));
+      Assert.assertEquals(k * Constants.KB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "k"));
+      Assert.assertEquals(k * Constants.KB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "K"));
     }
     for (long k = 0; k < max; k++) {
       Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "mb"));
       Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "Mb"));
       Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "MB"));
       Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "mB"));
+      Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "m"));
+      Assert.assertEquals(k * Constants.MB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "M"));
     }
     for (long k = 0; k < max; k++) {
       Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "gb"));
       Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "Gb"));
       Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "GB"));
       Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "gB"));
+      Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "g"));
+      Assert.assertEquals(k * Constants.GB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "G"));
     }
     for (long k = 0; k < max; k++) {
       Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "tb"));
       Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "Tb"));
       Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "TB"));
       Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "tB"));
+      Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "t"));
+      Assert.assertEquals(k * Constants.TB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "T"));
     }
     // We stop the pb test before 8192, since 8192 petabytes is beyond the scope of a java long.
     for (long k = 0; k < 8192; k++) {
@@ -238,6 +246,8 @@ public final class FormatUtilsTest {
       Assert.assertEquals(k * Constants.PB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "Pb"));
       Assert.assertEquals(k * Constants.PB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "PB"));
       Assert.assertEquals(k * Constants.PB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "pB"));
+      Assert.assertEquals(k * Constants.PB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "p"));
+      Assert.assertEquals(k * Constants.PB / 10, FormatUtils.parseSpaceSize(k / 10.0 + "P"));
     }
   }
 

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -12,11 +12,15 @@
 package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import alluxio.Constants;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests the {@link ShellUtils} class.
@@ -50,6 +54,7 @@ public final class ShellUtilsTest {
 
   @Test
   public void parseRamfsMountInfoWithType() throws Exception {
+    // Linux mount info.
     UnixMountInfo info =
         ShellUtils.parseMountInfo("ramfs on /mnt/ramdisk type ramfs (rw,relatime,size=1gb)");
     assertEquals("ramfs", info.getDeviceSpec());
@@ -60,6 +65,7 @@ public final class ShellUtilsTest {
 
   @Test
   public void parseMountInfoWithoutType() throws Exception {
+    // OS X mount info.
     UnixMountInfo info = ShellUtils.parseMountInfo("devfs on /dev (devfs, local, nobrowse)");
     assertEquals("devfs", info.getDeviceSpec());
     assertEquals("/dev", info.getMountPoint());
@@ -69,11 +75,19 @@ public final class ShellUtilsTest {
 
   @Test
   public void parseTmpfsMountInfo() throws Exception {
+    // Docker VM mount info.
     UnixMountInfo info = ShellUtils
         .parseMountInfo("shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)");
     assertEquals("shm", info.getDeviceSpec());
     assertEquals("/dev/shm", info.getMountPoint());
     assertEquals("tmpfs", info.getFsType());
     assertEquals(Long.valueOf(65536 * Constants.KB), info.getOptions().getSize());
+  }
+
+  @Test
+  public void getMountInfo() throws Exception {
+    assumeTrue(OSUtils.isMacOS() || OSUtils.isLinux());
+    List<UnixMountInfo> info = ShellUtils.getUnixMountInfo();
+    assertTrue(info.size() > 0);
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -12,11 +12,13 @@
 package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import alluxio.Constants;
 
+import com.google.common.base.Optional;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -57,20 +59,20 @@ public final class ShellUtilsTest {
     // Linux mount info.
     UnixMountInfo info =
         ShellUtils.parseMountInfo("ramfs on /mnt/ramdisk type ramfs (rw,relatime,size=1gb)");
-    assertEquals("ramfs", info.getDeviceSpec());
-    assertEquals("/mnt/ramdisk", info.getMountPoint());
-    assertEquals("ramfs", info.getFsType());
-    assertEquals(Long.valueOf(Constants.GB), info.getOptions().getSize());
+    assertEquals(Optional.of("ramfs"), info.getDeviceSpec());
+    assertEquals(Optional.of("/mnt/ramdisk"), info.getMountPoint());
+    assertEquals(Optional.of("ramfs"), info.getFsType());
+    assertEquals(Optional.of(Long.valueOf(Constants.GB)), info.getOptions().getSize());
   }
 
   @Test
   public void parseMountInfoWithoutType() throws Exception {
     // OS X mount info.
     UnixMountInfo info = ShellUtils.parseMountInfo("devfs on /dev (devfs, local, nobrowse)");
-    assertEquals("devfs", info.getDeviceSpec());
-    assertEquals("/dev", info.getMountPoint());
-    assertEquals(null, info.getFsType());
-    assertEquals(null, info.getOptions().getSize());
+    assertEquals(Optional.of("devfs"), info.getDeviceSpec());
+    assertEquals(Optional.of("/dev"), info.getMountPoint());
+    assertFalse(info.getFsType().isPresent());
+    assertFalse(info.getOptions().getSize().isPresent());
   }
 
   @Test
@@ -78,20 +80,20 @@ public final class ShellUtilsTest {
     // Docker VM mount info.
     UnixMountInfo info = ShellUtils
         .parseMountInfo("shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)");
-    assertEquals("shm", info.getDeviceSpec());
-    assertEquals("/dev/shm", info.getMountPoint());
-    assertEquals("tmpfs", info.getFsType());
-    assertEquals(Long.valueOf(65536 * Constants.KB), info.getOptions().getSize());
+    assertEquals(Optional.of("shm"), info.getDeviceSpec());
+    assertEquals(Optional.of("/dev/shm"), info.getMountPoint());
+    assertEquals(Optional.of("tmpfs"), info.getFsType());
+    assertEquals(Optional.of(Long.valueOf(65536 * Constants.KB)), info.getOptions().getSize());
   }
 
   @Test
   public void parseMountInfoSpaceInPath() throws Exception {
     UnixMountInfo info = ShellUtils.parseMountInfo("/dev/disk4s1 on /Volumes/Space Path "
         + "(hfs, local, nodev, nosuid, read-only, noowners, quarantine)");
-    assertEquals("/dev/disk4s1", info.getDeviceSpec());
-    assertEquals("/Volumes/Space Path", info.getMountPoint());
-    assertEquals(null, info.getFsType());
-    assertEquals(null, info.getOptions().getSize());
+    assertEquals(Optional.of("/dev/disk4s1"), info.getDeviceSpec());
+    assertEquals(Optional.of("/Volumes/Space Path"), info.getMountPoint());
+    assertFalse(info.getFsType().isPresent());
+    assertFalse(info.getOptions().getSize().isPresent());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -11,6 +11,10 @@
 
 package alluxio.util;
 
+import static org.junit.Assert.assertEquals;
+
+import alluxio.Constants;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,7 +29,7 @@ public final class ShellUtilsTest {
    * @throws Throwable when the execution of the command fails
    */
   @Test
-  public void execCommand() throws Throwable {
+  public void execCommand() throws Exception {
     String testString = "alluxio";
     // Execute echo for testing command execution.
     String result = ShellUtils.execCommand("bash", "-c", "echo " + testString);
@@ -38,9 +42,38 @@ public final class ShellUtilsTest {
    * @throws Throwable when the execution of the commands fails
    */
   @Test
-  public void execGetGroupCommand() throws Throwable {
+  public void execGetGroupCommand() throws Exception {
     String result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand("root"));
     // On Linux user "root" will be a part of the group "root". On OSX it will be a part of "admin".
     Assert.assertTrue(result.contains("root") || result.contains("admin"));
+  }
+
+  @Test
+  public void parseRamfsMountInfoWithType() throws Exception {
+    UnixMountInfo info =
+        ShellUtils.parseMountInfo("ramfs on /mnt/ramdisk type ramfs (rw,relatime,size=1gb)");
+    assertEquals("ramfs", info.getDeviceSpec());
+    assertEquals("/mnt/ramdisk", info.getMountPoint());
+    assertEquals("ramfs", info.getFsType());
+    assertEquals(Long.valueOf(Constants.GB), info.getOptions().getSize());
+  }
+
+  @Test
+  public void parseMountInfoWithoutType() throws Exception {
+    UnixMountInfo info = ShellUtils.parseMountInfo("devfs on /dev (devfs, local, nobrowse)");
+    assertEquals("devfs", info.getDeviceSpec());
+    assertEquals("/dev", info.getMountPoint());
+    assertEquals(null, info.getFsType());
+    assertEquals(null, info.getOptions().getSize());
+  }
+
+  @Test
+  public void parseTmpfsMountInfo() throws Exception {
+    UnixMountInfo info = ShellUtils
+        .parseMountInfo("shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)");
+    assertEquals("shm", info.getDeviceSpec());
+    assertEquals("/dev/shm", info.getMountPoint());
+    assertEquals("tmpfs", info.getFsType());
+    assertEquals(Long.valueOf(65536 * Constants.KB), info.getOptions().getSize());
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -86,10 +86,10 @@ public final class ShellUtilsTest {
 
   @Test
   public void parseMountInfoSpaceInPath() throws Exception {
-    UnixMountInfo info = ShellUtils.parseMountInfo("/dev/disk4s1 on /Volumes/Space Path"
+    UnixMountInfo info = ShellUtils.parseMountInfo("/dev/disk4s1 on /Volumes/Space Path "
         + "(hfs, local, nodev, nosuid, read-only, noowners, quarantine)");
     assertEquals("/dev/disk4s1", info.getDeviceSpec());
-    assertEquals("/Volumes/Amazon Music", info.getMountPoint());
+    assertEquals("/Volumes/Space Path", info.getMountPoint());
     assertEquals(null, info.getFsType());
     assertEquals(null, info.getOptions().getSize());
   }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -85,6 +85,16 @@ public final class ShellUtilsTest {
   }
 
   @Test
+  public void parseMountInfoSpaceInPath() throws Exception {
+    UnixMountInfo info = ShellUtils.parseMountInfo("/dev/disk4s1 on /Volumes/Space Path"
+        + "(hfs, local, nodev, nosuid, read-only, noowners, quarantine)");
+    assertEquals("/dev/disk4s1", info.getDeviceSpec());
+    assertEquals("/Volumes/Amazon Music", info.getMountPoint());
+    assertEquals(null, info.getFsType());
+    assertEquals(null, info.getOptions().getSize());
+  }
+
+  @Test
   public void getMountInfo() throws Exception {
     assumeTrue(OSUtils.isMacOS() || OSUtils.isLinux());
     List<UnixMountInfo> info = ShellUtils.getUnixMountInfo();

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -81,6 +81,10 @@ final class MasterUtils {
         }
       });
     }
-    CommonUtils.invokeAll(callables);
+    try {
+      CommonUtils.invokeAll(callables);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to start masters", e);
+    }
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class encapsulates the different master services that are configured to run.
@@ -82,7 +83,7 @@ final class MasterUtils {
       });
     }
     try {
-      CommonUtils.invokeAll(callables);
+      CommonUtils.invokeAll(callables, 10, TimeUnit.SECONDS);
     } catch (Exception e) {
       throw new RuntimeException("Failed to start masters", e);
     }

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -115,7 +116,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
           }
         });
       }
-      CommonUtils.invokeAll(callables);
+      CommonUtils.invokeAll(callables, 10, TimeUnit.SECONDS);
 
       // Setup web server
       mWebServer =

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -25,6 +25,7 @@ import alluxio.util.UnixMountInfo;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,12 +124,15 @@ public final class StorageTier {
       return;
     }
     for (UnixMountInfo mountInfo : info) {
-      String mountPoint = mountInfo.getMountPoint();
-      String fsType = mountInfo.getFsType();
-      Long size = mountInfo.getOptions().getSize();
-      if (mountPoint == null || fsType == null || size == null) {
+      Optional<String> mountPointOption = mountInfo.getMountPoint();
+      Optional<String> fsTypeOption = mountInfo.getFsType();
+      Optional<Long> sizeOption = mountInfo.getOptions().getSize();
+      if (!mountPointOption.isPresent() || !fsTypeOption.isPresent() || !sizeOption.isPresent()) {
         continue;
       }
+      String mountPoint = mountPointOption.get();
+      String fsType = fsTypeOption.get();
+      long size = sizeOption.get();
       try {
         // getDirPath gives something like "/mnt/tmpfs/alluxioworker".
         String rootStoragePath = PathUtils.getParent(storageDir.getDirPath());

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -103,12 +103,12 @@ public final class StorageTier {
   }
 
   /**
-   * Checks that a tmpfs backing the storage directory has enough capacity. If the storage directory
-   * is not backed by tmpfs or the size of the tmpfs cannot be determined, a warning is logged but
-   * no exception is thrown.
+   * Checks that a tmpfs/ramfs backing the storage directory has enough capacity. If the storage
+   * directory is not backed by tmpfs/ramfs or the size of the tmpfs/ramfs cannot be determined, a
+   * warning is logged but no exception is thrown.
    *
    * @param storageDir the storage dir to check
-   * @throws IllegalStateException if the tmpfs is smaller than the configured memory size.
+   * @throws IllegalStateException if the tmpfs/ramfs is smaller than the configured memory size.
    */
   private void checkEnoughMemSpace(StorageDir storageDir) {
     if (!OSUtils.isLinux()) {
@@ -129,7 +129,7 @@ public final class StorageTier {
         continue;
       }
       if (mountPoint.equals(storageDir.getDirPath())
-          && mountInfo.getFsType().equalsIgnoreCase("tmpfs")
+          && (fsType.equalsIgnoreCase("tmpfs") || fsType.equalsIgnoreCase("ramfs"))
           && size < storageDir.getCapacityBytes()) {
         throw new IllegalStateException(String.format(
             "tmpfs is smaller than the configured size: tmpfs size: %s, configured size: %s", size,

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -119,7 +119,7 @@ public final class StorageTier {
     try {
       info = ShellUtils.getUnixMountInfo();
     } catch (IOException e) {
-      LOG.warn("Failed to get mount information: {}", e.getMessage());
+      LOG.debug("Failed to get mount information: {}", e.getMessage());
       return;
     }
     for (UnixMountInfo mountInfo : info) {
@@ -142,8 +142,9 @@ public final class StorageTier {
       if ((fsType.equalsIgnoreCase("tmpfs") || fsType.equalsIgnoreCase("ramfs"))
           && size < storageDir.getCapacityBytes()) {
         throw new IllegalStateException(String.format(
-            "tmpfs is smaller than the configured size: tmpfs size: %s, configured size: %s", size,
-            storageDir.getCapacityBytes()));
+            "tmpfs is smaller than the configured size: tmpfs size: %s, configured size: %s",
+            FormatUtils.getSizeFromBytes(size),
+            FormatUtils.getSizeFromBytes(storageDir.getCapacityBytes())));
       }
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -142,8 +142,8 @@ public final class StorageTier {
       if ((fsType.equalsIgnoreCase("tmpfs") || fsType.equalsIgnoreCase("ramfs"))
           && size < storageDir.getCapacityBytes()) {
         throw new IllegalStateException(String.format(
-            "tmpfs is smaller than the configured size: tmpfs size: %s, configured size: %s",
-            FormatUtils.getSizeFromBytes(size),
+            "%s is smaller than the configured size: %s size: %s, configured size: %s", fsType,
+            fsType, FormatUtils.getSizeFromBytes(size),
             FormatUtils.getSizeFromBytes(storageDir.getCapacityBytes())));
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -109,7 +109,7 @@ public final class StorageTier {
    * warning is logged but no exception is thrown.
    *
    * @param storageDir the storage dir to check
-   * @throws IllegalStateException if the tmpfs/ramfs is smaller than the configured memory size.
+   * @throws IllegalStateException if the tmpfs/ramfs is smaller than the configured memory size
    */
   private void checkEnoughMemSpace(StorageDir storageDir) {
     if (!OSUtils.isLinux()) {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2559

This PR adds best-effort checking for the case where the ramfs/tmpfs is smaller than the memory it is configured as. If the size of the ramfs/tmpfs can't be determined, no checking is done.

Example output:
```
[ec2-user@ip-172-31-74-144 alluxio]$ cat logs/worker.out
Exception in thread "main" java.lang.RuntimeException: java.lang.IllegalStateException: tmpfs is smaller than the configured size: tmpfs size: 512MB, configured size: 3GB
	at alluxio.worker.AlluxioWorkerProcess.<init>(AlluxioWorkerProcess.java:147)
	at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:35)
	at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:54)
Caused by: java.lang.IllegalStateException: tmpfs is smaller than the configured size: tmpfs size: 512MB, configured size: 3GB
	at alluxio.worker.block.meta.StorageTier.checkEnoughMemSpace(StorageTier.java:144)
	at alluxio.worker.block.meta.StorageTier.initStorageTier(StorageTier.java:102)
```

I recommend reading the first 3 commits individually.