### PR TITLE
[SMALLFIX] Fix the example in generate-tarball script

### DIFF
--- a/dev/scripts/generate-tarball.sh
+++ b/dev/scripts/generate-tarball.sh
@@ -19,7 +19,7 @@
 # 5. Copy the generated client to the folder client/framework/
 # 6. Tar everything up and put it in dev/scripts/tarballs
 #
-# Example: BUILD_OPTS="-Dhadoop.version=2.7.2"; ./generate-tarball.sh
+# Example: BUILD_OPTS="-Dhadoop.version=2.7.2" ./generate-tarball.sh
 #
 
 set -e


### PR DESCRIPTION
The semi-colon should be removed, otherwise the `BUILD_OPTS` is not passed to the script in the next statement.