### PR TITLE
[ALLUXIO-2719] Deprecate Throwables.propagate with RuntimeException in CheckpointPlanner.java

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointPlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointPlanner.java
@@ -16,8 +16,8 @@ import alluxio.PropertyKey;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.lineage.meta.LineageStoreView;
 import alluxio.util.CommonUtils;
-
-import com.google.common.base.Throwables;
+ 
+//import com.google.common.base.Throwables;
 
 /**
  * Generates plans for lineage checkpointing.
@@ -44,7 +44,8 @@ public interface CheckpointPlanner {
             new Class[] {LineageStoreView.class, FileSystemMasterView.class},
             new Object[] {lineageStoreView, fileSystemMasterView});
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        //throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
   }


### PR DESCRIPTION
modifies core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointPlanner.java to
replace "throw Throwables.propagate(e);"  with "throw new RuntimeException(e);"
and remove "import com.google.common.base.Throwables;"
