### PR TITLE
[SMALLFIX] Use the correct command for stopping local cluster in documentation.

### DIFF
--- a/docs/_includes/Common-Commands/stop-alluxio.md
+++ b/docs/_includes/Common-Commands/stop-alluxio.md
@@ -1,3 +1,3 @@
 ```bash
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```

--- a/docs/_includes/Configuring-Alluxio-with-NFS/stop-alluxio.md
+++ b/docs/_includes/Configuring-Alluxio-with-NFS/stop-alluxio.md
@@ -1,3 +1,3 @@
 ```bash
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```

--- a/docs/_includes/Running-Alluxio-Locally/Alluxio-stop.md
+++ b/docs/_includes/Running-Alluxio-Locally/Alluxio-stop.md
@@ -1,3 +1,3 @@
 ```bash
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```

--- a/docs/_includes/Running-Hadoop-MapReduce-on-Alluxio/start-Alluxio.md
+++ b/docs/_includes/Running-Hadoop-MapReduce-on-Alluxio/start-Alluxio.md
@@ -1,4 +1,3 @@
 ```bash
-$ ./bin/alluxio-stop.sh all
 $ ./bin/alluxio-start.sh local
 ```

--- a/docs/cn/Configuring-Alluxio-with-Azure-Blob-Store.md
+++ b/docs/cn/Configuring-Alluxio-with-Azure-Blob-Store.md
@@ -89,5 +89,5 @@ AZURE_DIRECTORY/default_tests_files/BasicFile_CACHE_PROMOTE_MUST_CACHE
 若要停止Alluxio，你可以运行以下命令:
 
 ```
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```

--- a/docs/cn/Getting-Started.md
+++ b/docs/cn/Getting-Started.md
@@ -276,7 +276,7 @@ sys	0m0.240s
 你完成了本地安装和使用Alluxio，你可以使用如下命令关闭Alluxio：
 
 ```bash
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```
 
 ## 结论

--- a/docs/en/Configuring-Alluxio-with-Azure-Blob-Store.md
+++ b/docs/en/Configuring-Alluxio-with-Azure-Blob-Store.md
@@ -89,5 +89,5 @@ AZURE_DIRECTORY/default_tests_files/BasicFile_CACHE_PROMOTE_MUST_CACHE
 To stop Alluxio, you can run:
 
 ```
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -337,7 +337,7 @@ Once you are done with interacting with your local Alluxio installation, you can
 the following command:
 
 ```bash
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio-stop.sh local
 ```
 
 ## Conclusion


### PR DESCRIPTION
`bin/alluxio-start.sh local` should be coupled with `bin/alluxio-stop.sh local` not `bin/alluxio-stop.sh all`