### PR TITLE
[SMALLFIX] Update usages of libexec CLASSPATH

### DIFF
--- a/integration/docker/bin/alluxio-master.sh
+++ b/integration/docker/bin/alluxio-master.sh
@@ -31,4 +31,4 @@ ALLUXIO_MASTER_LOGGER="Console,MASTER_LOGGER"
 
 . ${SCRIPT_DIR}/../../../libexec/alluxio-config.sh
 
-${JAVA} -cp ${CLASSPATH} ${ALLUXIO_MASTER_JAVA_OPTS} alluxio.master.AlluxioMaster
+${JAVA} -cp ${ALLUXIO_SERVER_CLASSPATH} ${ALLUXIO_MASTER_JAVA_OPTS} alluxio.master.AlluxioMaster

--- a/integration/docker/bin/alluxio-proxy.sh
+++ b/integration/docker/bin/alluxio-proxy.sh
@@ -32,4 +32,4 @@ ALLUXIO_PROXY_LOGGER="Console,PROXY_LOGGER"
 
 . ${SCRIPT_DIR}/../../../libexec/alluxio-config.sh
 
-${JAVA} -cp ${CLASSPATH} ${ALLUXIO_PROXY_JAVA_OPTS} alluxio.proxy.AlluxioProxy
+${JAVA} -cp ${ALLUXIO_SERVER_CLASSPATH} ${ALLUXIO_PROXY_JAVA_OPTS} alluxio.proxy.AlluxioProxy

--- a/integration/docker/bin/alluxio-worker.sh
+++ b/integration/docker/bin/alluxio-worker.sh
@@ -31,4 +31,4 @@ ALLUXIO_WORKER_LOGGER="Console,WORKER_LOGGER"
 
 . ${SCRIPT_DIR}/../../../libexec/alluxio-config.sh
 
-${JAVA} -cp ${CLASSPATH} ${ALLUXIO_WORKER_JAVA_OPTS} alluxio.worker.AlluxioWorker
+${JAVA} -cp ${ALLUXIO_SERVER_CLASSPATH} ${ALLUXIO_WORKER_JAVA_OPTS} alluxio.worker.AlluxioWorker

--- a/integration/mesos/bin/alluxio-master-mesos.sh
+++ b/integration/mesos/bin/alluxio-master-mesos.sh
@@ -18,7 +18,7 @@ MESOS_LIBRARY_PATH="${MESOS_LIBRARY_PATH:-/usr/local/lib}"
 
 mkdir -p "${ALLUXIO_LOGS_DIR}"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_MASTER_JAVA_OPTS} \
   -Djava.library.path="${MESOS_LIBRARY_PATH}" \
   -Dalluxio.home="${ALLUXIO_HOME}" \

--- a/integration/mesos/bin/alluxio-mesos-start.sh
+++ b/integration/mesos/bin/alluxio-mesos-start.sh
@@ -60,7 +60,7 @@ if [[ -n "$2" ]]; then
   FRAMEWORK_ARGS+=" --alluxio-master $2"
 fi
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_FRAMEWORK_JAVA_OPTS} \
   -Djava.library.path="${MESOS_LIBRARY_PATH}" \
   -Dalluxio.home="${ALLUXIO_HOME}" \

--- a/integration/mesos/bin/alluxio-worker-mesos.sh
+++ b/integration/mesos/bin/alluxio-worker-mesos.sh
@@ -21,7 +21,7 @@ ${ALLUXIO_HOME}/bin/alluxio-mount.sh SudoMount
 
 mkdir -p "${ALLUXIO_LOGS_DIR}"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_WORKER_JAVA_OPTS}  \
   -Djava.library.path="${MESOS_LIBRARY_PATH}" \
   -Dalluxio.home="${ALLUXIO_HOME}" \

--- a/integration/yarn/bin/alluxio-application-master.sh
+++ b/integration/yarn/bin/alluxio-application-master.sh
@@ -12,12 +12,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
 
-# Yarn will set $CLASSPATH to point to important Yarn resources, but then
-# common.sh will reset $CLASSPATH to point to the jars needed by Alluxio.
-# We save $CLASSPATH before calling common.sh, then combine the two.
-YARN_CLASSPATH="${CLASSPATH}"
 source "${SCRIPT_DIR}/common.sh"
-export CLASSPATH="${CLASSPATH}:${YARN_CLASSPATH}"
+export CLASSPATH="${ALLUXIO_SERVER_CLASSPATH}:${CLASSPATH}"
 
 echo "Launching Application Master"
 

--- a/integration/yarn/bin/alluxio-master-yarn.sh
+++ b/integration/yarn/bin/alluxio-master-yarn.sh
@@ -19,7 +19,7 @@ YARN_LOG_DIR="$LOG_DIRS"
 
 echo "Formatting Alluxio Master"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_MASTER_JAVA_OPTS} \
   -Dalluxio.home="${ALLUXIO_HOME}" \
   -Dalluxio.logger.type="MASTER_LOGGER" \
@@ -28,7 +28,7 @@ echo "Formatting Alluxio Master"
 
 echo "Starting Alluxio Master"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_MASTER_JAVA_OPTS} \
   -Dalluxio.home="${ALLUXIO_HOME}" \
   -Dalluxio.logger.type="MASTER_LOGGER" \

--- a/integration/yarn/bin/alluxio-worker-yarn.sh
+++ b/integration/yarn/bin/alluxio-worker-yarn.sh
@@ -23,7 +23,7 @@ YARN_LOG_DIR="$LOG_DIRS"
 
 echo "Formatting Alluxio Worker"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_WORKER_JAVA_OPTS} \
   -Dalluxio.home="${ALLUXIO_HOME}" \
   -Dalluxio.logger.type="WORKER_LOGGER" \
@@ -32,7 +32,7 @@ echo "Formatting Alluxio Worker"
 
 echo "Starting Alluxio Worker"
 
-"${JAVA}" -cp "${CLASSPATH}" \
+"${JAVA}" -cp "${ALLUXIO_SERVER_CLASSPATH}" \
   ${ALLUXIO_WORKER_JAVA_OPTS} \
   -Dalluxio.home="${ALLUXIO_HOME}" \
   -Dalluxio.logger.type="WORKER_LOGGER" \


### PR DESCRIPTION
`alluxio-config.sh` no longer sets `CLASSPATH`. Instead, it sets `ALLUXIO_SERVER_CLASSPATH` and `ALLUXIO_CLIENT_CLASSPATH`.