### PR TITLE
[SMALLFIX] Include IOException in FileSystemMaster methods [WIP]

### DIFF
--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
  * Utilities for handling RPC calls.
  */
 public final class RpcUtils {
+
   /**
    * Calls the given {@link RpcCallable} and handles any exceptions thrown.
    *
@@ -33,28 +34,7 @@ public final class RpcUtils {
    * @return the return value from calling the callable
    * @throws AlluxioTException if the callable throws an exception
    */
-  public static <T> T call(Logger logger, RpcCallable<T> callable) throws AlluxioTException {
-    try {
-      return callable.call();
-    } catch (AlluxioException e) {
-      logger.debug("{}, Error={}", callable, e.getMessage());
-      throw AlluxioStatusException.fromAlluxioException(e).toThrift();
-    } catch (RuntimeException e) {
-      logger.error("{}", callable, e);
-      throw new InternalException(e).toThrift();
-    }
-  }
-
-  /**
-   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown.
-   *
-   * @param logger the logger to use for this call
-   * @param callable the callable to call
-   * @param <T> the return type of the callable
-   * @return the return value from calling the callable
-   * @throws AlluxioTException if the callable throws an exception
-   */
-  public static <T> T call(Logger logger, RpcCallableThrowsIOException<T> callable)
+  public static <T> T call(Logger logger, RpcCallable<T> callable)
       throws AlluxioTException {
     try {
       return callable.call();
@@ -95,50 +75,11 @@ public final class RpcUtils {
   }
 
   /**
-   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown. The
-   * callable should implement a toString with the following format:
-   * "CallName: arg1=value1, arg2=value2,...". The toString will be used to log enter and exit
-   * information with debug logging is enabled.
-   *
-   * @param logger the logger to use for this call
-   * @param callable the callable to call
-   * @param <T> the return type of the callable
-   * @return the return value from calling the callable
-   * @throws AlluxioTException if the callable throws an Alluxio or runtime exception
-   */
-  public static <T> T callAndLog(Logger logger, RpcCallableThrowsIOException<T> callable)
-      throws AlluxioTException {
-    logger.debug("Enter: {}", callable);
-    try {
-      T ret = call(logger, callable);
-      logger.debug("Exit (OK): {}", callable);
-      return ret;
-    } catch (AlluxioTException e) {
-      logger.debug("Exit (Error): {}, Error={}", callable, e.getMessage());
-      throw e;
-    }
-  }
-
-  /**
-   * An interface representing a callable which can only throw Alluxio exceptions.
-   *
-   * @param <T> the return type of the callable
-   */
-  public interface RpcCallable<T> {
-    /**
-     * The RPC implementation.
-     *
-     * @return the return value from the RPC
-     */
-    T call() throws AlluxioException;
-  }
-
-  /**
    * An interface representing a callable which can only throw Alluxio or IO exceptions.
    *
    * @param <T> the return type of the callable
    */
-  public interface RpcCallableThrowsIOException<T> {
+  public interface RpcCallable<T> {
     /**
      * The RPC implementation.
      *

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1563,8 +1563,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   @Override
   public long createDirectory(AlluxioURI path, CreateDirectoryOptions options)
-      throws InvalidPathException, FileAlreadyExistsException, IOException, AccessControlException,
-      FileDoesNotExistException {
+      throws InvalidPathException, FileAlreadyExistsException, AccessControlException,
+      FileDoesNotExistException, IOException {
     LOG.debug("createDirectory {} ", path);
     Metrics.CREATE_DIRECTORIES_OPS.inc();
 
@@ -2621,7 +2621,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   }
 
   @Override
-  public void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException {
+  public void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException, IOException {
     try (JournalContext journalContext = createJournalContext();
         LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE)) {
       scheduleAsyncPersistenceAndJournal(inodePath, journalContext);
@@ -2659,7 +2659,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   @Override
   public FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     for (long fileId : persistedFiles) {
       try {
         // Permission checking for each file is performed inside setAttribute

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -69,7 +69,7 @@ public interface FileSystemMaster extends Master {
    * @return the file id for a given path, or -1 if there is no file at that path
    * @throws AccessControlException if permission checking fails
    */
-  long getFileId(AlluxioURI path) throws AccessControlException;
+  long getFileId(AlluxioURI path) throws AccessControlException, IOException;
 
   /**
    * Returns the {@link FileInfo} for a given file id. This method is not user-facing but supposed
@@ -82,7 +82,7 @@ public interface FileSystemMaster extends Master {
    */
   // TODO(binfan): Add permission checking for internal APIs
   FileInfo getFileInfo(long fileId)
-      throws FileDoesNotExistException, AccessControlException;
+      throws FileDoesNotExistException, AccessControlException, IOException;
 
   /**
    * Returns the {@link FileInfo} for a given path.
@@ -97,7 +97,7 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    */
   FileInfo getFileInfo(AlluxioURI path, GetStatusOptions options)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * Returns the persistence state for a file id. This method is used by the lineage master.
@@ -107,7 +107,7 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if the file does not exist
    */
   // TODO(binfan): Add permission checking for internal APIs
-  PersistenceState getPersistenceState(long fileId) throws FileDoesNotExistException;
+  PersistenceState getPersistenceState(long fileId) throws FileDoesNotExistException, IOException;
 
   /**
    * Returns a list of {@link FileInfo} for a given path. If the given path is a file, the list only
@@ -125,7 +125,7 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if the path is invalid
    */
   List<FileInfo> listStatus(AlluxioURI path, ListStatusOptions listStatusOptions)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException;
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException;
 
   /**
    * @return a read-only view of the file system master
@@ -161,7 +161,7 @@ public interface FileSystemMaster extends Master {
    */
   void completeFile(AlluxioURI path, CompleteFileOptions options)
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
-      InvalidFileSizeException, FileAlreadyCompletedException, AccessControlException;
+      InvalidFileSizeException, FileAlreadyCompletedException, AccessControlException, IOException;
 
   /**
    * Creates a file (not a directory) for a given path.
@@ -180,7 +180,7 @@ public interface FileSystemMaster extends Master {
    */
   long createFile(AlluxioURI path, CreateFileOptions options)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
-      BlockInfoException, IOException, FileDoesNotExistException;
+      BlockInfoException, FileDoesNotExistException, IOException;
 
   /**
    * Reinitializes the blocks of an existing open file.
@@ -195,7 +195,7 @@ public interface FileSystemMaster extends Master {
    */
   // Used by lineage master
   long reinitializeFile(AlluxioURI path, long blockSizeBytes, long ttl, TtlAction ttlAction)
-      throws InvalidPathException, FileDoesNotExistException;
+      throws InvalidPathException, FileDoesNotExistException, IOException;
 
   /**
    * Gets a new block id for the next block of a given file to write to.
@@ -210,12 +210,12 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    */
   long getNewBlockIdForFile(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * @return a copy of the current mount table
    */
-  Map<String, MountPointInfo>  getMountTable();
+  Map<String, MountPointInfo> getMountTable();
 
   /**
    * @return the number of files and directories
@@ -239,9 +239,8 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
-  void delete(AlluxioURI path, DeleteOptions options) throws IOException,
-      FileDoesNotExistException, DirectoryNotEmptyException, InvalidPathException,
-      AccessControlException;
+  void delete(AlluxioURI path, DeleteOptions options) throws FileDoesNotExistException,
+      DirectoryNotEmptyException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * Gets the {@link FileBlockInfo} for all blocks of a file. If path is a directory, an exception
@@ -256,7 +255,7 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    */
   List<FileBlockInfo> getFileBlockInfoList(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * @return absolute paths of all in memory files
@@ -277,9 +276,8 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    */
-  long createDirectory(AlluxioURI path, CreateDirectoryOptions options)
-      throws InvalidPathException, FileAlreadyExistsException, IOException, AccessControlException,
-      FileDoesNotExistException;
+  long createDirectory(AlluxioURI path, CreateDirectoryOptions options) throws InvalidPathException,
+      FileAlreadyExistsException, AccessControlException, FileDoesNotExistException, IOException;
 
   /**
    * Renames a file to a destination.
@@ -297,7 +295,7 @@ public interface FileSystemMaster extends Master {
    */
   void rename(AlluxioURI srcPath, AlluxioURI dstPath, RenameOptions options)
       throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException, AccessControlException;
+      AccessControlException, IOException;
 
   /**
    * Frees or evicts all of the blocks of the file from alluxio storage. If the given file is a
@@ -318,7 +316,7 @@ public interface FileSystemMaster extends Master {
   // into RuntimeException on the client.
   void free(AlluxioURI path, FreeOptions options)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      UnexpectedAlluxioException;
+      UnexpectedAlluxioException, IOException;
 
   /**
    * Gets the path of a file with the given id.
@@ -329,7 +327,7 @@ public interface FileSystemMaster extends Master {
    */
   // Currently used by Lineage Master
   // TODO(binfan): Add permission checking for internal APIs
-  AlluxioURI getPath(long fileId) throws FileDoesNotExistException;
+  AlluxioURI getPath(long fileId) throws FileDoesNotExistException, IOException;
 
   /**
    * @return the set of inode ids which are pinned
@@ -365,7 +363,7 @@ public interface FileSystemMaster extends Master {
    */
   // Currently used by Lineage Master
   // TODO(binfan): Add permission checking for internal APIs
-  void reportLostFile(long fileId) throws FileDoesNotExistException;
+  void reportLostFile(long fileId) throws FileDoesNotExistException, IOException;
 
   /**
    * Loads metadata for the object identified by the given path from UFS into Alluxio.
@@ -386,7 +384,7 @@ public interface FileSystemMaster extends Master {
    */
   long loadMetadata(AlluxioURI path, LoadMetadataOptions options)
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
-      InvalidFileSizeException, FileAlreadyCompletedException, IOException, AccessControlException;
+      InvalidFileSizeException, FileAlreadyCompletedException, AccessControlException, IOException;
 
   /**
    * Mounts a UFS path onto an Alluxio path.
@@ -404,7 +402,7 @@ public interface FileSystemMaster extends Master {
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountOptions options)
       throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException, AccessControlException;
+      AccessControlException, IOException;
 
   /**
    * Unmounts a UFS path previously mounted onto an Alluxio path.
@@ -418,7 +416,7 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if the permission check fails
    */
   void unmount(AlluxioURI alluxioPath)
-      throws FileDoesNotExistException, InvalidPathException, IOException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * Resets a file. It first free the whole file, and then reinitializes it.
@@ -431,9 +429,8 @@ public interface FileSystemMaster extends Master {
    */
   // Currently used by Lineage Master
   // TODO(binfan): Add permission checking for internal APIs
-  void resetFile(long fileId)
-      throws UnexpectedAlluxioException, FileDoesNotExistException, InvalidPathException,
-      AccessControlException;
+  void resetFile(long fileId) throws UnexpectedAlluxioException, FileDoesNotExistException,
+      InvalidPathException, AccessControlException, IOException;
 
   /**
    * Sets the file attribute.
@@ -449,14 +446,14 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if the given path is invalid
    */
   void setAttribute(AlluxioURI path, SetAttributeOptions options)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException;
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException, IOException;
 
   /**
    * Schedules a file for async persistence.
    *
    * @param path the path of the file for persistence
    */
-  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
+  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException, IOException;
 
   /**
    * Instructs a worker to persist the files.
@@ -471,7 +468,7 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    */
   FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * @return a list of {@link WorkerInfo} objects representing the workers in Alluxio

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.RpcUtils;
 import alluxio.RpcUtils.RpcCallable;
-import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.master.file.options.CheckConsistencyOptions;
 import alluxio.master.file.options.CompleteFileOptions;
@@ -104,7 +103,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public CheckConsistencyTResponse checkConsistency(final String path,
       final CheckConsistencyTOptions options) throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<CheckConsistencyTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<CheckConsistencyTResponse>() {
       @Override
       public CheckConsistencyTResponse call() throws AlluxioException, IOException {
         List<AlluxioURI> inconsistentUris = mFileSystemMaster.checkConsistency(
@@ -128,7 +127,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<CompleteFileTResponse>() {
       @Override
-      public CompleteFileTResponse call() throws AlluxioException {
+      public CompleteFileTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.completeFile(new AlluxioURI(path), new CompleteFileOptions(options));
         return new CompleteFileTResponse();
       }
@@ -143,7 +142,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public CreateDirectoryTResponse createDirectory(final String path,
       final CreateDirectoryTOptions options) throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<CreateDirectoryTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<CreateDirectoryTResponse>() {
       @Override
       public CreateDirectoryTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.createDirectory(new AlluxioURI(path),
@@ -161,7 +160,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public CreateFileTResponse createFile(final String path, final CreateFileTOptions options)
       throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<CreateFileTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<CreateFileTResponse>() {
       @Override
       public CreateFileTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.createFile(new AlluxioURI(path), new CreateFileOptions(options));
@@ -180,7 +179,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<FreeTResponse>() {
       @Override
-      public FreeTResponse call() throws AlluxioException {
+      public FreeTResponse call() throws AlluxioException, IOException {
         if (options == null) {
           // For Alluxio client v1.4 or earlier.
           // NOTE, we try to be conservative here so early Alluxio clients will not be able to force
@@ -205,7 +204,7 @@ public final class FileSystemMasterClientServiceHandler implements
       final GetNewBlockIdForFileTOptions options) throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<GetNewBlockIdForFileTResponse>() {
       @Override
-      public GetNewBlockIdForFileTResponse call() throws AlluxioException {
+      public GetNewBlockIdForFileTResponse call() throws AlluxioException, IOException {
         return new GetNewBlockIdForFileTResponse(
             mFileSystemMaster.getNewBlockIdForFile(new AlluxioURI(path)));
       }
@@ -222,7 +221,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<GetStatusTResponse>() {
       @Override
-      public GetStatusTResponse call() throws AlluxioException {
+      public GetStatusTResponse call() throws AlluxioException, IOException {
         return new GetStatusTResponse(ThriftUtils.toThrift(
             mFileSystemMaster.getFileInfo(new AlluxioURI(path), new GetStatusOptions(options))));
       }
@@ -239,7 +238,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<ListStatusTResponse>() {
       @Override
-      public ListStatusTResponse call() throws AlluxioException {
+      public ListStatusTResponse call() throws AlluxioException, IOException {
         List<FileInfo> result = new ArrayList<>();
         for (alluxio.wire.FileInfo fileInfo : mFileSystemMaster
             .listStatus(new AlluxioURI(path), new ListStatusOptions(options))) {
@@ -265,7 +264,7 @@ public final class FileSystemMasterClientServiceHandler implements
   public LoadMetadataTResponse loadMetadata(final String alluxioPath, final boolean recursive,
       final LoadMetadataTOptions options)
       throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<LoadMetadataTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<LoadMetadataTResponse>() {
       @Override
       public LoadMetadataTResponse call() throws AlluxioException, IOException {
         return new LoadMetadataTResponse(mFileSystemMaster.loadMetadata(new AlluxioURI(alluxioPath),
@@ -283,7 +282,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public MountTResponse mount(final String alluxioPath, final String ufsPath,
       final MountTOptions options) throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<MountTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<MountTResponse>() {
       @Override
       public MountTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.mount(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath),
@@ -302,7 +301,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public DeleteTResponse remove(final String path, final boolean recursive,
       final DeleteTOptions options) throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<DeleteTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<DeleteTResponse>() {
       @Override
       public DeleteTResponse call() throws AlluxioException, IOException {
         if (options == null) {
@@ -327,7 +326,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public RenameTResponse rename(final String srcPath, final String dstPath,
       final RenameTOptions options) throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<RenameTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<RenameTResponse>() {
       @Override
       public RenameTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster
@@ -348,7 +347,7 @@ public final class FileSystemMasterClientServiceHandler implements
       final ScheduleAsyncPersistenceTOptions options) throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<ScheduleAsyncPersistenceTResponse>() {
       @Override
-      public ScheduleAsyncPersistenceTResponse call() throws AlluxioException {
+      public ScheduleAsyncPersistenceTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
         return new ScheduleAsyncPersistenceTResponse();
       }
@@ -365,7 +364,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.callAndLog(LOG, new RpcCallable<SetAttributeTResponse>() {
       @Override
-      public SetAttributeTResponse call() throws AlluxioException {
+      public SetAttributeTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.setAttribute(new AlluxioURI(path), new SetAttributeOptions(options));
         return new SetAttributeTResponse();
       }
@@ -380,7 +379,7 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public UnmountTResponse unmount(final String alluxioPath, final UnmountTOptions options)
       throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<UnmountTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallable<UnmountTResponse>() {
       @Override
       public UnmountTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.unmount(new AlluxioURI(alluxioPath));

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
@@ -32,6 +32,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -68,7 +69,7 @@ public final class FileSystemMasterWorkerServiceHandler
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcUtils.RpcCallable<FileSystemHeartbeatTResponse>() {
       @Override
-      public FileSystemHeartbeatTResponse call() throws AlluxioException {
+      public FileSystemHeartbeatTResponse call() throws AlluxioException, IOException {
         return new FileSystemHeartbeatTResponse(
             mFileSystemMaster.workerHeartbeat(workerId, persistedFiles));
       }
@@ -80,7 +81,7 @@ public final class FileSystemMasterWorkerServiceHandler
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcUtils.RpcCallable<GetFileInfoTResponse>() {
       @Override
-      public GetFileInfoTResponse call() throws AlluxioException {
+      public GetFileInfoTResponse call() throws AlluxioException, IOException {
         return new GetFileInfoTResponse(
             ThriftUtils.toThrift(mFileSystemMaster.getFileInfo(fileId)));
       }

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -25,6 +25,7 @@ import alluxio.util.CommonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -70,7 +71,7 @@ public interface AsyncPersistHandler {
    *
    * @param path the path to the file
    */
-  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
+  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException, IOException;
 
   /**
    * Polls the files for persistence on the given worker.
@@ -82,5 +83,5 @@ public interface AsyncPersistHandler {
    * @throws AccessControlException if permission checking fails
    */
   List<PersistFile> pollFilesToPersist(long workerId)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 }

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -62,7 +63,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
 
   @Override
   public synchronized void scheduleAsyncPersistence(AlluxioURI path)
-      throws AlluxioException {
+      throws AlluxioException, IOException {
     // find the worker
     long workerId = getWorkerStoringFile(path);
 
@@ -87,7 +88,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
    */
   // TODO(calvin): Propagate the exceptions in certain cases
   private long getWorkerStoringFile(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException, AccessControlException, IOException {
     long fileId = mFileSystemMasterView.getFileId(path);
     if (mFileSystemMasterView.getFileInfo(fileId).getLength() == 0) {
       // if file is empty, return any worker
@@ -150,7 +151,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
    */
   @Override
   public synchronized List<PersistFile> pollFilesToPersist(long workerId)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     List<PersistFile> filesToPersist = new ArrayList<>();
     List<Long> fileIdsToPersist = new ArrayList<>();
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
@@ -22,6 +22,7 @@ import alluxio.wire.WorkerInfo;
 
 import com.google.common.base.Preconditions;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -50,7 +51,7 @@ public final class FileSystemMasterView {
    * @throws FileDoesNotExistException if the file does not exist
    */
   public synchronized PersistenceState getFilePersistenceState(long fileId)
-      throws FileDoesNotExistException {
+      throws FileDoesNotExistException, IOException {
     return mFileSystemMaster.getPersistenceState(fileId);
   }
 
@@ -63,7 +64,7 @@ public final class FileSystemMasterView {
    * @throws AccessControlException if permission denied
    */
   public synchronized FileInfo getFileInfo(long fileId)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException, AccessControlException, IOException {
     return mFileSystemMaster.getFileInfo(fileId);
   }
 
@@ -84,7 +85,7 @@ public final class FileSystemMasterView {
    * @throws FileDoesNotExistException if file does not exist
    */
   public synchronized long getFileId(AlluxioURI path)
-      throws AccessControlException, FileDoesNotExistException {
+      throws AccessControlException, FileDoesNotExistException, IOException {
     return mFileSystemMaster.getFileId(path);
   }
 
@@ -96,7 +97,7 @@ public final class FileSystemMasterView {
    * @throws AccessControlException if permission checking fails
    */
   public synchronized List<FileBlockInfo> getFileBlockInfoList(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     return mFileSystemMaster.getFileBlockInfoList(path);
   }
 
@@ -107,7 +108,8 @@ public final class FileSystemMasterView {
    * @return the path of the file
    * @throws FileDoesNotExistException raise if the file does not exist
    */
-  public synchronized AlluxioURI getPath(long fileId) throws FileDoesNotExistException {
+  public synchronized AlluxioURI getPath(long fileId)
+      throws FileDoesNotExistException, IOException {
     return mFileSystemMaster.getPath(fileId);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -280,9 +280,8 @@ public final class LineageMaster extends AbstractMaster {
    * @throws FileDoesNotExistException if the path does not exist
    */
   public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl,
-      TtlAction ttlAction)
-      throws InvalidPathException, LineageDoesNotExistException, AccessControlException,
-      FileDoesNotExistException {
+      TtlAction ttlAction) throws InvalidPathException, LineageDoesNotExistException,
+          AccessControlException, FileDoesNotExistException, IOException {
     long fileId = mFileSystemMaster.getFileId(new AlluxioURI(path));
     FileInfo fileInfo;
     try {
@@ -305,7 +304,7 @@ public final class LineageMaster extends AbstractMaster {
    * @throws FileDoesNotExistException if any associated file does not exist
    */
   public synchronized List<LineageInfo> getLineageInfoList()
-      throws LineageDoesNotExistException, FileDoesNotExistException {
+      throws LineageDoesNotExistException, FileDoesNotExistException, IOException {
     List<LineageInfo> lineages = new ArrayList<>();
 
     for (Lineage lineage : mLineageStore.getAllInTopologicalOrder()) {
@@ -351,7 +350,7 @@ public final class LineageMaster extends AbstractMaster {
       for (long file : lineage.getOutputFiles()) {
         try {
           mFileSystemMaster.scheduleAsyncPersistence(mFileSystemMaster.getPath(file));
-        } catch (AlluxioException e) {
+        } catch (AlluxioException | IOException e) {
           LOG.error("Failed to persist the file {}.", file, e);
         }
       }
@@ -366,8 +365,8 @@ public final class LineageMaster extends AbstractMaster {
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
-  public synchronized void reportLostFile(String path) throws FileDoesNotExistException,
-      AccessControlException, InvalidPathException {
+  public synchronized void reportLostFile(String path)
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException, IOException {
     long fileId = mFileSystemMaster.getFileId(new AlluxioURI(path));
     mFileSystemMaster.reportLostFile(fileId);
   }

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.RpcUtils;
 import alluxio.RpcUtils.RpcCallable;
-import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.job.CommandLineJob;
 import alluxio.job.JobConf;
@@ -77,7 +76,7 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
   public CreateLineageTResponse createLineage(final List<String> inputFiles,
       final List<String> outputFiles, final CommandLineJobInfo jobInfo,
       CreateLineageTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<CreateLineageTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<CreateLineageTResponse>() {
       @Override
       public CreateLineageTResponse call() throws AlluxioException, IOException {
         // deserialization
@@ -113,7 +112,7 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<GetLineageInfoListTResponse>() {
       @Override
-      public GetLineageInfoListTResponse call() throws AlluxioException {
+      public GetLineageInfoListTResponse call() throws AlluxioException, IOException {
         List<LineageInfo> result = new ArrayList<>();
         for (alluxio.wire.LineageInfo lineageInfo : mLineageMaster.getLineageInfoList()) {
           result.add(ThriftUtils.toThrift(lineageInfo));
@@ -129,7 +128,7 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<ReinitializeFileTResponse>() {
       @Override
-      public ReinitializeFileTResponse call() throws AlluxioException {
+      public ReinitializeFileTResponse call() throws AlluxioException, IOException {
         return new ReinitializeFileTResponse(mLineageMaster
             .reinitializeFile(path, blockSizeBytes, ttl, ThriftUtils.fromThrift(ttlAction)));
       }
@@ -141,7 +140,7 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<ReportLostFileTResponse>() {
       @Override
-      public ReportLostFileTResponse call() throws AlluxioException {
+      public ReportLostFileTResponse call() throws AlluxioException, IOException {
         mLineageMaster.reportLostFile(path);
         return new ReportLostFileTResponse();
       }

--- a/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/checkpoint/CheckpointLatestPlanner.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -57,8 +58,8 @@ public final class CheckpointLatestPlanner implements CheckpointPlanner {
             || LineageStateUtils.isInCheckpointing(lineage, fileSystemMasterView)) {
           continue;
         }
-      } catch (FileDoesNotExistException | AccessControlException e) {
-        LOG.error("The lineage file does not exist", e);
+      } catch (FileDoesNotExistException | AccessControlException | IOException e) {
+        LOG.error("Failed to get lineage state", e);
         continue;
       }
       if (lineage.getCreationTime() > latestCreated) {

--- a/core/server/master/src/main/java/alluxio/master/lineage/meta/LineageStateUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/meta/LineageStateUtils.java
@@ -17,6 +17,7 @@ import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.wire.FileInfo;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public final class LineageStateUtils {
    * @throws AccessControlException if permission denied
    */
   public static boolean isCompleted(Lineage lineage, FileSystemMasterView fileSystemMasterView)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException, AccessControlException, IOException {
     for (long outputFile : lineage.getOutputFiles()) {
       FileInfo fileInfo = fileSystemMasterView.getFileInfo(outputFile);
       if (!fileInfo.isCompleted()) {
@@ -73,7 +74,7 @@ public final class LineageStateUtils {
    * @throws FileDoesNotExistException if the file does not exist
    */
   public static boolean isPersisted(Lineage lineage, FileSystemMasterView fileSystemMasterView)
-      throws FileDoesNotExistException {
+      throws FileDoesNotExistException, IOException {
     for (long outputFile : lineage.getOutputFiles()) {
       if (fileSystemMasterView.getFilePersistenceState(outputFile) != PersistenceState.PERSISTED) {
         return false;
@@ -89,7 +90,7 @@ public final class LineageStateUtils {
    * @throws FileDoesNotExistException if the file does not exist
    */
   public static boolean isInCheckpointing(Lineage lineage,
-      FileSystemMasterView fileSystemMasterView) throws FileDoesNotExistException {
+      FileSystemMasterView fileSystemMasterView) throws FileDoesNotExistException, IOException {
     for (long outputFile : lineage.getOutputFiles()) {
       if (fileSystemMasterView
           .getFilePersistenceState(outputFile) == PersistenceState.TO_BE_PERSISTED) {

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -107,14 +108,9 @@ public final class RecomputeExecutor implements HeartbeatExecutor {
               mFileSystemMaster.getFileSystemMasterView())) {
             try {
               mFileSystemMaster.resetFile(fileId);
-            } catch (UnexpectedAlluxioException e) {
-              LOG.error("the lost file {} can not be freed", fileId, e);
-            } catch (FileDoesNotExistException e) {
-              LOG.error("the lost file {} does not exist", fileId, e);
-            } catch (InvalidPathException e) {
-              LOG.error("the lost file {} is invalid", fileId, e);
-            } catch (AccessControlException e) {
-              LOG.error("the lost file {} cannot be accessed", fileId, e);
+            } catch (UnexpectedAlluxioException | InvalidPathException | AccessControlException
+                | IOException e) {
+              LOG.error("Failed to reinitialize file {}", fileId, e);
             }
           }
         } catch (FileDoesNotExistException e) {

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputePlanner.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -77,7 +78,7 @@ public class RecomputePlanner {
               mFileSystemMaster.getFileSystemMasterView())) {
             toRecompute.add(lineage);
           }
-        } catch (FileDoesNotExistException e) {
+        } catch (FileDoesNotExistException | IOException e) {
           throw new IllegalStateException(e); // should not happen
         }
       }

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceBrowseServlet.java
@@ -294,7 +294,7 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
    * @throws AccessControlException if permission checking fails
    */
   private void setPathDirectories(AlluxioURI path, HttpServletRequest request)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     FileSystemMaster fileSystemMaster = mMasterProcess.getMaster(FileSystemMaster.class);
     if (path.isRoot()) {
       request.setAttribute("pathInfos", new UIFileInfo[0]);

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -151,7 +151,7 @@ public final class KeyValueMaster extends AbstractMaster {
    * @throws InvalidPathException if the path is invalid
    */
   public synchronized void completePartition(AlluxioURI path, PartitionInfo info)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -193,7 +193,7 @@ public final class KeyValueMaster extends AbstractMaster {
    * @throws AccessControlException if permission checking fails
    */
   public synchronized void completeStore(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -229,7 +229,7 @@ public final class KeyValueMaster extends AbstractMaster {
    * @throws AccessControlException if permission checking fails
    */
   public synchronized void createStore(AlluxioURI path)
-      throws FileAlreadyExistsException, InvalidPathException, AccessControlException {
+      throws FileAlreadyExistsException, InvalidPathException, AccessControlException, IOException {
     try {
       // Create this dir
       mFileSystemMaster
@@ -293,7 +293,7 @@ public final class KeyValueMaster extends AbstractMaster {
   }
 
   private long getFileId(AlluxioURI uri)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException {
     long fileId = mFileSystemMaster.getFileId(uri);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
@@ -390,7 +390,7 @@ public final class KeyValueMaster extends AbstractMaster {
    * @throws InvalidPathException if the path is invalid
    */
   public synchronized List<PartitionInfo> getPartitionInfo(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException {
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException, IOException {
     long fileId = getFileId(path);
     List<PartitionInfo> partitions = mCompleteStoreToPartitions.get(fileId);
     if (partitions == null) {

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.RpcUtils;
 import alluxio.RpcUtils.RpcCallable;
-import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.CompletePartitionTOptions;
@@ -73,7 +72,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
       CompletePartitionTOptions options) throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<CompletePartitionTResponse>() {
       @Override
-      public CompletePartitionTResponse call() throws AlluxioException {
+      public CompletePartitionTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.completePartition(new AlluxioURI(path), info);
         return new CompletePartitionTResponse();
       }
@@ -85,7 +84,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<CreateStoreTResponse>() {
       @Override
-      public CreateStoreTResponse call() throws AlluxioException {
+      public CreateStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.createStore(new AlluxioURI(path));
         return new CreateStoreTResponse();
       }
@@ -97,7 +96,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<CompleteStoreTResponse>() {
       @Override
-      public CompleteStoreTResponse call() throws AlluxioException {
+      public CompleteStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.completeStore(new AlluxioURI(path));
         return new CompleteStoreTResponse();
       }
@@ -107,7 +106,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public DeleteStoreTResponse deleteStore(final String path, DeleteStoreTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<DeleteStoreTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<DeleteStoreTResponse>() {
       @Override
       public DeleteStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.deleteStore(new AlluxioURI(path));
@@ -121,7 +120,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
       GetPartitionInfoTOptions options) throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallable<GetPartitionInfoTResponse>() {
       @Override
-      public GetPartitionInfoTResponse call() throws AlluxioException {
+      public GetPartitionInfoTResponse call() throws AlluxioException, IOException {
         return new GetPartitionInfoTResponse(
             mKeyValueMaster.getPartitionInfo(new AlluxioURI(path)));
       }
@@ -131,7 +130,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public MergeStoreTResponse mergeStore(final String fromPath, final String toPath,
       MergeStoreTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<MergeStoreTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<MergeStoreTResponse>() {
       @Override
       public MergeStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.mergeStore(new AlluxioURI(fromPath), new AlluxioURI(toPath));
@@ -143,7 +142,7 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public RenameStoreTResponse renameStore(final String oldPath, final String newPath,
       RenameStoreTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<RenameStoreTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<RenameStoreTResponse>() {
       @Override
       public RenameStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.renameStore(new AlluxioURI(oldPath), new AlluxioURI(newPath));

--- a/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/worker/keyvalue/KeyValueWorkerClientServiceHandler.java
@@ -13,7 +13,7 @@ package alluxio.worker.keyvalue;
 
 import alluxio.Constants;
 import alluxio.RpcUtils;
-import alluxio.RpcUtils.RpcCallableThrowsIOException;
+import alluxio.RpcUtils.RpcCallable;
 import alluxio.Sessions;
 import alluxio.client.keyvalue.ByteBufferKeyValuePartitionReader;
 import alluxio.client.keyvalue.Index;
@@ -73,7 +73,7 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
   @Override
   public GetTResponse get(final long blockId, final ByteBuffer key, GetTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<GetTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<GetTResponse>() {
       @Override
       public GetTResponse call() throws AlluxioException, IOException {
         ByteBuffer value = getInternal(blockId, key);
@@ -128,7 +128,7 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
   @Override
   public GetNextKeysTResponse getNextKeys(final long blockId, final ByteBuffer key,
       final int numKeys, GetNextKeysTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<GetNextKeysTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<GetNextKeysTResponse>() {
       @Override
       public GetNextKeysTResponse call() throws AlluxioException, IOException {
         final long sessionId = Sessions.KEYVALUE_SESSION_ID;
@@ -164,7 +164,7 @@ public final class KeyValueWorkerClientServiceHandler implements KeyValueWorkerC
   @Override
   public GetSizeTResponse getSize(final long blockId, GetSizeTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<GetSizeTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallable<GetSizeTResponse>() {
       @Override
       public GetSizeTResponse call() throws AlluxioException, IOException {
         final long sessionId = Sessions.KEYVALUE_SESSION_ID;


### PR DESCRIPTION
By throwing `IOException`, we allow ourselves to propagate `AlluxioStatusExceptions` without needing to change the interface again in the future.