### PR TITLE
[SMALLFIX] third pull request, change time-related property-key value from getLong, getInt to getMs

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
@@ -93,7 +93,7 @@ public final class LocalFilePacketReader implements PacketReader {
    */
   public static class Factory implements PacketReader.Factory {
     private static final long READ_TIMEOUT_MS =
-        Configuration.getLong(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
+        Configuration.getMs(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
 
     private final FileSystemContext mContext;
     private final WorkerNetAddress mAddress;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketWriter.java
@@ -44,7 +44,7 @@ public final class LocalFilePacketWriter implements PacketWriter {
   private static final long FILE_BUFFER_BYTES =
       Configuration.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
   private static final long WRITE_TIMEOUT_MS =
-      Configuration.getLong(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
 
   private final FileSystemContext mContext;
   private final WorkerNetAddress mAddress;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
@@ -70,7 +70,7 @@ public final class NettyPacketReader implements PacketReader {
   private static final int MAX_PACKETS_IN_FLIGHT =
       Configuration.getInt(PropertyKey.USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS);
   private static final long READ_TIMEOUT_MS =
-      Configuration.getLong(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
 
   /** Special packet that indicates an exception is caught. */
   private static final ByteBuf THROWABLE = Unpooled.buffer(0);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -70,7 +70,7 @@ public final class NettyPacketWriter implements PacketWriter {
   private static final int MAX_PACKETS_IN_FLIGHT =
       Configuration.getInt(PropertyKey.USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS);
   private static final long WRITE_TIMEOUT_MS =
-      Configuration.getLong(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.USER_NETWORK_NETTY_TIMEOUT_MS);
 
   private final FileSystemContext mContext;
   private final Channel mChannel;
@@ -240,7 +240,7 @@ public final class NettyPacketWriter implements PacketWriter {
             throw new UnavailableException(mPacketWriteException);
           }
           if (!mDoneOrFailed
-              .await(Configuration.getLong(PropertyKey.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS),
+              .await(Configuration.getMs(PropertyKey.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS),
                   TimeUnit.MILLISECONDS)) {
             mChannel.close();
             throw new DeadlineExceededException(String.format(

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -94,7 +94,7 @@ public final class FileSystemUtils {
           throws IOException, AlluxioException, InterruptedException {
 
     final long deadline = System.currentTimeMillis() + tunit.toMillis(timeout);
-    final long pollPeriod = Configuration.getLong(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS);
+    final long pollPeriod = Configuration.getMs(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS);
     boolean completed = false;
     long timeleft = deadline - System.currentTimeMillis();
 

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -56,7 +56,7 @@ public abstract class AbstractClient implements Client {
   private static final int BASE_SLEEP_MS =
       Configuration.getInt(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS);
   private static final int MAX_SLEEP_MS =
-      Configuration.getInt(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
+      (int) Configuration.getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
 
   /** The number of times to retry a particular RPC. */
   protected static final int RPC_MAX_NUM_RETRY =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -288,9 +288,9 @@ public class PropertyKey {
       create(Name.WORKER_ALLOCATOR_CLASS, "alluxio.worker.block.allocator.MaxFreeAllocator");
   public static final PropertyKey WORKER_BIND_HOST = create(Name.WORKER_BIND_HOST, "0.0.0.0");
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_INTERVAL_MS =
-      create(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, 1000);
+      create(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "1sec");
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS =
-      create(Name.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS, 60000);
+      create(Name.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS, "1min");
   public static final PropertyKey WORKER_BLOCK_THREADS_MAX =
       create(Name.WORKER_BLOCK_THREADS_MAX, 2048);
   public static final PropertyKey WORKER_BLOCK_THREADS_MIN =
@@ -324,7 +324,7 @@ public class PropertyKey {
   public static final PropertyKey WORKER_FILE_BUFFER_SIZE =
       create(Name.WORKER_FILE_BUFFER_SIZE, "1MB");
   public static final PropertyKey WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS =
-      create(Name.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS, 1000);
+      create(Name.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS, "1sec");
   public static final PropertyKey WORKER_HOSTNAME = create(Name.WORKER_HOSTNAME, null);
   public static final PropertyKey WORKER_KEYTAB_FILE = create(Name.WORKER_KEYTAB_FILE, null);
   public static final PropertyKey WORKER_MEMORY_SIZE = create(Name.WORKER_MEMORY_SIZE, "1GB");
@@ -368,7 +368,7 @@ public class PropertyKey {
   public static final PropertyKey WORKER_PRINCIPAL = create(Name.WORKER_PRINCIPAL, null);
   public static final PropertyKey WORKER_RPC_PORT = create(Name.WORKER_RPC_PORT, 29998);
   public static final PropertyKey WORKER_SESSION_TIMEOUT_MS =
-      create(Name.WORKER_SESSION_TIMEOUT_MS, 60000);
+      create(Name.WORKER_SESSION_TIMEOUT_MS, "1min");
   public static final PropertyKey WORKER_TIERED_STORE_BLOCK_LOCK_READERS =
       create(Name.WORKER_TIERED_STORE_BLOCK_LOCK_READERS, 1000);
   public static final PropertyKey WORKER_TIERED_STORE_BLOCK_LOCKS =
@@ -432,7 +432,7 @@ public class PropertyKey {
   public static final PropertyKey WORKER_TIERED_STORE_RESERVER_ENABLED =
       create(Name.WORKER_TIERED_STORE_RESERVER_ENABLED, false);
   public static final PropertyKey WORKER_TIERED_STORE_RESERVER_INTERVAL_MS =
-      create(Name.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, 1000);
+      create(Name.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "1sec");
   public static final PropertyKey WORKER_TIERED_STORE_RETRY =
       create(Name.WORKER_TIERED_STORE_RETRY, 3);
   public static final PropertyKey WORKER_TIERED_STORE_FREE_SPACE_RATIO =
@@ -442,13 +442,13 @@ public class PropertyKey {
   public static final PropertyKey WORKER_WEB_HOSTNAME = create(Name.WORKER_WEB_HOSTNAME, null);
   public static final PropertyKey WORKER_WEB_PORT = create(Name.WORKER_WEB_PORT, 30000);
   public static final PropertyKey WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS =
-      create(Name.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS, 300000);
+      create(Name.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS, "5min");
 
   //
   // Proxy related properties
   //
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
-      create(Name.PROXY_STREAM_CACHE_TIMEOUT_MS, 3600000);
+      create(Name.PROXY_STREAM_CACHE_TIMEOUT_MS, "1hour");
   public static final PropertyKey PROXY_WEB_BIND_HOST = create(Name.PROXY_WEB_BIND_HOST, "0.0.0.0");
   public static final PropertyKey PROXY_WEB_HOSTNAME = create(Name.PROXY_WEB_HOSTNAME, null);
   public static final PropertyKey PROXY_WEB_PORT = create(Name.PROXY_WEB_PORT, 39999);
@@ -501,7 +501,7 @@ public class PropertyKey {
   public static final PropertyKey USER_FILE_SEEK_BUFFER_SIZE_BYTES =
       create(Name.USER_FILE_SEEK_BUFFER_SIZE_BYTES, "1MB");
   public static final PropertyKey USER_FILE_WAITCOMPLETED_POLL_MS =
-      create(Name.USER_FILE_WAITCOMPLETED_POLL_MS, 1000);
+      create(Name.USER_FILE_WAITCOMPLETED_POLL_MS, "1sec");
   public static final PropertyKey USER_FILE_WORKER_CLIENT_THREADS =
       create(Name.USER_FILE_WORKER_CLIENT_THREADS, 10);
   public static final PropertyKey USER_FILE_WORKER_CLIENT_POOL_SIZE_MAX =
@@ -517,7 +517,7 @@ public class PropertyKey {
   public static final PropertyKey USER_FILE_WRITE_TIER_DEFAULT =
       create(Name.USER_FILE_WRITE_TIER_DEFAULT, Constants.FIRST_TIER);
   public static final PropertyKey USER_HEARTBEAT_INTERVAL_MS =
-      create(Name.USER_HEARTBEAT_INTERVAL_MS, 1000);
+      create(Name.USER_HEARTBEAT_INTERVAL_MS, "1sec");
   public static final PropertyKey USER_HOSTNAME = create(Name.USER_HOSTNAME, null);
   public static final PropertyKey USER_LINEAGE_ENABLED = create(Name.USER_LINEAGE_ENABLED, false);
   public static final PropertyKey USER_LINEAGE_MASTER_CLIENT_THREADS =
@@ -529,7 +529,7 @@ public class PropertyKey {
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL =
       create(Name.USER_NETWORK_NETTY_CHANNEL, null);
   public static final PropertyKey USER_NETWORK_NETTY_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_TIMEOUT_MS, 30000);
+      create(Name.USER_NETWORK_NETTY_TIMEOUT_MS, "30sec");
   public static final PropertyKey USER_NETWORK_NETTY_WORKER_THREADS =
       create(Name.USER_NETWORK_NETTY_WORKER_THREADS, 0);
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX =
@@ -543,7 +543,7 @@ public class PropertyKey {
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS =
       create(Name.USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS, 16);
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS, 300000);
+      create(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS, "5min");
   public static final PropertyKey USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS =
       create(Name.USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS, 16);
   public static final PropertyKey USER_NETWORK_NETTY_READER_CANCEL_ENABLED =
@@ -556,7 +556,7 @@ public class PropertyKey {
   public static final PropertyKey USER_RPC_RETRY_MAX_NUM_RETRY =
       create(Name.USER_RPC_RETRY_MAX_NUM_RETRY, 20);
   public static final PropertyKey USER_RPC_RETRY_MAX_SLEEP_MS =
-      create(Name.USER_RPC_RETRY_MAX_SLEEP_MS, 5000);
+      create(Name.USER_RPC_RETRY_MAX_SLEEP_MS, "5min");
   /**
    * @deprecated It will be removed in 2.0.0.
    */
@@ -622,7 +622,7 @@ public class PropertyKey {
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS =
       create(Name.SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS, null);
   public static final PropertyKey SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS =
-      create(Name.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS, "600000");
+      create(Name.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS, "10min");
   public static final PropertyKey SECURITY_AUTHENTICATION_TYPE =
       create(Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE");
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_ENABLED =
@@ -632,7 +632,7 @@ public class PropertyKey {
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_UMASK =
       create(Name.SECURITY_AUTHORIZATION_PERMISSION_UMASK, "022");
   public static final PropertyKey SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS =
-      create(Name.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS, "60000");
+      create(Name.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS, "1min");
   public static final PropertyKey SECURITY_GROUP_MAPPING_CLASS =
       create(Name.SECURITY_GROUP_MAPPING_CLASS,
           "alluxio.security.group.provider.ShellBasedUnixGroupsMapping");

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -529,7 +529,7 @@ public class PropertyKey {
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL =
       create(Name.USER_NETWORK_NETTY_CHANNEL, null);
   public static final PropertyKey USER_NETWORK_NETTY_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_TIMEOUT_MS, "30sec");
+      create(Name.USER_NETWORK_NETTY_TIMEOUT_MS, 30000);
   public static final PropertyKey USER_NETWORK_NETTY_WORKER_THREADS =
       create(Name.USER_NETWORK_NETTY_WORKER_THREADS, 0);
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX =
@@ -543,7 +543,7 @@ public class PropertyKey {
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS =
       create(Name.USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS, 16);
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS, "5min");
+      create(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS, 300000);
   public static final PropertyKey USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS =
       create(Name.USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS, 16);
   public static final PropertyKey USER_NETWORK_NETTY_READER_CANCEL_ENABLED =

--- a/core/common/src/main/java/alluxio/security/authentication/NoSaslTransportProvider.java
+++ b/core/common/src/main/java/alluxio/security/authentication/NoSaslTransportProvider.java
@@ -39,7 +39,8 @@ public final class NoSaslTransportProvider implements TransportProvider {
    * Constructor for transport provider when authentication type is {@link AuthType#NOSASL}.
    */
   public NoSaslTransportProvider() {
-    mSocketTimeoutMs = Configuration.getInt(PropertyKey.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS);
+    mSocketTimeoutMs =
+        (int) Configuration.getMs(PropertyKey.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS);
     mThriftFrameSizeMax =
         (int) Configuration.getBytes(PropertyKey.NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX);
   }

--- a/core/common/src/main/java/alluxio/security/authentication/PlainSaslTransportProvider.java
+++ b/core/common/src/main/java/alluxio/security/authentication/PlainSaslTransportProvider.java
@@ -48,7 +48,8 @@ public final class PlainSaslTransportProvider implements TransportProvider {
    * Constructor for transport provider with {@link AuthType#SIMPLE} or {@link AuthType#CUSTOM}.
    */
   public PlainSaslTransportProvider() {
-    mSocketTimeoutMs = Configuration.getInt(PropertyKey.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS);
+    mSocketTimeoutMs =
+        (int) Configuration.getMs(PropertyKey.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
+++ b/core/common/src/main/java/alluxio/security/group/CachedGroupMapping.java
@@ -59,8 +59,7 @@ public class CachedGroupMapping implements GroupMappingService {
    */
   public CachedGroupMapping(GroupMappingService service) {
     mService = service;
-    long timeoutMs = Long.parseLong(Configuration.get(
-        PropertyKey.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS));
+    long timeoutMs = Configuration.getMs(PropertyKey.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS);
     mCacheEnabled = timeoutMs > 0;
     if (mCacheEnabled) {
       mCache = CacheBuilder.newBuilder()

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -61,7 +61,7 @@ public final class ProxyWebServer extends WebServer {
         getServletContext()
             .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, FileSystem.Factory.get());
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
-            new StreamCache(Configuration.getLong(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
+            new StreamCache(Configuration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
       }
     };
     ServletHolder servletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);

--- a/core/server/worker/src/main/java/alluxio/Sessions.java
+++ b/core/server/worker/src/main/java/alluxio/Sessions.java
@@ -86,7 +86,7 @@ public final class Sessions {
       if (mSessions.containsKey(sessionId)) {
         mSessions.get(sessionId).heartbeat();
       } else {
-        int sessionTimeoutMs = Configuration.getInt(PropertyKey.WORKER_SESSION_TIMEOUT_MS);
+        int sessionTimeoutMs = (int) Configuration.getMs(PropertyKey.WORKER_SESSION_TIMEOUT_MS);
         mSessions.put(sessionId, new SessionInfo(sessionId, sessionTimeoutMs));
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -52,7 +52,7 @@ public final class SessionCleaner implements Runnable {
     for (SessionCleanable sc : sessionCleanable) {
       mSessionCleanables.add(sc);
     }
-    mCheckIntervalMs = Configuration.getInt(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS);
+    mCheckIntervalMs = (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS);
 
     mRunning = true;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -97,7 +97,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
     mWorkerId = workerId;
     mWorkerAddress = workerAddress;
     mMasterClient = masterClient;
-    mHeartbeatTimeoutMs = Configuration.getInt(PropertyKey.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS);
+    mHeartbeatTimeoutMs = (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS);
     mRemovingBlockIdToFinished = new HashMap<>();
 
     registerWithMaster();

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -213,17 +213,17 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
     if (Configuration.getBoolean(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED)) {
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, new SpaceReserver(this),
-              Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS)));
+              (int) Configuration.getMs(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS)));
     }
 
     getExecutorService()
         .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, mBlockMasterSync,
-            Configuration.getInt(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)));
+            (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)));
 
     // Start the pinlist syncer to perform the periodical fetching
     getExecutorService()
         .submit(new HeartbeatThread(HeartbeatContext.WORKER_PIN_LIST_SYNC, mPinListSync,
-            Configuration.getInt(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)));
+            (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)));
 
     // Start the session cleanup checker to perform the periodical checking
     getExecutorService().submit(mSessionCleaner);

--- a/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -112,7 +112,7 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
         new HeartbeatThread(HeartbeatContext.WORKER_FILESYSTEM_MASTER_SYNC,
             new FileWorkerMasterSyncExecutor(mFileDataManager, mFileSystemMasterWorkerClient,
                 mWorkerId),
-            Configuration.getInt(PropertyKey.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS)));
+            (int) Configuration.getMs(PropertyKey.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS)));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileOutStreamIntegrationTest.java
@@ -145,7 +145,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     try (FileOutStream os =
         mFileSystem.createFile(filePath, CreateFileOptions.defaults().setWriteType(mWriteType))) {
       os.write((byte) 0);
-      Thread.sleep(Configuration.getInt(PropertyKey.USER_HEARTBEAT_INTERVAL_MS) * 2);
+      Thread.sleep((int) Configuration.getMs(PropertyKey.USER_HEARTBEAT_INTERVAL_MS) * 2);
       os.write((byte) 1);
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2738
allow Configuration.getMs to accept input with different unit

This is the third pull request
I fixed the following 14 property keys.
WORKER_BLOCK_HEARTBEAT_INTERVAL_MS
WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS
WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS
WORKER_SESSION_TIMEOUT_MS
WORKER_TIERED_STORE_RESERVER_INTERVAL_MS
WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS
PROXY_STREAM_CACHE_TIMEOUT_MS
USER_FILE_WAITCOMPLETED_POLL_MS
USER_HEARTBEAT_INTERVAL_MS
USER_NETWORK_NETTY_TIMEOUT_MS
USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS
USER_RPC_RETRY_MAX_SLEEP_MS
SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS
SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS