### PR TITLE
[SMALLFIX] Remove unused mesos dependencies

### DIFF
--- a/integration/mesos/pom.xml
+++ b/integration/mesos/pom.xml
@@ -68,16 +68,6 @@
       <artifactId>alluxio-core-server-worker</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-local</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>


### PR DESCRIPTION
The mesos integration doesn't use these dependencies. We can remove them.