### PR TITLE
[SMALLFIX] Update Generate tarball script

### DIFF
--- a/dev/scripts/generate-release-tarballs.sh
+++ b/dev/scripts/generate-release-tarballs.sh
@@ -30,10 +30,8 @@ function main {
     echo "Building tarball for ${hadoop_profile}"
     "${GENERATE_TARBALL_SCRIPT}" --deleteUnrevisioned --hadoopProfile ${hadoop_profile}
     local tarball="${SCRIPT_DIR}/tarballs/$(ls -tr ${SCRIPT_DIR}/tarballs | tail -1)"
-    md5 "${tarball}" > "${tarball}.md5"
     if [[ "$(dirname ${tarball})" != "${build_directory}" ]]; then
       cp "${tarball}" "${build_directory}"
-      cp "${tarball}.md5" "${build_directory}"
     fi
   done
 }

--- a/dev/scripts/generate-release-tarballs.sh
+++ b/dev/scripts/generate-release-tarballs.sh
@@ -18,6 +18,17 @@ readonly HADOOP_PROFILES=( "default" "hadoop-1" "hadoop-2.2" "hadoop-2.3" "hadoo
 
 function main {
   local build_directory="${PWD}"
+
+  local md5_cmd
+  if hash md5 2>/dev/null; then
+    md5_cmd="md5"
+  elif hash md5sum 2>/dev/null; then
+    md5_cmd="md5sum"
+  else
+    echo "Could not find md5 or md5sum, md5 will not be generated"
+    md5_cmd=""
+  fi
+
   while [[ "$#" > 0 ]]; do
     case $1 in
       --directory) build_directory=$2; shift 2 ;;
@@ -29,9 +40,16 @@ function main {
   for hadoop_profile in "${HADOOP_PROFILES[@]}"; do
     echo "Building tarball for ${hadoop_profile}"
     "${GENERATE_TARBALL_SCRIPT}" --deleteUnrevisioned --hadoopProfile ${hadoop_profile}
-    local tarball="${SCRIPT_DIR}/tarballs/$(ls -tr ${SCRIPT_DIR}/tarballs | tail -1)"
-    if [[ "$(dirname ${tarball})" != "${build_directory}" ]]; then
-      cp "${tarball}" "${build_directory}"
+    local tarball="$(ls -tr ${SCRIPT_DIR}/tarballs | tail -1)"
+    local full_path_tarball="${SCRIPT_DIR}/tarballs/${tarball}"
+    if [[ "$(dirname ${full_path_tarball})" != "${build_directory}" ]]; then
+      cp "${full_path_tarball}" "${build_directory}"
+      if [[ ! -z ${md5_cmd} ]]; then
+        cd "${build_directory}"
+        ${md5_cmd} "${tarball}" > "${tarball}".md5
+        cp "${tarball}.md5" "${build_directory}"
+        cd -
+      fi
     fi
   done
 }

--- a/dev/scripts/generate-release-tarballs.sh
+++ b/dev/scripts/generate-release-tarballs.sh
@@ -46,6 +46,7 @@ function main {
       cp "${full_path_tarball}" "${build_directory}"
       if [[ ! -z ${md5_cmd} ]]; then
         cd "${build_directory}"
+        # Need to call md5 command on only the file, otherwise the full path will be included in the md5
         ${md5_cmd} "${tarball}" > "${tarball}".md5
         cp "${tarball}.md5" "${build_directory}"
         cd -

--- a/dev/scripts/generate-tarball.sh
+++ b/dev/scripts/generate-tarball.sh
@@ -98,16 +98,16 @@ function create_tarball {
   local hadoop_profile=$1
   local version="$(bin/alluxio version)"
   if [[ "${hadoop_profile}" == "default" ]]; then
-    local prefix="alluxio-${version}-bin"
+    local prefix="alluxio-${version}"
   else
-    local prefix="alluxio-${version}-${hadoop_profile}-bin"
+    local prefix="alluxio-${version}-${hadoop_profile}"
   fi
   # Remove any logs generated during the build.
   rm -rf logs/*.log
   cd ..
   rm -rf "${prefix}"
   mv "${REPO_COPY}" "${prefix}"
-  local target="${TARBALL_DIR}/${prefix}.tar.gz"
+  local target="${TARBALL_DIR}/${prefix}-bin.tar.gz"
   gtar -czf "${target}" "${prefix}" --exclude-vcs
   echo "Generated tarball at ${target}"
 }

--- a/dev/scripts/generate-tarball.sh
+++ b/dev/scripts/generate-tarball.sh
@@ -104,6 +104,8 @@ function create_tarball {
   fi
   # Remove any logs generated during the build.
   rm -rf logs/*.log
+  # Create the default under storage directory.
+  mkdir underFSStorage
   cd ..
   rm -rf "${prefix}"
   mv "${REPO_COPY}" "${prefix}"


### PR DESCRIPTION
md5 is not available everywhere, also I tacked on `-bin` on the tarred file name but not the untarred folder to be consistent with how previous distributions were generated.