### PR TITLE
[SMALLFIX] Randomly pick a worker correctly

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
@@ -54,7 +54,7 @@ public final class LocalFirstPolicy implements FileWriteLocationPolicy, BlockLoc
     // otherwise randomly pick a worker that has enough availability
     List<BlockWorkerInfo> shuffledWorkers = Lists.newArrayList(workerInfoList);
     Collections.shuffle(shuffledWorkers);
-    for (BlockWorkerInfo workerInfo : workerInfoList) {
+    for (BlockWorkerInfo workerInfo : shuffledWorkers) {
       if (workerInfo.getCapacityBytes() >= blockSizeBytes) {
         return workerInfo.getNetAddress();
       }


### PR DESCRIPTION
Since LocalFirstPolicy is the default policy, the current implementation will always pick the same worker for multiple threads, i.e. Performance.java