### PR TITLE
[SMALLFIX] Ensure no UFS init during journal replay

### DIFF
--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -92,7 +92,7 @@ public abstract class AbstractUfsManager implements UfsManager {
    * Maps from mount id to {@link UfsInfo} instances. This map helps efficiently retrieve
    * existing UFS info given its mount id.
    */
-  private final ConcurrentHashMap<Long, UfsInfo> mMountIdToUfsMap =
+  private final ConcurrentHashMap<Long, UfsInfo> mMountIdToUfsInfoMap =
       new ConcurrentHashMap<>();
 
   private UfsInfo mRootUfsInfo;
@@ -133,14 +133,13 @@ public abstract class AbstractUfsManager implements UfsManager {
   }
 
   @Override
-  public UfsInfo addMount(long mountId, AlluxioURI ufsUri,
+  public void addMount(long mountId, AlluxioURI ufsUri,
       UnderFileSystemConfiguration ufsConf) {
     Preconditions.checkArgument(mountId != IdUtils.INVALID_MOUNT_ID, "mountId");
     Preconditions.checkArgument(ufsUri != null, "uri");
     Preconditions.checkArgument(ufsConf != null, "ufsConf");
-    UfsInfo ufsInfo = new UfsInfo(getOrAdd(ufsUri, ufsConf), ufsUri);
-    mMountIdToUfsMap.put(mountId, ufsInfo);
-    return ufsInfo;
+    UfsInfo ufsInfo = new UfsInfo(ufsConf, ufsUri);
+    mMountIdToUfsInfoMap.put(mountId, ufsInfo);
   }
 
   @Override
@@ -148,17 +147,23 @@ public abstract class AbstractUfsManager implements UfsManager {
     Preconditions.checkArgument(mountId != IdUtils.INVALID_MOUNT_ID, "mountId");
     // TODO(binfan): check the refcount of this ufs in mUnderFileSystemMap and remove it if this is
     // no more used. Currently, it is possibly used by out mount too.
-    mMountIdToUfsMap.remove(mountId);
+    mMountIdToUfsInfoMap.remove(mountId);
   }
 
   @Override
   public UfsInfo get(long mountId) throws NotFoundException, UnavailableException {
-    UfsInfo ufsInfo = mMountIdToUfsMap.get(mountId);
-    if (ufsInfo == null) {
-      throw new NotFoundException(
-          String.format("Mount Id %d not found in cached mount points", mountId));
+    synchronized (this) {
+      UfsInfo ufsInfo = mMountIdToUfsInfoMap.get(mountId);
+      if (ufsInfo == null) {
+        throw new NotFoundException(
+            String.format("Mount Id %d not found in cached mount points", mountId));
+      }
+      if (ufsInfo.getUfs() == null) {
+        UnderFileSystem ufs = getOrAdd(ufsInfo.getUfsMountPointUri(), ufsInfo.getUfsConf());
+        ufsInfo.setUfs(ufs);
+      }
+      return ufsInfo;
     }
-    return ufsInfo;
   }
 
   @Override
@@ -171,9 +176,14 @@ public abstract class AbstractUfsManager implements UfsManager {
         boolean rootShared = Configuration.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_SHARED);
         Map<String, String> rootConf =
             Configuration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION);
-        mRootUfsInfo = addMount(IdUtils.ROOT_MOUNT_ID, new AlluxioURI(rootUri),
+        addMount(IdUtils.ROOT_MOUNT_ID, new AlluxioURI(rootUri),
             UnderFileSystemConfiguration.defaults().setReadOnly(rootReadOnly).setShared(rootShared)
                 .setUserSpecifiedConf(rootConf));
+        try {
+          mRootUfsInfo = get(IdUtils.ROOT_MOUNT_ID);
+        } catch (NotFoundException | UnavailableException e) {
+          Preconditions.checkState(false, "We should never reach here");
+        }
       }
       return mRootUfsInfo;
     }

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -138,8 +138,7 @@ public abstract class AbstractUfsManager implements UfsManager {
     Preconditions.checkArgument(mountId != IdUtils.INVALID_MOUNT_ID, "mountId");
     Preconditions.checkArgument(ufsUri != null, "uri");
     Preconditions.checkArgument(ufsConf != null, "ufsConf");
-    UfsInfo ufsInfo = new UfsInfo(ufsConf, ufsUri);
-    mMountIdToUfsInfoMap.put(mountId, ufsInfo);
+    mMountIdToUfsInfoMap.put(mountId, new UfsInfo(ufsConf, ufsUri));
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -181,7 +181,7 @@ public abstract class AbstractUfsManager implements UfsManager {
         try {
           mRootUfsInfo = get(IdUtils.ROOT_MOUNT_ID);
         } catch (NotFoundException | UnavailableException e) {
-          Preconditions.checkState(false, "We should never reach here");
+          throw new RuntimeException("We should never reach here", e);
         }
       }
       return mRootUfsInfo;

--- a/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
@@ -35,8 +35,8 @@ public interface UfsManager extends Closeable {
      * @param ufsMountPointUri the URI for the UFS path which is mounted in Alluxio
      */
     public UfsInfo(Supplier<UnderFileSystem> ufsSupplier, AlluxioURI ufsMountPointUri) {
-      mUfsMountPointUri = ufsMountPointUri;
       mUfsSupplier = Preconditions.checkNotNull(ufsSupplier, "ufsSupplier is null");
+      mUfsMountPointUri = Preconditions.checkNotNull(ufsMountPointUri, "ufsSupplier is null");
     }
 
     /**

--- a/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
@@ -36,19 +36,17 @@ public interface UfsManager extends Closeable {
      */
     public UfsInfo(Supplier<UnderFileSystem> ufsSupplier, AlluxioURI ufsMountPointUri) {
       mUfsSupplier = Preconditions.checkNotNull(ufsSupplier, "ufsSupplier is null");
-      mUfsMountPointUri = Preconditions.checkNotNull(ufsMountPointUri, "ufsSupplier is null");
+      mUfsMountPointUri = Preconditions.checkNotNull(ufsMountPointUri, "ufsMountPointUri is null");
     }
 
     /**
      * @return the UFS instance
      */
-    public UnderFileSystem getUfs() {
-      synchronized (this) {
-        if (mUfs == null) {
-          mUfs = mUfsSupplier.get();
-        }
-        return mUfs;
+    public synchronized UnderFileSystem getUfs() {
+      if (mUfs == null) {
+        mUfs = mUfsSupplier.get();
       }
+      return mUfs;
     }
 
     /**
@@ -79,10 +77,7 @@ public interface UfsManager extends Closeable {
   void removeMount(long mountId);
 
   /**
-   * Gets UFS information from the cache if exists, or throws exception otherwise. The UFS
-   * information is created lazily on get, based on the UFS uri and conf. If the UFS already exists
-   * in the cache, maps the mount id to the existing UFS. Otherwise, creates a new UFS and adds it
-   * to the cache.
+   * Gets UFS information from the manager if this mount ID exists, or throws exception otherwise.
    *
    * @param mountId the mount id
    * @return the UFS information

--- a/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/UfsManager.java
@@ -24,8 +24,8 @@ public interface UfsManager extends Closeable {
   /** Container for a UFS and the URI for that UFS. */
   class UfsInfo {
     private UnderFileSystem mUfs;
-    private AlluxioURI mUfsMountPointUri;
-    private UnderFileSystemConfiguration mUfsConf;
+    private final AlluxioURI mUfsMountPointUri;
+    private final UnderFileSystemConfiguration mUfsConf;
 
     /**
      * @param ufsConf a UFS configuration
@@ -66,8 +66,8 @@ public interface UfsManager extends Closeable {
   }
 
   /**
-   * Keeps track of a mount id and map it to a its URI and configuration. This is an Alluxio-only
-   * operation and no interaction to UFS is made.
+   * Keeps track of a mount id and maps it to its URI in Alluxio and configuration. This is an
+   * Alluxio-only operation and no interaction to UFS will be made.
    *
    * @param mountId the mount id
    * @param ufsUri the UFS path

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2426,11 +2426,13 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       boolean replayed, MountOptions options)
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     AlluxioURI alluxioPath = inodePath.getUri();
-    UnderFileSystem ufs = mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
+    // Adding the mount point will not create the UFS instance and thus not connect to UFS
+    mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
         UnderFileSystemConfiguration.defaults().setReadOnly(options.isReadOnly())
-            .setShared(options.isShared()).setUserSpecifiedConf(options.getProperties())).getUfs();
+            .setShared(options.isShared()).setUserSpecifiedConf(options.getProperties()));
     try {
       if (!replayed) {
+        UnderFileSystem ufs = mUfsManager.get(mountId).getUfs();
         ufs.connectFromMaster(
             NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC));
         // Check that the ufsPath exists and is a directory

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -45,8 +45,9 @@ public final class MountTableTest {
   @Before
   public void before() throws Exception {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    Mockito.when(ufsManager.get(Mockito.anyLong()))
-        .thenReturn(new UfsInfo(mTestUfs, AlluxioURI.EMPTY_URI));
+    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
+    ufsInfo.setUfs(mTestUfs);
+    Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
     mMountTable = new MountTable(ufsManager);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -25,6 +25,7 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.local.LocalUnderFileSystemFactory;
 import alluxio.util.IdUtils;
 
+import com.google.common.base.Suppliers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,8 +46,7 @@ public final class MountTableTest {
   @Before
   public void before() throws Exception {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
-    ufsInfo.setUfs(mTestUfs);
+    UfsInfo ufsInfo = new UfsInfo(Suppliers.ofInstance(mTestUfs), AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
     mMountTable = new MountTable(ufsManager);
   }

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -64,10 +64,11 @@ public final class WorkerUfsManager extends AbstractUfsManager {
           String.format("Failed to get UFS info for mount point with id %d", mountId), e);
     }
     Preconditions.checkState((info.isSetUri() && info.isSetProperties()), "unknown mountId");
-    UfsInfo ufsInfo = super.addMount(mountId, new AlluxioURI(info.getUri()),
+    super.addMount(mountId, new AlluxioURI(info.getUri()),
         UnderFileSystemConfiguration.defaults().setReadOnly(info.getProperties().isReadOnly())
             .setShared(info.getProperties().isShared())
             .setUserSpecifiedConf(info.getProperties().getProperties()));
+    UfsInfo ufsInfo = super.get(mountId);
     try {
       ufsInfo.getUfs().connectFromWorker(
           NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -19,6 +19,7 @@ import alluxio.proto.dataserver.Protocol;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.io.BufferUtils;
 import alluxio.worker.block.meta.TempBlockMeta;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
@@ -67,12 +68,14 @@ public final class UnderFileSystemBlockReaderTest {
     mAlluxioBlockStore = Mockito.mock(BlockStore.class);
     mTempBlockMeta = Mockito.mock(TempBlockMeta.class);
     mUfsManager = Mockito.mock(UfsManager.class);
+    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(),
+        new AlluxioURI(testFilePath));
+    ufsInfo.setUfs(UnderFileSystem.Factory.create(testFilePath));
     Mockito.when(mAlluxioBlockStore
         .createBlock(Mockito.anyLong(), Mockito.anyLong(), Mockito.any(BlockStoreLocation.class),
             Mockito.anyLong())).thenReturn(mTempBlockMeta);
     Mockito.when(mTempBlockMeta.getPath()).thenReturn(mFolder.newFile().getAbsolutePath());
-    Mockito.when(mUfsManager.get(Mockito.anyLong())).thenReturn(
-        new UfsInfo(UnderFileSystem.Factory.create(testFilePath), new AlluxioURI(testFilePath)));
+    Mockito.when(mUfsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
 
     mOpenUfsBlockOptions = Protocol.OpenUfsBlockOptions.newBuilder().setMaxUfsReadConcurrency(10)
         .setBlockSize(TEST_BLOCK_SIZE).setOffsetInFile(TEST_BLOCK_SIZE).setUfsPath(testFilePath)

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -19,11 +19,11 @@ import alluxio.proto.dataserver.Protocol;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.io.BufferUtils;
 import alluxio.worker.block.meta.TempBlockMeta;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
 
+import com.google.common.base.Suppliers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import org.junit.After;
@@ -68,9 +68,9 @@ public final class UnderFileSystemBlockReaderTest {
     mAlluxioBlockStore = Mockito.mock(BlockStore.class);
     mTempBlockMeta = Mockito.mock(TempBlockMeta.class);
     mUfsManager = Mockito.mock(UfsManager.class);
-    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(),
+    UfsInfo ufsInfo = new UfsInfo(
+        Suppliers.ofInstance(UnderFileSystem.Factory.create(testFilePath)),
         new AlluxioURI(testFilePath));
-    ufsInfo.setUfs(UnderFileSystem.Factory.create(testFilePath));
     Mockito.when(mAlluxioBlockStore
         .createBlock(Mockito.anyLong(), Mockito.anyLong(), Mockito.any(BlockStoreLocation.class),
             Mockito.anyLong())).thenReturn(mTempBlockMeta);

--- a/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -25,6 +25,7 @@ import alluxio.exception.InvalidWorkerStateException;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
@@ -78,11 +79,12 @@ public final class FileDataManagerTest {
         new FileDataManager(mBlockWorker, mMockRateLimiter.getGuavaRateLimiter(), mUfsManager);
 
     mMockFileSystem = PowerMockito.mock(FileSystem.class);
+    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
+    ufsInfo.setUfs(mUfs);
     PowerMockito.mockStatic(FileSystem.Factory.class);
     Mockito.when(FileSystem.Factory.get()).thenReturn(mMockFileSystem);
     Mockito.when(mUfs.isDirectory(Mockito.anyString())).thenReturn(true);
-    Mockito.when(mUfsManager.get(Mockito.anyLong()))
-        .thenReturn(new UfsInfo(mUfs, AlluxioURI.EMPTY_URI));
+    Mockito.when(mUfsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
   }
 
   @After

--- a/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -25,7 +25,6 @@ import alluxio.exception.InvalidWorkerStateException;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
@@ -34,6 +33,7 @@ import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.meta.BlockMeta;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MockRateLimiter;
@@ -79,8 +79,7 @@ public final class FileDataManagerTest {
         new FileDataManager(mBlockWorker, mMockRateLimiter.getGuavaRateLimiter(), mUfsManager);
 
     mMockFileSystem = PowerMockito.mock(FileSystem.class);
-    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
-    ufsInfo.setUfs(mUfs);
+    UfsInfo ufsInfo = new UfsInfo(Suppliers.ofInstance(mUfs), AlluxioURI.EMPTY_URI);
     PowerMockito.mockStatic(FileSystem.Factory.class);
     Mockito.when(FileSystem.Factory.get()).thenReturn(mMockFileSystem);
     Mockito.when(mUfs.isDirectory(Mockito.anyString())).thenReturn(true);

--- a/core/server/worker/src/test/java/alluxio/worker/netty/DataServerUfsFileWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/DataServerUfsFileWriteHandlerTest.java
@@ -21,6 +21,7 @@ import alluxio.proto.status.Status.PStatus;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.proto.ProtoMessage;
@@ -53,8 +54,9 @@ public final class DataServerUfsFileWriteHandlerTest extends DataServerWriteHand
 
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    Mockito.when(ufsManager.get(Mockito.anyLong()))
-        .thenReturn(new UfsInfo(mockUfs, AlluxioURI.EMPTY_URI));
+    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
+    ufsInfo.setUfs(mockUfs);
+    Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
     Mockito.when(mockUfs.create(Mockito.anyString(), Mockito.any(CreateOptions.class)))
         .thenReturn(mOutputStream);
 

--- a/core/server/worker/src/test/java/alluxio/worker/netty/DataServerUfsFileWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/DataServerUfsFileWriteHandlerTest.java
@@ -21,11 +21,11 @@ import alluxio.proto.status.Status.PStatus;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.proto.ProtoMessage;
 
+import com.google.common.base.Suppliers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -54,8 +54,7 @@ public final class DataServerUfsFileWriteHandlerTest extends DataServerWriteHand
 
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    UfsInfo ufsInfo = new UfsInfo(UnderFileSystemConfiguration.defaults(), AlluxioURI.EMPTY_URI);
-    ufsInfo.setUfs(mockUfs);
+    UfsInfo ufsInfo = new UfsInfo(Suppliers.ofInstance(mockUfs), AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsInfo);
     Mockito.when(mockUfs.create(Mockito.anyString(), Mockito.any(CreateOptions.class)))
         .thenReturn(mOutputStream);


### PR DESCRIPTION
Further fix the journal replaying problem when a S3 bucket is mounted, unmounted, then deleted, and we restart Alluxio master