### PR TITLE
[SMALLFIX] Fix flaky freeWildcardPinnedFile test

### DIFF
--- a/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/FreeCommandTest.java
@@ -98,15 +98,13 @@ public final class FreeCommandTest extends AbstractAlluxioShellTest {
   @Test
   public void freeWildCardPinnedFile() throws IOException, AlluxioException {
     String testDir = AlluxioShellUtilsTest.resetFileHierarchy(mFileSystem, WriteType.CACHE_THROUGH);
-    mFsShell.run("pin", testDir + "/foo/foobar1");
+    mFsShell.run("pin", testDir + "/foo/*");
     Assert.assertEquals(-1, mFsShell.run("free", testDir + "/foo/*"));
     IntegrationTestUtils.waitForBlocksToBeFreed(
         mLocalAlluxioCluster.getWorkerProcess().getWorker(BlockWorker.class));
     // freeing non pinned files is expected to fail without "-f"
     Assert.assertTrue(isInMemoryTest(testDir + "/foo/foobar1"));
     Assert.assertTrue(isInMemoryTest(testDir + "/foo/foobar2"));
-    Assert.assertTrue(isInMemoryTest(testDir + "/bar/foobar3"));
-    Assert.assertTrue(isInMemoryTest(testDir + "/foobar4"));
   }
 
   @Test


### PR DESCRIPTION
The test assumed that the wildcard match would discover /foo/foobar1 before
/foo/foobar2. If it matched /foo/foobar2 first, /foo/foobar2 would be freed
before noticing that /foo/foobar1 is pinned.