### PR TITLE
[DOCFIX] Update Spark docs not to recompile Alluxio

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,6 +12,7 @@ ALLUXIO_MASTER_VERSION_SHORT: 1.5.0
 # Otherwise the macro name remains in the output.
 ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/core/client/runtime/target/alluxio-core-client-runtime-1.5.0-jar-with-dependencies.jar
 ALLUXIO_CLIENT_JAR_PATH_PRESTO: /<PATH_TO_ALLUXIO>/client/presto/alluxio-1.5.0-presto-client.jar
+ALLUXIO_CLIENT_JAR_PATH_SPARK: /<PATH_TO_ALLUXIO>/client/spark/alluxio-1.5.0-spark-client.jar
 
 # These attach the pages of different languages with different 'lang' attributes
 defaults:

--- a/docs/_includes/Running-Spark-on-Alluxio/earlier-spark-version-bash.md
+++ b/docs/_includes/Running-Spark-on-Alluxio/earlier-spark-version-bash.md
@@ -1,4 +1,4 @@
 ```bash
-$ spark.driver.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH}}
-$ spark.executor.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH}}
+$ spark.driver.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH_SPARK}}
+$ spark.executor.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH_SPARK}}
 ```

--- a/docs/_includes/Running-Spark-on-Alluxio/spark-profile-build.md
+++ b/docs/_includes/Running-Spark-on-Alluxio/spark-profile-build.md
@@ -1,3 +1,0 @@
-```bash
-$ mvn clean package -Pspark -DskipTests
-```

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -15,15 +15,9 @@ priority: 0
 
 Alluxio直接兼容Spark 1.1或更新版本而无需修改.
 
-## 前期准备
-
 ### 一般设置
 
 * Alluxio集群根据向导搭建完成(可以是[本地模式](Running-Alluxio-Locally.html)或者[集群模式](Running-Alluxio-on-a-Cluster.html))。
-
-* Alluxio client需要在编译时指定Spark选项。在顶层`alluxio`目录中执行如下命令构建Alluxio:
-
-{% include Running-Spark-on-Alluxio/spark-profile-build.md %}
 
 * 请添加如下代码到`spark/conf/spark-defaults.conf`。
 

--- a/docs/en/Running-Spark-on-Alluxio.md
+++ b/docs/en/Running-Spark-on-Alluxio.md
@@ -18,17 +18,10 @@ data to any number of those systems.
 
 Alluxio works together with Spark 1.1 or later out-of-the-box.
 
-## Prerequisites
-
 ### General Setup
 
 * Alluxio cluster has been set up in accordance to these guides for either
 [Local Mode](Running-Alluxio-Locally.html) or [Cluster Mode](Running-Alluxio-on-a-Cluster.html).
-
-* Alluxio client will need to be compiled with the Spark specific profile. Build the entire project
-from the top level `alluxio` directory with the following command:
-
-{% include Running-Spark-on-Alluxio/spark-profile-build.md %}
 
 * Add the following line to `spark/conf/spark-defaults.conf`.
 

--- a/docs/pt/Running-Spark-on-Alluxio.md
+++ b/docs/pt/Running-Spark-on-Alluxio.md
@@ -23,11 +23,6 @@ O Alluxio funciona com o `Spark 1.1` ou superiores `out-of-the-box`.
 * Alluxio `cluster` deve ser configurado de acordo com os guias
 [Local Mode](Running-Alluxio-Locally.html) ou [Cluster Mode](Running-Alluxio-on-a-Cluster.html).
 
-* Alluxio `client` irá precisar ser compilado com o perfil específico do `Spark`. Construa o
-projeto inteiro a partir do diretório raiz do Alluxio com o comando:
-
-{% include Running-Spark-on-Alluxio/spark-profile-build.md %}
-
 * Adicione a linha seguinte para `spark/conf/spark-defaults.conf`:
 
 {% include Running-Spark-on-Alluxio/earlier-spark-version-bash.md %}


### PR DESCRIPTION
Since we already precompile Spark client and bundle it within the distribution, there is no need to recompile Alluxio with the Spark profile in the instruction.