### PR TITLE
[SMALLFIX] Do not close stream twice in the REST server's close endpoint.

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
@@ -20,7 +20,6 @@ import alluxio.web.ProxyWebServer;
 import com.google.common.io.ByteStreams;
 import com.qmino.miredot.annotations.ReturnType;
 
-import java.io.Closeable;
 import java.io.InputStream;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -74,12 +73,10 @@ public final class StreamsRestServiceHandler {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
       @Override
       public Void call() throws Exception {
-        Closeable stream = mStreamCache.invalidate(id);
-        if (stream != null) {
-          stream.close();
-          return null;
+        if (mStreamCache.invalidate(id) != null) {
+          throw new IllegalArgumentException("stream does not exist");
         }
-        throw new IllegalArgumentException("stream does not exist");
+        return null;
       }
     });
   }


### PR DESCRIPTION
During a stress testing of python client, I saw the following errors in proxy.log:

```
2017-06-15 18:04:47,864 ERROR StreamCache - Failed to close stream: 
java.util.ConcurrentModificationException
	at java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:966)
	at java.util.LinkedList$ListItr.next(LinkedList.java:888)
	at alluxio.client.file.FileOutStream.close(FileOutStream.java:143)
	at alluxio.StreamCache$1.onRemoval(StreamCache.java:45)
	at com.google.common.cache.LocalCache.processPendingNotifications(LocalCache.java:2016)
	at com.google.common.cache.LocalCache$Segment.runUnlockedCleanup(LocalCache.java:3521)
	at com.google.common.cache.LocalCache$Segment.postWriteCleanup(LocalCache.java:3497)
	at com.google.common.cache.LocalCache$Segment.remove(LocalCache.java:3168)
	at com.google.common.cache.LocalCache.remove(LocalCache.java:4236)
	at com.google.common.cache.LocalCache$LocalManualCache.invalidate(LocalCache.java:4815)
	at alluxio.StreamCache.invalidate(StreamCache.java:117)
	at alluxio.proxy.StreamsRestServiceHandler$1.call(StreamsRestServiceHandler.java:77)
	at alluxio.proxy.StreamsRestServiceHandler$1.call(StreamsRestServiceHandler.java:74)
	at alluxio.RestUtils.call(RestUtils.java:51)
	at alluxio.proxy.StreamsRestServiceHandler.close(StreamsRestServiceHandler.java:74)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:160)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99)
```