### PR TITLE
[ALLUXIO-2851] NPE fixes for StartupConsistencyCheck

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -630,7 +630,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     if (!Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
       return StartupConsistencyCheck.disabled();
     }
-    if (!mStartupConsistencyCheck.isDone()) {
+    if (mStartupConsistencyCheck == null || !mStartupConsistencyCheck.isDone()) {
       return StartupConsistencyCheck.running();
     }
     try {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -630,7 +630,10 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     if (!Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
       return StartupConsistencyCheck.disabled();
     }
-    if (mStartupConsistencyCheck == null || !mStartupConsistencyCheck.isDone()) {
+    if (mStartupConsistencyCheck == null) {
+      return StartupConsistencyCheck.notStarted();
+    }
+    if (!mStartupConsistencyCheck.isDone()) {
       return StartupConsistencyCheck.running();
     }
     try {

--- a/core/server/master/src/main/java/alluxio/master/file/StartupConsistencyCheck.java
+++ b/core/server/master/src/main/java/alluxio/master/file/StartupConsistencyCheck.java
@@ -13,6 +13,8 @@ package alluxio.master.file;
 
 import alluxio.AlluxioURI;
 
+import com.google.common.base.Preconditions;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,8 +61,8 @@ public final class StartupConsistencyCheck {
     return new StartupConsistencyCheck(Status.RUNNING, new ArrayList<AlluxioURI>());
   }
 
-  private Status mStatus;
-  private List<AlluxioURI> mInconsistentUris;
+  private final Status mStatus;
+  private final List<AlluxioURI> mInconsistentUris;
 
   /**
    * Create a new startup consistency check result.
@@ -69,8 +71,8 @@ public final class StartupConsistencyCheck {
    * @param inconsistentUris the uris which are inconsistent with the underlying storage
    */
   private StartupConsistencyCheck(Status status, List<AlluxioURI> inconsistentUris) {
-    mStatus = status;
-    mInconsistentUris = inconsistentUris;
+    mStatus = Preconditions.checkNotNull(status, "status");
+    mInconsistentUris = Preconditions.checkNotNull(inconsistentUris, "inconsistentUris");
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/StartupConsistencyCheck.java
+++ b/core/server/master/src/main/java/alluxio/master/file/StartupConsistencyCheck.java
@@ -29,6 +29,7 @@ public final class StartupConsistencyCheck {
     COMPLETE,
     DISABLED,
     FAILED,
+    NOT_STARTED,
     RUNNING
   }
 
@@ -45,6 +46,13 @@ public final class StartupConsistencyCheck {
    */
   public static StartupConsistencyCheck disabled() {
     return new StartupConsistencyCheck(Status.DISABLED, new ArrayList<AlluxioURI>());
+  }
+
+  /**
+   * @return a result set to the disabled status
+   */
+  public static StartupConsistencyCheck notStarted() {
+    return new StartupConsistencyCheck(Status.NOT_STARTED, new ArrayList<AlluxioURI>());
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/StartupConsistencyCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/StartupConsistencyCheckTest.java
@@ -42,6 +42,13 @@ public final class StartupConsistencyCheckTest {
   }
 
   @Test
+  public void createNotStartedCheck() {
+    StartupConsistencyCheck check = StartupConsistencyCheck.notStarted();
+    assertEquals(Status.NOT_STARTED, check.getStatus());
+    assertEquals(Collections.EMPTY_LIST, check.getInconsistentUris());
+  }
+
+  @Test
   public void createFailedCheck() {
     StartupConsistencyCheck check = StartupConsistencyCheck.failed();
     assertEquals(Status.FAILED, check.getStatus());


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2851

The changes to StartupConsistencyCheck.java guarantee that getInconsistentUris() can never return null.

The change to DefaultFileSystemMaster.java fixes a race condition where we start the web server before initializing mStartupConsistencyCheck, causing queries to getStartupConsistencyCheck() to hit NPE