### PR TITLE
[SMALLFIX] Handle null value for Get Worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/policy/BlockLocationPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/BlockLocationPolicy.java
@@ -14,7 +14,6 @@ package alluxio.client.block.policy;
 import alluxio.annotation.PublicApi;
 import alluxio.client.block.policy.options.CreateOptions;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.status.UnavailableException;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerNetAddress;
 
@@ -67,8 +66,7 @@ public interface BlockLocationPolicy {
    * Gets the worker's network address for serving operations requested for the block.
    *
    * @param options the options to get a block worker network address for a block
-   * @return the address of the worker to write to
-   * @throws UnavailableException if there are no workers eligible to serve the request
+   * @return the address of the worker to write to, null if no worker can be selected
    */
-  WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException;
+  WorkerNetAddress getWorker(GetWorkerOptions options);
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
@@ -13,8 +13,6 @@ package alluxio.client.block.policy;
 
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Objects;
@@ -60,7 +58,7 @@ public final class DeterministicHashPolicy implements BlockLocationPolicy {
   }
 
   @Override
-  public WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException {
+  public WorkerNetAddress getWorker(GetWorkerOptions options) {
     List<BlockWorkerInfo> workerInfos = Lists.newArrayList(options.getBlockWorkerInfos());
     Collections.sort(workerInfos, new Comparator<BlockWorkerInfo>() {
       @Override
@@ -89,11 +87,7 @@ public final class DeterministicHashPolicy implements BlockLocationPolicy {
       }
       index = (index + 1) % workerInfos.size();
     }
-    if (workers.isEmpty()) {
-      throw new UnavailableException(
-          ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(options.getBlockSize()));
-    }
-    return workers.get(mRandom.nextInt(workers.size()));
+    return workers.isEmpty() ? null : workers.get(mRandom.nextInt(workers.size()));
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/FileWriteLocationPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/FileWriteLocationPolicy.java
@@ -14,7 +14,6 @@ package alluxio.client.file.policy;
 import alluxio.annotation.PublicApi;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileOutStream;
-import alluxio.exception.status.UnavailableException;
 import alluxio.wire.WorkerNetAddress;
 
 /**
@@ -40,9 +39,8 @@ public interface FileWriteLocationPolicy {
    *
    * @param workerInfoList the info of the active workers
    * @param blockSizeBytes the size of the block in bytes
-   * @return the address of the worker to write to
-   * @throws UnavailableException if no worker is eligible to serve the request
+   * @return the address of the worker to write to, null if no worker can be selected
    */
   WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
-      long blockSizeBytes) throws UnavailableException;
+      long blockSizeBytes);
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
@@ -16,8 +16,6 @@ import alluxio.PropertyKey;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.WorkerNetAddress;
 
@@ -31,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A policy that returns local host first, and if the local worker doesn't have enough availability,
  * it randomly picks a worker from the active workers list for each block write.
- * If no worker meets the demands, return local host if a local worker exists.
+ * If No worker meets the demands, return local host.
  * USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES is used to reserve some space of the worker
  * to store the block, for the values mCapacityBytes minus mUsedBytes is not the available bytes.
  */
@@ -50,7 +48,7 @@ public final class LocalFirstAvoidEvictionPolicy
 
   @Override
   public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
-      long blockSizeBytes) throws UnavailableException {
+      long blockSizeBytes) {
     // try the local host first
     WorkerNetAddress localWorkerNetAddress = null;
     for (BlockWorkerInfo workerInfo : workerInfoList) {
@@ -73,15 +71,11 @@ public final class LocalFirstAvoidEvictionPolicy
     if (localWorkerNetAddress == null && shuffledWorkers.size() > 0) {
       return shuffledWorkers.get(0).getNetAddress();
     }
-    if (localWorkerNetAddress == null) {
-      throw new UnavailableException(
-          ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(blockSizeBytes));
-    }
     return localWorkerNetAddress;
   }
 
   @Override
-  public WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException {
+  public WorkerNetAddress getWorker(GetWorkerOptions options) {
     return getWorkerForNextBlock(options.getBlockWorkerInfos(), options.getBlockSize());
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A policy that returns local host first, and if the local worker doesn't have enough availability,
  * it randomly picks a worker from the active workers list for each block write.
- * If No worker meets the demands, return local host.
+ * If no worker meets the demands, return local host.
  * USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES is used to reserve some space of the worker
  * to store the block, for the values mCapacityBytes minus mUsedBytes is not the available bytes.
  */

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstPolicy.java
@@ -14,8 +14,6 @@ package alluxio.client.file.policy;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.WorkerNetAddress;
 
@@ -44,7 +42,7 @@ public final class LocalFirstPolicy implements FileWriteLocationPolicy, BlockLoc
 
   @Override
   public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
-      long blockSizeBytes) throws UnavailableException {
+      long blockSizeBytes) {
     // first try the local host
     for (BlockWorkerInfo workerInfo : workerInfoList) {
       if (workerInfo.getNetAddress().getHost().equals(mLocalHostName)
@@ -61,12 +59,11 @@ public final class LocalFirstPolicy implements FileWriteLocationPolicy, BlockLoc
         return workerInfo.getNetAddress();
       }
     }
-    throw new UnavailableException(
-        ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(blockSizeBytes));
+    return null;
   }
 
   @Override
-  public WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException {
+  public WorkerNetAddress getWorker(GetWorkerOptions options) {
     return getWorkerForNextBlock(options.getBlockWorkerInfos(), options.getBlockSize());
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/MostAvailableFirstPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/MostAvailableFirstPolicy.java
@@ -14,8 +14,6 @@ package alluxio.client.file.policy;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Objects;
@@ -23,7 +21,8 @@ import com.google.common.base.Objects;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A policy that returns the worker with the most available bytes.
+ * A policy that returns the worker with the most available bytes. The policy returns null if no
+ * worker is qualified.
  */
 // TODO(peis): Move the BlockLocationPolicy implementation to alluxio.client.block.policy.
 @ThreadSafe
@@ -37,7 +36,7 @@ public final class MostAvailableFirstPolicy
 
   @Override
   public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
-      long blockSizeBytes) throws UnavailableException {
+      long blockSizeBytes) {
     long mostAvailableBytes = -1;
     WorkerNetAddress result = null;
     for (BlockWorkerInfo workerInfo : workerInfoList) {
@@ -46,15 +45,11 @@ public final class MostAvailableFirstPolicy
         result = workerInfo.getNetAddress();
       }
     }
-    if (result == null) {
-      throw new UnavailableException(
-          ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(blockSizeBytes));
-    }
     return result;
   }
 
   @Override
-  public WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException {
+  public WorkerNetAddress getWorker(GetWorkerOptions options) {
     return getWorkerForNextBlock(options.getBlockWorkerInfos(), options.getBlockSize());
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/SpecificHostPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/SpecificHostPolicy.java
@@ -14,8 +14,6 @@ package alluxio.client.file.policy;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Objects;
@@ -24,7 +22,8 @@ import com.google.common.base.Preconditions;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A policy which always returns a worker with the specified hostname.
+ * Always returns a worker with the specified hostname. Returns null if no active worker on that
+ * hostname found.
  */
 // TODO(peis): Move the BlockLocationPolicy implementation to alluxio.client.block.policy.
 @ThreadSafe
@@ -42,19 +41,18 @@ public final class SpecificHostPolicy implements FileWriteLocationPolicy, BlockL
 
   @Override
   public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
-      long blockSizeBytes) throws UnavailableException {
+      long blockSizeBytes) {
     // find the first worker matching the host name
     for (BlockWorkerInfo info : workerInfoList) {
       if (info.getNetAddress().getHost().equals(mHostname)) {
         return info.getNetAddress();
       }
     }
-    throw new UnavailableException(
-        ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(blockSizeBytes));
+    return null;
   }
 
   @Override
-  public WorkerNetAddress getWorker(GetWorkerOptions options) throws UnavailableException {
+  public WorkerNetAddress getWorker(GetWorkerOptions options) {
     return getWorkerForNextBlock(options.getBlockWorkerInfos(), options.getBlockSize());
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -17,7 +17,9 @@ import alluxio.client.file.options.OutStreamOptions;
 import alluxio.client.file.policy.FileWriteLocationPolicy;
 import alluxio.client.netty.NettyRPC;
 import alluxio.client.netty.NettyRPCContext;
+import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
+import alluxio.exception.status.UnavailableException;
 import alluxio.network.protocol.RPCMessageDecoder;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.resource.DummyCloseableResource;
@@ -33,7 +35,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
@@ -83,15 +85,15 @@ public final class AlluxioBlockStoreTest {
     @Override
     public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
         long blockSizeBytes) {
+      if (mWorkerNetAddresses.isEmpty()) {
+        return null;
+      }
       return mWorkerNetAddresses.get(mIndex++);
     }
   }
 
-  /**
-   * The rule for a temporary folder.
-   */
   @Rule
-  public TemporaryFolder mTestFolder = new TemporaryFolder();
+  public ExpectedException mException = ExpectedException.none();
 
   private BlockMasterClient mMasterClient;
   private AlluxioBlockStore mBlockStore;
@@ -130,12 +132,8 @@ public final class AlluxioBlockStoreTest {
             throw new RuntimeException("policy threw exception");
           }
         });
-    try {
-      mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
-      Assert.fail("An exception should have been thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("policy threw exception", e.getMessage());
-    }
+    mException.expect(Exception.class);
+    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
   }
 
   @Test
@@ -143,20 +141,31 @@ public final class AlluxioBlockStoreTest {
     OutStreamOptions options =
         OutStreamOptions.defaults().setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.MUST_CACHE).setLocationPolicy(null);
-    try {
-      mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
-      Assert.fail("missing location policy should fail");
-    } catch (NullPointerException e) {
-      Assert.assertEquals(PreconditionMessage.FILE_WRITE_LOCATION_POLICY_UNSPECIFIED.toString(),
-          e.getMessage());
-    }
+    mException.expect(NullPointerException.class);
+    mException.expectMessage(PreconditionMessage.FILE_WRITE_LOCATION_POLICY_UNSPECIFIED.toString());
+    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
+  }
+
+  @Test
+  public void getOutStreamNoWorker() throws IOException {
+    OutStreamOptions options =
+        OutStreamOptions
+            .defaults()
+            .setBlockSizeBytes(BLOCK_LENGTH)
+            .setWriteType(WriteType.MUST_CACHE)
+            .setLocationPolicy(
+                new MockFileWriteLocationPolicy(Lists.<WorkerNetAddress>newArrayList()));
+    mException.expect(UnavailableException.class);
+    mException
+        .expectMessage(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH));
+    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
   }
 
   @Test
   public void getOutStreamLocal() throws Exception {
-    File tmp = mTestFolder.newFile();
+    File file = File.createTempFile("test", ".tmp");
     ProtoMessage message = new ProtoMessage(
-        Protocol.LocalBlockCreateResponse.newBuilder().setPath(tmp.getAbsolutePath()).build());
+        Protocol.LocalBlockCreateResponse.newBuilder().setPath(file.getAbsolutePath()).build());
     PowerMockito.mockStatic(NettyRPC.class);
     Mockito.when(NettyRPC.call(Mockito.any(NettyRPCContext.class), Mockito.any(ProtoMessage.class)))
         .thenReturn(message);

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
@@ -52,7 +52,7 @@ public final class DeterministicHashPolicyTest {
   }
 
   @Test
-  public void getWorkerDeterministically() throws Exception {
+  public void getWorkerDeterministically() {
     DeterministicHashPolicy policy = (DeterministicHashPolicy) BlockLocationPolicy.Factory.create(
         CreateOptions.defaults()
             .setLocationPolicyClassName(DeterministicHashPolicy.class.getCanonicalName()));
@@ -74,7 +74,7 @@ public final class DeterministicHashPolicyTest {
   }
 
   @Test
-  public void getWorkerEnoughCapacity() throws Exception {
+  public void getWorkerEnoughCapacity() {
     DeterministicHashPolicy policy = (DeterministicHashPolicy) BlockLocationPolicy.Factory.create(
         CreateOptions.defaults()
             .setLocationPolicyClassName(DeterministicHashPolicy.class.getCanonicalName()));
@@ -87,7 +87,7 @@ public final class DeterministicHashPolicyTest {
   }
 
   @Test
-  public void getWorkerMultipleShards() throws Exception {
+  public void getWorkerMultipleShards() {
     DeterministicHashPolicy policy2 = (DeterministicHashPolicy) BlockLocationPolicy.Factory.create(
         CreateOptions.defaults()
             .setLocationPolicyClassName(DeterministicHashPolicy.class.getCanonicalName())

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -37,9 +37,11 @@ import alluxio.client.block.stream.UnderFileSystemFileOutStream;
 import alluxio.client.file.options.CompleteFileOptions;
 import alluxio.client.file.options.GetStatusOptions;
 import alluxio.client.file.options.OutStreamOptions;
+import alluxio.client.file.policy.FileWriteLocationPolicy;
 import alluxio.client.util.ClientTestUtils;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
+import alluxio.exception.status.UnavailableException;
 import alluxio.resource.DummyCloseableResource;
 import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.util.io.BufferUtils;
@@ -52,6 +54,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -74,6 +77,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class FileOutStreamTest {
   @Rule
   public LoginUserRule mLoginUser = new LoginUserRule("Test");
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
 
   private static final long BLOCK_LENGTH = 100L;
   private static final AlluxioURI FILE_NAME = new AlluxioURI("/file");
@@ -389,6 +395,21 @@ public class FileOutStreamTest {
       mTestStream.flush();
       Assert.assertEquals(BLOCK_LENGTH, mTestStream.getBytesWritten());
     }
+  }
+
+  @Test
+  public void createWithNoWorker() throws Exception {
+    OutStreamOptions options =
+        OutStreamOptions.defaults().setLocationPolicy(new FileWriteLocationPolicy() {
+          @Override
+          public WorkerNetAddress getWorkerForNextBlock(Iterable<BlockWorkerInfo> workerInfoList,
+              long blockSizeBytes) {
+            return null;
+          }
+        }).setWriteType(WriteType.CACHE_THROUGH);
+    mException.expect(UnavailableException.class);
+    mException.expectMessage(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
+    mTestStream = createTestStream(FILE_NAME, options);
   }
 
   private void verifyIncreasingBytesWritten(int len) {

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -33,7 +33,7 @@ public class LocalFirstAvoidEvictionPolicyTest {
    * Tests that the local host is returned first.
    */
   @Test
-  public void getLocalFirst() throws Exception {
+  public void getLocalFirst() {
     String localhostName = NetworkAddressUtils.getLocalHostName();
     LocalFirstAvoidEvictionPolicy policy = new LocalFirstAvoidEvictionPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
@@ -49,7 +49,7 @@ public class LocalFirstAvoidEvictionPolicyTest {
    * Tests that another worker is picked in case the local host does not have enough space.
    */
   @Test
-  public void getOthersWhenNotEnoughSpaceOnLocal() throws Exception {
+  public void getOthersWhenNotEnoughSpaceOnLocal() {
     String localhostName = NetworkAddressUtils.getLocalHostName();
     LocalFirstAvoidEvictionPolicy policy = new LocalFirstAvoidEvictionPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
@@ -65,7 +65,7 @@ public class LocalFirstAvoidEvictionPolicyTest {
    * Tests that local host is picked if none of the workers has enough availability.
    */
   @Test
-  public void getLocalWhenNoneHasSpace() throws Exception {
+  public void getLocalWhenNoneHasSpace() {
     String localhostName = NetworkAddressUtils.getLocalHostName();
     LocalFirstAvoidEvictionPolicy policy = new LocalFirstAvoidEvictionPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstPolicyTest.java
@@ -33,7 +33,7 @@ public final class LocalFirstPolicyTest {
    * Tests that the local host is returned first.
    */
   @Test
-  public void getLocalFirst() throws Exception {
+  public void getLocalFirst() {
     String localhostName = NetworkAddressUtils.getLocalHostName();
     LocalFirstPolicy policy = new LocalFirstPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
@@ -49,7 +49,7 @@ public final class LocalFirstPolicyTest {
    * Tests that another worker is picked in case the local host does not have enough space.
    */
   @Test
-  public void getOthersWhenNotEnoughSpaceOnLocal() throws Exception {
+  public void getOthersWhenNotEnoughSpaceOnLocal() {
     String localhostName = NetworkAddressUtils.getLocalHostName();
     LocalFirstPolicy policy = new LocalFirstPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
@@ -65,7 +65,7 @@ public final class LocalFirstPolicyTest {
    * Tests that non-local workers are randomly selected.
    */
   @Test
-  public void getOthersRandomly() throws Exception {
+  public void getOthersRandomly() {
     LocalFirstPolicy policy = new LocalFirstPolicy();
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/MostAvailableFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/MostAvailableFirstPolicyTest.java
@@ -32,7 +32,7 @@ public final class MostAvailableFirstPolicyTest {
    * Tests that the worker with the most available space is chosen.
    */
   @Test
-  public void getMostAvailableWorker() throws Exception {
+  public void getMostAvailableWorker() {
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/RoundRobinPolicyTest.java
@@ -32,7 +32,7 @@ public final class RoundRobinPolicyTest {
    * Tests that the correct workers are chosen when round robin is used.
    */
   @Test
-  public void getWorker() throws Exception {
+  public void getWorker() {
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/SpecificHostPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/SpecificHostPolicyTest.java
@@ -13,14 +13,10 @@ package alluxio.client.file.policy;
 
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.status.UnavailableException;
 import alluxio.wire.WorkerNetAddress;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,14 +27,11 @@ import java.util.List;
 public final class SpecificHostPolicyTest {
   private static final int PORT = 1;
 
-  @Rule
-  public ExpectedException mExpectedException = ExpectedException.none();
-
   /**
    * Tests that the correct worker is returned when using the policy.
    */
   @Test
-  public void policy() throws Exception {
+  public void policy() {
     SpecificHostPolicy policy = new SpecificHostPolicy("worker2");
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
@@ -54,16 +47,13 @@ public final class SpecificHostPolicyTest {
    * worker list.
    */
   @Test
-  public void noMatchingHost() throws Exception {
+  public void noMatchingHost() {
     SpecificHostPolicy policy = new SpecificHostPolicy("worker3");
     List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker2")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));
-    mExpectedException.expect(UnavailableException.class);
-    mExpectedException.expectMessage(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER
-        .getMessage(Constants.MB));
-    policy.getWorkerForNextBlock(workerInfoList, Constants.MB);
+    Assert.assertNull(policy.getWorkerForNextBlock(workerInfoList, Constants.MB));
   }
 }


### PR DESCRIPTION
GetWorker should not be communicating with any other components so IOExceptions do not make as much sense as `null`. @apc999 will consider null annotation after we decide how to enforce.