### PR TITLE
[SMALLFIX] Start web server after initializing worker state

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -209,7 +209,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     // Start serving metrics system, this will not block
     MetricsSystem.startSinks();
 
-    // Start each worker
+    // Start each worker. This must be done before starting the web or RPC servers.
     // Requirement: NetAddress set in WorkerContext, so block worker can initialize BlockMasterSync
     // Consequence: worker id is granted
     startWorkers();

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -209,15 +209,15 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     // Start serving metrics system, this will not block
     MetricsSystem.startSinks();
 
-    // Start serving the web server, this will not block.
-    mWebServer.addHandler(mMetricsServlet.getHandler());
-    mWebServer.start();
-
     // Start each worker
     // Requirement: NetAddress set in WorkerContext, so block worker can initialize BlockMasterSync
     // Consequence: worker id is granted
     startWorkers();
     LOG.info("Started {} with id {}", this, mRegistry.get(BlockWorker.class).getWorkerId());
+
+    // Start serving the web server, this will not block.
+    mWebServer.addHandler(mMetricsServlet.getHandler());
+    mWebServer.start();
 
     mIsServingRPC = true;
 


### PR DESCRIPTION
Avoid a small time window where REST server requests could be served before the worker is ready