### PR TITLE
[SMALLFIX]Change debug argument to first argument

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -13,6 +13,10 @@
 function printUsage {
   echo "Usage: alluxio [-jvmdebug] COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
   echo
+  echo "Flag description:"
+  echo -e "  -jvmdebug     \t If this flag specified, the env variable ALLUXIO_USER_DEBUG_JAVA_OPTS will be added to jvm flags."
+  echo -e "                \t ALLUXIO_USER_DEBUG_JAVA_OPTS can be '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=6609'"
+  echo
   echo "COMMAND is one of:"
   echo -e "  format [-s]   \t Format Alluxio master and all workers (if -s specified, only format if underfs is local and doesn't already exist)"
   echo -e "  formatWorker  \t Format Alluxio worker storage"

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -163,7 +163,12 @@ function copyDir {
 function runJavaClass {
   CLASS_ARGS=()
   if [[ ${IS_DEBUG_MODE} == true ]]; then
-    ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}"
+    if [[ $ALLUXIO_USER_DEBUG_JAVA_OPTS ]];then
+      ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}"
+    else
+      echo "env variable ALLUXIO_USER_DEBUG_JAVA_OPTS is not define."
+      exit 3
+    fi
   fi
   for arg in "$@"; do
       case "${arg}" in

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -11,7 +11,7 @@
 #
 
 function printUsage {
-  echo "Usage: alluxio [-debug] COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
+  echo "Usage: alluxio [-jvmdebug] COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
   echo
   echo "COMMAND is one of:"
   echo -e "  format [-s]   \t Format Alluxio master and all workers (if -s specified, only format if underfs is local and doesn't already exist)"
@@ -186,7 +186,7 @@ function main {
   fi
 
   IS_DEBUG_MODE=false
-  if [[ "$1" == "-debug" ]]; then
+  if [[ "$1" == "-jvmdebug" ]]; then
     IS_DEBUG_MODE=true
     shift
   fi

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -11,7 +11,7 @@
 #
 
 function printUsage {
-  echo "Usage: alluxio COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
+  echo "Usage: alluxio [-debug] COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
   echo
   echo "COMMAND is one of:"
   echo -e "  format [-s]   \t Format Alluxio master and all workers (if -s specified, only format if underfs is local and doesn't already exist)"
@@ -158,10 +158,11 @@ function copyDir {
 
 function runJavaClass {
   CLASS_ARGS=()
+  if $IS_DEBUG_MODE; then
+    ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_SHELL_DEBUG_JAVA_OPTS}"
+  fi
   for arg in "$@"; do
       case "${arg}" in
-          -debug)
-              ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
           -D*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
@@ -182,6 +183,12 @@ function main {
   if [[ $# == 0 ]]; then
     printUsage
     exit 1
+  fi
+
+  IS_DEBUG_MODE=false
+  if [ "$1" == "-debug" ]; then
+    IS_DEBUG_MODE=true
+    shift
   fi
 
   COMMAND=$1

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -158,8 +158,8 @@ function copyDir {
 
 function runJavaClass {
   CLASS_ARGS=()
-  if $IS_DEBUG_MODE; then
-    ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_SHELL_DEBUG_JAVA_OPTS}"
+  if [[ ${IS_DEBUG_MODE} == true ]]; then
+    ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}"
   fi
   for arg in "$@"; do
       case "${arg}" in
@@ -186,7 +186,7 @@ function main {
   fi
 
   IS_DEBUG_MODE=false
-  if [ "$1" == "-debug" ]; then
+  if [[ "$1" == "-debug" ]]; then
     IS_DEBUG_MODE=true
     shift
   fi

--- a/docs/cn/Debugging-Guide.md
+++ b/docs/cn/Debugging-Guide.md
@@ -31,7 +31,7 @@ export ALLUXIO_MASTER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_
 export ALLUXIO_USER_DEBUG_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=6609"
 ```
 
-特别的，如果你想调试shell命令，可以通过加上`-debug`标志来加上jvm调试参数`ALLUXIO_USER_DEBUG_JAVA_OPTS`来开启调试服务。例如`alluxio fs -debug ls /`。
+特别的，如果你想调试shell命令，可以通过加上`-jvmdebug`标志来加上jvm调试参数`ALLUXIO_USER_DEBUG_JAVA_OPTS`来开启调试服务。例如`alluxio -jvmdebug fs ls /`。
 
 
 `suspend = y/n` 会决定JVM进程是否等待直至调试器连接。如果你希望在命令行中进行调试，设置`suspend = y`。否则，设置 `suspend = n` ，这样就可以避免不必要的等待时间。

--- a/docs/en/Debugging-Guide.md
+++ b/docs/en/Debugging-Guide.md
@@ -37,7 +37,7 @@ export ALLUXIO_MASTER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_
 export ALLUXIO_USER_DEBUG_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=6609"
 ```
 
-Specially, if you want to debug shell command, you can add the `-debug` flag to start a debug server with the jvm debug parameters `ALLUXIO_USER_DEBUG_JAVA_OPTS`. Such as `alluxio fs -debug ls /`.
+Specially, if you want to debug shell command, you can add the `-jvmdebug` flag to start a debug server with the jvm debug parameters `ALLUXIO_USER_DEBUG_JAVA_OPTS`. Such as `alluxio -jvmdebug fs ls /`.
 
 `suspend = y/n` will decide whether the JVM process wait until the debugger connects. If you want to debug with the shell command, set the `suspend = y`. Otherwise, you can set `suspend = n` so that avoid unnecessary waiting time. 
 


### PR DESCRIPTION
Goal: To debug all command

Bofore this modification, the `-debug` argument can not debug some command, such as alluxio format.