### PR TITLE
[SMALLFIX] Reset the interrupt flag when MasterInquireClient is interrupted.

### DIFF
--- a/core/common/src/main/java/alluxio/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/MasterInquireClient.java
@@ -129,6 +129,8 @@ public final class MasterInquireClient {
         }
         CommonUtils.sleepMs(LOG, Constants.SECOND_MS);
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     } catch (Exception e) {
       LOG.error("Error getting the leader master address from zookeeper. Zookeeper address: {}",
           mZookeeperAddress, e);


### PR DESCRIPTION
Otherwise this can cause the `stopWorkers` call to hang making some tests timeout.