### PR TITLE
[ALLUXIO-2901] Support change owner and group of a file or directory with one chown

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2603,8 +2603,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   /**
    * Checks whether the owner belongs to the group.
    *
-   * @param owner The owner to check
-   * @param group The group to check
+   * @param owner the owner to check
+   * @param group the group to check
    * @throws FailedPreconditionException if owner does not belong to group
    * @throws AccessControlException if this operation is not permitted
    */
@@ -2613,7 +2613,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     try {
       List<String> groups = CommonUtils.getGroups(owner);
       if (groups == null || !groups.contains(group)) {
-        throw new FailedPreconditionException("setOwner: owner " + owner
+        throw new FailedPreconditionException("Owner " + owner
             + " does not belong to the group " + group);
       }
     } catch (IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2602,16 +2602,16 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   /**
    * Checks whether the owner belongs to the group.
+   *
    * @param owner The owner to check
    * @param group The group to check
    * @throws FailedPreconditionException if owner does not belong to group
    * @throws AccessControlException if this operation is not permitted
    */
   private void checkUserBelongsToGroup(String owner, String group)
-  throws FailedPreconditionException, AccessControlException {
+      throws FailedPreconditionException, AccessControlException {
     try {
-      List<String> groups = null;
-      groups = CommonUtils.getGroups(owner);
+      List<String> groups = CommonUtils.getGroups(owner);
       if (groups == null || !groups.contains(group)) {
         throw new FailedPreconditionException("setOwner: owner " + owner
             + " does not belong to the group " + group);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2583,7 +2583,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public void setAttribute(AlluxioURI path, SetAttributeOptions options)
       throws FileDoesNotExistException, AccessControlException, InvalidPathException,
-      FailedPreconditionException {
+      IOException {
     Metrics.SET_ATTRIBUTE_OPS.inc();
     // for chown
     boolean rootRequired = options.getOwner() != null;
@@ -2609,16 +2609,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws AccessControlException if this operation is not permitted
    */
   private void checkUserBelongsToGroup(String owner, String group)
-      throws FailedPreconditionException, AccessControlException {
-    try {
-      List<String> groups = CommonUtils.getGroups(owner);
-      if (groups == null || !groups.contains(group)) {
-        throw new FailedPreconditionException("Owner " + owner
-            + " does not belong to the group " + group);
-      }
-    } catch (IOException e) {
-      throw new AccessControlException("Could not setOwner for file."
-          + " Aborting the setAttribute operation in Alluxio.", e);
+      throws AccessControlException, IOException {
+    List<String> groups = CommonUtils.getGroups(owner);
+    if (groups == null || !groups.contains(group)) {
+      throw new FailedPreconditionException("Owner " + owner
+          + " does not belong to the group " + group);
     }
   }
 
@@ -2743,7 +2738,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      FailedPreconditionException {
+      IOException {
     for (long fileId : persistedFiles) {
       try {
         // Permission checking for each file is performed inside setAttribute

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2591,7 +2591,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     boolean ownerRequired =
         (options.getGroup() != null) || (options.getMode() != Constants.INVALID_MODE);
     if (options.getOwner() != null && options.getGroup() != null) {
-      checkUserBelongsToGroup(options.getOwner(), options.getGroup());
+      try {
+        checkUserBelongsToGroup(options.getOwner(), options.getGroup());
+      } catch (IOException e) {
+        throw new FailedPreconditionException("Could not setOwner.", e);
+      }
     }
     try (JournalContext journalContext = createJournalContext();
         LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE)) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2594,7 +2594,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       try {
         checkUserBelongsToGroup(options.getOwner(), options.getGroup());
       } catch (IOException e) {
-        throw new FailedPreconditionException("Could not setOwner.", e);
+        throw new IOException("Could not setOwner for " + path.toString() + ".", e);
       }
     }
     try (JournalContext journalContext = createJournalContext();
@@ -2610,10 +2610,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param owner the owner to check
    * @param group the group to check
    * @throws FailedPreconditionException if owner does not belong to group
-   * @throws AccessControlException if this operation is not permitted
    */
   private void checkUserBelongsToGroup(String owner, String group)
-      throws AccessControlException, IOException {
+      throws IOException {
     List<String> groups = CommonUtils.getGroups(owner);
     if (groups == null || !groups.contains(group)) {
       throw new FailedPreconditionException("Owner " + owner

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2594,7 +2594,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       try {
         checkUserBelongsToGroup(options.getOwner(), options.getGroup());
       } catch (IOException e) {
-        throw new IOException("Could not setOwner for " + path.toString() + ".", e);
+        throw new IOException(String.format("Could not update owner:group for %s to %s:%s. %s",
+            path.toString(), options.getOwner(), options.getGroup(), e.toString()), e);
       }
     }
     try (JournalContext journalContext = createJournalContext();

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -22,7 +22,6 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidFileSizeException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.UnexpectedAlluxioException;
-import alluxio.exception.status.FailedPreconditionException;
 import alluxio.master.Master;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.file.meta.PersistenceState;
@@ -451,7 +450,7 @@ public interface FileSystemMaster extends Master {
    */
   void setAttribute(AlluxioURI path, SetAttributeOptions options)
       throws FileDoesNotExistException, AccessControlException, InvalidPathException,
-      FailedPreconditionException;
+      IOException;
 
   /**
    * Schedules a file for async persistence.
@@ -474,7 +473,7 @@ public interface FileSystemMaster extends Master {
    */
   FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      FailedPreconditionException;
+      IOException;
 
   /**
    * @return a list of {@link WorkerInfo} objects representing the workers in Alluxio

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -22,6 +22,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidFileSizeException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.UnexpectedAlluxioException;
+import alluxio.exception.status.FailedPreconditionException;
 import alluxio.master.Master;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.file.meta.PersistenceState;
@@ -449,7 +450,8 @@ public interface FileSystemMaster extends Master {
    * @throws InvalidPathException if the given path is invalid
    */
   void setAttribute(AlluxioURI path, SetAttributeOptions options)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException;
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException,
+      FailedPreconditionException;
 
   /**
    * Schedules a file for async persistence.
@@ -471,7 +473,8 @@ public interface FileSystemMaster extends Master {
    * @throws AccessControlException if permission checking fails
    */
   FileSystemCommand workerHeartbeat(long workerId, List<Long> persistedFiles)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException,
+      FailedPreconditionException;
 
   /**
    * @return a list of {@link WorkerInfo} objects representing the workers in Alluxio

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -363,9 +363,9 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public SetAttributeTResponse setAttribute(final String path, final SetAttributeTOptions options)
       throws AlluxioTException {
-    return RpcUtils.callAndLog(LOG, new RpcCallable<SetAttributeTResponse>() {
+    return RpcUtils.callAndLog(LOG, new RpcCallableThrowsIOException<SetAttributeTResponse>() {
       @Override
-      public SetAttributeTResponse call() throws AlluxioException {
+      public SetAttributeTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.setAttribute(new AlluxioURI(path), new SetAttributeOptions(options));
         return new SetAttributeTResponse();
       }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterWorkerServiceHandler.java
@@ -32,6 +32,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -66,13 +67,15 @@ public final class FileSystemMasterWorkerServiceHandler
   public FileSystemHeartbeatTResponse fileSystemHeartbeat(final long workerId,
       final List<Long> persistedFiles, FileSystemHeartbeatTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcUtils.RpcCallable<FileSystemHeartbeatTResponse>() {
-      @Override
-      public FileSystemHeartbeatTResponse call() throws AlluxioException {
-        return new FileSystemHeartbeatTResponse(
-            mFileSystemMaster.workerHeartbeat(workerId, persistedFiles));
-      }
-    });
+    return RpcUtils.call(LOG,
+        new RpcUtils.RpcCallableThrowsIOException<FileSystemHeartbeatTResponse>() {
+          @Override
+          public FileSystemHeartbeatTResponse call() throws AlluxioException, IOException {
+            return new FileSystemHeartbeatTResponse(
+                mFileSystemMaster.workerHeartbeat(workerId, persistedFiles));
+          }
+        }
+    );
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -66,7 +66,7 @@ public final class ChownCommand extends AbstractShellCommand {
   private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*)");
 
   private static final Pattern USER_GROUP_PATTERN =
-      Pattern.compile("(?<user>[a-zA-Z_][\\w_-]*):(?<group>[\\w][\\w-]*)");
+      Pattern.compile("(?<user>[\\w][\\w_-]*):(?<group>[\\w][\\w-]*)");
 
   /**
    * Changes the owner for the directory or file with the path specified in args.

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -63,10 +63,15 @@ public final class ChownCommand extends AbstractShellCommand {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 
-  private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*)");
+  /*
+  See https://paulgorman.org/technical/presentations/linux_username_conventions.pdf
+  in which the author refers to IEEE Std 1003.1-2001 regarding the standards for
+  valid POSIX usernames.
+   */
+  private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*[$]?)");
 
   private static final Pattern USER_GROUP_PATTERN =
-      Pattern.compile("(?<user>[\\w][\\w_-]*):(?<group>[\\w][\\w-]*)");
+      Pattern.compile("(?<user>[\\w][\\w-]*[$]?):(?<group>[\\w][\\w-]*[$]?)");
 
   /**
    * Changes the owner for the path specified in args.

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -77,13 +77,14 @@ public final class ChownCommand extends AbstractShellCommand {
 
   /**
    * Changes the owner and group for the directory or file with the path specified in args.
+   *
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param owner The owner to be updated to the file or directory
    * @param group The group to be updated to the file or directory
    * @param recursive Whether change the owner and group recursively
    */
   private void chown(AlluxioURI path, String owner, String group, boolean recursive)
-    throws AlluxioException, IOException {
+      throws AlluxioException, IOException {
     SetAttributeOptions options =
         SetAttributeOptions.defaults().setOwner(owner).setGroup(group).setRecursive(recursive);
     mFileSystem.setAttribute(path, options);
@@ -113,7 +114,7 @@ public final class ChownCommand extends AbstractShellCommand {
 
   @Override
   public String getUsage() {
-    return "chown [-R] <owner> <path>";
+    return "chown [-R] <owner>[:<group>] <path>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -117,7 +117,7 @@ public final class ChownCommand extends AbstractShellCommand {
       }
       return 0;
     }
-    System.out.println("Failed to parse " + args[0] + "as user or user:group");
+    System.out.println("Failed to parse " + args[0] + " as user or user:group");
     return -1;
   }
 

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -68,10 +68,8 @@ public final class ChownCommand extends AbstractShellCommand {
    * in which the author refers to IEEE Std 1003.1-2001 regarding the standards for
    * valid POSIX usernames.
    */
-  private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*[$]?)");
-
   private static final Pattern USER_GROUP_PATTERN =
-      Pattern.compile("(?<user>[\\w][\\w-]*[$]?):(?<group>[\\w][\\w-]*[$]?)");
+      Pattern.compile("(?<user>[\\w][\\w-]*\\$?)(:(?<group>[\\w][\\w-]*\\$?))?");
 
   /**
    * Changes the owner for the path specified in args.
@@ -112,13 +110,11 @@ public final class ChownCommand extends AbstractShellCommand {
     if (matchUserGroup.matches()) {
       String owner = matchUserGroup.group("user");
       String group = matchUserGroup.group("group");
-      chown(path, owner, group, cl.hasOption("R"));
-      return 0;
-    }
-    Matcher matchUserOnly = USER_PATTERN.matcher(args[0]);
-    if (matchUserOnly.matches()) {
-      String owner = matchUserOnly.group("user");
-      chown(path, owner, cl.hasOption("R"));
+      if (group == null) {
+        chown(path, owner, cl.hasOption("R"));
+      } else {
+        chown(path, owner, group, cl.hasOption("R"));
+      }
       return 0;
     }
     System.out.println("Failed to parse " + args[0] + "as user or user:group");

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -69,7 +69,7 @@ public final class ChownCommand extends AbstractShellCommand {
       Pattern.compile("(?<user>[\\w][\\w_-]*):(?<group>[\\w][\\w-]*)");
 
   /**
-   * Changes the owner for the directory or file with the path specified in args.
+   * Changes the owner for the path specified in args.
    *
    * @param path The {@link AlluxioURI} path as the input of the command
    * @param owner The owner to be updated to the file or directory
@@ -84,19 +84,19 @@ public final class ChownCommand extends AbstractShellCommand {
   }
 
   /**
-   * Changes the owner and group for the directory or file with the path specified in args.
+   * Changes the owner and group for the path specified in args.
    *
-   * @param path the {@link AlluxioURI} path as the input of the command
-   * @param owner the owner to be updated to the file or directory
-   * @param group the group to be updated to the file or directory
-   * @param recursive whether change the owner and group recursively
+   * @param path the {@link AlluxioURI} path to update
+   * @param owner the new owner to be updated to the file or directory
+   * @param group the new group to be updated to the file or directory
+   * @param recursive whether to change the owner and group recursively
    */
   private void chown(AlluxioURI path, String owner, String group, boolean recursive)
       throws AlluxioException, IOException {
     SetAttributeOptions options =
         SetAttributeOptions.defaults().setOwner(owner).setGroup(group).setRecursive(recursive);
     mFileSystem.setAttribute(path, options);
-    System.out.println("Changed owner:group of " + path + " to " + owner + ":" + group);
+    System.out.println("Changed owner:group of " + path + " to " + owner + ":" + group + ".");
   }
 
   @Override

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -55,10 +55,10 @@ public final class ChownCommand extends AbstractShellCommand {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 
-  private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[a-z_][a-z0-9_-]*)");
+  private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*)");
 
   private static final Pattern USER_GROUP_PATTERN =
-      Pattern.compile("(?<user>[a-z_][a-z0-9_-]*):(?<group>[a-z_][a-z0-9_-]*)");
+      Pattern.compile("(?<user>[a-zA-Z_][\\w_-]*):(?<group>[\\w][\\w-]*)");
 
   /**
    * Changes the owner for the directory or file with the path specified in args.

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -78,10 +78,10 @@ public final class ChownCommand extends AbstractShellCommand {
   /**
    * Changes the owner and group for the directory or file with the path specified in args.
    *
-   * @param path The {@link AlluxioURI} path as the input of the command
-   * @param owner The owner to be updated to the file or directory
-   * @param group The group to be updated to the file or directory
-   * @param recursive Whether change the owner and group recursively
+   * @param path the {@link AlluxioURI} path as the input of the command
+   * @param owner the owner to be updated to the file or directory
+   * @param group the group to be updated to the file or directory
+   * @param recursive whether change the owner and group recursively
    */
   private void chown(AlluxioURI path, String owner, String group, boolean recursive)
       throws AlluxioException, IOException {

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -87,8 +87,8 @@ public final class ChownCommand extends AbstractShellCommand {
    * Changes the owner and group for the path specified in args.
    *
    * @param path the {@link AlluxioURI} path to update
-   * @param owner the new owner to be updated to the file or directory
-   * @param group the new group to be updated to the file or directory
+   * @param owner the new owner
+   * @param group the new group
    * @param recursive whether to change the owner and group recursively
    */
   private void chown(AlluxioURI path, String owner, String group, boolean recursive)
@@ -116,7 +116,7 @@ public final class ChownCommand extends AbstractShellCommand {
       chown(path, owner, cl.hasOption("R"));
       return 0;
     }
-    System.out.println("The syntax of user/group is invalid.");
+    System.out.println("Failed to parse " + args[0] + "as user or user:group");
     return -1;
   }
 

--- a/shell/src/main/java/alluxio/shell/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/shell/command/ChownCommand.java
@@ -63,10 +63,10 @@ public final class ChownCommand extends AbstractShellCommand {
     return new Options().addOption(RECURSIVE_OPTION);
   }
 
-  /*
-  See https://paulgorman.org/technical/presentations/linux_username_conventions.pdf
-  in which the author refers to IEEE Std 1003.1-2001 regarding the standards for
-  valid POSIX usernames.
+  /**
+   * See https://paulgorman.org/technical/presentations/linux_username_conventions.pdf
+   * in which the author refers to IEEE Std 1003.1-2001 regarding the standards for
+   * valid POSIX usernames.
    */
   private static final Pattern USER_PATTERN = Pattern.compile("(?<user>[\\w][\\w-]*[$]?)");
 

--- a/shell/src/test/java/alluxio/shell/command/ChownCommandTest.java
+++ b/shell/src/test/java/alluxio/shell/command/ChownCommandTest.java
@@ -1,0 +1,84 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell.command;
+
+import alluxio.exception.AlluxioException;
+
+import org.apache.commons.cli.CommandLine;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+public class ChownCommandTest {
+  private ByteArrayOutputStream mOutput = new ByteArrayOutputStream();
+  private ByteArrayOutputStream mError  = new ByteArrayOutputStream();
+
+  @Before
+  public void setupStreams() {
+    System.setOut(new PrintStream(mOutput));
+    System.setErr(new PrintStream(mError));
+  }
+
+  @After
+  public void cleanupStreams() {
+    System.setOut(null);
+    System.setErr(null);
+  }
+
+  @Test
+  public void chownPanicIllegalOwnerName() throws AlluxioException, IOException {
+    ChownCommand command = new ChownCommand(null);
+
+    String expectedOutput =
+        String.format("Failed to parse user.1:group1 as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "user.1:group1", "/testFile");
+
+    String[] args2 = {"user#1:group1", "/testFile"};
+    expectedOutput = String.format("Failed to parse user#1:group1 as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "user#1:group1", "/testFile");
+
+    String[] args3 = {"6user^$group$", "/testFile"};
+    expectedOutput = String.format("Failed to parse 6user^$group$ as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "6user^$group$", "/testFile");
+  }
+
+  @Test
+  public void chownPanicIllegalGroupName() throws AlluxioException, IOException {
+    ChownCommand command = new ChownCommand(null);
+
+    String expectedOutput = String.format("Failed to parse user1:group.1 as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "user1:group.1", "/testFile");
+
+    expectedOutput = String.format("Failed to parse user1:^6group$ as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "user1:^6group$", "/testFile");
+  }
+
+  private void verifyChownCommandReturnValueAndOutput(ChownCommand command,
+      int expectedReturnValue, String expectedOutput, String... args)
+    throws AlluxioException, IOException {
+    mOutput.reset();
+    CommandLine cl = command.parseAndValidateArgs(args);
+    int ret = command.run(cl);
+    Assert.assertEquals(expectedReturnValue, ret);
+    Assert.assertEquals(expectedOutput, mOutput.toString());
+  }
+}

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -251,7 +251,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
     Assert.assertNotEquals(defaultGroup, nonexistentGroup);
 
     mThrown.expect(IOException.class);
-    mThrown.expectMessage("Could not setOwner");
+    mThrown.expectMessage("Could not update owner");
     sTFS.setOwner(fileC, nonexistentOwner, nonexistentGroup);
   }
 

--- a/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/hadoop/FileSystemAclIntegrationTest.java
@@ -251,7 +251,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
     Assert.assertNotEquals(defaultGroup, nonexistentGroup);
 
     mThrown.expect(IOException.class);
-    mThrown.expectMessage("Could not setOwner for UFS file");
+    mThrown.expectMessage("Could not setOwner");
     sTFS.setOwner(fileC, nonexistentOwner, nonexistentGroup);
   }
 

--- a/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
+++ b/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
@@ -269,4 +269,18 @@ public abstract class AbstractAlluxioShellTest extends BaseIntegrationTest {
       Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(size), actual);
     }
   }
+
+  /**
+   * Verify the return value and output of executing command meet expectations.
+   *
+   * @param expectedReturnValue the expected return value
+   * @param expectedOutput the expected output string
+   * @param command command to execute
+   */
+  protected void verifyCommandReturnValueAndOutput(int expectedReturnValue, String expectedOutput,
+      String... command) {
+    int ret = mFsShell.run(command);
+    Assert.assertEquals(expectedReturnValue, ret);
+    Assert.assertTrue(mOutput.toString().contains(expectedOutput));
+  }
 }

--- a/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
+++ b/tests/src/test/java/alluxio/shell/AbstractAlluxioShellTest.java
@@ -273,7 +273,7 @@ public abstract class AbstractAlluxioShellTest extends BaseIntegrationTest {
   }
 
   /**
-   * Verify the return value and output of executing command meet expectations.
+   * Verifies the return value and output of executing command meet expectations.
    *
    * @param expectedReturnValue the expected return value
    * @param expectedOutput the expected output string

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.HashMap;
 import java.util.List;
 
@@ -127,7 +126,8 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
     String group = "staff";
-    String expectedCommandOutput = "Could not setOwner for /testFile.";
+    String expectedCommandOutput =
+        String.format("Could not update owner:group for /testFile to %s:%s", nonexistUser, group);
     runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
         "chown", nonexistUser + ":" + group, "/testFile");
   }
@@ -140,7 +140,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String nonexistGroup = "nonexistgroup";
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-    String expectedCommandOutput = "Could not setOwner for /testFile.";
+    String expectedCommandOutput =
+        String.format("Could not update owner:group for /testFile to %s:%s",
+        newOwner, nonexistGroup);
     runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
         "chown", newOwner + ":" + nonexistGroup, "/testFile");
   }
@@ -153,7 +155,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String nonexistGroup = "nonexistgroup";
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-    String expectedCommandOutput = "Could not setOwner for /testFile.";
+    String expectedCommandOutput =
+        String.format("Could not update owner:group for /testFile to %s:%s",
+        nonexistUser, nonexistGroup);
     runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
         "chown", nonexistUser + ":" + nonexistGroup, "/testFile");
   }

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
@@ -107,7 +107,7 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
   }
 
   @Test
-  public void chownValidOwnerValidGroup() throws Exception {
+  public void chownValidOwnerValidGroupSuccess() throws Exception {
     clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
     String newOwner = TEST_USER_1.getUser();
@@ -115,6 +115,20 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String expectedCommandOutput =
         "Changed owner:group of /testFile to " + newOwner + ":" +  group + ".";
     runChownOwnerAndGroup("/testFile", 0, expectedCommandOutput, newOwner, group,
+        "chown", newOwner + ":" + group, "/testFile");
+  }
+
+  @Test
+  public void chownValidOwnerValidGroupFail() throws Exception {
+    clearLoginUser();
+    FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
+    String newOwner = TEST_USER_2.getUser();
+    String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+    String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+    String group = "alice";
+    String expectedCommandOutput =
+        String.format("Could not update owner:group for /testFile to %s:%s", newOwner, group);
+    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
         "chown", newOwner + ":" + group, "/testFile");
   }
 

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
@@ -114,8 +114,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String group = "staff";
     String expectedCommandOutput =
         "Changed owner:group of /testFile to " + newOwner + ":" +  group + ".";
-    runChownOwnerAndGroup("/testFile", 0, expectedCommandOutput, newOwner, group,
+    verifyCommandReturnValueAndOutput(0, expectedCommandOutput,
         "chown", newOwner + ":" + group, "/testFile");
+    checkPathOwnerAndGroup("/testFile", newOwner, group);
   }
 
   @Test
@@ -128,8 +129,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String group = "alice";
     String expectedCommandOutput =
         String.format("Could not update owner:group for /testFile to %s:%s", newOwner, group);
-    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+    verifyCommandReturnValueAndOutput(-1, expectedCommandOutput,
         "chown", newOwner + ":" + group, "/testFile");
+    checkPathOwnerAndGroup("/testFile", originalOwner, originalGroup);
   }
 
   @Test
@@ -142,8 +144,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String group = "staff";
     String expectedCommandOutput =
         String.format("Could not update owner:group for /testFile to %s:%s", nonexistUser, group);
-    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+    verifyCommandReturnValueAndOutput(-1, expectedCommandOutput,
         "chown", nonexistUser + ":" + group, "/testFile");
+    checkPathOwnerAndGroup("/testFile", originalOwner, originalGroup);
   }
 
   @Test
@@ -157,8 +160,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String expectedCommandOutput =
         String.format("Could not update owner:group for /testFile to %s:%s",
         newOwner, nonexistGroup);
-    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+    verifyCommandReturnValueAndOutput(-1, expectedCommandOutput,
         "chown", newOwner + ":" + nonexistGroup, "/testFile");
+    checkPathOwnerAndGroup("/testFile", originalOwner, originalGroup);
   }
 
   @Test
@@ -172,8 +176,9 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     String expectedCommandOutput =
         String.format("Could not update owner:group for /testFile to %s:%s",
         nonexistUser, nonexistGroup);
-    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+    verifyCommandReturnValueAndOutput(-1, expectedCommandOutput,
         "chown", nonexistUser + ":" + nonexistGroup, "/testFile");
+    checkPathOwnerAndGroup("/testFile", originalOwner, originalGroup);
   }
 
   /**
@@ -191,22 +196,6 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
     mFsShell.run("chown", "-R", TEST_USER_2.getUser(), "/testDir");
     owner = mFileSystem.getStatus(new AlluxioURI("/testDir/testFile")).getOwner();
     Assert.assertEquals(TEST_USER_2.getUser(), owner);
-  }
-
-  /**
-   * Run chown command to change owner and group of a path.
-   *
-   * @param command the command to run
-   * @param expectedReturnValue return value expected from running the command
-   * @param expectedCommandOutput command output expected from running the command
-   * @param expectedOwner expected owner of the path
-   * @param expectedGroup expected group of the path
-   */
-  private void runChownOwnerAndGroup(String path, int expectedReturnValue,
-      String expectedCommandOutput, String expectedOwner, String expectedGroup, String... command)
-      throws Exception {
-    verifyCommandReturnValueAndOutput(expectedReturnValue, expectedCommandOutput, command);
-    checkPathOwnerAndGroup(path, expectedOwner, expectedGroup);
   }
 
   /**

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandIntegrationTest.java
@@ -210,7 +210,7 @@ public final class ChownCommandIntegrationTest extends AbstractAlluxioShellTest 
   }
 
   /**
-   * Check whether the owner and group of the path are expectedOwner and expectedGroup.
+   * Checks whether the owner and group of the path are expectedOwner and expectedGroup.
    *
    * @param path the path to check
    * @param expectedOwner the owner that we expect to own the path

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
@@ -12,21 +12,28 @@
 package alluxio.shell.command;
 
 import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.exception.AlluxioException;
+import alluxio.security.GroupMappingServiceTestUtils;
+import alluxio.security.authentication.AuthType;
+import alluxio.security.group.provider.IdentityUserGroupsMapping;
 import alluxio.shell.AbstractAlluxioShellTest;
+import alluxio.util.CommonUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Tests for chown command.
  */
 public final class ChownCommandTest extends AbstractAlluxioShellTest {
-
   @Test
   public void chown() throws IOException, AlluxioException {
     clearLoginUser();
@@ -37,6 +44,71 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     mFsShell.run("chown", "user2", "/testFile");
     owner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     Assert.assertEquals("user2", owner);
+  }
+
+  @Test
+  public void chownUserAndGroup() throws IOException, AlluxioException, Exception {
+    clearLoginUser();
+    GroupMappingServiceTestUtils.resetCache();
+    Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
+        IdentityUserGroupsMapping.class.getName());
+    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
+    Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
+
+    FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
+    String newOwner = "alice";
+    String nonexistUser = "nonexistuser";
+    List<String> groups = CommonUtils.getGroups(newOwner);
+    String nonexistGroup = "nonexistgroup";
+    Random rand = new Random();
+    int numOfGroups = groups.size();
+    // chown legalUser:legalGroup
+    for (int i = 0; i < 8; i++) {
+      try {
+        int k = rand.nextInt(numOfGroups);
+        String group = groups.get(k);
+        mFsShell.run("chown", newOwner + ":" + group, "/testFile");
+        String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+        Assert.assertEquals(group, currentGroup);
+      } catch (IllegalArgumentException e) {
+        mOldOutput.format("The user %s does not belong any group.%n", newOwner);
+      }
+    }
+
+    String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+    String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+    // chown illegalUser:legalGroup
+    for (int i = 0; i < 8; i++) {
+      try {
+        int k = rand.nextInt(numOfGroups);
+        String group = groups.get(k);
+        mFsShell.run("chown", nonexistUser + ":" + group, "/testFile");
+        String currentOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+        String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+        Assert.assertEquals(originalOwner, currentOwner);
+        Assert.assertEquals(originalGroup, currentGroup);
+      } catch (IllegalArgumentException e) {
+        mOldOutput.format("The user %s does not belong to any group.%n", newOwner);
+      }
+    }
+
+    // chown illegalUser:illegalGroup
+    mFsShell.run("chown", nonexistUser + ":" + nonexistGroup, "/testFile");
+    do {
+      String currentOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+      String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+      Assert.assertEquals(originalOwner, currentOwner);
+      Assert.assertEquals(originalGroup, currentGroup);
+    } while (false);
+
+    // chown legalUser:illegalGroup
+    mFsShell.run("chown", newOwner + ":" + nonexistGroup, "/testFile");
+    do {
+      String currentOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+      String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+      Assert.assertEquals(originalOwner, currentOwner);
+      Assert.assertEquals(originalGroup, currentGroup);
+    } while (false);
   }
 
   /**

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
@@ -12,62 +12,121 @@
 package alluxio.shell.command;
 
 import alluxio.AlluxioURI;
-import alluxio.Configuration;
+import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.exception.AlluxioException;
-import alluxio.security.GroupMappingServiceTestUtils;
-import alluxio.security.authentication.AuthType;
-import alluxio.security.group.provider.IdentityUserGroupsMapping;
+import alluxio.security.group.GroupMappingService;
 import alluxio.shell.AbstractAlluxioShellTest;
-import alluxio.util.CommonUtils;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * Tests for chown command.
  */
 public final class ChownCommandTest extends AbstractAlluxioShellTest {
+  /*
+   * The user and group mappings for testing are:
+   *    alice -> alice,staff
+   *    bob   -> bob,staff
+   */
+  private static final TestUser TEST_USER_1 =
+      new TestUser("alice", "alice,staff");
+  private static final TestUser TEST_USER_2 =
+      new TestUser("bob", "bob,staff");
+
+  @Rule
+  public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
+      .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()));
+
+  /**
+   * A simple structure to represent a user and its groups.
+   */
+  private static final class TestUser {
+    private String mUser;
+    private String mGroup;
+
+    TestUser(String user, String group) {
+      mUser = user;
+      mGroup = group;
+    }
+
+    String getUser() {
+      return mUser;
+    }
+
+    String getGroup() {
+      return mGroup;
+    }
+  }
+
+  /**
+   * Test class implements {@link GroupMappingService} providing user-to-groups mapping.
+   */
+  public static class FakeUserGroupsMapping implements GroupMappingService {
+    private HashMap<String, String> mUserGroups = new HashMap<>();
+
+    /**
+     * Constructor of {@link FakeUserGroupsMapping} to put the user and groups in user-to-groups
+     * HashMap.
+     */
+    public FakeUserGroupsMapping() {
+      mUserGroups.put(TEST_USER_1.getUser(), TEST_USER_1.getGroup());
+      mUserGroups.put(TEST_USER_2.getUser(), TEST_USER_2.getGroup());
+    }
+
+    @Override
+    public List<String> getGroups(String user) throws IOException {
+      if (mUserGroups.containsKey(user)) {
+        return Lists.newArrayList(mUserGroups.get(user).split(","));
+      }
+      return new ArrayList<>();
+    }
+  }
+
   @Test
   public void chown() throws IOException, AlluxioException {
     clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
-    mFsShell.run("chown", "user1", "/testFile");
+    mFsShell.run("chown", TEST_USER_1.getUser(), "/testFile");
     String owner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
-    Assert.assertEquals("user1", owner);
-    mFsShell.run("chown", "user2", "/testFile");
+    Assert.assertEquals(TEST_USER_1.getUser(), owner);
+    mFsShell.run("chown", TEST_USER_2.getUser(), "/testFile");
     owner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
-    Assert.assertEquals("user2", owner);
+    Assert.assertEquals(TEST_USER_2.getUser(), owner);
   }
 
   @Test
   public void chownValidOwnerValidGroup() throws Exception {
-    setupTestGroupMappingService();
+    clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
-    String newOwner = "alice";
-    List<String> groups = CommonUtils.getGroups(newOwner);
-    String group = groups.get(0);
+    String newOwner = TEST_USER_1.getUser();
+    String group = "staff";
     String expectedCommandOutput =
-        "Changed owner:group of /testFile to alice:" +  group + ".";
+        "Changed owner:group of /testFile to " + newOwner + ":" +  group + ".";
     runChownOwnerAndGroup("/testFile", 0, expectedCommandOutput, newOwner, group,
         "chown", newOwner + ":" + group, "/testFile");
   }
 
   @Test
   public void chownInvalidOwnerValidGroup() throws Exception {
-    setupTestGroupMappingService();
+    clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
-    String user = "alice";
     String nonexistUser = "nonexistuser";
-    List<String> groups = CommonUtils.getGroups(user);
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-    String group = groups.get(0);
+    String group = "staff";
     String expectedCommandOutput = "Could not setOwner for /testFile.";
     runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
         "chown", nonexistUser + ":" + group, "/testFile");
@@ -75,9 +134,9 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
 
   @Test
   public void chownValidOwnerInvalidGroup() throws Exception {
-    setupTestGroupMappingService();
+    clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
-    String newOwner = "alice";
+    String newOwner = TEST_USER_1.getUser();
     String nonexistGroup = "nonexistgroup";
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
@@ -88,7 +147,7 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
 
   @Test
   public void chownInvalidOwnerInvalidGroup() throws Exception {
-    setupTestGroupMappingService();
+    clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.MUST_CACHE, 10);
     String nonexistUser = "nonexistuser";
     String nonexistGroup = "nonexistgroup";
@@ -106,14 +165,14 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
   public void chownRecursive() throws IOException, AlluxioException {
     clearLoginUser();
     FileSystemTestUtils.createByteFile(mFileSystem, "/testDir/testFile", WriteType.MUST_CACHE, 10);
-    mFsShell.run("chown", "-R", "user1", "/testDir");
+    mFsShell.run("chown", "-R", TEST_USER_1.getUser(), "/testDir");
     String owner = mFileSystem.getStatus(new AlluxioURI("/testDir/testFile")).getOwner();
-    Assert.assertEquals("user1", owner);
+    Assert.assertEquals(TEST_USER_1.getUser(), owner);
     owner = mFileSystem.getStatus(new AlluxioURI("/testDir")).getOwner();
-    Assert.assertEquals("user1", owner);
-    mFsShell.run("chown", "-R", "user2", "/testDir");
+    Assert.assertEquals(TEST_USER_1.getUser(), owner);
+    mFsShell.run("chown", "-R", TEST_USER_2.getUser(), "/testDir");
     owner = mFileSystem.getStatus(new AlluxioURI("/testDir/testFile")).getOwner();
-    Assert.assertEquals("user2", owner);
+    Assert.assertEquals(TEST_USER_2.getUser(), owner);
   }
 
   /**
@@ -145,17 +204,5 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     String currentGroup = mFileSystem.getStatus(new AlluxioURI(path)).getGroup();
     Assert.assertEquals(expectedOwner, currentOwner);
     Assert.assertEquals(expectedGroup, currentGroup);
-  }
-
-  /**
-   * Set up a group mapping service for test with {@link IdentityUserGroupsMapping}.
-   */
-  private void setupTestGroupMappingService() {
-    clearLoginUser();
-    GroupMappingServiceTestUtils.resetCache();
-    Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
-        IdentityUserGroupsMapping.class.getName());
-    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
-    Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true");
   }
 }

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
@@ -52,10 +52,10 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     String newOwner = "alice";
     List<String> groups = CommonUtils.getGroups(newOwner);
     String group = groups.get(0);
-    String[] command = new String[] {"chown", newOwner + ":" + group, "/testFile"};
     String expectedCommandOutput =
         "Changed owner:group of /testFile to alice:" +  group + ".";
-    runChownOwnerAndGroup(command, 0, expectedCommandOutput, newOwner, group);
+    runChownOwnerAndGroup("/testFile", 0, expectedCommandOutput, newOwner, group,
+        "chown", newOwner + ":" + group, "/testFile");
   }
 
   @Test
@@ -68,9 +68,9 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
     String group = groups.get(0);
-    String[] command = new String[] {"chown", nonexistUser + ":" + group, "/testFile"};
     String expectedCommandOutput = "Could not setOwner for /testFile.";
-    runChownOwnerAndGroup(command, -1, expectedCommandOutput, originalOwner, originalGroup);
+    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+        "chown", nonexistUser + ":" + group, "/testFile");
   }
 
   @Test
@@ -81,9 +81,9 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     String nonexistGroup = "nonexistgroup";
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-    String[] command = new String[] {"chown", newOwner + ":" + nonexistGroup, "/testFile"};
     String expectedCommandOutput = "Could not setOwner for /testFile.";
-    runChownOwnerAndGroup(command, -1, expectedCommandOutput, originalOwner, originalGroup);
+    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+        "chown", newOwner + ":" + nonexistGroup, "/testFile");
   }
 
   @Test
@@ -94,9 +94,9 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     String nonexistGroup = "nonexistgroup";
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-    String[] command = new String[] {"chown", nonexistUser + ":" + nonexistGroup, "/testFile"};
     String expectedCommandOutput = "Could not setOwner for /testFile.";
-    runChownOwnerAndGroup(command, -1, expectedCommandOutput, originalOwner, originalGroup);
+    runChownOwnerAndGroup("/testFile", -1, expectedCommandOutput, originalOwner, originalGroup,
+        "chown", nonexistUser + ":" + nonexistGroup, "/testFile");
   }
 
   /**
@@ -124,14 +124,12 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
    * @param expectedCommandOutput command output expected from running the command
    * @param expectedOwner expected owner of the path
    * @param expectedGroup expected group of the path
-   * @throws Exception
    */
-  private void runChownOwnerAndGroup(String[] command, int expectedReturnValue,
-      String expectedCommandOutput, String expectedOwner, String expectedGroup) throws Exception {
-    int ret = mFsShell.run(command[0], command[1], command[2]);
-    Assert.assertEquals(expectedReturnValue, ret);
-    Assert.assertTrue(mOutput.toString().contains(expectedCommandOutput));
-    checkPathOwnerAndGroup(command[2], expectedOwner, expectedGroup);
+  private void runChownOwnerAndGroup(String path, int expectedReturnValue,
+      String expectedCommandOutput, String expectedOwner, String expectedGroup, String... command)
+      throws Exception {
+    verifyCommandReturnValueAndOutput(expectedReturnValue, expectedCommandOutput, command);
+    checkPathOwnerAndGroup(path, expectedOwner, expectedGroup);
   }
 
   /**
@@ -140,7 +138,6 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
    * @param path the path to check
    * @param expectedOwner the owner that we expect to own the path
    * @param expectedGroup the expected group of the path
-   * @throws Exception
    */
   private void checkPathOwnerAndGroup(String path, String expectedOwner, String expectedGroup)
       throws Exception {

--- a/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
+++ b/tests/src/test/java/alluxio/shell/command/ChownCommandTest.java
@@ -47,7 +47,7 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
   }
 
   @Test
-  public void chownUserAndGroup() throws IOException, AlluxioException, Exception {
+  public void chownUserAndGroup() throws Exception {
     clearLoginUser();
     GroupMappingServiceTestUtils.resetCache();
     Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
@@ -64,32 +64,24 @@ public final class ChownCommandTest extends AbstractAlluxioShellTest {
     int numOfGroups = groups.size();
     // chown legalUser:legalGroup
     for (int i = 0; i < 8; i++) {
-      try {
-        int k = rand.nextInt(numOfGroups);
-        String group = groups.get(k);
-        mFsShell.run("chown", newOwner + ":" + group, "/testFile");
-        String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-        Assert.assertEquals(group, currentGroup);
-      } catch (IllegalArgumentException e) {
-        mOldOutput.format("The user %s does not belong any group.%n", newOwner);
-      }
+      int k = rand.nextInt(numOfGroups);
+      String group = groups.get(k);
+      mFsShell.run("chown", newOwner + ":" + group, "/testFile");
+      String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+      Assert.assertEquals(group, currentGroup);
     }
 
     String originalOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
     String originalGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
     // chown illegalUser:legalGroup
     for (int i = 0; i < 8; i++) {
-      try {
-        int k = rand.nextInt(numOfGroups);
-        String group = groups.get(k);
-        mFsShell.run("chown", nonexistUser + ":" + group, "/testFile");
-        String currentOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
-        String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
-        Assert.assertEquals(originalOwner, currentOwner);
-        Assert.assertEquals(originalGroup, currentGroup);
-      } catch (IllegalArgumentException e) {
-        mOldOutput.format("The user %s does not belong to any group.%n", newOwner);
-      }
+      int k = rand.nextInt(numOfGroups);
+      String group = groups.get(k);
+      mFsShell.run("chown", nonexistUser + ":" + group, "/testFile");
+      String currentOwner = mFileSystem.getStatus(new AlluxioURI("/testFile")).getOwner();
+      String currentGroup = mFileSystem.getStatus(new AlluxioURI("/testFile")).getGroup();
+      Assert.assertEquals(originalOwner, currentOwner);
+      Assert.assertEquals(originalGroup, currentGroup);
     }
 
     // chown illegalUser:illegalGroup


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2901

1. On the client side, use simple regular expressions to parse user:group or user option string and extract corresponding information. Not fully compatible with UNIX/Linux chown syntax yet
2. On the server side, check whether user belongs to the group. If the check fails, throw a FailedPreconditionException. Note that this check is enforced on non-persistent files as well as persistent UFS files. For this reason, I need to modify the FileSystemAclIntegration test.