### PR TITLE
[SMALLFIX] Alter retry times

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -573,7 +573,7 @@ public class PropertyKey {
   public static final PropertyKey USER_RPC_RETRY_MAX_NUM_RETRY =
       create(Name.USER_RPC_RETRY_MAX_NUM_RETRY, 20);
   public static final PropertyKey USER_RPC_RETRY_MAX_SLEEP_MS =
-      create(Name.USER_RPC_RETRY_MAX_SLEEP_MS, "5min");
+      create(Name.USER_RPC_RETRY_MAX_SLEEP_MS, "30sec");
   /**
    * @deprecated It will be removed in 2.0.0.
    */

--- a/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
+++ b/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
@@ -13,7 +13,7 @@ package alluxio.retry;
 
 import com.google.common.base.Preconditions;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -24,7 +24,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class ExponentialBackoffRetry extends SleepingRetry {
-  private final Random mRandom = new Random();
   private final int mBaseSleepTimeMs;
   private final int mMaxSleepMs;
 
@@ -52,7 +51,9 @@ public class ExponentialBackoffRetry extends SleepingRetry {
       // current logic overflows at 30, so set value to max
       return mMaxSleepMs;
     } else {
-      int sleepMs = mBaseSleepTimeMs * Math.max(1, mRandom.nextInt(1 << (count + 1)));
+      // use randomness to avoid contention between many operations using the same retry policy
+      int sleepMs =
+          mBaseSleepTimeMs * (ThreadLocalRandom.current().nextInt(1 << count, 1 << (count + 1)));
       return Math.min(abs(sleepMs, mMaxSleepMs), mMaxSleepMs);
     }
   }

--- a/docs/_data/table/user-configuration.csv
+++ b/docs/_data/table/user-configuration.csv
@@ -31,7 +31,7 @@ alluxio.user.ufs.delegation.write.buffer.size.bytes,2MB
 alluxio.user.ufs.file.reader.class,alluxio.client.netty.&#8203;NettyUnderFileSystemFileReader
 alluxio.user.ufs.file.writer.class,alluxio.client.netty.&#8203;NettyUnderFileSystemFileWriter
 alluxio.user.rpc.retry.base.sleep.ms,50
-alluxio.user.rpc.retry.max.sleep.ms,5000
+alluxio.user.rpc.retry.max.sleep.ms,30000
 alluxio.user.rpc.retry.max.num.retry,20
 alluxio.user.date.format.pattern,MM-dd-yyyy HH:mm:ss:SSS
 alluxio.user.short.circuit.enabled,true


### PR DESCRIPTION
Lower the max time from 5min to 30sec to make clients more responsive while still waiting a significant amount of time between max-wait periods.
Choose a random sleep time between `n` and `n/2` so that the backoff times increase monotonically.