### PR TITLE
[ALLUXIO-2952] Show both status code and error message for error responses from REST calls

### DIFF
--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -11,6 +11,8 @@
 
 package alluxio;
 
+import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.Status;
 import alluxio.security.LoginUser;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.SecurityUtils;
@@ -44,14 +46,14 @@ public final class RestUtils {
       }
     } catch (IOException e) {
       LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.getMessage());
-      return createErrorResponse(e.getMessage());
+      return createErrorResponse(e);
     }
 
     try {
       return createResponse(callable.call());
     } catch (Exception e) {
       LOG.warn("Unexpected error invoking rest endpoint: {}", e.getMessage());
-      return createErrorResponse(e.getMessage());
+      return createErrorResponse(e);
     }
   }
 
@@ -85,20 +87,44 @@ public final class RestUtils {
       try {
         return Response.ok(mapper.writeValueAsString(object)).build();
       } catch (JsonProcessingException e) {
-        return createErrorResponse(e.getMessage());
+        return createErrorResponse(e);
       }
     }
     return Response.ok(object).build();
   }
 
   /**
-   * Creates an error response using the given message.
+   * Error response when {@link RestCallable#call()} throws an exception.
+   * It will be encoded into a Json string to be returned as an error response for the REST call.
+   */
+  private static class ErrorResponse {
+    private Status mStatus;
+    private String mMessage;
+
+    public ErrorResponse(Status status, String message) {
+      mStatus = status;
+      mMessage = message;
+    }
+
+    public Status getStatus() {
+      return mStatus;
+    }
+
+    public String getMessage() {
+      return mMessage;
+    }
+  }
+
+  /**
+   * Creates an error response using the given exception.
    *
-   * @param message the message to respond with
+   * @param e the exception to be converted into {@link ErrorResponse} and encoded into json
    * @return the response
    */
-  private static Response createErrorResponse(String message) {
-    return Response.serverError().entity(message).build();
+  private static Response createErrorResponse(Exception e) {
+    AlluxioStatusException se = AlluxioStatusException.fromThrowable(e);
+    ErrorResponse response = new ErrorResponse(se.getStatus(), se.getMessage());
+    return Response.serverError().entity(response).build();
   }
 
   private RestUtils() {} // prevent instantiation


### PR DESCRIPTION
With status code, clients for different languages based on the REST API can have more fine-grained exceptions.