### PR TITLE
[SMALLFIX] Clean up test configuration usage in PermissionCheckTest

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -11,11 +11,11 @@
 
 package alluxio.master.file;
 
+import alluxio.AlluxioTestDirectory;
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.Configuration;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.LoginUserRule;
 import alluxio.PropertyKey;
@@ -113,9 +113,13 @@ public final class PermissionCheckTest {
   private InodeTree mInodeTree;
 
   @Rule
-  public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
-      .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName(),
-          PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, TEST_SUPER_GROUP));
+  public ConfigurationRule mConfiguration =
+      new ConfigurationRule(new ImmutableMap.Builder<PropertyKey, String>()
+          .put(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName())
+          .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, TEST_SUPER_GROUP)
+          .put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, AlluxioTestDirectory
+              .createTemporaryDirectory("PermissionCheckTest").getAbsolutePath())
+          .build());
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser =
@@ -195,7 +199,6 @@ public final class PermissionCheckTest {
   public void after() throws Exception {
     mRegistry.stop();
     GroupMappingServiceTestUtils.resetCache();
-    ConfigurationTestUtils.resetConfiguration();
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -14,7 +14,6 @@ package alluxio.master.file;
 import alluxio.AlluxioTestDirectory;
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
-import alluxio.Configuration;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.LoginUserRule;
@@ -180,7 +179,6 @@ public final class PermissionCheckTest {
 
   @Before
   public void before() throws Exception {
-    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, mTestFolder.newFolder());
     GroupMappingServiceTestUtils.resetCache();
     mRegistry = new MasterRegistry();
     JournalFactory factory =


### PR DESCRIPTION
Avoid manual configuration modification by using `AlluxioTestDirectory` instead of `mTestFolder`