### PR TITLE
[ALLUXIO-2909] use Builder Pattern to replace factory method of PropertyKey

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class PropertyKey {
      * @return the updated builder instance
      */
     public Builder setAlias(String[] alias) {
-      mAlias = alias;
+      mAlias = Arrays.copyOf(alias, alias.length);
       return this;
     }
 

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -176,7 +176,6 @@ public class PropertyKey {
           .build();
   public static final PropertyKey ZOOKEEPER_ADDRESS =
       new Builder(Name.ZOOKEEPER_ADDRESS)
-          .setDefaultValue(null)
           .build();
   public static final PropertyKey ZOOKEEPER_ELECTION_PATH =
       new Builder(Name.ZOOKEEPER_ELECTION_PATH)

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -47,7 +47,7 @@ public class PropertyKey {
     private final String mName;
 
     /**
-     * @param name name of this property to build.
+     * @param name name of this property to build
      */
     public Builder(String name) {
       mName = name;
@@ -62,7 +62,7 @@ public class PropertyKey {
     }
 
     /**
-     * @param alias alias of this property key to build.
+     * @param alias alias of this property key to build
      * @return the updated builder instance
      */
     public Builder setAlias(String[] alias) {
@@ -71,7 +71,7 @@ public class PropertyKey {
     }
 
     /**
-     * @param defaultValue default value of this property key to build.
+     * @param defaultValue default value of this property key to build
      * @return the updated builder instance
      */
     public Builder setDefaultValue(Object defaultValue) {
@@ -80,7 +80,7 @@ public class PropertyKey {
     }
 
     /**
-     * @param description of this property key to build.
+     * @param description of this property key to build
      * @return the updated builder instance
      */
     public Builder setDescription(String description) {
@@ -232,8 +232,8 @@ public class PropertyKey {
           .build();
   public static final PropertyKey UNDERFS_HDFS_CONFIGURATION =
       new Builder(Name.UNDERFS_HDFS_CONFIGURATION)
-          .setDefaultValue( String.format("${%s}/core-site.xml:${%s}/hdfs-site.xml",
-              Name.CONF_DIR, Name.CONF_DIR))
+          .setDefaultValue(String.format(
+              "${%s}/core-site.xml:${%s}/hdfs-site.xml", Name.CONF_DIR, Name.CONF_DIR))
           .build();
   public static final PropertyKey UNDERFS_HDFS_IMPL =
       new Builder(Name.UNDERFS_HDFS_IMPL)

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -37,42 +37,162 @@ public class PropertyKey {
   /** A map from default property key's string name to the key. */
   private static final Map<PropertyKey, Object> DEFAULT_VALUES = new HashMap<>();
 
-  public static final PropertyKey CONF_DIR =
-      create(Name.CONF_DIR, String.format("${%s}/conf", Name.HOME));
-  public static final PropertyKey DEBUG = create(Name.DEBUG, false);
-  public static final PropertyKey HOME = create(Name.HOME, "/opt/alluxio");
-  public static final PropertyKey KEY_VALUE_ENABLED = create(Name.KEY_VALUE_ENABLED, false);
-  public static final PropertyKey KEY_VALUE_PARTITION_SIZE_BYTES_MAX =
-      create(Name.KEY_VALUE_PARTITION_SIZE_BYTES_MAX, "512MB");
-  public static final PropertyKey LOGGER_TYPE = create(Name.LOGGER_TYPE, "Console");
-  public static final PropertyKey LOGS_DIR =
-      create(Name.LOGS_DIR, String.format("${%s}/logs", Name.WORK_DIR));
-  public static final PropertyKey METRICS_CONF_FILE =
-      create(Name.METRICS_CONF_FILE, String.format("${%s}/metrics.properties", Name.CONF_DIR));
-  public static final PropertyKey NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
-      create(Name.NETWORK_HOST_RESOLUTION_TIMEOUT_MS, "5sec");
-  public static final PropertyKey NETWORK_NETTY_HEARTBEAT_TIMEOUT_MS =
-      create(Name.NETWORK_NETTY_HEARTBEAT_TIMEOUT_MS, "30sec");
-  public static final PropertyKey NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX =
-      create(Name.NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX, "16MB");
-  public static final PropertyKey SITE_CONF_DIR =
-      create(Name.SITE_CONF_DIR, "${user.home}/.alluxio/,/etc/alluxio/");
+  /**
+   * Builder to create {@link PropertyKey} instances.
+   */
+  public static final class Builder {
+    private String[] mAlias;
+    private Object mDefaultValue;
+    private String mDescription;
+    private final String mName;
 
-  public static final PropertyKey TEST_MODE = create(Name.TEST_MODE, false);
-  public static final PropertyKey VERSION = create(Name.VERSION, ProjectConstants.VERSION);
-  public static final PropertyKey WEB_RESOURCES = create(Name.WEB_RESOURCES,
-      String.format("${%s}/core/server/common/src/main/webapp", Name.HOME));
-  public static final PropertyKey WEB_THREADS = create(Name.WEB_THREADS, 1);
+    /**
+     * @param name name of this property to build.
+     */
+    public Builder(String name) {
+      mName = name;
+    }
+
+    /**
+     * @param template template of the name of the property to build
+     * @param params parameters of the template
+     */
+    public Builder(PropertyKey.Template template, Object... params) {
+      mName = String.format(template.mFormat, params);
+    }
+
+    /**
+     * @param alias alias of this property key to build.
+     * @return the updated builder instance
+     */
+    public Builder setAlias(String[] alias) {
+      mAlias = alias;
+      return this;
+    }
+
+    /**
+     * @param defaultValue default value of this property key to build.
+     * @return the updated builder instance
+     */
+    public Builder setDefaultValue(Object defaultValue) {
+      mDefaultValue = defaultValue;
+      return this;
+    }
+
+    /**
+     * @param description of this property key to build.
+     * @return the updated builder instance
+     */
+    public Builder setDescription(String description) {
+      mDescription = description;
+      return this;
+    }
+
+    /**
+     * @return the created property key instance
+     */
+    public PropertyKey build() {
+      return PropertyKey.create(mName, mDefaultValue, mAlias);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+          .add("alias", mAlias)
+          .add("defaultValue", mDefaultValue)
+          .add("description", mDescription)
+          .add("name", mName).toString();
+    }
+  }
+
+  public static final PropertyKey CONF_DIR =
+      new Builder(Name.CONF_DIR)
+          .setDefaultValue(String.format("${%s}/conf", Name.HOME))
+          .build();
+  public static final PropertyKey DEBUG =
+      new Builder(Name.DEBUG)
+          .setDefaultValue(false)
+          .build();
+  public static final PropertyKey HOME =
+      new Builder(Name.HOME)
+          .setDefaultValue("/opt/alluxio")
+          .build();
+  public static final PropertyKey KEY_VALUE_ENABLED =
+      new Builder(Name.KEY_VALUE_ENABLED)
+          .setDefaultValue(false)
+          .build();
+  public static final PropertyKey KEY_VALUE_PARTITION_SIZE_BYTES_MAX =
+      new Builder(Name.KEY_VALUE_PARTITION_SIZE_BYTES_MAX)
+          .setDefaultValue("512MB")
+          .build();
+  public static final PropertyKey LOGGER_TYPE =
+      new Builder(Name.LOGGER_TYPE)
+          .setDefaultValue("Console")
+          .build();
+  public static final PropertyKey LOGS_DIR =
+      new Builder(Name.LOGS_DIR)
+          .setDefaultValue(String.format("${%s}/logs", Name.WORK_DIR))
+          .build();
+  public static final PropertyKey METRICS_CONF_FILE =
+      new Builder(Name.METRICS_CONF_FILE)
+          .setDefaultValue(String.format("${%s}/metrics.properties", Name.CONF_DIR))
+          .build();
+  public static final PropertyKey NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
+      new Builder(Name.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)
+          .setDefaultValue("5sec")
+          .build();
+  public static final PropertyKey NETWORK_NETTY_HEARTBEAT_TIMEOUT_MS =
+      new Builder(Name.NETWORK_NETTY_HEARTBEAT_TIMEOUT_MS)
+          .setDefaultValue("30sec")
+          .build();
+  public static final PropertyKey NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX =
+      new Builder(Name.NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX)
+          .setDefaultValue("16MB")
+          .build();
+  public static final PropertyKey SITE_CONF_DIR =
+      new Builder(Name.SITE_CONF_DIR)
+          .setDefaultValue("${user.home}/.alluxio/,/etc/alluxio/")
+          .build();
+  public static final PropertyKey TEST_MODE =
+      new Builder(Name.TEST_MODE)
+          .setDefaultValue(false)
+          .build();
+  public static final PropertyKey VERSION =
+      new Builder(Name.VERSION)
+          .setDefaultValue(ProjectConstants.VERSION)
+          .build();
+  public static final PropertyKey WEB_RESOURCES =
+      new Builder(Name.WEB_RESOURCES)
+          .setDefaultValue(String.format("${%s}/core/server/common/src/main/webapp", Name.HOME))
+          .build();
+  public static final PropertyKey WEB_THREADS =
+      new Builder(Name.WEB_THREADS)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey WORK_DIR =
-      create(Name.WORK_DIR, String.format("${%s}", Name.HOME));
-  public static final PropertyKey ZOOKEEPER_ADDRESS = create(Name.ZOOKEEPER_ADDRESS, null);
+      new Builder(Name.WORK_DIR)
+          .setDefaultValue(String.format("${%s}", Name.HOME))
+          .build();
+  public static final PropertyKey ZOOKEEPER_ADDRESS =
+      new Builder(Name.ZOOKEEPER_ADDRESS)
+          .setDefaultValue(null)
+          .build();
   public static final PropertyKey ZOOKEEPER_ELECTION_PATH =
-      create(Name.ZOOKEEPER_ELECTION_PATH, "/election");
-  public static final PropertyKey ZOOKEEPER_ENABLED = create(Name.ZOOKEEPER_ENABLED, false);
+      new Builder(Name.ZOOKEEPER_ELECTION_PATH)
+          .setDefaultValue("/election")
+          .build();
+  public static final PropertyKey ZOOKEEPER_ENABLED =
+      new Builder(Name.ZOOKEEPER_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey ZOOKEEPER_LEADER_INQUIRY_RETRY_COUNT =
-      create(Name.ZOOKEEPER_LEADER_INQUIRY_RETRY_COUNT, 10);
+      new Builder(Name.ZOOKEEPER_LEADER_INQUIRY_RETRY_COUNT)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey ZOOKEEPER_LEADER_PATH =
-      create(Name.ZOOKEEPER_LEADER_PATH, "/leader");
+      new Builder(Name.ZOOKEEPER_LEADER_PATH)
+          .setDefaultValue("/leader")
+          .build();
 
   /**
    * UFS related properties.
@@ -81,120 +201,201 @@ public class PropertyKey {
    */
   @Deprecated
   public static final PropertyKey UNDERFS_ADDRESS =
-      create(Name.UNDERFS_ADDRESS, String.format("${%s}/underFSStorage", Name.WORK_DIR));
+      new Builder(Name.UNDERFS_ADDRESS)
+          .setDefaultValue(String.format("${%s}/underFSStorage", Name.WORK_DIR))
+          .build();
   public static final PropertyKey UNDERFS_ALLOW_SET_OWNER_FAILURE =
-      create(Name.UNDERFS_ALLOW_SET_OWNER_FAILURE, false);
+      new Builder(Name.UNDERFS_ALLOW_SET_OWNER_FAILURE)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_LISTING_LENGTH =
-      create(Name.UNDERFS_LISTING_LENGTH, 1000);
+      new Builder(Name.UNDERFS_LISTING_LENGTH)
+          .setDefaultValue(1000)
+          .build();
   public static final PropertyKey UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING =
-      create(Name.UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING, "");
+      new Builder(Name.UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING)
+          .setDefaultValue("")
+          .build();
   public static final PropertyKey UNDERFS_GLUSTERFS_IMPL =
-      create(Name.UNDERFS_GLUSTERFS_IMPL, "org.apache.hadoop.fs.glusterfs.GlusterFileSystem");
+      new Builder(Name.UNDERFS_GLUSTERFS_IMPL)
+          .setDefaultValue("org.apache.hadoop.fs.glusterfs.GlusterFileSystem")
+          .build();
   public static final PropertyKey UNDERFS_GLUSTERFS_MOUNTS =
-      create(Name.UNDERFS_GLUSTERFS_MOUNTS, null);
+      new Builder(Name.UNDERFS_GLUSTERFS_MOUNTS)
+          .build();
   public static final PropertyKey UNDERFS_GLUSTERFS_MR_DIR =
-      create(Name.UNDERFS_GLUSTERFS_MR_DIR, "glusterfs:///mapred/system");
+      new Builder(Name.UNDERFS_GLUSTERFS_MR_DIR)
+          .setDefaultValue("glusterfs:///mapred/system")
+          .build();
   public static final PropertyKey UNDERFS_GLUSTERFS_VOLUMES =
-      create(Name.UNDERFS_GLUSTERFS_VOLUMES, null);
+      new Builder(Name.UNDERFS_GLUSTERFS_VOLUMES)
+          .build();
   public static final PropertyKey UNDERFS_HDFS_CONFIGURATION =
-      create(Name.UNDERFS_HDFS_CONFIGURATION,
-          String.format("${%s}/core-site.xml:${%s}/hdfs-site.xml", Name.CONF_DIR, Name.CONF_DIR));
+      new Builder(Name.UNDERFS_HDFS_CONFIGURATION)
+          .setDefaultValue( String.format("${%s}/core-site.xml:${%s}/hdfs-site.xml",
+              Name.CONF_DIR, Name.CONF_DIR))
+          .build();
   public static final PropertyKey UNDERFS_HDFS_IMPL =
-      create(Name.UNDERFS_HDFS_IMPL, "org.apache.hadoop.hdfs.DistributedFileSystem");
+      new Builder(Name.UNDERFS_HDFS_IMPL)
+          .setDefaultValue("org.apache.hadoop.hdfs.DistributedFileSystem")
+          .build();
   public static final PropertyKey UNDERFS_HDFS_PREFIXES =
-      create(Name.UNDERFS_HDFS_PREFIXES, "hdfs://,glusterfs:///,maprfs:///");
-  public static final PropertyKey UNDERFS_HDFS_REMOTE = create(Name.UNDERFS_HDFS_REMOTE, false);
+      new Builder(Name.UNDERFS_HDFS_PREFIXES)
+          .setDefaultValue("hdfs://,glusterfs:///,maprfs:///")
+          .build();
+  public static final PropertyKey UNDERFS_HDFS_REMOTE =
+      new Builder(Name.UNDERFS_HDFS_REMOTE)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_SERVICE_THREADS =
-      create(Name.UNDERFS_OBJECT_STORE_SERVICE_THREADS, 20);
+      new Builder(Name.UNDERFS_OBJECT_STORE_SERVICE_THREADS)
+          .setDefaultValue(20)
+          .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY =
-      create(Name.UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY, false);
+      new Builder(Name.UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_OSS_CONNECT_MAX =
-      create(Name.UNDERFS_OSS_CONNECT_MAX, 1024);
+      new Builder(Name.UNDERFS_OSS_CONNECT_MAX)
+          .setDefaultValue(1024)
+          .build();
   public static final PropertyKey UNDERFS_OSS_CONNECT_TIMEOUT =
-      create(Name.UNDERFS_OSS_CONNECT_TIMEOUT, "50sec");
+      new Builder(Name.UNDERFS_OSS_CONNECT_TIMEOUT)
+          .setDefaultValue("50sec")
+          .build();
   public static final PropertyKey UNDERFS_OSS_CONNECT_TTL =
-      create(Name.UNDERFS_OSS_CONNECT_TTL, -1);
+      new Builder(Name.UNDERFS_OSS_CONNECT_TTL)
+          .setDefaultValue(-1)
+          .build();
   public static final PropertyKey UNDERFS_OSS_SOCKET_TIMEOUT =
-      create(Name.UNDERFS_OSS_SOCKET_TIMEOUT, "50sec");
+      new Builder(Name.UNDERFS_OSS_SOCKET_TIMEOUT)
+          .setDefaultValue("50sec")
+          .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
-      create(Name.UNDERFS_S3_ADMIN_THREADS_MAX, 20);
+      new Builder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
+          .setDefaultValue(20)
+          .build();
   public static final PropertyKey UNDERFS_S3_DISABLE_DNS_BUCKETS =
-      create(Name.UNDERFS_S3_DISABLE_DNS_BUCKETS, false);
-  public static final PropertyKey UNDERFS_S3_ENDPOINT = create(Name.UNDERFS_S3_ENDPOINT, null);
+      new Builder(Name.UNDERFS_S3_DISABLE_DNS_BUCKETS)
+          .setDefaultValue(false)
+          .build();
+  public static final PropertyKey UNDERFS_S3_ENDPOINT =
+      new Builder(Name.UNDERFS_S3_ENDPOINT)
+          .build();
   public static final PropertyKey UNDERFS_S3_ENDPOINT_HTTP_PORT =
-      create(Name.UNDERFS_S3_ENDPOINT_HTTP_PORT, null);
+      new Builder(Name.UNDERFS_S3_ENDPOINT_HTTP_PORT)
+          .build();
   public static final PropertyKey UNDERFS_S3_ENDPOINT_HTTPS_PORT =
-      create(Name.UNDERFS_S3_ENDPOINT_HTTPS_PORT, null);
+      new Builder(Name.UNDERFS_S3_ENDPOINT_HTTPS_PORT)
+          .build();
   public static final PropertyKey UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING =
-      create(Name.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "");
-  public static final PropertyKey UNDERFS_S3_PROXY_HOST = create(Name.UNDERFS_S3_PROXY_HOST, null);
+      new Builder(Name.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING)
+          .setDefaultValue("")
+          .build();
+  public static final PropertyKey UNDERFS_S3_PROXY_HOST =
+      new Builder(Name.UNDERFS_S3_PROXY_HOST)
+          .build();
   public static final PropertyKey UNDERFS_S3_PROXY_HTTPS_ONLY =
-      create(Name.UNDERFS_S3_PROXY_HTTPS_ONLY, true);
-  public static final PropertyKey UNDERFS_S3_PROXY_PORT = create(Name.UNDERFS_S3_PROXY_PORT, null);
-  public static final PropertyKey UNDERFS_S3_THREADS_MAX = create(Name.UNDERFS_S3_THREADS_MAX, 40);
+      new Builder(Name.UNDERFS_S3_PROXY_HTTPS_ONLY)
+          .setDefaultValue(true)
+          .build();
+  public static final PropertyKey UNDERFS_S3_PROXY_PORT =
+      new Builder(Name.UNDERFS_S3_PROXY_PORT)
+          .build();
+  public static final PropertyKey UNDERFS_S3_THREADS_MAX =
+      new Builder(Name.UNDERFS_S3_THREADS_MAX)
+          .setDefaultValue(40)
+          .build();
   public static final PropertyKey UNDERFS_S3_UPLOAD_THREADS_MAX =
-      create(Name.UNDERFS_S3_UPLOAD_THREADS_MAX, 20);
+      new Builder(Name.UNDERFS_S3_UPLOAD_THREADS_MAX)
+          .setDefaultValue(20)
+          .build();
   public static final PropertyKey UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS =
-      create(Name.UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS, "1min");
+      new Builder(Name.UNDERFS_S3A_CONSISTENCY_TIMEOUT_MS)
+          .setDefaultValue("1min")
+          .build();
   public static final PropertyKey UNDERFS_S3A_DIRECTORY_SUFFIX =
-      create(Name.UNDERFS_S3A_DIRECTORY_SUFFIX, "/");
+      new Builder(Name.UNDERFS_S3A_DIRECTORY_SUFFIX)
+          .setDefaultValue("/")
+          .build();
   public static final PropertyKey UNDERFS_S3A_INHERIT_ACL =
-      create(Name.UNDERFS_S3A_INHERIT_ACL, true);
+      new Builder(Name.UNDERFS_S3A_INHERIT_ACL)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey UNDERFS_S3A_LIST_OBJECTS_VERSION_1 =
-      create(Name.UNDERFS_S3A_LIST_OBJECTS_VERSION_1, false);
+      new Builder(Name.UNDERFS_S3A_LIST_OBJECTS_VERSION_1)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_S3A_REQUEST_TIMEOUT =
-      create(Name.UNDERFS_S3A_REQUEST_TIMEOUT_MS, "1min");
+      new Builder(Name.UNDERFS_S3A_REQUEST_TIMEOUT_MS)
+          .setDefaultValue("1min")
+          .build();
   public static final PropertyKey UNDERFS_S3A_SECURE_HTTP_ENABLED =
-      create(Name.UNDERFS_S3A_SECURE_HTTP_ENABLED, false);
+      new Builder(Name.UNDERFS_S3A_SECURE_HTTP_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED =
-      create(Name.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED, false);
+      new Builder(Name.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey UNDERFS_S3A_SIGNER_ALGORITHM =
-      create(Name.UNDERFS_S3A_SIGNER_ALGORITHM, null);
+      new Builder(Name.UNDERFS_S3A_SIGNER_ALGORITHM)
+          .build();
   public static final PropertyKey UNDERFS_S3A_SOCKET_TIMEOUT_MS =
-      create(Name.UNDERFS_S3A_SOCKET_TIMEOUT_MS, "50sec");
+      new Builder(Name.UNDERFS_S3A_SOCKET_TIMEOUT_MS)
+          .setDefaultValue("50sec")
+          .build();
 
   //
   // UFS access control related properties
   //
   // Not prefixed with fs, the s3a property names mirror the aws-sdk property names for ease of use
-  public static final PropertyKey GCS_ACCESS_KEY = create(Name.GCS_ACCESS_KEY, null);
-  public static final PropertyKey GCS_SECRET_KEY = create(Name.GCS_SECRET_KEY, null);
-  public static final PropertyKey OSS_ACCESS_KEY = create(Name.OSS_ACCESS_KEY, null);
-  public static final PropertyKey OSS_ENDPOINT_KEY = create(Name.OSS_ENDPOINT_KEY, null);
-  public static final PropertyKey OSS_SECRET_KEY = create(Name.OSS_SECRET_KEY, null);
-  public static final PropertyKey S3A_ACCESS_KEY = create(Name.S3A_ACCESS_KEY, null);
-  public static final PropertyKey S3A_SECRET_KEY = create(Name.S3A_SECRET_KEY, null);
-  public static final PropertyKey S3N_ACCESS_KEY = create(Name.S3N_ACCESS_KEY, null);
-  public static final PropertyKey S3N_SECRET_KEY = create(Name.S3N_SECRET_KEY, null);
-  public static final PropertyKey SWIFT_API_KEY = create(Name.SWIFT_API_KEY, null);
-  public static final PropertyKey SWIFT_AUTH_METHOD_KEY = create(Name.SWIFT_AUTH_METHOD_KEY, null);
-  public static final PropertyKey SWIFT_AUTH_URL_KEY = create(Name.SWIFT_AUTH_URL_KEY, null);
-  public static final PropertyKey SWIFT_PASSWORD_KEY = create(Name.SWIFT_PASSWORD_KEY, null);
-  public static final PropertyKey SWIFT_SIMULATION = create(Name.SWIFT_SIMULATION, null);
-  public static final PropertyKey SWIFT_TENANT_KEY = create(Name.SWIFT_TENANT_KEY, null);
+  public static final PropertyKey GCS_ACCESS_KEY = new Builder(Name.GCS_ACCESS_KEY).build();
+  public static final PropertyKey GCS_SECRET_KEY = new Builder(Name.GCS_SECRET_KEY).build();
+  public static final PropertyKey OSS_ACCESS_KEY = new Builder(Name.OSS_ACCESS_KEY).build();
+  public static final PropertyKey OSS_ENDPOINT_KEY = new Builder(Name.OSS_ENDPOINT_KEY).build();
+  public static final PropertyKey OSS_SECRET_KEY = new Builder(Name.OSS_SECRET_KEY).build();
+  public static final PropertyKey S3A_ACCESS_KEY = new Builder(Name.S3A_ACCESS_KEY).build();
+  public static final PropertyKey S3A_SECRET_KEY = new Builder(Name.S3A_SECRET_KEY).build();
+  public static final PropertyKey S3N_ACCESS_KEY = new Builder(Name.S3N_ACCESS_KEY).build();
+  public static final PropertyKey S3N_SECRET_KEY = new Builder(Name.S3N_SECRET_KEY).build();
+  public static final PropertyKey SWIFT_API_KEY = new Builder(Name.SWIFT_API_KEY).build();
+  public static final PropertyKey SWIFT_AUTH_METHOD_KEY =
+      new Builder(Name.SWIFT_AUTH_METHOD_KEY).build();
+  public static final PropertyKey SWIFT_AUTH_URL_KEY = new Builder(Name.SWIFT_AUTH_URL_KEY).build();
+  public static final PropertyKey SWIFT_PASSWORD_KEY = new Builder(Name.SWIFT_PASSWORD_KEY).build();
+  public static final PropertyKey SWIFT_SIMULATION = new Builder(Name.SWIFT_SIMULATION).build();
+  public static final PropertyKey SWIFT_TENANT_KEY = new Builder(Name.SWIFT_TENANT_KEY).build();
   public static final PropertyKey SWIFT_USE_PUBLIC_URI_KEY =
-      create(Name.SWIFT_USE_PUBLIC_URI_KEY, null);
-  public static final PropertyKey SWIFT_USER_KEY = create(Name.SWIFT_USER_KEY, null);
-  public static final PropertyKey SWIFT_REGION_KEY = create(Name.SWIFT_REGION_KEY, null);
+      new Builder(Name.SWIFT_USE_PUBLIC_URI_KEY).build();
+  public static final PropertyKey SWIFT_USER_KEY = new Builder(Name.SWIFT_USER_KEY).build();
+  public static final PropertyKey SWIFT_REGION_KEY = new Builder(Name.SWIFT_REGION_KEY).build();
 
   // Journal ufs related properties
   public static final PropertyKey MASTER_JOURNAL_UFS_OPTION =
-      create(Template.MASTER_JOURNAL_UFS_OPTION, null);
+      new Builder(Template.MASTER_JOURNAL_UFS_OPTION).build();
 
   //
   // Mount table related properties
   //
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_ALLUXIO =
-      create(Template.MASTER_MOUNT_TABLE_ALLUXIO, "/", "root");
+      new Builder(Template.MASTER_MOUNT_TABLE_ALLUXIO, "root")
+          .setDefaultValue("/")
+          .build();
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_OPTION =
-      create(Template.MASTER_MOUNT_TABLE_OPTION, null, "root");
+      new Builder(Template.MASTER_MOUNT_TABLE_OPTION, "root").build();
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_READONLY =
-      create(Template.MASTER_MOUNT_TABLE_READONLY, false, "root");
+      new Builder(Template.MASTER_MOUNT_TABLE_READONLY, "root")
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_SHARED =
-      create(Template.MASTER_MOUNT_TABLE_SHARED, true, "root");
+      new Builder(Template.MASTER_MOUNT_TABLE_SHARED, "root")
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_UFS =
-      create(Template.MASTER_MOUNT_TABLE_UFS,
-          String.format("${%s}", Name.UNDERFS_ADDRESS), "root");
+      new Builder(Template.MASTER_MOUNT_TABLE_UFS, "root")
+          .setDefaultValue(String.format("${%s}", Name.UNDERFS_ADDRESS))
+          .build();
 
   /**
    * Master related properties.
@@ -202,197 +403,363 @@ public class PropertyKey {
    * @deprecated since version 1.3 and will be removed in version 2.0, use MASTER_HOSTNAME instead.
    */
   @Deprecated
-  public static final PropertyKey MASTER_ADDRESS = create(Name.MASTER_ADDRESS, null);
-  public static final PropertyKey MASTER_BIND_HOST = create(Name.MASTER_BIND_HOST, "0.0.0.0");
+  public static final PropertyKey MASTER_ADDRESS = new Builder(Name.MASTER_ADDRESS).build();
+  public static final PropertyKey MASTER_BIND_HOST =
+      new Builder(Name.MASTER_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
   public static final PropertyKey MASTER_CONNECTION_TIMEOUT_MS =
-      create(Name.MASTER_CONNECTION_TIMEOUT_MS, "0ms");
+      new Builder(Name.MASTER_CONNECTION_TIMEOUT_MS)
+          .setDefaultValue("0ms")
+          .build();
   public static final PropertyKey MASTER_FILE_ASYNC_PERSIST_HANDLER =
-      create(Name.MASTER_FILE_ASYNC_PERSIST_HANDLER,
-          "alluxio.master.file.async.DefaultAsyncPersistHandler");
+      new Builder(Name.MASTER_FILE_ASYNC_PERSIST_HANDLER)
+          .setDefaultValue("alluxio.master.file.async.DefaultAsyncPersistHandler")
+          .build();
   public static final PropertyKey MASTER_FORMAT_FILE_PREFIX =
-      create(Name.MASTER_FORMAT_FILE_PREFIX, "_format_");
+      new Builder(Name.MASTER_FORMAT_FILE_PREFIX)
+          .setDefaultValue("_format_")
+          .build();
   public static final PropertyKey MASTER_HEARTBEAT_INTERVAL_MS =
-      create(Name.MASTER_HEARTBEAT_INTERVAL_MS, "1sec");
-  public static final PropertyKey MASTER_HOSTNAME = create(Name.MASTER_HOSTNAME, null);
+      new Builder(Name.MASTER_HEARTBEAT_INTERVAL_MS)
+          .setDefaultValue("1sec")
+          .build();
+  public static final PropertyKey MASTER_HOSTNAME = new Builder(Name.MASTER_HOSTNAME).build();
   public static final PropertyKey MASTER_JOURNAL_FLUSH_BATCH_TIME_MS =
-      create(Name.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "5ms");
+      new Builder(Name.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS)
+          .setDefaultValue("5ms")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_FLUSH_TIMEOUT_MS =
-      create(Name.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min");
+      new Builder(Name.MASTER_JOURNAL_FLUSH_TIMEOUT_MS)
+          .setDefaultValue("5min")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_FOLDER =
-      create(Name.MASTER_JOURNAL_FOLDER, String.format("${%s}/journal", Name.WORK_DIR));
+      new Builder(Name.MASTER_JOURNAL_FOLDER)
+          .setDefaultValue(String.format("${%s}/journal", Name.WORK_DIR))
+          .build();
   /**
    * @deprecated since 1.5.0 and will be removed in 2.0.
    */
   @Deprecated
   public static final PropertyKey MASTER_JOURNAL_FORMATTER_CLASS =
-      create(Name.MASTER_JOURNAL_FORMATTER_CLASS,
-          "alluxio.master.journalv0.ProtoBufJournalFormatter");
+      new Builder(Name.MASTER_JOURNAL_FORMATTER_CLASS)
+          .setDefaultValue("alluxio.master.journalv0.ProtoBufJournalFormatter")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
-      create(Name.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "10MB");
+      new Builder(Name.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX)
+          .setDefaultValue("10MB")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS =
-      create(Name.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "5sec");
+      new Builder(Name.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS)
+          .setDefaultValue("5sec")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TAILER_SLEEP_TIME_MS =
-      create(Name.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "1sec");
+      new Builder(Name.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS)
+          .setDefaultValue("1sec")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES =
-      create(Name.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2000000);
+      new Builder(Name.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
+          .setDefaultValue(2000000)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_GC_PERIOD_MS =
-      create(Name.MASTER_JOURNAL_GC_PERIOD_MS, "2min");
+      new Builder(Name.MASTER_JOURNAL_GC_PERIOD_MS)
+          .setDefaultValue("2min")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_GC_THRESHOLD_MS =
-      create(Name.MASTER_JOURNAL_GC_THRESHOLD_MS, "5min");
+      new Builder(Name.MASTER_JOURNAL_GC_THRESHOLD_MS)
+          .setDefaultValue("5min")
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS =
-      create(Name.MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS, "30min");
+      new Builder(Name.MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS)
+          .setDefaultValue("30min")
+          .build();
   public static final PropertyKey MASTER_KEYTAB_KEY_FILE =
-      create(Name.MASTER_KEYTAB_KEY_FILE, null);
+      new Builder(Name.MASTER_KEYTAB_KEY_FILE).build();
   public static final PropertyKey MASTER_LINEAGE_CHECKPOINT_CLASS =
-      create(Name.MASTER_LINEAGE_CHECKPOINT_CLASS,
-          "alluxio.master.lineage.checkpoint.CheckpointLatestPlanner");
+      new Builder(Name.MASTER_LINEAGE_CHECKPOINT_CLASS)
+          .setDefaultValue("alluxio.master.lineage.checkpoint.CheckpointLatestPlanner")
+          .build();
   public static final PropertyKey MASTER_LINEAGE_CHECKPOINT_INTERVAL_MS =
-      create(Name.MASTER_LINEAGE_CHECKPOINT_INTERVAL_MS, "5min");
+      new Builder(Name.MASTER_LINEAGE_CHECKPOINT_INTERVAL_MS)
+          .setDefaultValue("5min")
+          .build();
   public static final PropertyKey MASTER_LINEAGE_RECOMPUTE_INTERVAL_MS =
-      create(Name.MASTER_LINEAGE_RECOMPUTE_INTERVAL_MS, "5min");
+      new Builder(Name.MASTER_LINEAGE_RECOMPUTE_INTERVAL_MS)
+          .setDefaultValue("5min")
+          .build();
   public static final PropertyKey MASTER_LINEAGE_RECOMPUTE_LOG_PATH =
-      create(Name.MASTER_LINEAGE_RECOMPUTE_LOG_PATH,
-          String.format("${%s}/recompute.log", Name.LOGS_DIR));
-  public static final PropertyKey MASTER_PRINCIPAL = create(Name.MASTER_PRINCIPAL, null);
+      new Builder(Name.MASTER_LINEAGE_RECOMPUTE_LOG_PATH)
+          .setDefaultValue(String.format("${%s}/recompute.log", Name.LOGS_DIR))
+          .build();
+  public static final PropertyKey MASTER_PRINCIPAL = new Builder(Name.MASTER_PRINCIPAL).build();
   /**
    * @deprecated since version 1.4 and will be removed in version 2.0,
    * use USER_RPC_RETRY_MAX_NUM_RETRY instead.
    */
   @Deprecated
   public static final PropertyKey MASTER_RETRY =
-      create(Name.MASTER_RETRY, String.format("${%s}", Name.USER_RPC_RETRY_MAX_NUM_RETRY));
-  public static final PropertyKey MASTER_RPC_PORT = create(Name.MASTER_RPC_PORT, 19998);
+      new Builder(Name.MASTER_RETRY)
+          .setDefaultValue(String.format("${%s}", Name.USER_RPC_RETRY_MAX_NUM_RETRY))
+          .build();
+  public static final PropertyKey MASTER_RPC_PORT =
+      new Builder(Name.MASTER_RPC_PORT)
+          .setDefaultValue(19998)
+          .build();
   public static final PropertyKey MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
-      create(Name.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, true);
+      new Builder(Name.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
-      create(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS, "MEM");
+      new Builder(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS)
+          .setDefaultValue("MEM")
+          .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS =
-      create(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS, "SSD");
+      new Builder(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS)
+          .setDefaultValue("SSD")
+          .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVEL2_ALIAS =
-      create(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL2_ALIAS, "HDD");
+      new Builder(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL2_ALIAS)
+          .setDefaultValue("HDD")
+          .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVELS =
-      create(Name.MASTER_TIERED_STORE_GLOBAL_LEVELS, 3);
+      new Builder(Name.MASTER_TIERED_STORE_GLOBAL_LEVELS)
+          .setDefaultValue(3)
+          .build();
   public static final PropertyKey MASTER_TTL_CHECKER_INTERVAL_MS =
-      create(Name.MASTER_TTL_CHECKER_INTERVAL_MS, "1hour");
+      new Builder(Name.MASTER_TTL_CHECKER_INTERVAL_MS)
+          .setDefaultValue("1hour")
+          .build();
   public static final PropertyKey MASTER_UFS_PATH_CACHE_CAPACITY =
-      create(Name.MASTER_UFS_PATH_CACHE_CAPACITY, 100000);
+      new Builder(Name.MASTER_UFS_PATH_CACHE_CAPACITY)
+          .setDefaultValue(100000)
+          .build();
   public static final PropertyKey MASTER_UFS_PATH_CACHE_THREADS =
-      create(Name.MASTER_UFS_PATH_CACHE_THREADS, 64);
+      new Builder(Name.MASTER_UFS_PATH_CACHE_THREADS)
+          .setDefaultValue(64)
+          .build();
   public static final PropertyKey MASTER_WEB_BIND_HOST =
-      create(Name.MASTER_WEB_BIND_HOST, "0.0.0.0");
-  public static final PropertyKey MASTER_WEB_HOSTNAME = create(Name.MASTER_WEB_HOSTNAME, null);
-  public static final PropertyKey MASTER_WEB_PORT = create(Name.MASTER_WEB_PORT, 19999);
-  public static final PropertyKey MASTER_WHITELIST = create(Name.MASTER_WHITELIST, "/");
+      new Builder(Name.MASTER_WEB_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
+  public static final PropertyKey MASTER_WEB_HOSTNAME =
+      new Builder(Name.MASTER_WEB_HOSTNAME).build();
+  public static final PropertyKey MASTER_WEB_PORT =
+      new Builder(Name.MASTER_WEB_PORT)
+          .setDefaultValue(19999)
+          .build();
+  public static final PropertyKey MASTER_WHITELIST =
+      new Builder(Name.MASTER_WHITELIST)
+          .setDefaultValue("/")
+          .build();
   public static final PropertyKey MASTER_WORKER_THREADS_MAX =
-      create(Name.MASTER_WORKER_THREADS_MAX, 2048);
+      new Builder(Name.MASTER_WORKER_THREADS_MAX)
+          .setDefaultValue(2048)
+          .build();
   public static final PropertyKey MASTER_WORKER_THREADS_MIN =
-      create(Name.MASTER_WORKER_THREADS_MIN, 512);
+      new Builder(Name.MASTER_WORKER_THREADS_MIN)
+          .setDefaultValue(512)
+          .build();
   public static final PropertyKey MASTER_WORKER_TIMEOUT_MS =
-      create(Name.MASTER_WORKER_TIMEOUT_MS, "5min");
+      new Builder(Name.MASTER_WORKER_TIMEOUT_MS)
+          .setDefaultValue("5min")
+          .build();
 
   //
   // Worker related properties
   //
   public static final PropertyKey WORKER_ALLOCATOR_CLASS =
-      create(Name.WORKER_ALLOCATOR_CLASS, "alluxio.worker.block.allocator.MaxFreeAllocator");
-  public static final PropertyKey WORKER_BIND_HOST = create(Name.WORKER_BIND_HOST, "0.0.0.0");
+      new Builder(Name.WORKER_ALLOCATOR_CLASS)
+          .setDefaultValue("alluxio.worker.block.allocator.MaxFreeAllocator")
+          .build();
+  public static final PropertyKey WORKER_BIND_HOST =
+      new Builder(Name.WORKER_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_INTERVAL_MS =
-      create(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "1sec");
+      new Builder(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)
+          .setDefaultValue("1sec")
+          .build();
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS =
-      create(Name.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS, "5min");
+      new Builder(Name.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS)
+          .setDefaultValue("5min")
+          .build();
   public static final PropertyKey WORKER_BLOCK_THREADS_MAX =
-      create(Name.WORKER_BLOCK_THREADS_MAX, 2048);
+      new Builder(Name.WORKER_BLOCK_THREADS_MAX)
+          .setDefaultValue(2048)
+          .build();
   public static final PropertyKey WORKER_BLOCK_THREADS_MIN =
-      create(Name.WORKER_BLOCK_THREADS_MIN, 256);
+      new Builder(Name.WORKER_BLOCK_THREADS_MIN)
+          .setDefaultValue(256)
+          .build();
   public static final PropertyKey WORKER_DATA_BIND_HOST =
-      create(Name.WORKER_DATA_BIND_HOST, "0.0.0.0");
+      new Builder(Name.WORKER_DATA_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
   public static final PropertyKey WORKER_DATA_FOLDER =
-      create(Name.WORKER_DATA_FOLDER, "/alluxioworker/");
-  public static final PropertyKey WORKER_DATA_HOSTNAME = create(Name.WORKER_DATA_HOSTNAME, null);
-  public static final PropertyKey WORKER_DATA_PORT = create(Name.WORKER_DATA_PORT, 29999);
+      new Builder(Name.WORKER_DATA_FOLDER)
+          .setDefaultValue("/alluxioworker/")
+          .build();
+  public static final PropertyKey WORKER_DATA_HOSTNAME =
+      new Builder(Name.WORKER_DATA_HOSTNAME).build();
+  public static final PropertyKey WORKER_DATA_PORT =
+      new Builder(Name.WORKER_DATA_PORT)
+          .setDefaultValue(29999)
+          .build();
   public static final PropertyKey WORKER_DATA_SERVER_CLASS =
-      create(Name.WORKER_DATA_SERVER_CLASS, "alluxio.worker.netty.NettyDataServer");
+      new Builder(Name.WORKER_DATA_SERVER_CLASS)
+          .setDefaultValue("alluxio.worker.netty.NettyDataServer")
+          .build();
   public static final PropertyKey WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS =
-      create(Name.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS, "");
+      new Builder(Name.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS)
+          .setDefaultValue("")
+          .build();
   public static final PropertyKey WORKER_DATA_TMP_FOLDER =
-      create(Name.WORKER_DATA_TMP_FOLDER, ".tmp_blocks");
+      new Builder(Name.WORKER_DATA_TMP_FOLDER)
+          .setDefaultValue(".tmp_blocks")
+          .build();
   public static final PropertyKey WORKER_DATA_TMP_SUBDIR_MAX =
-      create(Name.WORKER_DATA_TMP_SUBDIR_MAX, 1024);
+      new Builder(Name.WORKER_DATA_TMP_SUBDIR_MAX)
+          .setDefaultValue(1024)
+          .build();
   public static final PropertyKey WORKER_EVICTOR_CLASS =
-      create(Name.WORKER_EVICTOR_CLASS, "alluxio.worker.block.evictor.LRUEvictor");
+      new Builder(Name.WORKER_EVICTOR_CLASS)
+          .setDefaultValue("alluxio.worker.block.evictor.LRUEvictor")
+          .build();
   public static final PropertyKey WORKER_EVICTOR_LRFU_ATTENUATION_FACTOR =
-      create(Name.WORKER_EVICTOR_LRFU_ATTENUATION_FACTOR, 2.0);
+      new Builder(Name.WORKER_EVICTOR_LRFU_ATTENUATION_FACTOR)
+          .setDefaultValue(2.0)
+          .build();
   public static final PropertyKey WORKER_EVICTOR_LRFU_STEP_FACTOR =
-      create(Name.WORKER_EVICTOR_LRFU_STEP_FACTOR, 0.25);
+      new Builder(Name.WORKER_EVICTOR_LRFU_STEP_FACTOR)
+          .setDefaultValue(0.25)
+          .build();
   public static final PropertyKey WORKER_FILE_PERSIST_POOL_SIZE =
-      create(Name.WORKER_FILE_PERSIST_POOL_SIZE, 64);
+      new Builder(Name.WORKER_FILE_PERSIST_POOL_SIZE)
+          .setDefaultValue(64)
+          .build();
   public static final PropertyKey WORKER_FILE_PERSIST_RATE_LIMIT =
-      create(Name.WORKER_FILE_PERSIST_RATE_LIMIT, "2GB");
+      new Builder(Name.WORKER_FILE_PERSIST_RATE_LIMIT)
+          .setDefaultValue("2GB")
+          .build();
   public static final PropertyKey WORKER_FILE_PERSIST_RATE_LIMIT_ENABLED =
-      create(Name.WORKER_FILE_PERSIST_RATE_LIMIT_ENABLED, false);
+      new Builder(Name.WORKER_FILE_PERSIST_RATE_LIMIT_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey WORKER_FILE_BUFFER_SIZE =
-      create(Name.WORKER_FILE_BUFFER_SIZE, "1MB");
+      new Builder(Name.WORKER_FILE_BUFFER_SIZE)
+          .setDefaultValue("1MB")
+          .build();
   public static final PropertyKey WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS =
-      create(Name.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS, "1sec");
-  public static final PropertyKey WORKER_HOSTNAME = create(Name.WORKER_HOSTNAME, null);
-  public static final PropertyKey WORKER_KEYTAB_FILE = create(Name.WORKER_KEYTAB_FILE, null);
-  public static final PropertyKey WORKER_MEMORY_SIZE = create(Name.WORKER_MEMORY_SIZE, "1GB");
+      new Builder(Name.WORKER_FILESYSTEM_HEARTBEAT_INTERVAL_MS)
+          .setDefaultValue("1sec")
+          .build();
+  public static final PropertyKey WORKER_HOSTNAME = new Builder(Name.WORKER_HOSTNAME).build();
+  public static final PropertyKey WORKER_KEYTAB_FILE = new Builder(Name.WORKER_KEYTAB_FILE).build();
+  public static final PropertyKey WORKER_MEMORY_SIZE =
+      new Builder(Name.WORKER_MEMORY_SIZE)
+          .setDefaultValue("1GB")
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BACKLOG =
-      create(Name.WORKER_NETWORK_NETTY_BACKLOG, null);
+      new Builder(Name.WORKER_NETWORK_NETTY_BACKLOG).build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BOSS_THREADS =
-      create(Name.WORKER_NETWORK_NETTY_BOSS_THREADS, 1);
+      new Builder(Name.WORKER_NETWORK_NETTY_BOSS_THREADS)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BUFFER_RECEIVE =
-      create(Name.WORKER_NETWORK_NETTY_BUFFER_RECEIVE, null);
+      new Builder(Name.WORKER_NETWORK_NETTY_BUFFER_RECEIVE).build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BUFFER_SEND =
-      create(Name.WORKER_NETWORK_NETTY_BUFFER_SEND, null);
+      new Builder(Name.WORKER_NETWORK_NETTY_BUFFER_SEND).build();
   public static final PropertyKey WORKER_NETWORK_NETTY_CHANNEL =
-      create(Name.WORKER_NETWORK_NETTY_CHANNEL, null);
+      new Builder(Name.WORKER_NETWORK_NETTY_CHANNEL).build();
   public static final PropertyKey WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE =
-      create(Name.WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE, "MAPPED");
+      new Builder(Name.WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE)
+          .setDefaultValue("MAPPED")
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD =
-      create(Name.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD, 2);
+      new Builder(Name.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD)
+          .setDefaultValue(2)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT =
-      create(Name.WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT, 15);
+      new Builder(Name.WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT)
+          .setDefaultValue(15)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_WATERMARK_HIGH =
-      create(Name.WORKER_NETWORK_NETTY_WATERMARK_HIGH, "32KB");
+      new Builder(Name.WORKER_NETWORK_NETTY_WATERMARK_HIGH)
+          .setDefaultValue("32KB")
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_WATERMARK_LOW =
-      create(Name.WORKER_NETWORK_NETTY_WATERMARK_LOW, "8KB");
+      new Builder(Name.WORKER_NETWORK_NETTY_WATERMARK_LOW)
+          .setDefaultValue("8KB")
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_WORKER_THREADS =
-      create(Name.WORKER_NETWORK_NETTY_WORKER_THREADS, 0);
+      new Builder(Name.WORKER_NETWORK_NETTY_WORKER_THREADS)
+          .setDefaultValue(0)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS =
-      create(Name.WORKER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS, 16);
+      new Builder(Name.WORKER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS)
+          .setDefaultValue(16)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS =
-      create(Name.WORKER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS, 16);
+      new Builder(Name.WORKER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS)
+          .setDefaultValue(16)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX =
-      create(Name.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX, 2048);
+      new Builder(Name.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX)
+          .setDefaultValue(2048)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX =
-      create(Name.WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX, 1024);
+      new Builder(Name.WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX)
+          .setDefaultValue(1024)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_FILE_READER_THREADS_MAX =
-      create(Name.WORKER_NETWORK_NETTY_FILE_READER_THREADS_MAX, 128);
+      new Builder(Name.WORKER_NETWORK_NETTY_FILE_READER_THREADS_MAX)
+          .setDefaultValue(128)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX =
-      create(Name.WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX, 1024);
+      new Builder(Name.WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX)
+          .setDefaultValue(1024)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_RPC_THREADS_MAX =
-      create(Name.WORKER_NETWORK_NETTY_RPC_THREADS_MAX, 2048);
+      new Builder(Name.WORKER_NETWORK_NETTY_RPC_THREADS_MAX)
+          .setDefaultValue(2048)
+          .build();
   // The default is set to 11. One client is reserved for some light weight operations such as
   // heartbeat. The other 10 clients are used by commitBlock issued from the worker to the block
   // master.
   public static final PropertyKey WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =
-      create(Name.WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE, 11);
+      new Builder(Name.WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE)
+          .setDefaultValue(11)
+          .build();
 
-  public static final PropertyKey WORKER_PRINCIPAL = create(Name.WORKER_PRINCIPAL, null);
-  public static final PropertyKey WORKER_RPC_PORT = create(Name.WORKER_RPC_PORT, 29998);
+  public static final PropertyKey WORKER_PRINCIPAL = new Builder(Name.WORKER_PRINCIPAL).build();
+  public static final PropertyKey WORKER_RPC_PORT =
+      new Builder(Name.WORKER_RPC_PORT)
+          .setDefaultValue(29998)
+          .build();
   public static final PropertyKey WORKER_SESSION_TIMEOUT_MS =
-      create(Name.WORKER_SESSION_TIMEOUT_MS, "1min");
+      new Builder(Name.WORKER_SESSION_TIMEOUT_MS)
+          .setDefaultValue("1min")
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_BLOCK_LOCK_READERS =
-      create(Name.WORKER_TIERED_STORE_BLOCK_LOCK_READERS, 1000);
+      new Builder(Name.WORKER_TIERED_STORE_BLOCK_LOCK_READERS)
+          .setDefaultValue(1000)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_BLOCK_LOCKS =
-      create(Name.WORKER_TIERED_STORE_BLOCK_LOCKS, 1000);
+      new Builder(Name.WORKER_TIERED_STORE_BLOCK_LOCKS)
+          .setDefaultValue(1000)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_ALIAS =
-      create(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, "MEM", 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, 0)
+          .setDefaultValue("MEM")
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_DIRS_PATH =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, "/mnt/ramdisk", 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, 0)
+          .setDefaultValue("/mnt/ramdisk")
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_DIRS_QUOTA =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, "${alluxio.worker.memory.size}", 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, 0)
+          .setDefaultValue("${alluxio.worker.memory.size}")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    * Use {@link #WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO} and
@@ -400,17 +767,21 @@ public class PropertyKey {
    */
   @Deprecated
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_RESERVED_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, null, 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 0).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 1.0, 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 0)
+          .setDefaultValue(1.0)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_LOW_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 0.7, 0);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 0)
+          .setDefaultValue(0.7)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_ALIAS =
-      create(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, null, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, 1).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_DIRS_PATH =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, null, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, 1).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_DIRS_QUOTA =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, null, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, 1).build();
   /**
    * @deprecated It will be removed in 2.0.0.
    * Use {@link #WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO} and
@@ -418,17 +789,21 @@ public class PropertyKey {
    */
   @Deprecated
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_RESERVED_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, null, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 1).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 1.0, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 1)
+          .setDefaultValue(1.0)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_LOW_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 0.7, 1);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 1)
+          .setDefaultValue(0.7)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_ALIAS =
-      create(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, null, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_ALIAS, 2).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_DIRS_PATH =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, null, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH, 2).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_DIRS_QUOTA =
-      create(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, null, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, 2).build();
   /**
    * @deprecated It will be removed in 2.0.0.
    * Use {@link #WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO} and
@@ -436,259 +811,458 @@ public class PropertyKey {
    */
   @Deprecated
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_RESERVED_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, null, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 2).build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 1.0, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 2)
+          .setDefaultValue(1.0)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_LOW_WATERMARK_RATIO =
-      create(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 0.7, 2);
+      new Builder(Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO, 2)
+          .setDefaultValue(0.7)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVELS =
-      create(Name.WORKER_TIERED_STORE_LEVELS, 1);
+      new Builder(Name.WORKER_TIERED_STORE_LEVELS)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_RESERVER_ENABLED =
-      create(Name.WORKER_TIERED_STORE_RESERVER_ENABLED, false);
+      new Builder(Name.WORKER_TIERED_STORE_RESERVER_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_RESERVER_INTERVAL_MS =
-      create(Name.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "1sec");
+      new Builder(Name.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS)
+          .setDefaultValue("1sec")
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_RETRY =
-      create(Name.WORKER_TIERED_STORE_RETRY, 3);
+      new Builder(Name.WORKER_TIERED_STORE_RETRY)
+          .setDefaultValue(3)
+          .build();
   public static final PropertyKey WORKER_TIERED_STORE_FREE_SPACE_RATIO =
-      create(Name.WORKER_TIERED_STORE_FREE_SPACE_RATIO, 0.0f);
+      new Builder(Name.WORKER_TIERED_STORE_FREE_SPACE_RATIO)
+          .setDefaultValue(0.0f)
+          .build();
   public static final PropertyKey WORKER_WEB_BIND_HOST =
-      create(Name.WORKER_WEB_BIND_HOST, "0.0.0.0");
-  public static final PropertyKey WORKER_WEB_HOSTNAME = create(Name.WORKER_WEB_HOSTNAME, null);
-  public static final PropertyKey WORKER_WEB_PORT = create(Name.WORKER_WEB_PORT, 30000);
+      new Builder(Name.WORKER_WEB_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
+  public static final PropertyKey WORKER_WEB_HOSTNAME =
+      new Builder(Name.WORKER_WEB_HOSTNAME).build();
+  public static final PropertyKey WORKER_WEB_PORT =
+      new Builder(Name.WORKER_WEB_PORT)
+          .setDefaultValue(30000)
+          .build();
   public static final PropertyKey WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS =
-      create(Name.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS, "5min");
+      new Builder(Name.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS)
+          .setDefaultValue("5min")
+          .build();
 
   //
   // Proxy related properties
   //
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
-      create(Name.PROXY_STREAM_CACHE_TIMEOUT_MS, "1hour");
-  public static final PropertyKey PROXY_WEB_BIND_HOST = create(Name.PROXY_WEB_BIND_HOST, "0.0.0.0");
-  public static final PropertyKey PROXY_WEB_HOSTNAME = create(Name.PROXY_WEB_HOSTNAME, null);
-  public static final PropertyKey PROXY_WEB_PORT = create(Name.PROXY_WEB_PORT, 39999);
+      new Builder(Name.PROXY_STREAM_CACHE_TIMEOUT_MS)
+          .setDefaultValue("1hour")
+          .build();
+  public static final PropertyKey PROXY_WEB_BIND_HOST =
+      new Builder(Name.PROXY_WEB_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .build();
+  public static final PropertyKey PROXY_WEB_HOSTNAME =
+      new Builder(Name.PROXY_WEB_HOSTNAME).build();
+  public static final PropertyKey PROXY_WEB_PORT =
+      new Builder(Name.PROXY_WEB_PORT)
+          .setDefaultValue(39999)
+          .build();
 
   //
   // User related properties
   //
   public static final PropertyKey USER_BLOCK_MASTER_CLIENT_THREADS =
-      create(Name.USER_BLOCK_MASTER_CLIENT_THREADS, 10);
+      new Builder(Name.USER_BLOCK_MASTER_CLIENT_THREADS)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES =
-      create(Name.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "8MB");
+      new Builder(Name.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES)
+          .setDefaultValue("8MB")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_BLOCK_REMOTE_READER_CLASS =
-      create(Name.USER_BLOCK_REMOTE_READER_CLASS, "alluxio.client.netty.NettyRemoteBlockReader");
+      new Builder(Name.USER_BLOCK_REMOTE_READER_CLASS)
+          .setDefaultValue("alluxio.client.netty.NettyRemoteBlockReader")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_BLOCK_REMOTE_WRITER_CLASS =
-      create(Name.USER_BLOCK_REMOTE_WRITER_CLASS, "alluxio.client.netty.NettyRemoteBlockWriter");
+      new Builder(Name.USER_BLOCK_REMOTE_WRITER_CLASS)
+          .setDefaultValue("alluxio.client.netty.NettyRemoteBlockWriter")
+          .build();
   public static final PropertyKey USER_BLOCK_SIZE_BYTES_DEFAULT =
-      create(Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "512MB");
+      new Builder(Name.USER_BLOCK_SIZE_BYTES_DEFAULT)
+          .setDefaultValue("512MB")
+          .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_THREADS =
-      create(Name.USER_BLOCK_WORKER_CLIENT_THREADS, 10);
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_THREADS)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_SIZE_MAX =
-      create(Name.USER_BLOCK_WORKER_CLIENT_POOL_SIZE_MAX, 128);
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_SIZE_MAX)
+          .setDefaultValue(128)
+          .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
-      create(Name.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS, 300 * Constants.SECOND_MS);
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS)
+          .setDefaultValue(300 * Constants.SECOND_MS)
+          .build();
   public static final PropertyKey USER_DATE_FORMAT_PATTERN =
-      create(Name.USER_DATE_FORMAT_PATTERN, "MM-dd-yyyy HH:mm:ss:SSS");
+      new Builder(Name.USER_DATE_FORMAT_PATTERN)
+          .setDefaultValue("MM-dd-yyyy HH:mm:ss:SSS")
+          .build();
   public static final PropertyKey USER_FAILED_SPACE_REQUEST_LIMITS =
-      create(Name.USER_FAILED_SPACE_REQUEST_LIMITS, 3);
+      new Builder(Name.USER_FAILED_SPACE_REQUEST_LIMITS)
+          .setDefaultValue(3)
+          .build();
   public static final PropertyKey USER_FILE_BUFFER_BYTES =
-      create(Name.USER_FILE_BUFFER_BYTES, "8MB");
+      new Builder(Name.USER_FILE_BUFFER_BYTES)
+          .setDefaultValue("8MB")
+          .build();
   public static final PropertyKey USER_FILE_CACHE_PARTIALLY_READ_BLOCK =
-      create(Name.USER_FILE_CACHE_PARTIALLY_READ_BLOCK, true);
+      new Builder(Name.USER_FILE_CACHE_PARTIALLY_READ_BLOCK)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey USER_FILE_COPY_FROM_LOCAL_WRITE_LOCATION_POLICY =
-      create(Name.USER_FILE_COPY_FROM_LOCAL_WRITE_LOCATION_POLICY,
-          "alluxio.client.file.policy.RoundRobinPolicy");
+      new Builder(Name.USER_FILE_COPY_FROM_LOCAL_WRITE_LOCATION_POLICY)
+          .setDefaultValue("alluxio.client.file.policy.RoundRobinPolicy")
+          .build();
   public static final PropertyKey USER_FILE_DELETE_UNCHECKED =
-      create(Name.USER_FILE_DELETE_UNCHECKED, false);
+      new Builder(Name.USER_FILE_DELETE_UNCHECKED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey USER_FILE_MASTER_CLIENT_THREADS =
-      create(Name.USER_FILE_MASTER_CLIENT_THREADS, 10);
+      new Builder(Name.USER_FILE_MASTER_CLIENT_THREADS)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey USER_FILE_METADATA_LOAD_TYPE =
-      create(Name.USER_FILE_METADATA_LOAD_TYPE, "Once");
+      new Builder(Name.USER_FILE_METADATA_LOAD_TYPE)
+          .setDefaultValue("Once")
+          .build();
   public static final PropertyKey USER_FILE_PASSIVE_CACHE_ENABLED =
-      create(Name.USER_FILE_PASSIVE_CACHE_ENABLED, true);
+      new Builder(Name.USER_FILE_PASSIVE_CACHE_ENABLED)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey USER_FILE_READ_TYPE_DEFAULT =
-      create(Name.USER_FILE_READ_TYPE_DEFAULT, "CACHE_PROMOTE");
+      new Builder(Name.USER_FILE_READ_TYPE_DEFAULT)
+          .setDefaultValue("CACHE_PROMOTE")
+          .build();
   public static final PropertyKey USER_FILE_SEEK_BUFFER_SIZE_BYTES =
-      create(Name.USER_FILE_SEEK_BUFFER_SIZE_BYTES, "1MB");
+      new Builder(Name.USER_FILE_SEEK_BUFFER_SIZE_BYTES)
+          .setDefaultValue("1MB")
+          .build();
   public static final PropertyKey USER_FILE_WAITCOMPLETED_POLL_MS =
-      create(Name.USER_FILE_WAITCOMPLETED_POLL_MS, "1sec");
+      new Builder(Name.USER_FILE_WAITCOMPLETED_POLL_MS)
+          .setDefaultValue("1sec")
+          .build();
   public static final PropertyKey USER_FILE_WORKER_CLIENT_THREADS =
-      create(Name.USER_FILE_WORKER_CLIENT_THREADS, 10);
+      new Builder(Name.USER_FILE_WORKER_CLIENT_THREADS)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey USER_FILE_WORKER_CLIENT_POOL_SIZE_MAX =
-      create(Name.USER_FILE_WORKER_CLIENT_POOL_SIZE_MAX, 128);
+      new Builder(Name.USER_FILE_WORKER_CLIENT_POOL_SIZE_MAX)
+          .setDefaultValue(128)
+          .build();
   public static final PropertyKey USER_FILE_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
-      create(Name.USER_FILE_WORKER_CLIENT_POOL_GC_THRESHOLD_MS, 300 * Constants.SECOND_MS);
+      new Builder(Name.USER_FILE_WORKER_CLIENT_POOL_GC_THRESHOLD_MS)
+          .setDefaultValue(300 * Constants.SECOND_MS)
+          .build();
   public static final PropertyKey USER_FILE_WRITE_LOCATION_POLICY =
-      create(Name.USER_FILE_WRITE_LOCATION_POLICY, "alluxio.client.file.policy.LocalFirstPolicy");
+      new Builder(Name.USER_FILE_WRITE_LOCATION_POLICY)
+          .setDefaultValue("alluxio.client.file.policy.LocalFirstPolicy")
+          .build();
   public static final PropertyKey USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES =
-      create(Name.USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES, "0MB");
+      new Builder(Name.USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES)
+          .setDefaultValue("0MB")
+          .build();
   public static final PropertyKey USER_FILE_WRITE_TYPE_DEFAULT =
-      create(Name.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+      new Builder(Name.USER_FILE_WRITE_TYPE_DEFAULT)
+          .setDefaultValue("MUST_CACHE")
+          .build();
   public static final PropertyKey USER_FILE_WRITE_TIER_DEFAULT =
-      create(Name.USER_FILE_WRITE_TIER_DEFAULT, Constants.FIRST_TIER);
+      new Builder(Name.USER_FILE_WRITE_TIER_DEFAULT)
+          .setDefaultValue(Constants.FIRST_TIER)
+          .build();
   public static final PropertyKey USER_HEARTBEAT_INTERVAL_MS =
-      create(Name.USER_HEARTBEAT_INTERVAL_MS, "1sec");
-  public static final PropertyKey USER_HOSTNAME = create(Name.USER_HOSTNAME, null);
-  public static final PropertyKey USER_LINEAGE_ENABLED = create(Name.USER_LINEAGE_ENABLED, false);
+      new Builder(Name.USER_HEARTBEAT_INTERVAL_MS)
+          .setDefaultValue("1sec")
+          .build();
+  public static final PropertyKey USER_HOSTNAME = new Builder(Name.USER_HOSTNAME).build();
+  public static final PropertyKey USER_LINEAGE_ENABLED =
+      new Builder(Name.USER_LINEAGE_ENABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey USER_LINEAGE_MASTER_CLIENT_THREADS =
-      create(Name.USER_LINEAGE_MASTER_CLIENT_THREADS, 10);
+      new Builder(Name.USER_LINEAGE_MASTER_CLIENT_THREADS)
+          .setDefaultValue(10)
+          .build();
   public static final PropertyKey USER_LOCAL_READER_PACKET_SIZE_BYTES =
-      create(Name.USER_LOCAL_READER_PACKET_SIZE_BYTES, "8MB");
+      new Builder(Name.USER_LOCAL_READER_PACKET_SIZE_BYTES)
+          .setDefaultValue("8MB")
+          .build();
   public static final PropertyKey USER_LOCAL_WRITER_PACKET_SIZE_BYTES =
-      create(Name.USER_LOCAL_WRITER_PACKET_SIZE_BYTES, "64KB");
+      new Builder(Name.USER_LOCAL_WRITER_PACKET_SIZE_BYTES)
+          .setDefaultValue("64KB")
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL =
-      create(Name.USER_NETWORK_NETTY_CHANNEL, null);
+      new Builder(Name.USER_NETWORK_NETTY_CHANNEL).build();
   public static final PropertyKey USER_NETWORK_NETTY_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_TIMEOUT_MS, 30000);
+      new Builder(Name.USER_NETWORK_NETTY_TIMEOUT_MS)
+          .setDefaultValue(30000)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_WORKER_THREADS =
-      create(Name.USER_NETWORK_NETTY_WORKER_THREADS, 0);
+      new Builder(Name.USER_NETWORK_NETTY_WORKER_THREADS)
+          .setDefaultValue(0)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX =
-      create(Name.USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX, 1024);
+      new Builder(Name.USER_NETWORK_NETTY_CHANNEL_POOL_SIZE_MAX)
+          .setDefaultValue(1024)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS =
-      create(Name.USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS, 300 * Constants.SECOND_MS);
+      new Builder(Name.USER_NETWORK_NETTY_CHANNEL_POOL_GC_THRESHOLD_MS)
+          .setDefaultValue(300 * Constants.SECOND_MS)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED =
-      create(Name.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED, false);
+      new Builder(Name.USER_NETWORK_NETTY_CHANNEL_POOL_DISABLED)
+          .setDefaultValue(false)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_PACKET_SIZE_BYTES =
-      create(Name.USER_NETWORK_NETTY_WRITER_PACKET_SIZE_BYTES, "64KB");
+      new Builder(Name.USER_NETWORK_NETTY_WRITER_PACKET_SIZE_BYTES)
+          .setDefaultValue("64KB")
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS =
-      create(Name.USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS, 16);
+      new Builder(Name.USER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS)
+          .setDefaultValue(16)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS =
-      create(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS, 300000);
+      new Builder(Name.USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS)
+          .setDefaultValue(300000)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS =
-      create(Name.USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS, 16);
+      new Builder(Name.USER_NETWORK_NETTY_READER_BUFFER_SIZE_PACKETS)
+          .setDefaultValue(16)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_READER_CANCEL_ENABLED =
-      create(Name.USER_NETWORK_NETTY_READER_CANCEL_ENABLED, true);
+      new Builder(Name.USER_NETWORK_NETTY_READER_CANCEL_ENABLED)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey USER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES =
-      create(Name.USER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES, "64KB");
-
+      new Builder(Name.USER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES)
+          .setDefaultValue("64KB")
+          .build();
   public static final PropertyKey USER_RPC_RETRY_BASE_SLEEP_MS =
-      create(Name.USER_RPC_RETRY_BASE_SLEEP_MS, 50);
+      new Builder(Name.USER_RPC_RETRY_BASE_SLEEP_MS)
+          .setDefaultValue(50)
+          .build();
   public static final PropertyKey USER_RPC_RETRY_MAX_NUM_RETRY =
-      create(Name.USER_RPC_RETRY_MAX_NUM_RETRY, 20);
+      new Builder(Name.USER_RPC_RETRY_MAX_NUM_RETRY)
+          .setDefaultValue(20)
+          .build();
   public static final PropertyKey USER_RPC_RETRY_MAX_SLEEP_MS =
-      create(Name.USER_RPC_RETRY_MAX_SLEEP_MS, "30sec");
+      new Builder(Name.USER_RPC_RETRY_MAX_SLEEP_MS)
+          .setDefaultValue("30sec")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_UFS_DELEGATION_ENABLED =
-      create(Name.USER_UFS_DELEGATION_ENABLED, true);
+      new Builder(Name.USER_UFS_DELEGATION_ENABLED)
+          .setDefaultValue(true)
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
-      create(Name.USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES, "8MB");
+      new Builder(Name.USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES)
+          .setDefaultValue("8MB")
+          .build();
   public static final PropertyKey USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES =
-      create(Name.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES, "2MB");
+      new Builder(Name.USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES)
+          .setDefaultValue("2MB")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_UFS_FILE_READER_CLASS =
-      create(Name.USER_UFS_FILE_READER_CLASS,
-          "alluxio.client.netty.NettyUnderFileSystemFileReader");
+      new Builder(Name.USER_UFS_FILE_READER_CLASS)
+          .setDefaultValue("alluxio.client.netty.NettyUnderFileSystemFileReader")
+          .build();
   /**
    * @deprecated It will be removed in 2.0.0.
    */
   @Deprecated
   public static final PropertyKey USER_UFS_FILE_WRITER_CLASS =
-      create(Name.USER_UFS_FILE_WRITER_CLASS,
-          "alluxio.client.netty.NettyUnderFileSystemFileWriter");
+      new Builder(Name.USER_UFS_FILE_WRITER_CLASS)
+          .setDefaultValue("alluxio.client.netty.NettyUnderFileSystemFileWriter")
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY =
-      create(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY,
-          "alluxio.client.file.policy.LocalFirstPolicy");
+      new Builder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY)
+          .setDefaultValue("alluxio.client.file.policy.LocalFirstPolicy")
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS =
-      create(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS, 1);
+      new Builder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_READ_CONCURRENCY_MAX =
-      create(Name.USER_UFS_BLOCK_READ_CONCURRENCY_MAX, Integer.MAX_VALUE);
+      new Builder(Name.USER_UFS_BLOCK_READ_CONCURRENCY_MAX)
+          .setDefaultValue(Integer.MAX_VALUE)
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_OPEN_TIMEOUT_MS =
-      create(Name.USER_UFS_BLOCK_OPEN_TIMEOUT_MS, 300000);
+      new Builder(Name.USER_UFS_BLOCK_OPEN_TIMEOUT_MS)
+          .setDefaultValue(300000)
+          .build();
   public static final PropertyKey USER_SHORT_CIRCUIT_ENABLED =
-      create(Name.USER_SHORT_CIRCUIT_ENABLED, true);
+      new Builder(Name.USER_SHORT_CIRCUIT_ENABLED)
+          .setDefaultValue(true)
+          .build();
 
   //
   // FUSE integration related properties
   //
   /** Maximum number of Alluxio paths to cache for fuse conversion. */
-  public static final PropertyKey FUSE_CACHED_PATHS_MAX = create(Name.FUSE_CACHED_PATHS_MAX, 500);
+  public static final PropertyKey FUSE_CACHED_PATHS_MAX =
+      new Builder(Name.FUSE_CACHED_PATHS_MAX)
+          .setDefaultValue(500)
+          .build();
   /** Have the fuse process log every FS request. */
-  public static final PropertyKey FUSE_DEBUG_ENABLED = create(Name.FUSE_DEBUG_ENABLED, false);
+  public static final PropertyKey FUSE_DEBUG_ENABLED =
+      new Builder(Name.FUSE_DEBUG_ENABLED)
+          .setDefaultValue(false)
+          .build();
 
   /** FUSE file system name. */
-  public static final PropertyKey FUSE_FS_NAME = create(Name.FUSE_FS_NAME, "alluxio-fuse");
-  public static final PropertyKey FUSE_FS_ROOT = create(Name.FUSE_FS_ROOT, "/");
+  public static final PropertyKey FUSE_FS_NAME =
+      new Builder(Name.FUSE_FS_NAME)
+          .setDefaultValue("alluxio-fuse")
+          .build();
+  public static final PropertyKey FUSE_FS_ROOT =
+      new Builder(Name.FUSE_FS_ROOT)
+          .setDefaultValue("/")
+          .build();
   /**
    * Passed to fuse-mount, maximum granularity of write operations:
    * Capped by the kernel to 128KB max (as of Linux 3.16.0),.
    */
-  public static final PropertyKey FUSE_MAXWRITE_BYTES = create(Name.FUSE_MAXWRITE_BYTES, 131072);
+  public static final PropertyKey FUSE_MAXWRITE_BYTES =
+      new Builder(Name.FUSE_MAXWRITE_BYTES)
+          .setDefaultValue(131072)
+          .build();
   public static final PropertyKey FUSE_MOUNT_DEFAULT =
-      create(Name.FUSE_MOUNT_DEFAULT, "/mnt/alluxio");
+      new Builder(Name.FUSE_MOUNT_DEFAULT)
+          .setDefaultValue("/mnt/alluxio")
+          .build();
 
   //
   // Security related properties
   //
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS =
-      create(Name.SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS, null);
+      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS).build();
   public static final PropertyKey SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS =
-      create(Name.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS, "10min");
+      new Builder(Name.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS)
+          .setDefaultValue("10min")
+          .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_TYPE =
-      create(Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE");
+      new Builder(Name.SECURITY_AUTHENTICATION_TYPE)
+          .setDefaultValue("SIMPLE")
+          .build();
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_ENABLED =
-      create(Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
+      new Builder(Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED)
+          .setDefaultValue(true)
+          .build();
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP =
-      create(Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "supergroup");
+      new Builder(Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP)
+          .setDefaultValue("supergroup")
+          .build();
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_UMASK =
-      create(Name.SECURITY_AUTHORIZATION_PERMISSION_UMASK, "022");
+      new Builder(Name.SECURITY_AUTHORIZATION_PERMISSION_UMASK)
+          .setDefaultValue("022")
+          .build();
   public static final PropertyKey SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS =
-      create(Name.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS, "1min");
+      new Builder(Name.SECURITY_GROUP_MAPPING_CACHE_TIMEOUT_MS)
+          .setDefaultValue("1min")
+          .build();
   public static final PropertyKey SECURITY_GROUP_MAPPING_CLASS =
-      create(Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.ShellBasedUnixGroupsMapping");
+      new Builder(Name.SECURITY_GROUP_MAPPING_CLASS)
+          .setDefaultValue("alluxio.security.group.provider.ShellBasedUnixGroupsMapping")
+          .build();
   public static final PropertyKey SECURITY_LOGIN_USERNAME =
-      create(Name.SECURITY_LOGIN_USERNAME, null);
+      new Builder(Name.SECURITY_LOGIN_USERNAME).build();
 
   //
   // Mesos and Yarn related properties
   //
   public static final PropertyKey INTEGRATION_MASTER_RESOURCE_CPU =
-      create(Name.INTEGRATION_MASTER_RESOURCE_CPU, 1);
+      new Builder(Name.INTEGRATION_MASTER_RESOURCE_CPU)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey INTEGRATION_MASTER_RESOURCE_MEM =
-      create(Name.INTEGRATION_MASTER_RESOURCE_MEM, "1024MB");
+      new Builder(Name.INTEGRATION_MASTER_RESOURCE_MEM)
+          .setDefaultValue("1024MB")
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_ALLUXIO_JAR_URL =
-      create(Name.INTEGRATION_MESOS_ALLUXIO_JAR_URL, String.format(
-          "http://downloads.alluxio.org/downloads/files/${%s}/" + "alluxio-${%s}-bin.tar.gz",
-          Name.VERSION, Name.VERSION));
+      new Builder(Name.INTEGRATION_MESOS_ALLUXIO_JAR_URL)
+          .setDefaultValue(String.format(
+              "http://downloads.alluxio.org/downloads/files/${%s}/alluxio-${%s}-bin.tar.gz",
+              Name.VERSION, Name.VERSION))
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_ALLUXIO_MASTER_NAME =
-      create(Name.INTEGRATION_MESOS_ALLUXIO_MASTER_NAME, "AlluxioMaster");
+      new Builder(Name.INTEGRATION_MESOS_ALLUXIO_MASTER_NAME)
+          .setDefaultValue("AlluxioMaster")
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_ALLUXIO_MASTER_NODE_COUNT =
-      create(Name.INTEGRATION_MESOS_ALLUXIO_MASTER_NODE_COUNT, 1);
+      new Builder(Name.INTEGRATION_MESOS_ALLUXIO_MASTER_NODE_COUNT)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_ALLUXIO_WORKER_NAME =
-      create(Name.INTEGRATION_MESOS_ALLUXIO_WORKER_NAME, "AlluxioWorker");
+      new Builder(Name.INTEGRATION_MESOS_ALLUXIO_WORKER_NAME)
+          .setDefaultValue("AlluxioWorker")
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_JDK_PATH =
-      create(Name.INTEGRATION_MESOS_JDK_PATH, "jdk1.7.0_79");
-  public static final PropertyKey INTEGRATION_MESOS_JDK_URL = create(Name.INTEGRATION_MESOS_JDK_URL,
-      "https://alluxio-mesos.s3.amazonaws.com/jdk-7u79-linux-x64.tar.gz");
+      new Builder(Name.INTEGRATION_MESOS_JDK_PATH)
+          .setDefaultValue("jdk1.7.0_79")
+          .build();
+  public static final PropertyKey INTEGRATION_MESOS_JDK_URL =
+      new Builder(Name.INTEGRATION_MESOS_JDK_URL)
+          .setDefaultValue("https://alluxio-mesos.s3.amazonaws.com/jdk-7u79-linux-x64.tar.gz")
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_PRINCIPAL =
-      create(Name.INTEGRATION_MESOS_PRINCIPAL, "alluxio");
-  public static final PropertyKey INTEGRATION_MESOS_ROLE = create(Name.INTEGRATION_MESOS_ROLE, "*");
+      new Builder(Name.INTEGRATION_MESOS_PRINCIPAL)
+          .setDefaultValue("alluxio")
+          .build();
+  public static final PropertyKey INTEGRATION_MESOS_ROLE =
+      new Builder(Name.INTEGRATION_MESOS_ROLE)
+          .setDefaultValue("*")
+          .build();
   public static final PropertyKey INTEGRATION_MESOS_SECRET =
-      create(Name.INTEGRATION_MESOS_SECRET, null);
-  public static final PropertyKey INTEGRATION_MESOS_USER = create(Name.INTEGRATION_MESOS_USER, "");
+      new Builder(Name.INTEGRATION_MESOS_SECRET).build();
+  public static final PropertyKey INTEGRATION_MESOS_USER =
+      new Builder(Name.INTEGRATION_MESOS_USER)
+          .setDefaultValue("")
+          .build();
   public static final PropertyKey INTEGRATION_WORKER_RESOURCE_CPU =
-      create(Name.INTEGRATION_WORKER_RESOURCE_CPU, 1);
+      new Builder(Name.INTEGRATION_WORKER_RESOURCE_CPU)
+          .setDefaultValue(1)
+          .build();
   public static final PropertyKey INTEGRATION_WORKER_RESOURCE_MEM =
-      create(Name.INTEGRATION_WORKER_RESOURCE_MEM, "1024MB");
+      new Builder(Name.INTEGRATION_WORKER_RESOURCE_MEM)
+          .setDefaultValue("1024MB")
+          .build();
   public static final PropertyKey INTEGRATION_YARN_WORKERS_PER_HOST_MAX =
-      create(Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX, 1);
+      new Builder(Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX)
+          .setDefaultValue(1)
+          .build();
 
   /**
    * A nested class to hold named string constants for their corresponding properties.
@@ -1282,32 +1856,6 @@ public class PropertyKey {
   }
 
   /**
-   * Factory method to create a constant default property and assign a default value.
-   *
-   * @param name String of this property
-   * @param defaultValue Default value of this property in compile time if not null
-   */
-  static PropertyKey create(String name, Object defaultValue) {
-    PropertyKey key = new PropertyKey(name);
-    DEFAULT_KEYS_MAP.put(name, key);
-    DEFAULT_VALUES.put(key, defaultValue);
-    return key;
-  }
-
-  /**
-   * Factory method to create a property from template and assign a default value.
-   *
-   * @param template String of this property
-   * @param defaultValue Default value of this property in compile time if not null
-   */
-  static PropertyKey create(Template template, Object defaultValue, Object... param) {
-    PropertyKey key = template.format(param);
-    DEFAULT_KEYS_MAP.put(key.toString(), key);
-    DEFAULT_VALUES.put(key, defaultValue);
-    return key;
-  }
-
-  /**
    * Factory method to create a constant default property
    * and assign a default value together with its alias.
    *
@@ -1316,7 +1864,9 @@ public class PropertyKey {
    * @param aliases String list of aliases of this property
    */
   static PropertyKey create(String name, Object defaultValue, String[] aliases) {
-    PropertyKey key = create(name, defaultValue);
+    PropertyKey key = new PropertyKey(name);
+    DEFAULT_KEYS_MAP.put(name, key);
+    DEFAULT_VALUES.put(key, defaultValue);
     if (aliases != null) {
       for (String alias : aliases) {
         DEFAULT_KEYS_MAP.put(alias, key);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2909

The purpose of this change is to enable more attributes of `PropertyKey` in the future, e.g., source (default, site-properties, system properties and etc), whether runtime determined, deprecated, without losing readability of the code (e.g., keep extending the factory method with more args will be messy)