### PR TITLE
[ALLUXIO-2974] Replace $ALLUXIO_LOG_DIR with $ALLUXIO_LOGS_DIR.

### DIFF
--- a/bin/alluxio-masters.sh
+++ b/bin/alluxio-masters.sh
@@ -30,9 +30,8 @@ ALLUXIO_LIBEXEC_DIR=${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}
 . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 
 HOSTLIST=$(cat "${ALLUXIO_CONF_DIR}/masters" | sed  "s/#.*$//;/^$/d")
-ALLUXIO_LOG_DIR="${BIN}/../logs"
-mkdir -p "${ALLUXIO_LOG_DIR}"
-ALLUXIO_TASK_LOG="${ALLUXIO_LOG_DIR}/task.log"
+mkdir -p "${ALLUXIO_LOGS_DIR}"
+ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
 
 echo "Executing the following command on all master nodes and logging to ${ALLUXIO_TASK_LOG}: $@" | tee -a ${ALLUXIO_TASK_LOG}
 

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -30,9 +30,8 @@ ALLUXIO_LIBEXEC_DIR=${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}
 . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
 
 HOSTLIST=$(cat ${ALLUXIO_CONF_DIR}/workers | sed  "s/#.*$//;/^$/d")
-ALLUXIO_LOG_DIR="${BIN}/../logs"
-mkdir -p "${ALLUXIO_LOG_DIR}"
-ALLUXIO_TASK_LOG="${ALLUXIO_LOG_DIR}/task.log"
+mkdir -p "${ALLUXIO_LOGS_DIR}"
+ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
 
 echo "Executing the following command on all worker nodes and logging to ${ALLUXIO_TASK_LOG}: $@" | tee -a ${ALLUXIO_TASK_LOG}
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2974

In alluxio-masters.sh and alluxio-workers.sh, we should not use
$ALLUXIO_LOG_DIR since we already have an enviroment variable called
$ALLUXIO_LOGS_DIR that we should always respect.