### PR TITLE
[DOCFIX] Avoid use of : and ` in yaml file

### DIFF
--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.worker.allocator.class:
-  The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include: `alluxio.worker.block.allocator.MaxFreeAllocator`, `alluxio.worker.block.allocator.GreedyAllocator`, `alluxio.worker.block.allocator.RoundRobinAllocator`.
+  The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include 'alluxio.worker.block.allocator.MaxFreeAllocator', 'alluxio.worker.block.allocator.GreedyAllocator', 'alluxio.worker.block.allocator.RoundRobinAllocator'.
 alluxio.worker.bind.host:
   The hostname Alluxio's worker node binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
 alluxio.worker.block.heartbeat.interval.ms:
@@ -9,7 +9,7 @@ alluxio.worker.block.heartbeat.timeout.ms:
 alluxio.worker.block.master.client.pool.size:
   The block master client pool size on the Alluxio workers.
 alluxio.worker.block.threads.max:
-  The maximum number of incoming RPC requests to block worker that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with block worker. This value should be greater than the sum of `alluxio.user.block.worker.client.threads` across concurrent Alluxio clients. Otherwise, the worker connection pool can be drained, preventing new connections from being established.
+  The maximum number of incoming RPC requests to block worker that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with block worker. This value should be greater than the sum of 'alluxio.user.block.worker.client.threads' across concurrent Alluxio clients. Otherwise, the worker connection pool can be drained, preventing new connections from being established.
 alluxio.worker.block.threads.min:
   The minimum number of threads used to handle incoming RPC requests to block worker. This value is used to configure minimum number of threads in Thrift thread pool with block worker.
 alluxio.worker.data.bind.host:
@@ -23,13 +23,13 @@ alluxio.worker.data.hostname:
 alluxio.worker.data.port:
   The port Alluxio's worker's data server runs on.
 alluxio.worker.data.server.class:
-  Selects the networking stack to run the worker with. Valid options are: `alluxio.worker.netty.NettyDataServer`.
+  Selects the networking stack to run the worker with. Valid options are 'alluxio.worker.netty.NettyDataServer'.
 alluxio.worker.data.server.domain.socket.address:
   The path to the domain socket. Short-circuit reads make use of a UNIX domain socket when this is set (non-empty). This is a special path in the file system that allows the client and the AlluxioWorker to communicate. You will need to set a path to this socket. The AlluxioWorker needs to be able to create this path.
 alluxio.worker.data.tmp.subdir.max:
   The maximum number of sub-directories allowed to be created in alluxio.worker.data.tmp.folder.
 alluxio.worker.evictor.class:
-  The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid options include `alluxio.worker.block.evictor.LRFUEvictor`, `alluxio.worker.block.evictor.GreedyEvictor`, `alluxio.worker.block.evictor.LRUEvictor`.
+  The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid options include 'alluxio.worker.block.evictor.LRFUEvictor', 'alluxio.worker.block.evictor.GreedyEvictor', 'alluxio.worker.block.evictor.LRUEvictor'.
 alluxio.worker.evictor.lrfu.attenuation.factor:
   A attenuation factor in [2, INF) to control the behavior of LRFU.
 alluxio.worker.evictor.lrfu.step.factor:
@@ -67,7 +67,7 @@ alluxio.worker.network.netty.channel:
 alluxio.worker.network.netty.file.reader.threads.max:
   N/A
 alluxio.worker.network.netty.file.transfer:
-  When returning files to the user, select how the data is transferred; valid options are `MAPPED` (uses java MappedByteBuffer) and `TRANSFER` (uses Java FileChannel.transferTo).
+  When returning files to the user, select how the data is transferred; valid options are 'MAPPED' (uses java MappedByteBuffer) and 'TRANSFER' (uses Java FileChannel.transferTo).
 alluxio.worker.network.netty.file.writer.threads.max:
   The maximum number of threads used to write files to UFS in the netty data server.
 alluxio.worker.network.netty.reader.buffer.size.packets:
@@ -101,7 +101,7 @@ alluxio.worker.tieredstore.free.space.ratio:
 alluxio.worker.tieredstore.level0.alias:
   The alias of the highest storage tier on this worker. It must match one of the global storage tiers from the master configuration. We disable placing an alias lower in the global hierarchy before an alias with a higher postion on the worker hierarchy. So by default, SSD cannot come before MEM on any worker.
 alluxio.worker.tieredstore.level0.dirs.path:
-  The path of storage directory path for the top storage layer. Note for MacOS the value should be `/Volumes/`
+  The path of storage directory path for the top storage layer. Note for MacOS the value should be '/Volumes/'
 alluxio.worker.tieredstore.level0.dirs.quota:
   The capacity of the top storage layer.
 alluxio.worker.tieredstore.level0.reserved.ratio:


### PR DESCRIPTION
The yaml won't compile with \` and : tokens

Replaced \` with ' and removed : since they weren't really needed anyway