### PR TITLE
[SMALLFIX] Use Null Appender for getConf during start.

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -13,6 +13,8 @@
 
 log4j.rootLogger=INFO, ${alluxio.logger.type}
 
+log4j.appender.Null=org.apache.log4j.varia.NullAppender
+
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -89,7 +89,7 @@ ALLUXIO_SERVER_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_AS
 ## Start reading site-properties to set certain variables.
 ####################################################################################################
 function getConf {
-  "${JAVA}" -cp ${ALLUXIO_CLIENT_CLASSPATH} ${ALLUXIO_JAVA_OPTS} -Dalluxio.logger.type=Console \
+  "${JAVA}" -cp ${ALLUXIO_CLIENT_CLASSPATH} ${ALLUXIO_JAVA_OPTS} -Dalluxio.logger.type=Null \
       alluxio.cli.GetConf "$1"
 }
 


### PR DESCRIPTION
The getConf function in alluxio-config.sh relies on the output to
stdout, therefore we do not want any logging message to mess up with
stdout.
@aaudiber @apc999 