### PR TITLE
[ALLUXIO-2989] [ALLUXIO-2990] Extend the validateEnv command to check max user processes

### DIFF
--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -96,13 +96,13 @@ public final class ValidateEnv {
       "worker.ramdisk.mount.privilege", new RamDiskMountPrivilegeValidationTask());
 
   // User limit validations
-  private static final ValidationTask ULIMIT_NUMBER_OF_OPEN_FILES_VALIDATION_TASK = registerTask(
+  private static final ValidationTask ULIMIT_OPEN_FILES_VALIDATION_TASK = registerTask(
       "ulimit.nofile",
-      UserLimitValidationTask.createNumberOfOpenFilesLimitValidationTask());
+      UserLimitValidationTask.createOpenFilesLimitValidationTask());
 
-  private static final ValidationTask ULIMIT_NUMBER_OF_USER_PROCS_VALIDATION_TASK = registerTask(
+  private static final ValidationTask ULIMIT_USER_PROCS_VALIDATION_TASK = registerTask(
       "ulimit.nproc",
-      UserLimitValidationTask.createNumberOfUserProcessesLimitValidationTask());
+      UserLimitValidationTask.createUserProcessesLimitValidationTask());
 
   private static final Map<String, Collection<ValidationTask>> TARGET_TASKS =
       initializeTargetTasks();
@@ -114,8 +114,8 @@ public final class ValidateEnv {
         SSH_TO_MASTERS_VALIDATION_TASK,
         SSH_TO_WORKERS_VALIDATION_TASK,
         UFS_ROOT_VALIDATION_TASK,
-        ULIMIT_NUMBER_OF_OPEN_FILES_VALIDATION_TASK,
-        ULIMIT_NUMBER_OF_USER_PROCS_VALIDATION_TASK
+        ULIMIT_OPEN_FILES_VALIDATION_TASK,
+        ULIMIT_USER_PROCS_VALIDATION_TASK
     };
     ValidationTask[] masterTasks = {
         MASTER_RPC_VALIDATION_TASK,
@@ -123,6 +123,7 @@ public final class ValidateEnv {
     };
     ValidationTask[] workerTasks = {
         WORKER_DATA_VALIDATION_TASK,
+        WORKER_RAMDISK_MOUNT_PRIVILEGE_VALIDATION_TASK,
         WORKER_RPC_VALIDATION_TASK,
         WORKER_WEB_VALIDATION_TASK
     };

--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -17,6 +17,7 @@ import alluxio.cli.validation.PortAvailabilityValidationTask;
 import alluxio.cli.validation.RamDiskMountPrivilegeValidationTask;
 import alluxio.cli.validation.SshValidationTask;
 import alluxio.cli.validation.UfsDirectoryValidationTask;
+import alluxio.cli.validation.UserLimitValidationTask;
 import alluxio.cli.validation.Utils;
 import alluxio.cli.validation.ValidationTask;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
@@ -92,6 +93,15 @@ public final class ValidateEnv {
   private static final ValidationTask WORKER_RAMDISK_MOUNT_PRIVILEGE_VALIDATION_TASK = registerTask(
       "worker.ramdisk.mount.privilege", new RamDiskMountPrivilegeValidationTask());
 
+  // User limit validations
+  private static final ValidationTask ULIMIT_NUMBER_OF_OPEN_FILES_VALIDATION_TASK = registerTask(
+      "ulimit.nofile",
+      UserLimitValidationTask.createNumberOfOpenFilesLimitValidationTask());
+
+  private static final ValidationTask ULIMIT_NUMBER_OF_USER_PROCS_VALIDATION_TASK = registerTask(
+      "ulimit.nproc",
+      UserLimitValidationTask.createNumberOfUserProcessesLimitValidationTask());
+
   private static final Map<String, Collection<ValidationTask>> TARGET_TASKS =
       initializeTargetTasks();
 
@@ -103,7 +113,9 @@ public final class ValidateEnv {
         PROXY_WEB_VALIDATION_TASK,
         MASTERS_SSH_VALIDATION_TASK,
         WORKERS_SSH_VALIDATION_TASK,
-        UFS_ROOT_VALIDATION_TASK
+        UFS_ROOT_VALIDATION_TASK,
+        ULIMIT_NUMBER_OF_OPEN_FILES_VALIDATION_TASK,
+        ULIMIT_NUMBER_OF_USER_PROCS_VALIDATION_TASK
     ));
     targetMap.put("worker", Arrays.asList(
         WORKER_DATA_VALIDATION_TASK,
@@ -113,7 +125,9 @@ public final class ValidateEnv {
         PROXY_WEB_VALIDATION_TASK,
         MASTERS_SSH_VALIDATION_TASK,
         WORKERS_SSH_VALIDATION_TASK,
-        UFS_ROOT_VALIDATION_TASK
+        UFS_ROOT_VALIDATION_TASK,
+        ULIMIT_NUMBER_OF_OPEN_FILES_VALIDATION_TASK,
+        ULIMIT_NUMBER_OF_USER_PROCS_VALIDATION_TASK
     ));
     targetMap.put("local", TASKS.keySet());
     return targetMap;

--- a/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
@@ -1,0 +1,101 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.validation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Task for validating system limit for current user.
+ */
+public final class UserLimitValidationTask implements ValidationTask {
+  private static final int NUMBER_OF_OPEN_FILES_MIN = 4096;
+  private static final int NUMBER_OF_OPEN_FILES_MAX = 800000;
+  private static final int NUMBER_OF_USER_PROCESSES_MIN = 1024;
+  private final String[] mCommand;
+  private final String mName;
+  private final Integer mLowerBound;
+  private final Integer mUpperBound;
+
+  private UserLimitValidationTask(String name, String command,
+                                  Integer lowerBound, Integer upperBound) {
+    mName = name;
+    mCommand = new String[] {"bash", "-c", command};
+    mLowerBound = lowerBound;
+    mUpperBound = upperBound;
+  }
+
+  @Override
+  public boolean validate() {
+    try {
+      // checks if the current user is root
+      Process process = Runtime.getRuntime().exec(mCommand);
+      try (BufferedReader processOutputReader = new BufferedReader(
+          new InputStreamReader(process.getInputStream()))) {
+        String line = processOutputReader.readLine();
+        if (line == null) {
+          System.err.format("Unable to check user limit for %s.%n", mName);
+          return false;
+        }
+
+        if (line.equals("unlimited")) {
+          if (mUpperBound != null) {
+            System.err.format("The user limit for %s is unlimited. It should be less than %d%n",
+                mName, mUpperBound);
+            return false;
+          }
+
+          return true;
+        }
+
+        int value = Integer.parseInt(line);
+        if (mUpperBound != null && value > mUpperBound) {
+          System.err.format("The user limit for %s is too large. The current value is %d. "
+              + "It should be less than %d%n", mName, value, mUpperBound);
+          return false;
+        }
+
+        if (mLowerBound != null && value < mLowerBound) {
+          System.err.format("The user limit for %s is too small. The current value is %d. "
+              + "It should be bigger than %d%n", mName, value, mLowerBound);
+          return false;
+        }
+
+        return true;
+      }
+    } catch (IOException e) {
+      System.err.format("Unable to check user limit for %s: %s.%n", mName, e.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Creates a validation task for checking whether the user limit for number of open files
+   * is within reasonable range.
+   * @return the validation task for this check
+   */
+  public static ValidationTask createNumberOfOpenFilesLimitValidationTask() {
+    return new UserLimitValidationTask("number of open files", "ulimit -n",
+        NUMBER_OF_OPEN_FILES_MIN, NUMBER_OF_OPEN_FILES_MAX);
+  }
+
+  /**
+   * Creates a validation task for checking whether the user limit for number of user processes
+   * is within reasonable range.
+   * @return the validation task for this check
+   */
+  public static ValidationTask createNumberOfUserProcessesLimitValidationTask() {
+    return new UserLimitValidationTask("number of user processes", "ulimit -u",
+        NUMBER_OF_USER_PROCESSES_MIN, null);
+  }
+}

--- a/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
@@ -19,9 +19,9 @@ import java.io.InputStreamReader;
  * Task for validating system limit for current user.
  */
 public final class UserLimitValidationTask implements ValidationTask {
-  private static final int NUMBER_OF_OPEN_FILES_MIN = 4096;
+  private static final int NUMBER_OF_OPEN_FILES_MIN = 16384;
   private static final int NUMBER_OF_OPEN_FILES_MAX = 800000;
-  private static final int NUMBER_OF_USER_PROCESSES_MIN = 1024;
+  private static final int NUMBER_OF_USER_PROCESSES_MIN = 16384;
   private final String mCommand;
   private final String mName;
   private final Integer mLowerBound;

--- a/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
@@ -38,7 +38,6 @@ public final class UserLimitValidationTask implements ValidationTask {
   @Override
   public boolean validate() {
     try {
-      // checks if the current user is root
       Process process = Runtime.getRuntime().exec(new String[] {"bash", "-c", mCommand});
       try (BufferedReader processOutputReader = new BufferedReader(
           new InputStreamReader(process.getInputStream()))) {
@@ -84,7 +83,7 @@ public final class UserLimitValidationTask implements ValidationTask {
    * is within reasonable range.
    * @return the validation task for this check
    */
-  public static ValidationTask createNumberOfOpenFilesLimitValidationTask() {
+  public static ValidationTask createOpenFilesLimitValidationTask() {
     return new UserLimitValidationTask("number of open files", "ulimit -n",
         NUMBER_OF_OPEN_FILES_MIN, NUMBER_OF_OPEN_FILES_MAX);
   }
@@ -94,7 +93,7 @@ public final class UserLimitValidationTask implements ValidationTask {
    * is within reasonable range.
    * @return the validation task for this check
    */
-  public static ValidationTask createNumberOfUserProcessesLimitValidationTask() {
+  public static ValidationTask createUserProcessesLimitValidationTask() {
     return new UserLimitValidationTask("number of user processes", "ulimit -u",
         NUMBER_OF_USER_PROCESSES_MIN, null);
   }

--- a/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UserLimitValidationTask.java
@@ -22,7 +22,7 @@ public final class UserLimitValidationTask implements ValidationTask {
   private static final int NUMBER_OF_OPEN_FILES_MIN = 4096;
   private static final int NUMBER_OF_OPEN_FILES_MAX = 800000;
   private static final int NUMBER_OF_USER_PROCESSES_MIN = 1024;
-  private final String[] mCommand;
+  private final String mCommand;
   private final String mName;
   private final Integer mLowerBound;
   private final Integer mUpperBound;
@@ -30,7 +30,7 @@ public final class UserLimitValidationTask implements ValidationTask {
   private UserLimitValidationTask(String name, String command,
                                   Integer lowerBound, Integer upperBound) {
     mName = name;
-    mCommand = new String[] {"bash", "-c", command};
+    mCommand = command;
     mLowerBound = lowerBound;
     mUpperBound = upperBound;
   }
@@ -39,7 +39,7 @@ public final class UserLimitValidationTask implements ValidationTask {
   public boolean validate() {
     try {
       // checks if the current user is root
-      Process process = Runtime.getRuntime().exec(mCommand);
+      Process process = Runtime.getRuntime().exec(new String[] {"bash", "-c", mCommand});
       try (BufferedReader processOutputReader = new BufferedReader(
           new InputStreamReader(process.getInputStream()))) {
         String line = processOutputReader.readLine();

--- a/docs/_includes/Building-Alluxio-Master-Branch/increase-number.md
+++ b/docs/_includes/Building-Alluxio-Master-Branch/increase-number.md
@@ -1,4 +1,4 @@
 ```bash
-$ sudo launchctl limit maxfiles 16384 16384
-$ sudo launchctl limit maxproc 2048 2048
+$ sudo launchctl limit maxfiles 32768 32768
+$ sudo launchctl limit maxproc 32768 32768
 ```


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2989
https://alluxio.atlassian.net/browse/ALLUXIO-2990

Added extensions for validateEnv command to check user limits for number of open files and number of processes.