### PR TITLE
[SMALLFIX] Remove explicit constructor check

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -255,11 +255,6 @@
 
     <!-- Checks that there is whitespace after various tokens. -->
     <module name="WhitespaceAfter"/>
-
-    <!-- Checks that classes (except abstract ones) define a constructor and don't rely on the default one. -->
-    <module name="MissingCtor">
-      <property name="id" value="ProductionScope"/>
-    </module>
   </module>
 
   <!-- always use Unix-style line separators -->


### PR DESCRIPTION
This requirement is burdensome when implementing 1-method subclasses like `Comparator`. It's also controversial whether or not empty constructors are even a good thing - PMD [has a rule](http://pmd.sourceforge.net/pmd-4.3.0/rules/controversial.html) for checking that empty constructors are *not* used. I think it makes more sense to use empty constructors when we think they make sense (e.g. an external dependency/tool relies on having an empty constructor), and not use them when they don't (e.g. when writing a `Comparator`)