### PR TITLE
[ALLUXIO-2997] [s3] Implement S3 GET bucket API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -33,7 +33,7 @@ public final class ListBucketOptions {
   /**
    * Constructs a new {@link ListBucketOptions}.
    */
-  public ListBucketOptions() {}
+  private ListBucketOptions() {}
 
   /**
    * @return the continuation token

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -23,6 +23,7 @@ public final class ListBucketOptions {
 
   /**
    * Creates a default {@link ListBucketOptions}.
+   *
    * @return the created {@link ListBucketOptions}
    */
   public static ListBucketOptions defaults() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -1,0 +1,112 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.google.common.base.Objects;
+
+/**
+ * The options for list bucket operation.
+ */
+public final class ListBucketOptions {
+  private String mContinuationToken = null;
+  private String mMaxKeys = null;
+  private String mPrefix = null;
+
+  /**
+   * Creates a default {@link ListBucketOptions}.
+   * @return the created {@link ListBucketOptions}
+   */
+  public static ListBucketOptions defaults() {
+    return new ListBucketOptions();
+  }
+
+  /**
+   * Constructs a new {@link ListBucketOptions}.
+   */
+  public ListBucketOptions() {}
+
+  /**
+   * @return the continuation token
+   */
+  public String getContinuationToken() {
+    return mContinuationToken;
+  }
+
+  /**
+   * @return the max keys
+   */
+  public String getMaxKeys() {
+    return mMaxKeys;
+  }
+
+  /**
+   * @return the prefix
+   */
+  public String getPrefix() {
+    return mPrefix;
+  }
+
+  /**
+   * @param continuationToken the continuation token to set
+   * @return the updated object
+   */
+  public ListBucketOptions setContinuationToken(String continuationToken) {
+    mContinuationToken = continuationToken;
+    return this;
+  }
+
+  /**
+   * @param maxKeys the max keys to set
+   * @return the updated object
+   */
+  public ListBucketOptions setMaxKeys(String maxKeys) {
+    mMaxKeys = maxKeys;
+    return this;
+  }
+
+  /**
+   * @param prefix the prefix to set
+   * @return the updated object
+   */
+  public ListBucketOptions setPrefix(String prefix) {
+    mPrefix = prefix;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ListBucketOptions)) {
+      return false;
+    }
+    ListBucketOptions that = (ListBucketOptions) o;
+    return Objects.equal(mContinuationToken, that.mContinuationToken)
+        && Objects.equal(mMaxKeys, that.mMaxKeys)
+        && Objects.equal(mPrefix, that.mPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mContinuationToken, mMaxKeys, mPrefix);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("continuationToken", mContinuationToken)
+        .add("maxKeys", mMaxKeys)
+        .add("prefix", mPrefix)
+        .toString();
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -264,18 +264,20 @@ public class ListBucketResult {
    */
   @JsonPropertyOrder({ "Key", "LastModified", "ETag", "Size", "StorageClass" })
   public class Content {
-    // The object's key.
+    /* The object's key. */
     private String mKey;
-    // Date and time the object was last modified.
+    /* Date and time the object was last modified. */
     private String mLastModified;
-    // The entity tag is an MD5 hash of the object.
+    /* The entity tag is an MD5 hash of the object. */
     // TODO(chaomin): for now this is always empty because file content's MD5 hash is not yet
     // part of Alluxio metadata
     private String mETag;
-    // Size in bytes of the object.
+    /* Size in bytes of the object. */
     private String mSize;
-    // Storage class (STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER). Alluxio only supports
-    // STANDARD for now.
+    /**
+     * Storage class (STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER). Alluxio only supports
+     * STANDARD for now.
+     */
     private String mStorageClass;
 
     /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -11,6 +11,7 @@
 
 package alluxio.proxy.s3;
 
+import alluxio.AlluxioURI;
 import alluxio.client.file.URIStatus;
 import alluxio.wire.FileInfo;
 
@@ -70,8 +71,8 @@ public class ListBucketResult {
    * @param objectsList a list of {@link URIStatus}, representing the objects
    * @param options the list bucket options
    */
-  public ListBucketResult(String bucketName, List<URIStatus> objectsList, ListBucketOptions options)
-      throws S3Exception {
+  public ListBucketResult(
+      String bucketName, List<URIStatus> objectsList, ListBucketOptions options) {
     mName = bucketName;
     mKeyCount = 0;
     if (options.getMaxKeys() != null) {
@@ -84,10 +85,11 @@ public class ListBucketResult {
 
     int startIndex = 0;
     if (options.getContinuationToken() != null) {
-      URIStatus tokenStatus = new URIStatus(new FileInfo().setPath(options.getContinuationToken()));
+      URIStatus tokenStatus = new URIStatus(new FileInfo().setPath(
+          mName + AlluxioURI.SEPARATOR + mContinuationToken));
       startIndex = Collections.binarySearch(objectsList, tokenStatus, new URIStatusComparator());
-      if (startIndex == -1) {
-        throw new S3Exception("No such continuation token", S3ErrorCode.NO_SUCH_KEY);
+      if (startIndex < 0) {
+        startIndex = 0;
       }
     }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -60,14 +61,15 @@ public class ListBucketResult {
    * Creates an {@link ListBucketResult}.
    *
    * @param bucketName the bucket name
-   * @param listStatusResult a list of {@link URIStatus}, the result of Alluxio listStatus
+   * @param objectsList a list of {@link URIStatus}, representing the objects
    */
-  public ListBucketResult(String bucketName, List<URIStatus> listStatusResult) {
+  public ListBucketResult(String bucketName, List<URIStatus> objectsList) {
     mName = bucketName;
-    mKeyCount = listStatusResult.size();
-    mMaxKeys = listStatusResult.size();
+    mKeyCount = objectsList.size();
+    mMaxKeys = objectsList.size();
     mContents = new ArrayList<>();
-    listStatusResult.sort(new Comparator<URIStatus>() {
+
+    Collections.sort(objectsList, new Comparator<URIStatus>() {
       @Override
       public int compare(URIStatus o1, URIStatus o2) {
         return o1.getName().compareTo(o2.getName());
@@ -75,10 +77,10 @@ public class ListBucketResult {
     });
     DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     // TODO(chaomin): support setting max-keys in the request param.
-    for (URIStatus status : listStatusResult) {
+    for (URIStatus status : objectsList) {
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
       mContents.add(new Content(
-          status.getName(),
+          status.getPath().substring(mName.length() + 1),
           format.format(new Date(status.getLastModificationTimeMs())),
           "",
           String.valueOf(status.getLength()),

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -34,6 +36,7 @@ import java.util.List;
 @JsonPropertyOrder(
     { "Name", "Prefix", "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
 public class ListBucketResult {
+
   // Name of the bucket.
   private String mName = "";
   // Keys that begin with the indicated prefix.
@@ -73,12 +76,13 @@ public class ListBucketResult {
         return o1.getPath().compareTo(o2.getPath());
       }
     });
+    final DateFormat s3DateFormat = new SimpleDateFormat(S3RestUtils.S3_DATE_FORMAT_REGEXP);
     // TODO(chaomin): support setting max-keys in the request param.
     for (URIStatus status : objectsList) {
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
-          S3RestUtils.S3_DATE_FORMAT.format(new Date(status.getLastModificationTimeMs())),
+          s3DateFormat.format(new Date(status.getLastModificationTimeMs())),
           S3RestUtils.S3_EMPTY_ETAG,
           String.valueOf(status.getLength()),
           S3RestUtils.S3_STANDARD_STORAGE_CLASS));
@@ -210,7 +214,7 @@ public class ListBucketResult {
       mLastModified = "";
       mETag = "";
       mSize = "";
-      mStorageClass = "STANDARD";
+      mStorageClass = S3RestUtils.S3_STANDARD_STORAGE_CLASS;
     }
 
     /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -74,6 +74,7 @@ public class ListBucketResult {
   public ListBucketResult(
       String bucketName, List<URIStatus> objectsList, ListBucketOptions options) {
     mName = bucketName;
+    mPrefix = options.getPrefix();
     mKeyCount = 0;
     if (options.getMaxKeys() != null) {
       mMaxKeys = Integer.parseInt(options.getMaxKeys());
@@ -103,6 +104,9 @@ public class ListBucketResult {
         return;
       }
       if (mContinuationToken != null && objectKey.compareTo(mContinuationToken) < 0) {
+        continue;
+      }
+      if (mPrefix != null && !objectKey.startsWith(mPrefix)) {
         continue;
       }
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -72,7 +72,7 @@ public class ListBucketResult {
     Collections.sort(objectsList, new Comparator<URIStatus>() {
       @Override
       public int compare(URIStatus o1, URIStatus o2) {
-        return o1.getName().compareTo(o2.getName());
+        return o1.getPath().compareTo(o2.getPath());
       }
     });
     DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -104,6 +104,7 @@ public class ListBucketResult {
         continue;
       }
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
+      // TODO(chaomin): construct the response with CommonPrefixes when delimiter support is added.
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
           s3DateFormat.format(new Date(status.getLastModificationTimeMs())),

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -75,7 +75,7 @@ public class ListBucketResult {
     mName = bucketName;
     mKeyCount = 0;
     if (options.getMaxKeys() != null) {
-      mMaxKeys = Integer.valueOf(options.getMaxKeys());
+      mMaxKeys = Integer.parseInt(options.getMaxKeys());
     }
     mContents = new ArrayList<>();
     mContinuationToken = options.getContinuationToken();

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 /**
  * Get bucket result defined in http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
- * It will be encoded into an XML string to be returned as an error response for the REST call.
+ * It will be encoded into an XML string to be returned as a response for the REST call.
  *
  * TODO(chaomin): consider add more required fields in S3 BucketGet API.
  */
@@ -39,24 +39,30 @@ import java.util.List;
     "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
 public class ListBucketResult {
 
-  // Name of the bucket.
+  /* Name of the bucket. */
   private String mName = "";
-  // Keys that begin with the indicated prefix.
+  /* Keys that begin with the indicated prefix. */
   private String mPrefix = null;
-  // ContinuationToken is included in the response if it was sent with the request.
+  /* ContinuationToken is included in the response if it was sent with the request. */
   private String mContinuationToken = null;
-  // Returns the number of keys included in the response. The value is always less than or equal
-  // to the mMaxKeys value.
+  /**
+   * Returns the number of keys included in the response. The value is always less than or equal
+   * to the mMaxKeys value.
+   */
   private int mKeyCount = 0;
-  // The maximum number of keys returned in the response body.
-  private int mMaxKeys = S3RestUtils.S3_DEFAULT_MAX_KEYS;
-  // Specifies whether or not all of the results were returned. If the number of
-  // results exceeds that specified by MaxKeys, all of the results might not be returned.
+  /* The maximum number of keys returned in the response body. */
+  private int mMaxKeys = S3Constants.S3_DEFAULT_MAX_KEYS;
+  /**
+   * Specifies whether or not all of the results were returned. If the number of
+   * results exceeds that specified by MaxKeys, all of the results might not be returned.
+   */
   private boolean mIsTruncated = false;
-  // If only partial results are returned (i.e. mIsTruncated = true), this value is set as the
-  // next continuation token. The continuation token is the full Alluxio path of the object.
+  /**
+   * If only partial results are returned (i.e. mIsTruncated = true), this value is set as the
+   * next continuation token. The continuation token is the full Alluxio path of the object.
+   */
   private String mNextContinuationToken = null;
-  // A list of objects with metadata.
+  /* A list of objects with metadata. */
   private List<Content> mContents = new ArrayList<>();
 
   /**
@@ -94,7 +100,7 @@ public class ListBucketResult {
       }
     }
 
-    final DateFormat s3DateFormat = new SimpleDateFormat(S3RestUtils.S3_DATE_FORMAT_REGEXP);
+    final DateFormat s3DateFormat = new SimpleDateFormat(S3Constants.S3_DATE_FORMAT_REGEXP);
     for (int i = startIndex; i < objectsList.size(); i++) {
       URIStatus status = objectsList.get(i);
       String objectKey = status.getPath().substring(mName.length() + 1);
@@ -114,9 +120,9 @@ public class ListBucketResult {
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
           s3DateFormat.format(new Date(status.getLastModificationTimeMs())),
-          S3RestUtils.S3_EMPTY_ETAG,
+          S3Constants.S3_EMPTY_ETAG,
           String.valueOf(status.getLength()),
-          S3RestUtils.S3_STANDARD_STORAGE_CLASS));
+          S3Constants.S3_STANDARD_STORAGE_CLASS));
       mKeyCount++;
     }
   }
@@ -278,7 +284,7 @@ public class ListBucketResult {
       mLastModified = "";
       mETag = "";
       mSize = "";
-      mStorageClass = S3RestUtils.S3_STANDARD_STORAGE_CLASS;
+      mStorageClass = S3Constants.S3_STANDARD_STORAGE_CLASS;
     }
 
     /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -12,6 +12,7 @@
 package alluxio.proxy.s3;
 
 import alluxio.client.file.URIStatus;
+import alluxio.wire.FileInfo;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -33,23 +34,27 @@ import java.util.List;
  * TODO(chaomin): consider add more required fields in S3 BucketGet API.
  */
 @JacksonXmlRootElement(localName = "ListBucketResult")
-@JsonPropertyOrder(
-    { "Name", "Prefix", "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
+@JsonPropertyOrder({ "Name", "Prefix", "ContinuationToken", "NextContinuationToken",
+    "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
 public class ListBucketResult {
 
   // Name of the bucket.
   private String mName = "";
   // Keys that begin with the indicated prefix.
   private String mPrefix = null;
+  // ContinuationToken is included in the response if it was sent with the request.
+  private String mContinuationToken = null;
   // Returns the number of keys included in the response. The value is always less than or equal
   // to the mMaxKeys value.
   private int mKeyCount = 0;
   // The maximum number of keys returned in the response body.
-  private int mMaxKeys = 0;
+  private int mMaxKeys = S3RestUtils.S3_DEFAULT_MAX_KEYS;
   // Specifies whether or not all of the results were returned. If the number of
   // results exceeds that specified by MaxKeys, all of the results might not be returned.
-  // TODO(chaomin): set mIsTruncated once Alluxio supports maxKeys and partial result in response.
   private boolean mIsTruncated = false;
+  // If only partial results are returned (i.e. mIsTruncated = true), this value is set as the
+  // next continuation token. The continuation token is the full Alluxio path of the object.
+  private String mNextContinuationToken = null;
   // A list of objects with metadata.
   private List<Content> mContents = new ArrayList<>();
 
@@ -63,22 +68,41 @@ public class ListBucketResult {
    *
    * @param bucketName the bucket name
    * @param objectsList a list of {@link URIStatus}, representing the objects
+   * @param options the list bucket options
    */
-  public ListBucketResult(String bucketName, List<URIStatus> objectsList) {
+  public ListBucketResult(String bucketName, List<URIStatus> objectsList, ListBucketOptions options)
+      throws S3Exception {
     mName = bucketName;
-    mKeyCount = objectsList.size();
-    mMaxKeys = objectsList.size();
+    mKeyCount = 0;
+    if (options.getMaxKeys() != null) {
+      mMaxKeys = Integer.valueOf(options.getMaxKeys());
+    }
     mContents = new ArrayList<>();
+    mContinuationToken = options.getContinuationToken();
 
-    Collections.sort(objectsList, new Comparator<URIStatus>() {
-      @Override
-      public int compare(URIStatus o1, URIStatus o2) {
-        return o1.getPath().compareTo(o2.getPath());
+    Collections.sort(objectsList, new URIStatusComparator());
+
+    int startIndex = 0;
+    if (options.getContinuationToken() != null) {
+      URIStatus tokenStatus = new URIStatus(new FileInfo().setPath(options.getContinuationToken()));
+      startIndex = Collections.binarySearch(objectsList, tokenStatus, new URIStatusComparator());
+      if (startIndex == -1) {
+        throw new S3Exception("No such continuation token", S3ErrorCode.NO_SUCH_KEY);
       }
-    });
+    }
+
     final DateFormat s3DateFormat = new SimpleDateFormat(S3RestUtils.S3_DATE_FORMAT_REGEXP);
-    // TODO(chaomin): support setting max-keys in the request param.
-    for (URIStatus status : objectsList) {
+    for (int i = startIndex; i < objectsList.size(); i++) {
+      URIStatus status = objectsList.get(i);
+      String objectKey = status.getPath().substring(mName.length() + 1);
+      if (mKeyCount >= mMaxKeys) {
+        mIsTruncated = true;
+        mNextContinuationToken = objectKey;
+        return;
+      }
+      if (mContinuationToken != null && objectKey.compareTo(mContinuationToken) < 0) {
+        continue;
+      }
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
@@ -86,6 +110,7 @@ public class ListBucketResult {
           S3RestUtils.S3_EMPTY_ETAG,
           String.valueOf(status.getLength()),
           S3RestUtils.S3_STANDARD_STORAGE_CLASS));
+      mKeyCount++;
     }
   }
 
@@ -103,6 +128,22 @@ public class ListBucketResult {
   @JacksonXmlProperty(localName = "Prefix")
   public String getPrefix() {
     return mPrefix;
+  }
+
+  /**
+   * @return the continuation token
+   */
+  @JacksonXmlProperty(localName = "ContinuationToken")
+  public String getContinuationToken() {
+    return mContinuationToken;
+  }
+
+  /**
+   * @return the next continuation token
+   */
+  @JacksonXmlProperty(localName = "NextContinuationToken")
+  public String getNextContinuationToken() {
+    return mNextContinuationToken;
   }
 
   /**
@@ -152,6 +193,22 @@ public class ListBucketResult {
   @JacksonXmlProperty(localName = "Prefix")
   public void setPrefix(String prefix) {
     mPrefix = prefix;
+  }
+
+  /**
+   * @param continuationToken the continuation token to set
+   */
+  @JacksonXmlProperty(localName = "ContinuationToken")
+  public void setContinuationToken(String continuationToken) {
+    mContinuationToken = continuationToken;
+  }
+
+  /**
+   * @param nextContinuationToken the next continuation token to set
+   */
+  @JacksonXmlProperty(localName = "NextContinuationToken")
+  public void setNextContinuationToken(String nextContinuationToken) {
+    mNextContinuationToken = nextContinuationToken;
   }
 
   /**
@@ -313,6 +370,18 @@ public class ListBucketResult {
     public void setStorageClass(String storageClass) {
       mStorageClass = storageClass;
     }
+  }
+
+  private class URIStatusComparator implements Comparator<URIStatus> {
+    @Override
+    public int compare(URIStatus o1, URIStatus o2) {
+      return o1.getPath().compareTo(o2.getPath());
+    }
+
+    /**
+     * Constructs a new {@link URIStatusComparator}.
+     */
+    public URIStatusComparator() {}
   }
 }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -96,7 +96,9 @@ public class ListBucketResult {
           mName + AlluxioURI.SEPARATOR + mContinuationToken));
       startIndex = Collections.binarySearch(objectsList, tokenStatus, new URIStatusComparator());
       if (startIndex < 0) {
-        startIndex = 0;
+        // If continuation token does not exist in the object list, find the first element which is
+        // greater than the token.
+        startIndex = (-1) * startIndex - 1;
       }
     }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -75,16 +73,15 @@ public class ListBucketResult {
         return o1.getPath().compareTo(o2.getPath());
       }
     });
-    DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     // TODO(chaomin): support setting max-keys in the request param.
     for (URIStatus status : objectsList) {
       // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
-          format.format(new Date(status.getLastModificationTimeMs())),
-          "",
+          S3RestUtils.S3_DATE_FORMAT.format(new Date(status.getLastModificationTimeMs())),
+          S3RestUtils.S3_EMPTY_ETAG,
           String.valueOf(status.getLength()),
-          "STANDARD"));
+          S3RestUtils.S3_STANDARD_STORAGE_CLASS));
     }
   }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -1,0 +1,315 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.client.file.URIStatus;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Get bucket result defined in http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+ * It will be encoded into an XML string to be returned as an error response for the REST call.
+ *
+ * TODO(chaomin): consider add more required fields in S3 BucketGet API.
+ */
+@JacksonXmlRootElement(localName = "ListBucketResult")
+@JsonPropertyOrder(
+    { "Name", "Prefix", "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
+public class ListBucketResult {
+  // Name of the bucket.
+  private String mName = "";
+  // Keys that begin with the indicated prefix.
+  private String mPrefix = null;
+  // Returns the number of keys included in the response. The value is always less than or equal
+  // to the mMaxKeys value.
+  private int mKeyCount = 0;
+  // The maximum number of keys returned in the response body.
+  private int mMaxKeys = 0;
+  // Specifies whether or not all of the results were returned. If the number of
+  // results exceeds that specified by MaxKeys, all of the results might not be returned.
+  // TODO(chaomin): set mIsTruncated once Alluxio supports maxKeys and partial result in response.
+  private boolean mIsTruncated = false;
+  // A list of objects with metadata.
+  private List<Content> mContents = new ArrayList<>();
+
+  /**
+   * Creates an {@link ListBucketResult}.
+   */
+  public ListBucketResult() {}
+
+  /**
+   * Creates an {@link ListBucketResult}.
+   *
+   * @param bucketName the bucket name
+   * @param listStatusResult a list of {@link URIStatus}, the result of Alluxio listStatus
+   */
+  public ListBucketResult(String bucketName, List<URIStatus> listStatusResult) {
+    mName = bucketName;
+    mKeyCount = listStatusResult.size();
+    mMaxKeys = listStatusResult.size();
+    mContents = new ArrayList<>();
+    listStatusResult.sort(new Comparator<URIStatus>() {
+      @Override
+      public int compare(URIStatus o1, URIStatus o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
+    DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    // TODO(chaomin): support setting max-keys in the request param.
+    for (URIStatus status : listStatusResult) {
+      // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
+      mContents.add(new Content(
+          status.getName(),
+          format.format(new Date(status.getLastModificationTimeMs())),
+          "",
+          String.valueOf(status.getLength()),
+          "STANDARD"));
+    }
+  }
+
+  /**
+   * @return the bucket name
+   */
+  @JacksonXmlProperty(localName = "Name")
+  public String getName() {
+    return mName;
+  }
+
+  /**
+   * @return the prefix
+   */
+  @JacksonXmlProperty(localName = "Prefix")
+  public String getPrefix() {
+    return mPrefix;
+  }
+
+  /**
+   * @return the number of keys included in the response
+   */
+  @JacksonXmlProperty(localName = "KeyCount")
+  public int getKeyCount() {
+    return mKeyCount;
+  }
+
+  /**
+   * @return the maximum number of keys returned in the response body
+   */
+  @JacksonXmlProperty(localName = "MaxKeys")
+  public int getMaxKeys() {
+    return mMaxKeys;
+  }
+
+  /**
+   * @return whether (true) or not (false) all of the results were returned
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public boolean isTruncated() {
+    return mIsTruncated;
+  }
+
+  /**
+   * @return the list of contents
+   */
+  @JacksonXmlProperty(localName = "Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public List<Content> getContents() {
+    return mContents;
+  }
+
+  /**
+   * @param name the bucket name to set
+   */
+  @JacksonXmlProperty(localName = "Name")
+  public void setName(String name) {
+    mName = name;
+  }
+
+  /**
+   * @param prefix the prefix to set
+   */
+  @JacksonXmlProperty(localName = "Prefix")
+  public void setPrefix(String prefix) {
+    mPrefix = prefix;
+  }
+
+  /**
+   * @param keyCount the number of keys to set
+   */
+  @JacksonXmlProperty(localName = "KeyCount")
+  public void setKeyCount(int keyCount) {
+    mKeyCount = keyCount;
+  }
+
+  /**
+   * @param maxKeys the maximum number of keys returned value to set
+   */
+  @JacksonXmlProperty(localName = "MaxKeys")
+  public void setMaxKeys(int maxKeys) {
+    mMaxKeys = maxKeys;
+  }
+
+  /**
+   * @param isTruncated the isTruncated value to set
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public void setIsTruncated(boolean isTruncated) {
+    mIsTruncated = isTruncated;
+  }
+
+  /**
+   * @param contents the contents list to set
+   */
+  @JacksonXmlProperty(localName = "Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setContent(List<Content> contents) {
+    mContents = contents;
+  }
+
+  /**
+   * Object metadata class.
+   */
+  @JsonPropertyOrder({ "Key", "LastModified", "ETag", "Size", "StorageClass" })
+  public class Content {
+    // The object's key.
+    private String mKey;
+    // Date and time the object was last modified.
+    private String mLastModified;
+    // The entity tag is an MD5 hash of the object.
+    // TODO(chaomin): for now this is always empty because file content's MD5 hash is not yet
+    // part of Alluxio metadata
+    private String mETag;
+    // Size in bytes of the object.
+    private String mSize;
+    // Storage class (STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER). Alluxio only supports
+    // STANDARD for now.
+    private String mStorageClass;
+
+    /**
+     * Constructs a new {@link Content}.
+     */
+    public Content() {
+      mKey = "";
+      mLastModified = "";
+      mETag = "";
+      mSize = "";
+      mStorageClass = "STANDARD";
+    }
+
+    /**
+     * Constructs a new {@link Content}.
+     *
+     * @param key the object key
+     * @param lastModified the data and time in string format the object was last modified
+     * @param eTag the entity tag (MD5 hash of the object contents)
+     * @param size size in bytes of the object
+     * @param storageClass storage class
+     */
+    public Content(String key, String lastModified, String eTag, String size, String storageClass) {
+      mKey = key;
+      mLastModified = lastModified;
+      mETag = eTag;
+      mSize = size;
+      mStorageClass = storageClass;
+    }
+
+    /**
+     * @return the object key
+     */
+    @JacksonXmlProperty(localName = "Key")
+    public String getKey() {
+      return mKey;
+    }
+
+    /**
+     * @return the last modified date and time in string format
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public String getLastModified() {
+      return mLastModified;
+    }
+
+    /**
+     * @return the ETag
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public String getETag() {
+      return mETag;
+    }
+
+    /**
+     * @return the size in bytes of the object
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public String getSize() {
+      return mSize;
+    }
+
+    /**
+     * @return the storage class
+     */
+    @JacksonXmlProperty(localName = "StorageClass")
+    public String getStorageClass() {
+      return mStorageClass;
+    }
+
+    /**
+     * @param key the object key to set
+     */
+    @JacksonXmlProperty(localName = "Key")
+    public void setKey(String key) {
+      mKey = key;
+    }
+
+    /**
+     * @param lastModified the last modified time to set
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public void setLastModified(String lastModified) {
+      mLastModified = lastModified;
+    }
+
+    /**
+     * @param eTag the ETag to set
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public void setETag(String eTag) {
+      mETag = eTag;
+    }
+
+    /**
+     * @param size the object size in bytes to set
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public void setSize(String size) {
+      mSize = size;
+    }
+
+    /**
+     * @param storageClass the storage class to set
+     */
+    @JacksonXmlProperty(localName = "StorageClass")
+    public void setStorageClass(String storageClass) {
+      mStorageClass = storageClass;
+    }
+  }
+}
+

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -1,0 +1,27 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Constants for S3 northbound API.
+ */
+@ThreadSafe
+public final class S3Constants {
+  public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
+  public static final String S3_EMPTY_ETAG = "";
+  public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  public static final int S3_DEFAULT_MAX_KEYS = 1000;
+
+  private S3Constants() {} // prevent instantiation
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
@@ -11,19 +11,19 @@
 
 package alluxio.proxy.s3;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Error response defined in http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html.
  * It will be encoded into an XML string to be returned as an error response for the REST call.
  */
-@XmlRootElement(name = "Error")
+@JacksonXmlRootElement(localName = "Error")
 public class S3Error {
-  private final String mCode;
-  private final String mMessage;
-  private final String mRequestId;
-  private final String mResource;
+  private String mCode;
+  private String mMessage;
+  private String mRequestId;
+  private String mResource;
 
   /**
    * Creates an {@link S3Error}.
@@ -53,7 +53,7 @@ public class S3Error {
   /**
    * @return the error code
    */
-  @XmlElement(name = "Code")
+  @JacksonXmlProperty(localName = "Code")
   public String getCode() {
     return mCode;
   }
@@ -61,7 +61,7 @@ public class S3Error {
   /**
    * @return the error message
    */
-  @XmlElement(name = "Message")
+  @JacksonXmlProperty(localName = "Message")
   public String getMessage() {
     return mMessage;
   }
@@ -69,7 +69,7 @@ public class S3Error {
   /**
    * @return the request ID
    */
-  @XmlElement(name = "RequestId")
+  @JacksonXmlProperty(localName = "RequestId")
   public String getRequestId() {
     return mRequestId;
   }
@@ -77,9 +77,41 @@ public class S3Error {
   /**
    * @return the resource name
    */
-  @XmlElement(name = "Resource")
+  @JacksonXmlProperty(localName = "Resource")
   public String getResource() {
     return mResource;
+  }
+
+  /**
+   * @param code the error code to set
+   */
+  @JacksonXmlProperty(localName = "Code")
+  public void setCode(String code) {
+    mCode = code;
+  }
+
+  /**
+   * @param message the error message to set
+   */
+  @JacksonXmlProperty(localName = "Message")
+  public void setMessage(String message) {
+    mMessage = message;
+  }
+
+  /**
+   * @param requestId the request ID to set
+   */
+  @JacksonXmlProperty(localName = "RequestId")
+  public void setRequestId(String requestId) {
+    mRequestId = requestId;
+  }
+
+  /**
+   * @param resource the resource name to set
+   */
+  @JacksonXmlProperty(localName = "Resource")
+  public void setResource(String resource) {
+    mResource = resource;
   }
 }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -55,7 +55,7 @@ public class S3ErrorCode {
       Response.Status.INTERNAL_SERVER_ERROR);
   public static final S3ErrorCode NO_SUCH_BUCKET = new S3ErrorCode(
       Name.NO_SUCH_BUCKET,
-      "The specified bucket does not exist",
+      "The specified bucket or prefix does not exist",
       Response.Status.NOT_FOUND);
   public static final S3ErrorCode NO_SUCH_KEY = new S3ErrorCode(
       Name.NO_SUCH_KEY,

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -287,15 +287,15 @@ public final class S3RestServiceHandler {
   }
 
   private List<URIStatus> listObjects(AlluxioURI uri, ListBucketOptions listBucketOptions)
-      throws IOException, AlluxioException {
+      throws FileDoesNotExistException, IOException, AlluxioException {
     List<URIStatus> objects = new ArrayList<>();
     Queue<URIStatus> traverseQueue = new ArrayDeque<>();
 
     List<URIStatus> children;
     String prefix = listBucketOptions.getPrefix();
     if (prefix != null && prefix.contains(AlluxioURI.SEPARATOR)) {
-      AlluxioURI prefixDirUri = new AlluxioURI(
-          uri.getPath() + prefix.substring(0, prefix.lastIndexOf(AlluxioURI.SEPARATOR)));
+      AlluxioURI prefixDirUri = new AlluxioURI(uri.getPath() + AlluxioURI.SEPARATOR
+          + prefix.substring(0, prefix.lastIndexOf(AlluxioURI.SEPARATOR)));
       children = mFileSystem.listStatus(prefixDirUri);
     } else {
       children = mFileSystem.listStatus(uri);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -141,38 +141,6 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * @summary deletes a object
-   * @param bucket the bucket name
-   * @param object the object name
-   * @return the response object
-   */
-  @DELETE
-  @Path(OBJECT_PARAM)
-  @ReturnType("Response.Status")
-  public Response deleteObject(@PathParam("bucket") final String bucket,
-                               @PathParam("object") final String object) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
-      @Override
-      public Response.Status call() throws S3Exception {
-        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
-
-        // Delete the object.
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        DeleteOptions options = DeleteOptions.defaults();
-        options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
-            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
-        try {
-          mFileSystem.delete(new AlluxioURI(objectPath), options);
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, objectPath);
-        }
-        // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
-        return Response.Status.NO_CONTENT;
-      }
-    });
-  }
-
-  /**
    * @summary gets a bucket and lists all the objects in it
    * @param bucket the bucket name
    * @return the response object
@@ -202,6 +170,38 @@ public final class S3RestServiceHandler {
         }
         ListBucketResult response = new ListBucketResult(bucketPath, objects);
         return response;
+      }
+    });
+  }
+
+  /**
+   * @summary deletes a object
+   * @param bucket the bucket name
+   * @param object the object name
+   * @return the response object
+   */
+  @DELETE
+  @Path(OBJECT_PARAM)
+  @ReturnType("Response.Status")
+  public Response deleteObject(@PathParam("bucket") final String bucket,
+                               @PathParam("object") final String object) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
+      @Override
+      public Response.Status call() throws S3Exception {
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+
+        // Delete the object.
+        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+        DeleteOptions options = DeleteOptions.defaults();
+        options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
+            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
+        try {
+          mFileSystem.delete(new AlluxioURI(objectPath), options);
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+        // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
+        return Response.Status.NO_CONTENT;
       }
     });
   }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -67,9 +67,9 @@ public final class S3RestServiceHandler {
    */
   public static final String BUCKET_SEPARATOR = ":";
 
-  // Bucket is the first component in the URL path.
+  /* Bucket is the first component in the URL path. */
   public static final String BUCKET_PARAM = "{bucket}/";
-  // Object is after bucket in the URL path.
+  /* Object is after bucket in the URL path */
   public static final String OBJECT_PARAM = "{bucket}/{object:.+}";
 
   private final FileSystem mFileSystem;
@@ -164,11 +164,7 @@ public final class S3RestServiceHandler {
       @Override
       public ListBucketResult call() throws S3Exception {
         Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
-        String bucketPath = AlluxioURI.SEPARATOR + bucket;
-        if (bucketPath.contains(BUCKET_SEPARATOR)) {
-          bucketPath = bucketPath.replace(BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
-          checkNestedBucketIsUnderMountPoint(bucketPath);
-        }
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
 
         checkBucketIsAlluxioDirectory(bucketPath);
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -21,8 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import javax.ws.rs.core.Response;
 
@@ -32,10 +30,9 @@ import javax.ws.rs.core.Response;
 public final class S3RestUtils {
   private static final Logger LOG = LoggerFactory.getLogger(S3RestUtils.class);
 
-  public static final DateFormat S3_DATE_FORMAT =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
   public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
   public static final String S3_EMPTY_ETAG = "";
+  public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
   /**
    * Calls the given {@link S3RestUtils.RestCallable} and handles any exceptions thrown.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -15,6 +15,8 @@ import alluxio.security.LoginUser;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.SecurityUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,10 +78,16 @@ public final class S3RestUtils {
    * @return the response
    */
   private static Response createResponse(Object object) {
-    if (object instanceof Void) {
+    if (object == null || object instanceof Void) {
       return Response.ok().build();
     }
-    return Response.ok(object).build();
+    // Need to explicitly encode the string as JSON because Jackson will not do it automatically.
+    XmlMapper mapper = new XmlMapper();
+    try {
+      return Response.ok(mapper.writeValueAsString(object)).build();
+    } catch (JsonProcessingException e) {
+      return createErrorResponse(new S3Exception(e.getMessage(), S3ErrorCode.INTERNAL_ERROR));
+    }
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -21,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 import javax.ws.rs.core.Response;
 
@@ -29,6 +31,11 @@ import javax.ws.rs.core.Response;
  */
 public final class S3RestUtils {
   private static final Logger LOG = LoggerFactory.getLogger(S3RestUtils.class);
+
+  public static final DateFormat S3_DATE_FORMAT =
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+  public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
+  public static final String S3_EMPTY_ETAG = "";
 
   /**
    * Calls the given {@link S3RestUtils.RestCallable} and handles any exceptions thrown.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -33,6 +33,7 @@ public final class S3RestUtils {
   public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
   public static final String S3_EMPTY_ETAG = "";
   public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  public static final int S3_DEFAULT_MAX_KEYS = 1000;
 
   /**
    * Calls the given {@link S3RestUtils.RestCallable} and handles any exceptions thrown.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -81,7 +81,7 @@ public final class S3RestUtils {
     if (object == null || object instanceof Void) {
       return Response.ok().build();
     }
-    // Need to explicitly encode the string as JSON because Jackson will not do it automatically.
+    // Need to explicitly encode the string as XML because Jackson will not do it automatically.
     XmlMapper mapper = new XmlMapper();
     try {
       return Response.ok(mapper.writeValueAsString(object)).build();

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -248,9 +248,24 @@ public final class S3ClientRestApiTest extends RestApiTest {
     ListBucketResult expected = new ListBucketResult(
         AlluxioURI.SEPARATOR + bucket, objectsList, ListBucketOptions.defaults());
 
-    // Verify
+    // Verify op with no param
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+
+    // Verify op with prefix
+    final String prefix = "dir";
+    Map<String, String> prefixParam = new HashMap<>();
+    prefixParam.put("prefix", prefix);
+    List<URIStatus> filteredObjectsList = new ArrayList<>();
+    filteredObjectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file3, GetStatusOptions.defaults())));
+    filteredObjectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(dir2, GetStatusOptions.defaults())));
+    expected = new ListBucketResult(AlluxioURI.SEPARATOR + bucket, filteredObjectsList,
+        ListBucketOptions.defaults().setPrefix(prefix));
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket,
+        prefixParam, HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
   }
 

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -126,10 +126,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
       // Create a new bucket under a non-existing mount point should fail.
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
           HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
-      Assert.fail();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create bucket under non-existing mount point should fail");
   }
 
   @Test
@@ -145,10 +146,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
       // Create a new bucket under a non-mount-point directory should fail.
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
           HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
-      Assert.fail();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create bucket under non-mount-point directory should fail");
   }
 
   @Test
@@ -178,10 +180,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
       // Delete a non-existing bucket should fail.
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
           NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
-      Assert.fail("delete a non-existing bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete a non-existing bucket should fail");
   }
 
   @Test
@@ -202,10 +205,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
       // Delete a non-empty bucket should fail.
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
           NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
-      Assert.fail("delete a non-empty bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete a non-empty bucket should fail");
   }
 
   @Test
@@ -252,6 +256,34 @@ public final class S3ClientRestApiTest extends RestApiTest {
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void getBucketWithPrefix() throws Exception {
+    final String bucket = "bucket-to-get-with-prefix";
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
+        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with direct child objects and objects within sub directories:
+    // - /file1
+    // - /file2
+    // - /dir1/subdir1/file3
+    // - /dir2/
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+    AlluxioURI dir1 = new AlluxioURI(uri.getPath() + "/dir1");
+    mFileSystemMaster.createDirectory(dir1, CreateDirectoryOptions.defaults());
+    AlluxioURI dir2 = new AlluxioURI(uri.getPath() + "/dir2");
+    mFileSystemMaster.createDirectory(dir2, CreateDirectoryOptions.defaults());
+    AlluxioURI subdir1 = new AlluxioURI(uri.getPath() + "/dir1/subdir1");
+    mFileSystemMaster.createDirectory(subdir1, CreateDirectoryOptions.defaults());
+    AlluxioURI file3 = new AlluxioURI(subdir1.getPath() + "/file3");
+    mFileSystemMaster.createFile(file3, CreateFileOptions.defaults());
 
     // Verify op with prefix
     final String prefix = "dir";
@@ -262,8 +294,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
         new URIStatus(mFileSystemMaster.getFileInfo(file3, GetStatusOptions.defaults())));
     filteredObjectsList.add(
         new URIStatus(mFileSystemMaster.getFileInfo(dir2, GetStatusOptions.defaults())));
-    expected = new ListBucketResult(AlluxioURI.SEPARATOR + bucket, filteredObjectsList,
-        ListBucketOptions.defaults().setPrefix(prefix));
+    ListBucketResult expected = new ListBucketResult(AlluxioURI.SEPARATOR + bucket,
+        filteredObjectsList, ListBucketOptions.defaults().setPrefix(prefix));
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket,
         prefixParam, HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
@@ -369,10 +401,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
           NO_PARAMS, HttpMethod.GET, null,
           TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
-      Assert.fail("get a non-existing bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("get a non-existing bucket should fail");
   }
 
   @Test
@@ -449,7 +482,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
           NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete non-empty directory as an object should fail");
   }
 
   @Test
@@ -465,6 +500,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
           NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete non-existing object should fail");
   }
 }

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -217,20 +217,38 @@ public final class S3ClientRestApiTest extends RestApiTest {
     // Verify the directory is created for the new bucket.
     Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
 
-    AlluxioURI fileUri1 = new AlluxioURI(uri.getPath() + "/file1");
-    mFileSystemMaster.createFile(fileUri1, CreateFileOptions.defaults());
-    AlluxioURI fileUri2 = new AlluxioURI(uri.getPath() + "/file2");
-    mFileSystemMaster.createFile(fileUri2, CreateFileOptions.defaults());
+    // Prepare a bucket with direct child objects and objects within sub directories:
+    // - /file1
+    // - /file2
+    // - /dir1/subdir1/file3
+    // - /dir2/
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+    AlluxioURI dir1 = new AlluxioURI(uri.getPath() + "/dir1");
+    mFileSystemMaster.createDirectory(dir1, CreateDirectoryOptions.defaults());
+    AlluxioURI dir2 = new AlluxioURI(uri.getPath() + "/dir2");
+    mFileSystemMaster.createDirectory(dir2, CreateDirectoryOptions.defaults());
+    AlluxioURI subdir1 = new AlluxioURI(uri.getPath() + "/dir1/subdir1");
+    mFileSystemMaster.createDirectory(subdir1, CreateDirectoryOptions.defaults());
+    AlluxioURI file3 = new AlluxioURI(subdir1.getPath() + "/file3");
+    mFileSystemMaster.createFile(file3, CreateFileOptions.defaults());
 
+    // Expected result.
     List<URIStatus> objectsList = new ArrayList<>();
-
     objectsList.add(
-        new URIStatus(mFileSystemMaster.getFileInfo(fileUri1, GetStatusOptions.defaults())));
+        new URIStatus(mFileSystemMaster.getFileInfo(file1, GetStatusOptions.defaults())));
     objectsList.add(
-        new URIStatus(mFileSystemMaster.getFileInfo(fileUri2, GetStatusOptions.defaults())));
-
+        new URIStatus(mFileSystemMaster.getFileInfo(file2, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file3, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(dir2, GetStatusOptions.defaults())));
     ListBucketResult expected =
         new ListBucketResult(AlluxioURI.SEPARATOR + bucket, objectsList);
+
+    // Verify
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -222,15 +222,15 @@ public final class S3ClientRestApiTest extends RestApiTest {
     AlluxioURI fileUri2 = new AlluxioURI(uri.getPath() + "/file2");
     mFileSystemMaster.createFile(fileUri2, CreateFileOptions.defaults());
 
-    List<URIStatus> listStatusResult = new ArrayList<>();
+    List<URIStatus> objectsList = new ArrayList<>();
 
-    listStatusResult.add(
+    objectsList.add(
         new URIStatus(mFileSystemMaster.getFileInfo(fileUri1, GetStatusOptions.defaults())));
-    listStatusResult.add(
+    objectsList.add(
         new URIStatus(mFileSystemMaster.getFileInfo(fileUri2, GetStatusOptions.defaults())));
 
     ListBucketResult expected =
-        new ListBucketResult(AlluxioURI.SEPARATOR + bucket, listStatusResult);
+        new ListBucketResult(AlluxioURI.SEPARATOR + bucket, objectsList);
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -12,9 +12,11 @@
 package alluxio.rest;
 
 import alluxio.Constants;
+import alluxio.exception.status.InvalidArgumentException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -139,7 +141,7 @@ public final class TestCase {
     }
     if (mOptions.getBody() != null) {
       connection.setDoOutput(true);
-      connection.setRequestProperty("Content-Type", "application/json");
+      connection.setRequestProperty("Content-Type", mOptions.getContentType());
       ObjectMapper mapper = new ObjectMapper();
       // make sure that serialization of empty objects does not fail
       mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -165,11 +167,22 @@ public final class TestCase {
   public void run() throws Exception {
     String expected = "";
     if (mExpectedResult != null) {
-      ObjectMapper mapper = new ObjectMapper();
-      if (mOptions.isPrettyPrint()) {
-        expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+      if (mOptions.getContentType().equals(TestCaseOptions.JSON_CONTENT_TYPE)) {
+        ObjectMapper mapper = new ObjectMapper();
+        if (mOptions.isPrettyPrint()) {
+          expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+        } else {
+          expected = mapper.writeValueAsString(mExpectedResult);
+        }
+      } else if (mOptions.getContentType().equals(TestCaseOptions.XML_CONTENT_TYPE)) {
+        XmlMapper mapper = new XmlMapper();
+        if (mOptions.isPrettyPrint()) {
+          expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+        } else {
+          expected = mapper.writeValueAsString(mExpectedResult);
+        }
       } else {
-        expected = mapper.writeValueAsString(mExpectedResult);
+        throw new InvalidArgumentException("Invalid content type in TestCaseOptions!");
       }
     }
     String result = call();

--- a/tests/src/test/java/alluxio/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptions.java
@@ -23,9 +23,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 // TODO(jiri): consolidate input stream and body fields
 @NotThreadSafe
 public final class TestCaseOptions {
+  public static final String JSON_CONTENT_TYPE = "application/json";
+  public static final String XML_CONTENT_TYPE = "application/xml";
+
   private Object mBody;
   private InputStream mInputStream;
   private boolean mPrettyPrint;
+  private String mContentType;
 
   /**
    * @return the default {@link TestCaseOptions}
@@ -38,6 +42,7 @@ public final class TestCaseOptions {
     mBody = null;
     mInputStream = null;
     mPrettyPrint = false;
+    mContentType = JSON_CONTENT_TYPE;
   }
 
   /**
@@ -59,6 +64,13 @@ public final class TestCaseOptions {
    */
   public boolean isPrettyPrint() {
     return mPrettyPrint;
+  }
+
+  /**
+   * @return the content type
+   */
+  public String getContentType() {
+    return mContentType;
   }
 
   /**
@@ -88,6 +100,15 @@ public final class TestCaseOptions {
     return this;
   }
 
+  /**
+   * @param contentType the content type to set
+   * @return the updated options object
+   */
+  public TestCaseOptions setContentType(String contentType) {
+    mContentType = contentType;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -99,12 +120,13 @@ public final class TestCaseOptions {
     TestCaseOptions that = (TestCaseOptions) o;
     return Objects.equal(mBody, that.mBody)
         && Objects.equal(mInputStream, that.mInputStream)
-        && mPrettyPrint == that.mPrettyPrint;
+        && mPrettyPrint == that.mPrettyPrint
+        && mContentType == that.mContentType;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mBody, mInputStream, mPrettyPrint);
+    return Objects.hashCode(mBody, mInputStream, mPrettyPrint, mContentType);
   }
 
   @Override
@@ -113,6 +135,7 @@ public final class TestCaseOptions {
         .add("body", mBody)
         .add("input stream", mInputStream)
         .add("pretty print", mPrettyPrint)
+        .add("content type", mContentType)
         .toString();
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2997

This PR
- implements the GET bucket operation: recursively listing all the files and empty-directories as objects
- adds integration tests for the GET bucket
- Add Xml support in `rest/TestCase`

The API is compatible as the AWS S3 doc here: http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html

How to test:
Assuming `/default_tests_files` is a valid directory pre-existing in Alluxio namespace and there are some dirs and files under it.
```
import boto
import boto.s3.connection
access_key = 'put your access key here!'
secret_key = 'put your secret key here!'

conn = boto.connect_s3(
    aws_access_key_id = access_key,
    aws_secret_access_key = secret_key,
    host = 'localhost',
    port = 39999,
    path = '/api/v1/s3',
    is_secure=False,
    calling_format = boto.s3.connection.OrdinaryCallingFormat(),
)

# This will succeed.
bucket = conn.get_bucket('default_tests_files')

print bucket
for key in bucket.list():
    print "{name}\t{size}\t{modified}".format(
        name = key.name,
        size = key.size,
        modified = key.last_modified,
        )
```

Test Output:
```
➜  s3-go-server python alluxio-s3-client.py
<Bucket: default_tests_files>
BASIC_CACHE_ASYNC_THROUGH	80	2017-08-22T19:28:56.956Z
BASIC_CACHE_CACHE_THROUGH	80	2017-08-22T19:28:55.159Z
BASIC_CACHE_MUST_CACHE	80	2017-08-22T19:28:55.133Z
BASIC_CACHE_PROMOTE_ASYNC_THROUGH	80	2017-08-22T19:28:56.958Z
BASIC_CACHE_PROMOTE_CACHE_THROUGH	80	2017-08-22T19:28:54.997Z
BASIC_CACHE_PROMOTE_MUST_CACHE	80	2017-08-22T19:28:54.812Z
BASIC_CACHE_PROMOTE_THROUGH	80	2017-08-22T19:28:55.024Z
BASIC_CACHE_THROUGH	80	2017-08-22T19:28:55.178Z
BASIC_NON_BYTE_BUFFER_CACHE_ASYNC_THROUGH	84	2017-08-22T19:28:56.959Z
BASIC_NON_BYTE_BUFFER_CACHE_CACHE_THROUGH	84	2017-08-22T19:28:55.171Z
BASIC_NON_BYTE_BUFFER_CACHE_MUST_CACHE	84	2017-08-22T19:28:55.145Z
BASIC_NON_BYTE_BUFFER_CACHE_PROMOTE_ASYNC_THROUGH	84	2017-08-22T19:28:56.959Z
BASIC_NON_BYTE_BUFFER_CACHE_PROMOTE_CACHE_THROUGH	84	2017-08-22T19:28:55.016Z
BASIC_NON_BYTE_BUFFER_CACHE_PROMOTE_MUST_CACHE	84	2017-08-22T19:28:54.878Z
BASIC_NON_BYTE_BUFFER_CACHE_PROMOTE_THROUGH	84	2017-08-22T19:28:55.065Z
BASIC_NON_BYTE_BUFFER_CACHE_THROUGH	84	2017-08-22T19:28:55.198Z
BASIC_NON_BYTE_BUFFER_NO_CACHE_ASYNC_THROUGH	84	2017-08-22T19:28:56.958Z
BASIC_NON_BYTE_BUFFER_NO_CACHE_CACHE_THROUGH	84	2017-08-22T19:28:55.279Z
BASIC_NON_BYTE_BUFFER_NO_CACHE_MUST_CACHE	84	2017-08-22T19:28:55.254Z
BASIC_NON_BYTE_BUFFER_NO_CACHE_THROUGH	84	2017-08-22T19:28:55.294Z
BASIC_NO_CACHE_ASYNC_THROUGH	80	2017-08-22T19:28:56.958Z
BASIC_NO_CACHE_CACHE_THROUGH	80	2017-08-22T19:28:55.267Z
BASIC_NO_CACHE_MUST_CACHE	80	2017-08-22T19:28:55.243Z
BASIC_NO_CACHE_THROUGH	80	2017-08-22T19:28:55.287Z
```