### PR TITLE
[ALLUXIO-3002] Remove lock downgrade of the last node in inodetree

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2374,7 +2374,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         // After completing the inode, the lock on the last inode which stands for the created file
         // should be downgraded to a read lock, so that it won't block the reads operations from
         // other thread. More importantly, it's possible the subsequent read operations within the
-        // same thread may the read parent nodes along the path,and multiple similar threads may
+        // same thread may the read parent nodes along the path, and multiple similar threads may
         // lock each other. For example, getFileStatus will discover the metadata of UFS files and
         // it creates an inode per discovered. Concurrent getFileStatus of the same directory will
         // lead to such contention.

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -50,7 +50,6 @@ import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeLockList;
 import alluxio.master.file.meta.InodePathPair;
 import alluxio.master.file.meta.InodeTree;
-import alluxio.master.file.meta.InodeTree.LockMode;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.PersistenceState;
@@ -2370,7 +2369,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       createFileAndJournal(inodePath, createFileOptions, journalContext);
       CompleteFileOptions completeOptions = CompleteFileOptions.defaults().setUfsLength(ufsLength);
       completeFileAndJournal(inodePath, completeOptions, journalContext);
-      if (inodePath.getLockMode() == LockMode.READ) {
+      if (inodePath.getLockMode() == InodeTree.LockMode.READ) {
         // After completing the inode, the lock on the last inode which stands for the created file
         // should be downgraded to a read lock, so that it won't block the reads operations from
         // other thread. More importantly, it's possible the subsequent read operations within the

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -358,8 +358,6 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
    * @throws InvalidPathException if the parent is not as expected
    */
   public void lockReadAndCheckParent(Inode parent) throws InvalidPathException {
-    System.out.println(Thread.currentThread().getName() + " wants to lock inode " + mName + " "
-        + mId + " and check parent " + parent.getName() + " " + parent.getId());
     lockRead();
     if (mDeleted) {
       unlockRead();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -19,6 +19,8 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -32,6 +34,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class Inode<T> implements JournalEntryRepresentable {
+  private static final Logger LOG = LoggerFactory.getLogger(Inode.class);
   protected long mCreationTimeMs;
   private boolean mDeleted;
   protected final boolean mDirectory;
@@ -355,6 +358,8 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
    * @throws InvalidPathException if the parent is not as expected
    */
   public void lockReadAndCheckParent(Inode parent) throws InvalidPathException {
+    System.out.println(Thread.currentThread().getName() + " wants to lock inode " + mName + " "
+        + mId + " and check parent " + parent.getName() + " " + parent.getId());
     lockRead();
     if (mDeleted) {
       unlockRead();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -95,25 +95,6 @@ public final class InodeLockList implements AutoCloseable {
   }
 
   /**
-   * Downgrades the last inode that was locked, if the inode was previously WRITE locked. If the
-   * inode was previously READ locked, no additional locking will occur.
-   */
-  public synchronized void downgradeLast() {
-    if (mInodes.isEmpty()) {
-      return;
-    }
-    if (mLockModes.get(mLockModes.size() - 1) != InodeTree.LockMode.READ) {
-      // The last inode was previously WRITE locked, so downgrade the lock.
-      Inode<?> inode = mInodes.get(mInodes.size() - 1);
-      inode.lockRead();
-      inode.unlockWrite();
-      // Update the last lock mode to READ
-      mLockModes.remove(mLockModes.size() - 1);
-      mLockModes.add(InodeTree.LockMode.READ);
-    }
-  }
-
-  /**
    * Locks the given inode in write mode, and adds it to this lock list. This call should only be
    * used when locking the root or an inode by id and not path or parent.
    *

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -608,9 +608,6 @@ public class InodeTree implements JournalEntryIterable {
           // Journal the new inode.
           journalContext.append(dir.toJournalEntry());
           mInodes.add(dir);
-
-          // After creation and journaling, downgrade to a read lock.
-          lockList.downgradeLast();
         }
       }
 
@@ -695,11 +692,6 @@ public class InodeTree implements JournalEntryIterable {
 
         // Update state while holding the write lock.
         mInodes.add(lastInode);
-
-        if (extensibleInodePath.getLockMode() == LockMode.READ) {
-          // After creating the inode, downgrade to a read lock
-          lockList.downgradeLast();
-        }
 
         createdInodes.add(lastInode);
         extensibleInodePath.getInodes().add(lastInode);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -608,6 +608,9 @@ public class InodeTree implements JournalEntryIterable {
           // Journal the new inode.
           journalContext.append(dir.toJournalEntry());
           mInodes.add(dir);
+
+          // After creation and journaling, downgrade to a read lock.
+          lockList.downgradeLast();
         }
       }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -130,4 +130,12 @@ public abstract class LockedInodePath implements AutoCloseable {
   public synchronized void close() {
     mLockList.close();
   }
+
+  /**
+   * Downgrades the last inode that was locked, if the inode was previously WRITE locked. If the
+   * inode was previously READ locked, no additional locking will occur.
+   */
+  public synchronized void downgradeLast() {
+    mLockList.downgradeLast();
+  }
 }

--- a/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterCreateTest.java
+++ b/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterCreateTest.java
@@ -14,6 +14,8 @@ package alluxio.master.file;
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.BaseIntegrationTest;
+import alluxio.Configuration;
+import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
@@ -29,6 +31,7 @@ import alluxio.underfs.sleepfs.SleepingUnderFileSystemOptions;
 import alluxio.wire.LoadMetadataType;
 
 import com.google.common.io.Files;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -73,11 +76,18 @@ public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
   @ClassRule
   public static UnderFileSystemFactoryRegistryRule sUnderfilesystemfactoryregistry =
       new UnderFileSystemFactoryRegistryRule(new SleepingUnderFileSystemFactory(
-          new SleepingUnderFileSystemOptions().setMkdirsMs(SLEEP_MS).setIsDirectoryMs(SLEEP_MS)));
+          new SleepingUnderFileSystemOptions().setMkdirsMs(SLEEP_MS).setIsDirectoryMs(SLEEP_MS)
+              .setGetFileStatusMs(SLEEP_MS).setIsFileMs(SLEEP_MS)));
 
   @Before
   public void before() {
     mFileSystem = FileSystem.Factory.get();
+    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "2b");
+  }
+
+  @After
+  public void after() {
+    ConfigurationTestUtils.resetConfiguration();
   }
 
   /**
@@ -274,7 +284,7 @@ public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
     for (int i = 0; i < uniquePaths; i++) {
       if (createFiles) {
         FileWriter fileWriter = new FileWriter(mLocalUfsPath + "/existing/path/last_" + i);
-        fileWriter.write("test");
+        fileWriter.write("testtesttesttest");
         fileWriter.close();
       } else {
         new File(mLocalUfsPath + "/existing/path/last_" + i).mkdirs();

--- a/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterUtils.java
+++ b/tests/src/test/java/alluxio/master/file/ConcurrentFileSystemMasterUtils.java
@@ -101,6 +101,7 @@ public class ConcurrentFileSystemMasterUtils {
     // If there are exceptions, we will store them here.
     final List<Throwable> errors = Collections.synchronizedList(new ArrayList<Throwable>());
     Thread.UncaughtExceptionHandler exceptionHandler = new Thread.UncaughtExceptionHandler() {
+      @Override
       public void uncaughtException(Thread th, Throwable ex) {
         errors.add(ex);
       }
@@ -121,7 +122,10 @@ public class ConcurrentFileSystemMasterUtils {
                 fileSystem.delete(paths[iteration]);
                 break;
               case GET_FILE_INFO:
-                fileSystem.getStatus(paths[iteration]);
+                URIStatus status = fileSystem.getStatus(paths[iteration]);
+                if (!status.isFolder()) {
+                  Assert.assertNotEquals(0, status.getBlockIds().size());
+                }
                 break;
               case LIST_STATUS:
                 fileSystem.listStatus(paths[iteration]);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3002

The use of downgradeLast in inode.createFile is risky and could lead to race conditions.
The downgrade to read lock in create file was based on the assumption that file node creation is an atomic operation that after the inode is created it would not be modified and therefore it's safe for other threads to read, in order to improve the throughput.
However, such assumption is not necessarily true as in the case that a getFileInfo discovers a file in UFS and creates an inode in Alluxio. The creation consists of two steps: (1) create the inode in the inodetree (2) complete the file with the block IDs generation. If the lock is downgraded, it's possible that a concurrent getFileInfo request of the same file accesses the partial state before the inode is completed. Since the code block of create and then complete is guarded by the lock on the inode list, the lock should not be downgraded.