### PR TITLE
[ALLUXIO-2997] [s3] Implement S3 DELETE object API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -27,6 +27,8 @@ public class S3ErrorCode {
     public static final String INTERNAL_ERROR = "InternalError";
     public static final String INVALID_BUCKET_NAME = "InvalidBucketName";
     public static final String NO_SUCH_BUCKET = "NoSuchBucket";
+    public static final String NO_SUCH_KEY = "NoSuchKey";
+    public static final String PRECONDITION_FAILED = "PreconditionFailed";
 
     private Name() {
     } // prevents instantiation
@@ -55,6 +57,14 @@ public class S3ErrorCode {
       Name.NO_SUCH_BUCKET,
       "The specified bucket does not exist",
       Response.Status.NOT_FOUND);
+  public static final S3ErrorCode NO_SUCH_KEY = new S3ErrorCode(
+      Name.NO_SUCH_KEY,
+      "The specified key does not exist",
+      Response.Status.NOT_FOUND);
+  public static final S3ErrorCode PRECONDITION_FAILED = new S3ErrorCode(
+      Name.PRECONDITION_FAILED,
+      "At least one of the preconditions did not hold",
+      Response.Status.PRECONDITION_FAILED);
 
   //
   // Customized error codes.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -81,11 +81,11 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(BUCKET_PARAM)
-  @ReturnType("java.lang.Void")
+  @ReturnType("Response.Status")
   public Response createBucket(@PathParam("bucket") final String bucket) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Void>() {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
-      public Void call() throws S3Exception {
+      public Response.Status call() throws S3Exception {
         String bucketPath =  AlluxioURI.SEPARATOR + bucket;
         if (bucketPath.contains(BUCKET_SEPARATOR)) {
           bucketPath = bucketPath.replace(BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
@@ -101,7 +101,7 @@ public final class S3RestServiceHandler {
         } catch (Exception e) {
           throw toBucketS3Exception(e, bucketPath);
         }
-        return null;
+        return Response.Status.OK;
       }
     });
   }
@@ -113,11 +113,11 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(BUCKET_PARAM)
-  @ReturnType("java.lang.Void")
+  @ReturnType("Response.Status")
   public Response deleteBucket(@PathParam("bucket") final String bucket) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Void>() {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
-      public Void call() throws S3Exception {
+      public Response.Status call() throws S3Exception {
         String bucketPath =  AlluxioURI.SEPARATOR + bucket;
         if (bucketPath.contains(BUCKET_SEPARATOR)) {
           bucketPath = bucketPath.replace(BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
@@ -135,7 +135,7 @@ public final class S3RestServiceHandler {
         } catch (Exception e) {
           throw toBucketS3Exception(e, bucketPath);
         }
-        return null;
+        return Response.Status.OK;
       }
     });
   }
@@ -148,12 +148,12 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  @ReturnType("java.lang.Void")
+  @ReturnType("Response.Status")
   public Response deleteObject(@PathParam("bucket") final String bucket,
                                @PathParam("object") final String object) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Void>() {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
-      public Void call() throws S3Exception {
+      public Response.Status call() throws S3Exception {
         String bucketPath =  AlluxioURI.SEPARATOR + bucket;
         if (bucketPath.contains(BUCKET_SEPARATOR)) {
           bucketPath = bucketPath.replace(BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
@@ -170,9 +170,10 @@ public final class S3RestServiceHandler {
         try {
           mFileSystem.delete(new AlluxioURI(objectPath), options);
         } catch (Exception e) {
-          throw toBucketS3Exception(e, objectPath);
+          throw toObjectS3Exception(e, objectPath);
         }
-        return null;
+        // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
+        return Response.Status.NO_CONTENT;
       }
     });
   }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -161,7 +161,7 @@ public final class S3RestServiceHandler {
         }
 
         String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        checkObjectIsAlluxioFile(objectPath);
+        checkObjectInAlluxio(objectPath);
 
         // Delete the object.
         DeleteOptions options = DeleteOptions.defaults();
@@ -233,7 +233,13 @@ public final class S3RestServiceHandler {
     }
   }
 
-  private void checkObjectIsAlluxioFile(String objectPath) throws S3Exception {
+  /**
+   * Checks the given object is either a file or an empty directory in Alluxio.
+   *
+   * @param objectPath the object path in Alluxio
+   * @throws S3Exception if the object is not a valid in Alluxio
+   */
+  private void checkObjectInAlluxio(String objectPath) throws S3Exception {
     try {
       AlluxioURI uri = new AlluxioURI(objectPath);
       URIStatus status = mFileSystem.getStatus(uri);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -60,7 +60,7 @@ public final class S3RestServiceHandler {
   // Bucket is the first component in the URL path.
   public static final String BUCKET_PARAM = "{bucket}/";
   // Object is after bucket in the URL path.
-  public static final String OBJECT_PARAM = "{bucket}/{object:.*}";
+  public static final String OBJECT_PARAM = "{bucket}/{object:.+}";
 
   private final FileSystem mFileSystem;
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -86,7 +86,7 @@ public final class S3RestServiceHandler {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
       public Response.Status call() throws S3Exception {
-        String bucketPath = maybeUpdateAndCheckBucketPath(AlluxioURI.SEPARATOR + bucket);
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
 
         // Create the bucket.
         CreateDirectoryOptions options = CreateDirectoryOptions.defaults();
@@ -114,7 +114,7 @@ public final class S3RestServiceHandler {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
       public Response.Status call() throws S3Exception {
-        String bucketPath = maybeUpdateAndCheckBucketPath(AlluxioURI.SEPARATOR + bucket);
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
 
         checkBucketIsAlluxioDirectory(bucketPath);
 
@@ -146,7 +146,7 @@ public final class S3RestServiceHandler {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
       public Response.Status call() throws S3Exception {
-        String bucketPath = maybeUpdateAndCheckBucketPath(AlluxioURI.SEPARATOR + bucket);
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
 
         // Delete the object.
         String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
@@ -196,7 +196,7 @@ public final class S3RestServiceHandler {
     }
   }
 
-  private String maybeUpdateAndCheckBucketPath(String bucketPath) throws S3Exception {
+  private String parseBucketPath(String bucketPath) throws S3Exception {
     if (!bucketPath.contains(BUCKET_SEPARATOR)) {
       return bucketPath;
     }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -76,9 +76,25 @@ public final class S3RestUtils {
    * @return the response
    */
   private static Response createResponse(Object object) {
-    if (object instanceof Void) {
+    if (object == null) {
       return Response.ok().build();
     }
+
+    if (object instanceof Response.Status) {
+      Response.Status s = (Response.Status) object;
+      switch (s) {
+        case OK:
+          return Response.ok().build();
+        case ACCEPTED:
+          return Response.accepted().build();
+        case NO_CONTENT:
+          return Response.noContent().build();
+        default:
+          return createErrorResponse(
+              new S3Exception("Response status is invalid", S3ErrorCode.INTERNAL_ERROR));
+      }
+    }
+
     return Response.ok(object).build();
   }
 

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -60,7 +60,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void putBucket() throws Exception {
     final String bucket = "bucket";
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
     // Verify the directory is created for the new bucket.
@@ -150,7 +150,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteBucket() throws Exception {
     final String bucket = "bucket-to-delete";
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
         HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
     // Verify the directory is created for the new bucket.
@@ -184,7 +184,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   public void deleteNonEmptyBucket() throws Exception {
     final String bucketName = "non-empty-bucket";
 
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR);
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
         HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
 
@@ -199,6 +199,99 @@ public final class S3ClientRestApiTest extends RestApiTest {
       new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
           NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
       Assert.fail("delete a non-empty bucket should fail");
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void deleteObject() throws Exception {
+    final String bucketName = "bucket-with-object-to-delete";
+
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
+        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+
+    final String objectName = "file";
+    AlluxioURI fileUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createFile(fileUri, CreateFileOptions.defaults());
+
+    // Verify the directory is created for the new bucket, and file is created under it.
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+
+    new TestCase(mHostname, mPort,
+        S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
+        NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+
+    // Verify the object is deleted.
+    Assert.assertTrue(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void deleteObjectAsAlluxioEmptyDir() throws Exception {
+    final String bucketName = "bucket-with-empty-dir-to-delete";
+
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
+        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+
+    String objectName = "empty-dir/";
+    AlluxioURI dirUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
+
+    // Verify the directory is created for the new bucket, and empty-dir is created under it.
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+
+    new TestCase(mHostname, mPort,
+        S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
+        NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+
+    // Verify the empty-dir as a valid object is deleted.
+    Assert.assertTrue(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void deleteObjectAsAlluxioNonEmptyDir() throws Exception {
+    final String bucketName = "bucket-with-non-empty-dir-to-delete";
+
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
+        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+
+    String objectName = "non-empty-dir/";
+    AlluxioURI dirUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
+
+    mFileSystemMaster.createFile(
+        new AlluxioURI(dirUri.getPath() + "/file"), CreateFileOptions.defaults());
+
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(dirUri, ListStatusOptions.defaults()).isEmpty());
+
+    try {
+      new TestCase(mHostname, mPort,
+          S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
+          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void deleteNonExistingObject() throws Exception {
+    final String bucketName = "bucket-with-nothing";
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
+        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+
+    String objectName = "non-existing-object";
+    try {
+      new TestCase(mHostname, mPort,
+          S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
+          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
     } catch (AssertionError e) {
       // expected
     }

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -149,7 +149,8 @@ public final class TestCase {
     }
 
     connection.connect();
-    if (connection.getResponseCode() != Response.Status.OK.getStatusCode()) {
+    if (Response.Status.Family.familyOf(connection.getResponseCode())
+        != Response.Status.Family.SUCCESSFUL) {
       InputStream errorStream = connection.getErrorStream();
       if (errorStream != null) {
         Assert.fail("Request failed: " + IOUtils.toString(errorStream));


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2997

A valid object is either an existing Alluxio file or an empty Alluxio directory.
Also added tests.

How this PR is tested:
Along with the other [PR](https://github.com/Alluxio/alluxio/pull/5927) is merged, the following script works (assuming `/bucket1/key1` is a file exists in Alluxio) :
```import boto
import boto.s3.connection
access_key = 'put your access key here!'
secret_key = 'put your secret key here!'

conn = boto.connect_s3(
    aws_access_key_id = access_key,
    aws_secret_access_key = secret_key,
    host = 'localhost',
    port = 39999,
    path = '/api/v1/s3',
    is_secure=False,
    calling_format = boto.s3.connection.OrdinaryCallingFormat(),
)

# This will succeed.
bucket = conn.get_bucket('bucket1')

print bucket
for key in bucket.list():
    print "{name}\t{size}\t{modified}".format(
        name = key.name,
        size = key.size,
        modified = key.last_modified,
        )

bucket.delete_key('key1')
```