### PR TITLE
[DOCFIX] Fix colon in yml files

### DIFF
--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -1,204 +1,204 @@
 alluxio.conf.dir:
-  The directory containing files used to configure Alluxio.
+  'The directory containing files used to configure Alluxio.'
 alluxio.debug:
-  Set to true to enable debug mode which has additional logging and info in the Web UI.
+  'Set to true to enable debug mode which has additional logging and info in the Web UI.'
 alluxio.extensions.dir:
-  The directory containing Alluxio extensions.
+  'The directory containing Alluxio extensions.'
 alluxio.fuse.cached.paths.max:
-  N/A
+  'N/A'
 alluxio.fuse.debug.enabled:
-  N/A
+  'N/A'
 alluxio.fuse.fs.name:
-  N/A
+  'N/A'
 alluxio.fuse.fs.root:
-  N/A
+  'N/A'
 alluxio.fuse.maxwrite.bytes:
-  N/A
+  'N/A'
 alluxio.fuse.mount.default:
-  N/A
+  'N/A'
 alluxio.home:
-  Alluxio installation directory.
+  'Alluxio installation directory.'
 alluxio.integration.master.resource.cpu:
-  N/A
+  'N/A'
 alluxio.integration.master.resource.mem:
-  N/A
+  'N/A'
 alluxio.integration.mesos.alluxio.jar.url:
-  N/A
+  'N/A'
 alluxio.integration.mesos.jdk.path:
-  N/A
+  'N/A'
 alluxio.integration.mesos.jdk.url:
-  N/A
+  'N/A'
 alluxio.integration.mesos.master.name:
-  N/A
+  'N/A'
 alluxio.integration.mesos.master.node.count:
-  N/A
+  'N/A'
 alluxio.integration.mesos.principal:
-  N/A
+  'N/A'
 alluxio.integration.mesos.role:
-  N/A
+  'N/A'
 alluxio.integration.mesos.secret:
-  N/A
+  'N/A'
 alluxio.integration.mesos.user:
-  N/A
+  'N/A'
 alluxio.integration.mesos.worker.name:
-  N/A
+  'N/A'
 alluxio.integration.worker.resource.cpu:
-  N/A
+  'N/A'
 alluxio.integration.worker.resource.mem:
-  N/A
+  'N/A'
 alluxio.integration.yarn.workers.per.host.max:
-  N/A
+  'N/A'
 alluxio.logger.type:
-  N/A
+  'N/A'
 alluxio.logs.dir:
-  The path to store log files.
+  'The path to store log files.'
 alluxio.metrics.conf.file:
-  The file path of the metrics system configuration file. By default it is `metrics.properties` in the `conf` directory.
+  'The file path of the metrics system configuration file. By default it is `metrics.properties` in the `conf` directory.'
 alluxio.network.host.resolution.timeout:
-  During startup of the Master and Worker processes Alluxio needs to ensure that they are listening on externally resolvable and reachable host names. To do this, Alluxio will automatically attempt to select an appropriate host name if one was not explicitly specified. This represents the maximum amount of time spent waiting to determine if a candidate host name is resolvable over the network.
+  'During startup of the Master and Worker processes Alluxio needs to ensure that they are listening on externally resolvable and reachable host names. To do this, Alluxio will automatically attempt to select an appropriate host name if one was not explicitly specified. This represents the maximum amount of time spent waiting to determine if a candidate host name is resolvable over the network.'
 alluxio.network.netty.heartbeat.timeout:
-  The amount of time the server will wait before closing a netty connection if there has not been any incoming traffic. The client will periodically heartbeat when there is no activity on a connection. This value should be the same on the clients and server.
+  'The amount of time the server will wait before closing a netty connection if there has not been any incoming traffic. The client will periodically heartbeat when there is no activity on a connection. This value should be the same on the clients and server.'
 alluxio.network.thrift.frame.size.bytes.max:
-  (Experimental) The largest allowable frame size used for Thrift RPC communication.
+  '(Experimental) The largest allowable frame size used for Thrift RPC communication.'
 alluxio.proxy.stream.cache.timeout:
-  N/A
+  'N/A'
 alluxio.proxy.web.bind.host:
-  N/A
+  'N/A'
 alluxio.proxy.web.hostname:
-  N/A
+  'N/A'
 alluxio.proxy.web.port:
-  N/A
+  'N/A'
 alluxio.site.conf.dir:
-  Comma-separated search path for alluxio-site.properties
+  'Comma-separated search path for alluxio-site.properties'
 alluxio.test.mode:
-  Flag used only during tests to allow special behavior.
+  'Flag used only during tests to allow special behavior.'
 alluxio.underfs.address:
-  Alluxio directory in the under file system.
+  'Alluxio directory in the under file system.'
 alluxio.underfs.allow.set.owner.failure:
-  N/A
+  'N/A'
 alluxio.underfs.gcs.owner.id.to.username.mapping:
-  Optionally, specify a preset gcs owner id to Alluxio username static mapping in the format "id1=user1;id2=user2". The Google Cloud Storage IDs can be found at the console address https://console.cloud.google.com/storage/settings . Please use the "Owners" one.
+  'Optionally, specify a preset gcs owner id to Alluxio username static mapping in the format "id1=user1;id2=user2". The Google Cloud Storage IDs can be found at the console address https://console.cloud.google.com/storage/settings . Please use the "Owners" one.'
 alluxio.underfs.glusterfs.impl:
-  Glusterfs hook with hadoop.
+  'Glusterfs hook with hadoop.'
 alluxio.underfs.glusterfs.mapred.system.dir:
-  Optionally, specify subdirectory under GlusterFS for intermediary MapReduce data.
+  'Optionally, specify subdirectory under GlusterFS for intermediary MapReduce data.'
 alluxio.underfs.glusterfs.mounts:
-  N/A
+  'N/A'
 alluxio.underfs.glusterfs.volumes:
-  N/A
+  'N/A'
 alluxio.underfs.hdfs.configuration:
-  Location of the hdfs configuration file.
+  'Location of the hdfs configuration file.'
 alluxio.underfs.hdfs.impl:
-  The implementation class of the HDFS as the under storage system.
+  'The implementation class of the HDFS as the under storage system.'
 alluxio.underfs.hdfs.prefixes:
-  Optionally, specify which prefixes should run through the Apache Hadoop implementation of UnderFileSystem. The delimiter is any whitespace and/or ','.
+  'Optionally, specify which prefixes should run through the Apache Hadoop implementation of UnderFileSystem. The delimiter is any whitespace and/or '',''.'
 alluxio.underfs.hdfs.remote:
-  Boolean indicating whether or not the under storage worker nodes are remote with respect to Alluxio worker nodes. If set to true, Alluxio will not attempt to discover locality information from the under storage because locality is impossible. This will improve performance. The default value is false.
+  'Boolean indicating whether or not the under storage worker nodes are remote with respect to Alluxio worker nodes. If set to true, Alluxio will not attempt to discover locality information from the under storage because locality is impossible. This will improve performance. The default value is false.'
 alluxio.underfs.listing.length:
-  The maximum number of directory entries to list in a single query to under file system. If the total number of entries is greater than the specified length, multiple queries will be issued.
+  'The maximum number of directory entries to list in a single query to under file system. If the total number of entries is greater than the specified length, multiple queries will be issued.'
 alluxio.underfs.object.store.mount.shared.publicly:
-  Whether or not to share object storage under storage system mounted point with all Alluxio users. Note that this configuration has no effect on HDFS nor local UFS.
+  'Whether or not to share object storage under storage system mounted point with all Alluxio users. Note that this configuration has no effect on HDFS nor local UFS.'
 alluxio.underfs.object.store.service.threads:
-  The number of threads in executor pool for parallel object store UFS operations.
+  'The number of threads in executor pool for parallel object store UFS operations.'
 alluxio.underfs.oss.connection.max:
-  N/A
+  'N/A'
 alluxio.underfs.oss.connection.timeout:
-  N/A
+  'N/A'
 alluxio.underfs.oss.connection.ttl:
-  N/A
+  'N/A'
 alluxio.underfs.oss.socket.timeout:
-  N/A
+  'N/A'
 alluxio.underfs.s3.admin.threads.max:
-  The maximum number of threads to use for metadata operations when communicating with S3. These operations may be fairly concurrent and frequent but should not take much time to process.
+  'The maximum number of threads to use for metadata operations when communicating with S3. These operations may be fairly concurrent and frequent but should not take much time to process.'
 alluxio.underfs.s3.disable.dns.buckets:
-  Optionally, specify to make all S3 requests path style.
+  'Optionally, specify to make all S3 requests path style.'
 alluxio.underfs.s3.endpoint:
-  Optinally, to reduce data latency or visit resources which are sepreted in defferent AWS regions, specify a regional endpoint to make aws requests. An endpoint is a URL that is the entry point for a web service. For example, s3.cn-north-1.amazonaws.com.cn is an entry point for the Amazon S3 service in beijing region.
+  'Optinally, to reduce data latency or visit resources which are sepreted in defferent AWS regions, specify a regional endpoint to make aws requests. An endpoint is a URL that is the entry point for a web service. For example, s3.cn-north-1.amazonaws.com.cn is an entry point for the Amazon S3 service in beijing region.'
 alluxio.underfs.s3.endpoint.http.port:
-  N/A
+  'N/A'
 alluxio.underfs.s3.endpoint.https.port:
-  N/A
+  'N/A'
 alluxio.underfs.s3.owner.id.to.username.mapping:
-  Optionally, specify a preset s3 canonical id to Alluxio username static mapping, in the format "id1=user1;id2=user2". The AWS S3 canonical ID can be found at the console address https://console.aws.amazon.com/iam/home?#security_credential . Please expand the "Account Identifiers" tab and refer to "Canonical User ID".
+  'Optionally, specify a preset s3 canonical id to Alluxio username static mapping, in the format "id1=user1;id2=user2". The AWS S3 canonical ID can be found at the console address https://console.aws.amazon.com/iam/home?#security_credential . Please expand the "Account Identifiers" tab and refer to "Canonical User ID".'
 alluxio.underfs.s3.proxy.host:
-  Optionally, specify a proxy host for communicating with S3.
+  'Optionally, specify a proxy host for communicating with S3.'
 alluxio.underfs.s3.proxy.https.only:
-  If using a proxy to communicate with S3, determine whether to talk to the proxy using https.
+  'If using a proxy to communicate with S3, determine whether to talk to the proxy using https.'
 alluxio.underfs.s3.proxy.port:
-  Optionally, specify a proxy port for communicating with S3.
+  'Optionally, specify a proxy port for communicating with S3.'
 alluxio.underfs.s3.threads.max:
-  The maximum number of threads to use for communicating with S3 and the maximum number of concurrent connections to S3. Includes both threads for data upload and metadata operations. This number should be at least as large as the max admin threads plus max upload threads.
+  'The maximum number of threads to use for communicating with S3 and the maximum number of concurrent connections to S3. Includes both threads for data upload and metadata operations. This number should be at least as large as the max admin threads plus max upload threads.'
 alluxio.underfs.s3.upload.threads.max:
-  The maximum number of threads to use for uploading data to S3 for multipart uploads. These operations can be fairly expensive, so multiple threads are encouraged. However, this also splits the bandwidth between threads, meaning the overall latency for completing an upload will be higher for more threads.
+  'The maximum number of threads to use for uploading data to S3 for multipart uploads. These operations can be fairly expensive, so multiple threads are encouraged. However, this also splits the bandwidth between threads, meaning the overall latency for completing an upload will be higher for more threads.'
 alluxio.underfs.s3a.consistency.timeout:
-  The duration to wait for metadata consistency from the under storage. This is only used by internal Alluxio operations which should be successful, but may appear unsuccessful due to eventual consistency.
+  'The duration to wait for metadata consistency from the under storage. This is only used by internal Alluxio operations which should be successful, but may appear unsuccessful due to eventual consistency.'
 alluxio.underfs.s3a.directory.suffix:
-  Directories are represented in S3 as zero-byte objects named with the specified suffix.
+  'Directories are represented in S3 as zero-byte objects named with the specified suffix.'
 alluxio.underfs.s3a.inherit_acl:
-  Optionally disable this to disable inheriting bucket ACLs on objects.
+  'Optionally disable this to disable inheriting bucket ACLs on objects.'
 alluxio.underfs.s3a.list.objects.v1:
-  Whether to use version 1 of GET Bucket (List Objects) API.
+  'Whether to use version 1 of GET Bucket (List Objects) API.'
 alluxio.underfs.s3a.request.timeout:
-  The timeout for a single request to S3. Infinity if set to 0. Setting this property to a non-zero value can improve performance by avoiding the long tail of requests to S3. For very slow connections to S3, consider increasing this value or setting it to 0.
+  'The timeout for a single request to S3. Infinity if set to 0. Setting this property to a non-zero value can improve performance by avoiding the long tail of requests to S3. For very slow connections to S3, consider increasing this value or setting it to 0.'
 alluxio.underfs.s3a.secure.http.enabled:
-  Whether or not to use HTTPS protocol when communicating with s3.
+  'Whether or not to use HTTPS protocol when communicating with s3.'
 alluxio.underfs.s3a.server.side.encryption.enabled:
-  Whether or not to encrypt data stored in s3.
+  'Whether or not to encrypt data stored in s3.'
 alluxio.underfs.s3a.signer.algorithm:
-  The signature algorithm which should be used to sign requests to the s3 service. This is optional, and if not set, the client will automatically determine it. For interacting with an s3 endpoint which only supports v2 signatures, set this to "S3SignerType".
+  'The signature algorithm which should be used to sign requests to the s3 service. This is optional, and if not set, the client will automatically determine it. For interacting with an s3 endpoint which only supports v2 signatures, set this to "S3SignerType".'
 alluxio.underfs.s3a.socket.timeout:
-  Length of the socket timeout when communicating with s3.
+  'Length of the socket timeout when communicating with s3.'
 alluxio.version:
-  N/A
+  'N/A'
 alluxio.web.resources:
-  Path to the web application resources.
+  'Path to the web application resources.'
 alluxio.web.threads:
-  How many threads to use for the web server.
+  'How many threads to use for the web server.'
 alluxio.work.dir:
-  The directory to use for Alluxio's working directory. By default, the journal, logs, and under file system data (if using local filesystem) are written here.
+  'The directory to use for Alluxio''s working directory. By default, the journal, logs, and under file system data (if using local filesystem) are written here.'
 alluxio.zookeeper.address:
-  Address of ZooKeeper
+  'Address of ZooKeeper'
 alluxio.zookeeper.election.path:
-  Election directory in ZooKeeper.
+  'Election directory in ZooKeeper.'
 alluxio.zookeeper.enabled:
-  If true, setup master fault tolerant mode using ZooKeeper.
+  'If true, setup master fault tolerant mode using ZooKeeper.'
 alluxio.zookeeper.leader.inquiry.retry:
-  The number of retries to inquire leader from ZooKeeper.
+  'The number of retries to inquire leader from ZooKeeper.'
 alluxio.zookeeper.leader.path:
-  Leader directory in ZooKeeper.
+  'Leader directory in ZooKeeper.'
 aws.accessKeyId:
-  N/A
+  'N/A'
 aws.secretKey:
-  N/A
+  'N/A'
 fs.gcs.accessKeyId:
-  N/A
+  'N/A'
 fs.gcs.secretAccessKey:
-  N/A
+  'N/A'
 fs.oss.accessKeyId:
-  N/A
+  'N/A'
 fs.oss.accessKeySecret:
-  N/A
+  'N/A'
 fs.oss.endpoint:
-  N/A
+  'N/A'
 fs.s3n.awsAccessKeyId:
-  N/A
+  'N/A'
 fs.s3n.awsSecretAccessKey:
-  N/A
+  'N/A'
 fs.swift.apikey:
-  N/A
+  'N/A'
 fs.swift.auth.method:
-  N/A
+  'N/A'
 fs.swift.auth.url:
-  N/A
+  'N/A'
 fs.swift.password:
-  N/A
+  'N/A'
 fs.swift.region:
-  N/A
+  'N/A'
 fs.swift.simulation:
-  N/A
+  'N/A'
 fs.swift.tenant:
-  N/A
+  'N/A'
 fs.swift.use.public.url:
-  N/A
+  'N/A'
 fs.swift.user:
-  N/A
+  'N/A'

--- a/docs/_data/table/en/key-value-configuration.yml
+++ b/docs/_data/table/en/key-value-configuration.yml
@@ -1,4 +1,4 @@
 alluxio.keyvalue.enabled:
-  Whether the key-value service is enabled.
+  'Whether the key-value service is enabled.'
 alluxio.keyvalue.partition.size.bytes.max:
-  Maximum allowable size (in bytes) of a single key-value partition in a store. This value should be no larger than the block size (Name.USER_BLOCK_SIZE_BYTES_DEFAULT)
+  'Maximum allowable size (in bytes) of a single key-value partition in a store. This value should be no larger than the block size (Name.USER_BLOCK_SIZE_BYTES_DEFAULT)'

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -1,92 +1,94 @@
 alluxio.master.bind.host:
-  The hostname that Alluxio master binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
+  'The hostname that Alluxio master binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>'
 alluxio.master.connection.timeout:
-  Timeout (in milliseconds) between master and client.
+  'Timeout (in milliseconds) between master and client.'
 alluxio.master.file.async.persist.handler:
-  The handler for processing the async persistence requests.
+  'The handler for processing the async persistence requests.'
 alluxio.master.format.file_prefix:
-  The file prefix of the file generated in the journal directory when the journal is formatted. The master will search for a file with this prefix when determining of the journal was once formatted.
+  'The file prefix of the file generated in the journal directory when the journal is formatted. The master will search for a file with this prefix when determining of the journal was once formatted.'
 alluxio.master.heartbeat.interval:
-  The interval (in milliseconds) between Alluxio master's heartbeats
+  'The interval (in milliseconds) between Alluxio master''s heartbeats'
 alluxio.master.hostname:
-  The hostname of Alluxio master.
+  'The hostname of Alluxio master.'
 alluxio.master.journal.checkpoint.period.entries:
-  N/A
+  'N/A'
 alluxio.master.journal.flush.batch.time:
-  Time (in milliseconds) to wait for batching journal writes.
+  'Time (in milliseconds) to wait for batching journal writes.'
 alluxio.master.journal.flush.timeout:
-  The amount of time (in milliseconds) to keep retrying journal writes before giving up and shutting down the master.
+  'The amount of time (in milliseconds) to keep retrying journal writes before giving up and shutting down the master.'
 alluxio.master.journal.folder:
-  The path to store master journal logs.
+  'The path to store master journal logs.'
 alluxio.master.journal.formatter.class:
-  The class to serialize the journal in a specified format.
+  'The class to serialize the journal in a specified format.'
 alluxio.master.journal.gc.period:
-  N/A
+  'N/A'
 alluxio.master.journal.gc.threshold:
-  N/A
+  'N/A'
 alluxio.master.journal.log.size.bytes.max:
-  If a log file is bigger than this value, it will rotate to next file
+  'If a log file is bigger than this value, it will rotate to next file'
 alluxio.master.journal.tailer.shutdown.quiet.wait.time:
-  Before the standby master shuts down its tailer thread, there should be no update to the leader master's journal in this specified time period (in milliseconds).
+  'Before the standby master shuts down its tailer thread, there should be no update to the leader master''s journal in this specified time period (in milliseconds).'
 alluxio.master.journal.tailer.sleep.time:
-  Time (in milliseconds) the standby master sleeps for when it cannot find anything new in leader master's journal.
+  'Time (in milliseconds) the standby master sleeps for when it cannot find anything new in leader master''s journal.'
 alluxio.master.journal.temporary.file.gc.threshold:
-  N/A
+  'N/A'
+alluxio.master.journal.type:
+  'The type of journal to use. Valid options are UFS (store journal in UFS) and NOOP (do not use a journal).'
 alluxio.master.journal.ufs.option:
-  N/A
+  'N/A'
 alluxio.master.keytab.file:
-  Kerberos keytab file for Alluxio master.
+  'Kerberos keytab file for Alluxio master.'
 alluxio.master.lineage.checkpoint.class:
-  The class name of the checkpoint strategy for lineage output files. The default strategy is to checkpoint the latest completed lineage, i.e. the lineage whose output files are completed.
+  'The class name of the checkpoint strategy for lineage output files. The default strategy is to checkpoint the latest completed lineage, i.e. the lineage whose output files are completed.'
 alluxio.master.lineage.checkpoint.interval:
-  The interval (in milliseconds) between Alluxio's checkpoint scheduling.
+  'The interval (in milliseconds) between Alluxio''s checkpoint scheduling.'
 alluxio.master.lineage.recompute.interval:
-  The interval (in milliseconds) between Alluxio's recompute execution. The executor scans the all the lost files tracked by lineage, and re-executes the corresponding jobs. every 10 minutes.
+  'The interval (in milliseconds) between Alluxio''s recompute execution. The executor scans the all the lost files tracked by lineage, and re-executes the corresponding jobs. every 10 minutes.'
 alluxio.master.lineage.recompute.log.path:
-  The path to the log that the recompute executor redirects the job's stdout into.
+  'The path to the log that the recompute executor redirects the job''s stdout into.'
 alluxio.master.mount.table.root.alluxio:
-  N/A
+  'N/A'
 alluxio.master.mount.table.root.option:
-  N/A
+  'N/A'
 alluxio.master.mount.table.root.readonly:
-  N/A
+  'N/A'
 alluxio.master.mount.table.root.shared:
-  N/A
+  'N/A'
 alluxio.master.mount.table.root.ufs:
-  N/A
+  'N/A'
 alluxio.master.port:
-  The port that Alluxio master node runs on.
+  'The port that Alluxio master node runs on.'
 alluxio.master.principal:
-  Kerberos principal for Alluxio master.
+  'Kerberos principal for Alluxio master.'
 alluxio.master.retry:
-  The number of retries that the client connects to master. (NOTE: this property is deprecated, use `Name.USER_RPC_RETRY_MAX_NUM_RETRY` instead)
+  'The number of retries that the client connects to master. (NOTE: this property is deprecated, use `Name.USER_RPC_RETRY_MAX_NUM_RETRY` instead)'
 alluxio.master.startup.consistency.check.enabled:
-  Whether the system should be checked for consistency with the underlying storage on startup. During the time the check is running, Alluxio will be in read only mode. Enabled by default.
+  'Whether the system should be checked for consistency with the underlying storage on startup. During the time the check is running, Alluxio will be in read only mode. Enabled by default.'
 alluxio.master.tieredstore.global.level0.alias:
-  The name of the highest storage tier in the entire system
+  'The name of the highest storage tier in the entire system'
 alluxio.master.tieredstore.global.level1.alias:
-  The name of the second highest storage tier in the entire system
+  'The name of the second highest storage tier in the entire system'
 alluxio.master.tieredstore.global.level2.alias:
-  The name of the third highest storage tier in the entire system
+  'The name of the third highest storage tier in the entire system'
 alluxio.master.tieredstore.global.levels:
-  The total number of storage tiers in the system
+  'The total number of storage tiers in the system'
 alluxio.master.ttl.checker.interval:
-  Time interval (in milliseconds) to periodically delete the files with expired ttl value.
+  'Time interval (in milliseconds) to periodically delete the files with expired ttl value.'
 alluxio.master.ufs.path.cache.capacity:
-  The capacity of the UFS path cache. This cache is used to approximate the `Once` metadata load behavior (see `alluxio.user.file.metadata.load.type`). Larger caches will consume more memory, but will better approximate the `Once` behavior.
+  'The capacity of the UFS path cache. This cache is used to approximate the `Once` metadata load behavior (see `alluxio.user.file.metadata.load.type`). Larger caches will consume more memory, but will better approximate the `Once` behavior.'
 alluxio.master.ufs.path.cache.threads:
-  The maximum size of the thread pool for asynchronously processing paths for the UFS path cache. Greater number of threads will decrease the amount of staleness in the async cache, but may impact performance. If this is set to 0, the cache will be disabled, and `alluxio.user.file.metadata.load.type=Once` will behave like `Always`.
+  'The maximum size of the thread pool for asynchronously processing paths for the UFS path cache. Greater number of threads will decrease the amount of staleness in the async cache, but may impact performance. If this is set to 0, the cache will be disabled, and `alluxio.user.file.metadata.load.type=Once` will behave like `Always`.'
 alluxio.master.web.bind.host:
-  The hostname Alluxio master web UI binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
+  'The hostname Alluxio master web UI binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>'
 alluxio.master.web.hostname:
-  The hostname of Alluxio Master web UI.
+  'The hostname of Alluxio Master web UI.'
 alluxio.master.web.port:
-  The port Alluxio web UI runs on.
+  'The port Alluxio web UI runs on.'
 alluxio.master.whitelist:
-  A comma-separated list of prefixes of the paths which are cacheable, separated by semi-colons. Alluxio will try to cache the cacheable file when it is read for the first time.
+  'A comma-separated list of prefixes of the paths which are cacheable, separated by semi-colons. Alluxio will try to cache the cacheable file when it is read for the first time.'
 alluxio.master.worker.threads.max:
-  The maximum number of incoming RPC requests to master that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with master.
+  'The maximum number of incoming RPC requests to master that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with master.'
 alluxio.master.worker.threads.min:
-  The minimum number of threads used to handle incoming RPC requests to master. This value is used to configure minimum number of threads in Thrift thread pool with master.
+  'The minimum number of threads used to handle incoming RPC requests to master. This value is used to configure minimum number of threads in Thrift thread pool with master.'
 alluxio.master.worker.timeout:
-  Timeout (in milliseconds) between master and worker indicating a lost worker.
+  'Timeout (in milliseconds) between master and worker indicating a lost worker.'

--- a/docs/_data/table/en/security-configuration.yml
+++ b/docs/_data/table/en/security-configuration.yml
@@ -1,18 +1,18 @@
 alluxio.security.authentication.custom.provider.class:
-  The class to provide customized authentication implementation, when alluxio.security.authentication.type is set to CUSTOM. It must implement the interface 'alluxio.security.authentication.AuthenticationProvider'.
+  'The class to provide customized authentication implementation, when alluxio.security.authentication.type is set to CUSTOM. It must implement the interface ''alluxio.security.authentication.AuthenticationProvider''.'
 alluxio.security.authentication.socket.timeout:
-  The maximum amount of time (in milliseconds) for a user to create a Thrift socket which will connect to the master.
+  'The maximum amount of time (in milliseconds) for a user to create a Thrift socket which will connect to the master.'
 alluxio.security.authentication.type:
-  The authentication mode. Currently three modes are supported: NOSASL, SIMPLE, CUSTOM. The default value SIMPLE indicates that a simple authentication is enabled. Server trusts whoever the client claims to be.
+  'The authentication mode. Currently three modes are supported: NOSASL, SIMPLE, CUSTOM. The default value SIMPLE indicates that a simple authentication is enabled. Server trusts whoever the client claims to be.'
 alluxio.security.authorization.permission.enabled:
-  Whether to enable access control based on file permission.
+  'Whether to enable access control based on file permission.'
 alluxio.security.authorization.permission.supergroup:
-  The super group of Alluxio file system. All users in this group have super permission.
+  'The super group of Alluxio file system. All users in this group have super permission.'
 alluxio.security.authorization.permission.umask:
-  The umask of creating file and directory. The initial creation permission is 777, and the difference between directory and file is 111. So for default umask value 022, the created directory has permission 755 and file has permission 644.
+  'The umask of creating file and directory. The initial creation permission is 777, and the difference between directory and file is 111. So for default umask value 022, the created directory has permission 755 and file has permission 644.'
 alluxio.security.group.mapping.cache.timeout:
-  N/A
+  'N/A'
 alluxio.security.group.mapping.class:
-  The class to provide user-to-groups mapping service. Master could get the various group memberships of a given user.  It must implement the interface 'alluxio.security.group.GroupMappingService'. The default implementation execute the 'groups' shell command to fetch the group memberships of a given user.
+  'The class to provide user-to-groups mapping service. Master could get the various group memberships of a given user.  It must implement the interface ''alluxio.security.group.GroupMappingService''. The default implementation execute the ''groups'' shell command to fetch the group memberships of a given user.'
 alluxio.security.login.username:
-  When alluxio.security.authentication.type is set to SIMPLE or CUSTOM, user application uses this property to indicate the user requesting Alluxio service. If it is not set explicitly, the OS login user will be used.
+  'When alluxio.security.authentication.type is set to SIMPLE or CUSTOM, user application uses this property to indicate the user requesting Alluxio service. If it is not set explicitly, the OS login user will be used.'

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -1,116 +1,116 @@
 alluxio.user.block.master.client.threads:
-  The number of threads used by a block master client pool to talk to the block master.
+  'The number of threads used by a block master client pool to talk to the block master.'
 alluxio.user.block.remote.read.buffer.size.bytes:
-  The size of the file buffer to read data from remote Alluxio worker.
+  'The size of the file buffer to read data from remote Alluxio worker.'
 alluxio.user.block.remote.reader.class:
-  Selects networking stack to run the client with. Currently only `alluxio.client.netty.NettyRemoteBlockReader` (read remote data using netty) is valid. This is deprecated and will be removed in 2.0.0.
+  'Selects networking stack to run the client with. Currently only `alluxio.client.netty.NettyRemoteBlockReader` (read remote data using netty) is valid. This is deprecated and will be removed in 2.0.0.'
 alluxio.user.block.remote.writer.class:
-  Selects networking stack to run the client with for block writes. This is deprecated and will be removed in 2.0.0.
+  'Selects networking stack to run the client with for block writes. This is deprecated and will be removed in 2.0.0.'
 alluxio.user.block.size.bytes.default:
-  Default block size for Alluxio files.
+  'Default block size for Alluxio files.'
 alluxio.user.block.worker.client.pool.gc.threshold:
-  A block worker client is closed if it has been idle for more than this threshold.
+  'A block worker client is closed if it has been idle for more than this threshold.'
 alluxio.user.block.worker.client.pool.size.max:
-  The maximum number of block worker clients cached in the block worker client pool.
+  'The maximum number of block worker clients cached in the block worker client pool.'
 alluxio.user.block.worker.client.threads:
-  The number of threads used by a block worker client pool for heartbeating to a worker. Increase this value if worker failures affect client connections to healthy workers.
+  'The number of threads used by a block worker client pool for heartbeating to a worker. Increase this value if worker failures affect client connections to healthy workers.'
 alluxio.user.date.format.pattern:
-  Display formatted date in cli command and web UI by given date format pattern.
+  'Display formatted date in cli command and web UI by given date format pattern.'
 alluxio.user.failed.space.request.limits:
-  The number of times to request space from the file system before aborting.
+  'The number of times to request space from the file system before aborting.'
 alluxio.user.file.buffer.bytes:
-  The size of the file buffer to use for file system reads/writes.
+  'The size of the file buffer to use for file system reads/writes.'
 alluxio.user.file.cache.partially.read.block:
-  When read type is CACHE_PROMOTE or CACHE and this property is set to true, the entire block will be cached by Alluxio space even if the client only reads a part of this block.
+  'When read type is CACHE_PROMOTE or CACHE and this property is set to true, the entire block will be cached by Alluxio space even if the client only reads a part of this block.'
 alluxio.user.file.copyfromlocal.write.location.policy.class:
-  The default location policy for choosing workers for writing a file's blocks using copyFromLocal command
+  'The default location policy for choosing workers for writing a file''s blocks using copyFromLocal command'
 alluxio.user.file.delete.unchecked:
-  Whether to check if the UFS contents are in sync with Alluxio before attempting to delete persisted directories recursively.
+  'Whether to check if the UFS contents are in sync with Alluxio before attempting to delete persisted directories recursively.'
 alluxio.user.file.master.client.threads:
-  The number of threads used by a file master client to talk to the file master.
+  'The number of threads used by a file master client to talk to the file master.'
 alluxio.user.file.metadata.load.type:
-  The behavior of loading metadata from UFS. When information about a path is requested and the path does not exist in Alluxio, metadata can be loaded from the UFS. Valid options are `Always`, `Never`, and `Once`. `Always` will always access UFS to see if the path exists in the UFS. `Never` will never consult the UFS. `Once` will access the UFS the "first" time (according to a cache), but not after that.
+  'The behavior of loading metadata from UFS. When information about a path is requested and the path does not exist in Alluxio, metadata can be loaded from the UFS. Valid options are `Always`, `Never`, and `Once`. `Always` will always access UFS to see if the path exists in the UFS. `Never` will never consult the UFS. `Once` will access the UFS the "first" time (according to a cache), but not after that.'
 alluxio.user.file.passive.cache.enabled:
-  N/A
+  'N/A'
 alluxio.user.file.readtype.default:
-  Default read type when creating Alluxio files. Valid options are `CACHE_PROMOTE` (move data to highest tier if already in Alluxio storage, write data into highest tier of local Alluxio if data needs to be read from under storage), `CACHE` (write data into highest tier of local Alluxio if data needs to be read from under storage), `NO_CACHE` (no data interaction with Alluxio, if the read is from Alluxio data migration or eviction will not occur).
+  'Default read type when creating Alluxio files. Valid options are `CACHE_PROMOTE` (move data to highest tier if already in Alluxio storage, write data into highest tier of local Alluxio if data needs to be read from under storage), `CACHE` (write data into highest tier of local Alluxio if data needs to be read from under storage), `NO_CACHE` (no data interaction with Alluxio, if the read is from Alluxio data migration or eviction will not occur).'
 alluxio.user.file.seek.buffer.size.bytes:
-  The file seek buffer size. This is only used when alluxio.user.file.cache.partially.read.block is enabled.
+  'The file seek buffer size. This is only used when alluxio.user.file.cache.partially.read.block is enabled.'
 alluxio.user.file.waitcompleted.poll:
-  The time interval to poll a file for its completion status when using waitCompleted.
+  'The time interval to poll a file for its completion status when using waitCompleted.'
 alluxio.user.file.worker.client.pool.gc.threshold:
-  N/A
+  'N/A'
 alluxio.user.file.worker.client.pool.size.max:
-  N/A
+  'N/A'
 alluxio.user.file.worker.client.threads:
-  How many threads to use for file worker clients to read from workers.
+  'How many threads to use for file worker clients to read from workers.'
 alluxio.user.file.write.avoid.eviction.policy.reserved.size.bytes:
-  The portion of space reserved in worker when user use the LocalFirstAvoidEvictionPolicy class as file write location policy.
+  'The portion of space reserved in worker when user use the LocalFirstAvoidEvictionPolicy class as file write location policy.'
 alluxio.user.file.write.location.policy.class:
-  The default location policy for choosing workers for writing a file's blocks
+  'The default location policy for choosing workers for writing a file''s blocks'
 alluxio.user.file.write.tier.default:
-  The default tier for choosing a where to write a block. Valid option is any integer. Non-negative values identify tiers starting from top going down (0 identifies the first tier, 1 identifies the second tier, and so on). If the provided value is greater than the number of tiers, it identifies the last tier. Negative values identify tiers starting from the bottom going up (-1 identifies the last tier, -2 identifies the second to last tier, and so on). If the absolute value of the provided value is greater than the number of tiers, it identifies the first tier.
+  'The default tier for choosing a where to write a block. Valid option is any integer. Non-negative values identify tiers starting from top going down (0 identifies the first tier, 1 identifies the second tier, and so on). If the provided value is greater than the number of tiers, it identifies the last tier. Negative values identify tiers starting from the bottom going up (-1 identifies the last tier, -2 identifies the second to last tier, and so on). If the absolute value of the provided value is greater than the number of tiers, it identifies the first tier.'
 alluxio.user.file.writetype.default:
-  Default write type when creating Alluxio files. Valid options are `MUST_CACHE` (write will only go to Alluxio and must be stored in Alluxio), `CACHE_THROUGH` (try to cache, write to UnderFS synchronously), `THROUGH` (no cache, write to UnderFS synchronously).
+  'Default write type when creating Alluxio files. Valid options are `MUST_CACHE` (write will only go to Alluxio and must be stored in Alluxio), `CACHE_THROUGH` (try to cache, write to UnderFS synchronously), `THROUGH` (no cache, write to UnderFS synchronously).'
 alluxio.user.heartbeat.interval:
-  The interval (in milliseconds) between Alluxio worker's heartbeats
+  'The interval (in milliseconds) between Alluxio worker''s heartbeats'
 alluxio.user.hostname:
-  The hostname to use for the client.
+  'The hostname to use for the client.'
 alluxio.user.lineage.enabled:
-  Flag to enable lineage feature.
+  'Flag to enable lineage feature.'
 alluxio.user.lineage.master.client.threads:
-  The number of threads used by a lineage master client to talk to the lineage master.
+  'The number of threads used by a lineage master client to talk to the lineage master.'
 alluxio.user.local.reader.packet.size.bytes:
-  N/A
+  'N/A'
 alluxio.user.local.writer.packet.size.bytes:
-  N/A
+  'N/A'
 alluxio.user.network.netty.channel:
-  N/A
+  'N/A'
 alluxio.user.network.netty.channel.pool.disabled:
-  Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.x.
+  'Disable netty channel pool. This should be turned on if the client version is >= 1.3.0 but server version is <= 1.2.x.'
 alluxio.user.network.netty.channel.pool.gc.threshold:
-  A netty channel is closed if it has been idle for more than this threshold.
+  'A netty channel is closed if it has been idle for more than this threshold.'
 alluxio.user.network.netty.channel.pool.size.max:
-  The maximum number of netty channels cached in the netty channel pool.
+  'The maximum number of netty channels cached in the netty channel pool.'
 alluxio.user.network.netty.reader.buffer.size.packets:
-  N/A
+  'N/A'
 alluxio.user.network.netty.reader.cancel.enabled:
-  N/A
+  'N/A'
 alluxio.user.network.netty.reader.packet.size.bytes:
-  N/A
+  'N/A'
 alluxio.user.network.netty.timeout:
-  The maximum number of milliseconds for a netty client (for block reads and block writes) to wait for a response from the data server.
+  'The maximum number of milliseconds for a netty client (for block reads and block writes) to wait for a response from the data server.'
 alluxio.user.network.netty.worker.threads:
-  How many threads to use for remote block worker client to read from remote block workers.
+  'How many threads to use for remote block worker client to read from remote block workers.'
 alluxio.user.network.netty.writer.buffer.size.packets:
-  N/A
+  'N/A'
 alluxio.user.network.netty.writer.close.timeout:
-  The maximum number of milliseconds to close a netty writer client.
+  'The maximum number of milliseconds to close a netty writer client.'
 alluxio.user.network.netty.writer.packet.size.bytes:
-  N/A
+  'N/A'
 alluxio.user.rpc.retry.base.sleep:
-  Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the base time in milliseconds in the exponential backoff.
+  'Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the base time in milliseconds in the exponential backoff.'
 alluxio.user.rpc.retry.max.num.retry:
-  Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the maximum number of retries.
+  'Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the maximum number of retries.'
 alluxio.user.rpc.retry.max.sleep:
-  Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the maximum wait time in milliseconds in the backoff.
+  'Alluxio client RPCs automatically retry for transient errors with an exponential backoff. This property detemines the maximum wait time in milliseconds in the backoff.'
 alluxio.user.short.circuit.enabled:
-  The short circuit read/write which allows the clients to read/write data without going through Alluxio workers if the data is local is enabled if set to true.
+  'The short circuit read/write which allows the clients to read/write data without going through Alluxio workers if the data is local is enabled if set to true.'
 alluxio.user.ufs.block.open.timeout:
-  N/A
+  'N/A'
 alluxio.user.ufs.block.read.concurrency.max:
-  The maximum concurrent readers for one UFS block on one Block Worker.
+  'The maximum concurrent readers for one UFS block on one Block Worker.'
 alluxio.user.ufs.block.read.location.policy:
-  The policy block workers follow for reading UFS blocks.
+  'The policy block workers follow for reading UFS blocks.'
 alluxio.user.ufs.block.read.location.policy.deterministic.hash.shards:
-  When alluxio.user.ufs.block.read.location.policy is set to alluxio.client.block.policy.DeterministicHashPolicy, this specifies the number of hash shards.
+  'When alluxio.user.ufs.block.read.location.policy is set to alluxio.client.block.policy.DeterministicHashPolicy, this specifies the number of hash shards.'
 alluxio.user.ufs.delegation.enabled:
-  N/A
+  'N/A'
 alluxio.user.ufs.delegation.read.buffer.size.bytes:
-  Size of the read buffer when reading from the ufs through the Alluxio worker. Each read request will fetch at least this many bytes, unless the read reaches the end of the file.
+  'Size of the read buffer when reading from the ufs through the Alluxio worker. Each read request will fetch at least this many bytes, unless the read reaches the end of the file.'
 alluxio.user.ufs.delegation.write.buffer.size.bytes:
-  Size of the write buffer when writing to the ufs through the Alluxio worker. Each write request will write at least this many bytes, unless the write is at the end of the file.
+  'Size of the write buffer when writing to the ufs through the Alluxio worker. Each write request will write at least this many bytes, unless the write is at the end of the file.'
 alluxio.user.ufs.file.reader.class:
-  Selects networking stack to run the client with for reading from under file system through a worker's data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileReader` (remote read using netty) is valid.
+  'Selects networking stack to run the client with for reading from under file system through a worker''s data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileReader` (remote read using netty) is valid.'
 alluxio.user.ufs.file.writer.class:
-  Selects networking stack to run the client with for writing to under file system through a worker's data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileWriter` (remote write using netty) is valid.
+  'Selects networking stack to run the client with for writing to under file system through a worker''s data server. Currently only `alluxio.client.netty.NettyUnderFileSystemFileWriter` (remote write using netty) is valid.'

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.worker.allocator.class:
-  The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include: `alluxio.worker.block.allocator.MaxFreeAllocator`, `alluxio.worker.block.allocator.GreedyAllocator`, `alluxio.worker.block.allocator.RoundRobinAllocator`.
+  "The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include: `alluxio.worker.block.allocator.MaxFreeAllocator`, `alluxio.worker.block.allocator.GreedyAllocator`, `alluxio.worker.block.allocator.RoundRobinAllocator`."
 alluxio.worker.bind.host:
   The hostname Alluxio's worker node binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
 alluxio.worker.block.heartbeat.interval:
@@ -23,7 +23,7 @@ alluxio.worker.data.hostname:
 alluxio.worker.data.port:
   The port Alluxio's worker's data server runs on.
 alluxio.worker.data.server.class:
-  Selects the networking stack to run the worker with. Valid options are: `alluxio.worker.netty.NettyDataServer`.
+  "Selects the networking stack to run the worker with. Valid options are: `alluxio.worker.netty.NettyDataServer`."
 alluxio.worker.data.server.domain.socket.address:
   The path to the domain socket. Short-circuit reads make use of a UNIX domain socket when this is set (non-empty). This is a special path in the file system that allows the client and the AlluxioWorker to communicate. You will need to set a path to this socket. The AlluxioWorker needs to be able to create this path.
 alluxio.worker.data.tmp.subdir.max:

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -1,152 +1,152 @@
 alluxio.worker.allocator.class:
-  "The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include: `alluxio.worker.block.allocator.MaxFreeAllocator`, `alluxio.worker.block.allocator.GreedyAllocator`, `alluxio.worker.block.allocator.RoundRobinAllocator`."
+  'The strategy that a worker uses to allocate space among storage directories in certain storage layer. Valid options include: `alluxio.worker.block.allocator.MaxFreeAllocator`, `alluxio.worker.block.allocator.GreedyAllocator`, `alluxio.worker.block.allocator.RoundRobinAllocator`.'
 alluxio.worker.bind.host:
-  The hostname Alluxio's worker node binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
+  'The hostname Alluxio''s worker node binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>'
 alluxio.worker.block.heartbeat.interval:
-  The interval (in milliseconds) between block worker's heartbeats
+  'The interval (in milliseconds) between block worker''s heartbeats'
 alluxio.worker.block.heartbeat.timeout:
-  The timeout value (in milliseconds) of block worker's heartbeat
+  'The timeout value (in milliseconds) of block worker''s heartbeat'
 alluxio.worker.block.master.client.pool.size:
-  The block master client pool size on the Alluxio workers.
+  'The block master client pool size on the Alluxio workers.'
 alluxio.worker.block.threads.max:
-  The maximum number of incoming RPC requests to block worker that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with block worker. This value should be greater than the sum of `alluxio.user.block.worker.client.threads` across concurrent Alluxio clients. Otherwise, the worker connection pool can be drained, preventing new connections from being established.
+  'The maximum number of incoming RPC requests to block worker that can be handled. This value is used to configure maximum number of threads in Thrift thread pool with block worker. This value should be greater than the sum of `alluxio.user.block.worker.client.threads` across concurrent Alluxio clients. Otherwise, the worker connection pool can be drained, preventing new connections from being established.'
 alluxio.worker.block.threads.min:
-  The minimum number of threads used to handle incoming RPC requests to block worker. This value is used to configure minimum number of threads in Thrift thread pool with block worker.
+  'The minimum number of threads used to handle incoming RPC requests to block worker. This value is used to configure minimum number of threads in Thrift thread pool with block worker.'
 alluxio.worker.data.bind.host:
-  The hostname that the Alluxio worker's data server runs on. See <a href="#configure-multihomed-networks">multi-homed networks</a>
+  'The hostname that the Alluxio worker''s data server runs on. See <a href="#configure-multihomed-networks">multi-homed networks</a>'
 alluxio.worker.data.folder:
-  A relative path within each storage directory used as the data folder for Alluxio worker to put data for tiered store.
+  'A relative path within each storage directory used as the data folder for Alluxio worker to put data for tiered store.'
 alluxio.worker.data.folder.tmp:
-  A relative path in alluxio.worker.data.folder used to store the temporary data for uncommitted files.
+  'A relative path in alluxio.worker.data.folder used to store the temporary data for uncommitted files.'
 alluxio.worker.data.hostname:
-  N/A
+  'N/A'
 alluxio.worker.data.port:
-  The port Alluxio's worker's data server runs on.
+  'The port Alluxio''s worker''s data server runs on.'
 alluxio.worker.data.server.class:
-  "Selects the networking stack to run the worker with. Valid options are: `alluxio.worker.netty.NettyDataServer`."
+  'Selects the networking stack to run the worker with. Valid options are: `alluxio.worker.netty.NettyDataServer`.'
 alluxio.worker.data.server.domain.socket.address:
-  The path to the domain socket. Short-circuit reads make use of a UNIX domain socket when this is set (non-empty). This is a special path in the file system that allows the client and the AlluxioWorker to communicate. You will need to set a path to this socket. The AlluxioWorker needs to be able to create this path.
+  'The path to the domain socket. Short-circuit reads make use of a UNIX domain socket when this is set (non-empty). This is a special path in the file system that allows the client and the AlluxioWorker to communicate. You will need to set a path to this socket. The AlluxioWorker needs to be able to create this path.'
 alluxio.worker.data.tmp.subdir.max:
-  The maximum number of sub-directories allowed to be created in alluxio.worker.data.tmp.folder.
+  'The maximum number of sub-directories allowed to be created in alluxio.worker.data.tmp.folder.'
 alluxio.worker.evictor.class:
-  The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid options include `alluxio.worker.block.evictor.LRFUEvictor`, `alluxio.worker.block.evictor.GreedyEvictor`, `alluxio.worker.block.evictor.LRUEvictor`.
+  'The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid options include `alluxio.worker.block.evictor.LRFUEvictor`, `alluxio.worker.block.evictor.GreedyEvictor`, `alluxio.worker.block.evictor.LRUEvictor`.'
 alluxio.worker.evictor.lrfu.attenuation.factor:
-  A attenuation factor in [2, INF) to control the behavior of LRFU.
+  'A attenuation factor in [2, INF) to control the behavior of LRFU.'
 alluxio.worker.evictor.lrfu.step.factor:
-  A factor in [0, 1] to control the behavior of LRFU: smaller value makes LRFU more similar to LFU; and larger value makes LRFU closer to LRU.
+  'A factor in [0, 1] to control the behavior of LRFU: smaller value makes LRFU more similar to LFU; and larger value makes LRFU closer to LRU.'
 alluxio.worker.file.buffer.size:
-  N/A
+  'N/A'
 alluxio.worker.file.persist.pool.size:
-  The size of the thread pool per worker, in which the thread persists an ASYNC_THROUGH file to under storage.
+  'The size of the thread pool per worker, in which the thread persists an ASYNC_THROUGH file to under storage.'
 alluxio.worker.file.persist.rate.limit:
-  The rate limit of asynchronous persistence per second.
+  'The rate limit of asynchronous persistence per second.'
 alluxio.worker.file.persist.rate.limit.enabled:
-  Whether to enable rate limiting when performing asynchronous persistence.
+  'Whether to enable rate limiting when performing asynchronous persistence.'
 alluxio.worker.filesystem.heartbeat.interval:
-  The heartbeat interval (in milliseconds) between the worker and file system master.
+  'The heartbeat interval (in milliseconds) between the worker and file system master.'
 alluxio.worker.hostname:
-  The hostname of Alluxio worker.
+  'The hostname of Alluxio worker.'
 alluxio.worker.keytab.file:
-  Kerberos keytab file for Alluxio worker.
+  'Kerberos keytab file for Alluxio worker.'
 alluxio.worker.memory.size:
-  Memory capacity of each worker node.
+  'Memory capacity of each worker node.'
 alluxio.worker.network.netty.backlog:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.block.reader.threads.max:
-  The maximum number of threads used to read blocks in the netty data server.
+  'The maximum number of threads used to read blocks in the netty data server.'
 alluxio.worker.network.netty.block.writer.threads.max:
-  The maximum number of threads used to write blocks in the netty data server.
+  'The maximum number of threads used to write blocks in the netty data server.'
 alluxio.worker.network.netty.boss.threads:
-  How many threads to use for accepting new requests.
+  'How many threads to use for accepting new requests.'
 alluxio.worker.network.netty.buffer.receive:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.buffer.send:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.channel:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.file.reader.threads.max:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.file.transfer:
-  When returning files to the user, select how the data is transferred; valid options are `MAPPED` (uses java MappedByteBuffer) and `TRANSFER` (uses Java FileChannel.transferTo).
+  'When returning files to the user, select how the data is transferred; valid options are `MAPPED` (uses java MappedByteBuffer) and `TRANSFER` (uses Java FileChannel.transferTo).'
 alluxio.worker.network.netty.file.writer.threads.max:
-  The maximum number of threads used to write files to UFS in the netty data server.
+  'The maximum number of threads used to write files to UFS in the netty data server.'
 alluxio.worker.network.netty.reader.buffer.size.packets:
-  N/A
+  'N/A'
 alluxio.worker.network.netty.rpc.threads.max:
-  The maximum number of threads used to handle worker side RPCs in the netty data server.
+  'The maximum number of threads used to handle worker side RPCs in the netty data server.'
 alluxio.worker.network.netty.shutdown.quiet.period:
-  The quiet period (in seconds). When the netty server is shutting down, it will ensure that no RPCs occur during the quiet period. If an RPC occurs, then the quiet period will restart before shutting down the netty server.
+  'The quiet period (in seconds). When the netty server is shutting down, it will ensure that no RPCs occur during the quiet period. If an RPC occurs, then the quiet period will restart before shutting down the netty server.'
 alluxio.worker.network.netty.shutdown.timeout:
-  Maximum amount of time to wait (in seconds) until the netty server is shutdown (regardless of the quiet period).
+  'Maximum amount of time to wait (in seconds) until the netty server is shutdown (regardless of the quiet period).'
 alluxio.worker.network.netty.watermark.high:
-  Determines how many bytes can be in the write queue before switching to non-writable.
+  'Determines how many bytes can be in the write queue before switching to non-writable.'
 alluxio.worker.network.netty.watermark.low:
-  Once the high watermark limit is reached, the queue must be flushed down to the low watermark before switching back to writable.
+  'Once the high watermark limit is reached, the queue must be flushed down to the low watermark before switching back to writable.'
 alluxio.worker.network.netty.worker.threads:
-  How many threads to use for processing requests. Zero defaults to #cpuCores * 2.
+  'How many threads to use for processing requests. Zero defaults to #cpuCores * 2.'
 alluxio.worker.network.netty.writer.buffer.size.packets:
-  N/A
+  'N/A'
 alluxio.worker.port:
-  The port Alluxio's worker node runs on.
+  'The port Alluxio''s worker node runs on.'
 alluxio.worker.principal:
-  Kerberos principal for Alluxio worker.
+  'Kerberos principal for Alluxio worker.'
 alluxio.worker.session.timeout:
-  Timeout (in milliseconds) between worker and client connection indicating a lost session connection.
+  'Timeout (in milliseconds) between worker and client connection indicating a lost session connection.'
 alluxio.worker.tieredstore.block.lock.readers:
-  The max number of concurrent readers for a block lock.
+  'The max number of concurrent readers for a block lock.'
 alluxio.worker.tieredstore.block.locks:
-  Total number of block locks for an Alluxio block worker. Larger value leads to finer locking granularity, but uses more space.
+  'Total number of block locks for an Alluxio block worker. Larger value leads to finer locking granularity, but uses more space.'
 alluxio.worker.tieredstore.free.space.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level0.alias:
-  The alias of the highest storage tier on this worker. It must match one of the global storage tiers from the master configuration. We disable placing an alias lower in the global hierarchy before an alias with a higher postion on the worker hierarchy. So by default, SSD cannot come before MEM on any worker.
+  'The alias of the highest storage tier on this worker. It must match one of the global storage tiers from the master configuration. We disable placing an alias lower in the global hierarchy before an alias with a higher postion on the worker hierarchy. So by default, SSD cannot come before MEM on any worker.'
 alluxio.worker.tieredstore.level0.dirs.path:
-  The path of storage directory path for the top storage layer. Note for MacOS the value should be `/Volumes/`
+  'The path of storage directory path for the top storage layer. Note for MacOS the value should be `/Volumes/`'
 alluxio.worker.tieredstore.level0.dirs.quota:
-  The capacity of the top storage layer.
+  'The capacity of the top storage layer.'
 alluxio.worker.tieredstore.level0.reserved.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level0.watermark.high.ratio:
-  The high watermark of the space in the top storage layer (a value between 0 and 1).
+  'The high watermark of the space in the top storage layer (a value between 0 and 1).'
 alluxio.worker.tieredstore.level0.watermark.low.ratio:
-  The low watermark of the space in the top storage layer (a value between 0 and 1).
+  'The low watermark of the space in the top storage layer (a value between 0 and 1).'
 alluxio.worker.tieredstore.level1.alias:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level1.dirs.path:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level1.dirs.quota:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level1.reserved.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level1.watermark.high.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level1.watermark.low.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.alias:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.dirs.path:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.dirs.quota:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.reserved.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.watermark.high.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.level2.watermark.low.ratio:
-  N/A
+  'N/A'
 alluxio.worker.tieredstore.levels:
-  The number of storage tiers on the worker
+  'The number of storage tiers on the worker'
 alluxio.worker.tieredstore.reserver.enabled:
-  Whether to enable tiered store reserver service or not.
+  'Whether to enable tiered store reserver service or not.'
 alluxio.worker.tieredstore.reserver.interval:
-  The time period (in milliseconds) of space reserver service, which keeps certain portion of available space on each layer.
+  'The time period (in milliseconds) of space reserver service, which keeps certain portion of available space on each layer.'
 alluxio.worker.tieredstore.retry:
-  The number of retries that the worker uses to process blocks.
+  'The number of retries that the worker uses to process blocks.'
 alluxio.worker.ufs.block.open.timeout:
-  N/A
+  'N/A'
 alluxio.worker.web.bind.host:
-  The hostname Alluxio worker's web server binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>
+  'The hostname Alluxio worker''s web server binds to. See <a href="#configure-multihomed-networks">multi-homed networks</a>'
 alluxio.worker.web.hostname:
-  The hostname Alluxio worker's web UI binds to.
+  'The hostname Alluxio worker''s web UI binds to.'
 alluxio.worker.web.port:
-  The port Alluxio worker's web UI runs on.
+  'The port Alluxio worker''s web UI runs on.'

--- a/docs/_data/table/master-configuration.csv
+++ b/docs/_data/table/master-configuration.csv
@@ -16,6 +16,7 @@ alluxio.master.journal.log.size.bytes.max,10MB
 alluxio.master.journal.tailer.shutdown.quiet.wait.time,5sec
 alluxio.master.journal.tailer.sleep.time,1sec
 alluxio.master.journal.temporary.file.gc.threshold,30min
+alluxio.master.journal.type,UFS
 alluxio.master.journal.ufs.option,
 alluxio.master.keytab.file,
 alluxio.master.lineage.checkpoint.class,alluxio.master.lineage.checkpoint.CheckpointLatestPlanner

--- a/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
@@ -153,6 +153,9 @@ public final class ConfigurationDocGenerator {
 
       for (PropertyKey iteratorPK : dfkeys) {
         String pKey = iteratorPK.toString();
+
+        // Puts descriptions in single quotes to avoid having to escaping reserved characters.
+        // Still needs to escape single quotes with double single quotes.
         String description = iteratorPK.getDescription().replace("'", "''");
 
         // Write property key and default value to yml files

--- a/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
@@ -153,10 +153,10 @@ public final class ConfigurationDocGenerator {
 
       for (PropertyKey iteratorPK : dfkeys) {
         String pKey = iteratorPK.toString();
-        String description = iteratorPK.getDescription();
+        String description = iteratorPK.getDescription().replace("'", "''");
 
         // Write property key and default value to yml files
-        String keyValueStr = pKey + ":\n  " + description + "\n";
+        String keyValueStr = pKey + ":\n  '" + description + "'\n";
         if (pKey.startsWith("alluxio.user.")) {
           fileWriter = fileWriterMap.get("user");
         } else if (pKey.startsWith("alluxio.master.")) {

--- a/tests/src/test/java/alluxio/cli/ConfigurationDocGeneratorTest.java
+++ b/tests/src/test/java/alluxio/cli/ConfigurationDocGeneratorTest.java
@@ -18,6 +18,8 @@ import alluxio.PropertyKey;
 import alluxio.collections.Pair;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Joiner;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -103,8 +105,8 @@ public class ConfigurationDocGeneratorTest {
       assertEquals(ConfigurationDocGenerator.CSV_FILE_HEADER, target.get(0));
       assertEquals(source, target.get(1));
     } else if (fType == TYPE.YML) {
-      assertEquals(2, target.size());
-      assertEquals(source, target.get(0) + "\n" + target.get(1));
+      assertEquals(StringUtils.countMatches(source, "\n") + 1, target.size());
+      assertEquals(source, Joiner.on("\n").join(target));
     }
   }
 
@@ -145,6 +147,7 @@ public class ConfigurationDocGeneratorTest {
 
     //assert file contents
     List<String> keyDescription = Files.readAllLines(p, StandardCharsets.UTF_8);
-    checkFileContents(pKey + ":\n  " + description, keyDescription, mFileType);
+    String expected = pKey + ":\n  '" + description.replace("'", "''") + "'";
+    checkFileContents(expected, keyDescription, mFileType);
   }
 }


### PR DESCRIPTION
We recently added colon marks in yml file which broke the syntax. Put them in quotes fixed it.