### PR TITLE
[SMALLFIX] Re-query for the address during each connection attempt

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -164,7 +164,6 @@ public abstract class AbstractClient implements Client {
       return;
     }
     disconnect();
-    mAddress = getAddress();
     Preconditions.checkState(!mClosed, "Client is closed, will not try to connect.");
 
     RetryPolicy retryPolicy =
@@ -173,6 +172,7 @@ public abstract class AbstractClient implements Client {
       if (mClosed) {
         throw new FailedPreconditionException("Failed to connect: client has been closed");
       }
+      mAddress = getAddress();
       LOG.info("Alluxio client (version {}) is trying to connect with {} @ {}",
           RuntimeConstants.VERSION, getServiceName(), mAddress);
 

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -172,6 +172,7 @@ public abstract class AbstractClient implements Client {
       if (mClosed) {
         throw new FailedPreconditionException("Failed to connect: client has been closed");
       }
+      // Re-query the address in each loop iteration in case it has changed (e.g. master failover).
       mAddress = getAddress();
       LOG.info("Alluxio client (version {}) is trying to connect with {} @ {}",
           RuntimeConstants.VERSION, getServiceName(), mAddress);


### PR DESCRIPTION
Reverts the accidental movement of `mAddress = getAddress()` in https://github.com/Alluxio/alluxio/pull/5886/files#diff-d7dc60da6f1005850b481cc5792912c5R167

The address needs to be fetched inside the loop so that we detect primary master changes. Otherwise we keep retrying with a stale master address