### PR TITLE
[SMALLFIX] Fix documentation header style

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -22,7 +22,7 @@
 }
 .navbar-inner {
     /*padding-top: 2px;*/
-    height: 50px;
+    height: 85px;
 }
 .navbar-inner .nav {
     margin-top: 5px;
@@ -37,6 +37,7 @@
     margin-left: 10px;
 }
 body #content {
+    margin-top: 50px;
     line-height: 1.6;
     /* Inspired by Github's wiki style */
 }


### PR DESCRIPTION
This fixes the documentation generated by Jekyll.

Before: 
![screen shot 2017-08-24 at 4 41 07 pm](https://user-images.githubusercontent.com/4421455/29693681-0282338a-88ec-11e7-847e-d7b7f6d61086.png)

After:
![screen shot 2017-08-24 at 4 35 28 pm](https://user-images.githubusercontent.com/4421455/29693684-07ad9480-88ec-11e7-9f2b-7eb12116366f.png)

