### PR TITLE
[SMALLFIX]If parent is inconsistent, do not check children

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -834,11 +834,12 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       try (InodeLockList children = mInodeTree.lockDescendants(parent, InodeTree.LockMode.READ)) {
         if (!checkConsistencyInternal(parent.getInode(), parent.getUri())) {
           inconsistentUris.add(parent.getUri());
-        }
-        for (Inode child : children.getInodes()) {
-          AlluxioURI currentPath = mInodeTree.getPath(child);
-          if (!checkConsistencyInternal(child, currentPath)) {
-            inconsistentUris.add(currentPath);
+        } else {
+          for (Inode child : children.getInodes()) {
+            AlluxioURI currentPath = mInodeTree.getPath(child);
+            if (!checkConsistencyInternal(child, currentPath)) {
+              inconsistentUris.add(currentPath);
+            }
           }
         }
       }


### PR DESCRIPTION
if parent Inode is inconsistent, no need to check children, because we will delete the parent inode recursive