### PR TITLE
[ALLUXIO-2997] [s3] Implement HEAD, GET and PUT object in S3 API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -22,6 +22,7 @@ public class S3ErrorCode {
    * Error code names used in {@link S3ErrorCode}.
    */
   public static final class Name {
+    public static final String BAD_DIGEST = "BadDigest";
     public static final String BUCKET_ALREADY_EXISTS = "BucketAlreadyExists";
     public static final String BUCKET_NOT_EMPTY = "BucketNotEmpty";
     public static final String INTERNAL_ERROR = "InternalError";
@@ -37,6 +38,10 @@ public class S3ErrorCode {
   //
   // Official error codes.
   //
+  public static final S3ErrorCode BAD_DIGEST = new S3ErrorCode(
+      Name.BAD_DIGEST,
+      "The Content-MD5 you specified did not match what we received.",
+      Response.Status.BAD_REQUEST);
   public static final S3ErrorCode BUCKET_ALREADY_EXISTS = new S3ErrorCode(
       Name.BUCKET_ALREADY_EXISTS,
       "The requested bucket name already exists",

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -90,7 +90,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(BUCKET_PARAM)
-  @ReturnType("Response.Status")
+  @ReturnType("javax.ws.rs.core.Response.Status")
   public Response createBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -117,7 +117,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(BUCKET_PARAM)
-  @ReturnType("Response.Status")
+  @ReturnType("javax.ws.rs.core.Response.Status")
   public Response deleteBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -150,7 +150,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(OBJECT_PARAM)
-  @ReturnType("Response")
+  @ReturnType("javax.ws.rs.core.Response")
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
   public Response createObject(@HeaderParam("Content-MD5") final String contentMD5,
                                @PathParam("bucket") final String bucket,
@@ -205,7 +205,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  @ReturnType("Response.Status")
+  @ReturnType("javax.ws.rs.core.Response.Status")
   public Response deleteObject(@PathParam("bucket") final String bucket,
                                @PathParam("object") final String object) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -16,9 +16,11 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.client.WriteType;
+import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.CreateDirectoryOptions;
+import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.options.DeleteOptions;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.FileAlreadyExistsException;
@@ -26,12 +28,19 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.web.ProxyWebServer;
 
+import com.google.common.io.BaseEncoding;
 import com.qmino.miredot.annotations.ReturnType;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.io.InputStream;
+import java.security.MessageDigest;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -75,9 +84,9 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * @summary creates a bucket
    * @param bucket the bucket name
    * @return the response object
+   * @summary creates a bucket
    */
   @PUT
   @Path(BUCKET_PARAM)
@@ -89,9 +98,8 @@ public final class S3RestServiceHandler {
         String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
 
         // Create the bucket.
-        CreateDirectoryOptions options = CreateDirectoryOptions.defaults();
-        options.setWriteType(Configuration.getEnum(PropertyKey.PROXY_S3_WRITE_TYPE,
-            WriteType.class));
+        CreateDirectoryOptions options = CreateDirectoryOptions.defaults()
+            .setWriteType(getS3WriteType());
         try {
           mFileSystem.createDirectory(new AlluxioURI(bucketPath), options);
         } catch (Exception e) {
@@ -103,9 +111,9 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * @summary deletes a bucket
    * @param bucket the bucket name
    * @return the response object
+   * @summary deletes a bucket
    */
   @DELETE
   @Path(BUCKET_PARAM)
@@ -133,10 +141,67 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * @summary deletes a object
+   * @summary creates an object without using multipart upload
+   * @param contentMD5 the Base64 encoded 128-bit MD5 digest of the object
+   * @param bucket the bucket name
+   * @param object the object name
+   * @param is the request body
+   * @return the response object
+   */
+  @PUT
+  @Path(OBJECT_PARAM)
+  @ReturnType("Response")
+  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  public Response createObject(@HeaderParam("Content-MD5") final String contentMD5,
+                               @PathParam("bucket") final String bucket,
+                               @PathParam("object") final String object,
+                               final InputStream is) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
+      @Override
+      public Response call() throws S3Exception {
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+        checkBucketIsAlluxioDirectory(bucketPath);
+        AlluxioURI objectURI = new AlluxioURI(bucketPath + AlluxioURI.SEPARATOR + object);
+
+        try {
+          CreateFileOptions options = CreateFileOptions.defaults().setRecursive(true)
+              .setWriteType(getS3WriteType());
+          FileOutStream os = mFileSystem.createFile(objectURI, options);
+          MessageDigest md5 = MessageDigest.getInstance("MD5");
+
+          byte[] buf = new byte[4096];
+          while (true) {
+            int len = is.read(buf);
+            if (len == -1) {
+              break;
+            }
+            md5.update(buf, 0, len);
+            os.write(buf, 0, len);
+          }
+          os.close();
+
+          byte[] digest = md5.digest();
+          String base64Digest = BaseEncoding.base64().encode(digest);
+          if (!contentMD5.equals(base64Digest)) {
+            // The object may be corrupted, delete the written object and return an error.
+            mFileSystem.delete(objectURI);
+            throw new S3Exception(objectURI.getPath(), S3ErrorCode.BAD_DIGEST);
+          }
+
+          String entityTag = Hex.encodeHexString(digest);
+          return Response.ok().tag(entityTag).build();
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, bucketPath);
+        }
+      }
+    });
+  }
+
+  /**
    * @param bucket the bucket name
    * @param object the object name
    * @return the response object
+   * @summary deletes an object
    */
   @DELETE
   @Path(OBJECT_PARAM)
@@ -226,5 +291,9 @@ public final class S3RestServiceHandler {
     } catch (Exception e) {
       throw toBucketS3Exception(e, bucketPath);
     }
+  }
+
+  private WriteType getS3WriteType() {
+    return Configuration.getEnum(PropertyKey.PROXY_S3_WRITE_TYPE, WriteType.class);
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -90,7 +90,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(BUCKET_PARAM)
-  @ReturnType("javax.ws.rs.core.Response.Status")
+  @ReturnType("Void")
   public Response createBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -117,7 +117,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(BUCKET_PARAM)
-  @ReturnType("javax.ws.rs.core.Response.Status")
+  @ReturnType("Void")
   public Response deleteBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -150,7 +150,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(OBJECT_PARAM)
-  @ReturnType("javax.ws.rs.core.Response")
+  @ReturnType("Void")
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
   public Response createObject(@HeaderParam("Content-MD5") final String contentMD5,
                                @PathParam("bucket") final String bucket,
@@ -205,7 +205,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  @ReturnType("javax.ws.rs.core.Response.Status")
+  @ReturnType("Void")
   public Response deleteObject(@PathParam("bucket") final String bucket,
                                @PathParam("object") final String object) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -139,7 +139,7 @@ public final class S3RestServiceHandler {
         } catch (Exception e) {
           throw toBucketS3Exception(e, bucketPath);
         }
-        return Response.Status.OK;
+        return Response.Status.NO_CONTENT;
       }
     });
   }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -223,6 +223,7 @@ public final class S3RestServiceHandler {
         try {
           URIStatus status = mFileSystem.getStatus(objectURI);
           FileInStream is = mFileSystem.openFile(objectURI);
+          // TODO(cc): Consider how to respond with the object's ETag.
           return Response.ok(is).lastModified(new Date(status.getLastModificationTimeMs())).build();
         } catch (Exception e) {
           throw toObjectS3Exception(e, bucketPath);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -90,7 +90,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(BUCKET_PARAM)
-  @ReturnType("Void")
+  @ReturnType("java.lang.Void")
   public Response createBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -117,7 +117,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(BUCKET_PARAM)
-  @ReturnType("Void")
+  @ReturnType("java.lang.Void")
   public Response deleteBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -150,7 +150,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(OBJECT_PARAM)
-  @ReturnType("Void")
+  @ReturnType("java.lang.Void")
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
   public Response createObject(@HeaderParam("Content-MD5") final String contentMD5,
                                @PathParam("bucket") final String bucket,
@@ -205,7 +205,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  @ReturnType("Void")
+  @ReturnType("java.lang.Void")
   public Response deleteObject(@PathParam("bucket") final String bucket,
                                @PathParam("object") final String object) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -80,6 +80,10 @@ public final class S3RestUtils {
       return Response.ok().build();
     }
 
+    if (object instanceof Response) {
+      return (Response) object;
+    }
+
     if (object instanceof Response.Status) {
       Response.Status s = (Response.Status) object;
       switch (s) {

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -323,7 +323,10 @@ public final class S3ClientRestApiTest extends RestApiTest {
     HttpURLConnection connection = getObjectMetadataRestCall(objectKey);
     URIStatus status = mFileSystem.getStatus(
         new AlluxioURI(AlluxioURI.SEPARATOR + objectKey));
-    Assert.assertEquals(status.getLastModificationTimeMs(), connection.getLastModified());
+    // remove the milliseconds from the last modification time because the accuracy of HTTP dates
+    // is up to seconds.
+    long lastModified = status.getLastModificationTimeMs() / 1000 * 1000;
+    Assert.assertEquals(lastModified, connection.getLastModified());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -128,10 +128,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     try {
       // Create a new bucket under a non-existing mount point should fail.
       createBucketRestCall(s3Path);
-      Assert.fail();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create bucket under non-existing mount point should fail");
   }
 
   @Test
@@ -146,10 +147,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     try {
       // Create a new bucket under a non-mount-point directory should fail.
       createBucketRestCall(s3Path);
-      Assert.fail();
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create bucket under non-mount-point directory should fail");
   }
 
   @Test
@@ -165,10 +167,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       mFileSystemMaster.getFileInfo(uri, GET_STATUS_OPTIONS);
-      Assert.fail("bucket should have been removed");
     } catch (FileDoesNotExistException e) {
       // expected
+      return;
     }
+    Assert.fail("bucket should have been removed");
   }
 
   @Test
@@ -178,10 +181,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     try {
       // Delete a non-existing bucket should fail.
       deleteBucketRestCall(bucketName);
-      Assert.fail("delete a non-existing bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete a non-existing bucket should fail");
   }
 
   @Test
@@ -200,10 +204,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     try {
       // Delete a non-empty bucket should fail.
       deleteBucketRestCall(bucketName);
-      Assert.fail("delete a non-empty bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete a non-empty bucket should fail");
   }
 
   @Test
@@ -238,10 +243,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     String message = "hello world";
     try {
       createObjectRestCall(objectKey, message.getBytes(), null);
-      Assert.fail("create object under non-existent bucket should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create object under non-existent bucket should fail");
   }
 
   @Test
@@ -254,10 +260,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     try {
       String wrongMD5 = BaseEncoding.base64().encode(message.getBytes());
       createObjectRestCall(objectKey, message.getBytes(), wrongMD5);
-      Assert.fail("create object with wrong Content-MD5 should fail");
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("create object with wrong Content-MD5 should fail");
   }
 
   @Test
@@ -325,7 +332,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
       deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete non-empty directory as an object should fail");
   }
 
   @Test
@@ -338,7 +347,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
       deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
     } catch (AssertionError e) {
       // expected
+      return;
     }
+    Assert.fail("delete non-existing object should fail");
   }
 
   private void createBucketRestCall(String bucketName) throws Exception {

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -12,6 +12,8 @@
 package alluxio.proxy.s3;
 
 import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.CreateDirectoryOptions;
@@ -21,14 +23,20 @@ import alluxio.master.file.options.MountOptions;
 import alluxio.rest.RestApiTest;
 import alluxio.rest.TestCase;
 import alluxio.rest.TestCaseOptions;
+import alluxio.wire.FileInfo;
 
+import com.google.common.io.BaseEncoding;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.HttpMethod;
@@ -44,6 +52,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   private static final String S3_SERVICE_PREFIX = "s3";
   private static final String BUCKET_SEPARATOR = ":";
 
+  private FileSystem mFileSystem;
   private FileSystemMaster mFileSystemMaster;
 
   @Rule
@@ -55,15 +64,15 @@ public final class S3ClientRestApiTest extends RestApiTest {
     mPort = mResource.get().getProxyProcess().getWebLocalPort();
     mFileSystemMaster = mResource.get().getLocalAlluxioMaster().getMasterProcess()
         .getMaster(FileSystemMaster.class);
+    mFileSystem = mResource.get().getClient();
   }
 
   @Test
   public void putBucket() throws Exception {
     final String bucket = "bucket";
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucket);
     // Verify the directory is created for the new bucket.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
     Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
   }
 
@@ -78,12 +87,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
         MountOptions.defaults());
 
     // Create a new bucket under an existing mount point.
-    AlluxioURI uri = new AlluxioURI(
-        AlluxioURI.SEPARATOR + mountPoint + AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(s3Path);
 
     // Verify the directory is created for the new bucket, under the mount point.
+    AlluxioURI uri = new AlluxioURI(
+        AlluxioURI.SEPARATOR + mountPoint + AlluxioURI.SEPARATOR + bucketName);
     Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
   }
 
@@ -95,20 +103,19 @@ public final class S3ClientRestApiTest extends RestApiTest {
     final String s3Path =
         mountPointParent + BUCKET_SEPARATOR + mountPointName + BUCKET_SEPARATOR + bucketName;
 
-    mFileSystemMaster.createDirectory(new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent),
-        CreateDirectoryOptions.defaults());
+    mFileSystemMaster.createDirectory(new AlluxioURI(
+        AlluxioURI.SEPARATOR + mountPointParent), CreateDirectoryOptions.defaults());
     AlluxioURI mountPointPath = new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent
         + AlluxioURI.SEPARATOR + mountPointName);
     mFileSystemMaster.mount(mountPointPath, new AlluxioURI(mFolder.newFolder().getAbsolutePath()),
         MountOptions.defaults());
 
     // Create a new bucket under an existing nested mount point.
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent + AlluxioURI.SEPARATOR
-        + mountPointName + AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(s3Path);
 
     // Verify the directory is created for the new bucket, under the mount point.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent
+        + AlluxioURI.SEPARATOR + mountPointName + AlluxioURI.SEPARATOR + bucketName);
     Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
   }
 
@@ -120,8 +127,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       // Create a new bucket under a non-existing mount point should fail.
-      new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
-          HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+      createBucketRestCall(s3Path);
       Assert.fail();
     } catch (AssertionError e) {
       // expected
@@ -139,8 +145,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       // Create a new bucket under a non-mount-point directory should fail.
-      new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + s3Path, NO_PARAMS,
-          HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+      createBucketRestCall(s3Path);
       Assert.fail();
     } catch (AssertionError e) {
       // expected
@@ -150,14 +155,14 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteBucket() throws Exception {
     final String bucket = "bucket-to-delete";
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucket);
+
     // Verify the directory is created for the new bucket.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
     Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
 
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
-        HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+    deleteBucketRestCall(bucket);
+
     try {
       mFileSystemMaster.getFileInfo(uri, GET_STATUS_OPTIONS);
       Assert.fail("bucket should have been removed");
@@ -172,8 +177,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       // Delete a non-existing bucket should fail.
-      new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
-          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+      deleteBucketRestCall(bucketName);
       Assert.fail("delete a non-existing bucket should fail");
     } catch (AssertionError e) {
       // expected
@@ -184,10 +188,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
   public void deleteNonEmptyBucket() throws Exception {
     final String bucketName = "non-empty-bucket";
 
-    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucketName);
 
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
     AlluxioURI fileUri = new AlluxioURI(uri.getPath() + "/file");
     mFileSystemMaster.createFile(fileUri, CreateFileOptions.defaults());
 
@@ -196,9 +199,62 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       // Delete a non-empty bucket should fail.
-      new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
-          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+      deleteBucketRestCall(bucketName);
       Assert.fail("delete a non-empty bucket should fail");
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void putObject() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String objectContent = "hello world";
+    createObjectRestCall(objectKey, objectContent.getBytes(), null);
+
+    // Verify the object is created for the new bucket.
+    AlluxioURI bucketURI = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
+    AlluxioURI objectURI = new AlluxioURI(AlluxioURI.SEPARATOR + objectKey);
+    List<FileInfo> fileInfos = mFileSystemMaster.listStatus(bucketURI,
+        ListStatusOptions.defaults());
+    Assert.assertEquals(1, fileInfos.size());
+    Assert.assertEquals(objectURI.getPath(), fileInfos.get(0).getPath());
+
+    // Verify the object's content.
+    FileInStream is = mFileSystem.openFile(objectURI);
+    String writtenObjectContent = IOUtils.toString(is);
+    is.close();
+    Assert.assertEquals(objectContent, writtenObjectContent);
+  }
+
+  @Test
+  public void putObjectUnderNonExistentBucket() throws Exception {
+    final String bucket = "non-existent-bucket";
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String message = "hello world";
+    try {
+      createObjectRestCall(objectKey, message.getBytes(), null);
+      Assert.fail("create object under non-existent bucket should fail");
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void putObjectWithWrongMD5() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String message = "hello world";
+    try {
+      String wrongMD5 = BaseEncoding.base64().encode(message.getBytes());
+      createObjectRestCall(objectKey, message.getBytes(), wrongMD5);
+      Assert.fail("create object with wrong Content-MD5 should fail");
     } catch (AssertionError e) {
       // expected
     }
@@ -207,22 +263,19 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteObject() throws Exception {
     final String bucketName = "bucket-with-object-to-delete";
-
-    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucketName);
 
     final String objectName = "file";
-    AlluxioURI fileUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI fileUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
     mFileSystemMaster.createFile(fileUri, CreateFileOptions.defaults());
 
     // Verify the directory is created for the new bucket, and file is created under it.
     Assert.assertFalse(
         mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
 
-    new TestCase(mHostname, mPort,
-        S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
-        NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+    deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
 
     // Verify the object is deleted.
     Assert.assertTrue(
@@ -232,22 +285,19 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteObjectAsAlluxioEmptyDir() throws Exception {
     final String bucketName = "bucket-with-empty-dir-to-delete";
-
-    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucketName);
 
     String objectName = "empty-dir/";
-    AlluxioURI dirUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI dirUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
     mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
 
     // Verify the directory is created for the new bucket, and empty-dir is created under it.
     Assert.assertFalse(
         mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
 
-    new TestCase(mHostname, mPort,
-        S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
-        NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+    deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
 
     // Verify the empty-dir as a valid object is deleted.
     Assert.assertTrue(
@@ -257,13 +307,12 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteObjectAsAlluxioNonEmptyDir() throws Exception {
     final String bucketName = "bucket-with-non-empty-dir-to-delete";
-
-    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucketName);
 
     String objectName = "non-empty-dir/";
-    AlluxioURI dirUri = new AlluxioURI(bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI dirUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
     mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
 
     mFileSystemMaster.createFile(
@@ -273,9 +322,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         mFileSystemMaster.listStatus(dirUri, ListStatusOptions.defaults()).isEmpty());
 
     try {
-      new TestCase(mHostname, mPort,
-          S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
-          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+      deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
     } catch (AssertionError e) {
       // expected
     }
@@ -284,16 +331,46 @@ public final class S3ClientRestApiTest extends RestApiTest {
   @Test
   public void deleteNonExistingObject() throws Exception {
     final String bucketName = "bucket-with-nothing";
-    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName, NO_PARAMS,
-        HttpMethod.PUT, null, TestCaseOptions.defaults()).run();
+    createBucketRestCall(bucketName);
 
     String objectName = "non-existing-object";
     try {
-      new TestCase(mHostname, mPort,
-          S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR + objectName,
-          NO_PARAMS, HttpMethod.DELETE, null, TestCaseOptions.defaults()).run();
+      deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
     } catch (AssertionError e) {
       // expected
     }
+  }
+
+  private void createBucketRestCall(String bucketName) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName;
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null,
+        TestCaseOptions.defaults()).run();
+  }
+
+  private void deleteBucketRestCall(String bucketName) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName;
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.DELETE, null,
+        TestCaseOptions.defaults()).run();
+  }
+
+  private void createObjectRestCall(String objectKey, byte[] objectContent, String md5)
+      throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    TestCaseOptions options = TestCaseOptions.defaults();
+    if (md5 == null) {
+      MessageDigest md5Hash = MessageDigest.getInstance("MD5");
+      byte[] md5Digest = md5Hash.digest(objectContent);
+      md5 = BaseEncoding.base64().encode(md5Digest);
+    }
+    options.setMD5(md5);
+    options.setInputStream(new ByteArrayInputStream(objectContent));
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null, options)
+        .run();
+  }
+
+  private void deleteObjectRestCall(String objectKey) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.DELETE, null,
+        TestCaseOptions.defaults()).run();
   }
 }

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -127,9 +127,9 @@ public final class TestCase {
   }
 
   /**
-   * Runs the test case and returns the output.
+   * Runs the test case and returns the {@link HttpURLConnection}.
    */
-  public String call() throws Exception {
+  public HttpURLConnection execute() throws Exception {
     HttpURLConnection connection = (HttpURLConnection) createURL().openConnection();
     connection.setRequestMethod(mMethod);
     if (mOptions.getMD5() != null) {
@@ -160,7 +160,14 @@ public final class TestCase {
       }
       Assert.fail("Request failed with status code " + connection.getResponseCode());
     }
-    return getResponse(connection);
+    return connection;
+  }
+
+  /**
+   * Runs the test case and returns the output.
+   */
+  public String call() throws Exception {
+    return getResponse(execute());
   }
 
   /**

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -132,6 +132,9 @@ public final class TestCase {
   public String call() throws Exception {
     HttpURLConnection connection = (HttpURLConnection) createURL().openConnection();
     connection.setRequestMethod(mMethod);
+    if (mOptions.getMD5() != null) {
+      connection.setRequestProperty("Content-MD5", mOptions.getMD5());
+    }
     if (mOptions.getInputStream() != null) {
       connection.setDoOutput(true);
       connection.setRequestProperty("Content-Type", "application/octet-stream");

--- a/tests/src/test/java/alluxio/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptions.java
@@ -117,7 +117,7 @@ public final class TestCaseOptions {
     return Objects.equal(mBody, that.mBody)
         && Objects.equal(mInputStream, that.mInputStream)
         && mPrettyPrint == that.mPrettyPrint
-        && mMD5.equals(that.mMD5);
+        && Objects.equal(mMD5, that.mMD5);
   }
 
   @Override

--- a/tests/src/test/java/alluxio/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptions.java
@@ -26,6 +26,7 @@ public final class TestCaseOptions {
   private Object mBody;
   private InputStream mInputStream;
   private boolean mPrettyPrint;
+  private String mMD5;
 
   /**
    * @return the default {@link TestCaseOptions}
@@ -38,6 +39,7 @@ public final class TestCaseOptions {
     mBody = null;
     mInputStream = null;
     mPrettyPrint = false;
+    mMD5 = null;
   }
 
   /**
@@ -59,6 +61,13 @@ public final class TestCaseOptions {
    */
   public boolean isPrettyPrint() {
     return mPrettyPrint;
+  }
+
+  /**
+   * @return the Base64 encoded MD5 digest of the request body
+   */
+  public String getMD5() {
+    return mMD5;
   }
 
   /**
@@ -88,6 +97,15 @@ public final class TestCaseOptions {
     return this;
   }
 
+  /**
+   * @param md5 the Base64 encoded MD5 digest of the request body
+   */
+  public TestCaseOptions setMD5(String md5) {
+    mMD5 = md5;
+    return this;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -99,12 +117,13 @@ public final class TestCaseOptions {
     TestCaseOptions that = (TestCaseOptions) o;
     return Objects.equal(mBody, that.mBody)
         && Objects.equal(mInputStream, that.mInputStream)
-        && mPrettyPrint == that.mPrettyPrint;
+        && mPrettyPrint == that.mPrettyPrint
+        && mMD5.equals(that.mMD5);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mBody, mInputStream, mPrettyPrint);
+    return Objects.hashCode(mBody, mInputStream, mPrettyPrint, mMD5);
   }
 
   @Override
@@ -113,6 +132,7 @@ public final class TestCaseOptions {
         .add("body", mBody)
         .add("input stream", mInputStream)
         .add("pretty print", mPrettyPrint)
+        .add("MD5", mMD5)
         .toString();
   }
 }

--- a/tests/src/test/java/alluxio/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptions.java
@@ -105,7 +105,6 @@ public final class TestCaseOptions {
     return this;
   }
 
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/tests/src/test/java/alluxio/rest/TestCaseOptionsTest.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptionsTest.java
@@ -13,6 +13,7 @@ package alluxio.rest;
 
 import alluxio.CommonTestUtils;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,6 +35,7 @@ public class TestCaseOptionsTest {
     Assert.assertNull(options.getBody());
     Assert.assertNull(options.getInputStream());
     Assert.assertFalse(options.isPrettyPrint());
+    Assert.assertNull(options.getMD5());
   }
 
   /**
@@ -48,14 +50,17 @@ public class TestCaseOptionsTest {
     InputStream inputStream = new ByteArrayInputStream(bytes);
     boolean prettyPrint = random.nextBoolean();
     TestCaseOptions options = TestCaseOptions.defaults();
+    String md5 = RandomStringUtils.random(64);
 
     options.setBody(body);
     options.setInputStream(inputStream);
     options.setPrettyPrint(prettyPrint);
+    options.setMD5(md5);
 
     Assert.assertEquals(body, options.getBody());
     Assert.assertEquals(inputStream, options.getInputStream());
     Assert.assertEquals(prettyPrint, options.isPrettyPrint());
+    Assert.assertEquals(md5, options.getMD5());
   }
 
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2997

Implements 
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html.
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html.
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html.

Options in GET object are not considered in this PR.

The following Python script works under this implementation.

```python
import boto
import boto.s3.connection

conn = boto.connect_s3(
    aws_access_key_id = '',
    aws_secret_access_key = '',
    host = 'localhost',
    port = 39999,
    path = '/api/v1/s3',
    is_secure=False,
    calling_format = boto.s3.connection.OrdinaryCallingFormat(),
)

bucketName = 'bucket'
bucket = conn.create_bucket(bucketName)

smallObjectKey = 'small.txt'
smallObjectContent = 'Hello World!'

key = bucket.new_key(smallObjectKey)
key.set_contents_from_string(smallObjectContent)

assert smallObjectContent == key.get_contents_as_string()

largeObjectKey = 'large.txt'
largeObjectFile = '8mb.data'

key = bucket.new_key(largeObjectKey)
with open(largeObjectFile, 'rb') as f:
    key.set_contents_from_file(f)
with open(largeObjectFile, 'rb') as f:
    largeObject = f.read()

assert largeObject == key.get_contents_as_string()


bucket.delete_key(smallObjectKey)
bucket.delete_key(largeObjectKey)
conn.delete_bucket(bucketName)
```