### PR TITLE
[ALLUXIO-2997] [s3] Improve S3 object APIs

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -22,6 +22,7 @@ public final class S3Constants {
   public static final String S3_EMPTY_ETAG = "";
   public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public static final int S3_DEFAULT_MAX_KEYS = 1000;
+  public static final String S3_CONTENT_LENGTH_HEADER = "Content-Length";
 
   private S3Constants() {} // prevent instantiation
 }

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -284,6 +284,19 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   @Test
+  public void putObjectWithNoMD5() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String objectContent = "no md5 set";
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    TestCaseOptions options = TestCaseOptions.defaults();
+    options.setInputStream(new ByteArrayInputStream(objectContent.getBytes()));
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null, options).run();
+  }
+
+  @Test
   public void getBucket() throws Exception {
     final String bucket = "bucket-to-get";
     createBucketRestCall(bucket);
@@ -561,6 +574,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
     // is up to seconds.
     long lastModified = status.getLastModificationTimeMs() / 1000 * 1000;
     Assert.assertEquals(lastModified, connection.getLastModified());
+    Assert.assertEquals(String.valueOf(status.getLength()),
+        connection.getHeaderField(S3Constants.S3_CONTENT_LENGTH_HEADER));
   }
 
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2997

Follow-up for object PUT/GET/HEAD api.
Addressed major comments in https://github.com/Alluxio/alluxio/pull/5949
- Use `DigestOutputStream`
- Add `Content-Length` in GET/HEAD response.
- Allow `Content-MD5` unspecified.