### PR TITLE
[ALLUXIO-2995] More fixes on partial caching

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -61,7 +61,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   private PacketReader mPacketReader;
   private PacketReader.Factory mPacketReaderFactory;
 
-  protected boolean mClosed = false;
+  private boolean mClosed = false;
   private boolean mEOF = false;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -61,7 +61,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   private PacketReader mPacketReader;
   private PacketReader.Factory mPacketReaderFactory;
 
-  private boolean mClosed = false;
+  protected boolean mClosed = false;
   private boolean mEOF = false;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -503,9 +503,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     }
     Preconditions.checkNotNull(mCurrentBlockInStream, "mCurrentBlockInStream");
 
-    // do not create cache stream when the block is in local worker or from UFS
-    if (!mShouldCache || mCurrentBlockInStream.Source() == BlockInStreamSource.LOCAL
-        || mCurrentBlockInStream.Source() == BlockInStreamSource.UFS) {
+    // do not create cache stream when the block is not in remote worker
+    if (!mShouldCache || mCurrentBlockInStream.Source() != BlockInStreamSource.REMOTE) {
       return;
     }
 
@@ -641,7 +640,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       updateStreams();
       if (mCurrentBlockInStream != null
           && mCurrentBlockInStream.Source() != BlockInStreamSource.LOCAL) {
-        //
+        // read till the position for partial caching when not reading from local worker
         readCurrentBlockToPos(pos);
       } else if (mCurrentBlockInStream != null) {
         seekInternal(pos);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -93,7 +93,10 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
   // The following 3 fields must be kept in sync. They are only updated in updateStreams together.
   /** Current block in stream backing this stream. */
   protected BlockInStream mCurrentBlockInStream;
-  /** Current block out stream writing the data into Alluxio. */
+  /**
+   * Current block out stream writing the data into the local worker. This is only used when the in
+   * stream reads from a remote worker.
+   */
   protected BlockOutStream mCurrentCacheStream;
   /** The blockId used in the block streams. */
   private long mStreamBlockId;
@@ -360,8 +363,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
   }
 
   /**
-   * Checks whether block instream and cache outstream should be updated.
-   * This function is only called by {@link #updateStreams()}.
+   * Checks whether block instream and cache outstream should be updated. This function is only
+   * called by {@link #updateStreams()}.
    *
    * @param currentBlockId cached result of {@link #getCurrentBlockId()}
    * @return true if the block stream should be updated
@@ -372,9 +375,9 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     }
     if (mCurrentCacheStream != null
         && mCurrentBlockInStream.remaining() != mCurrentCacheStream.remaining()) {
-      throw new IllegalStateException(String.format(
-          "BlockInStream and CacheStream is out of sync %d %d.", mCurrentBlockInStream.remaining(),
-          mCurrentCacheStream.remaining()));
+      throw new IllegalStateException(
+          String.format("BlockInStream and CacheStream is out of sync %d %d.",
+              mCurrentBlockInStream.remaining(), mCurrentCacheStream.remaining()));
     }
     return mCurrentBlockInStream.remaining() == 0;
   }
@@ -477,8 +480,11 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
 
   /**
    * Updates {@link #mCurrentCacheStream}. When {@code mShouldCache} is true, {@code FileInStream}
-   * will create an {@code BlockOutStream} to cache the data read only if the file is read from a
-   * remote worker and we have an available local worker.
+   * will create an {@code BlockOutStream} to cache the data read only if the block is read from a
+   * remote worker and we have an available local worker. Note that when the block is in UFS but not
+   * in Alluxio, the cache stream is not needed in the client because the worker caches directly the
+   * block when it reads from UFS. And if the block is already in local worker, then the block
+   * should not be cached again.
    *
    * The following preconditions are checked inside:
    * <ol>
@@ -504,7 +510,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     Preconditions.checkNotNull(mCurrentBlockInStream, "mCurrentBlockInStream");
 
     // do not create cache stream when the block is not in remote worker
-    if (!mShouldCache || mCurrentBlockInStream.Source() != BlockInStreamSource.REMOTE) {
+    if (!(mShouldCache && mCurrentBlockInStream.Source() == BlockInStreamSource.REMOTE)) {
       return;
     }
 
@@ -584,30 +590,58 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
   }
 
   /**
-   * Seeks to a file position. Blocks are cached even if they are not fully read. This is only
-   * called by {@link FileInStream#seek}.
+   * Seeks to a file position with partial caching if needed. Blocks are cached even if they are not
+   * fully read. This is only called by {@link FileInStream#seek}.
+   *
+   * The seek could involve at most two blocks: the current block and the target block. And it's
+   * possible that the current block and the target block are the same block when the seek is within
+   * the same block.
+   *
+   * The behavior for the current block:
+   * <ol>
+   * <li>If the current block is already available in the local worker, then the caching of the
+   * current block is not needed. And if the seek position is within the current block, directly
+   * move the position to the seek position. Otherwise the position is moved outside the current
+   * block.</li>
+   * <li>If the current block is not available locally, then the partial caching is needed. And data
+   * needs to read from the current position till the seek position, when the position is within the
+   * current block, otherwise reads the rest of the current block.</li>
+   * <li>However, a caveat is that if this is the first seek before any data is read from the file
+   * and this seeks is outside the first block, then the first block should not be cached.</li>
+   * </ol>
+   *
+   * The behavior on the target block:
+   * <ol>
+   * <li>If the target block is already available in the local worker, then the caching on the
+   * target block is not needed. Directly move the position to the seek position.</li>
+   * <li>Otherwise data from the beginning of the block till the seek position needs to be read and
+   * cached.</li>
+   * </ol>
+   *
    * Invariant: if the current block is to be cached, [0, mPos) should have been cached already.
    *
    * @param pos The position to seek to. It is guaranteed to be valid (pos >= 0 && pos != mPos &&
-   *            pos <= mFileLength).
+   *        pos <= mFileLength).
    */
   private void seekInternalWithCachingPartiallyReadBlock(long pos) throws IOException {
     // Precompute this because mPos will be updated several times in this function.
     final boolean isInCurrentBlock = pos / mBlockSize == mPos / mBlockSize;
 
-    // No need to cache if (1) the stream hasn't read anything and the seek position is not within
-    // the block, or (2) the in stream reads from the local worker
-    boolean firstReadAcrossBlock = mPos == 0 && mCurrentBlockInStream == null && !isInCurrentBlock;
+    // cache the current block if neither of these conditions hold:
+    // (1) this is the first seek before any read, and the seek is outside the first block
+    // (2) the in stream reads from the local worker
+    boolean firstSeekOutsideFirstBlock =
+        mPos == 0 && mCurrentBlockInStream == null && !isInCurrentBlock;
     boolean readFromLocalWorker = mCurrentBlockInStream != null
         && mCurrentBlockInStream.Source() == BlockInStreamSource.LOCAL;
-    if (!firstReadAcrossBlock && !readFromLocalWorker) {
+    if (!firstSeekOutsideFirstBlock && !readFromLocalWorker) {
       // Make sure that mCurrentBlockInStream and mCurrentCacheStream is updated.
       // mPos is not updated here.
       updateStreams();
 
       // Cache till pos if seeking forward within the current block. Otherwise cache the whole
       // block.
-      if (pos > mPos) {
+      if (isInCurrentBlock && pos > mPos) {
         readCurrentBlockToPos(pos);
       } else {
         readCurrentBlockToEnd();
@@ -621,12 +655,9 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       // The early return above guarantees that we won't close an incomplete cache stream.
       Preconditions.checkState(mCurrentCacheStream == null || mCurrentCacheStream.remaining() == 0);
       closeOrCancelCacheStream();
-    }
-
-    // If seeks within the current block, directly seeks to pos if we are not yet there.
-    // If seeks outside the current block, seek to the beginning of that block first, then
-    // cache the prefix (pos % mBlockSize) of that block.
-    if (isInCurrentBlock) {
+    } else if (isInCurrentBlock) {
+      // the current block is not cached, and the seek is within the block
+      // directly seeks to position if we are not yet there.
       mPos = pos;
       // updateStreams is necessary when pos = mFileLength.
       updateStreams();
@@ -635,18 +666,21 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       } else {
         Preconditions.checkState(remaining() == 0);
       }
+      return;
+    }
+
+    // the seeks outside the current block, seek to the beginning of that block first
+    mPos = pos / mBlockSize * mBlockSize;
+    updateStreams();
+    if (mCurrentBlockInStream != null
+        && mCurrentBlockInStream.Source() != BlockInStreamSource.LOCAL) {
+      // cache till the seek position of the block unless it's already available in local worker
+      readCurrentBlockToPos(pos);
+    } else if (mCurrentBlockInStream != null) {
+      // otherwise directly seek to the position
+      seekInternal(pos);
     } else {
-      mPos = pos / mBlockSize * mBlockSize;
-      updateStreams();
-      if (mCurrentBlockInStream != null
-          && mCurrentBlockInStream.Source() != BlockInStreamSource.LOCAL) {
-        // read till the position for partial caching when not reading from local worker
-        readCurrentBlockToPos(pos);
-      } else if (mCurrentBlockInStream != null) {
-        seekInternal(pos);
-      } else {
-        Preconditions.checkState(remaining() == 0);
-      }
+      Preconditions.checkState(remaining() == 0);
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -656,7 +656,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       Preconditions.checkState(mCurrentCacheStream == null || mCurrentCacheStream.remaining() == 0);
       closeOrCancelCacheStream();
     } else if (isInCurrentBlock) {
-      // the current block is not cached, and the seek is within the block
+      // no need to partial cache the current block, and the seek is within the block
       // directly seeks to position if we are not yet there.
       mPos = pos;
       // updateStreams is necessary when pos = mFileLength.

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 public class TestBlockInStream extends BlockInStream {
   /** A field tracks how much bytes read. */
   private int mBytesRead;
+  private boolean mClosed;
 
   public TestBlockInStream(byte[] mData, long id, long length, boolean shortCircuit,
       BlockInStreamSource source) {
@@ -43,6 +44,12 @@ public class TestBlockInStream extends BlockInStream {
 
   public boolean isClosed() {
     return mClosed;
+  }
+
+  @Override
+  public void close() throws IOException {
+    mClosed = true;
+    super.close();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -11,13 +11,45 @@
 
 package alluxio.client.block.stream;
 
+import java.io.IOException;
+
 /**
- * A {@link BlockInStream} which reads from the given byte array.
+ * A {@link BlockInStream} which reads from the given byte array. The stream is able to track how
+ * much bytes that have been read from the extended BlockInStream.
  */
 public class TestBlockInStream extends BlockInStream {
+  /** A field tracks how much bytes read. */
+  private int mBytesRead;
+
   public TestBlockInStream(byte[] mData, long id, long length, boolean shortCircuit,
       BlockInStreamSource source) {
     super(new Factory(mData, shortCircuit), source, id, length);
+    mBytesRead = 0;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int bytesRead = super.read(b, off, len);
+    mBytesRead += bytesRead;
+    return bytesRead;
+  }
+
+  @Override
+  public int positionedRead(long pos, byte[] b, int off, int len) throws IOException {
+    int bytesRead = super.positionedRead(pos, b, off, len);
+    mBytesRead += bytesRead;
+    return bytesRead;
+  }
+
+  public boolean isClosed() {
+    return mClosed;
+  }
+
+  /**
+   * @return how many bytes been read
+   */
+  public int getBytesRead() {
+    return mBytesRead;
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -71,6 +71,7 @@ public final class FileInStreamTest {
   private FileInfo mInfo;
   private URIStatus mStatus;
 
+  private List<TestBlockInStream> mInStreams;
   private List<TestBlockOutStream> mCacheStreams;
 
   private FileInStream mTestStream;
@@ -115,23 +116,27 @@ public final class FileInStreamTest {
     PowerMockito.when(mBlockStore.getWorkerInfoList()).thenReturn(new ArrayList<BlockWorkerInfo>());
 
     // Set up BufferedBlockInStreams and caching streams
+    mInStreams = new ArrayList<>();
     mCacheStreams = new ArrayList<>();
     List<Long> blockIds = new ArrayList<>();
     for (int i = 0; i < NUM_STREAMS; i++) {
       blockIds.add((long) i);
+      final byte[] input = BufferUtils
+          .getIncreasingByteArray((int) (i * BLOCK_LENGTH), (int) getBlockLength(i));
+      mInStreams.add(new TestBlockInStream(input, i, input.length, false, mBlockSource));
       mCacheStreams.add(new TestBlockOutStream(ByteBuffer.allocate(1000), getBlockLength(i)));
       Mockito.when(mBlockStore.getWorkerInfoList())
           .thenReturn(Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress(), 0, 0)));
       Mockito
-          .when(mBlockStore.getInStream(Mockito.eq((long) i), Mockito.any(
-              Protocol.OpenUfsBlockOptions.class), Mockito.any(InStreamOptions.class)))
+          .when(mBlockStore.getInStream(Mockito.eq((long) i),
+              Mockito.any(Protocol.OpenUfsBlockOptions.class), Mockito.any(InStreamOptions.class)))
           .thenAnswer(new Answer<BlockInStream>() {
             @Override
             public BlockInStream answer(InvocationOnMock invocation) throws Throwable {
               long i = (Long) invocation.getArguments()[0];
-              byte[] input = BufferUtils
-                  .getIncreasingByteArray((int) (i * BLOCK_LENGTH), (int) getBlockLength((int) i));
-              return new TestBlockInStream(input, i, input.length, false, mBlockSource);
+              return mInStreams.get((int) i).isClosed()
+                  ? new TestBlockInStream(input, i, input.length, false, mBlockSource)
+                  : mInStreams.get((int) i);
             }
           });
       Mockito.when(mBlockStore.getOutStream(Mockito.eq((long) i), Mockito.anyLong(),
@@ -272,7 +277,7 @@ public final class FileInStreamTest {
     Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
 
     // second block is cached if the block is not local
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
+    byte[] expected = mBlockSource != BlockInStreamSource.REMOTE ? new byte[0]
         : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
     Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
 
@@ -301,9 +306,7 @@ public final class FileInStreamTest {
     mTestStream.seek(readAmount - seekAmount);
 
     // Block 2 is cached though it is not fully read.
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray(2 * (int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(2).getWrittenData());
+    validatePartialCaching(2, (int) BLOCK_LENGTH);
   }
 
   /**
@@ -323,17 +326,13 @@ public final class FileInStreamTest {
     mTestStream.seek(readAmount - seekAmount);
 
     // Block 1 is cached though it is not fully read.
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+    validatePartialCaching(1, (int) BLOCK_LENGTH);
 
     // Seek many times. It will cache block 1 only once.
     for (int i = 0; i <= seekAmount; i++) {
       mTestStream.seek(readAmount - seekAmount - i);
     }
-    expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+    validatePartialCaching(1, (int) BLOCK_LENGTH);
   }
 
   /**
@@ -353,14 +352,10 @@ public final class FileInStreamTest {
     mTestStream.seek(readAmount + seekAmount);
 
     // Block 0 is cached though it is not fully read.
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray(0, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(0).getWrittenData());
+    validatePartialCaching(0, (int) BLOCK_LENGTH);
+
     // Block 1 is being cached though its prefix it not read.
-    expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH / 4 * 3);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
-    mTestStream.seek(FILE_LENGTH);
+    validatePartialCaching(1, (int) BLOCK_LENGTH / 4 * 3);
   }
 
   /**
@@ -380,17 +375,12 @@ public final class FileInStreamTest {
     mTestStream.seek(readAmount + seekAmount);
 
     // Block 1 (till seek pos) is being cached.
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH / 4 * 3);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+    validatePartialCaching(1, (int) BLOCK_LENGTH / 4 * 3);
 
     // Seek forward many times. The prefix is always cached.
     for (int i = 0; i < seekAmount; i++) {
       mTestStream.seek(readAmount + seekAmount + i);
-      expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-          : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH,
-              (int) BLOCK_LENGTH / 2 + seekAmount + i);
-      Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+      validatePartialCaching(1, (int) BLOCK_LENGTH / 2 + seekAmount + i);
     }
   }
 
@@ -408,9 +398,7 @@ public final class FileInStreamTest {
 
     mTestStream.seek(readAmount - 1);
 
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray(0, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(0).getWrittenData());
+    validatePartialCaching(0, (int) BLOCK_LENGTH);
     Assert.assertEquals(0, mCacheStreams.get(1).getWrittenData().length);
   }
 
@@ -428,29 +416,20 @@ public final class FileInStreamTest {
     // Seek forward.
     mTestStream.seek(seekAmount);
 
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH / 4);
     // Block 1 is partially cached though it is not fully read.
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+    validatePartialCaching(1, (int) BLOCK_LENGTH / 4);
     // Block 0 is not cached.
     Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
 
     // Seek backward.
     mTestStream.seek(0);
 
-    expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
     // Block 1 is fully cached though it is not fully read.
-    Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
+    validatePartialCaching(1, (int) BLOCK_LENGTH);
 
     // Block 0 is not cached.
     Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
     mTestStream.close();
-
-    // Block 0 is fully cached if data is not already cached.
-    expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
-        : BufferUtils.getIncreasingByteArray(0, (int) BLOCK_LENGTH);
-    Assert.assertArrayEquals(expected, mCacheStreams.get(0).getWrittenData());
   }
 
   /**
@@ -471,7 +450,7 @@ public final class FileInStreamTest {
     Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
 
     // second block is cached
-    byte[] expected = mBlockSource == BlockInStreamSource.LOCAL ? new byte[0]
+    byte[] expected = mBlockSource != BlockInStreamSource.REMOTE ? new byte[0]
         : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
     Assert.assertArrayEquals(expected, mCacheStreams.get(1).getWrittenData());
 
@@ -586,8 +565,7 @@ public final class FileInStreamTest {
     mTestStream.close();
 
     Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(dataRead), buffer);
-    int cachedData = (int) ((dataRead / BLOCK_LENGTH) * BLOCK_LENGTH);
-    verifyCacheStreams(cachedData);
+    verifyCacheStreams(dataRead);
   }
 
   /**
@@ -596,17 +574,54 @@ public final class FileInStreamTest {
    * @param dataRead the bytes to read
    */
   private void verifyCacheStreams(long dataRead) {
+    int cachedData = (int) ((dataRead / BLOCK_LENGTH) * BLOCK_LENGTH);
     for (int streamIndex = 0; streamIndex < NUM_STREAMS; streamIndex++) {
+      TestBlockInStream inStream = mInStreams.get(streamIndex);
       TestBlockOutStream stream = mCacheStreams.get(streamIndex);
       byte[] data = stream.getWrittenData();
-      if (streamIndex * BLOCK_LENGTH > dataRead || mBlockSource == BlockInStreamSource.LOCAL) {
+      if (streamIndex * BLOCK_LENGTH > dataRead) {
         Assert.assertEquals(0, data.length);
       } else {
         long dataStart = streamIndex * BLOCK_LENGTH;
-        for (int i = 0; i < BLOCK_LENGTH && dataStart + i < dataRead; i++) {
-          Assert.assertEquals((byte) (dataStart + i), data[i]);
+        Assert.assertEquals(Math.min(BLOCK_LENGTH, dataRead - dataStart), inStream.getBytesRead());
+        if (mBlockSource != BlockInStreamSource.REMOTE) {
+          // no data is written cache stream if the read is not from remote worker
+          Assert.assertEquals(0, data.length);
+        } else {
+          for (int i = 0; i < BLOCK_LENGTH && dataStart + i < cachedData; i++) {
+            Assert.assertEquals((byte) (dataStart + i), data[i]);
+          }
         }
       }
+    }
+  }
+
+  /**
+   * Validates the partial caching behavior given the different block source type. This function
+   * assumes the block at the given index is cached for the given size.
+   *
+   */
+  private void validatePartialCaching(int index, int cacheSize) {
+    switch (mBlockSource) {
+      case LOCAL:
+        // nothing is cached, and the entire block is not read
+        Assert.assertTrue(mInStreams.get(index).getBytesRead() <= cacheSize);
+        Assert.assertArrayEquals(new byte[0], mCacheStreams.get(index).getWrittenData());
+        break;
+      case REMOTE:
+        // the block is cached
+        Assert.assertEquals(cacheSize, mInStreams.get(index).getBytesRead());
+        Assert.assertArrayEquals(
+            BufferUtils.getIncreasingByteArray(index * (int) BLOCK_LENGTH, cacheSize),
+            mCacheStreams.get(index).getWrittenData());
+        break;
+      case UFS:
+        // nothing is cached, but the entire block is read
+        Assert.assertArrayEquals(new byte[0], mCacheStreams.get(index).getWrittenData());
+        Assert.assertEquals(cacheSize, mInStreams.get(index).getBytesRead());
+        break;
+      default:
+        throw new IllegalStateException("Unrecognized block source type " + mBlockSource);
     }
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2995

This PR addresses the issue that when the file is read from UFS, the client still needs to drive the partial caching but should not create a cache stream, as the worker will perform the caching.