### PR TITLE
[MERGE] Merge s3 feature branch to master

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -151,8 +151,8 @@ public final class Constants {
   public static final int LAST_TIER = -1;
 
   // S3 northbound API constants
-  public static final String DELETE_IN_ALLUXIO_ONLY = "ALLUXIO_ONLY";
-  public static final String DELETE_IN_ALLUXIO_AND_UFS = "ALLUXIO_AND_UFS";
+  public static final String S3_DELETE_IN_ALLUXIO_ONLY = "ALLUXIO_ONLY";
+  public static final String S3_DELETE_IN_ALLUXIO_AND_UFS = "ALLUXIO_AND_UFS";
 
   private Constants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -150,5 +150,9 @@ public final class Constants {
   public static final int SECOND_TIER = 1;
   public static final int LAST_TIER = -1;
 
+  // S3 northbound API constants
+  public static final String DELETE_IN_ALLUXIO_ONLY = "ALLUXIO_ONLY";
+  public static final String DELETE_IN_ALLUXIO_AND_UFS = "ALLUXIO_AND_UFS";
+
   private Constants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1192,6 +1192,24 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   //
   // Proxy related properties
   //
+  public static final PropertyKey PROXY_S3_WRITE_TYPE =
+      new Builder(Name.PROXY_S3_WRITE_TYPE)
+          .setDefaultValue("CACHE_THROUGH")
+          .setDescription("Write type when creating buckets and objects through S3 API. "
+              + "Valid options are "
+              + "`MUST_CACHE` (write will only go to Alluxio and must be stored in Alluxio), "
+              + "`CACHE_THROUGH` (try to cache, write to UnderFS synchronously), "
+              + "`THROUGH` (no cache, write to UnderFS synchronously).")
+          .build();
+  public static final PropertyKey PROXY_S3_DELETE_TYPE =
+      new Builder(Name.PROXY_S3_DELETE_TYPE)
+          .setDefaultValue(Constants.DELETE_IN_ALLUXIO_AND_UFS)
+          .setDescription(String.format(
+              "Delete type when deleting buckets and objects through S3 API. Valid options are "
+                  + "`%s` (delete both in Alluxio and UFS), "
+                  + "`%s` (delete only the buckets or objects in Alluxio namespace).",
+              Constants.DELETE_IN_ALLUXIO_AND_UFS, Constants.DELETE_IN_ALLUXIO_ONLY))
+          .build();
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
       new Builder(Name.PROXY_STREAM_CACHE_TIMEOUT_MS)
           .setAlias(new String[]{"alluxio.proxy.stream.cache.timeout.ms"})
@@ -2066,6 +2084,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     // Proxy related properties
     //
+    public static final String PROXY_S3_WRITE_TYPE = "alluxio.proxy.s3.writetype";
+    public static final String PROXY_S3_DELETE_TYPE = "alluxio.proxy.s3.deletetype";
     public static final String PROXY_STREAM_CACHE_TIMEOUT_MS =
         "alluxio.proxy.stream.cache.timeout";
     public static final String PROXY_WEB_BIND_HOST = "alluxio.proxy.web.bind.host";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1203,12 +1203,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey PROXY_S3_DELETE_TYPE =
       new Builder(Name.PROXY_S3_DELETE_TYPE)
-          .setDefaultValue(Constants.DELETE_IN_ALLUXIO_AND_UFS)
+          .setDefaultValue(Constants.S3_DELETE_IN_ALLUXIO_AND_UFS)
           .setDescription(String.format(
               "Delete type when deleting buckets and objects through S3 API. Valid options are "
                   + "`%s` (delete both in Alluxio and UFS), "
                   + "`%s` (delete only the buckets or objects in Alluxio namespace).",
-              Constants.DELETE_IN_ALLUXIO_AND_UFS, Constants.DELETE_IN_ALLUXIO_ONLY))
+              Constants.S3_DELETE_IN_ALLUXIO_AND_UFS, Constants.S3_DELETE_IN_ALLUXIO_ONLY))
           .build();
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
       new Builder(Name.PROXY_STREAM_CACHE_TIMEOUT_MS)

--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -41,6 +41,7 @@ public final class RestUtils {
    */
   public static <T> Response call(RestUtils.RestCallable<T> callable) {
     try {
+      // TODO(cc): reconsider how to enable authentication
       if (SecurityUtils.isSecurityEnabled() && AuthenticatedClientUser.get() == null) {
         AuthenticatedClientUser.set(LoginUser.get().getName());
       }

--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -33,6 +33,10 @@
   <dependencies>
     <!-- External dependencies -->
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -1,0 +1,113 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.google.common.base.Objects;
+
+/**
+ * The options for list bucket operation.
+ */
+public final class ListBucketOptions {
+  private String mContinuationToken = null;
+  private String mMaxKeys = null;
+  private String mPrefix = null;
+
+  /**
+   * Creates a default {@link ListBucketOptions}.
+   *
+   * @return the created {@link ListBucketOptions}
+   */
+  public static ListBucketOptions defaults() {
+    return new ListBucketOptions();
+  }
+
+  /**
+   * Constructs a new {@link ListBucketOptions}.
+   */
+  private ListBucketOptions() {}
+
+  /**
+   * @return the continuation token
+   */
+  public String getContinuationToken() {
+    return mContinuationToken;
+  }
+
+  /**
+   * @return the max keys
+   */
+  public String getMaxKeys() {
+    return mMaxKeys;
+  }
+
+  /**
+   * @return the prefix
+   */
+  public String getPrefix() {
+    return mPrefix;
+  }
+
+  /**
+   * @param continuationToken the continuation token to set
+   * @return the updated object
+   */
+  public ListBucketOptions setContinuationToken(String continuationToken) {
+    mContinuationToken = continuationToken;
+    return this;
+  }
+
+  /**
+   * @param maxKeys the max keys to set
+   * @return the updated object
+   */
+  public ListBucketOptions setMaxKeys(String maxKeys) {
+    mMaxKeys = maxKeys;
+    return this;
+  }
+
+  /**
+   * @param prefix the prefix to set
+   * @return the updated object
+   */
+  public ListBucketOptions setPrefix(String prefix) {
+    mPrefix = prefix;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ListBucketOptions)) {
+      return false;
+    }
+    ListBucketOptions that = (ListBucketOptions) o;
+    return Objects.equal(mContinuationToken, that.mContinuationToken)
+        && Objects.equal(mMaxKeys, that.mMaxKeys)
+        && Objects.equal(mPrefix, that.mPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mContinuationToken, mMaxKeys, mPrefix);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("continuationToken", mContinuationToken)
+        .add("maxKeys", mMaxKeys)
+        .add("prefix", mPrefix)
+        .toString();
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -1,0 +1,404 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.wire.FileInfo;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Get bucket result defined in http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+ * It will be encoded into an XML string to be returned as a response for the REST call.
+ *
+ * TODO(chaomin): consider add more required fields in S3 BucketGet API.
+ */
+@JacksonXmlRootElement(localName = "ListBucketResult")
+@JsonPropertyOrder({ "Name", "Prefix", "ContinuationToken", "NextContinuationToken",
+    "KeyCount", "MaxKeys", "IsTruncated", "Contents" })
+public class ListBucketResult {
+
+  /* Name of the bucket. */
+  private String mName = "";
+  /* Keys that begin with the indicated prefix. */
+  private String mPrefix = null;
+  /* ContinuationToken is included in the response if it was sent with the request. */
+  private String mContinuationToken = null;
+  /**
+   * Returns the number of keys included in the response. The value is always less than or equal
+   * to the mMaxKeys value.
+   */
+  private int mKeyCount = 0;
+  /* The maximum number of keys returned in the response body. */
+  private int mMaxKeys = S3Constants.S3_DEFAULT_MAX_KEYS;
+  /**
+   * Specifies whether or not all of the results were returned. If the number of
+   * results exceeds that specified by MaxKeys, all of the results might not be returned.
+   */
+  private boolean mIsTruncated = false;
+  /**
+   * If only partial results are returned (i.e. mIsTruncated = true), this value is set as the
+   * next continuation token. The continuation token is the full Alluxio path of the object.
+   */
+  private String mNextContinuationToken = null;
+  /* A list of objects with metadata. */
+  private List<Content> mContents = new ArrayList<>();
+
+  /**
+   * Creates an {@link ListBucketResult}.
+   */
+  public ListBucketResult() {}
+
+  /**
+   * Creates an {@link ListBucketResult}.
+   *
+   * @param bucketName the bucket name
+   * @param objectsList a list of {@link URIStatus}, representing the objects
+   * @param options the list bucket options
+   */
+  public ListBucketResult(
+      String bucketName, List<URIStatus> objectsList, ListBucketOptions options) {
+    mName = bucketName;
+    mPrefix = options.getPrefix();
+    mKeyCount = 0;
+    if (options.getMaxKeys() != null) {
+      mMaxKeys = Integer.parseInt(options.getMaxKeys());
+    }
+    mContents = new ArrayList<>();
+    mContinuationToken = options.getContinuationToken();
+
+    Collections.sort(objectsList, new URIStatusComparator());
+
+    int startIndex = 0;
+    if (options.getContinuationToken() != null) {
+      URIStatus tokenStatus = new URIStatus(new FileInfo().setPath(
+          mName + AlluxioURI.SEPARATOR + mContinuationToken));
+      startIndex = Collections.binarySearch(objectsList, tokenStatus, new URIStatusComparator());
+      if (startIndex < 0) {
+        // If continuation token does not exist in the object list, find the first element which is
+        // greater than the token.
+        startIndex = (-1) * startIndex - 1;
+      }
+    }
+
+    final DateFormat s3DateFormat = new SimpleDateFormat(S3Constants.S3_DATE_FORMAT_REGEXP);
+    for (int i = startIndex; i < objectsList.size(); i++) {
+      URIStatus status = objectsList.get(i);
+      String objectKey = status.getPath().substring(mName.length() + 1);
+      if (mKeyCount >= mMaxKeys) {
+        mIsTruncated = true;
+        mNextContinuationToken = objectKey;
+        return;
+      }
+      if (mContinuationToken != null && objectKey.compareTo(mContinuationToken) < 0) {
+        continue;
+      }
+      if (mPrefix != null && !objectKey.startsWith(mPrefix)) {
+        continue;
+      }
+      // TODO(chaomin): set ETag once there's a way to get MD5 hash of an Alluxio file.
+      // TODO(chaomin): construct the response with CommonPrefixes when delimiter support is added.
+      mContents.add(new Content(
+          status.getPath().substring(mName.length() + 1),
+          s3DateFormat.format(new Date(status.getLastModificationTimeMs())),
+          S3Constants.S3_EMPTY_ETAG,
+          String.valueOf(status.getLength()),
+          S3Constants.S3_STANDARD_STORAGE_CLASS));
+      mKeyCount++;
+    }
+  }
+
+  /**
+   * @return the bucket name
+   */
+  @JacksonXmlProperty(localName = "Name")
+  public String getName() {
+    return mName;
+  }
+
+  /**
+   * @return the prefix
+   */
+  @JacksonXmlProperty(localName = "Prefix")
+  public String getPrefix() {
+    return mPrefix;
+  }
+
+  /**
+   * @return the continuation token
+   */
+  @JacksonXmlProperty(localName = "ContinuationToken")
+  public String getContinuationToken() {
+    return mContinuationToken;
+  }
+
+  /**
+   * @return the next continuation token
+   */
+  @JacksonXmlProperty(localName = "NextContinuationToken")
+  public String getNextContinuationToken() {
+    return mNextContinuationToken;
+  }
+
+  /**
+   * @return the number of keys included in the response
+   */
+  @JacksonXmlProperty(localName = "KeyCount")
+  public int getKeyCount() {
+    return mKeyCount;
+  }
+
+  /**
+   * @return the maximum number of keys returned in the response body
+   */
+  @JacksonXmlProperty(localName = "MaxKeys")
+  public int getMaxKeys() {
+    return mMaxKeys;
+  }
+
+  /**
+   * @return whether (true) or not (false) all of the results were returned
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public boolean isTruncated() {
+    return mIsTruncated;
+  }
+
+  /**
+   * @return the list of contents
+   */
+  @JacksonXmlProperty(localName = "Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public List<Content> getContents() {
+    return mContents;
+  }
+
+  /**
+   * @param name the bucket name to set
+   */
+  @JacksonXmlProperty(localName = "Name")
+  public void setName(String name) {
+    mName = name;
+  }
+
+  /**
+   * @param prefix the prefix to set
+   */
+  @JacksonXmlProperty(localName = "Prefix")
+  public void setPrefix(String prefix) {
+    mPrefix = prefix;
+  }
+
+  /**
+   * @param continuationToken the continuation token to set
+   */
+  @JacksonXmlProperty(localName = "ContinuationToken")
+  public void setContinuationToken(String continuationToken) {
+    mContinuationToken = continuationToken;
+  }
+
+  /**
+   * @param nextContinuationToken the next continuation token to set
+   */
+  @JacksonXmlProperty(localName = "NextContinuationToken")
+  public void setNextContinuationToken(String nextContinuationToken) {
+    mNextContinuationToken = nextContinuationToken;
+  }
+
+  /**
+   * @param keyCount the number of keys to set
+   */
+  @JacksonXmlProperty(localName = "KeyCount")
+  public void setKeyCount(int keyCount) {
+    mKeyCount = keyCount;
+  }
+
+  /**
+   * @param maxKeys the maximum number of keys returned value to set
+   */
+  @JacksonXmlProperty(localName = "MaxKeys")
+  public void setMaxKeys(int maxKeys) {
+    mMaxKeys = maxKeys;
+  }
+
+  /**
+   * @param isTruncated the isTruncated value to set
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public void setIsTruncated(boolean isTruncated) {
+    mIsTruncated = isTruncated;
+  }
+
+  /**
+   * @param contents the contents list to set
+   */
+  @JacksonXmlProperty(localName = "Contents")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setContent(List<Content> contents) {
+    mContents = contents;
+  }
+
+  /**
+   * Object metadata class.
+   */
+  @JsonPropertyOrder({ "Key", "LastModified", "ETag", "Size", "StorageClass" })
+  public class Content {
+    /* The object's key. */
+    private String mKey;
+    /* Date and time the object was last modified. */
+    private String mLastModified;
+    /* The entity tag is an MD5 hash of the object. */
+    // TODO(chaomin): for now this is always empty because file content's MD5 hash is not yet
+    // part of Alluxio metadata
+    private String mETag;
+    /* Size in bytes of the object. */
+    private String mSize;
+    /**
+     * Storage class (STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER). Alluxio only supports
+     * STANDARD for now.
+     */
+    private String mStorageClass;
+
+    /**
+     * Constructs a new {@link Content}.
+     */
+    public Content() {
+      mKey = "";
+      mLastModified = "";
+      mETag = "";
+      mSize = "";
+      mStorageClass = S3Constants.S3_STANDARD_STORAGE_CLASS;
+    }
+
+    /**
+     * Constructs a new {@link Content}.
+     *
+     * @param key the object key
+     * @param lastModified the data and time in string format the object was last modified
+     * @param eTag the entity tag (MD5 hash of the object contents)
+     * @param size size in bytes of the object
+     * @param storageClass storage class
+     */
+    public Content(String key, String lastModified, String eTag, String size, String storageClass) {
+      mKey = key;
+      mLastModified = lastModified;
+      mETag = eTag;
+      mSize = size;
+      mStorageClass = storageClass;
+    }
+
+    /**
+     * @return the object key
+     */
+    @JacksonXmlProperty(localName = "Key")
+    public String getKey() {
+      return mKey;
+    }
+
+    /**
+     * @return the last modified date and time in string format
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public String getLastModified() {
+      return mLastModified;
+    }
+
+    /**
+     * @return the ETag
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public String getETag() {
+      return mETag;
+    }
+
+    /**
+     * @return the size in bytes of the object
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public String getSize() {
+      return mSize;
+    }
+
+    /**
+     * @return the storage class
+     */
+    @JacksonXmlProperty(localName = "StorageClass")
+    public String getStorageClass() {
+      return mStorageClass;
+    }
+
+    /**
+     * @param key the object key to set
+     */
+    @JacksonXmlProperty(localName = "Key")
+    public void setKey(String key) {
+      mKey = key;
+    }
+
+    /**
+     * @param lastModified the last modified time to set
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public void setLastModified(String lastModified) {
+      mLastModified = lastModified;
+    }
+
+    /**
+     * @param eTag the ETag to set
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public void setETag(String eTag) {
+      mETag = eTag;
+    }
+
+    /**
+     * @param size the object size in bytes to set
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public void setSize(String size) {
+      mSize = size;
+    }
+
+    /**
+     * @param storageClass the storage class to set
+     */
+    @JacksonXmlProperty(localName = "StorageClass")
+    public void setStorageClass(String storageClass) {
+      mStorageClass = storageClass;
+    }
+  }
+
+  private class URIStatusComparator implements Comparator<URIStatus> {
+    @Override
+    public int compare(URIStatus o1, URIStatus o2) {
+      return o1.getPath().compareTo(o2.getPath());
+    }
+
+    /**
+     * Constructs a new {@link URIStatusComparator}.
+     */
+    public URIStatusComparator() {}
+  }
+}
+

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -1,0 +1,28 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Constants for S3 northbound API.
+ */
+@ThreadSafe
+public final class S3Constants {
+  public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
+  public static final String S3_EMPTY_ETAG = "";
+  public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  public static final int S3_DEFAULT_MAX_KEYS = 1000;
+  public static final String S3_CONTENT_LENGTH_HEADER = "Content-Length";
+
+  private S3Constants() {} // prevent instantiation
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -18,11 +18,11 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class S3Constants {
-  public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
-  public static final String S3_EMPTY_ETAG = "";
+  public static final String S3_CONTENT_LENGTH_HEADER = "Content-Length";
   public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public static final int S3_DEFAULT_MAX_KEYS = 1000;
-  public static final String S3_CONTENT_LENGTH_HEADER = "Content-Length";
+  public static final String S3_EMPTY_ETAG = "";
+  public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
 
   private S3Constants() {} // prevent instantiation
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
@@ -27,6 +27,7 @@ public class S3Error {
 
   /**
    * Creates an {@link S3Error}.
+   *
    * This is needed for {@link S3Error} to be encoded into XML, see <a>https://stackoverflow.com/
    * questions/26014184/jersey-returns-500-when-trying-to-return-an-xml-response</a> for details.
    */

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Error.java
@@ -1,0 +1,117 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Error response defined in http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html.
+ * It will be encoded into an XML string to be returned as an error response for the REST call.
+ */
+@JacksonXmlRootElement(localName = "Error")
+public class S3Error {
+  private String mCode;
+  private String mMessage;
+  private String mRequestId;
+  private String mResource;
+
+  /**
+   * Creates an {@link S3Error}.
+   * This is needed for {@link S3Error} to be encoded into XML, see <a>https://stackoverflow.com/
+   * questions/26014184/jersey-returns-500-when-trying-to-return-an-xml-response</a> for details.
+   */
+  public S3Error() {
+    mCode = "";
+    mMessage = "";
+    mRequestId = "";
+    mResource = "";
+  }
+
+  /**
+   * Creates a new {@link Error}.
+   *
+   * @param resource the resource (bucket or object key) where the error happens
+   * @param code the error code
+   */
+  public S3Error(String resource, S3ErrorCode code) {
+    mCode = code.getCode();
+    mMessage = code.getDescription();
+    mRequestId = "";
+    mResource = resource;
+  }
+
+  /**
+   * @return the error code
+   */
+  @JacksonXmlProperty(localName = "Code")
+  public String getCode() {
+    return mCode;
+  }
+
+  /**
+   * @return the error message
+   */
+  @JacksonXmlProperty(localName = "Message")
+  public String getMessage() {
+    return mMessage;
+  }
+
+  /**
+   * @return the request ID
+   */
+  @JacksonXmlProperty(localName = "RequestId")
+  public String getRequestId() {
+    return mRequestId;
+  }
+
+  /**
+   * @return the resource name
+   */
+  @JacksonXmlProperty(localName = "Resource")
+  public String getResource() {
+    return mResource;
+  }
+
+  /**
+   * @param code the error code to set
+   */
+  @JacksonXmlProperty(localName = "Code")
+  public void setCode(String code) {
+    mCode = code;
+  }
+
+  /**
+   * @param message the error message to set
+   */
+  @JacksonXmlProperty(localName = "Message")
+  public void setMessage(String message) {
+    mMessage = message;
+  }
+
+  /**
+   * @param requestId the request ID to set
+   */
+  @JacksonXmlProperty(localName = "RequestId")
+  public void setRequestId(String requestId) {
+    mRequestId = requestId;
+  }
+
+  /**
+   * @param resource the resource name to set
+   */
+  @JacksonXmlProperty(localName = "Resource")
+  public void setResource(String resource) {
+    mResource = resource;
+  }
+}
+

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -1,0 +1,119 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Error codes defined in http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html with
+ * API version 2006-03-01. Some error codes are customized.
+ */
+public class S3ErrorCode {
+  /**
+   * Error code names used in {@link S3ErrorCode}.
+   */
+  public static final class Name {
+    public static final String BAD_DIGEST = "BadDigest";
+    public static final String BUCKET_ALREADY_EXISTS = "BucketAlreadyExists";
+    public static final String BUCKET_NOT_EMPTY = "BucketNotEmpty";
+    public static final String INTERNAL_ERROR = "InternalError";
+    public static final String INVALID_BUCKET_NAME = "InvalidBucketName";
+    public static final String NO_SUCH_BUCKET = "NoSuchBucket";
+    public static final String NO_SUCH_KEY = "NoSuchKey";
+    public static final String PRECONDITION_FAILED = "PreconditionFailed";
+
+    private Name() {
+    } // prevents instantiation
+  }
+
+  //
+  // Official error codes.
+  //
+  public static final S3ErrorCode BAD_DIGEST = new S3ErrorCode(
+      Name.BAD_DIGEST,
+      "The Content-MD5 you specified did not match what we received.",
+      Response.Status.BAD_REQUEST);
+  public static final S3ErrorCode BUCKET_ALREADY_EXISTS = new S3ErrorCode(
+      Name.BUCKET_ALREADY_EXISTS,
+      "The requested bucket name already exists",
+      Response.Status.CONFLICT);
+  public static final S3ErrorCode BUCKET_NOT_EMPTY = new S3ErrorCode(
+      Name.BUCKET_NOT_EMPTY,
+      "The bucket you tried to delete is not empty",
+      Response.Status.CONFLICT);
+  public static final S3ErrorCode INVALID_BUCKET_NAME = new S3ErrorCode(
+      Name.INVALID_BUCKET_NAME,
+      "The specified bucket name is invalid",
+      Response.Status.BAD_REQUEST);
+  public static final S3ErrorCode INTERNAL_ERROR = new S3ErrorCode(
+      Name.INTERNAL_ERROR,
+      "We encountered an internal error. Please try again.",
+      Response.Status.INTERNAL_SERVER_ERROR);
+  public static final S3ErrorCode NO_SUCH_BUCKET = new S3ErrorCode(
+      Name.NO_SUCH_BUCKET,
+      "The specified bucket or prefix does not exist",
+      Response.Status.NOT_FOUND);
+  public static final S3ErrorCode NO_SUCH_KEY = new S3ErrorCode(
+      Name.NO_SUCH_KEY,
+      "The specified key does not exist",
+      Response.Status.NOT_FOUND);
+  public static final S3ErrorCode PRECONDITION_FAILED = new S3ErrorCode(
+      Name.PRECONDITION_FAILED,
+      "At least one of the preconditions did not hold",
+      Response.Status.PRECONDITION_FAILED);
+
+  //
+  // Customized error codes.
+  //
+  public static final S3ErrorCode INVALID_NESTED_BUCKET_NAME = new S3ErrorCode(
+      Name.BUCKET_ALREADY_EXISTS,
+      "The specified bucket is not a directory directly under a mount point",
+      Response.Status.BAD_REQUEST);
+
+  private final String mCode;
+  private final String mDescription;
+  private final Response.Status mStatus;
+
+  /**
+   * Constructs a new {@link S3ErrorCode}.
+   *
+   * @param code the error code defined in {@link Name}
+   * @param description the error description
+   * @param status the HTTP status code for the error
+   */
+  public S3ErrorCode(String code, String description, Response.Status status) {
+    mCode = code;
+    mDescription = description;
+    mStatus = status;
+  }
+
+  /**
+   * @return the error code
+   */
+  public String getCode() {
+    return mCode;
+  }
+
+  /**
+   * @return the description
+   */
+  public String getDescription() {
+    return mDescription;
+  }
+
+  /**
+   * @return the HTTP status
+   */
+  public Response.Status getStatus() {
+    return mStatus;
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Exception.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Exception.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+/**
+ * An exception thrown during processing S3 REST requests.
+ */
+public class S3Exception extends Exception {
+  private final String mResource;
+  private final S3ErrorCode mErrorCode;
+
+  /**
+   * Constructs a new {@link S3Exception}.
+   *
+   * @param resource the resource name (bucket or object key)
+   * @param errorCode the error code
+   */
+  public S3Exception(String resource, S3ErrorCode errorCode) {
+    mResource = resource;
+    mErrorCode = errorCode;
+  }
+
+  /**
+   * Derives a new {@link S3Exception} from an existing exception.
+   *
+   * @param exception the existing exception
+   * @param resource the resource name (bucket or object key)
+   * @param errorCode the error code
+   */
+  public S3Exception(Exception exception, String resource, S3ErrorCode errorCode) {
+    mResource = resource;
+    mErrorCode = new S3ErrorCode(errorCode.getCode(), exception.getMessage(),
+        errorCode.getStatus());
+  }
+
+  /**
+   * @return the error code
+   */
+  public S3ErrorCode getErrorCode() {
+    return mErrorCode;
+  }
+
+  /**
+   * @return the resource name
+   */
+  public String getResource() {
+    return mResource;
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -1,0 +1,471 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.Constants;
+import alluxio.PropertyKey;
+import alluxio.client.WriteType;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.options.CreateDirectoryOptions;
+import alluxio.client.file.options.CreateFileOptions;
+import alluxio.client.file.options.DeleteOptions;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.DirectoryNotEmptyException;
+import alluxio.exception.FileAlreadyExistsException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.InvalidPathException;
+import alluxio.web.ProxyWebServer;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
+import com.qmino.miredot.annotations.ReturnType;
+import org.apache.commons.codec.binary.Hex;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Queue;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.servlet.ServletContext;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * This class is a REST handler for Amazon S3 API.
+ */
+@NotThreadSafe
+@Path(S3RestServiceHandler.SERVICE_PREFIX)
+@Produces(MediaType.APPLICATION_XML)
+@Consumes(MediaType.APPLICATION_XML)
+public final class S3RestServiceHandler {
+  public static final String SERVICE_PREFIX = "s3";
+
+  /**
+   * Bucket must be a directory directly under a mount point. If it is under a non-root mount point,
+   * the bucket separator must be used as the separator in the bucket name, for example,
+   * mount:point:bucket represents Alluxio directory /mount/point/bucket.
+   */
+  public static final String BUCKET_SEPARATOR = ":";
+
+  /* Bucket is the first component in the URL path. */
+  public static final String BUCKET_PARAM = "{bucket}/";
+  /* Object is after bucket in the URL path */
+  public static final String OBJECT_PARAM = "{bucket}/{object:.+}";
+
+  private final FileSystem mFileSystem;
+
+  /**
+   * Constructs a new {@link S3RestServiceHandler}.
+   *
+   * @param context context for the servlet
+   */
+  public S3RestServiceHandler(@Context ServletContext context) {
+    mFileSystem =
+        (FileSystem) context.getAttribute(ProxyWebServer.FILE_SYSTEM_SERVLET_RESOURCE_KEY);
+  }
+
+  /**
+   * @summary creates a bucket
+   * @param bucket the bucket name
+   * @return the response object
+   */
+  @PUT
+  @Path(BUCKET_PARAM)
+  @ReturnType("java.lang.Void")
+  public Response createBucket(@PathParam("bucket") final String bucket) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
+      @Override
+      public Response.Status call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+
+        // Create the bucket.
+        CreateDirectoryOptions options = CreateDirectoryOptions.defaults()
+            .setWriteType(getS3WriteType());
+        try {
+          mFileSystem.createDirectory(new AlluxioURI(bucketPath), options);
+        } catch (Exception e) {
+          throw toBucketS3Exception(e, bucketPath);
+        }
+        return Response.Status.OK;
+      }
+    });
+  }
+
+  /**
+   * @summary deletes a bucket
+   * @param bucket the bucket name
+   * @return the response object
+   */
+  @DELETE
+  @Path(BUCKET_PARAM)
+  @ReturnType("java.lang.Void")
+  public Response deleteBucket(@PathParam("bucket") final String bucket) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
+      @Override
+      public Response.Status call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+
+        checkBucketIsAlluxioDirectory(bucketPath);
+
+        // Delete the bucket.
+        DeleteOptions options = DeleteOptions.defaults();
+        options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
+            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
+        try {
+          mFileSystem.delete(new AlluxioURI(bucketPath), options);
+        } catch (Exception e) {
+          throw toBucketS3Exception(e, bucketPath);
+        }
+        return Response.Status.NO_CONTENT;
+      }
+    });
+  }
+
+  /**
+   * @summary gets a bucket and lists all the objects in it
+   * @param bucket the bucket name
+   * @param continuationToken the optional continuation token param
+   * @param maxKeys the optional max keys param
+   * @param prefix the optional prefix param
+   * @return the response object
+   */
+  @GET
+  @Path(BUCKET_PARAM)
+  @ReturnType("ListBucketResult")
+  // TODO(chaomin): consider supporting more request params like prefix and delimiter.
+  public Response getBucket(@PathParam("bucket") final String bucket,
+      @QueryParam("continuation-token") final String continuationToken,
+      @QueryParam("max-keys") final String maxKeys,
+      @QueryParam("prefix") final String prefix) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<ListBucketResult>() {
+      @Override
+      public ListBucketResult call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+
+        checkBucketIsAlluxioDirectory(bucketPath);
+
+        List<URIStatus> objects;
+        ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
+            .setContinuationToken(continuationToken)
+            .setMaxKeys(maxKeys)
+            .setPrefix(prefix);
+        try {
+          objects = listObjects(new AlluxioURI(bucketPath), listBucketOptions);
+          ListBucketResult response = new ListBucketResult(bucketPath, objects, listBucketOptions);
+          return response;
+        } catch (Exception e) {
+          throw toBucketS3Exception(e, bucketPath);
+        }
+      }
+    });
+  }
+
+  /**
+   * @summary creates an object without using multipart upload
+   * @param contentMD5 the optional Base64 encoded 128-bit MD5 digest of the object
+   * @param bucket the bucket name
+   * @param object the object name
+   * @param is the request body
+   * @return the response object
+   */
+  @PUT
+  @Path(OBJECT_PARAM)
+  @ReturnType("java.lang.Void")
+  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  public Response createObject(@HeaderParam("Content-MD5") final String contentMD5,
+      @PathParam("bucket") final String bucket,
+      @PathParam("object") final String object,
+      final InputStream is) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
+      @Override
+      public Response call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+        checkBucketIsAlluxioDirectory(bucketPath);
+        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+        AlluxioURI objectURI = new AlluxioURI(objectPath);
+
+        try {
+          CreateFileOptions options = CreateFileOptions.defaults().setRecursive(true)
+              .setWriteType(getS3WriteType());
+          FileOutStream os = mFileSystem.createFile(objectURI, options);
+          MessageDigest md5 = MessageDigest.getInstance("MD5");
+          DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5);
+
+          try {
+            ByteStreams.copy(is, digestOutputStream);
+          } finally {
+            try {
+              digestOutputStream.flush();
+            } finally {
+              digestOutputStream.close();
+            }
+          }
+
+          byte[] digest = md5.digest();
+          String base64Digest = BaseEncoding.base64().encode(digest);
+          if (contentMD5 != null && !contentMD5.equals(base64Digest)) {
+            // The object may be corrupted, delete the written object and return an error.
+            try {
+              mFileSystem.delete(objectURI);
+            } catch (Exception e2) {
+              // intend to continue and return BAD_DIGEST S3Exception.
+            }
+            throw new S3Exception(objectURI.getPath(), S3ErrorCode.BAD_DIGEST);
+          }
+
+          String entityTag = Hex.encodeHexString(digest);
+          return Response.ok().tag(entityTag).build();
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+      }
+    });
+  }
+
+  /**
+   * @summary retrieves an object's metadata
+   * @param bucket the bucket name
+   * @param object the object name
+   * @return the response object
+   */
+  @HEAD
+  @Path(OBJECT_PARAM)
+  @ReturnType("java.lang.Void")
+  public Response getObjectMetadata(@PathParam("bucket") final String bucket,
+      @PathParam("object") final String object) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
+      @Override
+      public Response call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+        checkBucketIsAlluxioDirectory(bucketPath);
+        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+        AlluxioURI objectURI = new AlluxioURI(objectPath);
+
+        try {
+          URIStatus status = mFileSystem.getStatus(objectURI);
+          // TODO(cc): Consider how to respond with the object's ETag.
+          return Response.ok()
+              .lastModified(new Date(status.getLastModificationTimeMs()))
+              .header(S3Constants.S3_CONTENT_LENGTH_HEADER, status.getLength())
+              .build();
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+      }
+    });
+  }
+
+  /**
+   * @summary downloads an object
+   * @param bucket the bucket name
+   * @param object the object name
+   * @return the response object
+   */
+  @GET
+  @Path(OBJECT_PARAM)
+  @ReturnType("java.io.InputStream")
+  @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_OCTET_STREAM})
+  public Response getObject(@PathParam("bucket") final String bucket,
+      @PathParam("object") final String object) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
+      @Override
+      public Response call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+        checkBucketIsAlluxioDirectory(bucketPath);
+        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+        AlluxioURI objectURI = new AlluxioURI(objectPath);
+
+        try {
+          URIStatus status = mFileSystem.getStatus(objectURI);
+          FileInStream is = mFileSystem.openFile(objectURI);
+          // TODO(cc): Consider how to respond with the object's ETag.
+          return Response.ok(is)
+              .lastModified(new Date(status.getLastModificationTimeMs()))
+              .header(S3Constants.S3_CONTENT_LENGTH_HEADER, status.getLength())
+              .build();
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+      }
+    });
+  }
+
+  /**
+   * @summary deletes a object
+   * @param bucket the bucket name
+   * @param object the object name
+   * @return the response object
+   */
+  @DELETE
+  @Path(OBJECT_PARAM)
+  @ReturnType("java.lang.Void")
+  public Response deleteObject(@PathParam("bucket") final String bucket,
+      @PathParam("object") final String object) {
+    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
+      @Override
+      public Response.Status call() throws S3Exception {
+        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+
+        String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+        // Delete the object.
+        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+        DeleteOptions options = DeleteOptions.defaults();
+        options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
+            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
+        try {
+          mFileSystem.delete(new AlluxioURI(objectPath), options);
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+        // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
+        return Response.Status.NO_CONTENT;
+      }
+    });
+  }
+
+  private S3Exception toBucketS3Exception(Exception exception, String resource) {
+    try {
+      throw exception;
+    } catch (S3Exception e) {
+      return e;
+    } catch (DirectoryNotEmptyException e) {
+      return new S3Exception(resource, S3ErrorCode.BUCKET_NOT_EMPTY);
+    } catch (FileAlreadyExistsException e) {
+      return new S3Exception(resource, S3ErrorCode.BUCKET_ALREADY_EXISTS);
+    } catch (FileDoesNotExistException e) {
+      return new S3Exception(resource, S3ErrorCode.NO_SUCH_BUCKET);
+    } catch (InvalidPathException e) {
+      return new S3Exception(resource, S3ErrorCode.INVALID_BUCKET_NAME);
+    } catch (Exception e) {
+      return new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  private S3Exception toObjectS3Exception(Exception exception, String resource) {
+    try {
+      throw exception;
+    } catch (S3Exception e) {
+      return e;
+    } catch (DirectoryNotEmptyException e) {
+      return new S3Exception(resource, S3ErrorCode.PRECONDITION_FAILED);
+    } catch (FileDoesNotExistException e) {
+      return new S3Exception(resource, S3ErrorCode.NO_SUCH_KEY);
+    } catch (Exception e) {
+      return new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  private String parseBucketPath(String bucketPath) throws S3Exception {
+    if (!bucketPath.contains(BUCKET_SEPARATOR)) {
+      return bucketPath;
+    }
+    String normalizedPath = bucketPath.replace(BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
+    checkNestedBucketIsUnderMountPoint(normalizedPath);
+    return normalizedPath;
+  }
+
+  private void checkNestedBucketIsUnderMountPoint(String bucketPath) throws S3Exception {
+    // Assure that the bucket is directly under a mount point.
+    AlluxioURI parent = new AlluxioURI(bucketPath).getParent();
+    try {
+      if (!mFileSystem.getMountTable().containsKey(parent.getPath())) {
+        throw new S3Exception(bucketPath, S3ErrorCode.INVALID_NESTED_BUCKET_NAME);
+      }
+    } catch (Exception e) {
+      throw toBucketS3Exception(e, bucketPath);
+    }
+  }
+
+  private void checkBucketIsAlluxioDirectory(String bucketPath) throws S3Exception {
+    try {
+      URIStatus status = mFileSystem.getStatus(new AlluxioURI(bucketPath));
+      if (!status.isFolder()) {
+        throw new InvalidPathException("Bucket name is not a valid Alluxio directory.");
+      }
+    } catch (Exception e) {
+      throw toBucketS3Exception(e, bucketPath);
+    }
+  }
+
+  private List<URIStatus> listObjects(AlluxioURI uri, ListBucketOptions listBucketOptions)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    List<URIStatus> objects = new ArrayList<>();
+    Queue<URIStatus> traverseQueue = new ArrayDeque<>();
+
+    List<URIStatus> children;
+    String prefix = listBucketOptions.getPrefix();
+    if (prefix != null && prefix.contains(AlluxioURI.SEPARATOR)) {
+      AlluxioURI prefixDirUri = new AlluxioURI(uri.getPath() + AlluxioURI.SEPARATOR
+          + prefix.substring(0, prefix.lastIndexOf(AlluxioURI.SEPARATOR)));
+      children = mFileSystem.listStatus(prefixDirUri);
+    } else {
+      children = mFileSystem.listStatus(uri);
+    }
+    traverseQueue.addAll(children);
+    while (!traverseQueue.isEmpty()) {
+      URIStatus cur = traverseQueue.remove();
+      if (!cur.isFolder()) {
+        // Alluxio file is an object.
+        objects.add(cur);
+      } else {
+        List<URIStatus> curChildren = mFileSystem.listStatus(new AlluxioURI(cur.getPath()));
+        if (curChildren.isEmpty()) {
+          // An empty Alluxio directory is considered as a valid object.
+          objects.add(cur);
+        } else {
+          traverseQueue.addAll(curChildren);
+        }
+      }
+    }
+    return objects;
+  }
+
+  private WriteType getS3WriteType() {
+    return Configuration.getEnum(PropertyKey.PROXY_S3_WRITE_TYPE, WriteType.class);
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -144,7 +144,7 @@ public final class S3RestServiceHandler {
         // Delete the bucket.
         DeleteOptions options = DeleteOptions.defaults();
         options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
-            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
+            .equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY));
         try {
           mFileSystem.delete(new AlluxioURI(bucketPath), options);
         } catch (Exception e) {
@@ -232,11 +232,7 @@ public final class S3RestServiceHandler {
           try {
             ByteStreams.copy(is, digestOutputStream);
           } finally {
-            try {
-              digestOutputStream.flush();
-            } finally {
-              digestOutputStream.close();
-            }
+            digestOutputStream.close();
           }
 
           byte[] digest = md5.digest();
@@ -356,7 +352,7 @@ public final class S3RestServiceHandler {
         String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
         DeleteOptions options = DeleteOptions.defaults();
         options.setAlluxioOnly(Configuration.get(PropertyKey.PROXY_S3_DELETE_TYPE)
-            .equals(Constants.DELETE_IN_ALLUXIO_ONLY));
+            .equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY));
         try {
           mFileSystem.delete(new AlluxioURI(objectPath), options);
         } catch (Exception e) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -1,0 +1,134 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.security.LoginUser;
+import alluxio.security.authentication.AuthenticatedClientUser;
+import alluxio.util.SecurityUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Utilities for handling S3 REST calls.
+ */
+public final class S3RestUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(S3RestUtils.class);
+
+  /**
+   * Calls the given {@link S3RestUtils.RestCallable} and handles any exceptions thrown.
+   *
+   * @param <T> the return type of the callable
+   * @param resource the resource (bucket or object) to be operated on
+   * @param callable the callable to call
+   * @return the response object
+   */
+  public static <T> Response call(String resource, S3RestUtils.RestCallable<T> callable) {
+    try {
+      // TODO(cc): reconsider how to enable authentication
+      if (SecurityUtils.isSecurityEnabled() && AuthenticatedClientUser.get() == null) {
+        AuthenticatedClientUser.set(LoginUser.get().getName());
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.getMessage());
+      return createErrorResponse(new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR));
+    }
+
+    try {
+      return createResponse(callable.call());
+    } catch (S3Exception e) {
+      LOG.warn("Unexpected error invoking REST endpoint: {}", e.getErrorCode().getDescription());
+      return createErrorResponse(e);
+    }
+  }
+
+  /**
+   * An interface representing a callable.
+   *
+   * @param <T> the return type of the callable
+   */
+  public interface RestCallable<T> {
+    /**
+     * The REST endpoint implementation.
+     *
+     * @return the return value from the callable
+     */
+    T call() throws S3Exception;
+  }
+
+  /**
+   * Creates a response using the given object.
+   *
+   * @param object the object to respond with
+   * @return the response
+   */
+  private static Response createResponse(Object object) {
+    if (object == null) {
+      return Response.ok().build();
+    }
+
+    if (object instanceof Response) {
+      return (Response) object;
+    }
+
+    if (object instanceof Response.Status) {
+      Response.Status s = (Response.Status) object;
+      switch (s) {
+        case OK:
+          return Response.ok().build();
+        case ACCEPTED:
+          return Response.accepted().build();
+        case NO_CONTENT:
+          return Response.noContent().build();
+        default:
+          return createErrorResponse(
+              new S3Exception("Response status is invalid", S3ErrorCode.INTERNAL_ERROR));
+      }
+    }
+
+    // Need to explicitly encode the string as XML because Jackson will not do it automatically.
+    XmlMapper mapper = new XmlMapper();
+    try {
+      return Response.ok(mapper.writeValueAsString(object)).build();
+    } catch (JsonProcessingException e) {
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Failed to encode XML: " + e.getMessage()).build();
+    }
+  }
+
+  /**
+   * Creates an error response using the given exception.
+   *
+   * @param e the exception to be converted into {@link Error} and encoded into XML
+   * @return the response
+   */
+  private static Response createErrorResponse(S3Exception e) {
+    S3Error errorResponse = new S3Error(e.getResource(), e.getErrorCode());
+    // Need to explicitly encode the string as XML because Jackson will not do it automatically.
+    XmlMapper mapper = new XmlMapper();
+    try {
+      return Response.status(e.getErrorCode().getStatus())
+          .entity(mapper.writeValueAsString(errorResponse)).build();
+    } catch (JsonProcessingException e2) {
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Failed to encode XML: " + e2.getMessage()).build();
+    }
+  }
+
+  private S3RestUtils() {} // prevent instantiation
+}

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -50,7 +50,7 @@ public final class ProxyWebServer extends WebServer {
     super(serviceName, address);
 
     // REST configuration
-    ResourceConfig config = new ResourceConfig().packages("alluxio.proxy");
+    ResourceConfig config = new ResourceConfig().packages("alluxio.proxy", "alluxio.proxy.s3");
     ServletContainer servlet = new ServletContainer(config) {
       private static final long serialVersionUID = 7756010860672831556L;
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
         <version>2.6.6</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>2.6.6</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
         <version>0.3</version>

--- a/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/s3/S3ClientRestApiTest.java
@@ -1,0 +1,722 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.master.file.FileSystemMaster;
+import alluxio.master.file.options.CreateDirectoryOptions;
+import alluxio.master.file.options.CreateFileOptions;
+import alluxio.master.file.options.GetStatusOptions;
+import alluxio.master.file.options.ListStatusOptions;
+import alluxio.master.file.options.MountOptions;
+import alluxio.rest.RestApiTest;
+import alluxio.rest.TestCase;
+import alluxio.rest.TestCaseOptions;
+import alluxio.util.CommonUtils;
+import alluxio.wire.FileInfo;
+
+import com.google.common.io.BaseEncoding;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.io.ByteArrayInputStream;
+import java.net.HttpURLConnection;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
+
+/**
+ * Test cases for {@link S3RestServiceHandler}.
+ */
+public final class S3ClientRestApiTest extends RestApiTest {
+  private static final alluxio.master.file.options.GetStatusOptions GET_STATUS_OPTIONS =
+      alluxio.master.file.options.GetStatusOptions.defaults();
+  private static final Map<String, String> NO_PARAMS = new HashMap<>();
+
+  private static final String S3_SERVICE_PREFIX = "s3";
+  private static final String BUCKET_SEPARATOR = ":";
+
+  private FileSystem mFileSystem;
+  private FileSystemMaster mFileSystemMaster;
+
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Before
+  public void before() throws Exception {
+    mHostname = mResource.get().getHostname();
+    mPort = mResource.get().getProxyProcess().getWebLocalPort();
+    mFileSystemMaster = mResource.get().getLocalAlluxioMaster().getMasterProcess()
+        .getMaster(FileSystemMaster.class);
+    mFileSystem = mResource.get().getClient();
+  }
+
+  @Test
+  public void putBucket() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+    // Verify the directory is created for the new bucket.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void putBucketUnderMountPoint() throws Exception {
+    final String mountPoint = "s3";
+    final String bucketName = "bucket";
+    final String s3Path = mountPoint + BUCKET_SEPARATOR + bucketName;
+
+    AlluxioURI mountPointPath = new AlluxioURI(AlluxioURI.SEPARATOR + mountPoint);
+    mFileSystemMaster.mount(mountPointPath, new AlluxioURI(mFolder.newFolder().getAbsolutePath()),
+        MountOptions.defaults());
+
+    // Create a new bucket under an existing mount point.
+    createBucketRestCall(s3Path);
+
+    // Verify the directory is created for the new bucket, under the mount point.
+    AlluxioURI uri = new AlluxioURI(
+        AlluxioURI.SEPARATOR + mountPoint + AlluxioURI.SEPARATOR + bucketName);
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void putBucketUnderNestedMountPoint() throws Exception {
+    final String mountPointParent = "mounts";
+    final String mountPointName = "s3";
+    final String bucketName = "bucket";
+    final String s3Path =
+        mountPointParent + BUCKET_SEPARATOR + mountPointName + BUCKET_SEPARATOR + bucketName;
+
+    mFileSystemMaster.createDirectory(new AlluxioURI(
+        AlluxioURI.SEPARATOR + mountPointParent), CreateDirectoryOptions.defaults());
+    AlluxioURI mountPointPath = new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent
+        + AlluxioURI.SEPARATOR + mountPointName);
+    mFileSystemMaster.mount(mountPointPath, new AlluxioURI(mFolder.newFolder().getAbsolutePath()),
+        MountOptions.defaults());
+
+    // Create a new bucket under an existing nested mount point.
+    createBucketRestCall(s3Path);
+
+    // Verify the directory is created for the new bucket, under the mount point.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + mountPointParent
+        + AlluxioURI.SEPARATOR + mountPointName + AlluxioURI.SEPARATOR + bucketName);
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void putBucketUnderNonExistingMountPoint() throws Exception {
+    final String mountPoint = "s3";
+    final String bucketName = "bucket";
+    final String s3Path = mountPoint + BUCKET_SEPARATOR + bucketName;
+
+    try {
+      // Create a new bucket under a non-existing mount point should fail.
+      createBucketRestCall(s3Path);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("create bucket under non-existing mount point should fail");
+  }
+
+  @Test
+  public void putBucketUnderNonMountPointDirectory() throws Exception {
+    final String dirName = "dir";
+    final String bucketName = "bucket";
+    final String s3Path = dirName + BUCKET_SEPARATOR + bucketName;
+
+    AlluxioURI dirPath = new AlluxioURI(AlluxioURI.SEPARATOR + dirName);
+    mFileSystemMaster.createDirectory(dirPath, CreateDirectoryOptions.defaults());
+
+    try {
+      // Create a new bucket under a non-mount-point directory should fail.
+      createBucketRestCall(s3Path);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("create bucket under non-mount-point directory should fail");
+  }
+
+  @Test
+  public void deleteBucket() throws Exception {
+    final String bucket = "bucket-to-delete";
+    createBucketRestCall(bucket);
+
+    // Verify the directory is created for the new bucket.
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    HttpURLConnection connection = deleteBucketRestCall(bucket);
+    Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), connection.getResponseCode());
+
+    try {
+      mFileSystemMaster.getFileInfo(uri, GET_STATUS_OPTIONS);
+    } catch (FileDoesNotExistException e) {
+      // expected
+      return;
+    }
+    Assert.fail("bucket should have been removed");
+  }
+
+  @Test
+  public void deleteNonExistingBucket() throws Exception {
+    final String bucketName = "non-existing-bucket";
+
+    try {
+      // Delete a non-existing bucket should fail.
+      deleteBucketRestCall(bucketName);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("delete a non-existing bucket should fail");
+  }
+
+  @Test
+  public void deleteNonEmptyBucket() throws Exception {
+    final String bucketName = "non-empty-bucket";
+
+    createBucketRestCall(bucketName);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI fileUri = new AlluxioURI(uri.getPath() + "/file");
+    mFileSystemMaster.createFile(fileUri, CreateFileOptions.defaults());
+
+    // Verify the directory is created for the new bucket, and file is created under it.
+    Assert.assertFalse(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    try {
+      // Delete a non-empty bucket should fail.
+      deleteBucketRestCall(bucketName);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("delete a non-empty bucket should fail");
+  }
+
+  private void putObjectTest(byte[] object) throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    createObjectRestCall(objectKey, object, null);
+
+    // Verify the object is created for the new bucket.
+    AlluxioURI bucketURI = new AlluxioURI(AlluxioURI.SEPARATOR + bucket);
+    AlluxioURI objectURI = new AlluxioURI(AlluxioURI.SEPARATOR + objectKey);
+    List<FileInfo> fileInfos = mFileSystemMaster.listStatus(bucketURI,
+        ListStatusOptions.defaults());
+    Assert.assertEquals(1, fileInfos.size());
+    Assert.assertEquals(objectURI.getPath(), fileInfos.get(0).getPath());
+
+    // Verify the object's content.
+    FileInStream is = mFileSystem.openFile(objectURI);
+    byte[] writtenObjectContent = IOUtils.toString(is).getBytes();
+    is.close();
+    Assert.assertArrayEquals(object, writtenObjectContent);
+  }
+
+  @Test
+  public void putSmallObject() throws Exception {
+    putObjectTest("Hello World!".getBytes());
+  }
+
+  @Test
+  public void putLargeObject() throws Exception {
+    putObjectTest(CommonUtils.randomAlphaNumString(Constants.MB).getBytes());
+  }
+
+  @Test
+  public void putObjectUnderNonExistentBucket() throws Exception {
+    final String bucket = "non-existent-bucket";
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String message = "hello world";
+    try {
+      createObjectRestCall(objectKey, message.getBytes(), null);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("create object under non-existent bucket should fail");
+  }
+
+  @Test
+  public void putObjectWithWrongMD5() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String objectContent = "hello world";
+    try {
+      String wrongMD5 = BaseEncoding.base64().encode(objectContent.getBytes());
+      createObjectRestCall(objectKey, objectContent.getBytes(), wrongMD5);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("create object with wrong Content-MD5 should fail");
+  }
+
+  @Test
+  public void putObjectWithNoMD5() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    String objectContent = "no md5 set";
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    TestCaseOptions options = TestCaseOptions.defaults();
+    options.setInputStream(new ByteArrayInputStream(objectContent.getBytes()));
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null, options).run();
+  }
+
+  @Test
+  public void getBucket() throws Exception {
+    final String bucket = "bucket-to-get";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with direct child objects and objects within sub directories:
+    // - /file1
+    // - /file2
+    // - /dir1/subdir1/file3
+    // - /dir2/
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+    AlluxioURI dir1 = new AlluxioURI(uri.getPath() + "/dir1");
+    mFileSystemMaster.createDirectory(dir1, CreateDirectoryOptions.defaults());
+    AlluxioURI dir2 = new AlluxioURI(uri.getPath() + "/dir2");
+    mFileSystemMaster.createDirectory(dir2, CreateDirectoryOptions.defaults());
+    AlluxioURI subdir1 = new AlluxioURI(uri.getPath() + "/dir1/subdir1");
+    mFileSystemMaster.createDirectory(subdir1, CreateDirectoryOptions.defaults());
+    AlluxioURI file3 = new AlluxioURI(subdir1.getPath() + "/file3");
+    mFileSystemMaster.createFile(file3, CreateFileOptions.defaults());
+
+    // Expected result.
+    List<URIStatus> objectsList = new ArrayList<>();
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file1, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file2, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file3, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(dir2, GetStatusOptions.defaults())));
+    ListBucketResult expected = new ListBucketResult(
+        AlluxioURI.SEPARATOR + bucket, objectsList, ListBucketOptions.defaults());
+
+    // Verify op with no param
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
+        HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void getBucketWithPrefix() throws Exception {
+    final String bucket = "bucket-to-get-with-prefix";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with direct child objects and objects within sub directories:
+    // - /file1
+    // - /file2
+    // - /dir1/subdir1/file3
+    // - /dir2/
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+    AlluxioURI dir1 = new AlluxioURI(uri.getPath() + "/dir1");
+    mFileSystemMaster.createDirectory(dir1, CreateDirectoryOptions.defaults());
+    AlluxioURI dir2 = new AlluxioURI(uri.getPath() + "/dir2");
+    mFileSystemMaster.createDirectory(dir2, CreateDirectoryOptions.defaults());
+    AlluxioURI subdir1 = new AlluxioURI(uri.getPath() + "/dir1/subdir1");
+    mFileSystemMaster.createDirectory(subdir1, CreateDirectoryOptions.defaults());
+    AlluxioURI file3 = new AlluxioURI(subdir1.getPath() + "/file3");
+    mFileSystemMaster.createFile(file3, CreateFileOptions.defaults());
+
+    // Verify op with prefix
+    final String prefix = "dir";
+    Map<String, String> prefixParam = new HashMap<>();
+    prefixParam.put("prefix", prefix);
+    List<URIStatus> filteredObjectsList = new ArrayList<>();
+    filteredObjectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file3, GetStatusOptions.defaults())));
+    filteredObjectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(dir2, GetStatusOptions.defaults())));
+    ListBucketResult expected = new ListBucketResult(AlluxioURI.SEPARATOR + bucket,
+        filteredObjectsList, ListBucketOptions.defaults().setPrefix(prefix));
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket,
+        prefixParam, HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void getBucketWithMaxKeys() throws Exception {
+    final String bucket = "bucket-to-get-with-max-keys";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with two objects:
+    // - /file1
+    // - /file2
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+
+    // Expected result, with max-keys = 1.
+    List<URIStatus> objectsList = new ArrayList<>();
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file1, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file2, GetStatusOptions.defaults())));
+    ListBucketResult expected = new ListBucketResult(
+        AlluxioURI.SEPARATOR + bucket, objectsList, ListBucketOptions.defaults().setMaxKeys("1"));
+
+    // Verify
+    HashMap<String, String> maxKeysParam = new HashMap<>();
+    maxKeysParam.put("max-keys", "1");
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, maxKeysParam,
+        HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void getBucketWithMaxKeysAndContinuationToken() throws Exception {
+    final String bucket = "bucket-to-get-with-max-keys-and-token";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with two objects:
+    // - /file1
+    // - /file2
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+
+    // Expected result, with max-keys = 1.
+    List<URIStatus> objectsList = new ArrayList<>();
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file1, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file2, GetStatusOptions.defaults())));
+    String maxKeys = "1";
+    String continuationToken = file1.getPath();
+    ListBucketResult expected = new ListBucketResult(
+        AlluxioURI.SEPARATOR + bucket, objectsList,
+        ListBucketOptions.defaults().setMaxKeys("1").setContinuationToken(continuationToken));
+
+    // Verify
+    HashMap<String, String> maxKeysParam = new HashMap<>();
+    maxKeysParam.put("max-keys", maxKeys);
+    maxKeysParam.put("continuation-token", continuationToken);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, maxKeysParam,
+        HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void getBucketWithNonExistingContinuationToken() throws Exception {
+    final String bucket = "bucket-to-get-with-non-existing-token";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    // Prepare a bucket with two objects:
+    // - /file1
+    // - /file2
+    AlluxioURI file1 = new AlluxioURI(uri.getPath() + "/file1");
+    mFileSystemMaster.createFile(file1, CreateFileOptions.defaults());
+    AlluxioURI file2 = new AlluxioURI(uri.getPath() + "/file2");
+    mFileSystemMaster.createFile(file2, CreateFileOptions.defaults());
+
+    // Expected result, with max-keys = 1.
+    List<URIStatus> objectsList = new ArrayList<>();
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file1, GetStatusOptions.defaults())));
+    objectsList.add(
+        new URIStatus(mFileSystemMaster.getFileInfo(file2, GetStatusOptions.defaults())));
+    String continuationToken = file1.getPath() + "random-tail";
+    ListBucketResult expected = new ListBucketResult(
+        AlluxioURI.SEPARATOR + bucket, objectsList,
+        ListBucketOptions.defaults().setContinuationToken(continuationToken));
+
+    // Verify
+    HashMap<String, String> maxKeysParam = new HashMap<>();
+    maxKeysParam.put("continuation-token", continuationToken);
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, maxKeysParam,
+        HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+  }
+
+  @Test
+  public void listEmptyBucket() throws Exception {
+    final String bucket = "empty-bucket-to-list";
+    createBucketRestCall(bucket);
+
+    AlluxioURI uri = new AlluxioURI(AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR);
+    // Verify the directory is created for the new bucket.
+    Assert.assertTrue(mFileSystemMaster.listStatus(uri, ListStatusOptions.defaults()).isEmpty());
+
+    List<URIStatus> listStatusResult = new ArrayList<>();
+    ListBucketResult expected = new ListBucketResult(
+        AlluxioURI.SEPARATOR + bucket, listStatusResult, ListBucketOptions.defaults());
+
+    new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucket, NO_PARAMS,
+        HttpMethod.GET, expected,
+        TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE))
+        .run();
+  }
+
+  @Test
+  public void getNonExistingBucket() throws Exception {
+    final String bucketName = "non-existing-bucket";
+
+    try {
+      // Delete a non-existing bucket should fail.
+      new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName,
+          NO_PARAMS, HttpMethod.GET, null,
+          TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("get a non-existing bucket should fail");
+  }
+
+  private void getObjectTest(byte[] expectedObject) throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    createObjectRestCall(objectKey, expectedObject, null);
+    Assert.assertArrayEquals(expectedObject, getObjectRestCall(objectKey).getBytes());
+  }
+
+  @Test
+  public void getSmallObject() throws Exception {
+    getObjectTest("Hello World!".getBytes());
+  }
+
+  @Test
+  public void getLargeObject() throws Exception {
+    getObjectTest(CommonUtils.randomAlphaNumString(Constants.MB).getBytes());
+  }
+
+  @Test
+  public void getNonExistentObject() throws Exception {
+    final String objectKey = "bucket/non-existent-object";
+    try {
+      getObjectRestCall(objectKey);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("get non-existent object should fail");
+  }
+
+  @Test
+  public void getObjectMetadata() throws Exception {
+    final String bucket = "bucket";
+    createBucketRestCall(bucket);
+
+    final String objectKey = bucket + AlluxioURI.SEPARATOR + "object.txt";
+    final byte[] objectContent = CommonUtils.randomAlphaNumString(10).getBytes();
+    createObjectRestCall(objectKey, objectContent, null);
+
+    HttpURLConnection connection = getObjectMetadataRestCall(objectKey);
+    URIStatus status = mFileSystem.getStatus(
+        new AlluxioURI(AlluxioURI.SEPARATOR + objectKey));
+    // remove the milliseconds from the last modification time because the accuracy of HTTP dates
+    // is up to seconds.
+    long lastModified = status.getLastModificationTimeMs() / 1000 * 1000;
+    Assert.assertEquals(lastModified, connection.getLastModified());
+    Assert.assertEquals(String.valueOf(status.getLength()),
+        connection.getHeaderField(S3Constants.S3_CONTENT_LENGTH_HEADER));
+  }
+
+  @Test
+  public void getNonExistentObjectMetadata() throws Exception {
+    final String objectKey = "bucket/non-existent-object";
+    try {
+      getObjectMetadataRestCall(objectKey);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("get metadata of non-existent object should fail");
+  }
+
+  @Test
+  public void deleteObject() throws Exception {
+    final String bucketName = "bucket-with-object-to-delete";
+    createBucketRestCall(bucketName);
+
+    final String objectName = "file";
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI fileUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createFile(fileUri, CreateFileOptions.defaults());
+
+    // Verify the directory is created for the new bucket, and file is created under it.
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+
+    deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
+
+    // Verify the object is deleted.
+    Assert.assertTrue(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void deleteObjectAsAlluxioEmptyDir() throws Exception {
+    final String bucketName = "bucket-with-empty-dir-to-delete";
+    createBucketRestCall(bucketName);
+
+    String objectName = "empty-dir/";
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI dirUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
+
+    // Verify the directory is created for the new bucket, and empty-dir is created under it.
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+
+    deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
+
+    // Verify the empty-dir as a valid object is deleted.
+    Assert.assertTrue(
+        mFileSystemMaster.listStatus(bucketUri, ListStatusOptions.defaults()).isEmpty());
+  }
+
+  @Test
+  public void deleteObjectAsAlluxioNonEmptyDir() throws Exception {
+    final String bucketName = "bucket-with-non-empty-dir-to-delete";
+    createBucketRestCall(bucketName);
+
+    String objectName = "non-empty-dir/";
+    AlluxioURI bucketUri = new AlluxioURI(AlluxioURI.SEPARATOR + bucketName);
+    AlluxioURI dirUri = new AlluxioURI(
+        bucketUri.getPath() + AlluxioURI.SEPARATOR + objectName);
+    mFileSystemMaster.createDirectory(dirUri, CreateDirectoryOptions.defaults());
+
+    mFileSystemMaster.createFile(
+        new AlluxioURI(dirUri.getPath() + "/file"), CreateFileOptions.defaults());
+
+    Assert.assertFalse(
+        mFileSystemMaster.listStatus(dirUri, ListStatusOptions.defaults()).isEmpty());
+
+    try {
+      deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("delete non-empty directory as an object should fail");
+  }
+
+  @Test
+  public void deleteNonExistingObject() throws Exception {
+    final String bucketName = "bucket-with-nothing";
+    createBucketRestCall(bucketName);
+
+    String objectName = "non-existing-object";
+    try {
+      deleteObjectRestCall(bucketName + AlluxioURI.SEPARATOR + objectName);
+    } catch (AssertionError e) {
+      // expected
+      return;
+    }
+    Assert.fail("delete non-existing object should fail");
+  }
+
+  private void createBucketRestCall(String bucketName) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName;
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null,
+        TestCaseOptions.defaults()).run();
+  }
+
+  private HttpURLConnection deleteBucketRestCall(String bucketName) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + bucketName;
+    return new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.DELETE, null,
+        TestCaseOptions.defaults()).execute();
+  }
+
+  private void createObjectRestCall(String objectKey, byte[] objectContent, String md5)
+      throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    TestCaseOptions options = TestCaseOptions.defaults();
+    if (md5 == null) {
+      MessageDigest md5Hash = MessageDigest.getInstance("MD5");
+      byte[] md5Digest = md5Hash.digest(objectContent);
+      md5 = BaseEncoding.base64().encode(md5Digest);
+    }
+    options.setMD5(md5);
+    options.setInputStream(new ByteArrayInputStream(objectContent));
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.PUT, null, options)
+        .run();
+  }
+
+  private HttpURLConnection getObjectMetadataRestCall(String objectKey) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    return new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.HEAD, null,
+        TestCaseOptions.defaults()).execute();
+  }
+
+  private String getObjectRestCall(String objectKey) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    return new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.GET, null,
+        TestCaseOptions.defaults()).call();
+  }
+
+  private void deleteObjectRestCall(String objectKey) throws Exception {
+    String uri = S3_SERVICE_PREFIX + AlluxioURI.SEPARATOR + objectKey;
+    new TestCase(mHostname, mPort, uri, NO_PARAMS, HttpMethod.DELETE, null,
+        TestCaseOptions.defaults()).run();
+  }
+}

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -12,9 +12,11 @@
 package alluxio.rest;
 
 import alluxio.Constants;
+import alluxio.exception.status.InvalidArgumentException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -127,11 +129,14 @@ public final class TestCase {
   }
 
   /**
-   * Runs the test case and returns the output.
+   * Runs the test case and returns the {@link HttpURLConnection}.
    */
-  public String call() throws Exception {
+  public HttpURLConnection execute() throws Exception {
     HttpURLConnection connection = (HttpURLConnection) createURL().openConnection();
     connection.setRequestMethod(mMethod);
+    if (mOptions.getMD5() != null) {
+      connection.setRequestProperty("Content-MD5", mOptions.getMD5());
+    }
     if (mOptions.getInputStream() != null) {
       connection.setDoOutput(true);
       connection.setRequestProperty("Content-Type", "application/octet-stream");
@@ -139,7 +144,7 @@ public final class TestCase {
     }
     if (mOptions.getBody() != null) {
       connection.setDoOutput(true);
-      connection.setRequestProperty("Content-Type", "application/json");
+      connection.setRequestProperty("Content-Type", mOptions.getContentType());
       ObjectMapper mapper = new ObjectMapper();
       // make sure that serialization of empty objects does not fail
       mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -149,14 +154,22 @@ public final class TestCase {
     }
 
     connection.connect();
-    if (connection.getResponseCode() != Response.Status.OK.getStatusCode()) {
+    if (Response.Status.Family.familyOf(connection.getResponseCode())
+        != Response.Status.Family.SUCCESSFUL) {
       InputStream errorStream = connection.getErrorStream();
       if (errorStream != null) {
         Assert.fail("Request failed: " + IOUtils.toString(errorStream));
       }
       Assert.fail("Request failed with status code " + connection.getResponseCode());
     }
-    return getResponse(connection);
+    return connection;
+  }
+
+  /**
+   * Runs the test case and returns the output.
+   */
+  public String call() throws Exception {
+    return getResponse(execute());
   }
 
   /**
@@ -165,11 +178,22 @@ public final class TestCase {
   public void run() throws Exception {
     String expected = "";
     if (mExpectedResult != null) {
-      ObjectMapper mapper = new ObjectMapper();
-      if (mOptions.isPrettyPrint()) {
-        expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+      if (mOptions.getContentType().equals(TestCaseOptions.JSON_CONTENT_TYPE)) {
+        ObjectMapper mapper = new ObjectMapper();
+        if (mOptions.isPrettyPrint()) {
+          expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+        } else {
+          expected = mapper.writeValueAsString(mExpectedResult);
+        }
+      } else if (mOptions.getContentType().equals(TestCaseOptions.XML_CONTENT_TYPE)) {
+        XmlMapper mapper = new XmlMapper();
+        if (mOptions.isPrettyPrint()) {
+          expected = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mExpectedResult);
+        } else {
+          expected = mapper.writeValueAsString(mExpectedResult);
+        }
       } else {
-        expected = mapper.writeValueAsString(mExpectedResult);
+        throw new InvalidArgumentException("Invalid content type in TestCaseOptions!");
       }
     }
     String result = call();

--- a/tests/src/test/java/alluxio/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptions.java
@@ -23,9 +23,14 @@ import javax.annotation.concurrent.NotThreadSafe;
 // TODO(jiri): consolidate input stream and body fields
 @NotThreadSafe
 public final class TestCaseOptions {
+  public static final String JSON_CONTENT_TYPE = "application/json";
+  public static final String XML_CONTENT_TYPE = "application/xml";
+
   private Object mBody;
   private InputStream mInputStream;
   private boolean mPrettyPrint;
+  private String mContentType;
+  private String mMD5;
 
   /**
    * @return the default {@link TestCaseOptions}
@@ -38,6 +43,8 @@ public final class TestCaseOptions {
     mBody = null;
     mInputStream = null;
     mPrettyPrint = false;
+    mContentType = JSON_CONTENT_TYPE;
+    mMD5 = null;
   }
 
   /**
@@ -59,6 +66,20 @@ public final class TestCaseOptions {
    */
   public boolean isPrettyPrint() {
     return mPrettyPrint;
+  }
+
+  /**
+   * @return the content type
+   */
+  public String getContentType() {
+    return mContentType;
+  }
+
+  /**
+   * @return the Base64 encoded MD5 digest of the request body
+   */
+  public String getMD5() {
+    return mMD5;
   }
 
   /**
@@ -88,6 +109,24 @@ public final class TestCaseOptions {
     return this;
   }
 
+  /**
+   * @param contentType the content type to set
+   * @return the updated options object
+   */
+  public TestCaseOptions setContentType(String contentType) {
+    mContentType = contentType;
+    return this;
+  }
+
+  /**
+   * @param md5 the Base64 encoded MD5 digest of the request body
+   * @return the updated options object
+   */
+  public TestCaseOptions setMD5(String md5) {
+    mMD5 = md5;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -99,12 +138,14 @@ public final class TestCaseOptions {
     TestCaseOptions that = (TestCaseOptions) o;
     return Objects.equal(mBody, that.mBody)
         && Objects.equal(mInputStream, that.mInputStream)
-        && mPrettyPrint == that.mPrettyPrint;
+        && mPrettyPrint == that.mPrettyPrint
+        && Objects.equal(mContentType, that.mContentType)
+        && Objects.equal(mMD5, that.mMD5);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mBody, mInputStream, mPrettyPrint);
+    return Objects.hashCode(mBody, mInputStream, mPrettyPrint, mContentType, mMD5);
   }
 
   @Override
@@ -113,6 +154,8 @@ public final class TestCaseOptions {
         .add("body", mBody)
         .add("input stream", mInputStream)
         .add("pretty print", mPrettyPrint)
+        .add("content type", mContentType)
+        .add("MD5", mMD5)
         .toString();
   }
 }

--- a/tests/src/test/java/alluxio/rest/TestCaseOptionsTest.java
+++ b/tests/src/test/java/alluxio/rest/TestCaseOptionsTest.java
@@ -13,6 +13,7 @@ package alluxio.rest;
 
 import alluxio.CommonTestUtils;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,6 +35,7 @@ public class TestCaseOptionsTest {
     Assert.assertNull(options.getBody());
     Assert.assertNull(options.getInputStream());
     Assert.assertFalse(options.isPrettyPrint());
+    Assert.assertNull(options.getMD5());
   }
 
   /**
@@ -48,14 +50,17 @@ public class TestCaseOptionsTest {
     InputStream inputStream = new ByteArrayInputStream(bytes);
     boolean prettyPrint = random.nextBoolean();
     TestCaseOptions options = TestCaseOptions.defaults();
+    String md5 = RandomStringUtils.random(64);
 
     options.setBody(body);
     options.setInputStream(inputStream);
     options.setPrettyPrint(prettyPrint);
+    options.setMD5(md5);
 
     Assert.assertEquals(body, options.getBody());
     Assert.assertEquals(inputStream, options.getInputStream());
     Assert.assertEquals(prettyPrint, options.isPrettyPrint());
+    Assert.assertEquals(md5, options.getMD5());
   }
 
   @Test


### PR DESCRIPTION
This `s3` feature branch adds northbound S3 API to Alluxio, via Alluxio proxy.
It includes:
- PUT/GET/DELETE bucket which maps to directory in Alluxio
- PUT/GET/HEAD/DELETE object which maps to file/empty-dir in Alluxio
- Integration tests covered for all new ops.

No support yet:
- POST object, Multi-part upload/download are not supported yet.
- Options for ETag, security/ACL, Delimiter/CommonPrefixes are not supported yet.

How to use/test:
Option1: via REST API
```
# curl -i -X PUT http://localhost:39999/api/v1/s3/testbucket
# curl -i -X GET http://localhost:39999/api/v1/s3/testbucket
# curl -i -X PUT -T "LICENSE" http://localhost:39999/api/v1/s3/testbucket/testobject
# curl -i -X HEAD http://localhost:39999/api/v1/s3/testbucket/testobject
# curl -i -X GET http://localhost:39999/api/v1/s3/testbucket/testobject
# curl -i -X GET http://localhost:39999/api/v1/s3/testbucket
# curl -i -X DELETE http://localhost:39999/api/v1/s3/testbucket/testobject
# curl -i -X GET http://localhost:39999/api/v1/s3/testbucket/testobject
# curl -i -X DELETE http://localhost:39999/api/v1/s3/testbucket
# curl -i -X GET http://localhost:39999/api/v1/s3/testbucket
```

Option2: use a sample S3 client script:
```
import boto
import boto.s3.connection

conn = boto.connect_s3(
    aws_access_key_id = '',
    aws_secret_access_key = '',
    host = 'localhost',
    port = 39999,
    path = '/api/v1/s3',
    is_secure=False,
    calling_format = boto.s3.connection.OrdinaryCallingFormat(),
)

bucketName = 'bucket-for-testing'
bucket = conn.create_bucket(bucketName)

smallObjectKey = 'small.txt'
smallObjectContent = 'Hello World!'

key = bucket.new_key(smallObjectKey)
key.set_contents_from_string(smallObjectContent)

assert smallObjectContent == key.get_contents_as_string()

largeObjectKey = 'large.txt'
largeObjectFile = '8mb.data'

key = bucket.new_key(largeObjectKey)
with open(largeObjectFile, 'rb') as f:
    key.set_contents_from_file(f)
with open(largeObjectFile, 'rb') as f:
    largeObject = f.read()

assert largeObject == key.get_contents_as_string()

bucket.delete_key(smallObjectKey)
bucket.delete_key(largeObjectKey)
conn.delete_bucket(bucketName)
```