### PR TITLE
[SMALLFIX] Remove seek tests from UFS Contract Test

### DIFF
--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -14,7 +14,6 @@ package alluxio.underfs;
 import alluxio.Configuration;
 import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
-import alluxio.Seekable;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;

--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -187,42 +187,6 @@ public abstract class AbstractUnderFileSystemContractTest {
   }
 
   @Test
-  public void createOpenSeek() throws IOException {
-    String testFile = PathUtils.concatPath(mUnderfsAddress, "createOpenSeek");
-    OutputStream outputStream = mUfs.create(testFile);
-    int numBytes = 10;
-    for (int i = 0; i < numBytes; ++i) {
-      outputStream.write(i);
-    }
-    outputStream.close();
-    InputStream inputStream = mUfs.open(testFile);
-    for (int i = 0; i < numBytes; ++i) {
-      ((Seekable) inputStream).seek(i);
-      int readValue = inputStream.read();
-      Assert.assertEquals(i, readValue);
-    }
-    inputStream.close();
-  }
-
-  @Test
-  public void createOpenSeekReverse() throws IOException {
-    String testFile = PathUtils.concatPath(mUnderfsAddress, "createOpenSeekReverse");
-    OutputStream outputStream = mUfs.create(testFile);
-    int numBytes = 10;
-    for (int i = 0; i < numBytes; ++i) {
-      outputStream.write(i);
-    }
-    outputStream.close();
-    InputStream inputStream = mUfs.open(testFile);
-    for (int i = numBytes - 1; i >= 0; --i) {
-      ((Seekable) inputStream).seek(i);
-      int readValue = inputStream.read();
-      Assert.assertEquals(i, readValue);
-    }
-    inputStream.close();
-  }
-
-  @Test
   public void deleteFile() throws IOException {
     String testFile = PathUtils.concatPath(mUnderfsAddress, "deleteFile");
     createEmptyFile(testFile);


### PR DESCRIPTION
We don't expect the InputStream returned to implement Seekable anymore.