### PR TITLE
[ALLUXIO-2997] [S3] S3 multipart upload

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -153,6 +153,7 @@ public final class Constants {
   // S3 northbound API constants
   public static final String S3_DELETE_IN_ALLUXIO_ONLY = "ALLUXIO_ONLY";
   public static final String S3_DELETE_IN_ALLUXIO_AND_UFS = "ALLUXIO_AND_UFS";
+  public static final String S3_MULTIPART_TEMPORARY_DIR_SUFFIX = "_s3_multipart_tmp";
 
   private Constants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1190,6 +1190,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   + "`%s` (delete only the buckets or objects in Alluxio namespace).",
               Constants.S3_DELETE_IN_ALLUXIO_AND_UFS, Constants.S3_DELETE_IN_ALLUXIO_ONLY))
           .build();
+  public static final PropertyKey PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX =
+      new Builder(Name.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX)
+          .setDefaultValue(Constants.S3_MULTIPART_TEMPORARY_DIR_SUFFIX)
+          .setDescription("Suffix for the directory which holds parts during a multipart upload.")
+          .build();
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
       new Builder(Name.PROXY_STREAM_CACHE_TIMEOUT_MS)
           .setAlias(new String[]{"alluxio.proxy.stream.cache.timeout.ms"})
@@ -2086,6 +2091,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     public static final String PROXY_S3_WRITE_TYPE = "alluxio.proxy.s3.writetype";
     public static final String PROXY_S3_DELETE_TYPE = "alluxio.proxy.s3.deletetype";
+    public static final String PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX =
+        "alluxio.proxy.s3.multipart.temporary.dir.suffix";
     public static final String PROXY_STREAM_CACHE_TIMEOUT_MS =
         "alluxio.proxy.stream.cache.timeout";
     public static final String PROXY_WEB_BIND_HOST = "alluxio.proxy.web.bind.host";

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
@@ -1,0 +1,123 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Result returned after requests for completing a multipart upload.
+ * It is defined in http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html.
+ * It will be encoded into an XML string to be returned as a response for the REST call.
+ */
+@JacksonXmlRootElement(localName = "CompleteMultipartUploadResult")
+@JsonPropertyOrder({ "Location", "Bucket", "Key", "ETag" })
+public class CompleteMultipartUploadResult {
+  // The URI that identifies the newly created object.
+  private String mLocation;
+  // Name of the bucket.
+  private String mBucket;
+  // Object key.
+  private String mKey;
+  // Entity tag of the object.
+  private String mETag;
+
+  /**
+   * Constructs an {@link CompleteMultipartUploadResult} with fields initialized to empty strings.
+   */
+  public CompleteMultipartUploadResult() {
+    mLocation = "";
+    mBucket = "";
+    mKey = "";
+    mETag = "";
+  }
+
+  /**
+   * Constructs an {@link CompleteMultipartUploadResult} with the specified values.
+   *
+   * @param location the URI that identifies the newly created object
+   * @param bucket name of the bucket
+   * @param key object key
+   * @param etag entity tag of the newly created object, the etag should not be surrounded by quotes
+   */
+  public CompleteMultipartUploadResult(String location, String bucket, String key, String etag) {
+    mLocation = location;
+    mBucket = bucket;
+    mKey = key;
+    mETag = "\"" + etag + "\"";
+  }
+
+  /**
+   * @return the location
+   */
+  @JacksonXmlProperty(localName = "Location")
+  public String getLocation() {
+    return mLocation;
+  }
+
+  /**
+   * @param location the location to set
+   */
+  @JacksonXmlProperty(localName = "Location")
+  public void setLocation(String location) {
+    mLocation = location;
+  }
+
+  /**
+   * @return the bucket name
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public String getBucket() {
+    return mBucket;
+  }
+
+  /**
+   * @param bucket the bucket name to set
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public void setBucket(String bucket) {
+    mBucket = bucket;
+  }
+
+  /**
+   * @return the object key
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public String getKey() {
+    return mKey;
+  }
+
+  /**
+   * @param key the object key to set
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public void setKey(String key) {
+    mKey = key;
+  }
+
+  /**
+   * @return the entity tag surrounded by quotes
+   */
+  @JacksonXmlProperty(localName = "ETag")
+  public String getETag() {
+    return mETag;
+  }
+
+  /**
+   * @param etag the entity tag to be set, should not be surrounded by quotes
+   */
+  @JacksonXmlProperty(localName = "ETag")
+  public void setUploadId(String etag) {
+    mETag = "\"" + etag + "\"";
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
@@ -54,7 +54,7 @@ public class CompleteMultipartUploadResult {
     mLocation = location;
     mBucket = bucket;
     mKey = key;
-    mETag = "\"" + etag + "\"";
+    mETag = S3RestUtils.quoteETag(etag);
   }
 
   /**
@@ -117,7 +117,7 @@ public class CompleteMultipartUploadResult {
    * @param etag the entity tag to be set, should not be surrounded by quotes
    */
   @JacksonXmlProperty(localName = "ETag")
-  public void setUploadId(String etag) {
-    mETag = "\"" + etag + "\"";
+  public void setETag(String etag) {
+    mETag = S3RestUtils.quoteETag(etag);
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
@@ -23,13 +23,13 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 @JacksonXmlRootElement(localName = "CompleteMultipartUploadResult")
 @JsonPropertyOrder({ "Location", "Bucket", "Key", "ETag" })
 public class CompleteMultipartUploadResult {
-  // The URI that identifies the newly created object.
+  /* The URI that identifies the newly created object. */
   private String mLocation;
-  // Name of the bucket.
+  /* Name of the bucket. */
   private String mBucket;
-  // Object key.
+  /* Object key. */
   private String mKey;
-  // Entity tag of the object.
+  /* Entity tag of the object. */
   private String mETag;
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/InitiateMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/InitiateMultipartUploadResult.java
@@ -23,11 +23,11 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 @JacksonXmlRootElement(localName = "InitiateMultipartUploadResult")
 @JsonPropertyOrder({ "Bucket", "Key", "UploadId" })
 public class InitiateMultipartUploadResult {
-  // Name of the bucket to which the multipart upload was initiated.
+  /* Name of the bucket to which the multipart upload was initiated. */
   private String mBucket;
-  // Object key for which the multipart upload was initiated.
+  /* Object key for which the multipart upload was initiated. */
   private String mKey;
-  // ID for the initiated multipart upload.
+  /* ID for the initiated multipart upload. */
   private String mUploadId;
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/InitiateMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/InitiateMultipartUploadResult.java
@@ -1,0 +1,102 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Result returned after requests for initiating a multipart upload.
+ * It is defined in http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html.
+ * It will be encoded into an XML string to be returned as a response for the REST call.
+ */
+@JacksonXmlRootElement(localName = "InitiateMultipartUploadResult")
+@JsonPropertyOrder({ "Bucket", "Key", "UploadId" })
+public class InitiateMultipartUploadResult {
+  // Name of the bucket to which the multipart upload was initiated.
+  private String mBucket;
+  // Object key for which the multipart upload was initiated.
+  private String mKey;
+  // ID for the initiated multipart upload.
+  private String mUploadId;
+
+  /**
+   * Constructs an {@link InitiateMultipartUploadResult} with fields initialized to empty strings.
+   */
+  public InitiateMultipartUploadResult() {
+    mBucket = "";
+    mKey = "";
+    mUploadId = "";
+  }
+
+  /**
+   * Constructs an {@link InitiateMultipartUploadResult} with the specified values.
+   *
+   * @param bucket name of the bucket to which the multipart upload was initiated
+   * @param key object key for which the multipart upload was initiated
+   * @param uploadId ID for the initiated multipart upload
+   */
+  public InitiateMultipartUploadResult(String bucket, String key, String uploadId) {
+    mBucket = bucket;
+    mKey = key;
+    mUploadId = uploadId;
+  }
+
+  /**
+   * @return the bucket name
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public String getBucket() {
+    return mBucket;
+  }
+
+  /**
+   * @param bucket the bucket name to set
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public void setBucket(String bucket) {
+    mBucket = bucket;
+  }
+
+  /**
+   * @return the object key
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public String getKey() {
+    return mKey;
+  }
+
+  /**
+   * @param key the object key to set
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public void setKey(String key) {
+    mKey = key;
+  }
+
+  /**
+   * @return the upload ID
+   */
+  @JacksonXmlProperty(localName = "UploadId")
+  public String getUploadId() {
+    return mUploadId;
+  }
+
+  /**
+   * @param uploadId the upload ID to set
+   */
+  @JacksonXmlProperty(localName = "UploadId")
+  public void setUploadId(String uploadId) {
+    mUploadId = uploadId;
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -20,12 +20,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -102,7 +99,6 @@ public class ListBucketResult {
       }
     }
 
-    final DateFormat s3DateFormat = new SimpleDateFormat(S3Constants.S3_DATE_FORMAT_REGEXP);
     for (int i = startIndex; i < objectsList.size(); i++) {
       URIStatus status = objectsList.get(i);
       String objectKey = status.getPath().substring(mName.length() + 1);
@@ -121,7 +117,7 @@ public class ListBucketResult {
       // TODO(chaomin): construct the response with CommonPrefixes when delimiter support is added.
       mContents.add(new Content(
           status.getPath().substring(mName.length() + 1),
-          s3DateFormat.format(new Date(status.getLastModificationTimeMs())),
+          S3RestUtils.toS3Date(status.getLastModificationTimeMs()),
           S3Constants.S3_EMPTY_ETAG,
           String.valueOf(status.getLength()),
           S3Constants.S3_STANDARD_STORAGE_CLASS));

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -174,7 +174,7 @@ public class ListBucketResult {
   }
 
   /**
-   * @return whether (true) or not (false) all of the results were returned
+   * @return false if all results are returned, otherwise true
    */
   @JacksonXmlProperty(localName = "IsTruncated")
   public boolean isTruncated() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
@@ -1,0 +1,259 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.client.file.URIStatus;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Result returned after requests for listing parts of a multipart upload.
+ * It is defined in http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html.
+ * It will be encoded into an XML string to be returned as a response for the REST call.
+ */
+// TODO(cc): Support more fields
+@JacksonXmlRootElement(localName = "ListPartsResult")
+@JsonPropertyOrder({ "Bucket", "Key", "UploadId", "StorageClass", "IsTruncated", "Part" })
+public class ListPartsResult {
+  // Name of the bucket.
+  private String mBucket;
+  // Object key.
+  private String mKey;
+  // ID of the multipart upload to be listed.
+  private String mUploadId;
+  // Storage class, only STANDARD is supported in Alluxio now.
+  private String mStorageClass;
+  // Indicates whether the returned list of parts is truncated.
+  // A true value indicates that the list was truncated.
+  // A list can be truncated if the number of parts exceeds the limit returned in the MaxParts
+  // element.
+  private boolean mIsTruncated;
+  // Parts of the multipart upload.
+  List<Part> mParts;
+
+  /**
+   * Constructs a default {@link ListPartsResult}.
+   */
+  public ListPartsResult() {
+    mBucket = "";
+    mKey = "";
+    mUploadId = "";
+    mStorageClass = S3Constants.S3_STANDARD_STORAGE_CLASS;
+    mIsTruncated = false;
+    mParts = new ArrayList<>();
+  }
+
+  /**
+   * @return the bucket name
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public String getBucket() {
+    return mBucket;
+  }
+
+  /**
+   * @param bucket the bucket name to set
+   */
+  @JacksonXmlProperty(localName = "Bucket")
+  public void setBucket(String bucket) {
+    mBucket = bucket;
+  }
+
+  /**
+   * @return the object key
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public String getKey() {
+    return mKey;
+  }
+
+  /**
+   * @param key the object key to set
+   */
+  @JacksonXmlProperty(localName = "Key")
+  public void setKey(String key) {
+    mKey = key;
+  }
+
+  /**
+   * @return the upload ID
+   */
+  @JacksonXmlProperty(localName = "UploadId")
+  public String getUploadId() {
+    return mUploadId;
+  }
+
+  /**
+   * @param uploadId the upload ID to set
+   */
+  @JacksonXmlProperty(localName = "UploadId")
+  public void setUploadId(String uploadId) {
+    mUploadId = uploadId;
+  }
+
+  /**
+   * @return the storage class
+   */
+  @JacksonXmlProperty(localName = "StorageClass")
+  public String getStorageClass() {
+    return mStorageClass;
+  }
+
+  /**
+   * @param storageClass the storage class to set
+   */
+  @JacksonXmlProperty(localName = "StorageClass")
+  public void setStorageClass(String storageClass) {
+    mStorageClass = storageClass;
+  }
+
+  /**
+   * @return whether (true) or not (false) all of the results were returned
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public boolean isTruncated() {
+    return mIsTruncated;
+  }
+
+  /**
+   * @param isTruncated whether the results are truncated
+   */
+  @JacksonXmlProperty(localName = "IsTruncated")
+  public void setIsTruncated(boolean isTruncated) {
+    mIsTruncated = isTruncated;
+  }
+
+  /**
+   * @return the list of parts
+   */
+  @JacksonXmlProperty(localName = "Part")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public List<Part> getParts() {
+    return mParts;
+  }
+
+  /**
+   * @param parts the list of parts to set
+   */
+  @JacksonXmlProperty(localName = "Part")
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setParts(List<Part> parts) {
+    mParts = parts;
+  }
+
+  /**
+   * Part contains metadata of a part of the object in multipart upload.
+   */
+  @JsonPropertyOrder({ "PartNumber", "LastModified", "ETag", "Size" })
+  public static class Part {
+    // Part number.
+    private int mPartNumber;
+    // Last modification time of the part.
+    private String mLastModified;
+    // Entity tag of the part.
+    private String mETag;
+    // Size of the part in bytes.
+    private long mSize;
+
+    /**
+     * @param status the status of the part file
+     * @return the {@link Part} parsed from the status
+     */
+    public static Part fromURIStatus(URIStatus status) {
+      Part result = new Part();
+      result.setPartNumber(Integer.parseInt(status.getName()));
+      result.setLastModified(S3RestUtils.toS3Date(status.getLastModificationTimeMs()));
+      result.setSize(status.getLength());
+      return result;
+    }
+
+    /**
+     * Constructs a default {@link Part}.
+     */
+    public Part() {
+      mPartNumber = 0;
+      mLastModified = "";
+      mETag = "\"\"";
+      mSize = 0;
+    }
+
+    /**
+     * @return the part number
+     */
+    @JacksonXmlProperty(localName = "PartNumber")
+    public int getPartNumber() {
+      return mPartNumber;
+    }
+
+    /**
+     * @param partNumber the part number to set
+     */
+    @JacksonXmlProperty(localName = "PartNumber")
+    public void setPartNumber(int partNumber) {
+      mPartNumber = partNumber;
+    }
+
+    /**
+     * @return the last modification time
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public String getLastModified() {
+      return mLastModified;
+    }
+
+    /**
+     * @param lastModified the last modification time to set
+     */
+    @JacksonXmlProperty(localName = "LastModified")
+    public void setLastModified(String lastModified) {
+      mLastModified = lastModified;
+    }
+
+    /**
+     * @return the entity tag surrounded by quotes
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public String getETag() {
+      return mETag;
+    }
+
+    /**
+     * @param etag the entity tag to set (without surrounding quotes)
+     */
+    @JacksonXmlProperty(localName = "ETag")
+    public void setETag(String etag) {
+      mETag = "\"" + etag + "\"";
+    }
+
+    /**
+     * @return the size of the part in bytes
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public long getSize() {
+      return mSize;
+    }
+
+    /**
+     * @param size the size of the part (in bytes) to set
+     */
+    @JacksonXmlProperty(localName = "Size")
+    public void setSize(long size) {
+      mSize = size;
+    }
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
@@ -30,20 +30,22 @@ import java.util.List;
 @JacksonXmlRootElement(localName = "ListPartsResult")
 @JsonPropertyOrder({ "Bucket", "Key", "UploadId", "StorageClass", "IsTruncated", "Part" })
 public class ListPartsResult {
-  // Name of the bucket.
+  /* Name of the bucket. */
   private String mBucket;
-  // Object key.
+  /* Object key. */
   private String mKey;
-  // ID of the multipart upload to be listed.
+  /* ID of the multipart upload to be listed. */
   private String mUploadId;
-  // Storage class, only STANDARD is supported in Alluxio now.
+  /* Storage class, only STANDARD is supported in Alluxio now. */
   private String mStorageClass;
-  // Indicates whether the returned list of parts is truncated.
-  // A true value indicates that the list was truncated.
-  // A list can be truncated if the number of parts exceeds the limit returned in the MaxParts
-  // element.
+  /**
+   * Indicates whether the returned list of parts is truncated.
+   * A true value indicates that the list was truncated.
+   * A list can be truncated if the number of parts exceeds the limit returned in the MaxParts
+   * element.
+   */
   private boolean mIsTruncated;
-  // Parts of the multipart upload.
+  /* Parts of the multipart upload. */
   List<Part> mParts;
 
   /**
@@ -123,7 +125,7 @@ public class ListPartsResult {
   }
 
   /**
-   * @return whether (true) or not (false) all of the results were returned
+   * @return false if all results are returned, otherwise true
    */
   @JacksonXmlProperty(localName = "IsTruncated")
   public boolean isTruncated() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListPartsResult.java
@@ -163,13 +163,13 @@ public class ListPartsResult {
    */
   @JsonPropertyOrder({ "PartNumber", "LastModified", "ETag", "Size" })
   public static class Part {
-    // Part number.
+    /* Part number. */
     private int mPartNumber;
-    // Last modification time of the part.
+    /* Last modification time of the part. */
     private String mLastModified;
-    // Entity tag of the part.
+    /* Entity tag of the part. */
     private String mETag;
-    // Size of the part in bytes.
+    /* Size of the part in bytes. */
     private long mSize;
 
     /**
@@ -190,7 +190,7 @@ public class ListPartsResult {
     public Part() {
       mPartNumber = 0;
       mLastModified = "";
-      mETag = "\"\"";
+      mETag = S3RestUtils.quoteETag("");
       mSize = 0;
     }
 
@@ -239,7 +239,7 @@ public class ListPartsResult {
      */
     @JacksonXmlProperty(localName = "ETag")
     public void setETag(String etag) {
-      mETag = "\"" + etag + "\"";
+      mETag = S3RestUtils.quoteETag(etag);
     }
 
     /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -29,6 +29,7 @@ public class S3ErrorCode {
     public static final String INVALID_BUCKET_NAME = "InvalidBucketName";
     public static final String NO_SUCH_BUCKET = "NoSuchBucket";
     public static final String NO_SUCH_KEY = "NoSuchKey";
+    public static final String NO_SUCH_UPLOAD = "NoSuchUpload";
     public static final String PRECONDITION_FAILED = "PreconditionFailed";
 
     private Name() {
@@ -65,6 +66,12 @@ public class S3ErrorCode {
   public static final S3ErrorCode NO_SUCH_KEY = new S3ErrorCode(
       Name.NO_SUCH_KEY,
       "The specified key does not exist",
+      Response.Status.NOT_FOUND);
+  public static final S3ErrorCode NO_SUCH_UPLOAD = new S3ErrorCode(
+      Name.NO_SUCH_UPLOAD,
+      "The specified multipart upload does not exist. "
+      + "The upload ID might be invalid, or the multipart upload might have been aborted "
+      + "or completed.",
       Response.Status.NOT_FOUND);
   public static final S3ErrorCode PRECONDITION_FAILED = new S3ErrorCode(
       Name.PRECONDITION_FAILED,

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -294,6 +294,8 @@ public final class S3RestServiceHandler {
   public Response initiateOrCompleteMultipartUpload(@PathParam("bucket") final String bucket,
       @PathParam("object") final String object, @QueryParam("uploads") final String uploads,
       @QueryParam("uploadId") final Long uploadId) {
+    Preconditions.checkArgument(uploads != null || uploadId != null,
+        "parameter 'uploads' or 'uploadId' should exist");
     if (uploads != null) {
       return initiateMultipartUpload(bucket, object);
     } else {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -519,6 +519,7 @@ public final class S3RestServiceHandler {
     });
   }
 
+  // TODO(cc): Support automatic abortion after a timeout.
   private void abortMultipartUpload(String bucket, String object, long uploadId)
       throws S3Exception {
     String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -315,6 +315,7 @@ public final class S3RestServiceHandler {
 
         try {
           mFileSystem.createDirectory(multipartTemporaryDir);
+          // Use the file ID of multipartTemporaryDir as the upload ID.
           long uploadId = mFileSystem.getStatus(multipartTemporaryDir).getFileId();
           return new InitiateMultipartUploadResult(bucket, object, Long.toString(uploadId));
         } catch (Exception e) {
@@ -646,7 +647,8 @@ public final class S3RestServiceHandler {
       if (!cur.isFolder()) {
         // Alluxio file is an object.
         objects.add(cur);
-      } else {
+      } else if (!cur.getName().endsWith(Constants.S3_MULTIPART_TEMPORARY_DIR_SUFFIX)) {
+        // The directory is not a temporary directory of multipart upload, list recursively.
         List<URIStatus> curChildren = mFileSystem.listStatus(new AlluxioURI(cur.getPath()));
         if (curChildren.isEmpty()) {
           // An empty Alluxio directory is considered as a valid object.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -487,18 +487,18 @@ public final class S3RestServiceHandler {
 
   private void abortMultipartUpload(String bucket, String object, long uploadId)
       throws S3Exception {
-      String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
-      checkBucketIsAlluxioDirectory(bucketPath);
-      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-      AlluxioURI multipartTemporaryDir =
-          new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucket, object));
-      checkUploadId(multipartTemporaryDir, uploadId);
+    String bucketPath = parseBucketPath(AlluxioURI.SEPARATOR + bucket);
+    checkBucketIsAlluxioDirectory(bucketPath);
+    String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+    AlluxioURI multipartTemporaryDir =
+        new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucket, object));
+    checkUploadId(multipartTemporaryDir, uploadId);
 
-      try {
-        mFileSystem.delete(multipartTemporaryDir, DeleteOptions.defaults().setRecursive(true));
-      } catch (Exception e) {
-        throw toObjectS3Exception(e, objectPath);
-      }
+    try {
+      mFileSystem.delete(multipartTemporaryDir, DeleteOptions.defaults().setRecursive(true));
+    } catch (Exception e) {
+      throw toObjectS3Exception(e, objectPath);
+    }
   }
 
   private void deleteObject(String bucket, String object) throws S3Exception {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -156,5 +156,16 @@ public final class S3RestUtils {
     return s3DateFormat.format(new Date(epoch));
   }
 
+  /**
+   * @param etag the entity tag to be used in the ETag field in the HTTP header
+   * @return the etag surrounded by quotes, if etag is already surrounded by quotes, return itself
+   */
+  public static String quoteETag(String etag) {
+    if (etag.startsWith("\"") && etag.endsWith("\"")) {
+      return etag;
+    }
+    return "\"" + etag + "\"";
+  }
+
   private S3RestUtils() {} // prevent instantiation
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -24,6 +24,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import javax.ws.rs.core.Response;
 
@@ -134,15 +137,23 @@ public final class S3RestUtils {
   }
 
   /**
-   * @param bucket the bucket name
-   * @param object the object name
+   * @param bucketPath the bucket path like "/bucket", "/mount/point/bucket"
+   * @param objectKey the object key like "img/2017/9/1/s3.jpg"
    * @return the temporary directory used to hold parts of the object during multipart uploads
    */
-  public static String getMultipartTemporaryDirForObject(String bucket, String object) {
+  public static String getMultipartTemporaryDirForObject(String bucketPath, String objectKey) {
     String multipartTemporaryDirSuffix =
         Configuration.get(PropertyKey.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX);
-    return AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR + object
-        + multipartTemporaryDirSuffix;
+    return bucketPath + AlluxioURI.SEPARATOR + objectKey + multipartTemporaryDirSuffix;
+  }
+
+  /**
+   * @param epoch the milliseconds from the epoch
+   * @return the string representation of the epoch in the S3 date format
+   */
+  public static String toS3Date(long epoch) {
+    final DateFormat s3DateFormat = new SimpleDateFormat(S3Constants.S3_DATE_FORMAT_REGEXP);
+    return s3DateFormat.format(new Date(epoch));
   }
 
   private S3RestUtils() {} // prevent instantiation

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -11,6 +11,9 @@
 
 package alluxio.proxy.s3;
 
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.security.LoginUser;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.SecurityUtils;
@@ -128,6 +131,16 @@ public final class S3RestUtils {
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity("Failed to encode XML: " + e2.getMessage()).build();
     }
+  }
+
+  /**
+   * @param objectKey object key (not starting with /)
+   * @return the temporary directory used to hold parts of the object during multipart uploads
+   */
+  public static String getMultipartTemporaryDirForObject(String objectKey) {
+    String multipartTemporaryDirSuffix =
+        Configuration.get(PropertyKey.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX);
+    return AlluxioURI.SEPARATOR + objectKey + multipartTemporaryDirSuffix;
   }
 
   private S3RestUtils() {} // prevent instantiation

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -134,13 +134,15 @@ public final class S3RestUtils {
   }
 
   /**
-   * @param objectKey object key (not starting with /)
+   * @param bucket the bucket name
+   * @param object the object name
    * @return the temporary directory used to hold parts of the object during multipart uploads
    */
-  public static String getMultipartTemporaryDirForObject(String objectKey) {
+  public static String getMultipartTemporaryDirForObject(String bucket, String object) {
     String multipartTemporaryDirSuffix =
         Configuration.get(PropertyKey.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX);
-    return AlluxioURI.SEPARATOR + objectKey + multipartTemporaryDirSuffix;
+    return AlluxioURI.SEPARATOR + bucket + AlluxioURI.SEPARATOR + object
+        + multipartTemporaryDirSuffix;
   }
 
   private S3RestUtils() {} // prevent instantiation

--- a/tests/src/test/java/alluxio/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/rest/TestCase.java
@@ -102,7 +102,11 @@ public final class TestCase {
   public URL createURL() throws Exception {
     StringBuilder sb = new StringBuilder();
     for (Map.Entry<String, String> parameter : mParameters.entrySet()) {
-      sb.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+      if (parameter.getValue() == null || parameter.getValue().isEmpty()) {
+        sb.append(parameter.getKey());
+      } else {
+        sb.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+      }
     }
     return new URL(
         "http://" + mHostname + ":" + mPort + Constants.REST_API_PREFIX + "/" + mEndpoint


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-2997

This PR implements

[DONE] [multipart upload initialization](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html)
[DONE] [upload part](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html)
[DONE] [abort upload](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html)
[DONE] [complete upload](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html)
[DONE] [list parts](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html)

The following Python script initiates a multipart upload, uploads the parts, and completes the upload.

```python
import math, os

import boto
import boto.s3.connection
from filechunkio import FileChunkIO

# Connect to S3
c = boto.connect_s3(
    aws_access_key_id = '',
    aws_secret_access_key = '',
    host = 'localhost',
    port = 39999,
    path = '/api/v1/s3',
    is_secure=False,
    calling_format = boto.s3.connection.OrdinaryCallingFormat(),
)
b = c.create_bucket('mybucket')

# Get file info
source_path = '8mb.data'
source_size = os.stat(source_path).st_size

# Create a multipart upload request
mp = b.initiate_multipart_upload(os.path.basename(source_path))

# Use a chunk size of 1MB (feel free to change this)
chunk_size = 1048576
chunk_count = int(math.ceil(source_size / float(chunk_size)))

# Send the file parts, using FileChunkIO to create a file-like object
# that points to a certain byte range within the original file. We
# set bytes to never exceed the original file size.
for i in range(chunk_count):
    offset = chunk_size * i
    bytes = min(chunk_size, source_size - offset)
    with FileChunkIO(source_path, 'r', offset=offset, bytes=bytes) as fp:
        mp.upload_part_from_file(fp, part_num=i + 1)

# Finish the upload
mp.complete_upload()
```

After initializing the multipart upload:

```
./bin/alluxio fs ls /mybucket
drwxr-xr-x     changcheng     staff          8              09-01-2017 13:30:49:579  Directory      /mybucket/8mb.data_s3_multipart_tmp
```

After uploading the parts:

```
./bin/alluxio fs ls /mybucket/8mb.data_s3_multipart_tmp
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:621  In Memory      /mybucket/8mb.data_s3_multipart_tmp/1
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:687  In Memory      /mybucket/8mb.data_s3_multipart_tmp/2
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:741  In Memory      /mybucket/8mb.data_s3_multipart_tmp/3
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:779  In Memory      /mybucket/8mb.data_s3_multipart_tmp/4
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:820  In Memory      /mybucket/8mb.data_s3_multipart_tmp/5
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:853  In Memory      /mybucket/8mb.data_s3_multipart_tmp/6
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:892  In Memory      /mybucket/8mb.data_s3_multipart_tmp/7
-rw-r--r--     changcheng     staff          1048576        09-01-2017 13:30:49:926  In Memory      /mybucket/8mb.data_s3_multipart_tmp/8
```

After completing the upload:

```
./bin/alluxio fs ls /mybucket
-rw-r--r--     changcheng     staff          8388608        09-01-2017 13:30:35:854  Not In Memory  /mybucket/8mb.data
```