### PR TITLE
[DOCFIX] Improve Spark doc page

### DIFF
--- a/docs/en/Running-Spark-on-Alluxio.md
+++ b/docs/en/Running-Spark-on-Alluxio.md
@@ -25,17 +25,16 @@ Alluxio works together with Spark 1.1 or later out-of-the-box.
 * Alluxio cluster has been set up in accordance to these guides for either
 [Local Mode](Running-Alluxio-Locally.html) or [Cluster Mode](Running-Alluxio-on-a-Cluster.html).
 
-* Alluxio client will need to be compiled with the Spark specific profile. Build the entire project
-from the top level `alluxio` directory with the following command:
+* Alluxio client jar is required for Spark to access files on Alluxio. It is included in the
+compiled distribution. If Alluxio is deployed from source code, it needs to be compiled with the
+Spark specific profile. Build the entire project from the top level `alluxio` directory with the
+following command:
 
 {% include Running-Spark-on-Alluxio/spark-profile-build.md %}
 
 * Add the following line to `spark/conf/spark-defaults.conf`.
 
 {% include Running-Spark-on-Alluxio/earlier-spark-version-bash.md %}
-
-* Advanced users can choose to compile this client jar from the source code, follow the instructs [here](Building-Alluxio-Master-Branch.html#compute-framework-support) and use the generated jar at 
-`{{site.ALLUXIO_CLIENT_JAR_PATH_BUILD}}` for the rest of this guide.
 
 ### Additional Setup for HDFS
 


### PR DESCRIPTION
Updated the doc to mention that the client jar is included in the distribution. It is only required to be compiled if user is deploying Alluxio from source code.