### PR TITLE
[SMALLFIX] Prefer ArrayList over LinkedList

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -90,7 +90,7 @@ public class FileOutStream extends AbstractOutStream {
     mOptions = options;
     mContext = context;
     mBlockStore = AlluxioBlockStore.create(mContext);
-    mPreviousBlockOutStreams = new LinkedList<>();
+    mPreviousBlockOutStreams = new ArrayList<>();
     mClosed = false;
     mCanceled = false;
     mShouldCacheCurrentBlock = mAlluxioStorageType.isStore();

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -320,7 +320,7 @@ public final class Configuration {
         "Illegal separator for Alluxio properties as list");
     String rawValue = get(key);
 
-    return Lists.newLinkedList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
+    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
         .split(rawValue));
   }
 

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -293,7 +292,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     public DeleteBuffer() {
       mBatches = new ArrayList<>();
       mBatchesResult = new ArrayList<>();
-      mCurrentBatchBuffer = new LinkedList<>();
+      mCurrentBatchBuffer = new ArrayList<>();
       mEntriesAdded = 0;
     }
 
@@ -321,7 +320,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
      */
     public List<String> getResult() throws IOException {
       submitBatch();
-      LinkedList<String> result = new LinkedList<>();
+      List<String> result = new ArrayList<>();
       for (Future<List<String>> list : mBatchesResult) {
         try {
           result.addAll(list.get());
@@ -345,7 +344,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     private void submitBatch() throws IOException {
       if (mCurrentBatchBuffer.size() != 0) {
         int batchNumber = mBatches.size();
-        mBatches.add(new LinkedList<>(mCurrentBatchBuffer));
+        mBatches.add(new ArrayList<>(mCurrentBatchBuffer));
         mCurrentBatchBuffer.clear();
         mBatchesResult.add(batchNumber,
             mExecutorService.submit(new DeleteThread(mBatches.get(batchNumber))));
@@ -619,7 +618,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @return list of successfully deleted keys
    */
   protected List<String> deleteObjects(List<String> keys) throws IOException {
-    List<String> result = new LinkedList<>();
+    List<String> result = new ArrayList<>();
     for (String key : keys) {
       boolean status = deleteObject(key);
       // If key is a directory, it is possible that it was not created through Alluxio and no

--- a/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
+++ b/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
@@ -17,8 +17,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -91,7 +92,7 @@ public final class HeartbeatThreadTest {
    */
   @Test
   public void concurrentHeartbeatThread() throws Exception {
-    List<FutureTask<Void>> tasks = new LinkedList<>();
+    List<FutureTask<Void>> tasks = new ArrayList<>();
 
     // Start the threads.
     for (int i = 0; i < NUMBER_OF_THREADS; i++) {

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
@@ -85,7 +85,7 @@ public class CommonUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase(""));
     testCases.add(new TestCase("foo", "foo"));
     testCases.add(new TestCase("foo bar", "foo", "bar"));
@@ -110,7 +110,7 @@ public class CommonUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase());
     testCases.add(new TestCase("foo"));
     testCases.add(new TestCase("foo", "bar"));
@@ -145,7 +145,7 @@ public class CommonUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("hello", TestClassA.class, null));
     testCases.add(new TestCase("1", TestClassB.class, new Class[] {int.class}, 1));
 

--- a/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
@@ -17,7 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,7 +42,7 @@ public final class FormatUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("()", null));
     testCases.add(new TestCase("(null)", new Object[] {null}));
     testCases.add(new TestCase("()", new Object[] {""}));
@@ -74,7 +74,7 @@ public final class FormatUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("", ByteBuffer.wrap(new byte[] {})));
     testCases.add(new TestCase("", ByteBuffer.wrap(new byte[] {0})));
     testCases.add(new TestCase("", ByteBuffer.wrap(new byte[] {0, 0})));
@@ -117,7 +117,7 @@ public final class FormatUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("^Task A took (.*) ms.$", "Task A"));
     testCases.add(new TestCase("^Task B took (.*) ms.$", "Task B"));
 
@@ -147,7 +147,7 @@ public final class FormatUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("^Task A took (.*) ns.$", "Task A"));
     testCases.add(new TestCase("^Task B took (.*) ns.$", "Task B"));
 
@@ -177,7 +177,7 @@ public final class FormatUtilsTest {
       }
     }
 
-    List<TestCase> testCases = new LinkedList<>();
+    List<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase("4.00B", 1L << 2));
     testCases.add(new TestCase("8.00B", 1L << 3));
     testCases.add(new TestCase("4096.00B", 1L << 12));

--- a/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -132,7 +132,7 @@ public final class BufferUtilsTest {
       }
     }
 
-    LinkedList<TestCase> testCases = new LinkedList<>();
+    ArrayList<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase((byte) 0x00, 0x00));
     testCases.add(new TestCase((byte) 0x12, 0x12));
     testCases.add(new TestCase((byte) 0x34, 0x1234));
@@ -163,7 +163,7 @@ public final class BufferUtilsTest {
       }
     }
 
-    LinkedList<TestCase> testCases = new LinkedList<>();
+    ArrayList<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase(new byte[] {}, 0, 0));
     testCases.add(new TestCase(new byte[] {}, 0, 3));
     testCases.add(new TestCase(new byte[] {0}, 1, 0));
@@ -199,7 +199,7 @@ public final class BufferUtilsTest {
       }
     }
 
-    LinkedList<TestCase> testCases = new LinkedList<>();
+    ArrayList<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase(false, null, 0, 0));
     testCases.add(new TestCase(true, new byte[] {}, 0, 0));
     testCases.add(new TestCase(false, new byte[] {1}, 0, 0));
@@ -240,7 +240,7 @@ public final class BufferUtilsTest {
       }
     }
 
-    LinkedList<TestCase> testCases = new LinkedList<>();
+    ArrayList<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 0));
     testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 3));
     testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0}), 1, 0));
@@ -276,7 +276,7 @@ public final class BufferUtilsTest {
       }
     }
 
-    LinkedList<TestCase> testCases = new LinkedList<>();
+    ArrayList<TestCase> testCases = new ArrayList<>();
     testCases.add(new TestCase(false, null, 0, 0));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {}), 0, 0));
     testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1}), 0, 0));

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -20,7 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 
 /**
  * Tests for the {@link PathUtils} class.
@@ -316,7 +316,7 @@ public final class PathUtilsTest {
     PathUtils.validatePath("/foo/../bar/");
 
     // check invalid paths
-    LinkedList<String> invalidPaths = new LinkedList<>();
+    ArrayList<String> invalidPaths = new ArrayList<>();
     invalidPaths.add(null);
     invalidPaths.add("");
     invalidPaths.add(" /");

--- a/core/server/common/src/main/java/alluxio/cli/extensions/command/InstallCommand.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/command/InstallCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -65,7 +65,7 @@ public final class InstallCommand extends AbstractCommand {
   public int run(CommandLine cl) {
     String uri = cl.getArgs()[0];
     String extensionsDir = Configuration.get(PropertyKey.EXTENSIONS_DIR);
-    List<String> failedHosts = new LinkedList<>();
+    List<String> failedHosts = new ArrayList<>();
     for (String host : ExtensionsShellUtils.getServerHostnames()) {
       try {
         LOG.info("Attempting to install extension on host {}", host);

--- a/core/server/common/src/main/java/alluxio/cli/extensions/command/UninstallCommand.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/command/UninstallCommand.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -66,7 +66,7 @@ public final class UninstallCommand extends AbstractCommand {
   public int run(CommandLine cl) {
     String uri = cl.getArgs()[0];
     String extensionsDir = Configuration.get(PropertyKey.EXTENSIONS_DIR);
-    List<String> failedHosts = new LinkedList<>();
+    List<String> failedHosts = new ArrayList<>();
     for (String host : ExtensionsShellUtils.getServerHostnames()) {
       try {
         LOG.info("Attempting to uninstall extension on host {}", host);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -143,7 +143,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1379,7 +1379,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throw new InvalidPathException(ExceptionMessage.DELETE_ROOT_DIRECTORY.getMessage());
     }
 
-    List<Pair<AlluxioURI, Inode>> delInodes = new LinkedList<>();
+    List<Pair<AlluxioURI, Inode>> delInodes = new ArrayList<>();
     List<Inode<?>> deletedInodes = new ArrayList<>();
 
     Pair<AlluxioURI, Inode> inodePair = new Pair<AlluxioURI, Inode>(inodePath.getUri(), inode);
@@ -1398,11 +1398,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         ufsDeleter = new SafeUfsDeleter(mMountTable, delInodes, deleteOptions);
       }
       // Inodes to delete from tree after attempting to delete from UFS
-      List<Inode> inodesToDelete = new LinkedList<>();
+      List<Inode> inodesToDelete = new ArrayList<>();
       // Inodes that are not safe for recursive deletes
       Set<Long> unsafeInodes = new HashSet<>();
       // Alluxio URIs which could not be deleted
-      List<String> failedUris = new LinkedList<>();
+      List<String> failedUris = new ArrayList<>();
 
       TempInodePathForDescendant tempInodePath = new TempInodePathForDescendant(inodePath);
       // We go through each inode, removing it from its parent set and from mDelInodes. If it's a

--- a/core/server/master/src/main/java/alluxio/master/file/UfsSyncChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/UfsSyncChecker.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -145,7 +145,7 @@ public final class UfsSyncChecker {
     AlluxioURI curUri = ufsUri;
     while (curUri != null) {
       if (mListedDirectories.containsKey(curUri.toString())) {
-        List<UfsStatus> childrenList = new LinkedList<>();
+        List<UfsStatus> childrenList = new ArrayList<>();
         for (UfsStatus childStatus : mListedDirectories.get(curUri.toString())) {
           String childPath = PathUtils.concatPath(curUri, childStatus.getName());
           String prefix = PathUtils.normalizePath(ufsUri.toString(), AlluxioURI.SEPARATOR);
@@ -176,7 +176,7 @@ public final class UfsSyncChecker {
    * @return trimmed list, null if input is null
    */
   private UfsStatus[] trimIndirect(UfsStatus[] children) {
-    List<UfsStatus> childrenList = new LinkedList<>();
+    List<UfsStatus> childrenList = new ArrayList<>();
     for (UfsStatus child : children) {
       int index = child.getName().indexOf(AlluxioURI.SEPARATOR);
       if (index < 0 || index == child.getName().length()) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -86,7 +86,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -363,7 +363,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.delete(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL),
         DeleteOptions.defaults().setRecursive(true).setAlluxioOnly(false).setUnchecked(false));
     // Check all that could be deleted.
-    List<AlluxioURI> except = new LinkedList<>();
+    List<AlluxioURI> except = new ArrayList<>();
     except.add(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL));
     checkPersistedDirectoriesDeleted(1, ufsMount, except);
   }
@@ -403,7 +403,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.delete(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL),
         DeleteOptions.defaults().setRecursive(true).setAlluxioOnly(false).setUnchecked(false));
     // Check all that could be deleted.
-    List<AlluxioURI> except = new LinkedList<>();
+    List<AlluxioURI> except = new ArrayList<>();
     except.add(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL));
     except.add(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL).join(DIR_PREFIX + 0));
     checkPersistedDirectoriesDeleted(3, ufsMount, except);

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockStoreMeta.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockStoreMeta.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +83,7 @@ public final class DefaultBlockStoreMeta implements BlockStoreMeta {
     for (Pair<String, String> tierPath : mCapacityBytesOnDirs.keySet()) {
       String tier = tierPath.getFirst();
       if (pathsOnTiers.get(tier) == null) {
-        pathsOnTiers.put(tier, new LinkedList<String>());
+        pathsOnTiers.put(tier, new ArrayList<String>());
       }
       pathsOnTiers.get(tier).add(tierPath.getSecond());
     }

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Lists;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -125,7 +125,7 @@ public final class FileSystemShellUtils {
    */
   private static List<AlluxioURI> getAlluxioURIs(FileSystem alluxioClient, AlluxioURI inputURI,
       AlluxioURI parentDir) throws IOException {
-    List<AlluxioURI> res = new LinkedList<>();
+    List<AlluxioURI> res = new ArrayList<>();
     List<URIStatus> statuses;
     try {
       statuses = alluxioClient.listStatus(parentDir);
@@ -162,7 +162,7 @@ public final class FileSystemShellUtils {
   public static List<File> getFiles(String inputPath) {
     File file = new File(inputPath);
     if (!inputPath.contains("*")) {
-      List<File> res = new LinkedList<>();
+      List<File> res = new ArrayList<>();
       if (file.exists()) {
         res.add(file);
       }
@@ -184,7 +184,7 @@ public final class FileSystemShellUtils {
    * @return a list of files that matches the input path in the parent directory
    */
   private static List<File> getFiles(String inputPath, String parent) {
-    List<File> res = new LinkedList<>();
+    List<File> res = new ArrayList<>();
     File pFile = new File(parent);
     if (!pFile.exists() || !pFile.isDirectory()) {
       return res;

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -60,7 +60,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -308,13 +308,13 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   protected List<String> deleteObjects(List<String> keys) throws IOException {
     Preconditions.checkArgument(keys != null && keys.size() <= getListingChunkLengthMax());
     try {
-      List<DeleteObjectsRequest.KeyVersion> keysToDelete = new LinkedList<>();
+      List<DeleteObjectsRequest.KeyVersion> keysToDelete = new ArrayList<>();
       for (String key : keys) {
         keysToDelete.add(new DeleteObjectsRequest.KeyVersion(key));
       }
       DeleteObjectsResult deletedObjectsResult =
           mClient.deleteObjects(new DeleteObjectsRequest(mBucketName).withKeys(keysToDelete));
-      List<String> deletedObjects = new LinkedList<>();
+      List<String> deletedObjects = new ArrayList<>();
       for (DeleteObjectsResult.DeletedObject deletedObject : deletedObjectsResult
           .getDeletedObjects()) {
         deletedObjects.add(deletedObject.getKey());


### PR DESCRIPTION
ArrayList uses less space overhead and has better lookup time: O(1) vs O(n)
LinkedList is only better when we need to add or remove items
from somewhere besides the end of the list. This never happens
in our code base in practice. Uses of LinkedList should be viewed
with suspicion since it's easy to create performance bottlenecks through
use of #get(int index) on a long linked list, as was fixed in
https://github.com/Alluxio/alluxio/pull/6004

This PR changes all but one usage of LinkedList to ArrayList.
All usages for the lists were inspected to make sure we weren't
using any features of the list that would make LinkedList more
appropriate than ArrayList.