### PR TITLE
[SMALLFIX] Fix createAtomic ufs contract test

### DIFF
--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractUnderFileSystemContractTest {
   @Test
   public void createAtomic() throws IOException {
     String testFile = PathUtils.concatPath(mUnderfsAddress, "createAtomic");
-    OutputStream stream = mUfs.create(testFile);
+    OutputStream stream = mUfs.create(testFile, CreateOptions.defaults().setEnsureAtomic(true));
     stream.write(TEST_BYTES);
     Assert.assertFalse(mUfs.isFile(testFile));
     stream.close();


### PR DESCRIPTION
@aaudiber This fixes the failed contract test for the tutorial extension base on local ufs.

@calvinjia 