### PR TITLE
[SMALLFIX] Reduce thread usage in BlockMasterSync

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -240,6 +240,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
           synchronized (mRemovingBlockIdToFinished) {
             mRemovingBlockIdToFinished.put(block, true);
           }
+          LOG.debug("Removed block {} due to request from master", block);
           continue;
         } catch (IOException e) {
           LOG.warn("Failed master free block cmd for: {}.", block, e);
@@ -250,7 +251,9 @@ public final class BlockMasterSync implements HeartbeatExecutor {
         }
         // The remove operation fails, so remove the block from the map in order to make it
         // possible for another BlockRemover to remove it later.
-        mRemovingBlockIdToFinished.remove(block);
+        synchronized (mRemovingBlockIdToFinished) {
+          mRemovingBlockIdToFinished.remove(block);
+        }
       }
     }
   }


### PR DESCRIPTION
Before we would execute one executor task per block. Now we will perform at most one task per heartbeat. This could be relevant if hundreds of blocks are freed during a single heartbeat.