### PR TITLE
[SMALLFIX] Ignore several site properties set by user

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,7 +52,7 @@ ensure_dirs() {
     echo "ALLUXIO_LOGS_DIR: ${ALLUXIO_LOGS_DIR}"
     mkdir -p ${ALLUXIO_LOGS_DIR}
   fi
-  if [[ "${alluxio_remote_logging_enabled}" == "true" && ! -d "${ALLUXIO_LOGSERVER_LOGS_DIR}" ]]; then
+  if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" && ! -d "${ALLUXIO_LOGSERVER_LOGS_DIR}" ]]; then
     echo "ALLUXIO_LOGSERVER_LOGS_DIR: ${ALLUXIO_LOGSERVER_LOGS_DIR}"
     mkdir -p ${ALLUXIO_LOGSERVER_LOGS_DIR}
   fi
@@ -313,7 +313,7 @@ main() {
         stop all
         sleep 1
       fi
-      if [[ "${alluxio_remote_logging_enabled}" == "true" ]]; then
+      if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
           start_logserver
       fi
       start_masters "${FORMAT}"
@@ -326,7 +326,7 @@ main() {
         stop local
         sleep 1
       fi
-      if [[ "${alluxio_remote_logging_enabled}" == "true" ]]; then
+      if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
           start_logserver
       fi
       start_master "${FORMAT}"

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -52,10 +52,6 @@ ensure_dirs() {
     echo "ALLUXIO_LOGS_DIR: ${ALLUXIO_LOGS_DIR}"
     mkdir -p ${ALLUXIO_LOGS_DIR}
   fi
-  if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" && ! -d "${ALLUXIO_LOGSERVER_LOGS_DIR}" ]]; then
-    echo "ALLUXIO_LOGSERVER_LOGS_DIR: ${ALLUXIO_LOGSERVER_LOGS_DIR}"
-    mkdir -p ${ALLUXIO_LOGSERVER_LOGS_DIR}
-  fi
 }
 
 get_env() {
@@ -142,6 +138,11 @@ stop() {
 }
 
 start_logserver() {
+    if [[ ! -d "${ALLUXIO_LOGSERVER_LOGS_DIR}" ]]; then
+        echo "ALLUXIO_LOGSERVER_LOGS_DIR: ${ALLUXIO_LOGSERVER_LOGS_DIR}"
+        mkdir -p ${ALLUXIO_LOGSERVER_LOGS_DIR}
+    fi
+
     echo "Starting logserver @ $(hostname -f)."
     (nohup "${JAVA}" -cp ${CLASSPATH} \
      ${ALLUXIO_LOGSERVER_JAVA_OPTS} \
@@ -313,9 +314,6 @@ main() {
         stop all
         sleep 1
       fi
-      if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
-          start_logserver
-      fi
       start_masters "${FORMAT}"
       sleep 2
       start_workers "${MOPT}"
@@ -325,9 +323,6 @@ main() {
       if [[ "${killonstart}" != "no" ]]; then
         stop local
         sleep 1
-      fi
-      if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
-          start_logserver
       fi
       start_master "${FORMAT}"
       ALLUXIO_MASTER_SECONDARY=true

--- a/bin/alluxio-stop.sh
+++ b/bin/alluxio-stop.sh
@@ -71,7 +71,6 @@ case "${WHAT}" in
     stop_proxies
     stop_workers
     stop_masters
-    stop_logserver
     ;;
   local)
     stop_proxy
@@ -80,7 +79,6 @@ case "${WHAT}" in
     stop_master
     ALLUXIO_MASTER_SECONDARY=false
     stop_master
-    stop_logserver
     ;;
   master)
     stop_master

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -179,7 +179,7 @@ public final class Configuration {
    * Iterates a set of site properties and discards those that user should not use.
    *
    * @param siteProperties the set of site properties to check
-     */
+   */
   public static void discardIgnoredSiteProperties(Map<?, ?> siteProperties) {
     if (siteProperties != null) {
       Iterator<? extends Map.Entry<?, ?>> iter = siteProperties.entrySet().iterator();
@@ -190,10 +190,10 @@ public final class Configuration {
           PropertyKey propertyKey = PropertyKey.fromString(key);
           if (propertyKey.isIgnoredSiteProperty()) {
             iter.remove();
-            LOG.warn("Site property '{}' is deprecated. Its value '{}' will be ignored. "
-                + "Use corresponding system properties, JVM properties and environment variables "
-                + "instead. Otherwise, Alluxio will use default value '{}'",
-                key, entry.getValue(), propertyKey.getDefaultValue());
+            LOG.warn("{} is not accepted in alluxio-site.properties, "
+                + "and must be specified as a JVM property. "
+                + "If no JVM property is present, Alluxio will use default value '{}'.",
+                key, propertyKey.getDefaultValue());
           }
         }
       }

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -180,21 +180,19 @@ public final class Configuration {
    *
    * @param siteProperties the set of site properties to check
    */
-  public static void discardIgnoredSiteProperties(Map<?, ?> siteProperties) {
-    if (siteProperties != null) {
-      Iterator<? extends Map.Entry<?, ?>> iter = siteProperties.entrySet().iterator();
-      while (iter.hasNext()) {
-        Map.Entry<?, ?> entry  = iter.next();
-        String key = entry.getKey().toString();
-        if (PropertyKey.isValid(key)) {
-          PropertyKey propertyKey = PropertyKey.fromString(key);
-          if (propertyKey.isIgnoredSiteProperty()) {
-            iter.remove();
-            LOG.warn("{} is not accepted in alluxio-site.properties, "
-                + "and must be specified as a JVM property. "
-                + "If no JVM property is present, Alluxio will use default value '{}'.",
-                key, propertyKey.getDefaultValue());
-          }
+  private static void discardIgnoredSiteProperties(Map<?, ?> siteProperties) {
+    Iterator<? extends Map.Entry<?, ?>> iter = siteProperties.entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<?, ?> entry  = iter.next();
+      String key = entry.getKey().toString();
+      if (PropertyKey.isValid(key)) {
+        PropertyKey propertyKey = PropertyKey.fromString(key);
+        if (propertyKey.isIgnoredSiteProperty()) {
+          iter.remove();
+          LOG.warn("{} is not accepted in alluxio-site.properties, "
+              + "and must be specified as a JVM property. "
+              + "If no JVM property is present, Alluxio will use default value '{}'.",
+              key, propertyKey.getDefaultValue());
         }
       }
     }

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -104,7 +104,7 @@ public final class Configuration {
           ConfigurationUtils.searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
       // Update site properties and system properties in order
       if (siteProps != null) {
-        merge(siteProps);
+        mergeSiteProperties(siteProps);
         merge(systemProps);
       }
     }
@@ -171,6 +171,30 @@ public final class Configuration {
       }
     }
     checkUserFileBufferBytes();
+  }
+
+  /**
+   * Merges the current configuration properties with site properties. Some site properties, e.g.
+   * alluxio.logs.dir, alluxio.conf.dir, alluxio.site.conf.dir are ignored.
+   *
+   * @param siteProperties The {@link Properties} to be merged
+     */
+  public static void mergeSiteProperties(Map<?, ?> siteProperties) {
+    if (siteProperties != null) {
+      for (Map.Entry<?, ?> entry : siteProperties.entrySet()) {
+        String key = entry.getKey().toString();
+        String value = entry.getValue().toString();
+        if (PropertyKey.isValid(key)) {
+          PropertyKey propertyKey = PropertyKey.fromString(key);
+          if (!propertyKey.isIgnoredSiteProperty()) {
+            PROPERTIES.put(propertyKey.getName(), value);
+          } else {
+            LOG.info("{} should not be set using site property, its value here will be ignored. "
+                + "Use system property or JVM property or environmental variable instead.", key);
+          }
+        }
+      }
+    }
   }
 
   // Public accessor methods

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -194,12 +194,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("(Experimental) The largest allowable frame size used for Thrift "
               + "RPC communication.")
           .build();
-  public static final PropertyKey REMOTE_LOGGING_ENABLED =
-      new Builder(Name.REMOTE_LOGGING_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("Set to true to enable writing logs to a server.")
-          .setIgnoredSiteProperty(true)
-          .build();
   public static final PropertyKey SITE_CONF_DIR =
       new Builder(Name.SITE_CONF_DIR)
           .setDefaultValue(
@@ -1921,7 +1915,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.network.netty.heartbeat.timeout";
     public static final String NETWORK_THRIFT_FRAME_SIZE_BYTES_MAX =
         "alluxio.network.thrift.frame.size.bytes.max";
-    public static final String REMOTE_LOGGING_ENABLED = "alluxio.remote.logging.enabled";
     public static final String SITE_CONF_DIR = "alluxio.site.conf.dir";
     public static final String TEST_MODE = "alluxio.test.mode";
     public static final String VERSION = "alluxio.version";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -198,6 +198,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.REMOTE_LOGGING_ENABLED)
           .setDefaultValue(false)
           .setDescription("Set to true to enable writing logs to a server.")
+          .setIgnoredSiteProperty(true)
           .build();
   public static final PropertyKey SITE_CONF_DIR =
       new Builder(Name.SITE_CONF_DIR)
@@ -549,6 +550,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.MASTER_AUDIT_LOGGING_ENABLED)
           .setDefaultValue(false)
           .setDescription("Set to true to enable file system master audit.")
+          .setIgnoredSiteProperty(true)
           .build();
   public static final PropertyKey MASTER_AUDIT_LOGGING_QUEUE_CAPACITY =
       new Builder(Name.MASTER_AUDIT_LOGGING_QUEUE_CAPACITY)
@@ -1304,15 +1306,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.LOGSERVER_LOGS_DIR)
           .setDefaultValue(String.format("${%s}/logs", Name.WORK_DIR))
           .setDescription("Default location for remote log files.")
+          .setIgnoredSiteProperty(true)
           .build();
   public static final PropertyKey LOGSERVER_HOSTNAME =
       new Builder(Name.LOGSERVER_HOSTNAME)
           .setDescription("The hostname of Alluxio logserver.")
+          .setIgnoredSiteProperty(true)
           .build();
   public static final PropertyKey LOGSERVER_PORT =
       new Builder(Name.LOGSERVER_PORT)
           .setDefaultValue(45600)
           .setDescription("Default port number to receive logs from alluxio servers.")
+          .setIgnoredSiteProperty(true)
           .build();
   public static final PropertyKey LOGSERVER_THREADS_MAX =
       new Builder(Name.LOGSERVER_THREADS_MAX)

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -2478,6 +2478,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * @param description String description of this property key
    * @param defaultValue default value
    * @param aliases alias of this property key
+   * @param ignoredSiteProperty true if Alluxio ignores user-specified value for this property
+   *                            in site properties file
    */
   private PropertyKey(String name, String description, Object defaultValue, String[] aliases,
       boolean ignoredSiteProperty) {
@@ -2504,6 +2506,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * @param defaultValue Default value of this property in compile time if not null
    * @param aliases String list of aliases of this property
    * @param description String description of this property key
+   * @param ignoredSiteProperty true if Alluxio ignores user-specified value for this property
+   *                            in the site properties file
    */
   static PropertyKey create(String name, Object defaultValue, String[] aliases,
       String description, boolean ignoredSiteProperty) {

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -12,6 +12,7 @@
 package alluxio;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -509,20 +510,19 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void discardIgnoredSitePropertiesTest() throws Exception {
+  public void discardIgnoredSiteProperties() throws Exception {
     Properties siteProps = new Properties();
     siteProps.setProperty(PropertyKey.MASTER_HOSTNAME.toString(), "host-1");
     siteProps.setProperty(PropertyKey.LOGS_DIR.toString(), "/tmp/logs1");
     File propsFile = mFolder.newFile(Constants.SITE_PROPERTIES);
     siteProps.store(new FileOutputStream(propsFile), "tmp site properties file");
     Map<String, String> sysProps = new HashMap<>();
-    sysProps.put(PropertyKey.LOGS_DIR.toString(), "/tmp/logs2");
     sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getAbsolutePath());
     sysProps.put(PropertyKey.TEST_MODE.toString(), "false");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
       Configuration.init();
       assertEquals("host-1", Configuration.get(PropertyKey.MASTER_HOSTNAME));
-      assertEquals("/tmp/logs2", Configuration.get(PropertyKey.LOGS_DIR));
+      assertNotEquals("/tmp/logs1", Configuration.get(PropertyKey.LOGS_DIR));
     }
   }
 }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -513,12 +513,14 @@ public class ConfigurationTest {
     Properties siteProps = new Properties();
     siteProps.setProperty(PropertyKey.MASTER_HOSTNAME.toString(), "host-1");
     siteProps.setProperty(PropertyKey.LOGS_DIR.toString(), "/tmp/logs1");
+    File propsFile = mFolder.newFile(Constants.SITE_PROPERTIES);
+    siteProps.store(new FileOutputStream(propsFile), "tmp site properties file");
     Map<String, String> sysProps = new HashMap<>();
     sysProps.put(PropertyKey.LOGS_DIR.toString(), "/tmp/logs2");
+    sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getAbsolutePath());
+    sysProps.put(PropertyKey.TEST_MODE.toString(), "false");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      Configuration.discardIgnoredSiteProperties(siteProps);
-      Configuration.merge(siteProps);
-      Configuration.merge(sysProps);
+      Configuration.init();
       assertEquals("host-1", Configuration.get(PropertyKey.MASTER_HOSTNAME));
       assertEquals("/tmp/logs2", Configuration.get(PropertyKey.LOGS_DIR));
     }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -507,4 +507,20 @@ public class ConfigurationTest {
       assertEquals("TEST_LOGGER", Configuration.get(PropertyKey.LOGGER_TYPE));
     }
   }
+
+  @Test
+  public void discardIgnoredSitePropertiesTest() throws Exception {
+    Properties siteProps = new Properties();
+    siteProps.setProperty(PropertyKey.MASTER_HOSTNAME.toString(), "host-1");
+    siteProps.setProperty(PropertyKey.LOGS_DIR.toString(), "/tmp/logs1");
+    Map<String, String> sysProps = new HashMap<>();
+    sysProps.put(PropertyKey.LOGS_DIR.toString(), "/tmp/logs2");
+    try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
+      Configuration.discardIgnoredSiteProperties(siteProps);
+      Configuration.merge(siteProps);
+      Configuration.merge(sysProps);
+      assertEquals("host-1", Configuration.get(PropertyKey.MASTER_HOSTNAME));
+      assertEquals("/tmp/logs2", Configuration.get(PropertyKey.LOGS_DIR));
+    }
+  }
 }

--- a/core/common/src/test/java/alluxio/PropertyKeyTest.java
+++ b/core/common/src/test/java/alluxio/PropertyKeyTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 public final class PropertyKeyTest {
 
   private PropertyKey mTestProperty = PropertyKey.create("alluxio.test.property", false,
-       new String[] {"alluxio.test.property.alias1", "alluxio.test.property.alias2"}, "test");
+       new String[] {"alluxio.test.property.alias1", "alluxio.test.property.alias2"}, "test",
+       false);
 
   /**
    * Tests parsing string to PropertyKey by {@link PropertyKey#fromString}.

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -27,7 +27,6 @@ alluxio.proxy.stream.cache.timeout,1hour
 alluxio.proxy.web.bind.host,0.0.0.0
 alluxio.proxy.web.hostname,
 alluxio.proxy.web.port,39999
-alluxio.remote.logging.enabled,false
 alluxio.site.conf.dir,${alluxio.conf.dir}/,${user.home}/.alluxio/,/etc/alluxio/
 alluxio.test.mode,false
 alluxio.underfs.address,${alluxio.work.dir}/underFSStorage

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -21,6 +21,7 @@ alluxio.network.host.resolution.timeout,5sec
 alluxio.network.netty.heartbeat.timeout,30sec
 alluxio.network.thrift.frame.size.bytes.max,16MB
 alluxio.proxy.s3.deletetype,ALLUXIO_AND_UFS
+alluxio.proxy.s3.multipart.temporary.dir.suffix,_s3_multipart_tmp
 alluxio.proxy.s3.writetype,CACHE_THROUGH
 alluxio.proxy.stream.cache.timeout,1hour
 alluxio.proxy.web.bind.host,0.0.0.0
@@ -48,7 +49,6 @@ alluxio.underfs.s3.disable.dns.buckets,false
 alluxio.underfs.s3.endpoint,
 alluxio.underfs.s3.owner.id.to.username.mapping,
 alluxio.underfs.s3.proxy.host,
-alluxio.underfs.s3.proxy.https.only,true
 alluxio.underfs.s3.proxy.port,
 alluxio.underfs.s3.threads.max,40
 alluxio.underfs.s3.upload.threads.max,20

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -54,8 +54,6 @@ alluxio.proxy.web.hostname:
   'The hostname Alluxio proxy''s web UI binds to.'
 alluxio.proxy.web.port:
   'The port Alluxio proxy''s web UI runs on.'
-alluxio.remote.logging.enabled:
-  'Set to true to enable writing logs to a server. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.site.conf.dir:
   'Comma-separated search path for alluxio-site.properties. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.test.mode:

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.conf.dir:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The directory containing files used to configure Alluxio.'
+  'The directory containing files used to configure Alluxio. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.debug:
   'Set to true to enable debug mode which has additional logging and info in the Web UI.'
 alluxio.extensions.dir:
@@ -21,13 +21,13 @@ alluxio.home:
 alluxio.logger.type:
   'The type of logger.'
 alluxio.logs.dir:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The path to store log files.'
+  'The path to store log files. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.logserver.hostname:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The hostname of Alluxio logserver.'
+  'The hostname of Alluxio logserver. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.logserver.logs.dir:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Default location for remote log files.'
+  'Default location for remote log files. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.logserver.port:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Default port number to receive logs from alluxio servers.'
+  'Default port number to receive logs from alluxio servers. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.logserver.threads.max:
   'The maximum number of threads used by logserver to service logging requests.'
 alluxio.logserver.threads.min:
@@ -55,9 +55,9 @@ alluxio.proxy.web.hostname:
 alluxio.proxy.web.port:
   'The port Alluxio proxy''s web UI runs on.'
 alluxio.remote.logging.enabled:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Set to true to enable writing logs to a server.'
+  'Set to true to enable writing logs to a server. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.site.conf.dir:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Comma-separated search path for alluxio-site.properties.'
+  'Comma-separated search path for alluxio-site.properties. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.test.mode:
   'Flag used only during tests to allow special behavior.'
 alluxio.underfs.address:

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.conf.dir:
-  'The directory containing files used to configure Alluxio.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The directory containing files used to configure Alluxio.'
 alluxio.debug:
   'Set to true to enable debug mode which has additional logging and info in the Web UI.'
 alluxio.extensions.dir:
@@ -21,13 +21,13 @@ alluxio.home:
 alluxio.logger.type:
   'The type of logger.'
 alluxio.logs.dir:
-  'The path to store log files.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The path to store log files.'
 alluxio.logserver.hostname:
-  'The hostname of Alluxio logserver.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The hostname of Alluxio logserver.'
 alluxio.logserver.logs.dir:
-  'Default location for remote log files.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Default location for remote log files.'
 alluxio.logserver.port:
-  'Default port number to receive logs from alluxio servers.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Default port number to receive logs from alluxio servers.'
 alluxio.logserver.threads.max:
   'The maximum number of threads used by logserver to service logging requests.'
 alluxio.logserver.threads.min:
@@ -42,6 +42,8 @@ alluxio.network.thrift.frame.size.bytes.max:
   '(Experimental) The largest allowable frame size used for Thrift RPC communication.'
 alluxio.proxy.s3.deletetype:
   'Delete type when deleting buckets and objects through S3 API. Valid options are `ALLUXIO_AND_UFS` (delete both in Alluxio and UFS), `ALLUXIO_ONLY` (delete only the buckets or objects in Alluxio namespace).'
+alluxio.proxy.s3.multipart.temporary.dir.suffix:
+  'Suffix for the directory which holds parts during a multipart upload.'
 alluxio.proxy.s3.writetype:
   'Write type when creating buckets and objects through S3 API. Valid options are `MUST_CACHE` (write will only go to Alluxio and must be stored in Alluxio), `CACHE_THROUGH` (try to cache, write to UnderFS synchronously), `THROUGH` (no cache, write to UnderFS synchronously).'
 alluxio.proxy.stream.cache.timeout:
@@ -53,9 +55,9 @@ alluxio.proxy.web.hostname:
 alluxio.proxy.web.port:
   'The port Alluxio proxy''s web UI runs on.'
 alluxio.remote.logging.enabled:
-  'Set to true to enable writing logs to a server.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Set to true to enable writing logs to a server.'
 alluxio.site.conf.dir:
-  'Comma-separated search path for alluxio-site.properties.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Comma-separated search path for alluxio-site.properties.'
 alluxio.test.mode:
   'Flag used only during tests to allow special behavior.'
 alluxio.underfs.address:
@@ -96,8 +98,6 @@ alluxio.underfs.s3.owner.id.to.username.mapping:
   'Optionally, specify a preset s3 canonical id to Alluxio username static mapping, in the format "id1=user1;id2=user2". The AWS S3 canonical ID can be found at the console address https://console.aws.amazon.com/iam/home?#security_credential . Please expand the "Account Identifiers" tab and refer to "Canonical User ID".'
 alluxio.underfs.s3.proxy.host:
   'Optionally, specify a proxy host for communicating with S3.'
-alluxio.underfs.s3.proxy.https.only:
-  'If using a proxy to communicate with S3, determine whether to talk to the proxy using https.'
 alluxio.underfs.s3.proxy.port:
   'Optionally, specify a proxy port for communicating with S3.'
 alluxio.underfs.s3.threads.max:

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.conf.dir:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The directory containing files used to configure Alluxio.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The directory containing files used to configure Alluxio.'
 alluxio.debug:
   'Set to true to enable debug mode which has additional logging and info in the Web UI.'
 alluxio.extensions.dir:
@@ -21,13 +21,13 @@ alluxio.home:
 alluxio.logger.type:
   'The type of logger.'
 alluxio.logs.dir:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The path to store log files.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The path to store log files.'
 alluxio.logserver.hostname:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) The hostname of Alluxio logserver.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. The hostname of Alluxio logserver.'
 alluxio.logserver.logs.dir:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Default location for remote log files.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Default location for remote log files.'
 alluxio.logserver.port:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Default port number to receive logs from alluxio servers.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Default port number to receive logs from alluxio servers.'
 alluxio.logserver.threads.max:
   'The maximum number of threads used by logserver to service logging requests.'
 alluxio.logserver.threads.min:
@@ -55,9 +55,9 @@ alluxio.proxy.web.hostname:
 alluxio.proxy.web.port:
   'The port Alluxio proxy''s web UI runs on.'
 alluxio.remote.logging.enabled:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Set to true to enable writing logs to a server.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Set to true to enable writing logs to a server.'
 alluxio.site.conf.dir:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Comma-separated search path for alluxio-site.properties.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Comma-separated search path for alluxio-site.properties.'
 alluxio.test.mode:
   'Flag used only during tests to allow special behavior.'
 alluxio.underfs.address:

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.master.audit.logging.enabled:
-  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Set to true to enable file system master audit.'
+  'Set to true to enable file system master audit. Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties.'
 alluxio.master.audit.logging.queue.capacity:
   'Capacity of the queue used by audit logging.'
 alluxio.master.bind.host:

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.master.audit.logging.enabled:
-  'Set to true to enable file system master audit.'
+  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Set to true to enable file system master audit.'
 alluxio.master.audit.logging.queue.capacity:
   'Capacity of the queue used by audit logging.'
 alluxio.master.bind.host:

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -1,5 +1,5 @@
 alluxio.master.audit.logging.enabled:
-  '(Alluxio ignores the value you specify for this property in alluxio-site.properties. Use system or JVM properties.) Set to true to enable file system master audit.'
+  'Note: This property must be specified as a JVM property; it is not accepted in alluxio-site.properties. Set to true to enable file system master audit.'
 alluxio.master.audit.logging.queue.capacity:
   'Capacity of the queue used by audit logging.'
 alluxio.master.bind.host:

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -96,10 +96,6 @@ ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_MASTER_LOGGER:-MASTE
 if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" && -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_MASTER_LOGGER"
 fi
-if [[ "${ALLUXIO_MASTER_AUDIT_LOGGING_ENABLED}" == "true" ]]; then
-    ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.master.audit.logging.enabled=true"
-    ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.master.audit.logger.type=${ALLUXIO_MASTER_AUDIT_LOGGER:-MASTER_AUDIT_LOGGER}"
-fi
 
 # Secondary master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -32,6 +32,7 @@ ALLUXIO_HOME=$(dirname $(dirname "${this}"))
 ALLUXIO_ASSEMBLY_CLIENT_JAR="${ALLUXIO_HOME}/assembly/client/target/alluxio-assembly-client-${VERSION}-jar-with-dependencies.jar"
 ALLUXIO_ASSEMBLY_SERVER_JAR="${ALLUXIO_HOME}/assembly/server/target/alluxio-assembly-server-${VERSION}-jar-with-dependencies.jar"
 ALLUXIO_CONF_DIR="${ALLUXIO_CONF_DIR:-${ALLUXIO_HOME}/conf}"
+ALLUXIO_LOGS_DIR="${ALLUXIO_LOGS_DIR:-${ALLUXIO_HOME}/logs}"
 
 if [[ -z "$(which java)" ]]; then
   echo "Cannot find the 'java' command."
@@ -55,11 +56,7 @@ if [[ -n "${ALLUXIO_HOME}" ]]; then
   ALLUXIO_JAVA_OPTS+=" -Dalluxio.home=${ALLUXIO_HOME}"
 fi
 
-ALLUXIO_JAVA_OPTS+=" -Dalluxio.conf.dir=${ALLUXIO_CONF_DIR}"
-
-if [[ -n "${ALLUXIO_LOGS_DIR}" ]]; then
-  ALLUXIO_JAVA_OPTS+=" -Dalluxio.logs.dir=${ALLUXIO_LOGS_DIR}"
-fi
+ALLUXIO_JAVA_OPTS+=" -Dalluxio.conf.dir=${ALLUXIO_CONF_DIR} -Dalluxio.logs.dir=${ALLUXIO_LOGS_DIR}"
 
 if [[ -n "${ALLUXIO_RAM_FOLDER}" ]]; then
   ALLUXIO_JAVA_OPTS+=" -Dalluxio.worker.tieredstore.level0.alias=MEM"
@@ -91,11 +88,6 @@ ALLUXIO_SERVER_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_AS
 function getConf {
   "${JAVA}" -cp ${ALLUXIO_CLIENT_CLASSPATH} ${ALLUXIO_JAVA_OPTS} alluxio.cli.GetConf "$1"
 }
-
-if [[ -z "${ALLUXIO_LOGS_DIR}" ]]; then
-  ALLUXIO_LOGS_DIR=$(getConf "alluxio.logs.dir")
-  ALLUXIO_JAVA_OPTS+=" -Dalluxio.logs.dir=${ALLUXIO_LOGS_DIR}"
-fi
 
 alluxio_remote_logging_enabled=$(getConf "alluxio.remote.logging.enabled")
 if [[ "${alluxio_remote_logging_enabled}" == "true" ]]; then

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -82,20 +82,18 @@ ALLUXIO_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
 ALLUXIO_CLIENT_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_ASSEMBLY_CLIENT_JAR}"
 ALLUXIO_SERVER_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_ASSEMBLY_SERVER_JAR}"
 
-if [[ ${ALLUXIO_REMOTE_LOGGING_ENABLED} == "true" ]]; then
-    ALLUXIO_LOGSERVER_LOGS_DIR="${ALLUXIO_LOGSERVER_LOGS_DIR:-${ALLUXIO_HOME}/logs}"
-    if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" ]]; then
-        ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.hostname=${ALLUXIO_LOGSERVER_HOSTNAME}"
-    fi
-    if [[ -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
-        ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.port=${ALLUXIO_LOGSERVER_PORT}"
-    fi
+ALLUXIO_LOGSERVER_LOGS_DIR="${ALLUXIO_LOGSERVER_LOGS_DIR:-${ALLUXIO_HOME}/logs}"
+if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" ]]; then
+    ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.hostname=${ALLUXIO_LOGSERVER_HOSTNAME}"
+fi
+if [[ -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
+    ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.port=${ALLUXIO_LOGSERVER_PORT}"
 fi
 
 # Master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_MASTER_LOGGER:-MASTER_LOGGER}"
-if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
+if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" && -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_MASTER_LOGGER"
 fi
 if [[ "${ALLUXIO_MASTER_AUDIT_LOGGING_ENABLED}" == "true" ]]; then
@@ -106,21 +104,21 @@ fi
 # Secondary master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_SECONDARY_MASTER_LOGGER:-SECONDARY_MASTER_LOGGER}"
-if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
+if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" && -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_SECONDARY_MASTER_LOGGER"
 fi
 
 # Proxy specific parameters that will be shared to all workers based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_PROXY_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_PROXY_LOGGER:-PROXY_LOGGER}"
-if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
+if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" && -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
     ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_PROXY_LOGGER"
 fi
 
 # Worker specific parameters that will be shared to all workers based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_WORKER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_WORKER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_WORKER_LOGGER:-WORKER_LOGGER}"
-if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
+if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" && -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_WORKER_LOGGER"
 fi
 

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -82,52 +82,45 @@ ALLUXIO_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
 ALLUXIO_CLIENT_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_ASSEMBLY_CLIENT_JAR}"
 ALLUXIO_SERVER_CLASSPATH="${ALLUXIO_CONF_DIR}/:${ALLUXIO_CLASSPATH}:${ALLUXIO_ASSEMBLY_SERVER_JAR}"
 
-####################################################################################################
-## Start reading site-properties to set certain variables.
-####################################################################################################
-function getConf {
-  "${JAVA}" -cp ${ALLUXIO_CLIENT_CLASSPATH} ${ALLUXIO_JAVA_OPTS} alluxio.cli.GetConf "$1"
-}
-
-alluxio_remote_logging_enabled=$(getConf "alluxio.remote.logging.enabled")
-if [[ "${alluxio_remote_logging_enabled}" == "true" ]]; then
-    ALLUXIO_LOGSERVER_LOGS_DIR=$(getConf "alluxio.logserver.logs.dir")
-    ALLUXIO_LOGSERVER_HOSTNAME=$(getConf "alluxio.logserver.hostname")
-    ALLUXIO_LOGSERVER_PORT=$(getConf "alluxio.logserver.port")
-    ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.hostname=${ALLUXIO_LOGSERVER_HOSTNAME} -Dalluxio.logserver.port=${ALLUXIO_LOGSERVER_PORT}"
+if [[ ${ALLUXIO_REMOTE_LOGGING_ENABLED} == "true" ]]; then
+    ALLUXIO_LOGSERVER_LOGS_DIR="${ALLUXIO_LOGSERVER_LOGS_DIR:-${ALLUXIO_HOME}/logs}"
+    if [[ -n "${ALLUXIO_LOGSERVER_HOSTNAME}" ]]; then
+        ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.hostname=${ALLUXIO_LOGSERVER_HOSTNAME}"
+    fi
+    if [[ -n "${ALLUXIO_LOGSERVER_PORT}" ]]; then
+        ALLUXIO_JAVA_OPTS+=" -Dalluxio.logserver.port=${ALLUXIO_LOGSERVER_PORT}"
+    fi
 fi
-####################################################################################################
-## End reading site-properties
-####################################################################################################
 
 # Master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_MASTER_LOGGER:-MASTER_LOGGER}"
-if [[ ${alluxio_remote_logging_enabled} == "true" ]]; then
+if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_MASTER_LOGGER"
 fi
-if [[ "$(getConf "alluxio.master.audit.logging.enabled")" == "true" ]]; then
+if [[ "${ALLUXIO_MASTER_AUDIT_LOGGING_ENABLED}" == "true" ]]; then
+    ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.master.audit.logging.enabled=true"
     ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.master.audit.logger.type=${ALLUXIO_MASTER_AUDIT_LOGGER:-MASTER_AUDIT_LOGGER}"
 fi
 
 # Secondary master specific parameters based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_SECONDARY_MASTER_LOGGER:-SECONDARY_MASTER_LOGGER}"
-if [[ ${alluxio_remote_logging_enabled} == "true" ]]; then
+if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_SECONDARY_MASTER_LOGGER"
 fi
 
 # Proxy specific parameters that will be shared to all workers based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_PROXY_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_PROXY_LOGGER:-PROXY_LOGGER}"
-if [[ ${alluxio_remote_logging_enabled} == "true" ]]; then
+if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
     ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_PROXY_LOGGER"
 fi
 
 # Worker specific parameters that will be shared to all workers based on ALLUXIO_JAVA_OPTS.
 ALLUXIO_WORKER_JAVA_OPTS+=${ALLUXIO_JAVA_OPTS}
 ALLUXIO_WORKER_JAVA_OPTS+=" -Dalluxio.logger.type=${ALLUXIO_WORKER_LOGGER:-WORKER_LOGGER}"
-if [[ ${alluxio_remote_logging_enabled} == "true" ]]; then
+if [[ "${ALLUXIO_REMOTE_LOGGING_ENABLED}" == "true" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Dalluxio.remote.logger.type=REMOTE_WORKER_LOGGER"
 fi
 

--- a/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
@@ -164,6 +164,10 @@ public final class ConfigurationDocGenerator {
         String description = iteratorPK.getDescription().replace("'", "''");
 
         // Write property key and default value to yml files
+        if (iteratorPK.isIgnoredSiteProperty()) {
+          description = "(Alluxio ignores the value you specify for this property "
+              + "in alluxio-site.properties. Use system or JVM properties.) " + description;
+        }
         String keyValueStr = pKey + ":\n  '" + description + "'\n";
         if (pKey.startsWith("alluxio.user.")) {
           fileWriter = fileWriterMap.get("user");

--- a/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
@@ -165,8 +165,8 @@ public final class ConfigurationDocGenerator {
 
         // Write property key and default value to yml files
         if (iteratorPK.isIgnoredSiteProperty()) {
-          description = "Note: This property must be specified as a JVM property; "
-              + "it is not accepted in alluxio-site.properties. " + description;
+          description += " Note: This property must be specified as a JVM property; "
+              + "it is not accepted in alluxio-site.properties.";
         }
         String keyValueStr = pKey + ":\n  '" + description + "'\n";
         if (pKey.startsWith("alluxio.user.")) {

--- a/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/ConfigurationDocGenerator.java
@@ -165,8 +165,8 @@ public final class ConfigurationDocGenerator {
 
         // Write property key and default value to yml files
         if (iteratorPK.isIgnoredSiteProperty()) {
-          description = "(Alluxio ignores the value you specify for this property "
-              + "in alluxio-site.properties. Use system or JVM properties.) " + description;
+          description = "Note: This property must be specified as a JVM property; "
+              + "it is not accepted in alluxio-site.properties. " + description;
         }
         String keyValueStr = pKey + ":\n  '" + description + "'\n";
         if (pKey.startsWith("alluxio.user.")) {


### PR DESCRIPTION
@apc999 @aaudiber 
With this PR, Alluxio will ignore the user-specified values for certain properties in the alluxio-site.properties file. Instead user should use system or JVM properties for them.
Could you take a look and give some feedback? Thanks!
I will clean up unused code later if we decide to take the current approach proposed in this PR.