### PR TITLE
[SMALLFIX] No partial caching when no local worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
- * "License"). You may not use this work except in compliance with the License, which is available
- * at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -314,9 +314,8 @@ public class FileInStream extends InputStream
 
   /**
    * @return if the partially-read block should be cached to the local worker
-   * @throws IOException
    */
-  private boolean shouldCachePartiallyReadBlock() throws IOException {
+  private boolean shouldCachePartiallyReadBlock() {
     return mShouldCache && mCachePartiallyReadBlock;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -192,7 +192,7 @@ public class FileInStream extends InputStream
       return -1;
     }
 
-    mPos ++;
+    mPos++;
     if (mCurrentCacheStream != null) {
       try {
         mCurrentCacheStream.write(data);
@@ -612,8 +612,9 @@ public class FileInStream extends InputStream
    *
    * The behavior on the target block:
    * <ol>
-   * <li>If the target block is already available in the local worker, then the caching on the
-   * target block is not needed. Directly move the position to the seek position.</li>
+   * <li>If the target block is already available in the local worker or it's from remote worker but
+   * no local worker available, then the caching on the target block is not needed. Directly move
+   * the position to the seek position.</li>
    * <li>Otherwise data from the beginning of the block till the seek position needs to be read and
    * cached.</li>
    * </ol>

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
- * (the "License"). You may not use this work except in compliance with the License, which is
- * available at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.
@@ -54,8 +54,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @PublicApi
 @NotThreadSafe
-public class FileInStream extends InputStream implements BoundedStream, Seekable,
-    PositionedReadable {
+public class FileInStream extends InputStream
+    implements BoundedStream, Seekable, PositionedReadable {
   private static final Logger LOG = LoggerFactory.getLogger(FileInStream.class);
 
   private static final boolean PASSIVE_CACHE_ENABLED =
@@ -192,7 +192,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       return -1;
     }
 
-    mPos++;
+    mPos ++;
     if (mCurrentCacheStream != null) {
       try {
         mCurrentCacheStream.write(data);
@@ -317,7 +317,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    * @throws IOException
    */
   private boolean shouldCachePartiallyReadBlock() throws IOException {
-    return mShouldCache && mCachePartiallyReadBlock && mContext.getLocalWorker() != null;
+    return mShouldCache && mCachePartiallyReadBlock;
   }
 
   @Override
@@ -347,8 +347,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
   }
 
   /**
-   * If we are not in the last block or if the last block is equal to the normal block size,
-   * return the normal block size. Otherwise return the block size of the last block.
+   * If we are not in the last block or if the last block is equal to the normal block size, return
+   * the normal block size. Otherwise return the block size of the last block.
    *
    * @param pos the position to get the block size for
    * @return the size of the block that covers pos
@@ -432,14 +432,14 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    */
   private long getBlockId(long pos) {
     int index = (int) (pos / mBlockSize);
-    Preconditions
-        .checkState(index < mStatus.getBlockIds().size(), PreconditionMessage.ERR_BLOCK_INDEX);
+    Preconditions.checkState(index < mStatus.getBlockIds().size(),
+        PreconditionMessage.ERR_BLOCK_INDEX);
     return mStatus.getBlockIds().get(index);
   }
 
   /**
-   * Handles IO exceptions thrown in response to the worker cache request. Cache stream is closed
-   * or cancelled after logging some messages about the exceptions.
+   * Handles IO exceptions thrown in response to the worker cache request. Cache stream is closed or
+   * cancelled after logging some messages about the exceptions.
    *
    * @param e the exception to handle
    */
@@ -448,9 +448,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       // This can happen if there are two readers trying to cache the same block. The first one
       // created the block (either as temp block or committed block). The second sees this
       // exception.
-      LOG.info(
-          "The block with ID {} is already stored in the target worker, canceling the cache "
-              + "request.", getCurrentBlockId());
+      LOG.info("The block with ID {} is already stored in the target worker, canceling the cache "
+          + "request.", getCurrentBlockId());
     } else {
       LOG.warn("The block with ID {} could not be cached into Alluxio storage: {}",
           getCurrentBlockId(), e.toString());
@@ -460,11 +459,9 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
 
   /**
    * Only updates {@link #mCurrentCacheStream}, {@link #mCurrentBlockInStream} and
-   * {@link #mStreamBlockId} to be in sync with the current block (i.e.
-   * {@link #getCurrentBlockId()}).
-   * If this method is called multiple times, the subsequent invokes become no-op.
-   * Call this function every read and seek unless you are sure about the block streams are
-   * up-to-date.
+   * {@link #mStreamBlockId} to be in sync with the current block (i.e. {@link #getCurrentBlockId()}
+   * ). If this method is called multiple times, the subsequent invokes become no-op. Call this
+   * function every read and seek unless you are sure about the block streams are up-to-date.
    */
   private void updateStreams() throws IOException {
     long currentBlockId = getCurrentBlockId();
@@ -577,7 +574,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    * by {@link FileInStream#seek}.
    *
    * @param pos The position to seek to. It is guaranteed to be valid (pos >= 0 && pos != mPos &&
-   *            pos <= mFileLength)
+   *        pos <= mFileLength)
    */
   private void seekInternal(long pos) throws IOException {
     closeOrCancelCacheStream();
@@ -609,6 +606,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
    * current block, otherwise reads the rest of the current block.</li>
    * <li>However, a caveat is that if this is the first seek before any data is read from the file
    * and this seeks is outside the first block, then the first block should not be cached.</li>
+   * <li>Lastly, if the current block is from remote worker and there is no local worker then the
+   * caching is not needed</li>
    * </ol>
    *
    * The behavior on the target block:
@@ -628,9 +627,7 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     // Precompute this because mPos will be updated several times in this function.
     final boolean isInCurrentBlock = pos / mBlockSize == mPos / mBlockSize;
 
-    boolean readFromLocalWorker = mCurrentBlockInStream != null
-        && mCurrentBlockInStream.Source() == BlockInStreamSource.LOCAL;
-    if (isInCurrentBlock && readFromLocalWorker) {
+    if (isInCurrentBlock && isReadFromLocalWorker()) {
       // no need to partial cache the current block, and the seek is within the block
       // so directly seeks to position.
       mPos = pos;
@@ -647,9 +644,11 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     // cache the current block if neither of these conditions hold:
     // (1) this is the first seek before any read, and the seek is outside the first block
     // (2) the in stream reads from the local worker
+    // (3) the in stream reads from a remote worker but there is no local worker
     boolean firstSeekOutsideFirstBlock =
         mPos == 0 && mCurrentBlockInStream == null && !isInCurrentBlock;
-    if (!firstSeekOutsideFirstBlock && !readFromLocalWorker) {
+    if (!firstSeekOutsideFirstBlock && !isReadFromLocalWorker()
+        && !isRemoteReadButNoLocalWorker()) {
       // Make sure that mCurrentBlockInStream and mCurrentCacheStream is updated.
       // mPos is not updated here.
       updateStreams();
@@ -676,9 +675,10 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     // the seek is outside the current block, seek to the beginning of that block first
     mPos = pos / mBlockSize * mBlockSize;
     updateStreams();
-    if (mCurrentBlockInStream != null
-        && mCurrentBlockInStream.Source() != BlockInStreamSource.LOCAL) {
-      // cache till the seek position of the block unless it's already available in local worker
+    if (!isReadFromLocalWorker() && !isRemoteReadButNoLocalWorker()) {
+      // cache till the seek position of the block unless
+      // (1) the in stream reads from the local worker
+      // (2) the in stream reads from a remote worker but there is no local worker
       readCurrentBlockToPos(pos);
     } else if (mCurrentBlockInStream != null) {
       // otherwise directly seek to the position
@@ -686,6 +686,17 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     } else {
       Preconditions.checkState(remaining() == 0);
     }
+  }
+
+  private boolean isReadFromLocalWorker() {
+    return mCurrentBlockInStream != null
+        && mCurrentBlockInStream.Source() == BlockInStreamSource.LOCAL;
+  }
+
+  private boolean isRemoteReadButNoLocalWorker() throws IOException {
+    return mCurrentBlockInStream != null
+        && mCurrentBlockInStream.Source() == BlockInStreamSource.REMOTE
+        && mContext.getLocalWorker() == null;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -314,9 +314,10 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
 
   /**
    * @return if the partially-read block should be cached to the local worker
+   * @throws IOException
    */
-  private boolean shouldCachePartiallyReadBlock() {
-    return mShouldCache && mCachePartiallyReadBlock;
+  private boolean shouldCachePartiallyReadBlock() throws IOException {
+    return mShouldCache && mCachePartiallyReadBlock && mContext.getLocalWorker() != null;
   }
 
   @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -309,6 +309,27 @@ public final class FileInStreamTest {
     validatePartialCaching(2, (int) BLOCK_LENGTH);
   }
 
+  @Test
+  public void testSeekWithNoLocalWorker()  throws IOException{
+    // Overrides the get local worker call
+    PowerMockito.when(mContext.getLocalWorker()).thenReturn(null);
+    mTestStream = new FileInStream(mStatus,
+        InStreamOptions.defaults().setCachePartiallyReadBlock(true)
+            .setReadType(ReadType.CACHE_PROMOTE).setSeekBufferSizeBytes(7), mContext);
+    int readAmount = (int) (BLOCK_LENGTH / 2);
+    byte[] buffer = new byte[readAmount];
+    // read and seek several times
+    mTestStream.read(buffer);
+    Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
+    mTestStream.seek(BLOCK_LENGTH+1);
+    mTestStream.seek(0);
+
+    // check the read amount only
+    Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
+    // nothing is written to cache stream
+    Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
+  }
+
   /**
    * Tests seeking with incomplete block caching enabled. It seeks backward within 1 block.
    */

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -309,19 +309,22 @@ public final class FileInStreamTest {
     validatePartialCaching(2, (int) BLOCK_LENGTH);
   }
 
+  /**
+   * Tests reading and seeking with no local worker. Nothing should be cached.
+   */
   @Test
-  public void testSeekWithNoLocalWorker()  throws IOException{
+  public void testSeekWithNoLocalWorker() throws IOException {
     // Overrides the get local worker call
     PowerMockito.when(mContext.getLocalWorker()).thenReturn(null);
-    mTestStream = new FileInStream(mStatus,
-        InStreamOptions.defaults().setCachePartiallyReadBlock(true)
+    mTestStream =
+        new FileInStream(mStatus, InStreamOptions.defaults().setCachePartiallyReadBlock(true)
             .setReadType(ReadType.CACHE_PROMOTE).setSeekBufferSizeBytes(7), mContext);
     int readAmount = (int) (BLOCK_LENGTH / 2);
     byte[] buffer = new byte[readAmount];
     // read and seek several times
     mTestStream.read(buffer);
     Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
-    mTestStream.seek(BLOCK_LENGTH+1);
+    mTestStream.seek(BLOCK_LENGTH + 1);
     mTestStream.seek(0);
 
     // check the read amount only

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -324,11 +324,19 @@ public final class FileInStreamTest {
     // read and seek several times
     mTestStream.read(buffer);
     Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
-    mTestStream.seek(BLOCK_LENGTH + 1);
+    mTestStream.seek(BLOCK_LENGTH + BLOCK_LENGTH / 2);
     mTestStream.seek(0);
 
-    // check the read amount only
-    Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
+    if (mBlockSource == BlockInStreamSource.UFS) {
+      // reads the entire block to partial cache on the remote worker
+      Assert.assertEquals(BLOCK_LENGTH, mInStreams.get(0).getBytesRead());
+      Assert.assertEquals(BLOCK_LENGTH, mInStreams.get(1).getBytesRead());
+    } else {
+      // only reads the read amount
+      Assert.assertEquals(readAmount, mInStreams.get(0).getBytesRead());
+      Assert.assertEquals(0, mInStreams.get(1).getBytesRead());
+    }
+
     // nothing is written to cache stream
     Assert.assertEquals(0, mCacheStreams.get(0).getWrittenData().length);
   }


### PR DESCRIPTION
Partial caching should not be enabled when no local worker is available unless the block is from UFS.