### PR TITLE
[SMALLFIX] Fix mesos user configuration

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1851,7 +1851,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey INTEGRATION_MESOS_USER =
       new Builder(Name.INTEGRATION_MESOS_USER)
-          .setDescription("The Mesos user for the Alluxio Mesos Framework.")
+          .setDescription("The Mesos user for the Alluxio Mesos Framework. Defaults to the current "
+              + "user")
           .build();
   public static final PropertyKey INTEGRATION_WORKER_RESOURCE_CPU =
       new Builder(Name.INTEGRATION_WORKER_RESOURCE_CPU)

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioFramework.java
@@ -61,9 +61,11 @@ public class AlluxioFramework {
     if (Configuration.containsKey(PropertyKey.INTEGRATION_MESOS_ROLE)) {
       frameworkInfo.setRole(Configuration.get(PropertyKey.INTEGRATION_MESOS_ROLE));
     }
-    // Setting the user to an empty string will prompt Mesos to set it to the current user.
     if (Configuration.containsKey(PropertyKey.INTEGRATION_MESOS_USER)) {
       frameworkInfo.setUser(Configuration.get(PropertyKey.INTEGRATION_MESOS_USER));
+    } else {
+      // Setting the user to an empty string will prompt Mesos to set it to the current user.
+      frameworkInfo.setUser("");
     }
 
     if (Configuration.containsKey(PropertyKey.INTEGRATION_MESOS_PRINCIPAL)) {


### PR DESCRIPTION
During configuration refactoring we accidentally changed the default mesos user from empty string to `null`. The user field is required, so this caused the protobuf construction to fail.