### PR TITLE
[SMALLFIX] Move stream type logging to debug level

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -89,7 +89,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
         && !NettyUtils.isDomainSocketSupported(address)
         && blockSource == BlockInStreamSource.LOCAL) {
       try {
-        LOG.info("Creating short circuit input stream for block {} @ {}", blockId, address);
+        LOG.debug("Creating short circuit input stream for block {} @ {}", blockId, address);
         return createLocalBlockInStream(context, address, blockId, blockSize, options);
       } catch (NotFoundException e) {
         // Failed to do short circuit read because the block is not available in Alluxio.
@@ -103,7 +103,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
       builder.setOpenUfsBlockOptions(openUfsBlockOptions);
     }
 
-    LOG.info("Creating netty input stream for block {} @ {} from client {}", blockId, address,
+    LOG.debug("Creating netty input stream for block {} @ {} from client {}", blockId, address,
         NetworkAddressUtils.getClientHostName());
     return createNettyBlockInStream(context, address, blockSource, builder.buildPartial(),
         blockSize, options);


### PR DESCRIPTION
This logging happens every time the client opens a
stream. For random-read workloads especially, this can
cause excessive amounts of info-level logging.