### PR TITLE
[ALLUXIO-3015]update jets3t version from 0.8.1 to 0.9.4 to meet only signature v4 in cn-north-1 aws s3 region

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
         <version>0.4</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -253,8 +253,7 @@
       <dependency>
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
-        <version>0.4</version>
-        <optional>true</optional>
+        <version>1.1</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
       <dependency>
         <groupId>net.java.dev.jets3t</groupId>
         <artifactId>jets3t</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3015
update jets3t to 0.9.4 fix the problem alluxio can not mount aws s3 region cn-north-1 in china  , because jets3t version 0.8.1 do not support signature V4, AWS other regions support both signature V2 & V4 while cn-north-1 is a new region which only support signature V4. 