### PR TITLE
[SMALLFIX] LocalFilePacketReader fix

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFilePacketReader.java
@@ -59,7 +59,7 @@ public final class LocalFilePacketReader implements PacketReader {
     mReader = new LocalFileBlockReader(path);
     Preconditions.checkArgument(packetSize > 0);
     mPos = offset;
-    mEnd = offset + len;
+    mEnd = Math.min(mReader.getLength(), offset + len);
     mPacketSize = packetSize;
   }
 

--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -12,10 +12,10 @@
 package alluxio.client;
 
 import alluxio.AlluxioURI;
+import alluxio.BaseIntegrationTest;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
-import alluxio.BaseIntegrationTest;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
@@ -399,6 +399,22 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
       byte[] buf = new byte[8 * Constants.MB];
       while (in.read(buf) != -1) {
       }
+    }
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.USER_FILE_CACHE_PARTIALLY_READ_BLOCK, "false"})
+  public void positionedReadWithoutPartialCaching() throws Exception {
+    for (CreateFileOptions op : getOptionSet()) {
+      String filename = mTestPath + "/file_" + MIN_LEN + "_" + op.hashCode();
+      AlluxioURI uri = new AlluxioURI(filename);
+
+      FileInStream is = mFileSystem.openFile(uri, FileSystemTestUtils.toOpenFileOptions(op));
+      byte[] ret = new byte[DELTA - 1];
+      Assert.assertEquals(DELTA - 1, is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
+      is.close();
     }
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3017

Limit the end of the local file reader to be the file length, otherwise the reader may read outside the file.