### PR TITLE
[SMALLFIX] Move stream type logging to debug level

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -89,7 +89,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
         && !NettyUtils.isDomainSocketSupported(address)
         && blockSource == BlockInStreamSource.LOCAL) {
       try {
-        LOG.info("Creating short circuit input stream for block {} @ {}", blockId, address);
+        LOG.debug("Creating short circuit input stream for block {} @ {}", blockId, address);
         return createLocalBlockInStream(context, address, blockId, blockSize, options);
       } catch (NotFoundException e) {
         // Failed to do short circuit read because the block is not available in Alluxio.
@@ -103,7 +103,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
       builder.setOpenUfsBlockOptions(openUfsBlockOptions);
     }
 
-    LOG.info("Creating netty input stream for block {} @ {} from client {}", blockId, address,
+    LOG.debug("Creating netty input stream for block {} @ {} from client {}", blockId, address,
         NetworkAddressUtils.getClientHostName());
     return createNettyBlockInStream(context, address, blockSource, builder.buildPartial(),
         blockSize, options);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/PacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/PacketWriter.java
@@ -58,10 +58,10 @@ public interface PacketWriter extends Closeable, Cancelable {
       if (CommonUtils.isLocalHost(address) && Configuration
           .getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED) && !NettyUtils
           .isDomainSocketSupported(address)) {
-        LOG.info("Creating short circuit output stream for block {} @ {}", blockId, address);
+        LOG.debug("Creating short circuit output stream for block {} @ {}", blockId, address);
         return LocalFilePacketWriter.create(context, address, blockId, options);
       } else {
-        LOG.info("Creating netty output stream for block {} @ {} from client {}", blockId, address,
+        LOG.debug("Creating netty output stream for block {} @ {} from client {}", blockId, address,
             NetworkAddressUtils.getClientHostName());
         return NettyPacketWriter
             .create(context, address, blockId, blockSize, Protocol.RequestType.ALLUXIO_BLOCK,


### PR DESCRIPTION
When working with many small files, these log statements spam the logs. They can also impact the performance of random reads.