### PR TITLE
[SMALLFIX] Null check on worker address

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -147,6 +147,9 @@ public final class AlluxioBlockStore {
       address = blockLocationPolicy
           .getWorker(GetWorkerOptions.defaults().setBlockWorkerInfos(getWorkerInfoList())
               .setBlockId(blockId).setBlockSize(blockInfo.getLength()));
+      if (address == null) {
+        throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
+      }
     } else {
       // TODO(calvin): Get location via a policy.
       // Although blockInfo.locations are sorted by tier, we prefer reading from the local worker.

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/BlockLocationPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/BlockLocationPolicy.java
@@ -17,6 +17,8 @@ import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerNetAddress;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>
  * Interface for determining the Alluxio worker location to serve a block write or UFS block read.
@@ -68,5 +70,6 @@ public interface BlockLocationPolicy {
    * @param options the options to get a block worker network address for a block
    * @return the address of the worker to write to, null if no worker can be selected
    */
+  @Nullable
   WorkerNetAddress getWorker(GetWorkerOptions options);
 }

--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -417,8 +417,4 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
       is.close();
     }
   }
-
-  public void noAvailableWorker() throws Exception {
-
-  }
 }

--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -417,4 +417,8 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
       is.close();
     }
   }
+
+  public void noAvailableWorker() throws Exception {
+
+  }
 }


### PR DESCRIPTION
It's possible that the block location policy cannot find any available worker.