### PR TITLE
[SMALLFIX] Increase registry wait time

### DIFF
--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class Registry<T extends Server<U>, U> {
-  private static final int DEFAULT_GET_TIMEOUT_MS = 5000;
+  private static final int DEFAULT_GET_TIMEOUT_MS = 60 * Constants.SECOND_MS;
 
   private final Map<Class<? extends Server>, T> mRegistry = new HashMap<>();
   private final Lock mLock = new ReentrantLock();


### PR DESCRIPTION
5 seconds is sometimes too short because we may attempt DNS resolutions while constructing servers. The purpose of the timeout is to prevent hanging forever, so 60 seconds is a reasonable value.