### PR TITLE
[SMALLFIX] [branch-1.6] Improvement over ls command:

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -41,20 +41,6 @@ public final class Constants {
 
   public static final String EXTENSION_JAR = ".jar";
 
-  public static final String LS_FORMAT_PERMISSION = "%-11s";
-  public static final String LS_FORMAT_FILE_SIZE = "%15s";
-  public static final String LS_FORMAT_CREATE_TIME = "%24s";
-  public static final String LS_FORMAT_ALLUXIO_STATE = "%5s";
-  public static final String LS_FORMAT_PERSISTENCE_STATE = "%16s";
-  public static final String LS_FORMAT_USER_NAME = "%-15s";
-  public static final String LS_FORMAT_GROUP_NAME = "%-15s";
-  public static final String LS_FORMAT_FILE_PATH = "%-5s";
-  public static final String LS_FORMAT = LS_FORMAT_PERMISSION + LS_FORMAT_USER_NAME
-      + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
-      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
-  public static final String LS_FORMAT_NO_ACL = LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
-      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
-
   public static final String MESOS_RESOURCE_CPUS = "cpus";
   public static final String MESOS_RESOURCE_MEM = "mem";
   public static final String MESOS_RESOURCE_DISK = "disk";

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -41,18 +41,19 @@ public final class Constants {
 
   public static final String EXTENSION_JAR = ".jar";
 
-  public static final String LS_FORMAT_PERMISSION = "%-15s";
+  public static final String LS_FORMAT_PERMISSION = "%-12s";
   public static final String LS_FORMAT_FILE_SIZE = "%-15s";
   public static final String LS_FORMAT_CREATE_TIME = "%-25s";
-  public static final String LS_FORMAT_FILE_TYPE = "%-15s";
-  public static final String LS_FORMAT_USER_NAME = "%-15s";
-  public static final String LS_FORMAT_GROUP_NAME = "%-15s";
+  public static final String LS_FORMAT_ALLUXIO_STATE = "%-5s";
+  public static final String LS_FORMAT_PERSISTENCE_STATE = "%-20s";
+  public static final String LS_FORMAT_USER_NAME = "%-10s";
+  public static final String LS_FORMAT_GROUP_NAME = "%-10s";
   public static final String LS_FORMAT_FILE_PATH = "%-5s";
   public static final String LS_FORMAT = LS_FORMAT_PERMISSION + LS_FORMAT_USER_NAME
-      + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_CREATE_TIME + LS_FORMAT_FILE_TYPE
-      + LS_FORMAT_FILE_PATH + "%n";
-  public static final String LS_FORMAT_NO_ACL = LS_FORMAT_FILE_SIZE + LS_FORMAT_CREATE_TIME
-      + LS_FORMAT_FILE_TYPE + LS_FORMAT_FILE_PATH + "%n";
+      + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + LS_FORMAT_FILE_PATH + "%n";
+  public static final String LS_FORMAT_NO_ACL = LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + LS_FORMAT_FILE_PATH + "%n";
 
   public static final String MESOS_RESOURCE_CPUS = "cpus";
   public static final String MESOS_RESOURCE_MEM = "mem";

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -41,19 +41,19 @@ public final class Constants {
 
   public static final String EXTENSION_JAR = ".jar";
 
-  public static final String LS_FORMAT_PERMISSION = "%-12s";
-  public static final String LS_FORMAT_FILE_SIZE = "%-15s";
-  public static final String LS_FORMAT_CREATE_TIME = "%-25s";
-  public static final String LS_FORMAT_ALLUXIO_STATE = "%-5s";
-  public static final String LS_FORMAT_PERSISTENCE_STATE = "%-20s";
-  public static final String LS_FORMAT_USER_NAME = "%-10s";
-  public static final String LS_FORMAT_GROUP_NAME = "%-10s";
+  public static final String LS_FORMAT_PERMISSION = "%-11s";
+  public static final String LS_FORMAT_FILE_SIZE = "%15s";
+  public static final String LS_FORMAT_CREATE_TIME = "%24s";
+  public static final String LS_FORMAT_ALLUXIO_STATE = "%5s";
+  public static final String LS_FORMAT_PERSISTENCE_STATE = "%16s";
+  public static final String LS_FORMAT_USER_NAME = "%-15s";
+  public static final String LS_FORMAT_GROUP_NAME = "%-15s";
   public static final String LS_FORMAT_FILE_PATH = "%-5s";
   public static final String LS_FORMAT = LS_FORMAT_PERMISSION + LS_FORMAT_USER_NAME
       + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
-      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + LS_FORMAT_FILE_PATH + "%n";
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
   public static final String LS_FORMAT_NO_ACL = LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
-      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + LS_FORMAT_FILE_PATH + "%n";
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
 
   public static final String MESOS_RESOURCE_CPUS = "cpus";
   public static final String MESOS_RESOURCE_MEM = "mem";

--- a/core/common/src/main/java/alluxio/util/FormatUtils.java
+++ b/core/common/src/main/java/alluxio/util/FormatUtils.java
@@ -135,7 +135,7 @@ public final class FormatUtils {
   public static String getSizeFromBytes(long bytes) {
     double ret = bytes;
     if (ret <= 1024 * 5) {
-      return String.format(Locale.ENGLISH, "%.2fB", ret);
+      return String.format(Locale.ENGLISH, "%dB", bytes);
     }
     ret /= 1024;
     if (ret <= 1024 * 5) {

--- a/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/FormatUtilsTest.java
@@ -178,9 +178,9 @@ public final class FormatUtilsTest {
     }
 
     List<TestCase> testCases = new LinkedList<>();
-    testCases.add(new TestCase("4.00B", 1L << 2));
-    testCases.add(new TestCase("8.00B", 1L << 3));
-    testCases.add(new TestCase("4096.00B", 1L << 12));
+    testCases.add(new TestCase("4B", 1L << 2));
+    testCases.add(new TestCase("8B", 1L << 3));
+    testCases.add(new TestCase("4096B", 1L << 12));
     testCases.add(new TestCase("8.00KB", 1L << 13));
     testCases.add(new TestCase("4096.00KB", 1L << 22));
     testCases.add(new TestCase("8.00MB", 1L << 23));

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -42,8 +42,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class LsCommand extends WithWildCardPathCommand {
   public static final String STATE_FOLDER = "Directory";
-  public static final String STATE_FILE_IN_MEMORY = "In Memory";
-  public static final String STATE_FILE_NOT_IN_MEMORY = "Not In Memory";
+  public static final String STATE_FILE_IN_ALLUXIO = "In Alluxio";
+  public static final String STATE_FILE_NOT_IN_ALLUXIO = "Not In Alluxio";
 
   private static final Option FORCE_OPTION =
       Option.builder("f")
@@ -91,28 +91,28 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param groupName group name
    * @param size size of the file in bytes
    * @param createTimeMs the epoch time in ms when the path is created
-   * @param inMemory whether the file is in memory
+   * @param inAlluxio whether the file is in Alluxio
    * @param path path of the file or folder
    * @return the formatted string according to acl and isFolder
    */
   public static String formatLsString(boolean hSize, boolean acl, boolean isFolder, String
       permission,
-      String userName, String groupName, long size, long createTimeMs, boolean inMemory,
+      String userName, String groupName, long size, long createTimeMs, boolean inAlluxio,
       String path) {
-    String memoryState;
+    String inAlluxioState;
     if (isFolder) {
-      memoryState = STATE_FOLDER;
+      inAlluxioState = STATE_FOLDER;
     } else {
-      memoryState = inMemory ? STATE_FILE_IN_MEMORY : STATE_FILE_NOT_IN_MEMORY;
+      inAlluxioState = inAlluxio ? STATE_FILE_IN_ALLUXIO : STATE_FILE_NOT_IN_ALLUXIO;
     }
     String sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     if (acl) {
       return String.format(Constants.LS_FORMAT, permission, userName, groupName,
           sizeStr, CommonUtils.convertMsToDate(createTimeMs),
-          memoryState, path);
+          inAlluxioState, path);
     } else {
       return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr,
-          CommonUtils.convertMsToDate(createTimeMs), memoryState, path);
+          CommonUtils.convertMsToDate(createTimeMs), inAlluxioState, path);
     }
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -100,12 +100,15 @@ public final class LsCommand extends WithWildCardPathCommand {
       String userName, String groupName, long size, long createTimeMs, boolean inAlluxio,
       String path) {
     String inAlluxioState;
+    String sizeStr;
     if (isFolder) {
       inAlluxioState = STATE_FOLDER;
+      sizeStr = String.valueOf(size);
     } else {
       inAlluxioState = inAlluxio ? STATE_FILE_IN_ALLUXIO : STATE_FILE_NOT_IN_ALLUXIO;
+      sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     }
-    String sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
+
     if (acl) {
       return String.format(Constants.LS_FORMAT, permission, userName, groupName,
           sizeStr, CommonUtils.convertMsToDate(createTimeMs),

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -41,9 +41,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class LsCommand extends WithWildCardPathCommand {
-  public static final String IN_ALLUXIO_STATE_FOLDER = "";
+  public static final String IN_ALLUXIO_STATE_DIR = "DIR";
   public static final String IN_ALLUXIO_STATE_FILE_FORMAT = "%d%%";
-
 
   private static final Option FORCE_OPTION =
       Option.builder("f")
@@ -92,18 +91,18 @@ public final class LsCommand extends WithWildCardPathCommand {
    * @param size size of the file in bytes
    * @param createTimeMs the epoch time in ms when the path is created
    * @param inAlluxioPercentage whether the file is in Alluxio
+   * @param persistenceState the persistence state of the file
    * @param path path of the file or folder
    * @return the formatted string according to acl and isFolder
    */
   public static String formatLsString(boolean hSize, boolean acl, boolean isFolder, String
       permission,
       String userName, String groupName, long size, long createTimeMs, int inAlluxioPercentage,
-      String persistenceState,
-      String path) {
+      String persistenceState, String path) {
     String inAlluxioState;
     String sizeStr;
     if (isFolder) {
-      inAlluxioState = IN_ALLUXIO_STATE_FOLDER;
+      inAlluxioState = IN_ALLUXIO_STATE_DIR;
       sizeStr = String.valueOf(size);
     } else {
       inAlluxioState = String.format(IN_ALLUXIO_STATE_FILE_FORMAT, inAlluxioPercentage);
@@ -226,12 +225,10 @@ public final class LsCommand extends WithWildCardPathCommand {
 
   @Override
   public String getDescription() {
-    return "Displays information for all files and directories directly under the specified path."
-        + " Specify -d to list directories as plain files."
-        + " Specify -f to force loading files in the directory."
-        + " Specify -p to list all the pinned files."
-        + " Specify -R to display files and directories recursively."
-        + " Specify -h to print human-readable format sizes.";
+    return "Displays information for all files and directories directly under the specified path, "
+        + "including permission, owner, group, size (bytes for files or the number of children "
+        + "for directories, persistence state, creation time, the percentage of content already "
+        + "in Alluxio and the path in order.";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -12,7 +12,6 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.ListStatusOptions;
@@ -43,6 +42,19 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class LsCommand extends WithWildCardPathCommand {
   public static final String IN_ALLUXIO_STATE_DIR = "DIR";
   public static final String IN_ALLUXIO_STATE_FILE_FORMAT = "%d%%";
+  public static final String LS_FORMAT_PERMISSION = "%-11s";
+  public static final String LS_FORMAT_FILE_SIZE = "%15s";
+  public static final String LS_FORMAT_CREATE_TIME = "%24s";
+  public static final String LS_FORMAT_ALLUXIO_STATE = "%5s";
+  public static final String LS_FORMAT_PERSISTENCE_STATE = "%16s";
+  public static final String LS_FORMAT_USER_NAME = "%-15s";
+  public static final String LS_FORMAT_GROUP_NAME = "%-15s";
+  public static final String LS_FORMAT_FILE_PATH = "%-5s";
+  public static final String LS_FORMAT_NO_ACL = LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
+  public static final String LS_FORMAT = LS_FORMAT_PERMISSION + LS_FORMAT_USER_NAME
+      + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_PERSISTENCE_STATE
+      + LS_FORMAT_CREATE_TIME + LS_FORMAT_ALLUXIO_STATE + " " + LS_FORMAT_FILE_PATH + "%n";
 
   private static final Option FORCE_OPTION =
       Option.builder("f")
@@ -110,11 +122,11 @@ public final class LsCommand extends WithWildCardPathCommand {
     }
 
     if (acl) {
-      return String.format(Constants.LS_FORMAT, permission, userName, groupName,
+      return String.format(LS_FORMAT, permission, userName, groupName,
           sizeStr, persistenceState, CommonUtils.convertMsToDate(createTimeMs),
           inAlluxioState, path);
     } else {
-      return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr,
+      return String.format(LS_FORMAT_NO_ACL, sizeStr,
           persistenceState, CommonUtils.convertMsToDate(createTimeMs), inAlluxioState, path);
     }
   }

--- a/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
@@ -39,7 +39,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
       throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
     return getLsResultStr(uri.getPath(), status.getCreationTimeMs(), size,
-        LsCommand.STATE_FILE_IN_MEMORY, testUser, testGroup, status.getMode(),
+        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testGroup, status.getMode(),
         status.isFolder());
   }
 
@@ -103,11 +103,11 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "/testRoot");
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
         LsCommand.STATE_FOLDER);
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -124,11 +124,11 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     boolean hSize = true;
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), hSize, 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), hSize, 1,
         LsCommand.STATE_FOLDER);
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), hSize, 30,
-        LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -148,9 +148,9 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-pR",  "/testRoot");
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -203,13 +203,13 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "/testRoot");
     String expected = "";
     expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[0].getMode(),
+        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder());
     expected +=
         getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
             testUser, testUser, files[1].getMode(), files[1].isFolder());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_MEMORY, testUser, testUser, files[3].getMode(),
+        LsCommand.STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
         files[3].isFolder());
     Assert.assertEquals(expected, mOutput.toString());
   }
@@ -226,22 +226,22 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
 
     String expect = "";
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     mFsShell.run("ls", testDir + "/*/foo*");
     Assert.assertEquals(expect, mOutput.toString());
 
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     mFsShell.run("ls", testDir + "/*");
     Assert.assertEquals(expect, mOutput.toString());
   }
@@ -291,13 +291,13 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
         LsCommand.STATE_FOLDER);
     expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_MEMORY);
+        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -321,16 +321,16 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
     expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[0].getMode(),
+        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder());
     expected +=
         getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
             testUser, testUser, files[1].getMode(), files[1].isFolder());
     expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_MEMORY, testUser, testUser, files[2].getMode(),
+        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[2].getMode(),
         files[2].isFolder());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_MEMORY, testUser, testUser, files[3].getMode(),
+        LsCommand.STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
         files[3].isFolder());
     Assert.assertEquals(expected, mOutput.toString());
   }
@@ -348,7 +348,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
     mFsShell.run("ls", "/");
     String expected = getLsNoAclResultStr(fileName, file.getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_MEMORY);
+        LsCommand.STATE_FILE_IN_ALLUXIO);
     Assert.assertEquals(expected, mOutput.toString());
   }
 }

--- a/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
@@ -77,7 +77,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
       String inAlluxioState, String persistenceState)
       throws IOException, AlluxioException {
     String sizeStr;
-    if (inAlluxioState.equals(LsCommand.IN_ALLUXIO_STATE_FOLDER)) {
+    if (inAlluxioState.equals(LsCommand.IN_ALLUXIO_STATE_DIR)) {
       sizeStr = String.valueOf(size);
     } else {
       sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
@@ -116,7 +116,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
-        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
+        LsCommand.IN_ALLUXIO_STATE_DIR, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         STATE_FILE_NOT_IN_ALLUXIO, files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
@@ -137,7 +137,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), hSize, 10,
         STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), hSize, 1,
-        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
+        LsCommand.IN_ALLUXIO_STATE_DIR, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), hSize, 30,
         STATE_FILE_NOT_IN_ALLUXIO, files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
@@ -178,7 +178,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/testRoot/"));
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot", dirStatus.getCreationTimeMs(),
-        3 /* number of direct children under /testRoot/ dir */, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+        3 /* number of direct children under /testRoot/ dir */, LsCommand.IN_ALLUXIO_STATE_DIR,
         dirStatus.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
@@ -194,7 +194,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-d", "/");
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/"));
     String expected = "";
-    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.IN_ALLUXIO_STATE_DIR,
         dirStatus.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
@@ -219,7 +219,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
         STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder(), files[0].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_DIR,
             testUser, testUser, files[1].getMode(), files[1].isFolder(),
             files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
@@ -306,7 +306,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
         STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
-        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
+        LsCommand.IN_ALLUXIO_STATE_DIR, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
         STATE_FILE_IN_ALLUXIO, files[2].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
@@ -337,7 +337,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
         STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder(), files[1].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_DIR,
             testUser, testUser, files[1].getMode(), files[1].isFolder(),
             files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,

--- a/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
 import alluxio.client.WriteType;
@@ -53,7 +52,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
       String persistenceState)
       throws IOException, AlluxioException {
     return String
-        .format(Constants.LS_FORMAT, FormatUtils.formatMode((short) permission, isDir),
+        .format(LsCommand.LS_FORMAT, FormatUtils.formatMode((short) permission, isDir),
             testUser, testGroup, String.valueOf(size), persistenceState,
             CommonUtils.convertMsToDate(createTime), inAlluxioState, path);
   }
@@ -82,7 +81,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     } else {
       sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     }
-    return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr, persistenceState,
+    return String.format(LsCommand.LS_FORMAT_NO_ACL, sizeStr, persistenceState,
         CommonUtils.convertMsToDate(createTime), inAlluxioState, path);
   }
 

--- a/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
@@ -194,8 +194,9 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-d", "/");
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/"));
     String expected = "";
-    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.IN_ALLUXIO_STATE_DIR,
-        dirStatus.getPersistenceState());
+    expected +=
+        getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0,
+            LsCommand.IN_ALLUXIO_STATE_DIR, dirStatus.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -219,9 +220,9 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
         STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder(), files[0].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_DIR,
-            testUser, testUser, files[1].getMode(), files[1].isFolder(),
-            files[1].getPersistenceState());
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
+            LsCommand.IN_ALLUXIO_STATE_DIR, testUser, testUser, files[1].getMode(),
+            files[1].isFolder(), files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
         STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
         files[3].isFolder(), files[3].getPersistenceState());
@@ -254,7 +255,8 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
         STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
         STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40, STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40, STATE_FILE_IN_ALLUXIO,
+        PersistenceState.NOT_PERSISTED.name());
     mFsShell.run("ls", testDir + "/*");
     Assert.assertEquals(expect, mOutput.toString());
   }
@@ -337,9 +339,9 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
         STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
         files[0].isFolder(), files[1].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_DIR,
-            testUser, testUser, files[1].getMode(), files[1].isFolder(),
-            files[1].getPersistenceState());
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
+            LsCommand.IN_ALLUXIO_STATE_DIR, testUser, testUser, files[1].getMode(),
+            files[1].isFolder(), files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
         STATE_FILE_IN_ALLUXIO, testUser, testUser, files[2].getMode(),
         files[2].isFolder(), files[2].getPersistenceState());

--- a/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/LsCommandIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.client.file.options.SetAttributeOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.cli.fs.AbstractAlluxioShellTest;
 import alluxio.cli.fs.FileSystemShellUtilsTest;
+import alluxio.master.file.meta.PersistenceState;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 
@@ -34,45 +35,55 @@ import java.io.IOException;
  * Tests for ls command.
  */
 public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
+  private static final String STATE_FILE_IN_ALLUXIO = "100%";
+  private static final String STATE_FILE_NOT_IN_ALLUXIO = "0%";
+
   // Helper function to format ls result.
   private String getLsResultStr(AlluxioURI uri, int size, String testUser, String testGroup)
       throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
-    return getLsResultStr(uri.getPath(), status.getCreationTimeMs(), size,
-        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testGroup, status.getMode(),
-        status.isFolder());
+    return getLsResultStr(uri.getPath(), status.getCreationTimeMs(), size, STATE_FILE_IN_ALLUXIO,
+        testUser, testGroup, status.getMode(),
+        status.isFolder(), PersistenceState.NOT_PERSISTED.name());
   }
 
   // Helper function to format ls result.
-  private String getLsResultStr(String path, long createTime, int size, String fileType,
-      String testUser, String testGroup, int permission, boolean isDir)
+  private String getLsResultStr(String path, long createTime, int size, String inAlluxioState,
+      String testUser, String testGroup, int permission, boolean isDir,
+      String persistenceState)
       throws IOException, AlluxioException {
     return String
         .format(Constants.LS_FORMAT, FormatUtils.formatMode((short) permission, isDir),
-            testUser, testGroup, String.valueOf(size),
-            CommonUtils.convertMsToDate(createTime), fileType, path);
+            testUser, testGroup, String.valueOf(size), persistenceState,
+            CommonUtils.convertMsToDate(createTime), inAlluxioState, path);
   }
 
   // Helper function to format ls result without acl enabled.
-  private String getLsNoAclResultStr(AlluxioURI uri, int size, String fileType)
-      throws IOException, AlluxioException {
+  private String getLsNoAclResultStr(AlluxioURI uri, int size, String inAlluxioState,
+      String persistenceState) throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
-    return getLsNoAclResultStr(uri.getPath(), status.getCreationTimeMs(), size, fileType);
+    return getLsNoAclResultStr(uri.getPath(), status.getCreationTimeMs(), size, inAlluxioState,
+        persistenceState);
   }
 
   // Helper function to format ls result without acl enabled.
-  private String getLsNoAclResultStr(String path, long createTime, int size, String fileType)
-        throws IOException, AlluxioException {
-    return getLsNoAclResultStr(path, createTime, false, size, fileType);
+  private String getLsNoAclResultStr(String path, long createTime, int size, String inAlluxioState,
+      String persistenceState) throws IOException, AlluxioException {
+    return getLsNoAclResultStr(path, createTime, false, size, inAlluxioState, persistenceState);
   }
 
   // Helper function to format ls result without acl enabled.
   private String getLsNoAclResultStr(String path, long createTime, boolean hSize, int size,
-                                     String fileType)
+      String inAlluxioState, String persistenceState)
       throws IOException, AlluxioException {
-    String sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
-    return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr,
-        CommonUtils.convertMsToDate(createTime), fileType, path);
+    String sizeStr;
+    if (inAlluxioState.equals(LsCommand.IN_ALLUXIO_STATE_FOLDER)) {
+      sizeStr = String.valueOf(size);
+    } else {
+      sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
+    }
+    return String.format(Constants.LS_FORMAT_NO_ACL, sizeStr, persistenceState,
+        CommonUtils.convertMsToDate(createTime), inAlluxioState, path);
   }
 
   // Helper function to create a set of files in the file system
@@ -103,11 +114,11 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "/testRoot");
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
-        LsCommand.STATE_FOLDER);
+        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
+        STATE_FILE_NOT_IN_ALLUXIO, files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -124,11 +135,11 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     boolean hSize = true;
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), hSize, 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), hSize, 1,
-        LsCommand.STATE_FOLDER);
+        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), hSize, 30,
-        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
+        STATE_FILE_NOT_IN_ALLUXIO, files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -148,9 +159,9 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-pR",  "/testRoot");
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[2].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -167,7 +178,8 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/testRoot/"));
     String expected = "";
     expected += getLsNoAclResultStr("/testRoot", dirStatus.getCreationTimeMs(),
-        3 /* number of direct children under /testRoot/ dir */, LsCommand.STATE_FOLDER);
+        3 /* number of direct children under /testRoot/ dir */, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+        dirStatus.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -182,7 +194,8 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "-d", "/");
     URIStatus dirStatus = mFileSystem.getStatus(new AlluxioURI("/"));
     String expected = "";
-    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.STATE_FOLDER);
+    expected += getLsNoAclResultStr("/", dirStatus.getCreationTimeMs(), 0, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+        dirStatus.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -203,14 +216,15 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     mFsShell.run("ls", "/testRoot");
     String expected = "";
     expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
-        files[0].isFolder());
+        STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
+        files[0].isFolder(), files[0].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
-            testUser, testUser, files[1].getMode(), files[1].isFolder());
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+            testUser, testUser, files[1].getMode(), files[1].isFolder(),
+            files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
-        files[3].isFolder());
+        STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
+        files[3].isFolder(), files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -226,22 +240,21 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
 
     String expect = "";
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     mFsShell.run("ls", testDir + "/*/foo*");
     Assert.assertEquals(expect, mOutput.toString());
 
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/bar/foobar3"), 30,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar1"), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foo/foobar2"), 20,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
-    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
+    expect += getLsNoAclResultStr(new AlluxioURI(testDir + "/foobar4"), 40, STATE_FILE_IN_ALLUXIO, PersistenceState.NOT_PERSISTED.name());
     mFsShell.run("ls", testDir + "/*");
     Assert.assertEquals(expect, mOutput.toString());
   }
@@ -291,13 +304,13 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
     expected += getLsNoAclResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[0].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1,
-        LsCommand.STATE_FOLDER);
+        LsCommand.IN_ALLUXIO_STATE_FOLDER, files[1].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, files[2].getPersistenceState());
     expected += getLsNoAclResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_ALLUXIO);
+        STATE_FILE_NOT_IN_ALLUXIO, files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -321,17 +334,18 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     String expected = "";
     expected += "WARNING: lsr is deprecated. Please use ls -R instead.\n";
     expected += getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
-        files[0].isFolder());
+        STATE_FILE_IN_ALLUXIO, testUser, testUser, files[0].getMode(),
+        files[0].isFolder(), files[1].getPersistenceState());
     expected +=
-        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.STATE_FOLDER,
-            testUser, testUser, files[1].getMode(), files[1].isFolder());
+        getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 1, LsCommand.IN_ALLUXIO_STATE_FOLDER,
+            testUser, testUser, files[1].getMode(), files[1].isFolder(),
+            files[1].getPersistenceState());
     expected += getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-        LsCommand.STATE_FILE_IN_ALLUXIO, testUser, testUser, files[2].getMode(),
-        files[2].isFolder());
+        STATE_FILE_IN_ALLUXIO, testUser, testUser, files[2].getMode(),
+        files[2].isFolder(), files[2].getPersistenceState());
     expected += getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30,
-        LsCommand.STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
-        files[3].isFolder());
+        STATE_FILE_NOT_IN_ALLUXIO, testUser, testUser, files[3].getMode(),
+        files[3].isFolder(), files[3].getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 
@@ -348,7 +362,7 @@ public final class LsCommandIntegrationTest extends AbstractAlluxioShellTest {
     URIStatus file = mFileSystem.getStatus(new AlluxioURI(fileName));
     mFsShell.run("ls", "/");
     String expected = getLsNoAclResultStr(fileName, file.getCreationTimeMs(), 10,
-        LsCommand.STATE_FILE_IN_ALLUXIO);
+        STATE_FILE_IN_ALLUXIO, file.getPersistenceState());
     Assert.assertEquals(expected, mOutput.toString());
   }
 }


### PR DESCRIPTION
1. instead of "In Memory" and "Not In Memory", show the percentage In Alluxio to be consistent with the webUI
2. add the persistence state to output
3. with "-h" flag, when displaying size in bytes, not use float but directly use integers
4. with "-h" flag, dir size is always the number of child inodes
5. make fields right aligned except the last field of filename

output before:

```bash
-rw-r--r--     binfan         staff          2947.00B       09-19-2017 00:27:44:512  Not In Memory  /README.md
```

output after
```bash
-rw-r--r--     binfan     staff           2947           PERSISTED  09-19-2017 00:27:44:512   0% /README.md
```
