### PR TITLE
[SMALLFIX] Downgraded log level to debug when a lost file does not exist

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -51,7 +51,7 @@ final class LostFileDetector implements HeartbeatExecutor {
           inode.setPersistenceState(PersistenceState.LOST);
         }
       } catch (FileDoesNotExistException e) {
-        LOG.error("Exception trying to get inode from inode tree", e);
+        LOG.warn("Exception trying to get inode from inode tree", e);
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -51,7 +51,7 @@ final class LostFileDetector implements HeartbeatExecutor {
           inode.setPersistenceState(PersistenceState.LOST);
         }
       } catch (FileDoesNotExistException e) {
-        LOG.warn("Exception trying to get inode from inode tree", e);
+        LOG.debug("Exception trying to get inode from inode tree", e);
       }
     }
   }


### PR DESCRIPTION
Given the lost file detector is only used by lineage module, change it to debug so it won't flush the log.