### PR TITLE
[SMALLFIX] [branch-1.6] Throw exception when underlying BlockInStream is inconsistent

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -202,7 +202,8 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     if (mEOF) {
       closePacketReader();
       Preconditions.checkState(mPos >= mLength,
-          "Block %s is expected to be %s bytes, but only %s bytes are available", mId, mLength,
+          "Block %s is expected to be %s bytes, but only %s bytes are available. Please ensure the"
+              + "the file metadata is consistent between Alluxio and UFS.", mId, mLength,
           mPos);
       return -1;
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -201,10 +201,9 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     }
     if (mEOF) {
       closePacketReader();
-      Preconditions.checkState(mPos >= mLength,
-          "Block %s is expected to be %s bytes, but only %s bytes are available. Please ensure the"
-              + "the file metadata is consistent between Alluxio and UFS.", mId, mLength,
-          mPos);
+      Preconditions
+          .checkState(mPos >= mLength, PreconditionMessage.BLOCK_LENGTH_INCONSISTENT.toString(),
+              mId, mLength, mPos);
       return -1;
     }
     int toRead = Math.min(len, mCurrentPacket.readableBytes());

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -201,6 +201,9 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     }
     if (mEOF) {
       closePacketReader();
+      Preconditions.checkState(mPos >= mLength,
+          "Block %s is expected to be %s bytes, but only %s bytes are available", mId, mLength,
+          mPos);
       return -1;
     }
     int toRead = Math.min(len, mCurrentPacket.readableBytes());

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -22,15 +22,18 @@ public class TestBlockInStream extends BlockInStream {
   private int mBytesRead;
   private boolean mClosed;
 
-  public TestBlockInStream(byte[] mData, long id, long length, boolean shortCircuit,
+  public TestBlockInStream(byte[] data, long id, long length, boolean shortCircuit,
       BlockInStreamSource source) {
-    super(new Factory(mData, shortCircuit), source, id, length);
+    super(new Factory(data, shortCircuit), source, id, length);
     mBytesRead = 0;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     int bytesRead = super.read(b, off, len);
+    if (bytesRead <= 0) {
+      return bytesRead;
+    }
     mBytesRead += bytesRead;
     return bytesRead;
   }
@@ -38,6 +41,9 @@ public class TestBlockInStream extends BlockInStream {
   @Override
   public int positionedRead(long pos, byte[] b, int off, int len) throws IOException {
     int bytesRead = super.positionedRead(pos, b, off, len);
+    if (bytesRead <= 0) {
+      return bytesRead;
+    }
     mBytesRead += bytesRead;
     return bytesRead;
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestPacketReader.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestPacketReader.java
@@ -36,11 +36,11 @@ public class TestPacketReader implements PacketReader {
   @Override
   @Nullable
   public DataBuffer readPacket() {
-    if (mPos >= mEnd) {
+    if (mPos >= mEnd || mPos >= mData.length) {
       return null;
     }
-    ByteBuffer buffer =
-        ByteBuffer.wrap(mData, (int) mPos, (int) (Math.min(mPacketSize, mEnd - mPos)));
+    int bytesToRead = (int) (Math.min(Math.min(mPacketSize, mEnd - mPos), mData.length - mPos));
+    ByteBuffer buffer = ByteBuffer.wrap(mData, (int) mPos, bytesToRead);
     DataBuffer dataBuffer = new DataByteBuffer(buffer, buffer.remaining());
     mPos += dataBuffer.getLength();
     return dataBuffer;

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -601,7 +601,6 @@ public final class FileInStreamTest {
     }
   }
 
-
   /**
    * Tests that when the underlying blocks are inconsistent with the metadata in terms of block
    * length, an exception is thrown rather than client hanging indefinitely. This case may happen if
@@ -622,7 +621,7 @@ public final class FileInStreamTest {
     try {
       mTestStream.read(buffer, 0, (int) BLOCK_LENGTH);
       Assert.fail("BlockInStream is inconsistent, an Exception is expected");
-    } catch(IllegalStateException e) {
+    } catch (IllegalStateException e) {
       // expect an exception to throw
     }
   }

--- a/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
@@ -21,6 +21,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public enum PreconditionMessage {
   ASYNC_JOURNAL_WRITER_NULL("AsyncJournalWriter cannot be null"),
+  BLOCK_LENGTH_INCONSISTENT("Block %s is expected to be %s bytes, but only %s bytes are available. "
+      + "Please ensure its metadata is consistent between Alluxio and UFS."),
   COMMAND_LINE_LINEAGE_ONLY("Only command line jobs are supported by createLineage"),
   EMPTY_FILE_INFO_LIST_FOR_PERMISSION_CHECK(
       "The passed-in file info list can not be empty when checking permission"),


### PR DESCRIPTION
This fix the case when underlying BlockInStream is actually shorter than expected. E.g., the files are out of sync. In this case, this PR improves the client to throw an exception indicating the inconsistency. Otherwise, the client is returning meaningless data. 