### PR TITLE
[SMALLFIX] Increase timeout for waiting for worker factories.

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -105,6 +105,8 @@ public final class Constants {
   public static final String KEY_VALUE_MASTER_CLIENT_SERVICE_NAME = "KeyValueMasterClient";
   public static final String KEY_VALUE_WORKER_CLIENT_SERVICE_NAME = "KeyValueWorkerClient";
 
+  public static final int DEFAULT_REGISTRY_GET_TIMEOUT_MS = 60 * SECOND_MS;
+
   public static final String REST_API_PREFIX = "/api/v1";
 
   public static final String MASTER_COLUMN_FILE_PREFIX = "COL_";

--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -48,8 +48,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class Registry<T extends Server<U>, U> {
-  private static final int DEFAULT_GET_TIMEOUT_MS = 5000;
-
   private final Map<Class<? extends Server>, T> mRegistry = new HashMap<>();
   private final Lock mLock = new ReentrantLock();
 
@@ -66,7 +64,7 @@ public class Registry<T extends Server<U>, U> {
    * @return the {@link Server} instance
    */
   public <W extends T> W get(final Class<W> clazz) {
-    return get(clazz, DEFAULT_GET_TIMEOUT_MS);
+    return get(clazz, Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -116,7 +116,12 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
           }
         });
       }
-      CommonUtils.invokeAll(callables, 10, TimeUnit.SECONDS);
+      // In the worst case, each worker factory is blocked waiting for the dependent servers to be
+      // registered at worker registry, so the maximum timeout here is set to the multiply of
+      // the number of factories by the default timeout of getting a worker from the registry.
+      CommonUtils.invokeAll(callables,
+          (long) callables.size() * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS,
+          TimeUnit.MILLISECONDS);
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
In my testing of release 1.6.0 RC0, the worker always fails to be started due to timeout when creating the worker servers, the error is in logs/worker.out like

```
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: Timed out waiting for server alluxio.worker.block.BlockWorker to be created
        at alluxio.worker.AlluxioWorkerProcess.<init>(AlluxioWorkerProcess.java:148)
        at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:35)
        at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:54)
Caused by: java.lang.RuntimeException: Timed out waiting for server alluxio.worker.block.BlockWorker to be created
        at alluxio.util.CommonUtils.waitFor(CommonUtils.java:264)
        at alluxio.Registry.get(Registry.java:83)
        at alluxio.Registry.get(Registry.java:69)
        at alluxio.worker.file.FileSystemWorkerFactory.create(FileSystemWorkerFactory.java:44)
        at alluxio.worker.file.FileSystemWorkerFactory.create(FileSystemWorkerFactory.java:27)
        at alluxio.worker.AlluxioWorkerProcess$1.call(AlluxioWorkerProcess.java:113)
        at alluxio.worker.AlluxioWorkerProcess$1.call(AlluxioWorkerProcess.java:109)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:748)
```

The problem might be

1. the timeout for registry's get operation is too small
2. the timeout for the `invokeAll` operation for all worker factories is too small

This PR increases both timeouts and it works in my tests.