### PR TITLE
[SMALLFIX] [branch-1.6] Retry IOException for AbstractClient connect

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -197,7 +197,6 @@ public abstract class AbstractClient implements Client {
               getServiceName(), mAddress, e.getMessage(), RuntimeConstants.ALLUXIO_DEBUG_DOCS_URL);
           throw new UnimplementedException(message, e);
         }
-        throw e;
       } catch (TTransportException e) {
         LOG.warn("Failed to connect ({}) with {} @ {}: {}", retryPolicy.getRetryCount(),
             getServiceName(), mAddress, e.getMessage());

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -207,10 +207,10 @@ public abstract class AbstractClient implements Client {
               + "is not able to connect to servers with SIMPLE security mode.";
           throw new UnavailableException(message, e);
         }
-        // TODO(peis): Consider closing the connection here as well.
-        if (!retryPolicy.attemptRetry()) {
-          break;
-        }
+      }
+      // TODO(peis): Consider closing the connection here as well.
+      if (!retryPolicy.attemptRetry()) {
+        break;
       }
     }
     // Reaching here indicates that we did not successfully connect.


### PR DESCRIPTION
This PR fixes the issue that 1.6 start local cluster failure with NOSASL mode.
Without this PR:
```
2017-09-26 19:08:20,336 ERROR ProcessUtils - Uncaught exception while running Alluxio worker, stopping it and exiting.
java.lang.RuntimeException: Failed to get a worker id from block master: org.apache.thrift.transport.TTransportException: java.net.SocketException: Connection reset
	at alluxio.worker.block.DefaultBlockWorker.start(DefaultBlockWorker.java:202)
	at alluxio.worker.block.DefaultBlockWorker.start(DefaultBlockWorker.java:75)
	at alluxio.Registry.start(Registry.java:128)
	at alluxio.worker.AlluxioWorkerProcess.startWorkers(AlluxioWorkerProcess.java:242)
	at alluxio.worker.AlluxioWorkerProcess.start(AlluxioWorkerProcess.java:217)
	at alluxio.ProcessUtils.run(ProcessUtils.java:31)
	at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:55)
```
With this PR, this problem is resolved.

Root cause:
In `checkVersion`, any `TException` including `TTransportException` are wrapped with IOException. We should always retry those possibly transient exceptions, unless we know specific ones that should not be retried.


```
  protected void checkVersion(AlluxioService.Client client, long version) throws IOException {
    if (mServiceVersion == Constants.UNKNOWN_SERVICE_VERSION) {
      try {
        mServiceVersion = client.getServiceVersion(new GetServiceVersionTOptions()).getVersion();
      } catch (TException e) {
        throw new IOException(e);
      }
      if (mServiceVersion != version) {
        throw new IOException(ExceptionMessage.INCOMPATIBLE_VERSION.getMessage(getServiceName(),
            version, mServiceVersion));
      }
    }
  }
```