### PR TITLE
[ALLUXIO-3022] Supply the variable name to Preconditions.checkNotNull for class KeyValuePartitionReader

### DIFF
--- a/core/common/src/main/java/alluxio/wire/FileBlockInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileBlockInfo.java
@@ -84,7 +84,7 @@ public final class FileBlockInfo implements Serializable {
    * @return the file block information
    */
   public FileBlockInfo setBlockInfo(BlockInfo blockInfo) {
-    Preconditions.checkNotNull(blockInfo, "blockInfo");
+    Preconditions.checkNotNull(blockInfo, "blockInfo"); // do this instead
     mBlockInfo = blockInfo;
     return this;
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3022
Preconditions.checkNotNull(blockInfo); // Do not do this
Preconditions.checkNotNull(blockInfo, "blockInfo") // Do this instead