### PR TITLE
[SMALLFIX] Allow path absent cache threadpool size to decrease

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -78,6 +78,7 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
     mPool = new ThreadPoolExecutor(mThreads, mThreads, THREAD_KEEP_ALIVE_SECONDS,
         TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
         ThreadFactoryUtils.build("UFS-Absent-Path-Cache-%d", true));
+    mPool.allowCoreThreadTimeOut(true);
   }
 
   @Override


### PR DESCRIPTION
This setting will allow core threads to expire so that when we aren't under heavy load, we don't have 64 idle threads.