### PR TITLE
[ALLUXIO-3042] Fix to Docker's entrypoint.sh for environment variables violating the dash-to-dot rule

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -45,7 +45,7 @@ alluxio_env_vars=(
 
 # Map of environment variables that violate the "_ to ."-rule
 declare -A alluxio_env_violators=(
-  ["ALLUXIO_UNDERFS_S3A_INHERIT_ACL"]="alluxio.underfs.s3a.inherit_acl",
+  ["ALLUXIO_UNDERFS_S3A_INHERIT_ACL"]="alluxio.underfs.s3a.inherit_acl"
   ["ALLUXIO_MASTER_FORMAT_FILE_PREFIX"]="alluxio.master.format.file_prefix"
 )
 

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -43,25 +43,26 @@ alluxio_env_vars=(
   ALLUXIO_WORKER_JAVA_OPTS
 )
 
-# Map of environment variables that violates the "_ to ."-rule
+# Map of environment variables that violate the "_ to ."-rule
 declare -A alluxio_env_violators=(
-    ["ALLUXIO_UNDERFS_S3A_INHERIT_ACL"]="alluxio.underfs.s3a.inherit_acl"
+  ["ALLUXIO_UNDERFS_S3A_INHERIT_ACL"]="alluxio.underfs.s3a.inherit_acl",
+  ["ALLUXIO_MASTER_FORMAT_FILE_PREFIX"]="alluxio.master.format.file_prefix"
 )
 
 for keyvaluepair in $(env | grep "ALLUXIO_"); do
-    # split around the "="
-    key=$(echo ${keyvaluepair} | cut -d= -f1)
-    value=$(echo ${keyvaluepair} | cut -d= -f2)
-    if [[ "${alluxio_env_vars[*]}" =~ "${key}" ]]; then
-        echo "export ${key}=${value}" >> conf/alluxio-env.sh
+  # split around the "="
+  key=$(echo ${keyvaluepair} | cut -d= -f1)
+  value=$(echo ${keyvaluepair} | cut -d= -f2)
+  if [[ "${alluxio_env_vars[*]}" =~ "${key}" ]]; then
+    echo "export ${key}=${value}" >> conf/alluxio-env.sh
+  else
+    if [[ "${!alluxio_env_violators[*]}" =~ "${key}" ]]; then
+      echo "${alluxio_env_violators[${key}]}=${value}" >> conf/alluxio-site.properties
     else
-        if [[ "${!alluxio_env_violators[*]}" =~ "${key}" ]]; then
-            echo "${alluxio_env_violators[${key}]}=${value}" >> conf/alluxio-site.properties
-        else
-            confkey=$(echo ${key} | sed "s/_/./g" | tr '[:upper:]' '[:lower:]')
-            echo "${confkey}=${value}" >> conf/alluxio-site.properties
-        fi
+      confkey=$(echo ${key} | sed "s/_/./g" | tr '[:upper:]' '[:lower:]')
+      echo "${confkey}=${value}" >> conf/alluxio-site.properties
     fi
+  fi
 done
 
 case ${service,,} in


### PR DESCRIPTION
This fix adds a map to entrypoint.sh where offending environment variables can be listed along with the correct way they should be transformed from environment variable name to configuration property name.

https://alluxio.atlassian.net/browse/ALLUXIO-3042