### PR TITLE
[SMALLFIX]Use static imports for standard test utilities for DataByteBufferTest.java

### DIFF
--- a/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataByteBufferTest.java
+++ b/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataByteBufferTest.java
@@ -11,11 +11,13 @@
 
 package alluxio.network.protocol.databuffer;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
 import alluxio.util.io.BufferUtils;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.FileRegion;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +46,7 @@ public class DataByteBufferTest {
   public void nettyOutput() {
     DataByteBuffer data = new DataByteBuffer(mBuffer, LENGTH);
     Object output = data.getNettyOutput();
-    Assert.assertTrue(output instanceof ByteBuf || output instanceof FileRegion);
+    assertTrue(output instanceof ByteBuf || output instanceof FileRegion);
   }
 
   /**
@@ -53,7 +55,7 @@ public class DataByteBufferTest {
   @Test
   public void length() {
     DataByteBuffer data = new DataByteBuffer(mBuffer, LENGTH);
-    Assert.assertEquals(LENGTH, data.getLength());
+    assertEquals(LENGTH, data.getLength());
   }
 
   /**
@@ -63,7 +65,7 @@ public class DataByteBufferTest {
   public void readOnlyByteBuffer() {
     DataByteBuffer data = new DataByteBuffer(mBuffer, LENGTH);
     ByteBuffer readOnlyBuffer = data.getReadOnlyByteBuffer();
-    Assert.assertTrue(readOnlyBuffer.isReadOnly());
-    Assert.assertEquals(mBuffer, readOnlyBuffer);
+    assertTrue(readOnlyBuffer.isReadOnly());
+    assertEquals(mBuffer, readOnlyBuffer);
   }
 }


### PR DESCRIPTION
[SMALLFIX]Use static imports for standard test utilities for DataByteBufferTest.java