### PR TITLE
[SMALLFIX] In PropertyKey.java, update the value of UNDERFS_HDFS_PREFIXES using given tip

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -301,8 +301,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey UNDERFS_HDFS_PREFIXES =
       new Builder(Name.UNDERFS_HDFS_PREFIXES)
           .setDefaultValue("hdfs://,glusterfs:///,maprfs:///")
-          .setDescription("Optionally, specify which prefixes should run through the Apache "
-              + "Hadoop implementation of UnderFileSystem. The delimiter is any whitespace "
+          .setDescription("Optionally, specify which prefixes should run through the HDFS "
+              + "implementation of UnderFileSystem. The delimiter is any whitespace "
               + "and/or ','.")
           .build();
   public static final PropertyKey UNDERFS_HDFS_REMOTE =


### PR DESCRIPTION
`In PropertyKey.java, update

  public static final PropertyKey UNDERFS_HDFS_PREFIXES =
      new Builder(Name.UNDERFS_HDFS_PREFIXES)
          .setDefaultValue("hdfs://,glusterfs:///,maprfs:///")
          .setDescription("Optionally, specify which prefixes should run through the Apache "
              + "Hadoop implementation of UnderFileSystem. The delimiter is any whitespace "
              + "and/or ','.")
to

  public static final PropertyKey UNDERFS_HDFS_PREFIXES =
      new Builder(Name.UNDERFS_HDFS_PREFIXES)
          .setDefaultValue("hdfs://,glusterfs:///,maprfs:///")
          .setDescription("Optionally, specify which prefixes should run through the HDFS "
              + "implementation of UnderFileSystem. The delimiter is any whitespace "
              + "and/or ','.")`