### PR TITLE
Improve memory efficiency in IndexSet.Java with Java Collections util…

### DIFF
--- a/core/common/src/main/java/alluxio/collections/IndexedSet.java
+++ b/core/common/src/main/java/alluxio/collections/IndexedSet.java
@@ -123,7 +123,7 @@ public class IndexedSet<T> extends AbstractSet<T> {
   public IndexedSet(IndexDefinition<T> primaryIndexDefinition,
       IndexDefinition<T>... otherIndexDefinitions) {
     Iterable<IndexDefinition<T>> indexDefinitions =
-        Iterables.concat(Arrays.asList(primaryIndexDefinition),
+        Iterables.concat(Collections.singletonList(primaryIndexDefinition),
             Arrays.asList(otherIndexDefinitions));
 
     // initialization


### PR DESCRIPTION
In the constructor of alluxio.collections.IndexedSet, replace

Iterable<IndexDefinition<T>> indexDefinitions =
        Iterables.concat(Arrays.asList(primaryIndexDefinition),
            Arrays.asList(otherIndexDefinitions));
with

Iterable<IndexDefinition<T>> indexDefinitions =
        Iterables.concat(Collections.singletonList(primaryIndexDefinition),
            Arrays.asList(otherIndexDefinitions));
to save memory.