### PR TITLE
[ALLUXIO-6249]change the attribute of mBufferNotFullOrFailed to final

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -104,7 +104,7 @@ public final class NettyPacketWriter implements PacketWriter {
   /** This condition is met if mPacketWriteException != null or mDone = true. */
   private Condition mDoneOrFailed = mLock.newCondition();
   /** This condition is met if mPacketWriteException != null or the buffer is not full. */
-  private Condition mBufferNotFullOrFailed = mLock.newCondition();
+  private final Condition mBufferNotFullOrFailed = mLock.newCondition();
   /** This condition is met if there is nothing in the netty buffer. */
   private Condition mBufferEmptyOrFailed = mLock.newCondition();
 


### PR DESCRIPTION
Improve core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java as mBufferNotFullOrFailed can be marked as final.

Change

  private Condition mBufferNotFullOrFailed = mLock.newCondition();

to

  private final Condition mBufferNotFullOrFailed = mLock.newCondition();