### PR TITLE
[SMALLFIX] Use static imports for standard test utilities in DataFileChannelTest.java

### DIFF
--- a/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
+++ b/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.network.protocol.databuffer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.util.io.BufferUtils;
 
 import io.netty.channel.FileRegion;
@@ -23,9 +26,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link DataFileChannel} class.

--- a/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
+++ b/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 import alluxio.util.io.BufferUtils;
 
 import io.netty.channel.FileRegion;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
+++ b/core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java
@@ -24,6 +24,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests for the {@link DataFileChannel} class.
  */
@@ -58,7 +61,7 @@ public class DataFileChannelTest {
   public void nettyOutput() {
     DataFileChannel data = new DataFileChannel(mFile, OFFSET, LENGTH);
     Object output = data.getNettyOutput();
-    Assert.assertTrue(output instanceof FileRegion);
+    assertTrue(output instanceof FileRegion);
   }
 
   /**
@@ -67,6 +70,6 @@ public class DataFileChannelTest {
   @Test
   public void length() {
     DataFileChannel data = new DataFileChannel(mFile, OFFSET, LENGTH);
-    Assert.assertEquals(LENGTH, data.getLength());
+    assertEquals(LENGTH, data.getLength());
   }
 }


### PR DESCRIPTION
Use static imports for standard test utilities in
core/server/worker/src/test/java/alluxio/network/protocol/databuffer/DataFileChannelTest.java