### PR TITLE
[SMALLFIX]Supply the variable name to Preconditions.checkNotNull for CommandLineJobInfo.java

### DIFF
--- a/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
+++ b/core/common/src/main/java/alluxio/wire/CommandLineJobInfo.java
@@ -76,7 +76,7 @@ public final class CommandLineJobInfo implements Serializable {
    * @return the lineage command-line job information
    */
   public CommandLineJobInfo setConf(JobConfInfo conf) {
-    Preconditions.checkNotNull(conf);
+    Preconditions.checkNotNull(conf, "conf");
     mConf = conf;
     return this;
   }


### PR DESCRIPTION
Supply the variable name to Preconditions.checkNotNull for CommandLineJobInfo.java