### PR TITLE
[SMALLFIX] Fix formatting after Nullable in DefaultFileSystemMaster #27

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3219,7 +3219,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    *         the thread-local user is null. Normally this should not happen.
    */
   private FileSystemMasterAuditContext createAuditContext(String command, AlluxioURI srcPath,
-      @Nullable  AlluxioURI dstPath, @Nullable  Inode srcInode) throws AccessControlException {
+      @Nullable AlluxioURI dstPath, @Nullable Inode srcInode) throws AccessControlException {
     FileSystemMasterAuditContext auditContext =
         new FileSystemMasterAuditContext(mAsyncAuditLogWriter);
     if (mAsyncAuditLogWriter != null) {


### PR DESCRIPTION
core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java,
we have the signature

private FileSystemMasterAuditContext createAuditContext(String command,
AlluxioURI srcPath,
    @Nullable  AlluxioURI dstPath, @Nullable  Inode srcInode) throws
AccessControlException {
There are two spaces after each @Nullable annotation, but there should
be only one