### PR TITLE
[SMALLFIX]Use static imports for standard test utilities in GroupMappingServiceTest.java

### DIFF
--- a/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
+++ b/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
@@ -11,11 +11,13 @@
 
 package alluxio.security.group;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
 import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
 import alluxio.security.group.provider.IdentityUserGroupsMapping;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.Closeable;
@@ -37,10 +39,10 @@ public final class GroupMappingServiceTest {
             IdentityUserGroupsMapping.class.getName()).toResource()) {
       GroupMappingService groups = GroupMappingService.Factory.get();
 
-      Assert.assertNotNull(groups);
-      Assert.assertNotNull(groups.getGroups(userName));
-      Assert.assertEquals(groups.getGroups(userName).size(), 1);
-      Assert.assertEquals(groups.getGroups(userName).get(0), userName);
+      assertNotNull(groups);
+      assertNotNull(groups.getGroups(userName));
+      assertEquals(groups.getGroups(userName).size(), 1);
+      assertEquals(groups.getGroups(userName).get(0), userName);
     }
   }
 }


### PR DESCRIPTION
Use static imports for standard test utilities in GroupMappingServiceTest.java