### PR TITLE
[SMALLFIX]Change mSeekBuffer to final mSeekBuffer

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -102,7 +102,7 @@ public class FileInStream extends InputStream
   private long mStreamBlockId;
 
   /** The read buffer in file seek. This is used in {@link #readCurrentBlockToEnd()}. */
-  private byte[] mSeekBuffer;
+  private final byte[] mSeekBuffer;
 
   /**
    * Creates a new file input stream.


### PR DESCRIPTION
Improve core/client/fs/src/main/java/alluxio/client/file/FileInStream.java as mSeekBuffer can be marked as final.

Change

  private byte[] mSeekBuffer;
to

  private final byte[] mSeekBuffer;