### PR TITLE
[ALLUXIO-6291]  Improve Something

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -106,7 +106,7 @@ public final class NettyPacketWriter implements PacketWriter {
   /** This condition is met if mPacketWriteException != null or the buffer is not full. */
   private final Condition mBufferNotFullOrFailed = mLock.newCondition();
   /** This condition is met if there is nothing in the netty buffer. */
-  private Condition mBufferEmptyOrFailed = mLock.newCondition();
+  private final Condition mBufferEmptyOrFailed = mLock.newCondition();
 
   /**
    * @param context the file system context


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-6291

Improve core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java as mBufferEmptyOrFailed can be marked as final.

Change

  private Condition mBufferEmptyOrFailed = mLock.newCondition();
to

  private final Condition mBufferEmptyOrFailed = mLock.newCondition();