### PR TITLE
[SMALLFIX] Allow docs to build without javadoc

### DIFF
--- a/docs/_plugins/copy_javadoc_to_docs.rb
+++ b/docs/_plugins/copy_javadoc_to_docs.rb
@@ -11,7 +11,7 @@ puts "Making directory " + dest
 mkdir_p dest
 
 if !File.directory?(source)
-  puts source + " not found, continuing without javadoc"
+  puts "WARNING: " + source + " not found, continuing without javadoc"
 else
   puts "cp -r " + source + "/. " + dest
   cp_r(source + "/.", dest)

--- a/docs/_plugins/copy_javadoc_to_docs.rb
+++ b/docs/_plugins/copy_javadoc_to_docs.rb
@@ -10,7 +10,11 @@ dest = "api/java"
 puts "Making directory " + dest
 mkdir_p dest
 
-puts "cp -r " + source + "/. " + dest
-cp_r(source + "/.", dest)
+if !File.directory?(source)
+  puts source + " not found, continuing without javadoc"
+else
+  puts "cp -r " + source + "/. " + dest
+  cp_r(source + "/.", dest)
+end
 
 cd("..")


### PR DESCRIPTION
This is useful when developing documentation since building javadoc
takes a while.