### PR TITLE
[ALLUXIO-3045] Refactor to prepare for external process test cluster

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -107,7 +107,9 @@ public final class FileSystemContext implements Closeable {
 
   /**
    * @param subject the parent subject, set to null if not present
-   * @param masterInquireClient the client to use for determining the master
+   * @param masterInquireClient the client to use for determining the master; note that if the
+   *        context is reset, this client will be replaced with a new masterInquireClient based on
+   *        global configuration
    * @return the context
    */
   public static FileSystemContext create(Subject subject, MasterInquireClient masterInquireClient) {
@@ -127,6 +129,7 @@ public final class FileSystemContext implements Closeable {
 
   /**
    * Initializes the context. Only called in the factory methods and reset.
+   *
    * @param masterInquireClient the client to use for determining the master
    */
   private synchronized void init(MasterInquireClient masterInquireClient) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -56,7 +56,7 @@ import javax.security.auth.Subject;
  */
 @ThreadSafe
 public final class FileSystemContext implements Closeable {
-  public static final FileSystemContext INSTANCE = create(null);
+  public static final FileSystemContext INSTANCE = create();
 
   static {
     MetricsSystem.startSinks();
@@ -91,8 +91,6 @@ public final class FileSystemContext implements Closeable {
   private final Subject mParentSubject;
 
   /**
-   * Creates a new file system context.
-   *
    * @return the context
    */
   public static FileSystemContext create() {
@@ -100,14 +98,21 @@ public final class FileSystemContext implements Closeable {
   }
 
   /**
-   * Creates a file system context with a subject.
-   *
    * @param subject the parent subject, set to null if not present
    * @return the context
    */
   public static FileSystemContext create(Subject subject) {
+    return create(subject, MasterInquireClient.Factory.create());
+  }
+
+  /**
+   * @param subject the parent subject, set to null if not present
+   * @param masterInquireClient the client to use for determining the master
+   * @return the context
+   */
+  public static FileSystemContext create(Subject subject, MasterInquireClient masterInquireClient) {
     FileSystemContext context = new FileSystemContext(subject);
-    context.init();
+    context.init(masterInquireClient);
     return context;
   }
 
@@ -122,9 +127,10 @@ public final class FileSystemContext implements Closeable {
 
   /**
    * Initializes the context. Only called in the factory methods and reset.
+   * @param masterInquireClient the client to use for determining the master
    */
-  private synchronized void init() {
-    mMasterInquireClient = MasterInquireClient.Factory.create();
+  private synchronized void init(MasterInquireClient masterInquireClient) {
+    mMasterInquireClient = masterInquireClient;
     mFileSystemMasterClientPool =
         new FileSystemMasterClientPool(mParentSubject, mMasterInquireClient);
     mBlockMasterClientPool = new BlockMasterClientPool(mParentSubject, mMasterInquireClient);
@@ -141,6 +147,8 @@ public final class FileSystemContext implements Closeable {
     mFileSystemMasterClientPool = null;
     mBlockMasterClientPool.close();
     mBlockMasterClientPool = null;
+    mMasterInquireClient.close();
+    mMasterInquireClient = null;
 
     for (NettyChannelPool pool : mNettyChannelPools.values()) {
       pool.close();
@@ -148,7 +156,6 @@ public final class FileSystemContext implements Closeable {
     mNettyChannelPools.clear();
 
     synchronized (this) {
-      mMasterInquireClient = null;
       mLocalWorkerInitialized = false;
       mLocalWorker = null;
     }
@@ -160,7 +167,7 @@ public final class FileSystemContext implements Closeable {
    */
   public synchronized void reset() throws IOException {
     close();
-    init();
+    init(MasterInquireClient.Factory.create());
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -147,7 +147,6 @@ public final class FileSystemContext implements Closeable {
     mFileSystemMasterClientPool = null;
     mBlockMasterClientPool.close();
     mBlockMasterClientPool = null;
-    mMasterInquireClient.close();
     mMasterInquireClient = null;
 
     for (NettyChannelPool pool : mNettyChannelPools.values()) {

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -17,6 +17,7 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 
@@ -39,6 +40,9 @@ public interface MasterInquireClient extends AutoCloseable {
    * @throws UnavailableException if the master rpc addresses cannot be determined
    */
   List<InetSocketAddress> getMasterRpcAddresses() throws UnavailableException;
+
+  @Override
+  void close() throws IOException;
 
   /**
    * Factory for getting a master inquire client.

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -17,7 +17,6 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 
@@ -27,7 +26,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Client for determining the primary master.
  */
 @ThreadSafe
-public interface MasterInquireClient extends AutoCloseable {
+public interface MasterInquireClient {
   /**
    * @return the rpc address of the primary master. The implementation should perform retries if
    *         appropriate
@@ -40,9 +39,6 @@ public interface MasterInquireClient extends AutoCloseable {
    * @throws UnavailableException if the master rpc addresses cannot be determined
    */
   List<InetSocketAddress> getMasterRpcAddresses() throws UnavailableException;
-
-  @Override
-  void close() throws IOException;
 
   /**
    * Factory for getting a master inquire client.

--- a/core/common/src/main/java/alluxio/master/SingleMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/SingleMasterInquireClient.java
@@ -37,9 +37,4 @@ public class SingleMasterInquireClient implements MasterInquireClient {
   public List<InetSocketAddress> getMasterRpcAddresses() {
     return Arrays.asList(mAddress);
   }
-
-  @Override
-  public void close() {
-    // Nothing to close.
-  }
 }

--- a/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
@@ -28,6 +28,7 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Utility to get leader from zookeeper.
  */
 @ThreadSafe
-public final class ZkMasterInquireClient implements MasterInquireClient {
+public final class ZkMasterInquireClient implements MasterInquireClient, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(ZkMasterInquireClient.class);
 
   /** Map from key spliced by the address for Zookeeper and path of leader to created client. */
@@ -175,6 +176,7 @@ public final class ZkMasterInquireClient implements MasterInquireClient {
     throw new UnavailableException("Failed to query zookeeper for master RPC addresses");
   }
 
+  @Override
   public void close() {
     mClient.close();
   }

--- a/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
@@ -175,7 +175,6 @@ public final class ZkMasterInquireClient implements MasterInquireClient {
     throw new UnavailableException("Failed to query zookeeper for master RPC addresses");
   }
 
-  @Override
   public void close() {
     mClient.close();
   }

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -45,7 +45,8 @@ public final class ConfigurationTestUtils {
    * @param workDirectory the work directory in which to configure the journal and tiered storage
    * @return the configuration
    */
-  public static Map<PropertyKey, String> testConfigurationDefaults(String hostname, String workDirectory) {
+  public static Map<PropertyKey, String> testConfigurationDefaults(String hostname,
+      String workDirectory) {
     Map<PropertyKey, String> conf = new HashMap<>();
     conf.put(PropertyKey.MASTER_HOSTNAME, hostname);
     conf.put(PropertyKey.WORKER_BIND_HOST, hostname);

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -36,7 +36,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -25,11 +25,9 @@ import alluxio.security.LoginUserTestUtils;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.FileUtils;
-import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.WorkerProcess;
 
-import com.google.common.base.Joiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -261,55 +259,18 @@ public abstract class AbstractLocalAlluxioCluster {
     setAlluxioWorkDirectory();
     setHostname();
 
-    for (Entry<PropertyKey, String> entry : ConfigurationTestUtils.testConfigurationDefaults()
-        .entrySet()) {
+    for (Entry<PropertyKey, String> entry : ConfigurationTestUtils
+        .testConfigurationDefaults(mHostname, mWorkDirectory).entrySet()) {
       Configuration.set(entry.getKey(), entry.getValue());
     }
 
     Configuration.set(PropertyKey.TEST_MODE, true);
-    Configuration.set(PropertyKey.WORK_DIR, mWorkDirectory);
-    Configuration.set(PropertyKey.MASTER_HOSTNAME, mHostname);
     Configuration.set(PropertyKey.MASTER_RPC_PORT, 0);
     Configuration.set(PropertyKey.MASTER_WEB_PORT, 0);
-
-    Configuration.set(PropertyKey.MASTER_BIND_HOST, mHostname);
-    Configuration.set(PropertyKey.MASTER_WEB_BIND_HOST, mHostname);
-
     Configuration.set(PropertyKey.PROXY_WEB_PORT, 0);
-
     Configuration.set(PropertyKey.WORKER_RPC_PORT, 0);
     Configuration.set(PropertyKey.WORKER_DATA_PORT, 0);
     Configuration.set(PropertyKey.WORKER_WEB_PORT, 0);
-
-    Configuration.set(PropertyKey.WORKER_BIND_HOST, mHostname);
-    Configuration.set(PropertyKey.WORKER_DATA_BIND_HOST, mHostname);
-    Configuration.set(PropertyKey.WORKER_WEB_BIND_HOST, mHostname);
-
-    // Sets up the tiered store
-    String ramdiskPath = PathUtils.concatPath(mWorkDirectory, "ramdisk");
-    Configuration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(0), "MEM");
-    Configuration
-        .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0), ramdiskPath);
-
-    int numLevel = Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
-    for (int level = 1; level < numLevel; level++) {
-      PropertyKey tierLevelDirPath =
-          PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(level);
-      String[] dirPaths = Configuration.get(tierLevelDirPath).split(",");
-      List<String> newPaths = new ArrayList<>();
-      for (String dirPath : dirPaths) {
-        String newPath = mWorkDirectory + dirPath;
-        newPaths.add(newPath);
-      }
-      Configuration.set(
-          PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(level),
-          Joiner.on(',').join(newPaths));
-    }
-
-    // Sets up the journal folder
-    String journalFolder =
-        PathUtils.concatPath(mWorkDirectory, "journal" + RANDOM_GENERATOR.nextLong());
-    Configuration.set(PropertyKey.MASTER_JOURNAL_FOLDER, journalFolder);
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -14,7 +14,6 @@ package alluxio.master;
 import alluxio.AlluxioTestDirectory;
 import alluxio.Configuration;
 import alluxio.ConfigurationTestUtils;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.cli.Format;
 import alluxio.client.file.FileSystem;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Random;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -49,8 +49,6 @@ public abstract class AbstractLocalAlluxioCluster {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractLocalAlluxioCluster.class);
 
   private static final Random RANDOM_GENERATOR = new Random();
-  private static final int DEFAULT_BLOCK_SIZE_BYTES = Constants.KB;
-  private static final long DEFAULT_WORKER_MEMORY_BYTES = 100 * Constants.MB;
 
   protected ProxyProcess mProxyProcess;
   protected Thread mProxyThread;
@@ -263,57 +261,25 @@ public abstract class AbstractLocalAlluxioCluster {
     setAlluxioWorkDirectory();
     setHostname();
 
+    for (Entry<PropertyKey, String> entry : ConfigurationTestUtils.testConfigurationDefaults()
+        .entrySet()) {
+      Configuration.set(entry.getKey(), entry.getValue());
+    }
+
     Configuration.set(PropertyKey.TEST_MODE, true);
     Configuration.set(PropertyKey.WORK_DIR, mWorkDirectory);
-    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, DEFAULT_BLOCK_SIZE_BYTES);
-    Configuration.set(PropertyKey.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, 64);
     Configuration.set(PropertyKey.MASTER_HOSTNAME, mHostname);
     Configuration.set(PropertyKey.MASTER_RPC_PORT, 0);
     Configuration.set(PropertyKey.MASTER_WEB_PORT, 0);
-    Configuration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "1sec");
-    Configuration.set(PropertyKey.MASTER_WORKER_THREADS_MIN, 1);
-    Configuration.set(PropertyKey.MASTER_WORKER_THREADS_MAX, 100);
-    Configuration.set(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, false);
-    Configuration.set(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "1sec");
-
-    // Shutdown journal tailer quickly. Graceful shutdown is unnecessarily slow.
-    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "50ms");
-    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "10ms");
 
     Configuration.set(PropertyKey.MASTER_BIND_HOST, mHostname);
     Configuration.set(PropertyKey.MASTER_WEB_BIND_HOST, mHostname);
 
-    // If tests fail to connect they should fail early rather than using the default ridiculously
-    // high retries
-    Configuration.set(PropertyKey.USER_RPC_RETRY_MAX_NUM_RETRY, 3);
-
-    // Since tests are always running on a single host keep the resolution timeout low as otherwise
-    // people running with strange network configurations will see very slow tests
-    Configuration.set(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS, "250ms");
-
     Configuration.set(PropertyKey.PROXY_WEB_PORT, 0);
-
-    // default write type becomes MUST_CACHE, set this value to CACHE_THROUGH for tests.
-    // default Alluxio storage is STORE, and under storage is SYNC_PERSIST for tests.
-    // TODO(binfan): eliminate this setting after updating integration tests
-    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH");
-
-    Configuration.set(PropertyKey.WEB_THREADS, 1);
-    Configuration.set(PropertyKey.WEB_RESOURCES, PathUtils
-        .concatPath(System.getProperty("user.dir"), "../core/server/common/src/main/webapp"));
 
     Configuration.set(PropertyKey.WORKER_RPC_PORT, 0);
     Configuration.set(PropertyKey.WORKER_DATA_PORT, 0);
     Configuration.set(PropertyKey.WORKER_WEB_PORT, 0);
-    Configuration.set(PropertyKey.WORKER_MEMORY_SIZE, DEFAULT_WORKER_MEMORY_BYTES);
-    Configuration.set(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "15ms");
-    Configuration.set(PropertyKey.WORKER_BLOCK_THREADS_MIN, 1);
-    Configuration.set(PropertyKey.WORKER_BLOCK_THREADS_MAX, 2048);
-    Configuration.set(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS, 2);
-
-    // Shutdown data server quickly. Graceful shutdown is unnecessarily slow.
-    Configuration.set(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD, "0ms");
-    Configuration.set(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_TIMEOUT, "0ms");
 
     Configuration.set(PropertyKey.WORKER_BIND_HOST, mHostname);
     Configuration.set(PropertyKey.WORKER_DATA_BIND_HOST, mHostname);

--- a/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/master/AlluxioMasterRestApiTest.java
@@ -153,7 +153,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getTierCapacity() throws Exception {
-    long total = Configuration.getLong(PropertyKey.WORKER_MEMORY_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_MEMORY_SIZE);
     Capacity capacity = getInfo(NO_PARAMS).getTierCapacity().get("MEM");
     Assert.assertEquals(total, capacity.getTotal());
     Assert.assertEquals(0, capacity.getUsed());

--- a/tests/src/test/java/alluxio/worker/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/worker/AlluxioWorkerRestApiTest.java
@@ -80,7 +80,7 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
   @Test
   public void getTierCapacity() throws Exception {
-    long total = Configuration.getLong(PropertyKey.WORKER_MEMORY_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_MEMORY_SIZE);
     Capacity capacity = getInfo().getTierCapacity().get("MEM");
     Assert.assertEquals(total, capacity.getTotal());
     Assert.assertEquals(0, capacity.getUsed());


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3045

Default configuration that should be shared between all integration tests is moved to ConfigurationTestUtils. Configuration specific to AbstractLocalMiniCluster is left there.

FileSystemContext is updated to allow callers to inject a MasterInquireClient of their choice. No functionality should be changed.

MasterInquireClient no longer implements `AutoCloseable` because `ZkMasterInquireClients` are cached, so it is usually incorrect to close them.