### PR TITLE
[SMALLFIX] S3 Get Fix

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -668,7 +668,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @return {@link ObjectStatus} if key exists and successful, otherwise null
    */
   @Nullable
-  protected abstract ObjectStatus getObjectStatus(String key);
+  protected abstract ObjectStatus getObjectStatus(String key) throws IOException;
 
   /**
    * Get parent path.

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -479,19 +479,13 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Nullable
   protected ObjectStatus getObjectStatus(String key) {
     try {
-      LOG.info("Get Object Metadata for key: {}", key);
       ObjectMetadata meta = mClient.getObjectMetadata(mBucketName, key);
-      if (meta == null) {
-        return null;
-      }
       return new ObjectStatus(key, meta.getContentLength(), meta.getLastModified().getTime());
     } catch (AmazonServiceException e) {
-      if (e.getStatusCode() == 404) {
-        LOG.debug("getObjectStatus for {} returned 404. Assuming file does not exist.", key);
+      if (e.getStatusCode() == 404) { // file not found, possible for exists calls
         return null;
-      } else {
-        throw e;
       }
+      throw e;
     }
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -477,7 +477,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   @Nullable
-  protected ObjectStatus getObjectStatus(String key) {
+  protected ObjectStatus getObjectStatus(String key) throws IOException {
     try {
       ObjectMetadata meta = mClient.getObjectMetadata(mBucketName, key);
       return new ObjectStatus(key, meta.getContentLength(), meta.getLastModified().getTime());
@@ -485,7 +485,9 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       if (e.getStatusCode() == 404) { // file not found, possible for exists calls
         return null;
       }
-      throw e;
+      throw new IOException(e);
+    } catch (AmazonClientException e) {
+      throw new IOException(e);
     }
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -478,6 +478,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Nullable
   protected ObjectStatus getObjectStatus(String key) {
     try {
+      LOG.info("Get Object Metadata for key: {}", key);
       ObjectMetadata meta = mClient.getObjectMetadata(mBucketName, key);
       if (meta == null) {
         return null;

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -19,6 +19,7 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.internal.StaticCredentialsProvider;
@@ -83,6 +84,27 @@ public class S3AUnderFileSystemTest {
 
     mThrown.expect(IOException.class);
     mS3UnderFileSystem.deleteDirectory(PATH, DeleteOptions.defaults().setRecursive(true));
+  }
+
+  @Test
+  public void isFile404() throws IOException {
+    AmazonServiceException e = new AmazonServiceException("");
+    e.setStatusCode(404);
+    Mockito.when(mClient.getObjectMetadata(Matchers.anyString(), Matchers.anyString()))
+        .thenThrow(e);
+
+    Assert.assertFalse(mS3UnderFileSystem.isFile(SRC));
+  }
+
+  @Test
+  public void isFileException() throws IOException {
+    AmazonServiceException e = new AmazonServiceException("");
+    e.setStatusCode(403);
+    Mockito.when(mClient.getObjectMetadata(Matchers.anyString(), Matchers.anyString()))
+        .thenThrow(e);
+
+    mThrown.expect(IOException.class);
+    Assert.assertFalse(mS3UnderFileSystem.isFile(SRC));
   }
 
   @Test

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -87,11 +87,11 @@ public class S3AUnderFileSystemTest {
 
   @Test
   public void renameOnAmazonClientException() throws IOException {
-    Mockito.when(mClient.listObjectsV2(Matchers.any(ListObjectsV2Request.class)))
+    Mockito.when(mClient.getObjectMetadata(Matchers.anyString(), Matchers.anyString()))
         .thenThrow(AmazonClientException.class);
 
-    boolean result = mS3UnderFileSystem.renameFile(SRC, DST);
-    Assert.assertFalse(result);
+    mThrown.expect(IOException.class);
+    mS3UnderFileSystem.renameFile(SRC, DST);
   }
 
   @Test


### PR DESCRIPTION
Changes the `getObjectStatus` call to throw an IOException if we get anything other than a 404 for S3A. Also removes the unnecessary null check which was mistakenly causing a test to incorrectly pass. Also removes the noisy logging since the 404 errors were expected when an exists call returned false.