### PR TITLE
[SMALLFIX] Reduce log level of common s3a exception

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -484,7 +484,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       }
       return new ObjectStatus(key, meta.getContentLength(), meta.getLastModified().getTime());
     } catch (AmazonClientException e) {
-      LOG.warn("getObjectStatus error for {}, exception: {}. Assuming file does not exist.", key,
+      LOG.debug("getObjectStatus error for {}, exception: {}. Assuming file does not exist.", key,
           e.getMessage());
       return null;
     }


### PR DESCRIPTION
Checking the existence of a non-existent file should not generate a warning in the logs.