### PR TITLE
[SMALLFIX] Use static imports for standard test utilities in AbstractWriteHandlerTest.java

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/netty/AbstractWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/AbstractWriteHandlerTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.worker.netty;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.Constants;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.network.protocol.databuffer.DataBuffer;
@@ -27,7 +30,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -162,10 +164,10 @@ public abstract class AbstractWriteHandlerTest {
    * @param writeResponse the write response
    */
   protected void checkWriteResponse(PStatus expectedStatus, Object writeResponse) {
-    Assert.assertTrue(writeResponse instanceof RPCProtoMessage);
+    assertTrue(writeResponse instanceof RPCProtoMessage);
     ProtoMessage response = ((RPCProtoMessage) writeResponse).getMessage();
-    Assert.assertTrue(response.isResponse());
-    Assert.assertEquals(expectedStatus, response.asResponse().getStatus());
+    assertTrue(response.isResponse());
+    assertEquals(expectedStatus, response.asResponse().getStatus());
   }
 
   /**
@@ -189,8 +191,8 @@ public abstract class AbstractWriteHandlerTest {
       }
     }
 
-    Assert.assertEquals(expectedChecksum, actualChecksum);
-    Assert.assertEquals(size, actualSize);
+    assertEquals(expectedChecksum, actualChecksum);
+    assertEquals(size, actualSize);
   }
 
   /**


### PR DESCRIPTION
Use static imports for standard test utilities in
core/server/worker/src/test/java/alluxio/worker/netty/AbstractWriteHandlerTest.java