### PR TITLE
[SMALLFIX]Use static imports for standard test utilities in MasterFaultToleranceIntegrationTest.java

### DIFF
--- a/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/MasterFaultToleranceIntegrationTest.java
@@ -11,6 +11,10 @@
 
 package alluxio.master;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.Constants;
@@ -34,7 +38,6 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Function;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -113,11 +116,11 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       AlluxioException {
     List<String> files = FileSystemTestUtils.listFiles(mFileSystem, AlluxioURI.SEPARATOR);
     Collections.sort(files);
-    Assert.assertEquals(answers.size(), files.size());
+    assertEquals(answers.size(), files.size());
     for (Pair<Long, AlluxioURI> answer : answers) {
-      Assert.assertEquals(answer.getSecond().toString(),
+      assertEquals(answer.getSecond().toString(),
           mFileSystem.getStatus(answer.getSecond()).getPath());
-      Assert.assertEquals(answer.getFirst().longValue(),
+      assertEquals(answer.getFirst().longValue(),
           mFileSystem.getStatus(answer.getSecond()).getFileId());
     }
   }
@@ -154,7 +157,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     faultTestDataCheck(answer);
 
     for (int kills = 0; kills < MASTERS - 1; kills++) {
-      Assert.assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
+      assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
       waitForWorkerRegistration(AlluxioBlockStore.create(), 1, CLUSTER_WAIT_TIMEOUT_MS);
       faultTestDataCheck(answer);
@@ -167,7 +170,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     // Kill leader -> create files -> kill leader -> delete files, repeat.
     List<Pair<Long, AlluxioURI>> answer = new ArrayList<>();
     for (int kills = 0; kills < MASTERS - 1; kills++) {
-      Assert.assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
+      assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
       waitForWorkerRegistration(AlluxioBlockStore.create(), 1, CLUSTER_WAIT_TIMEOUT_MS);
 
@@ -187,7 +190,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       } else {
         // Create files.
 
-        Assert.assertEquals(0, answer.size());
+        assertEquals(0, answer.size());
         faultTestDataCheck(answer);
 
         faultTestDataCreation(new AlluxioURI(PathUtils.concatPath(
@@ -206,10 +209,10 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       mFileSystem.createFile(new AlluxioURI(AlluxioURI.SEPARATOR + k), option).close();
     }
     List<String> files = FileSystemTestUtils.listFiles(mFileSystem, AlluxioURI.SEPARATOR);
-    Assert.assertEquals(clients, files.size());
+    assertEquals(clients, files.size());
     Collections.sort(files);
     for (int k = 0; k < clients; k++) {
-      Assert.assertEquals(AlluxioURI.SEPARATOR + k, files.get(k));
+      assertEquals(AlluxioURI.SEPARATOR + k, files.get(k));
     }
   }
 
@@ -219,7 +222,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     // cluster should run properly.
 
     int leaderIndex = mMultiMasterLocalAlluxioCluster.getLeaderIndex();
-    Assert.assertNotEquals(-1, leaderIndex);
+    assertNotEquals(-1, leaderIndex);
 
     List<Pair<Long, AlluxioURI>> answer = new ArrayList<>();
     for (int k = 0; k < 5; k++) {
@@ -228,11 +231,11 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     faultTestDataCheck(answer);
 
     for (int kills = 0; kills < MASTERS - 1; kills++) {
-      Assert.assertTrue(mMultiMasterLocalAlluxioCluster.stopStandby());
+      assertTrue(mMultiMasterLocalAlluxioCluster.stopStandby());
       CommonUtils.sleepMs(Constants.SECOND_MS * 2);
 
       // Leader should not change.
-      Assert.assertEquals(leaderIndex, mMultiMasterLocalAlluxioCluster.getLeaderIndex());
+      assertEquals(leaderIndex, mMultiMasterLocalAlluxioCluster.getLeaderIndex());
       // Cluster should still work.
       faultTestDataCheck(answer);
       faultTestDataCreation(new AlluxioURI("/data_kills_" + kills), answer);
@@ -242,15 +245,15 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
   @Test
   public void workerReRegister() throws Exception {
     AlluxioBlockStore store = AlluxioBlockStore.create();
-    Assert.assertEquals(WORKER_CAPACITY_BYTES, store.getCapacityBytes());
+    assertEquals(WORKER_CAPACITY_BYTES, store.getCapacityBytes());
 
     for (int kills = 0; kills < MASTERS - 1; kills++) {
-      Assert.assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
+      assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
       waitForWorkerRegistration(store, 1, 1 * Constants.MINUTE_MS);
       // If worker is successfully re-registered, the capacity bytes should not change.
       long capacityFound = store.getCapacityBytes();
-      Assert.assertEquals(WORKER_CAPACITY_BYTES, capacityFound);
+      assertEquals(WORKER_CAPACITY_BYTES, capacityFound);
     }
   }
 
@@ -279,16 +282,16 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       blockMaster1.workerRegister(workerId2a, Collections.EMPTY_LIST, Collections.EMPTY_MAP,
           Collections.EMPTY_MAP, Collections.EMPTY_MAP);
 
-      Assert.assertEquals(2, blockMaster1.getWorkerCount());
+      assertEquals(2, blockMaster1.getWorkerCount());
       // Worker heartbeats should return "Nothing"
-      Assert.assertEquals(CommandType.Nothing, blockMaster1
+      assertEquals(CommandType.Nothing, blockMaster1
           .workerHeartbeat(workerId1a, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
               Collections.EMPTY_MAP).getCommandType());
-      Assert.assertEquals(CommandType.Nothing, blockMaster1
+      assertEquals(CommandType.Nothing, blockMaster1
           .workerHeartbeat(workerId2a, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
               Collections.EMPTY_MAP).getCommandType());
 
-      Assert.assertTrue(cluster.stopLeader());
+      assertTrue(cluster.stopLeader());
       cluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
 
       // Get the new block master, after the failover
@@ -296,7 +299,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
           .getMaster(BlockMaster.class);
 
       // Worker 2 tries to heartbeat (with original id), and should get "Register" in response.
-      Assert.assertEquals(CommandType.Register, blockMaster2
+      assertEquals(CommandType.Register, blockMaster2
           .workerHeartbeat(workerId2a, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
               Collections.EMPTY_MAP).getCommandType());
 
@@ -307,7 +310,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
           Collections.EMPTY_MAP, Collections.EMPTY_MAP);
 
       // Worker 1 tries to heartbeat (with original id), and should get "Register" in response.
-      Assert.assertEquals(CommandType.Register, blockMaster2
+      assertEquals(CommandType.Register, blockMaster2
           .workerHeartbeat(workerId1a, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
               Collections.EMPTY_MAP).getCommandType());
 


### PR DESCRIPTION
Use static imports for standard test utilities in MasterFaultToleranceIntegrationTest.java