### PR TITLE
[SMALLFIX] Through URI to special master address.

### DIFF
--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreWriter.java
@@ -23,10 +23,12 @@ import alluxio.thrift.PartitionInfo;
 import alluxio.util.io.BufferUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -65,8 +67,17 @@ class BaseKeyValueStoreWriter implements KeyValueStoreWriter {
    */
   BaseKeyValueStoreWriter(AlluxioURI uri) throws IOException {
     LOG.info("Create KeyValueStoreWriter for {}", uri);
-    mMasterClient = new KeyValueMasterClient(FileSystemContext.INSTANCE.getMasterAddress());
-
+    InetSocketAddress masterAddress = null;
+    if (!Strings.isNullOrEmpty(uri.getHost())) {
+      int port = uri.getPort();
+      if (port == -1) {
+        port = 80;
+      }
+      masterAddress = new InetSocketAddress(uri.getHost(), port);
+    } else {
+      masterAddress = FileSystemContext.INSTANCE.getMasterAddress();
+    }
+    mMasterClient = new KeyValueMasterClient(masterAddress);
     mStoreUri = Preconditions.checkNotNull(uri);
     mMasterClient.createStore(mStoreUri);
     mPartitionIndex = 0;


### PR DESCRIPTION
```java
KeyValueSystem kvs = KeyValueSystem.Factory.create();
KeyValueStoreWriter writer = kvs.createStore(new AlluxioURI("alluxio://192.168.1.200:19998/path/my-kvstore"));
```
The above code block want Alluxio master `192.168.1.200:19998` to create a keyValueStoreWriter. If we do nothing more, this program will use the default config, so that it think the master is localhost, but we can use `System.setProperty("alluxio.master.hostname", "192.168.1.200");` to special Alluxio master.

But i think the user gave the host and port mean that he want to special the master address through the uri, so i make this change.