### PR TITLE
[SMALLFIX] MultiProcessCluster improvements

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/ExternalProcess.java
+++ b/minicluster/src/main/java/alluxio/multi/process/ExternalProcess.java
@@ -14,6 +14,8 @@ package alluxio.multi.process;
 import alluxio.PropertyKey;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Preconditions;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class ExternalProcess {
-  private final Map<PropertyKey, Object> mConf;
+  private final Map<PropertyKey, String> mConf;
   private final Class<?> mClazz;
   private final File mOutFile;
 
@@ -40,7 +42,7 @@ public class ExternalProcess {
    * @param clazz the class to run
    * @param outfile the file to write process output to
    */
-  public ExternalProcess(Map<PropertyKey, Object> conf, Class<?> clazz, File outfile) {
+  public ExternalProcess(Map<PropertyKey, String> conf, Class<?> clazz, File outfile) {
     mConf = conf;
     mClazz = clazz;
     mOutFile = outfile;
@@ -50,10 +52,11 @@ public class ExternalProcess {
    * Starts the process.
    */
   public synchronized void start() throws IOException {
+    Preconditions.checkState(mProcess == null, "Process is already running");
     String java = PathUtils.concatPath(System.getProperty("java.home"), "bin", "java");
     String classpath = System.getProperty("java.class.path");
     List<String> args = new ArrayList<>(Arrays.asList(java, "-cp", classpath));
-    for (Entry<PropertyKey, Object> entry : mConf.entrySet()) {
+    for (Entry<PropertyKey, String> entry : mConf.entrySet()) {
       args.add(String.format("-D%s=%s", entry.getKey().toString(), entry.getValue()));
     }
     args.add(mClazz.getCanonicalName());

--- a/minicluster/src/main/java/alluxio/multi/process/Master.java
+++ b/minicluster/src/main/java/alluxio/multi/process/Master.java
@@ -13,10 +13,11 @@ package alluxio.multi.process;
 
 import alluxio.PropertyKey;
 
+import com.google.common.base.Preconditions;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -27,36 +28,26 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class Master implements Closeable {
   private final File mLogsDir;
-  private final File mConfDir;
-  private final MasterNetAddress mAddress;
+  private final Map<PropertyKey, String> mProperties;
 
   private ExternalProcess mProcess;
 
   /**
-   * @param confDir configuration directory
    * @param logsDir logs directory
-   * @param address address information for the master
+   * @param properties alluxio properties
    */
-  public Master(File confDir, File logsDir, MasterNetAddress address) throws IOException {
-    mConfDir = confDir;
+  public Master(File logsDir, Map<PropertyKey, String> properties) throws IOException {
     mLogsDir = logsDir;
-    mAddress = address;
+    mProperties = properties;
   }
 
   /**
    * Launches the master process.
    */
   public synchronized void start() throws IOException {
-    mLogsDir.mkdirs();
-    Map<PropertyKey, Object> conf = new HashMap<>();
-    conf.put(PropertyKey.LOGGER_TYPE, "MASTER_LOGGER");
-    conf.put(PropertyKey.CONF_DIR, mConfDir.getAbsolutePath());
-    conf.put(PropertyKey.LOGS_DIR, mLogsDir.getAbsolutePath());
-    conf.put(PropertyKey.MASTER_HOSTNAME, mAddress.getHostname());
-    conf.put(PropertyKey.MASTER_RPC_PORT, mAddress.getRpcPort());
-    conf.put(PropertyKey.MASTER_WEB_PORT, mAddress.getWebPort());
+    Preconditions.checkState(mProcess == null, "Master is already running");
     mProcess =
-        new ExternalProcess(conf, LimitedLifeMasterProcess.class, new File(mLogsDir, "master.out"));
+        new ExternalProcess(mProperties, LimitedLifeMasterProcess.class, new File(mLogsDir, "master.out"));
     mProcess.start();
   }
 

--- a/minicluster/src/main/java/alluxio/multi/process/Master.java
+++ b/minicluster/src/main/java/alluxio/multi/process/Master.java
@@ -46,8 +46,8 @@ public final class Master implements Closeable {
    */
   public synchronized void start() throws IOException {
     Preconditions.checkState(mProcess == null, "Master is already running");
-    mProcess =
-        new ExternalProcess(mProperties, LimitedLifeMasterProcess.class, new File(mLogsDir, "master.out"));
+    mProcess = new ExternalProcess(mProperties, LimitedLifeMasterProcess.class,
+        new File(mLogsDir, "master.out"));
     mProcess.start();
   }
 

--- a/minicluster/src/main/java/alluxio/multi/process/Worker.java
+++ b/minicluster/src/main/java/alluxio/multi/process/Worker.java
@@ -12,15 +12,14 @@
 package alluxio.multi.process;
 
 import alluxio.PropertyKey;
-import alluxio.network.PortUtils;
 
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -33,69 +32,27 @@ public class Worker implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Worker.class);
 
   private final File mLogsDir;
-  private final File mConfDir;
-  private final File mRamdiskFile;
-  private final int mRpcPort;
-  private final int mDataPort;
-  private final int mWebPort;
+  private final Map<PropertyKey, String> mProperties;
 
   private ExternalProcess mProcess;
 
   /**
-   * @param confDir the conf directory
-   * @param logsDir the work directory
-   * @param ramdisk the ramdisk
+   * @param logsDir log directory
+   * @param properties alluxio properties
    */
-  public Worker(File confDir, File logsDir, File ramdisk) throws IOException {
-    mConfDir = confDir;
+  public Worker(File logsDir, Map<PropertyKey, String> properties) throws IOException {
     mLogsDir = logsDir;
-    mRamdiskFile = ramdisk;
-    mRpcPort = PortUtils.getFreePort();
-    mDataPort = PortUtils.getFreePort();
-    mWebPort = PortUtils.getFreePort();
+    mProperties = properties;
   }
 
   /**
    * Launches the worker process.
    */
   public synchronized void start() throws IOException {
-    mLogsDir.mkdirs();
-    mRamdiskFile.mkdirs();
-    Map<PropertyKey, Object> conf = new HashMap<>();
-    conf.put(PropertyKey.LOGGER_TYPE, "WORKER_LOGGER");
-    conf.put(PropertyKey.CONF_DIR, mConfDir.getAbsolutePath());
-    conf.put(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
-        mRamdiskFile.getAbsolutePath());
-    conf.put(PropertyKey.LOGS_DIR, mLogsDir.getAbsolutePath());
-    conf.put(PropertyKey.WORKER_RPC_PORT, mRpcPort);
-    conf.put(PropertyKey.WORKER_DATA_PORT, mDataPort);
-    conf.put(PropertyKey.WORKER_WEB_PORT, mWebPort);
+    Preconditions.checkState(mProcess == null, "Worker is already running");
     mProcess =
-        new ExternalProcess(conf, LimitedLifeWorkerProcess.class, new File(mLogsDir, "worker.out"));
-    LOG.info("Starting worker with (rpc, data, web) ports ({}, {}, {})", mRpcPort, mDataPort,
-        mWebPort);
+        new ExternalProcess(mProperties, LimitedLifeWorkerProcess.class, new File(mLogsDir, "worker.out"));
     mProcess.start();
-  }
-
-  /**
-   * @return the worker's rpc port
-   */
-  public int getRpcPort() {
-    return mRpcPort;
-  }
-
-  /**
-   * @return the worker's web port
-   */
-  public int getDataPort() {
-    return mWebPort;
-  }
-
-  /**
-   * @return the worker's web port
-   */
-  public int getWebPort() {
-    return mWebPort;
   }
 
   @Override

--- a/minicluster/src/main/java/alluxio/multi/process/Worker.java
+++ b/minicluster/src/main/java/alluxio/multi/process/Worker.java
@@ -50,8 +50,8 @@ public class Worker implements Closeable {
    */
   public synchronized void start() throws IOException {
     Preconditions.checkState(mProcess == null, "Worker is already running");
-    mProcess =
-        new ExternalProcess(mProperties, LimitedLifeWorkerProcess.class, new File(mLogsDir, "worker.out"));
+    mProcess = new ExternalProcess(mProperties, LimitedLifeWorkerProcess.class,
+        new File(mLogsDir, "worker.out"));
     mProcess.start();
   }
 

--- a/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
+++ b/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 public final class MultiProcessClusterTest {
-  private boolean mSuccess = false;
   private MultiProcessCluster mCluster;
 
   @Rule
@@ -44,9 +43,9 @@ public final class MultiProcessClusterTest {
       mCluster.start();
       FileSystem fs = mCluster.getFileSystemClient();
       createAndOpenFile(fs);
-      mSuccess = true;
+      mCluster.notifySuccess();
     } finally {
-      cleanup();
+      mCluster.destroy();
     }
   }
 
@@ -62,23 +61,8 @@ public final class MultiProcessClusterTest {
       mCluster.start();
       FileSystem fs = mCluster.getFileSystemClient();
       createAndOpenFile(fs);
-      mSuccess = true;
+      mCluster.notifySuccess();
     } finally {
-      cleanup();
-    }
-  }
-
-  /**
-   * Destroys the test cluster, saving its work directory in case of failure.
-   *
-   * This cannot be done with @After because @After methods are not necessarily called when a test
-   * times out due to a Timeout rule.
-   */
-  private void cleanup() throws Exception {
-    if (mCluster != null) {
-      if (!mSuccess) {
-        mCluster.saveWorkdir();
-      }
       mCluster.destroy();
     }
   }

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -107,9 +107,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
       Assert.assertTrue(
           String.format("successFiles: %s, actualFiles: %s", successFiles, actualFiles),
           (successFiles == actualFiles) || (successFiles + 1 == actualFiles));
-    } catch (Throwable t) {
-      cluster.saveWorkdir();
-      throw t;
+      cluster.notifySuccess();
     } finally {
       cluster.destroy();
     }
@@ -143,9 +141,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
       Assert.assertTrue(
           String.format("successFiles: %s, actualFiles: %s", successFiles, actualFiles),
           (successFiles == actualFiles) || (successFiles + 1 == actualFiles));
-    } catch (Throwable t) {
-      cluster.saveWorkdir();
-      throw t;
+      cluster.notifySuccess();
     } finally {
       cluster.destroy();
     }


### PR DESCRIPTION
- Track within the cluster whether the test has succeeded or failed, and decide during `destroy` whether to save state for debugging.
- Use `Map<PropertyKey, String>` consistently
- Pass per-master properties into `Master` and `Worker` from `MultiProcessCluster`. This way, `MultiProcessCluster` is the source of truth for all configuration.
- Fix issue where restarting would append new masters to the masters list instead of replacing. Now we differentiate between create (populate the masters list) and start/stop (operate on specific masters without modifying the list).