### PR TITLE
[ALLUXIO-6339]In core/server/master/src/main/java/alluxio/master/file/meta/InodeTre…

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -65,7 +65,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Represents the tree of Inode's.
+ * Represents the tree of Inodes.
  */
 @NotThreadSafe
 // TODO(jiri): Make this class thread-safe.


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-6339

In core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java the javadoc says
"Represents the tree of Inode's". This should be "Inodes", not "Inode's"