### PR TITLE
[SMALLFIX] Add Zookeeper failure test

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -730,6 +730,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "underlying storage on startup. During the time the check is running, Alluxio "
               + "will be in read only mode. Enabled by default.")
           .build();
+  public static final PropertyKey MASTER_THRIFT_SHUTDOWN_TIMEOUT =
+         new Builder(Name.MASTER_THRIFT_SHUTDOWN_TIMEOUT)
+         .setDefaultValue("60sec")
+         .setDescription("Maximum time to wait for thrift servers to stop on shutdown")
+         .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
       new Builder(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS)
           .setDefaultValue("MEM")
@@ -2059,6 +2064,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_RPC_PORT = "alluxio.master.port";
     public static final String MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
         "alluxio.master.startup.consistency.check.enabled";
+    public static final String MASTER_THRIFT_SHUTDOWN_TIMEOUT =
+        "alluxio.master.thrift.shutdown.timeout";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
         "alluxio.master.tieredstore.global.level0.alias";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS =

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -84,6 +84,7 @@ public final class ConfigurationTestUtils {
     conf.put(PropertyKey.MASTER_WORKER_THREADS_MAX, "100");
     conf.put(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED, "false");
     conf.put(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "1sec");
+    conf.put(PropertyKey.MASTER_THRIFT_SHUTDOWN_TIMEOUT, "0sec");
 
     // Shutdown journal tailer quickly. Graceful shutdown is unnecessarily slow.
     conf.put(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "50ms");

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -319,11 +319,8 @@ public class AlluxioMasterProcess implements MasterProcess {
     Args args = new TThreadPoolServer.Args(mTServerSocket).maxWorkerThreads(mMaxWorkerThreads)
         .minWorkerThreads(mMinWorkerThreads).processor(processor).transportFactory(transportFactory)
         .protocolFactory(new TBinaryProtocol.Factory(true, true));
-    if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
-      args.stopTimeoutVal = 0;
-    } else {
-      args.stopTimeoutVal = Constants.THRIFT_STOP_TIMEOUT_SECONDS;
-    }
+
+    args.stopTimeoutVal = (int) Configuration.getMs(PropertyKey.MASTER_THRIFT_SHUTDOWN_TIMEOUT);
     mThriftServer = new TThreadPoolServer(args);
 
     // start thrift rpc server

--- a/docs/_data/table/common-configuration.csv
+++ b/docs/_data/table/common-configuration.csv
@@ -65,10 +65,12 @@ alluxio.web.resources,${alluxio.home}/core/server/common/src/main/webapp
 alluxio.web.threads,1
 alluxio.work.dir,${alluxio.home}
 alluxio.zookeeper.address,
+alluxio.zookeeper.connection.timeout,15s
 alluxio.zookeeper.election.path,/election
 alluxio.zookeeper.enabled,false
 alluxio.zookeeper.leader.inquiry.retry,10
 alluxio.zookeeper.leader.path,/leader
+alluxio.zookeeper.session.timeout,60s
 aws.accessKeyId,
 aws.secretKey,
 fs.gcs.accessKeyId,

--- a/docs/_data/table/en/cluster-management-configuration.yml
+++ b/docs/_data/table/en/cluster-management-configuration.yml
@@ -19,7 +19,7 @@ alluxio.integration.mesos.role:
 alluxio.integration.mesos.secret:
   'Secret token for authenticating with Mesos.'
 alluxio.integration.mesos.user:
-  'The Mesos user for the Alluxio Mesos Framework. Defaults to the current user'
+  'The Mesos user for the Alluxio Mesos Framework. Defaults to the current user.'
 alluxio.integration.mesos.worker.name:
   'The name of the worker process to use within Mesos.'
 alluxio.integration.worker.resource.cpu:

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -69,7 +69,7 @@ alluxio.underfs.hdfs.configuration:
 alluxio.underfs.hdfs.impl:
   'The implementation class of the HDFS as the under storage system.'
 alluxio.underfs.hdfs.prefixes:
-  'Optionally, specify which prefixes should run through the Apache Hadoop implementation of UnderFileSystem. The delimiter is any whitespace and/or '',''.'
+  'Optionally, specify which prefixes should run through the HDFS implementation of UnderFileSystem. The delimiter is any whitespace and/or '',''.'
 alluxio.underfs.hdfs.remote:
   'Boolean indicating whether or not the under storage worker nodes are remote with respect to Alluxio worker nodes. If set to true, Alluxio will not attempt to discover locality information from the under storage because locality is impossible. This will improve performance. The default value is false.'
 alluxio.underfs.listing.length:
@@ -130,6 +130,8 @@ alluxio.work.dir:
   'The directory to use for Alluxio''s working directory. By default, the journal, logs, and under file system data (if using local filesystem) are written here.'
 alluxio.zookeeper.address:
   'Address of ZooKeeper.'
+alluxio.zookeeper.connection.timeout:
+  'Connection timeout to use when connecting to Zookeeper'
 alluxio.zookeeper.election.path:
   'Election directory in ZooKeeper.'
 alluxio.zookeeper.enabled:
@@ -138,6 +140,8 @@ alluxio.zookeeper.leader.inquiry.retry:
   'The number of retries to inquire leader from ZooKeeper.'
 alluxio.zookeeper.leader.path:
   'Leader directory in ZooKeeper.'
+alluxio.zookeeper.session.timeout:
+  'Session timeout to use when connecting to Zookeeper'
 aws.accessKeyId:
   'The access key of S3 bucket.'
 aws.secretKey:
@@ -155,7 +159,7 @@ fs.oss.endpoint:
 fs.swift.apikey:
   '(deprecated) The API key used for user:tenant authentication.'
 fs.swift.auth.method:
-  'Choice of authenitcation method: [tempauth (default), swiftauth, keystone, keystonev3].'
+  'Choice of authentication method: [tempauth (default), swiftauth, keystone, keystonev3].'
 fs.swift.auth.url:
   'Authentication URL for REST server, e.g., http://server:8090/auth/v1.0.'
 fs.swift.password:

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -9,7 +9,7 @@ alluxio.master.connection.timeout:
 alluxio.master.file.async.persist.handler:
   'The handler for processing the async persistence requests.'
 alluxio.master.format.file_prefix:
-  'The file prefix of the file generated in the journal directory when the journal is formatted. The master will search for a file with this prefix when determining of the journal was once formatted.'
+  'The file prefix of the file generated in the journal directory when the journal is formatted. The master will search for a file with this prefix when determining if the journal is formatted.'
 alluxio.master.heartbeat.interval:
   'The interval between Alluxio masters'' heartbeats.'
 alluxio.master.hostname:

--- a/docs/_data/table/en/user-configuration.yml
+++ b/docs/_data/table/en/user-configuration.yml
@@ -31,7 +31,7 @@ alluxio.user.file.master.client.threads:
 alluxio.user.file.metadata.load.type:
   'The behavior of loading metadata from UFS. When information about a path is requested and the path does not exist in Alluxio, metadata can be loaded from the UFS. Valid options are `Always`, `Never`, and `Once`. `Always` will always access UFS to see if the path exists in the UFS. `Never` will never consult the UFS. `Once` will access the UFS the "first" time (according to a cache), but not after that.'
 alluxio.user.file.passive.cache.enabled:
-  'Whether to cache files to local Alluxio workers when the files are read from remote workers (not UFS). Whether to cache files to local worker is irrelevant of this option when the files are read from UFS.'
+  'Whether to cache files to local Alluxio workers when the files are read from remote workers (not UFS).'
 alluxio.user.file.readtype.default:
   'Default read type when creating Alluxio files. Valid options are `CACHE_PROMOTE` (move data to highest tier if already in Alluxio storage, write data into highest tier of local Alluxio if data needs to be read from under storage), `CACHE` (write data into highest tier of local Alluxio if data needs to be read from under storage), `NO_CACHE` (no data interaction with Alluxio, if the read is from Alluxio data migration or eviction will not occur).'
 alluxio.user.file.seek.buffer.size.bytes:

--- a/docs/_data/table/en/worker-configuration.yml
+++ b/docs/_data/table/en/worker-configuration.yml
@@ -19,7 +19,7 @@ alluxio.worker.data.folder:
 alluxio.worker.data.folder.tmp:
   'A relative path in alluxio.worker.data.folder used to store the temporary data for uncommitted files.'
 alluxio.worker.data.hostname:
-  'The hostname of Alluxio worker data service'
+  'The hostname of Alluxio worker data service.'
 alluxio.worker.data.port:
   'The port Alluxio''s worker''s data server runs on.'
 alluxio.worker.data.server.class:

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -75,7 +75,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class MultiProcessCluster implements TestRule {
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File("./target/artifacts");
-  private static final File TESTS_LOG = new File("./target/tests.log");
+  private static final File TESTS_LOG = new File("./target/logs/tests.log");
 
   private final Map<PropertyKey, String> mProperties;
   private final int mNumMasters;
@@ -297,6 +297,13 @@ public final class MultiProcessCluster implements TestRule {
   }
 
   /**
+   * @return return the list of master addresses
+   */
+  public List<MasterNetAddress> getMasterAddresses() {
+    return mMasterAddresses;
+  }
+
+  /**
    * Stops the Zookeeper cluster.
    */
   public void stopZk() throws IOException {
@@ -304,11 +311,11 @@ public final class MultiProcessCluster implements TestRule {
   }
 
   /**
-   * Starts the Zookeeper cluster.
+   * Restarts the Zookeeper cluster.
    */
-  public void startZk() throws Exception {
+  public void restartZk() throws Exception {
     Preconditions.checkNotNull(mCuratorServer, "mCuratorServer");
-    mCuratorServer.start();
+    mCuratorServer.restart();
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -299,21 +299,21 @@ public final class MultiProcessCluster implements TestRule {
   /**
    * @return return the list of master addresses
    */
-  public List<MasterNetAddress> getMasterAddresses() {
+  public synchronized List<MasterNetAddress> getMasterAddresses() {
     return mMasterAddresses;
   }
 
   /**
    * Stops the Zookeeper cluster.
    */
-  public void stopZk() throws IOException {
+  public synchronized void stopZk() throws IOException {
     mCuratorServer.stop();
   }
 
   /**
    * Restarts the Zookeeper cluster.
    */
-  public void restartZk() throws Exception {
+  public synchronized void restartZk() throws Exception {
     Preconditions.checkNotNull(mCuratorServer, "mCuratorServer");
     mCuratorServer.restart();
   }

--- a/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
+++ b/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
@@ -25,9 +25,7 @@ public final class RestartableTestingServer extends TestingServer {
   private final TestingZooKeeperServer mTestingZooKeeperServer;
 
   /**
-   * Creates the server using the given port.
-   *
-   * @param port the port
+   * @param port port to use
    * @param tempDirectory directory to use
    */
   public RestartableTestingServer(int port, File tempDirectory) throws Exception {

--- a/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
+++ b/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
@@ -1,0 +1,44 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.zookeeper;
+
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.test.TestingZooKeeperServer;
+import org.powermock.reflect.Whitebox;
+
+import java.io.File;
+
+/**
+ * Wrapper around to Curator's {@link TestingServer} which allows the server to be restarted.
+ */
+public final class RestartableTestingServer extends TestingServer {
+  private final TestingZooKeeperServer mTestingZooKeeperServer;
+
+  /**
+   * Creates the server using the given port.
+   *
+   * @param port the port
+   * @param tempDirectory directory to use
+   */
+  public RestartableTestingServer(int port, File tempDirectory) throws Exception {
+    super(new InstanceSpec(tempDirectory, port, -1, -1, true, -1));
+    mTestingZooKeeperServer = Whitebox.getInternalState(this, "testingZooKeeperServer");
+  }
+
+  /**
+   * Starts the internal testing server.
+   */
+  public void start() throws Exception {
+    mTestingZooKeeperServer.start();
+  }
+}

--- a/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
+++ b/minicluster/src/main/java/alluxio/zookeeper/RestartableTestingServer.java
@@ -36,9 +36,9 @@ public final class RestartableTestingServer extends TestingServer {
   }
 
   /**
-   * Starts the internal testing server.
+   * Restarts the internal testing server.
    */
-  public void start() throws Exception {
-    mTestingZooKeeperServer.start();
+  public void restart() throws Exception {
+    mTestingZooKeeperServer.restart();
   }
 }

--- a/tests/src/test/java/alluxio/AlluxioOperationThread.java
+++ b/tests/src/test/java/alluxio/AlluxioOperationThread.java
@@ -1,0 +1,126 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.options.CreateFileOptions;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A thread which performs operations on an Alluxio filesystem and tracks the results of the
+ * operations.
+ */
+public class AlluxioOperationThread extends Thread {
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioOperationThread.class);
+
+  private final FileSystem mFs;
+
+  // Configurable state
+  private List<Op> mOps = Arrays.asList(Op.values());
+  private long mIntervalMs = 10;
+
+  // Internal bookkeeping state
+  private final AtomicReference<Throwable> mLatestFailure = new AtomicReference<>();
+  private volatile boolean mStarted = false;
+  private int mSuccesses = 0;
+
+  /** Enum representing operations to perform on a cluster. */
+  enum Op {
+    /** Creates a small randomly named file at the root. */
+    CREATE_FILE,
+    /** Creates and deletes a file at the root. */
+    CREATE_AND_DELETE;
+  }
+
+  /**
+   * Constructs an {@link AlluxioOperationThread} which performs all types of operations.
+   *
+   * @param fs the filesystem on which to perform operations
+   */
+  public AlluxioOperationThread(FileSystem fs) {
+    mFs = fs;
+  }
+
+  /**
+   * @param ops the types of operation to perform
+   * @return the updated operation thread object
+   */
+  public AlluxioOperationThread withOps(List<Op> ops) {
+    Preconditions.checkState(ops.size() > 0);
+    Preconditions.checkState(!mStarted);
+    mOps = ops;
+    return this;
+  }
+
+  /**
+   * @param intervalMs the interval to wait between performing operations
+   * @return the updated operation thread object
+   */
+  public AlluxioOperationThread withDelay(long intervalMs) {
+    Preconditions.checkState(!mStarted);
+    mIntervalMs = intervalMs;
+    return this;
+  }
+
+  /**
+   * @return the latest exception thrown during an operation, or null if no failures have occurred
+   */
+  public Throwable getLatestFailure() {
+    return mLatestFailure.get();
+  }
+
+  /**
+   * @return the number of successful operations performed by the thread
+   */
+  public int successes() {
+    return mSuccesses;
+  }
+
+  @Override
+  public void run() {
+    mStarted = true;
+    while (!Thread.interrupted()) {
+      Op op = mOps.get(ThreadLocalRandom.current().nextInt(mOps.size()));
+      try {
+        switch (op) {
+          case CREATE_FILE:
+            createFile();
+            break;
+          case CREATE_AND_DELETE:
+            mFs.delete(createFile());
+            break;
+          default:
+            throw new IllegalStateException("Unknown op: " + op.toString());
+        }
+        mSuccesses++;
+      } catch (Throwable t) {
+        LOG.error("Failure during operation {}", op, t);
+        mLatestFailure.set(t);
+      }
+    }
+  }
+
+  private AlluxioURI createFile() {
+    String file = "/file" + ThreadLocalRandom.current().nextLong();
+    FileSystemTestUtils.createByteFile(mFs, file, 100, CreateFileOptions.defaults());
+    return new AlluxioURI(file);
+  }
+}

--- a/tests/src/test/java/alluxio/zookeeper/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/zookeeper/ZookeeperFailureIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.zookeeper;
+
+import static org.junit.Assert.assertNull;
+
+import alluxio.AlluxioOperationThread;
+import alluxio.BaseIntegrationTest;
+import alluxio.ConfigurationRule;
+import alluxio.PropertyKey;
+import alluxio.multi.process.MultiProcessCluster;
+import alluxio.util.CommonUtils;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests for Alluxio high availability when Zookeeper has failures.
+ */
+public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ZookeeperFailureIntegrationTest.class);
+
+  @Rule
+  public ConfigurationRule mConf = new ConfigurationRule(ImmutableMap.of(
+      PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "1000"));
+
+  @Rule
+  public MultiProcessCluster mCluster = MultiProcessCluster.newBuilder()
+      .setClusterName("ZookeeperFailure")
+      .addProperty(PropertyKey.ZOOKEEPER_ENABLED, "true")
+      .setNumMasters(2)
+      .setNumWorkers(1)
+      .build();
+
+  @Test
+  public void zkFailure() throws Exception {
+    final AlluxioOperationThread thread = new AlluxioOperationThread(mCluster.getFileSystemClient());
+    thread.start();
+    CommonUtils.waitFor("a successful operation to be performed", new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(Void input) {
+        return thread.successes() > 0;
+      }
+    });
+    assertNull(thread.getLatestFailure());
+    mCluster.stopZk();
+    long zkStopTime = System.currentTimeMillis();
+    CommonUtils.waitFor("operations to start failing", new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(Void input) {
+        return thread.getLatestFailure() != null;
+      }
+    });
+    LOG.info("First operation failed {}ms after stopping the Zookeeper cluster",
+        System.currentTimeMillis() - zkStopTime);
+    final long successes = thread.successes();
+    mCluster.startZk();
+    long zkStartTime = System.currentTimeMillis();
+    CommonUtils.waitFor("another successful operation to be performed", new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(Void input) {
+        return thread.successes() > successes;
+      }
+    });
+    LOG.info("Recovered after {}ms", System.currentTimeMillis() - zkStartTime);
+    mCluster.notifySuccess();
+  }
+}


### PR DESCRIPTION
This test ensures that the Alluxio primary stops serving when it loses access to Zookeeper.

Other changes:
- The master thrift shutdown timeout is made configurable so that the external cluster can shut down quickly. This reduces the test time from ~ 1.1 minutes to 0.4 minutes
- Curator's wrapper around Zookeeper's test cluster doesn't expose the restart method. This PR adds a `RestartableTestingServer` class which extends Curator's test cluster to expose restart functionality needed for the integration test.
- This PR adds an `AlluxioOperationThread` class that may be shared by future integration tests.