### PR TITLE
[ALLUXIO-3050] Do not always compute block ID based on mPos

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/UnknownLengthFileInStream.java
@@ -100,7 +100,7 @@ public final class UnknownLengthFileInStream extends FileInStream {
   }
 
   @Override
-  protected boolean shouldUpdateStreams(long currentBlockId) {
+  protected boolean shouldUpdateStreams(int blockIdIndex) {
     // Return true either at the beginning of a file or the end of a file.
     return mCurrentBlockInStream == null || mCurrentBlockInStream.remaining() == 0;
   }


### PR DESCRIPTION
For example, reading a 8GB file cached in Alluxio's memory tier with a 8B read buffer, the profiling of Alluxio client process shows that `getBlockId` and `getCurrentBlockId` takes more than 1/3 of the total time. 

<img width="1437" alt="screen shot 2017-10-26 at 4 49 15 pm" src="https://user-images.githubusercontent.com/3663941/32127844-71a6d7d8-bb2e-11e7-9e35-0bd496fde2b7.png">

This PR changes the logic in `updateStreams`:

* For streaming read, the block stream is updated based on whether the current block stream has all been consumed, we keep track of blockIdIndex instead of computing the index every time `updateStreams` is called.
* For `seek` and `skip`, they can update streams based on computing the new block index from `mPos`.

Here are the comparisons for reading a 4GB with 8B read buffer, data is cached in Alluxio, read type is CACHE_PROMOTE:

![screen shot 2017-10-27 at 3 54 06 pm](https://user-images.githubusercontent.com/3663941/32127952-2099ce62-bb2f-11e7-8e0c-f7c0a5c1cec1.png)
![screen shot 2017-10-27 at 3 54 13 pm](https://user-images.githubusercontent.com/3663941/32127953-20afd39c-bb2f-11e7-9662-85bffe02a392.png)
![screen shot 2017-10-27 at 3 54 20 pm](https://user-images.githubusercontent.com/3663941/32127954-20c50a00-bb2f-11e7-8102-931ee28e8cd0.png)

The 1.6.2-SNAPSHOT bars reflect the changes in this PR, you can see the improvement of read throughput, especially for 1 thread, it is around 48% improvement.



