### PR TITLE
[SMALLFIX] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,13 +31,14 @@
 /deploy/vagrant/spot/roles/tag_ec2/vars/
 /deploy/vagrant/vbox/.vagrant/
 /deploy/vagrant/vbox/alluxio-dev.box
-/dev/scripts/tarballs
-/dev/scripts/workdir
+/dev/scripts/*
+!/dev/scripts/*.sh
 /docs/_site/
 /docs/api/
 /docs/serve/
 /extensions/
 /journal/
+/lib/
 /logs/*.log*
 /logs/*.out*
 /underFSStorage/


### PR DESCRIPTION
This PR
* removes the `alluxio` directory which might be unintentionally included into the repo
* ignore `lib` directory which will be generated during compilation and contain different under storage connectors
* ignore everything (intermediate compilation results, generated release tarballs, etc) in `dev/scripts` except for the shell scripts that should be contained in the repo