### PR TITLE
[SMALLFIX] Assure correctness of URI scheme.

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -415,10 +415,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Override
   public void initialize(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
-    if (!uri.getScheme().equals(getScheme())) {
-      throw new IOException(ExceptionMessage.URI_SCHEME_MISMATCH.getMessage(uri.getScheme(),
-          getScheme()));
-    }
+    Preconditions.checkArgument(uri.getScheme().equals(getScheme()),
+        PreconditionMessage.URI_SCHEME_MISMATCH.toString(), uri.getScheme(), getScheme());
     super.initialize(uri, conf);
     LOG.debug("initialize({}, {}). Connecting to Alluxio", uri, conf);
     HadoopUtils.addSwiftCredentials(conf);

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -415,6 +415,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Override
   public void initialize(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
+    if (!uri.getScheme().equals(getScheme())) {
+      throw new IOException(ExceptionMessage.URI_SCHEME_MISMATCH.getMessage(uri.getScheme(),
+          getScheme()));
+    }
     super.initialize(uri, conf);
     LOG.debug("initialize({}, {}). Connecting to Alluxio", uri, conf);
     HadoopUtils.addSwiftCredentials(conf);

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -186,7 +186,6 @@ public enum ExceptionMessage {
   // client
   DIFFERENT_MASTER_ADDRESS("Master address {0} is different from that in file system context {1}"),
   INCOMPATIBLE_VERSION("{0} client version {1} is not compatible with server version {2}"),
-  URI_SCHEME_MISMATCH("URI scheme {0} does not match the expected scheme {1}"),
 
   // configuration
   DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST("The default Alluxio properties file does not exist"),

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -186,6 +186,7 @@ public enum ExceptionMessage {
   // client
   DIFFERENT_MASTER_ADDRESS("Master address {0} is different from that in file system context {1}"),
   INCOMPATIBLE_VERSION("{0} client version {1} is not compatible with server version {2}"),
+  URI_SCHEME_MISMATCH("URI scheme {0} does not match the expected scheme {1}"),
 
   // configuration
   DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST("The default Alluxio properties file does not exist"),

--- a/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/PreconditionMessage.java
@@ -73,7 +73,7 @@ public enum PreconditionMessage {
   URI_HOST_NULL("URI hostname must not be null"),
   URI_PORT_NULL("URI port must not be null"),
   URI_KEY_VALUE_STORE_NULL("URI of key-value store must not be null"),
-
+  URI_SCHEME_MISMATCH("URI scheme %s does not match the expected scheme %s"),
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 


### PR DESCRIPTION
The internal statistics cache maintains a mapping from scheme to statistics object, if the scheme mismatches, the key of the statistics cache will be wrong, although other functionality is not affected.