### PR TITLE
[ALLUXIO-3052] Allow multiple fuse mount points per machine

### DIFF
--- a/bin/alluxio-fuse.sh
+++ b/bin/alluxio-fuse.sh
@@ -74,14 +74,14 @@ mount_fuse() {
 
 umount_fuse () {
   local mount_point=$1
-  local fuse_pid=$(fuse_stat)
-  if [[ $? -eq 0 ]]; then
-    echo "Stopping alluxio-fuse on local host (PID: ${fuse_pid})."
+  local fuse_pid=$(fuse_stat | awk '{print $1 $2}' | grep "\<${mount_point}\>" | awk '{print $1}')  
+  if [[ -z ${fuse_pid} ]]; then
+    echo "No fuse mounted at ${mount_point}" >&2
+    return 1
+  else
+    echo "Unmount fuse at ${mount_point} (PID: ${fuse_pid})."
     kill ${fuse_pid}
     return $?
-  else
-    echo "alluxio-fuse is not running on local host." >&2
-    return 1
   fi
 }
 
@@ -129,7 +129,7 @@ case $1 in
       umount_fuse $2
       exit $?
     fi
-    echo -e "Usage\n\t$0 umount mount_point" >&2
+    echo -e "Usage\n\t$0 umount mount_point\n\tuse mount stat to show mount points" >&2
     exit 1
     ;;
   stat)

--- a/bin/alluxio-fuse.sh
+++ b/bin/alluxio-fuse.sh
@@ -12,7 +12,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"; pwd)"
 
-get_env () {
+function getEnv {
   DEFAULT_LIBEXEC_DIR="${SCRIPT_DIR}"/../libexec
   ALLUXIO_LIBEXEC_DIR=${ALLUXIO_LIBEXEC_DIR:-${DEFAULT_LIBEXEC_DIR}}
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
@@ -22,7 +22,7 @@ get_env () {
   CLASSPATH=${CLASSPATH}:${ALLUXIO_FUSE_JAR}
 }
 
-check_java_version () {
+function checkJavaVersion {
   local java_mjr_vers=$("${JAVA}" -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F'.' '{print $1 $2}')
   if [[ ${java_mjr_vers} -lt 18 ]]; then
     echo "You are running a version of Java which is older than Java 8.
@@ -33,7 +33,7 @@ check_java_version () {
   fi
 }
 
-check_fuse_jar () {
+function checkFuseJar {
   if ! [[ -f ${ALLUXIO_FUSE_JAR} ]]; then
     echo "Cannot find ${ALLUXIO_FUSE_JAR}. Please compile alluxio with fuse profile and Java 8"
     return 1
@@ -42,7 +42,7 @@ check_fuse_jar () {
   fi
 }
 
-set_java_opt () {
+function setJavaOpt {
   JAVA_OPTS+="
     -server
     -Xms1G
@@ -53,7 +53,7 @@ set_java_opt () {
   ALLUXIO_FUSE_JAVA_OPTS+=" -Dalluxio.logger.type=FUSE_LOGGER"
 }
 
-mount_fuse() {  
+function mountFuse {  
   echo "Starting alluxio-fuse on local host."
   local mount_point=$1
   local alluxio_root=$2
@@ -72,9 +72,9 @@ mount_fuse() {
   fi
 }
 
-umount_fuse () {
+function umountFuse {
   local mount_point=$1  
-  local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')  
+  local fuse_pid=$(fuseStat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')  
   if [[ -z ${fuse_pid} ]]; then
     echo "No fuse mounted at ${mount_point}" >&2
     return 1
@@ -85,7 +85,7 @@ umount_fuse () {
   fi
 }
 
-fuse_stat() {
+function fuseStat {
   local fuse_info=$("${JAVA_HOME}/bin/jps" | grep AlluxioFuse)
   if [[ -z ${fuse_info} ]]; then    
     echo "AlluxioFuse: not running"
@@ -104,9 +104,9 @@ if [[ $# -lt 1 ]]; then
   exit 1
 fi
 
-get_env
-check_java_version && check_fuse_jar
-set_java_opt
+getEnv
+checkJavaVersion && checkFuseJar
+setJavaOpt
 if [[ $? -ne 0 ]]; then
   exit 1
 fi
@@ -114,11 +114,11 @@ fi
 case $1 in
   mount)
     if [[ $# -eq 2 ]]; then
-      mount_fuse $2 /
+      mountFuse $2 /
       exit $?
     fi
     if [[ $# -eq 3 ]]; then
-      mount_fuse $2 $3
+      mountFuse $2 $3
       exit $?
     fi
     echo -e "Usage\n\t$0 mount mount_point alluxio_path" >&2
@@ -126,14 +126,14 @@ case $1 in
     ;;
   umount)    
     if [[ $# -eq 2 ]]; then
-      umount_fuse $2
+      umountFuse $2
       exit $?
     fi
     echo -e "Usage\n\t$0 umount mount_point\n\tuse mount stat to show mount points" >&2
     exit 1
     ;;
   stat)
-    fuse_stat
+    fuseStat
     ;;
   *)
     echo "${USAGE_MSG}" >&2

--- a/bin/alluxio-fuse.sh
+++ b/bin/alluxio-fuse.sh
@@ -73,8 +73,8 @@ mount_fuse() {
 }
 
 umount_fuse () {
-  local mount_point=$1
-  local fuse_pid=$(fuse_stat | awk '{print $1 $2}' | grep "\<${mount_point}\>" | awk '{print $1}')  
+  local mount_point=$1  
+  local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')  
   if [[ -z ${fuse_pid} ]]; then
     echo "No fuse mounted at ${mount_point}" >&2
     return 1

--- a/integration/fuse/bin/alluxio-fuse.sh
+++ b/integration/fuse/bin/alluxio-fuse.sh
@@ -59,7 +59,7 @@ function mountFuse {
   local alluxio_root=$2
   (nohup "${JAVA}" -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
     alluxio.fuse.AlluxioFuse \
-    -o big_writes,allow_other \
+    -o big_writes \
     -m ${mount_point} \
     -r ${alluxio_root} > ${ALLUXIO_LOGS_DIR}/fuse.out 2>&1) &
   # sleep: workaround to let the bg java process exit on errors, if any
@@ -93,7 +93,7 @@ function fuseStat {
     return 1
   else
     echo -e "pid\tmount_point\talluxio_path"
-    echo -e "$(ps -o pid,command | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-2) "\t" $NF}')"
+    echo -e "$(ps aux | grep [A]lluxioFuse | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $NF}')"
     return 0    
   fi
 }
@@ -122,7 +122,7 @@ case $1 in
       mountFuse $2 $3
       exit $?
     fi
-    echo -e "Usage\n\t$0 mount mount_point [alluxio_path]" >&2
+    echo -e "Usage\n\t$0 mount mount_point [alluxio_path]\n\t alluxio_path is default to root" >&2
     exit 1
     ;;
   umount)    

--- a/integration/fuse/bin/alluxio-fuse.sh
+++ b/integration/fuse/bin/alluxio-fuse.sh
@@ -65,6 +65,7 @@ function mountFuse {
   # sleep: workaround to let the bg java process exit on errors, if any
   sleep 2s
   if kill -0 $! > /dev/null 2>&1 ; then
+    echo "Alluxio-fuse mounted at ${mount_point}. See ${ALLUXIO_LOGS_DIR}/fuse.log for logs"
     return 0
   else
     echo "alluxio-fuse not started. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2

--- a/integration/fuse/bin/alluxio-fuse.sh
+++ b/integration/fuse/bin/alluxio-fuse.sh
@@ -121,7 +121,7 @@ case $1 in
       mountFuse $2 $3
       exit $?
     fi
-    echo -e "Usage\n\t$0 mount mount_point alluxio_path" >&2
+    echo -e "Usage\n\t$0 mount mount_point [alluxio_path]" >&2
     exit 1
     ;;
   umount)    

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -130,7 +130,7 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
    *
    * This operation only works when the group mapping service is shelled based and the user is
    * registered in unix. Otherwise it errors as not implemented. This is because the input uid and
-   * gid must map to the user and group in Unix.
+   * gid must match the user and group in Unix.
    */
   @Override
   public int chown(String path, @uid_t long uid, @gid_t long gid) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -129,7 +129,8 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
    * Changes the owner of an Alluxio file.
    *
    * This operation only works when the group mapping service is shelled based and the user is
-   * registered in unix. Otherwise it errors as not implemented.
+   * registered in unix. Otherwise it errors as not implemented. This is because the input uid and
+   * gid must map to the user and group in Unix.
    */
   @Override
   public int chown(String path, @uid_t long uid, @gid_t long gid) {


### PR DESCRIPTION
This PR changes the fuse command to:
 - Mount: ` mount mount_point [alluxio_path]`. Mount an Alluxio path to a given mount point. When `alluxio_path` is not given, default to `/`
 - Unmount: `unmount mount_point`. Unmount the fuse from the given mount point
 - Status: `stat`. Displays the `pid,mount_point,alluxio_path` of each fuse