### PR TITLE
[SMALLFIX]Java 8 Improvement: replace anonymous type with lambda in alluxio.client.file.RetryHandlingFileSystemMasterClient#unmount

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -284,7 +284,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
 
   @Override
   public synchronized void unmount(final AlluxioURI alluxioPath) throws IOException {
-    retryRPC(() -> { 
+    retryRPC(() -> {
       mClient.unmount(alluxioPath.toString(), new UnmountTOptions());
       return null;
     });

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -284,12 +284,9 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
 
   @Override
   public synchronized void unmount(final AlluxioURI alluxioPath) throws IOException {
-    retryRPC(new RpcCallable<Void>() {
-      @Override
-      public Void call() throws TException {
-        mClient.unmount(alluxioPath.toString(), new UnmountTOptions());
-        return null;
-      }
+    retryRPC(() -> { 
+      mClient.unmount(alluxioPath.toString(), new UnmountTOptions());
+      return null;
     });
   }
 }


### PR DESCRIPTION
Change

retryRPC(new RpcCallable<Void>() {
  @Override
  public Void call() throws TException {
    mClient.unmount(alluxioPath.toString(), new UnmountTOptions());
    return null;
  }
});
to

retryRPC(() -> { 
  mClient.unmount(alluxioPath.toString(), new UnmountTOptions());
  return null;
});

2nd attempt, done by DZ1733015
The previous attempt is failed because of one extra space.