### PR TITLE
[SMALLFIX] Cleanup the name of lib jars

### DIFF
--- a/underfs/gcs/pom.xml
+++ b/underfs/gcs/pom.xml
@@ -98,8 +98,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -133,8 +133,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/local/pom.xml
+++ b/underfs/local/pom.xml
@@ -57,8 +57,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/oss/pom.xml
+++ b/underfs/oss/pom.xml
@@ -109,8 +109,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -38,6 +38,7 @@
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
     <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
+    <lib.jar.name>${project.artifactId}-${project.version}.jar</lib.jar.name>
   </properties>
 
   <build>
@@ -75,24 +76,18 @@
           </executions>
         </plugin>
         <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
+          <groupId>com.coderplus.maven.plugins</groupId>
+          <artifactId>copy-rename-maven-plugin</artifactId>
           <executions>
             <execution>
-              <id>copy-assembly-jar</id>
+              <id>copy-and-rename-file</id>
               <phase>install</phase>
               <goals>
-                <goal>copy-resources</goal>
+                <goal>copy</goal>
               </goals>
               <configuration>
-                <outputDirectory>${project.parent.parent.basedir}/lib/</outputDirectory>
-                <resources>
-                  <resource>
-                    <directory>${basedir}/target/</directory>
-                    <includes>
-                      <include>${project.artifactId}-${project.version}-jar-with-dependencies.jar</include>
-                    </includes>
-                  </resource>
-                </resources>
+                <sourceFile>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</sourceFile>
+                <destinationFile>${project.parent.parent.basedir}/lib/${lib.jar.name}</destinationFile>
               </configuration>
             </execution>
           </executions>

--- a/underfs/s3a/pom.xml
+++ b/underfs/s3a/pom.xml
@@ -106,8 +106,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -102,8 +102,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -123,8 +123,8 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Set the convention for shaded jar name:

- In target dir, shaded uber jar will be suffixed with `-jar-with-dependencies.jar`
- In the `${ALLUXIO_HOME}/lib` dir, jars will not be suffixed with `-jar-with-dependencies.jar`