### PR TITLE
[SMALLFIX]Update wording for masterInfo command in docs/_data/table/en/operation-command.yml

### DIFF
--- a/docs/_data/table/en/operation-command.yml
+++ b/docs/_data/table/en/operation-command.yml
@@ -50,7 +50,7 @@ lsr:
   Recursively list all the files and directories under the given path with information such
   as size.
 masterInfo:
-  Prints information regarding master fault tolerance such as leader address, list of master addresses, and the configured Zookeeper address.
+  Print information regarding master fault tolerance such as leader address, list of master addresses, and configured Zookeeper address.
 mkdir:
   Create directory(ies) under the given paths, along with any necessary parent directories. Multiple paths separated by spaces or tabs. This
   command will fail if any of the given paths already exist.


### PR DESCRIPTION
Update
"Prints information regarding master fault tolerance such as leader address, list of master addresses, and the configured Zookeeper address."
to
"Print information regarding master fault tolerance such as leader address, list of master addresses, and configured Zookeeper address."