### PR TITLE
[ALLUXIO-3052] Track write positions to work around issues in OSXFUSE

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -689,10 +689,16 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       return -ErrorCodes.EEXIST();
     }
 
+    if(offset<= oe.getWriteOffset()) {
+      // no op
+      return sz;
+    }
+
     try {
       final byte[] dest = new byte[sz];
       buf.get(0, dest, 0, sz);
       oe.getOut().write(dest);
+      oe.setWriteOffset(offset);
     } catch (IOException e) {
       LOG.error("IOException while writing to {}.", path, e);
       return -ErrorCodes.EIO();

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -654,12 +654,14 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
   }
 
   /**
-   * Writes a buffer to an open Alluxio file.
+   * Writes a buffer to an open Alluxio file. Random write is not supported, so the offset argument
+   * is ignored. Also, due to an issue in OSXFUSE that may write the same content at a offset
+   * multiple times, the write also checks that the subsequent write of the same offset is ignored.
    *
    * @param buf The buffer with source data
-   * @param size How much data to write from the buffer. The maximum accepted size
-   *             for writes is {@link Integer#MAX_VALUE}. Note that current FUSE
-   *             implementation will anyway call write with at most 128K writes
+   * @param size How much data to write from the buffer. The maximum accepted size for writes is
+   *        {@link Integer#MAX_VALUE}. Note that current FUSE implementation will anyway call write
+   *        with at most 128K writes
    * @param offset The offset where to write in the file (IGNORED)
    * @param fi FileInfo data structure kept by FUSE
    * @return number of bytes written on success, a negative value on error
@@ -689,7 +691,7 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       return -ErrorCodes.EEXIST();
     }
 
-    if(offset<= oe.getWriteOffset()) {
+    if (offset <= oe.getWriteOffset()) {
       // no op
       return sz;
     }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -691,7 +691,7 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       return -ErrorCodes.EEXIST();
     }
 
-    if (offset <= oe.getWriteOffset()) {
+    if (offset < oe.getWriteOffset()) {
       // no op
       return sz;
     }
@@ -700,7 +700,7 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       final byte[] dest = new byte[sz];
       buf.get(0, dest, 0, sz);
       oe.getOut().write(dest);
-      oe.setWriteOffset(offset);
+      oe.setWriteOffset(offset + size);
     } catch (IOException e) {
       LOG.error("IOException while writing to {}.", path, e);
       return -ErrorCodes.EIO();

--- a/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
@@ -33,6 +33,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 final class OpenFileEntry implements Closeable {
   private final FileInStream mIn;
   private final FileOutStream mOut;
+  /** the most recent write offset.  */
+  private long mOffset;
 
   public OpenFileEntry(FileInStream in, FileOutStream out) {
     mIn = in;
@@ -57,6 +59,14 @@ final class OpenFileEntry implements Closeable {
    */
   public FileOutStream getOut() {
     return mOut;
+  }
+
+  public long getWriteOffset() {
+    return mOffset;
+  }
+
+  public void setWriteOffset(long offset) {
+    mOffset = offset;
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
@@ -39,6 +39,7 @@ final class OpenFileEntry implements Closeable {
   public OpenFileEntry(FileInStream in, FileOutStream out) {
     mIn = in;
     mOut = out;
+    mOffset = -1;
   }
 
   /**
@@ -61,10 +62,16 @@ final class OpenFileEntry implements Closeable {
     return mOut;
   }
 
+  /**
+   * @return the offset of the most recent write
+   */
   public long getWriteOffset() {
     return mOffset;
   }
 
+  /**
+   * Sets the offset of the most recent write.
+   */
   public void setWriteOffset(long offset) {
     mOffset = offset;
   }
@@ -81,5 +88,6 @@ final class OpenFileEntry implements Closeable {
     if (mOut != null) {
       mOut.close();
     }
+    mOffset = -1;
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/OpenFileEntry.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 final class OpenFileEntry implements Closeable {
   private final FileInStream mIn;
   private final FileOutStream mOut;
-  /** the most recent write offset.  */
+  /** the next write offset.  */
   private long mOffset;
 
   public OpenFileEntry(FileInStream in, FileOutStream out) {
@@ -63,14 +63,14 @@ final class OpenFileEntry implements Closeable {
   }
 
   /**
-   * @return the offset of the most recent write
+   * @return the offset of the next write
    */
   public long getWriteOffset() {
     return mOffset;
   }
 
   /**
-   * Sets the offset of the most recent write.
+   * Sets the offset of the next write.
    */
   public void setWriteOffset(long offset) {
     mOffset = offset;

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -260,6 +260,7 @@ public class AlluxioFuseFileSystemTest {
     mFuseFs.write("/foo/bar", ptr, 4, 0, mFileInfo);
     verify(fos).write(expected);
 
+    // the second write is no-op because the writes must be sequential and overwriting is supported
     mFuseFs.write("/foo/bar", ptr, 4, 0, mFileInfo);
     verify(fos, Mockito.times(1)).write(expected);
   }

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -39,6 +39,7 @@ import jnr.ffi.Runtime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import ru.serce.jnrfuse.ErrorCodes;
@@ -257,8 +258,10 @@ public class AlluxioFuseFileSystemTest {
     ptr.put(0, expected, 0, 4);
 
     mFuseFs.write("/foo/bar", ptr, 4, 0, mFileInfo);
-
     verify(fos).write(expected);
+
+    mFuseFs.write("/foo/bar", ptr, 4, 0, mFileInfo);
+    verify(fos, Mockito.times(1)).write(expected);
   }
 
   @Test


### PR DESCRIPTION
I have observed that on Mac writing sequentially in the application layer into `FileInputStream` will end up with the multiple writes of the same offset in the Fuse layer. This suggests from unexpected behavior with OSXFUSE (I used 3.7.1).
For example, when I write a file of 10MB sequentially, the `write` method in `AlluxioFuseFileSystem` is invoked to write 64kb at offsets 0, 64KB, 12  ...., 8MB, and then it starts again at 0, 64KB, ...10MB. It's unclear why it writes to 8MB and then starts over from 0 again. However, without this PR, writing 10MB file would end up with a file much larger than 10MB because of the repeat write of the same offsets.

But such issues are not encountered in Linux with libfuse. This might be related to the [issue](https://github.com/osxfuse/osxfuse/issues/244) seen some other people when they try to integrate with OSXFUSE.