### PR TITLE
[SMALLFIX]Issue117:Deprecate Throwables.propagate with RuntimeException in DefaultFileSystemMaster.java

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -127,7 +127,6 @@ import alluxio.wire.WorkerInfo;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -670,7 +669,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         inconsistentUris.addAll(result.get());
       } catch (Exception e) {
         // This shouldn't happen, all futures should be complete.
-        Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
     service.shutdown();
@@ -1810,7 +1809,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     } catch (BlockInfoException e) {
       // Since we are creating a directory, the block size is ignored, no such exception should
       // happen.
-      Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     return null;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1811,7 +1811,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // happen.
       throw new RuntimeException(e);
     }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
Deprecate Throwables.propagate with RuntimeException in DefaultFileSystemMaster.java