### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/tests/src/test/java/alluxio/cli/fs/command/UnsetTtlTest.java
+++ b/tests/src/test/java/alluxio/cli/fs/command/UnsetTtlTest.java
@@ -11,13 +11,14 @@
 
 package alluxio.cli.fs.command;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.cli.fs.AbstractAlluxioShellTest;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -29,16 +30,16 @@ public final class UnsetTtlTest extends AbstractAlluxioShellTest {
     String filePath = "/testFile";
     AlluxioURI uri = new AlluxioURI("/testFile");
     FileSystemTestUtils.createByteFile(mFileSystem, filePath, WriteType.MUST_CACHE, 1);
-    Assert.assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
+    assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
 
     // unsetTTL on a file originally with no TTL will leave the TTL unchanged.
-    Assert.assertEquals(0, mFsShell.run("unsetTtl", filePath));
-    Assert.assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
+    assertEquals(0, mFsShell.run("unsetTtl", filePath));
+    assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
 
     long ttl = 1000L;
-    Assert.assertEquals(0, mFsShell.run("setTtl", filePath, String.valueOf(ttl)));
-    Assert.assertEquals(ttl, mFileSystem.getStatus(uri).getTtl());
-    Assert.assertEquals(0, mFsShell.run("unsetTtl", filePath));
-    Assert.assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
+    assertEquals(0, mFsShell.run("setTtl", filePath, String.valueOf(ttl)));
+    assertEquals(ttl, mFileSystem.getStatus(uri).getTtl());
+    assertEquals(0, mFsShell.run("unsetTtl", filePath));
+    assertEquals(Constants.NO_TTL, mFileSystem.getStatus(uri).getTtl());
   }
 }


### PR DESCRIPTION
tests/src/test/java/alluxio/cli/fs/command/UnsetTtlTest.java