### PR TITLE
[SMALLFIX]Use static imports for standard test utilities for class ConfigurationDocGeneratorTest

### DIFF
--- a/tests/src/test/java/alluxio/cli/ConfigurationDocGeneratorTest.java
+++ b/tests/src/test/java/alluxio/cli/ConfigurationDocGeneratorTest.java
@@ -12,6 +12,7 @@
 package alluxio.cli;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
@@ -20,7 +21,6 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Joiner;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,7 +102,7 @@ public class ConfigurationDocGeneratorTest {
 
   private void checkFileContents(String source, List<String> target, TYPE fType)
       throws Exception {
-    Assert.assertTrue(fType.equals(TYPE.CSV) || fType.equals(TYPE.YML));
+    assertTrue(fType.equals(TYPE.CSV) || fType.equals(TYPE.YML));
     //assert file contents
     if (fType == TYPE.CSV) {
       assertEquals(2, target.size());
@@ -126,7 +126,7 @@ public class ConfigurationDocGeneratorTest {
     ConfigurationDocGenerator.writeCSVFile(defaultKeys, mLocation);
     String filePath = PathUtils.concatPath(mLocation, mTestConf.getSecond());
     Path p = Paths.get(filePath);
-    Assert.assertTrue(Files.exists(p));
+    assertTrue(Files.exists(p));
 
     //assert file contents
     List<String> userFile = Files.readAllLines(p, StandardCharsets.UTF_8);
@@ -147,7 +147,7 @@ public class ConfigurationDocGeneratorTest {
     ConfigurationDocGenerator.writeYMLFile(defaultKeys, mLocation);
     String filePath = PathUtils.concatPath(mLocation, mTestConf.getSecond());
     Path p = Paths.get(filePath);
-    Assert.assertTrue(Files.exists(p));
+    assertTrue(Files.exists(p));
 
     //assert file contents
     List<String> keyDescription = Files.readAllLines(p, StandardCharsets.UTF_8);


### PR DESCRIPTION
[SMALLFIX]Use static imports for standard test utilities for class ConfigurationDocGeneratorTest