### PR TITLE
[SMALLFIX] Add timeout in journal shutdown tests

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -28,6 +28,7 @@ import alluxio.master.SingleMasterInquireClient;
 import alluxio.master.ZkMasterInquireClient;
 import alluxio.network.PortUtils;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.zookeeper.RestartableTestingServer;
 
@@ -170,9 +171,10 @@ public final class MultiProcessCluster implements TestRule {
    * If no master is currently primary, this method blocks until a primary has been elected, then
    * kills it.
    *
+   * @param timeoutMs maximum amount of time to wait, in milliseconds
    * @return the ID of the killed master
    */
-  public synchronized int waitForAndKillPrimaryMaster() {
+  public synchronized int waitForAndKillPrimaryMaster(int timeoutMs) {
     final FileSystem fs = getFileSystemClient();
     final MasterInquireClient inquireClient = getMasterInquireClient();
     CommonUtils.waitFor("a primary master to be serving", new Function<Void, Boolean>() {
@@ -188,7 +190,7 @@ public final class MultiProcessCluster implements TestRule {
           throw new RuntimeException(e);
         }
       }
-    });
+    }, WaitForOptions.defaults().setTimeoutMs(timeoutMs));
     int primaryRpcPort;
     try {
       primaryRpcPort = inquireClient.getPrimaryRpcAddress().getPort();

--- a/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/JournalShutdownIntegrationTest.java
@@ -100,7 +100,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
       cluster.start();
       FileSystem fs = cluster.getFileSystemClient();
       runCreateFileThread(fs);
-      cluster.waitForAndKillPrimaryMaster();
+      cluster.waitForAndKillPrimaryMaster(10 * Constants.SECOND_MS);
       awaitClientTermination();
       cluster.startMaster(0);
       int actualFiles = fs.listStatus(new AlluxioURI(TEST_FILE_DIR)).size();
@@ -133,7 +133,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
       FileSystem fs = cluster.getFileSystemClient();
       runCreateFileThread(fs);
       for (int i = 0; i < TEST_NUM_MASTERS; i++) {
-        cluster.waitForAndKillPrimaryMaster();
+        cluster.waitForAndKillPrimaryMaster(30 * Constants.SECOND_MS);
       }
       awaitClientTermination();
       cluster.startMaster(0);


### PR DESCRIPTION
The global timeout rule applied to each integration test is
inadequate here because when it fails a test, the
test cleanup is skipped, so there is no way to collect
cluster logs for debugging.