### PR TITLE
[ALLUXIO-3052] Add utimens placeholder

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -42,6 +42,7 @@ import ru.serce.jnrfuse.FuseFillDir;
 import ru.serce.jnrfuse.FuseStubFS;
 import ru.serce.jnrfuse.struct.FileStat;
 import ru.serce.jnrfuse.struct.FuseFileInfo;
+import ru.serce.jnrfuse.struct.Timespec;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -651,6 +652,15 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
   public int unlink(String path) {
     LOG.trace("unlink({})", path);
     return rmInternal(path, true);
+  }
+
+  /**
+   * Alluxio does not have access time, and the file is created only once. So this operation is a
+   * no-op.
+   */
+  @Override
+  public int utimens(String path, Timespec[] timespec) {
+    return 0;
   }
 
   /**


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3052

Add a `utimens` implementation placeholder to suppress the errors on local file system operations. This method is invoked when the file is accessed and the kernel will try to update the access time, which is not supported by Alluxio.