### PR TITLE
[SMALLFIX]Use static imports for standard test utilities for FileSystemClientRestApiTest.java

### DIFF
--- a/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
@@ -11,6 +11,10 @@
 
 package alluxio.proxy;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+
 import alluxio.AlluxioURI;
 import alluxio.client.file.options.CreateDirectoryOptions;
 import alluxio.client.file.options.CreateFileOptions;
@@ -78,7 +82,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         PATHS_PREFIX + uri.toString() + "/" + PathsRestServiceHandler.CREATE_DIRECTORY, NO_PARAMS,
         HttpMethod.POST, null,
         TestCaseOptions.defaults().setBody(CreateDirectoryOptions.defaults())).run();
-    Assert.assertTrue(
+    assertTrue(
         mFileSystemMaster.listStatus(uri, alluxio.master.file.options.ListStatusOptions.defaults())
             .isEmpty());
   }
@@ -92,7 +96,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         HttpMethod.POST, null, TestCaseOptions.defaults().setBody(DeleteOptions.defaults())).run();
     try {
       mFileSystemMaster.getFileInfo(uri, GET_STATUS_OPTIONS);
-      Assert.fail("file should have been removed");
+      fail("file should have been removed");
     } catch (FileDoesNotExistException e) {
       // Expected
     }
@@ -103,7 +107,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
     AlluxioURI uri = new AlluxioURI("/file");
     String message = "Greetings traveller!";
     writeFile(uri, message.getBytes());
-    Assert.assertEquals(message, new String(readFile(uri)));
+    assertEquals(message, new String(readFile(uri)));
   }
 
   @Test
@@ -132,8 +136,8 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         PATHS_PREFIX + uri.toString() + "/" + PathsRestServiceHandler.GET_STATUS, NO_PARAMS,
         HttpMethod.POST, TestCaseOptions.defaults().setBody(GetStatusOptions.defaults())).call();
     FileInfo fileInfo = new ObjectMapper().readValue(result, FileInfo.class);
-    Assert.assertEquals(uri.getPath(), fileInfo.getPath());
-    Assert.assertEquals(0, fileInfo.getLength());
+    assertEquals(uri.getPath(), fileInfo.getPath());
+    assertEquals(0, fileInfo.getLength());
   }
 
   @Test
@@ -147,8 +151,8 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
     List<FileInfo> fileInfos =
         new ObjectMapper().readValue(result, new TypeReference<List<FileInfo>>() {});
     FileInfo fileInfo = Iterables.getOnlyElement(fileInfos);
-    Assert.assertEquals(uri.getPath(), fileInfo.getPath());
-    Assert.assertEquals(0, fileInfo.getLength());
+    assertEquals(uri.getPath(), fileInfo.getPath());
+    assertEquals(0, fileInfo.getLength());
   }
 
   @Test
@@ -173,7 +177,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         HttpMethod.POST, null, TestCaseOptions.defaults().setBody(RenameOptions.defaults())).run();
     try {
       mFileSystemMaster.getFileInfo(uri1, GET_STATUS_OPTIONS);
-      Assert.fail("file should have been removed");
+      fail("file should have been removed");
     } catch (FileDoesNotExistException e) {
       // Expected
     }
@@ -190,7 +194,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         .setBody(SetAttributeOptions.defaults().setMode(Mode.defaults())))
         .run();
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(uri, GET_STATUS_OPTIONS);
-    Assert.assertEquals(uri.toString(), fileInfo.getPath());
+    assertEquals(uri.toString(), fileInfo.getPath());
   }
 
   @Test
@@ -212,7 +216,7 @@ public final class FileSystemClientRestApiTest extends RestApiTest {
         PATHS_PREFIX + uri.toString() + "/" + PathsRestServiceHandler.GET_STATUS, NO_PARAMS,
         HttpMethod.POST, null).call();
     FileInfo fileInfo = new ObjectMapper().readValue(result, FileInfo.class);
-    Assert.assertEquals(message.length(), fileInfo.getLength());
+    assertEquals(message.length(), fileInfo.getLength());
   }
 
   private byte[] readFile(AlluxioURI path) throws Exception {

--- a/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/proxy/FileSystemClientRestApiTest.java
@@ -39,7 +39,6 @@ import alluxio.wire.FileInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
Use static imports for standard test utilities for FileSystemClientRestApiTest.java