### PR TITLE
[SMALLFIX] Better exception handling

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketWriter.java
@@ -357,7 +357,7 @@ public final class NettyPacketWriter implements PacketWriter {
    */
   @GuardedBy("mLock")
   private void updateException(Throwable e) {
-    if (mPacketWriteException == null) {
+    if (mPacketWriteException == null || mPacketWriteException == e) {
       mPacketWriteException = e;
     } else {
       mPacketWriteException.addSuppressed(e);


### PR DESCRIPTION
Exception does not allow self-suppression, so when netty packet writer handles the same exception,   it throws runtime exception:

```
java.lang.IllegalArgumentException: Self-suppression not permitted
	at java.lang.Throwable.addSuppressed(Throwable.java:1043)
	at alluxio.client.block.stream.NettyPacketWriter.updateException(NettyPacketWriter.java:363)
	at alluxio.client.block.stream.NettyPacketWriter.access$600(NettyPacketWriter.java:69)
	at alluxio.client.block.stream.NettyPacketWriter$WriteListener.operationComplete(NettyPacketWriter.java:459)
	at alluxio.client.block.stream.NettyPacketWriter$WriteListener.operationComplete(NettyPacketWriter.java:436)
```