### PR TITLE
[SMALLFIX] Reduce string comparison operations in getMountPoint.

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -236,17 +236,15 @@ public final class MountTable implements JournalEntryIterable {
    */
   public String getMountPoint(AlluxioURI uri) throws InvalidPathException {
     String path = uri.getPath();
-    String mountPoint = null;
 
     try (LockResource r = new LockResource(mReadLock)) {
       for (Map.Entry<String, MountInfo> entry : mMountTable.entrySet()) {
         String alluxioPath = entry.getKey();
-        if (PathUtils.hasPrefix(path, alluxioPath)
-            && (mountPoint == null || PathUtils.hasPrefix(alluxioPath, mountPoint))) {
-          mountPoint = alluxioPath;
+        if (!alluxioPath.equals(ROOT) && PathUtils.hasPrefix(path, alluxioPath)) {
+          return alluxioPath;
         }
       }
-      return mountPoint;
+      return mMountTable.containsKey(ROOT) ? ROOT : null;
     }
   }
 


### PR DESCRIPTION
A more scalable internal data structure for `MountTable` can be:

```
Trie<String, Long> mMountPathToMountId;
Trie<String, Long> mUfsPathToMountId;
Map<Long, MountInfo> mMountTable;
```

Then finding the mount point prefix is more efficient due to the Trie and `getMountInfo(long id)` is O(1) instead of O(n). 

But I think there will be just a few mount points, so the current implementation is ok. 