### PR TITLE
[SMALLFIX] Explicitly return root when the path component is omitted

### DIFF
--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -266,7 +266,12 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
    * @return the path
    */
   public String getPath() {
-    return mUri.getPath();
+    String path = mUri.getPath();
+    if ("".equals(path)) {
+      // if path component is omitted, use root path explicitly
+      return "/";
+    }
+    return path;
   }
 
   /**

--- a/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -154,7 +154,7 @@ public class AlluxioURITest {
     assertEquals(0, uri.getDepth());
     assertEquals(null, uri.getHost());
     assertEquals("", uri.getName());
-    assertEquals("", uri.getPath());
+    assertEquals("/", uri.getPath());
     assertEquals(-1, uri.getPort());
     assertEquals(null, uri.getScheme());
     assertFalse(uri.hasAuthority());
@@ -164,6 +164,13 @@ public class AlluxioURITest {
     assertEquals("/d", uri.join("/d").toString());
     assertEquals("/d", uri.join(new AlluxioURI("/d")).toString());
     assertEquals("", uri.toString());
+  }
+
+  @Test
+  public void rootURI() {
+    AlluxioURI uri = new AlluxioURI("hdfs://localhost");
+    assertEquals("", uri.getPath());
+    assertEquals("hdfs://localhost/d", uri.join("d").toString());
   }
 
   /**


### PR DESCRIPTION
Several call sites of the `getPath` method assume it never returns an empty string. So make it explicit to return `/` when the path component is omitted.