### PR TITLE
[SMALLFIX] Do not process persisted paths during updating absent paths.

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -888,7 +888,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       exists = true;
     } finally {
       if (!exists) {
-        mUfsAbsentPathCache.process(inodePath.getUri());
+        mUfsAbsentPathCache.process(inodePath.getUri(), inodePath.getInodeList());
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -83,8 +83,8 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path, List<Inode<?>> existingInodes) {
-    mPool.submit(new ProcessPathTask(path, existingInodes));
+  public void process(AlluxioURI path, List<Inode<?>> prefixInodes) {
+    mPool.submit(new ProcessPathTask(path, prefixInodes));
   }
 
   @Override
@@ -286,14 +286,15 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
    */
   private final class ProcessPathTask implements Runnable {
     private final AlluxioURI mPath;
-    private final List<Inode<?>> mExistingInodes;
+    private final List<Inode<?>> mPrefixInodes;
 
     /**
      * @param path the path to add
+     * @param prefixInodes the existing inodes for the path prefix
      */
-    private ProcessPathTask(AlluxioURI path, List<Inode<?>> existingInodes) {
+    private ProcessPathTask(AlluxioURI path, List<Inode<?>> prefixInodes) {
       mPath = path;
-      mExistingInodes = existingInodes;
+      mPrefixInodes = prefixInodes;
     }
 
     @Override
@@ -305,8 +306,8 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
 
       // baseIndex should be the index of the first non-persisted inode under the mount point.
       int baseIndex = mountInfo.getAlluxioUri().getDepth();
-      while (baseIndex < mExistingInodes.size()) {
-        if (mExistingInodes.get(baseIndex).isPersisted()) {
+      while (baseIndex < mPrefixInodes.size()) {
+        if (mPrefixInodes.get(baseIndex).isPersisted()) {
           baseIndex++;
         } else {
           break;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -82,8 +83,8 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path) {
-    mPool.submit(new ProcessPathTask(path));
+  public void process(AlluxioURI path, List<Inode<?>> existingInodes) {
+    mPool.submit(new ProcessPathTask(path, existingInodes));
   }
 
   @Override
@@ -98,7 +99,7 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
     // since the locks are not being used in this code path, there could be a race between this
     // invalidating thread, and a processing of the path from the thread pool. To avoid the race,
     // this invalidating thread must set the intention to invalidate before invalidating.
-    for (AlluxioURI alluxioUri : getNestedPaths(path, mountInfo)) {
+    for (AlluxioURI alluxioUri : getNestedPaths(path, mountInfo.getAlluxioUri().getDepth())) {
       PathLock pathLock = mCurrentPaths.get(alluxioUri.getPath());
       if (pathLock != null) {
         pathLock.setInvalidate();
@@ -214,29 +215,24 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   /**
-   * Returns a sequence of Alluxio paths for a specified path, starting from the base of the
-   * mount point, to the specified path.
+   * Returns a sequence of Alluxio paths for a specified path, starting from the path component at
+   * a specific index, to the specified path.
    *
    * @param alluxioUri the Alluxio path to get the nested paths for
-   * @param mountInfo the mount info for this Alluxio path
-   * @return a list of nested paths from the mount base to the given path
+   * @param startComponentIndex the index to the starting path component,
+   *        root directory has index 0
+   * @return a list of nested paths from the starting component to the given path
    */
-  private List<AlluxioURI> getNestedPaths(AlluxioURI alluxioUri, MountInfo mountInfo) {
+  private List<AlluxioURI> getNestedPaths(AlluxioURI alluxioUri, int startComponentIndex) {
     try {
       String[] fullComponents = PathUtils.getPathComponents(alluxioUri.getPath());
-      // create a uri of the base of the mount point.
-      AlluxioURI mountBaseUri = mountInfo.getAlluxioUri();
-      int mountBaseDepth = mountBaseUri.getDepth();
-
-      List<AlluxioURI> components = new ArrayList<>(fullComponents.length - mountBaseDepth);
-      for (int i = 0; i < fullComponents.length; i++) {
-        if (i > 0 && i <= mountBaseDepth) {
-          // Do not include components before the base of the mount point.
-          // However, include the first component, since that will be the actual mount point base.
-          continue;
-        }
-        mountBaseUri = mountBaseUri.join(fullComponents[i]);
-        components.add(mountBaseUri);
+      String[] baseComponents = Arrays.copyOfRange(fullComponents, 0, startComponentIndex);
+      AlluxioURI uri = new AlluxioURI(
+          PathUtils.concatPath(AlluxioURI.SEPARATOR, baseComponents));
+      List<AlluxioURI> components = new ArrayList<>(fullComponents.length - startComponentIndex);
+      for (int i = startComponentIndex; i < fullComponents.length; i++) {
+        uri = uri.join(fullComponents[i]);
+        components.add(uri);
       }
       return components;
     } catch (InvalidPathException e) {
@@ -290,12 +286,14 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
    */
   private final class ProcessPathTask implements Runnable {
     private final AlluxioURI mPath;
+    private final List<Inode<?>> mExistingInodes;
 
     /**
      * @param path the path to add
      */
-    private ProcessPathTask(AlluxioURI path) {
+    private ProcessPathTask(AlluxioURI path, List<Inode<?>> existingInodes) {
       mPath = path;
+      mExistingInodes = existingInodes;
     }
 
     @Override
@@ -304,7 +302,18 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
       if (mountInfo == null) {
         return;
       }
-      for (AlluxioURI alluxioUri : getNestedPaths(mPath, mountInfo)) {
+
+      // baseIndex should be the index of the first non-persisted inode under the mount point.
+      int baseIndex = mountInfo.getAlluxioUri().getDepth();
+      while (baseIndex < mExistingInodes.size()) {
+        if (mExistingInodes.get(baseIndex).isPersisted()) {
+          baseIndex++;
+        } else {
+          break;
+        }
+      }
+
+      for (AlluxioURI alluxioUri : getNestedPaths(mPath, baseIndex)) {
         if (!processSinglePath(alluxioUri, mountInfo)) {
           break;
         }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
@@ -16,6 +16,8 @@ import alluxio.AlluxioURI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -33,7 +35,7 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path) {
+  public void process(AlluxioURI path, List<Inode<?>> existingInodes) {
     // Do nothing
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
@@ -35,7 +35,7 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path, List<Inode<?>> existingInodes) {
+  public void process(AlluxioURI path, List<Inode<?>> prefixInodes) {
     // Do nothing
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -18,6 +18,8 @@ import alluxio.PropertyKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 /**
  * Cache for recording information about paths that are not present in UFS.
  */
@@ -27,8 +29,9 @@ public interface UfsAbsentPathCache {
    * components which do and do not exist in the UFS, and updates the cache accordingly.
    *
    * @param path the path to process for the cache
+   * @param existingInodes the existing inodes for the path components
    */
-  void process(AlluxioURI path);
+  void process(AlluxioURI path, List<Inode<?>> existingInodes);
 
   /**
    * Processes the given path that already exists. This will sequentially walk down the path and

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -29,9 +29,9 @@ public interface UfsAbsentPathCache {
    * components which do and do not exist in the UFS, and updates the cache accordingly.
    *
    * @param path the path to process for the cache
-   * @param existingInodes the existing inodes for the path components
+   * @param prefixInodes the existing inodes for the path prefix
    */
-  void process(AlluxioURI path, List<Inode<?>> existingInodes);
+  void process(AlluxioURI path, List<Inode<?>> prefixInodes);
 
   /**
    * Processes the given path that already exists. This will sequentially walk down the path and

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -199,7 +199,7 @@ public class AsyncUfsAbsentPathCacheTest {
   private void addAbsent(AlluxioURI path) throws Exception {
     final ThreadPoolExecutor pool = Whitebox.getInternalState(mUfsAbsentPathCache, "mPool");
     final long initialTasks = pool.getCompletedTaskCount();
-    mUfsAbsentPathCache.process(path);
+    mUfsAbsentPathCache.process(path, Collections.emptyList());
     // Wait until the async task is completed.
     CommonUtils
         .waitFor("path (" + path + ") to be added to absent cache", new Function<Void, Boolean>() {
@@ -216,7 +216,7 @@ public class AsyncUfsAbsentPathCacheTest {
   private void removeAbsent(AlluxioURI path) throws Exception {
     final ThreadPoolExecutor pool = Whitebox.getInternalState(mUfsAbsentPathCache, "mPool");
     final long initialTasks = pool.getCompletedTaskCount();
-    mUfsAbsentPathCache.process(path);
+    mUfsAbsentPathCache.process(path, Collections.emptyList());
     // Wait until the async task is completed.
     CommonUtils.waitFor("path (" + path + ") to be removed from absent cache",
         new Function<Void, Boolean>() {


### PR DESCRIPTION
For a path like `/mnt/task/level/file` where `/` is the only mount point,  if `/mnt/task/level` is persisted, but `file` is not persisted, then every time `listStatus` is called, the `AsyncUfsAbsentPathCache#process` will call `ufs.exists` on `/`, `/mnt`, `/mnt/task`, `/mnt/task/level`, and `/mnt/task/level/file`. 

This PR changes this behavior by starting `process` from the first component that is not yet persisted.