### PR TITLE
[SMALLFIX]Improve grammar in docs/en/Configuring-Alluxio-with-GCS.md 

### DIFF
--- a/docs/en/Configuring-Alluxio-with-GCS.md
+++ b/docs/en/Configuring-Alluxio-with-GCS.md
@@ -23,7 +23,7 @@ the bucket, or using an existing one. For the purposes of this guide, the GCS bu
 `GCS_BUCKET`, and the directory in that bucket is called `GCS_DIRECTORY`.
 
 If you are new to GCS, please read its
-[documentations](https://cloud.google.com/storage/docs/overview).
+[documentation](https://cloud.google.com/storage/docs/overview).
 
 ## Configuring Alluxio
 


### PR DESCRIPTION
In docs/en/Configuring-Alluxio-with-GCS.md, in "Initial Setup" section, in the last sentence, change "documentations" to "documentation". So, the sentence should be:

If you are new to GCS, please read its documentation.