### PR TITLE
[SMALLFIX] Fix mount table resolution when the root path is omitted

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -149,7 +149,7 @@ public final class MountTable implements JournalEntryIterable {
    */
   public void add(AlluxioURI alluxioUri, AlluxioURI ufsUri, long mountId, MountOptions options)
       throws FileAlreadyExistsException, InvalidPathException {
-    String alluxioPath = alluxioUri.getPath();
+    String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Mounting {} at {}", ufsUri, alluxioPath);
 
     try (LockResource r = new LockResource(mWriteLock)) {
@@ -171,8 +171,8 @@ public final class MountTable implements JournalEntryIterable {
         if ((ufsUri.getScheme() == null || ufsUri.getScheme().equals(mountedUfsUri.getScheme()))
             && (ufsUri.getAuthority() == null || ufsUri.getAuthority()
             .equals(mountedUfsUri.getAuthority()))) {
-          String ufsPath = ufsUri.getPath();
-          String mountedUfsPath = mountedUfsUri.getPath();
+          String ufsPath = ufsUri.getPath().isEmpty() ? "/" : ufsUri.getPath();
+          String mountedUfsPath = mountedUfsUri.getPath().isEmpty() ? "/" : mountedUfsUri.getPath();
           if (PathUtils.hasPrefix(ufsPath, mountedUfsPath)) {
             throw new InvalidPathException(ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER
                 .getMessage(mountedUfsUri.toString(), ufsUri.toString()));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -138,6 +138,19 @@ public final class MountTableTest {
     Assert.assertTrue(mMountTable.delete(new AlluxioURI("/mnt/foo")));
     Assert.assertFalse(mMountTable.delete(new AlluxioURI("/mnt/foo")));
     Assert.assertFalse(mMountTable.delete(new AlluxioURI("/")));
+
+    try {
+      mMountTable.add(new AlluxioURI("alluxio://localhost"), new AlluxioURI("s3a://localhost"), 4L,
+          mDefaultOptions);
+      mMountTable.add(new AlluxioURI("alluxio://localhost/t2"), new AlluxioURI("s3a://localhost"), 4L,
+          mDefaultOptions);
+      Assert.fail("mount fails");
+    } catch (InvalidPathException e) {
+      // Exception expected
+      Assert.assertEquals(
+          ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER.getMessage("s3a://localhost", "s3a://localhost"),
+          e.getMessage());
+    }
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -79,6 +79,19 @@ public final class MountTableTest {
           e.getMessage());
     }
 
+    try {
+      mMountTable.add(new AlluxioURI("/test1"), new AlluxioURI("hdfs://localhost"), 4L,
+          mDefaultOptions);
+      mMountTable.add(new AlluxioURI("/test2"), new AlluxioURI("hdfs://localhost"), 4L,
+          mDefaultOptions);
+      Assert.fail("mount fails");
+    } catch (InvalidPathException e) {
+      // Exception expected
+      Assert.assertEquals(
+          ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER.getMessage("hdfs://localhost", "hdfs://localhost"),
+          e.getMessage());
+    }
+
     // Test resolve()
     MountTable.Resolution res1 = mMountTable.resolve(new AlluxioURI("/mnt/foo"));
     Assert.assertEquals(new AlluxioURI("/foo"), res1.getUri());

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -70,8 +70,7 @@ public final class MountTableTest {
     }
 
     try {
-      mMountTable.add(new AlluxioURI("/mnt/bar/baz"), new AlluxioURI("/baz"), 4L,
-          mDefaultOptions);
+      mMountTable.add(new AlluxioURI("/mnt/bar/baz"), new AlluxioURI("/baz"), 4L, mDefaultOptions);
     } catch (InvalidPathException e) {
       // Exception expected
       Assert.assertEquals(
@@ -87,9 +86,8 @@ public final class MountTableTest {
       Assert.fail("mount fails");
     } catch (InvalidPathException e) {
       // Exception expected
-      Assert.assertEquals(
-          ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER.getMessage("hdfs://localhost", "hdfs://localhost"),
-          e.getMessage());
+      Assert.assertEquals(ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER
+          .getMessage("hdfs://localhost", "hdfs://localhost"), e.getMessage());
     }
 
     // Test resolve()
@@ -142,14 +140,13 @@ public final class MountTableTest {
     try {
       mMountTable.add(new AlluxioURI("alluxio://localhost"), new AlluxioURI("s3a://localhost"), 4L,
           mDefaultOptions);
-      mMountTable.add(new AlluxioURI("alluxio://localhost/t2"), new AlluxioURI("s3a://localhost"), 4L,
-          mDefaultOptions);
+      mMountTable.add(new AlluxioURI("alluxio://localhost/t2"), new AlluxioURI("s3a://localhost"),
+          4L, mDefaultOptions);
       Assert.fail("mount fails");
     } catch (InvalidPathException e) {
       // Exception expected
-      Assert.assertEquals(
-          ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER.getMessage("s3a://localhost", "s3a://localhost"),
-          e.getMessage());
+      Assert.assertEquals(ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER
+          .getMessage("s3a://localhost", "s3a://localhost"), e.getMessage());
     }
   }
 


### PR DESCRIPTION
When the path is omitted such as in `hdfs://localhost`, the `getPath` method returns emtpy string, which in turn would fail the `PathUtils.hasPrefix` check with `Path  is invalid` exception.