### PR TITLE
[SMALLFIX] Save one RPC call to HDFS.

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -231,9 +231,8 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
     }
     List<String> ret = new ArrayList<>();
     try {
-      FileStatus fStatus = mFileSystem.getFileStatus(new Path(path));
       BlockLocation[] bLocations =
-          mFileSystem.getFileBlockLocations(fStatus, options.getOffset(), 1);
+          mFileSystem.getFileBlockLocations(new Path(path), options.getOffset(), 1);
       if (bLocations.length > 0) {
         String[] names = bLocations[0].getHosts();
         Collections.addAll(ret, names);


### PR DESCRIPTION
This PR saves a `getFileInfo` RPC call to HDFS when getting HDFS block locations.