### PR TITLE
[SMALLFIX] Update Netty minor version

### DIFF
--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -91,8 +91,8 @@
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <relocations>
                 <relocation>
-                  <pattern>META-INF/native/libnetty-transport-native-epoll.so</pattern>
-                  <shadedPattern>META-INF/native/liballuxio-core-client-runtime-netty-transport-native-epoll.so</shadedPattern>
+                  <pattern>META-INF/native/libnetty_transport_native_epoll_x86_64.so</pattern>
+                  <shadedPattern>META-INF/native/liballuxio_core_client_runtime_netty_transport_native_epoll_x86_64.so</shadedPattern>
                   <rawString>true</rawString>
                 </relocation>
                 <relocation>

--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -90,6 +90,7 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <relocations>
+                <!-- Relocate the native netty libraries to be prefixed with our shade prefix -->
                 <relocation>
                   <pattern>META-INF/native/libnetty_transport_native_epoll_x86_64.so</pattern>
                   <shadedPattern>META-INF/native/liballuxio_core_client_runtime_netty_transport_native_epoll_x86_64.so</shadedPattern>

--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -91,6 +91,11 @@
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <relocations>
                 <relocation>
+                  <pattern>META-INF/native/libnetty-transport-native-epoll.so</pattern>
+                  <shadedPattern>META-INF/native/liballuxio-core-client-runtime-netty-transport-native-epoll.so</shadedPattern>
+                  <rawString>true</rawString>
+                </relocation>
+                <relocation>
                   <pattern>com.codahale.metrics</pattern>
                   <shadedPattern>${shading.prefix}.com.codahale.metrics</shadedPattern>
                 </relocation>

--- a/core/common/src/test/java/alluxio/EmbeddedChannels.java
+++ b/core/common/src/test/java/alluxio/EmbeddedChannels.java
@@ -50,8 +50,6 @@ public final class EmbeddedChannels {
       ChannelPipeline p = super.pipeline();
       // Remove the dummy handler.
       p.removeFirst();
-      // Remove the LastInboundHandler in super;
-      p.removeLast();
       // Add a LastInboundHandler instance of this class
       p.addLast(new LastInboundHandler());
       mPipeline = new EmbeddedChannelPipeline(p);

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
         <artifactId>metrics-jvm</artifactId>
         <version>${metrics.version}</version>
       </dependency>
+      <!-- Netty 4.0.50+ required for shading in client runtime jar to work -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.29.Final</version>
+        <version>4.0.53.Final</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
Requires the changes to remove usages of chmv8. Version >= 4.0.50 is required to support shading without needing to specify system properties.