### PR TITLE
[SMALLFIX][k8s] Add template for persistent volume

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -73,6 +73,7 @@ case ${service,,} in
   master)
     if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
       echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+      exit 1
     fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
       bin/alluxio format
@@ -82,6 +83,7 @@ case ${service,,} in
   worker)
     if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
       echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+      exit 1
     fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
       bin/alluxio formatWorker

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -12,13 +12,16 @@
 
 set -e
 
-expected='"formatMaster", "formatWorker", "launchMaster", "launchWorker", "master, "worker", or "proxy"'
-if [[ $# -ne 1 ]]; then
-  echo 'expected one argument: ' ${expected}
+EXPECTED='"master [--no-format]", "worker [--no-format]", or "proxy"'
+NO_FORMAT='--no-format'
+
+if [[ $# -lt 1 ]]; then
+  echo 'expected atleast one argument: ' ${EXPECTED}
   exit 1
 fi
 
 service=$1
+options=$2
 
 # Only set ALLUXIO_RAM_FOLDER if tiered storage isn't explicitly configured
 if [[ -z "${ALLUXIO_WORKER_TIEREDSTORE_LEVEL0_DIRS_PATH}" ]]; then
@@ -67,31 +70,23 @@ for keyvaluepair in $(env | grep "ALLUXIO_"); do
 done
 
 case ${service,,} in
-  format)
-    bin/alluxio format
-    ;;
-  formatWorker)
-    bin/alluxio formatWorker
-    ;;
-  launchMaster)
-    integration/docker/bin/alluxio-master.sh
-    ;;
-  launchWorker)
-    integration/docker/bin/alluxio-worker.sh
-    ;;
   master)
-    bin/alluxio format
+    if [[ ${options} != ${NO_FORMAT} ]]; then
+      bin/alluxio format
+    fi
     integration/docker/bin/alluxio-master.sh
     ;;
   worker)
-    bin/alluxio formatWorker
+    if [[ ${options} != ${NO_FORMAT} ]]; then
+      bin/alluxio formatWorker
+    fi
     integration/docker/bin/alluxio-worker.sh
     ;;
   proxy)
     integration/docker/bin/alluxio-proxy.sh
     ;;
   *)
-    echo 'expected ' ${expected};
+    echo 'expected ' ${EXPECTED};
     exit 1
     ;;
 esac

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -12,8 +12,9 @@
 
 set -e
 
+expected='"formatMaster", "formatWorker", "launchMaster", "launchWorker", "master, "worker", or "proxy"'
 if [[ $# -ne 1 ]]; then
-  echo 'expected one argument: "master", "worker", or "proxy"'
+  echo 'expected one argument: ' ${expected}
   exit 1
 fi
 
@@ -66,6 +67,18 @@ for keyvaluepair in $(env | grep "ALLUXIO_"); do
 done
 
 case ${service,,} in
+  format)
+    bin/alluxio format
+    ;;
+  formatWorker)
+    bin/alluxio formatWorker
+    ;;
+  launchMaster)
+    integration/docker/bin/alluxio-master.sh
+    ;;
+  launchWorker)
+    integration/docker/bin/alluxio-worker.sh
+    ;;
   master)
     bin/alluxio format
     integration/docker/bin/alluxio-master.sh
@@ -78,7 +91,7 @@ case ${service,,} in
     integration/docker/bin/alluxio-proxy.sh
     ;;
   *)
-    echo 'expected "master", "worker", or "proxy"';
+    echo 'expected ' ${expected};
     exit 1
     ;;
 esac

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -12,11 +12,19 @@
 
 set -e
 
-EXPECTED='"master [--no-format]", "worker [--no-format]", or "proxy"'
 NO_FORMAT='--no-format'
 
+function printUsage {
+  echo "Usage: COMMAND [COMMAND_OPTIONS]"
+  echo
+  echo "COMMAND is one of:"
+  echo -e " master [--no-format]    \t Start Alluxio master. If --no-format is specified, do not format"
+  echo -e " worker [--no-format]    \t Start Alluxio worker. If --no-format is specified, do not format"
+  echo -e " proxy                   \t Start Alluxio proxy"
+}
+
 if [[ $# -lt 1 ]]; then
-  echo 'expected at least one argument: ' ${EXPECTED}
+  printUsage
   exit 1
 fi
 
@@ -94,7 +102,7 @@ case ${service,,} in
     integration/docker/bin/alluxio-proxy.sh
     ;;
   *)
-    echo 'expected ' ${EXPECTED};
+    printUsage
     exit 1
     ;;
 esac

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -80,7 +80,7 @@ done
 case ${service,,} in
   master)
     if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
-      echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+      printUsage
       exit 1
     fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
@@ -90,7 +90,7 @@ case ${service,,} in
     ;;
   worker)
     if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
-      echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+      printUsage
       exit 1
     fi
     if [[ ${options} != ${NO_FORMAT} ]]; then

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -71,12 +71,18 @@ done
 
 case ${service,,} in
   master)
+    if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
+      echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+    fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
       bin/alluxio format
     fi
     integration/docker/bin/alluxio-master.sh
     ;;
   worker)
+    if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
+      echo 'invalid option ' ${options} ', expected ' ${NO_FORMAT}
+    fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
       bin/alluxio formatWorker
     fi

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -16,7 +16,7 @@ EXPECTED='"master [--no-format]", "worker [--no-format]", or "proxy"'
 NO_FORMAT='--no-format'
 
 if [[ $# -lt 1 ]]; then
-  echo 'expected atleast one argument: ' ${EXPECTED}
+  echo 'expected at least one argument: ' ${EXPECTED}
   exit 1
 fi
 

--- a/integration/kubernetes/README.md
+++ b/integration/kubernetes/README.md
@@ -1,13 +1,22 @@
 ## Pre-requisites
 
-Alluxio workers use `emptyDir` volumes with `sizeLimit`; an alpha feature in Kubernetes 1.8. Please ensure the feature is enabled.
+- Alluxio workers use `emptyDir` volumes with `sizeLimit`; an alpha feature in Kubernetes 1.8. Please ensure the feature is enabled.
 
-Nodes running Alluxio workers require a manual step for using domain sockets. Execute the following on host nodes.
+- Nodes running Alluxio workers require a manual step for using domain sockets. Execute the following on host nodes.
 ```bash
 mkdir /tmp/domain
 chmod a+w /tmp/domain
 touch /tmp/domain/d
 chmod a+w /tmp/domain/d
+```
+
+- Alluxio masters use a persistent volume for storing the journal. Create a persistent volume using the template.
+```bash
+mv alluxio-pv-volume.yaml.template alluxio-pv-volume.yaml
+# Create persistent volume
+kubectl create -f alluxio-pv-volume.yaml
+# Inspect status
+kubectl get pv alluxio-pv-volume
 ```
 
 ## Create spec and configuration from templates

--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -25,6 +25,18 @@ spec:
   selector:
     app: alluxio-master
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alluxio-pv-claim
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -71,8 +83,8 @@ spec:
       restartPolicy: Always
       volumes:
         - name: alluxio-journal
-          emptyDir:
-            sizeLimit: "1G"
+          persistentVolumeClaim:
+            claimName: alluxio-pv-claim
         - name: alluxio-domain
           hostPath:
             path: /tmp/domain

--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -32,7 +32,7 @@ metadata:
 spec:
   storageClassName: standard
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi

--- a/integration/kubernetes/alluxio-pv-volume.yaml.template
+++ b/integration/kubernetes/alluxio-pv-volume.yaml.template
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: alluxio-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: standard
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/data"

--- a/integration/kubernetes/alluxio-pv-volume.yaml.template
+++ b/integration/kubernetes/alluxio-pv-volume.yaml.template
@@ -9,6 +9,6 @@ spec:
   capacity:
     storage: 1Gi
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   hostPath:
     path: "/tmp/data"


### PR DESCRIPTION
- The template can be used for requesting NFS volumes for journal
- Docker entrypoint has added commands, e.g, for starting master without format