### PR TITLE
[SMALLFIX] Supply the variable name to Preconditions.checkNotNull in BaseKeyValueStoreReader.java

### DIFF
--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BaseKeyValueStoreReader.java
@@ -70,7 +70,7 @@ class BaseKeyValueStoreReader implements KeyValueStoreReader {
   @Override
   @Nullable
   public ByteBuffer get(ByteBuffer key) throws IOException, AlluxioException {
-    Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(key, "key");
     int left = 0;
     int right = mPartitions.size();
     while (left < right) {


### PR DESCRIPTION
Supply the variable name to Preconditions.checkNotNull in BaseKeyValueStoreReader.java