### PR TITLE
[SMALLFIX] Mark alluxio.master.file.meta.TtlBucket#sTtlIntervalMs final

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class TtlBucket implements Comparable<TtlBucket> {
   /** The time interval of this bucket is the same as ttl checker's interval. */
-  private static long sTtlIntervalMs =
+  private static final long TTL_INTERVAL_MS =
       Configuration.getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
   /**
    * Each bucket has a time to live interval, this value is the start of the interval, interval
@@ -61,14 +61,14 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * @return the ttl interval end time in milliseconds
    */
   public long getTtlIntervalEndTimeMs() {
-    return mTtlIntervalStartTimeMs + sTtlIntervalMs;
+    return mTtlIntervalStartTimeMs + TTL_INTERVAL_MS;
   }
 
   /**
    * @return the ttl interval in milliseconds
    */
   public static long getTtlIntervalMs() {
-    return sTtlIntervalMs;
+    return TTL_INTERVAL_MS;
   }
 
   /**


### PR DESCRIPTION
In alluxio/master/file/meta/TtlBucket.java, change the definition and reference of sTtlIntervalMs as it is used as a constant.