### PR TITLE
[SMALLFIX] implement CephFS UFS

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -70,6 +70,7 @@ public final class Constants {
   // Google Cloud Storage header convention is "gs://".
   // See https://cloud.google.com/storage/docs/cloud-console
   public static final String HEADER_GCS = "gs://";
+  public static final String HEADER_CEPHFS = "cephfs://";
 
   public static final int MAX_PORT = 65535;
 

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -470,6 +470,66 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("50sec")
           .setDescription("Length of the socket timeout when communicating with S3.")
           .build();
+  public static final PropertyKey UNDERFS_CEPHFS_AUTH_ID =
+      new Builder(Name.UNDERFS_CEPHFS_AUTH_ID)
+          .setDefaultValue("")
+          .setDescription("Ceph client id for authentication.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_CONF_FILE =
+      new Builder(Name.UNDERFS_CEPHFS_CONF_FILE)
+          .setDefaultValue("")
+          .setDescription("Path to Ceph configuration file.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_CONF_OPTS =
+      new Builder(Name.UNDERFS_CEPHFS_CONF_OPTS)
+          .setDefaultValue("")
+          .setDescription("Extra configuration options for CephFS client.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_AUTH_KEY =
+      new Builder(Name.UNDERFS_CEPHFS_AUTH_KEY)
+          .setDefaultValue("")
+          .setDescription("CephX authentication key, base64 encoded.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_AUTH_KEYFILE =
+      new Builder(Name.UNDERFS_CEPHFS_AUTH_KEYFILE)
+          .setDefaultValue("")
+          .setDescription("Path to CephX authentication key file.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_AUTH_KEYRING =
+      new Builder(Name.UNDERFS_CEPHFS_AUTH_KEYRING)
+          .setDefaultValue("")
+          .setDescription("Path to CephX authentication keyring file.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_MON_HOST =
+      new Builder(Name.UNDERFS_CEPHFS_MON_HOST)
+          .setDefaultValue("")
+          .setDescription("List of hosts or addresses to search for a Ceph monitor.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_MDS_NAMESPACE =
+      new Builder(Name.UNDERFS_CEPHFS_MDS_NAMESPACE)
+          .setDefaultValue("")
+          .setDescription("CephFS filesystem to mount.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_MOUNT_UID =
+      new Builder(Name.UNDERFS_CEPHFS_MOUNT_UID)
+          .setDefaultValue(0)
+          .setDescription("The user ID of CephFS mount.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_MOUNT_GID =
+      new Builder(Name.UNDERFS_CEPHFS_MOUNT_GID)
+          .setDefaultValue(0)
+          .setDescription("The group ID of CephFS mount.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_MOUNT_POINT =
+      new Builder(Name.UNDERFS_CEPHFS_MOUNT_POINT)
+          .setDefaultValue("/")
+          .setDescription("Directory to mount on the CephFS filesystem.")
+          .build();
+  public static final PropertyKey UNDERFS_CEPHFS_LOCALIZE_READS =
+      new Builder(Name.UNDERFS_CEPHFS_LOCALIZE_READS)
+          .setDefaultValue(false)
+          .setDescription("Utilize Ceph localized reads feature.")
+          .build();
 
   //
   // UFS access control related properties
@@ -2019,6 +2079,30 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_S3_THREADS_MAX = "alluxio.underfs.s3.threads.max";
     public static final String UNDERFS_S3_UPLOAD_THREADS_MAX =
         "alluxio.underfs.s3.upload.threads.max";
+    public static final String UNDERFS_CEPHFS_AUTH_ID =
+        "alluxio.underfs.cephfs.auth.id";
+    public static final String UNDERFS_CEPHFS_CONF_FILE =
+        "alluxio.underfs.cephfs.conf.file";
+    public static final String UNDERFS_CEPHFS_CONF_OPTS =
+        "alluxio.underfs.cephfs.conf.options";
+    public static final String UNDERFS_CEPHFS_AUTH_KEY =
+        "alluxio.underfs.cephfs.auth.key";
+    public static final String UNDERFS_CEPHFS_AUTH_KEYFILE =
+        "alluxio.underfs.cephfs.auth.keyfile";
+    public static final String UNDERFS_CEPHFS_AUTH_KEYRING =
+        "alluxio.underfs.cephfs.auth.keyring";
+    public static final String UNDERFS_CEPHFS_MON_HOST =
+        "alluxio.underfs.cephfs.mon.host";
+    public static final String UNDERFS_CEPHFS_MDS_NAMESPACE =
+        "alluxio.underfs.cephfs.mds.namespce";
+    public static final String UNDERFS_CEPHFS_MOUNT_UID =
+        "alluxio.underfs.cephfs.mount.uid";
+    public static final String UNDERFS_CEPHFS_MOUNT_GID =
+        "alluxio.underfs.cephfs.mount.gid";
+    public static final String UNDERFS_CEPHFS_MOUNT_POINT =
+        "alluxio.underfs.cephfs.mount.point";
+    public static final String UNDERFS_CEPHFS_LOCALIZE_READS =
+        "alluxio.underfs.cephfs.localize.reads";
 
     //
     // UFS access control related properties

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -130,6 +130,14 @@ public final class UnderFileSystemUtils {
   }
 
   /**
+   * @param ufs the {@link UnderFileSystem} implementation to check
+   * @return true if the implementation is a CephFS storage implementation
+   */
+  public static boolean isCephFS(UnderFileSystem ufs) {
+    return "cephfs".equals(ufs.getUnderFSType());
+  }
+
+  /**
    * @param uri the UFS path
    * @return the bucket or container name of the object storage
    */

--- a/underfs/cephfs/pom.xml
+++ b/underfs/cephfs/pom.xml
@@ -1,0 +1,102 @@
+<!--
+
+    The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+    (the "License"). You may not use this work except in compliance with the License, which is
+    available at www.apache.org/licenses/LICENSE-2.0
+
+    This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, as more fully set forth in the License.
+
+    See the NOTICE file distributed with this work for information regarding copyright ownership.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
+    <version>1.7.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>alluxio-underfs-cephfs</artifactId>
+  <name>Alluxio Under File System - CephFS</name>
+  <description>CephFS Under File System implementation</description>
+
+  <properties>
+    <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
+    <!-- run properly from sub-project directories -->
+    <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
+    <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
+    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
+  </properties>
+
+  <dependencies>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>com.ceph</groupId>
+      <artifactId>libcephfs</artifactId>
+      <version>12.2.1</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Internal test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>ufsContractTest</id>
+      <activation>
+        <property>
+          <name>testCephFSBaseDir</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <testExcludes combine.self="override" />
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <testExcludes>
+            <!-- Skip UFS contract tests unless -DtestCephFSBaseDir="cephfs:///alluxio_test" is specified -->
+            <exclude>**/CephFSUnderFileSystemContractTest.java</exclude>
+          </testExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
@@ -1,0 +1,705 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.AlluxioURI;
+import alluxio.PropertyKey;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.InvalidPathException;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.AtomicFileOutputStream;
+import alluxio.underfs.AtomicFileOutputStreamCallback;
+import alluxio.underfs.BaseUnderFileSystem;
+import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
+
+import alluxio.util.io.PathUtils;
+
+import com.ceph.fs.CephFileAlreadyExistsException;
+import com.ceph.fs.CephMount;
+import com.ceph.fs.CephNotDirectoryException;
+import com.ceph.fs.CephStat;
+import com.ceph.fs.CephStatVFS;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import java.util.List;
+import java.util.Stack;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * CephFS {@link UnderFileSystem} implementation.
+ */
+@ThreadSafe
+public class CephFSUnderFileSystem extends BaseUnderFileSystem
+    implements AtomicFileOutputStreamCallback {
+  private static final Logger LOG = LoggerFactory.getLogger(CephFSUnderFileSystem.class);
+  private static final int MAX_TRY = 5;
+
+  private CephMount mMount;
+
+  /**
+   * Factory method to constructs a new CephFS {@link UnderFileSystem} instance.
+   *
+   * @param ufsUri the {@link AlluxioURI} for this UFS
+   * @param conf the configuration for Hadoop
+   * @return a new CephFS {@link UnderFileSystem} instance
+   */
+  public static CephFSUnderFileSystem createInstance(
+      AlluxioURI ufsUri, UnderFileSystemConfiguration conf) throws IOException {
+    LOG.info("CephFS URI: {}", ufsUri.toString());
+
+    /*
+     * Create mount with auth user id
+     */
+    String userId = conf.getValue(PropertyKey.UNDERFS_CEPHFS_AUTH_ID);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_AUTH_ID, userId);
+    if (userId != null && userId.isEmpty()) {
+      userId = null;
+    }
+    CephMount mount = new CephMount(userId);
+
+    /*
+     * Load a configuration file if specified
+     */
+    String configfile = conf.getValue(PropertyKey.UNDERFS_CEPHFS_CONF_FILE);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_CONF_FILE, configfile);
+    if (configfile != null && !configfile.isEmpty()) {
+      mount.conf_read_file(configfile);
+    }
+
+    /*
+     * Parse and set Ceph configuration options
+     */
+    String configopts = conf.getValue(PropertyKey.UNDERFS_CEPHFS_CONF_OPTS);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_CONF_OPTS, configopts);
+    if (configopts != null && !configopts.isEmpty()) {
+      String[] options = configopts.split(";");
+      for (String option : options) {
+        String[] keyval = option.split("=");
+        if (keyval.length != 2) {
+          throw new IllegalArgumentException("Invalid Ceph option: " + option);
+        }
+        String k = keyval[0];
+        String v = keyval[1];
+        try {
+          mount.conf_set(k, v);
+        } catch (Exception e) {
+          throw new IOException("Error setting Ceph option " + k + " = " + v);
+        }
+      }
+    }
+
+    /*
+     * Set auth key
+     */
+    String key = conf.getValue(PropertyKey.UNDERFS_CEPHFS_AUTH_KEY);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_AUTH_KEY, key);
+    if (key != null && !key.isEmpty()) {
+      mount.conf_set("key", key);
+    }
+
+    /*
+     * Set auth keyfile
+     */
+    String keyfile = conf.getValue(PropertyKey.UNDERFS_CEPHFS_AUTH_KEYFILE);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_AUTH_KEYFILE, keyfile);
+    if (keyfile != null && !keyfile.isEmpty()) {
+      mount.conf_set("keyfile", keyfile);
+    }
+
+    /*
+     * Set auth keyring
+     */
+    String keyring = conf.getValue(PropertyKey.UNDERFS_CEPHFS_AUTH_KEYRING);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_AUTH_KEYRING, keyring);
+    if (keyring != null && !keyring.isEmpty()) {
+      mount.conf_set("keyring", keyring);
+    }
+
+    /*
+     * Set monitor hosts
+     */
+    String monHost;
+    monHost = conf.getValue(PropertyKey.UNDERFS_CEPHFS_MON_HOST);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_MON_HOST, monHost);
+    if (monHost == null || monHost.isEmpty()) {
+      String host = ufsUri.getHost();
+      int port = ufsUri.getPort();
+      if (host != null && port != -1) {
+        monHost = host + ":" + port;
+      } else if (host != null) {
+        monHost = host;
+      }
+    }
+    if (monHost != null && !monHost.isEmpty()) {
+      mount.conf_set("mon_host", monHost);
+    }
+
+    /*
+     * Set filesystem to mount
+     */
+    String namespace = conf.getValue(PropertyKey.UNDERFS_CEPHFS_MDS_NAMESPACE);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_MDS_NAMESPACE, namespace);
+    if (namespace != null && !namespace.isEmpty()) {
+      mount.conf_set("client_mds_namespace", namespace);
+    }
+
+    /*
+     * Set uid/gid to mount
+     */
+    String uid = conf.getValue(PropertyKey.UNDERFS_CEPHFS_MOUNT_UID);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_MOUNT_UID, uid);
+    if (uid != null && !uid.isEmpty()) {
+      mount.conf_set("client_mount_uid", uid);
+    }
+
+    String gid = conf.getValue(PropertyKey.UNDERFS_CEPHFS_MOUNT_GID);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_MOUNT_GID, gid);
+    if (gid != null && !gid.isEmpty()) {
+      mount.conf_set("client_mount_gid", gid);
+    }
+
+    /*
+     * Actually mount the file system
+     */
+    String root = conf.getValue(PropertyKey.UNDERFS_CEPHFS_MOUNT_POINT);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_MOUNT_POINT, root);
+    mount.mount(root);
+
+    /*
+     * Allow reads from replica objects?
+     */
+    String localizeReads = conf.getValue(PropertyKey.UNDERFS_CEPHFS_LOCALIZE_READS);
+    LOG.info("CephFS config: {} = {}", PropertyKey.UNDERFS_CEPHFS_LOCALIZE_READS, localizeReads);
+    if (localizeReads != null && !localizeReads.isEmpty()) {
+      boolean bLocalize = Boolean.parseBoolean(localizeReads);
+      mount.localize_reads(bLocalize);
+    }
+
+    return new CephFSUnderFileSystem(ufsUri, mount, conf);
+  }
+
+  /**
+   * Constructs a new CephFS {@link UnderFileSystem}.
+   *
+   * @param ufsUri the {@link AlluxioURI} for this UFS
+   * @param mount CephMount instance
+   * @param conf the configuration for this UFS
+   */
+  public CephFSUnderFileSystem(AlluxioURI ufsUri, CephMount mount,
+      UnderFileSystemConfiguration conf) {
+    super(ufsUri, conf);
+    mMount = mount;
+  }
+
+  @Override
+  public String getUnderFSType() {
+    return "cephfs";
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (null != mMount) {
+      mMount.unmount();
+    }
+    mMount = null;
+  }
+
+  @Override
+  public OutputStream create(String path, CreateOptions options) throws IOException {
+    if (!options.isEnsureAtomic()) {
+      return createDirect(path, options);
+    }
+    return new AtomicFileOutputStream(path, this, options);
+  }
+
+  @Override
+  public OutputStream createDirect(String path, CreateOptions options) throws IOException {
+    path = stripPath(path);
+    String parentPath;
+    try {
+      parentPath = PathUtils.getParent(path);
+    } catch (InvalidPathException e) {
+      throw new IOException("Invalid path");
+    }
+
+    IOException te = null;
+    RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+    while (retryPolicy.attemptRetry()) {
+      try {
+        // TODO(runsisi): support creating CephFS files with specified block size and replication.
+        if (options.getCreateParent()) {
+          if (mkdirs(parentPath, MkdirsOptions.defaults()) && !isDirectory(parentPath)) {
+            throw new IOException(ExceptionMessage.PARENT_CREATION_FAILED.getMessage(path));
+          }
+        }
+
+        int flags = CephMount.O_WRONLY | CephMount.O_CREAT | CephMount.O_TRUNC;
+        short mode = options.getMode().toShort();
+
+        int fd = openInternal(path, flags, mode);
+        return new CephOutputStream(mMount, fd);
+      } catch (IOException e) {
+        LOG.warn("Retry count {} : {}", retryPolicy.getRetryCount(), e.getMessage());
+        te = e;
+      }
+    }
+    throw te;
+  }
+
+  @Override
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    path = stripPath(path);
+    if (isDirectory(path)) {
+      IOException te = null;
+      RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+      while (retryPolicy.attemptRetry()) {
+        try {
+          return deleteInternal(path, options.isRecursive());
+        } catch (IOException e) {
+          LOG.warn("Retry count {} : {}", retryPolicy.getRetryCount(), e.getMessage());
+          te = e;
+        }
+      }
+      throw te;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
+    path = stripPath(path);
+    if (isFile(path)) {
+      IOException te = null;
+      RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+      while (retryPolicy.attemptRetry()) {
+        try {
+          return deleteInternal(path, false);
+        } catch (IOException e) {
+          LOG.warn("Retry count {} : {}", retryPolicy.getRetryCount(), e.getMessage());
+          te = e;
+        }
+      }
+      throw te;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean exists(String path) throws IOException {
+    path = stripPath(path);
+    try {
+      CephStat stat = new CephStat();
+      lstat(path, stat);
+      return true;
+    } catch (FileNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public long getBlockSizeByte(String path) throws IOException {
+    path = stripPath(path);
+    CephStat stat = new CephStat();
+    lstat(path, stat);
+
+    return stat.blksize;
+  }
+
+  @Override
+  public UfsDirectoryStatus getDirectoryStatus(String path) throws IOException {
+    path = stripPath(path);
+    CephStat stat = new CephStat();
+    lstat(path, stat);
+
+    return new UfsDirectoryStatus(path, "", "", (short) stat.mode);
+  }
+
+  @Override
+  public List<String> getFileLocations(String path) throws IOException {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public List<String> getFileLocations(String path, FileLocationOptions options)
+      throws IOException {
+    return null;
+  }
+
+  /**
+   * Get stat information on a file. This does not fill owner or group, as
+   * Ceph's support for these is a bit different.
+   * @param path The path to stat
+   * @return FileStatus object containing the stat information
+   * @throws FileNotFoundException if the path could not be resolved
+   */
+  @Override
+  public UfsFileStatus getFileStatus(String path) throws IOException {
+    path = stripPath(path);
+    CephStat stat = new CephStat();
+    lstat(path, stat);
+
+    return new UfsFileStatus(path, stat.size, stat.m_time,
+        "", "", (short) stat.mode);
+  }
+
+  @Override
+  public long getSpace(String path, SpaceType type) throws IOException {
+    path = stripPath(path);
+    CephStatVFS stat = new CephStatVFS();
+    statfs(path, stat);
+
+    // Ignoring the path given, will give information for entire cluster
+    // as Alluxio can load/store data out of entire CephFS cluster
+    switch (type) {
+      case SPACE_TOTAL:
+        return stat.bsize * stat.blocks;
+      case SPACE_USED:
+        return stat.bsize * (stat.blocks - stat.bavail);
+      case SPACE_FREE:
+        return stat.bsize * stat.bavail;
+      default:
+        throw new IOException("Unknown space type: " + type);
+    }
+  }
+
+  @Override
+  public boolean isDirectory(String path) throws IOException {
+    path = stripPath(path);
+    try {
+      CephStat stat = new CephStat();
+      lstat(path, stat);
+      return stat.isDir();
+    } catch (FileNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean isFile(String path) throws IOException {
+    path = stripPath(path);
+    try {
+      CephStat stat = new CephStat();
+      lstat(path, stat);
+      return stat.isFile();
+    } catch (FileNotFoundException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Each string is a name rather than a complete path.
+   * @param path the path to list
+   * @return An array with the statuses of the files and directories in the directory
+   * denoted by this path. The array will be empty if the directory is empty. Returns
+   * null if this path does not denote a directory
+   */
+  @Override
+  @Nullable
+  public UfsStatus[] listStatus(String path) throws IOException {
+    path = stripPath(path);
+    String[] lst = listDirectory(path);
+    if (lst != null) {
+      UfsStatus[] status = new UfsStatus[lst.length];
+
+      for (int i = 0; i < status.length; i++) {
+        CephStat stat = new CephStat();
+        lstat(PathUtils.concatPath(path, lst[i]), stat);
+
+        if (!stat.isDir()) {
+          status[i] = new UfsFileStatus(lst[i], stat.size, stat.m_time,
+              "", "", (short) stat.mode);
+        } else {
+          status[i] = new UfsDirectoryStatus(lst[i], "", "",
+              (short) stat.mode);
+        }
+      }
+      return status;
+    }
+    return null;
+  }
+
+  @Override
+  public void connectFromMaster(String host) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void connectFromWorker(String host) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public boolean mkdirs(String path, MkdirsOptions options) throws IOException {
+    path = stripPath(path);
+    IOException te = null;
+    RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+    while (retryPolicy.attemptRetry()) {
+      try {
+        if (exists(path)) {
+          LOG.debug("Trying to create existing directory at {}", path);
+          return false;
+        }
+        String parent = getParentPath(path);
+        if (!options.getCreateParent() && !isDirectory(parent)) {
+          return false;
+        }
+        // Create directories one by one with explicit permissions to ensure no umask is applied,
+        // using mkdirs will apply the permission only to the last directory
+        Stack<String> dirsToMake = new Stack<>();
+        dirsToMake.push(path);
+        while (!exists(parent)) {
+          dirsToMake.push(parent);
+          parent = getParentPath(parent);
+        }
+        while (!dirsToMake.empty()) {
+          String dirToMake = dirsToMake.pop();
+          try {
+            mMount.mkdirs(dirToMake, options.getMode().toShort());
+          } catch (CephFileAlreadyExistsException e) {
+            // can be ignored safely
+          }
+          try {
+            setOwner(dirToMake, options.getOwner(), options.getGroup());
+          } catch (IOException e) {
+            LOG.warn("Failed to update the ufs dir ownership, default values will be used. " + e);
+          }
+        }
+        return true;
+      } catch (IOException e) {
+        LOG.warn("{} try to make directory for {} : {}", retryPolicy.getRetryCount(), path,
+            e.getMessage());
+        te = e;
+      }
+    }
+    throw te;
+  }
+
+  @Override
+  public InputStream open(String path, OpenOptions options) throws IOException {
+    path = stripPath(path);
+    IOException te = null;
+    RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+    while (retryPolicy.attemptRetry()) {
+      try {
+        int mode = CreateOptions.defaults().getMode().toShort();
+        int fd = openInternal(path, CephMount.O_RDONLY, mode);
+        CephStat stat = new CephStat();
+        mMount.fstat(fd, stat);
+        CephInputStream inputStream = new CephInputStream(mMount, fd, stat.size);
+        try {
+          inputStream.seek(options.getOffset());
+        } catch (IOException e) {
+          inputStream.close();
+          throw e;
+        }
+        return inputStream;
+      } catch (IOException e) {
+        LOG.warn("{} try to open {} : {}", retryPolicy.getRetryCount(), path, e.getMessage());
+        te = e;
+      }
+    }
+    throw te;
+  }
+
+  @Override
+  public boolean renameDirectory(String src, String dst) throws IOException {
+    if (!isDirectory(src)) {
+      LOG.warn("Unable to rename {} to {} because source does not exist or is a file", src, dst);
+      return false;
+    }
+    return rename(src, dst);
+  }
+
+  @Override
+  public boolean renameFile(String src, String dst) throws IOException {
+    if (!isFile(src)) {
+      LOG.warn("Unable to rename {} to {} because source does not exist or is a directory", src,
+          dst);
+      return false;
+    }
+    return rename(src, dst);
+  }
+
+  @Override
+  public void setOwner(String path, String user, String group) throws IOException {
+    // no-op, Ceph's support for these is a bit different
+  }
+
+  @Override
+  public void setMode(String path, short mode) throws IOException {
+    path = stripPath(path);
+    mMount.chmod(path, mode);
+  }
+
+  @Override
+  public boolean supportsFlush() {
+    return true;
+  }
+
+  /**
+   * @param path the path to strip the scheme from
+   * @return the path, with the optional scheme stripped away
+   */
+  private String stripPath(String path) {
+    return new AlluxioURI(path).getPath();
+  }
+
+  private String getParentPath(String path) throws IOException {
+    try {
+      return PathUtils.getParent(path);
+    } catch (InvalidPathException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private String getFileName(String path) throws IOException {
+    try {
+      String parent = PathUtils.getParent(path);
+      return PathUtils.subtractPaths(path, parent);
+    } catch (InvalidPathException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private String[] listDirectory(String path) throws IOException {
+    CephStat stat = new CephStat();
+    try {
+      mMount.lstat(path, stat);
+    } catch (FileNotFoundException e) {
+      return null;
+    }
+    if (!stat.isDir()) {
+      return null;
+    }
+    return mMount.listdir(path);
+  }
+
+  private int openInternal(String path, int flags, int mode) throws IOException {
+    int fd = mMount.open(path, flags, mode);
+    CephStat stat = new CephStat();
+    mMount.fstat(fd, stat);
+    if (stat.isDir()) {
+      mMount.close(fd);
+      throw new FileNotFoundException();
+    }
+    return fd;
+  }
+
+  private boolean deleteInternal(String path, boolean recursive) throws IOException {
+    CephStat stat = new CephStat();
+    try {
+      lstat(path, stat);
+    } catch (FileNotFoundException e) {
+      return false;
+    }
+
+    /* we're done if it's a file */
+    if (stat.isFile()) {
+      mMount.unlink(path);
+      return true;
+    }
+
+    /* get directory contents */
+    String[] lst = listDirectory(path);
+    if (lst == null) {
+      return false;
+    }
+
+    if (!recursive && lst.length > 0) {
+      throw new IOException("Directory " + path + " is not empty.");
+    }
+
+    for (String fname : lst) {
+      String fullPath = PathUtils.concatPath(path, fname);
+      if (!deleteInternal(fullPath, recursive)) {
+        return false;
+      }
+    }
+
+    mMount.rmdir(path);
+    return true;
+  }
+
+  /**
+   * Rename a file or folder to a file or folder.
+   *
+   * @param src path of source file or directory
+   * @param dst path of destination file or directory
+   * @return true if rename succeeds
+   */
+  private boolean rename(String src, String dst) throws IOException {
+    src = stripPath(src);
+    dst = stripPath(dst);
+    IOException te = null;
+    RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+    while (retryPolicy.attemptRetry()) {
+      try {
+        try {
+          CephStat stat = new CephStat();
+          lstat(dst, stat);
+          if (stat.isDir()) {
+            String fileName = getFileName(src);
+            mMount.rename(src, PathUtils.concatPath(dst, fileName));
+            return true;
+          }
+          return false;
+        } catch (FileNotFoundException e) {
+          // can be ignored safely
+        }
+
+        mMount.rename(src, dst);
+        return true;
+      } catch (IOException e) {
+        LOG.warn("{} try to rename {} to {} : {}", retryPolicy.getRetryCount(), src, dst,
+            e.getMessage());
+        te = e;
+      }
+    }
+    throw te;
+  }
+
+  private void lstat(String path, CephStat stat) throws IOException {
+    try {
+      mMount.lstat(path, stat);
+    } catch (CephNotDirectoryException e) {
+      throw new FileNotFoundException();
+    }
+  }
+
+  private void statfs(String path, CephStatVFS stat) throws IOException {
+    try {
+      mMount.statfs(path, stat);
+    } catch (FileNotFoundException e) {
+      throw new FileNotFoundException();
+    }
+  }
+}

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystemFactory.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystemFactory.java
@@ -1,0 +1,57 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+
+/**
+ * Factory for creating {@link CephFSUnderFileSystem}.
+ *
+ * It caches created {@link CephFSUnderFileSystem}s, using the scheme and authority pair as the key.
+ */
+@ThreadSafe
+public final class CephFSUnderFileSystemFactory implements UnderFileSystemFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(CephFSUnderFileSystemFactory.class);
+  /**
+   * Constructs a new {@link CephFSUnderFileSystemFactory}.
+   */
+  public CephFSUnderFileSystemFactory() {}
+
+  @Override
+  public UnderFileSystem create(String path, UnderFileSystemConfiguration conf) {
+    Preconditions.checkNotNull(path, "path");
+    try {
+      return CephFSUnderFileSystem.createInstance(new AlluxioURI(path), conf);
+    } catch (IOException e) {
+      LOG.error("Failed to create CephFSUnderFileSystem.", e);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public boolean supportsPath(String path) {
+    return path != null && path.startsWith(Constants.HEADER_CEPHFS);
+  }
+}

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephInputStream.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephInputStream.java
@@ -1,0 +1,131 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import com.ceph.fs.CephMount;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A stream for reading a file from CephFS.
+ */
+@NotThreadSafe
+public final class CephInputStream extends InputStream {
+  private CephMount mMount;
+  private int mFileHandle;
+  private long mFileLength;
+  private long mPos = 0;
+
+  /** Flag to indicate this stream has been closed, to ensure close is only done once. */
+  private AtomicBoolean mClosed = new AtomicBoolean(false);
+
+  /**
+   * Create a new CephInputStream.
+   * @param mount CephFileSystem mount
+   * @param fh The filehandle provided by Ceph to reference
+   * @param flength The current length of the file. If the length changes
+   *                you will need to close and re-open it to access the new data
+   */
+  public CephInputStream(CephMount mount, int fh, long flength) {
+    mFileLength = flength;
+    mFileHandle = fh;
+    mMount = mount;
+  }
+
+  @Override
+  public int available() throws IOException {
+    return (int) (mFileLength - mPos);
+  }
+
+  /**
+   * Seek.
+   * @param targetPos Position
+   * @throws IOException throws
+   */
+  public void seek(long targetPos) throws IOException {
+    if (targetPos > mFileLength) {
+      throw new IOException(
+          "CephInputStream.seek: failed seek to position " + targetPos
+          + " on fd " + mFileHandle + ": Cannot seek after EOF " + mFileLength);
+    }
+
+    long oldPos = mPos;
+    mPos = mMount.lseek(mFileHandle, targetPos, CephMount.SEEK_SET);
+    if (mPos < 0) {
+      int ret = (int) mPos;
+      mPos = oldPos;
+      throw new IOException("ceph.lseek: ret = " + ret);
+    }
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (n <= 0) {
+      return 0;
+    }
+    long targetPos = mPos + n;
+    seek(targetPos);
+    return n;
+  }
+
+  @Override
+  public int read() throws IOException {
+    byte[] result = new byte[1];
+
+    if (-1 == read(result, 0, 1)) {
+      return -1;
+    }
+    if (result[0] < 0) {
+      return 256 + (int) result[0];
+    } else {
+      return result[0];
+    }
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (b == null) {
+      throw new NullPointerException();
+    } else if (off < 0 || len < 0 || len > b.length - off) {
+      throw new IndexOutOfBoundsException();
+    } else if (len == 0) {
+      return 0;
+    }
+
+    // ensure we're not past the end of the file
+    if (mPos >= mFileLength) {
+      return -1;
+    }
+
+    int ret = (int) mMount.read(mFileHandle, b, len, -1);
+    if (ret < 0) {
+      // attempt to reset to old position.
+      mMount.lseek(mFileHandle, mPos, CephMount.SEEK_SET);
+      throw new IOException("ceph.read: ret = " + ret);
+    }
+    mPos += ret;
+    return ret;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed.getAndSet(true)) {
+      return;
+    }
+    mMount.close(mFileHandle);
+  }
+}

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephOutputStream.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephOutputStream.java
@@ -1,0 +1,92 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import com.ceph.fs.CephMount;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A stream for writing a file into CephFS. The data will be persisted to a temporary
+ * directory on the local disk and copied as a complete file when the {@link #close()}
+ * method is called.
+ */
+@NotThreadSafe
+public final class CephOutputStream extends OutputStream {
+  private CephMount mMount;
+  private int mFileHandle;
+
+  /** Flag to indicate this stream has been closed, to ensure close is only done once. */
+  private AtomicBoolean mClosed = new AtomicBoolean(false);
+
+  /**
+   * Construct the CephOutputStream.
+   * @param mount CephFileSystem mount
+   * @param fh The Ceph filehandle to connect to
+   */
+  public CephOutputStream(CephMount mount, int fh) {
+    mMount = mount;
+    mFileHandle = fh;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    byte[] buf = new byte[1];
+    buf[0] = (byte) b;
+    write(buf, 0, 1);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (b == null) {
+      throw new NullPointerException();
+    } else if ((off < 0) || (off > b.length) || (len < 0)
+        || ((off + len) > b.length) || ((off + len) < 0)) {
+      throw new IndexOutOfBoundsException();
+    } else if (len == 0) {
+      return;
+    }
+
+    if (off == 0) {
+      int ret = (int) mMount.write(mFileHandle, b, len, -1);
+      if (ret < 0) {
+        throw new IOException("ceph.write: ret = " + ret);
+      }
+    } else {
+      byte[] sub = new byte[len];
+      System.arraycopy(b, off, sub, 0, len);
+      int ret = (int) mMount.write(mFileHandle, sub, len, -1);
+      if (ret < 0) {
+        throw new IOException("ceph.write: ret = " + ret);
+      }
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    mMount.fsync(mFileHandle, false);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed.getAndSet(true)) {
+      return;
+    }
+    flush();
+    mMount.close(mFileHandle);
+  }
+}

--- a/underfs/cephfs/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
+++ b/underfs/cephfs/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
@@ -1,0 +1,12 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.underfs.cephfs.CephFSUnderFileSystemFactory

--- a/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemContractTest.java
+++ b/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.underfs.AbstractUnderFileSystemContractTest;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+
+import com.google.common.base.Preconditions;
+import org.junit.BeforeClass;
+
+/**
+ * This UFS contract test will use CephFS as the backing store.
+ */
+public final class CephFSUnderFileSystemContractTest extends AbstractUnderFileSystemContractTest {
+  private static final String CEPHFS_BASE_DIR_CONF = "testCephFSBaseDir";
+  private static final String CEPHFS_BASE_DIR = System.getProperty(CEPHFS_BASE_DIR_CONF);
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Preconditions.checkNotNull(CEPHFS_BASE_DIR, "CEPHFS_BASE_DIR");
+    Preconditions.checkState(new CephFSUnderFileSystemFactory().supportsPath(CEPHFS_BASE_DIR),
+        "%s is not a valid CephFS path", CEPHFS_BASE_DIR);
+  }
+
+  @Override
+  public UnderFileSystem createUfs(String path, UnderFileSystemConfiguration conf)
+      throws Exception {
+    return new CephFSUnderFileSystemFactory().create(path, conf);
+  }
+
+  @Override
+  public String getUfsBaseDir() {
+    return CEPHFS_BASE_DIR;
+  }
+}

--- a/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemFactoryTest.java
+++ b/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.underfs.UnderFileSystemFactory;
+import alluxio.underfs.UnderFileSystemFactoryRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link CephFSUnderFileSystemFactory}.
+ */
+public class CephFSUnderFileSystemFactoryTest {
+
+  /**
+   * This test ensures the CephFS UFS module correctly accepts paths that begin with cephfs://.
+   */
+  @Test
+  public void factory() {
+    UnderFileSystemFactory factory =
+        UnderFileSystemFactoryRegistry.find("cephfs://localhost/test/path");
+    Assert.assertNotNull(
+        "A UnderFileSystemFactory should exist for CephFS paths when using this module", factory);
+
+    factory = UnderFileSystemFactoryRegistry.find("hdfs://localhost/test/path");
+    Assert.assertNull(
+        "A UnderFileSystemFactory should not exist for HDFS paths when using this module", factory);
+
+    factory = UnderFileSystemFactoryRegistry.find("s3://localhost/test/path");
+    Assert.assertNull(
+        "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
+
+    factory = UnderFileSystemFactoryRegistry.find("s3n://localhost/test/path");
+    Assert.assertNull(
+        "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
+
+    factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost:19999/test");
+    Assert.assertNull("A UnderFileSystemFactory should not exist for non supported paths when "
+        + "using this module", factory);
+  }
+}

--- a/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemTest.java
+++ b/underfs/cephfs/src/test/java/alluxio/underfs/cephfs/CephFSUnderFileSystemTest.java
@@ -1,0 +1,48 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.AlluxioURI;
+import alluxio.underfs.UnderFileSystemConfiguration;
+
+import com.ceph.fs.CephMount;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * Tests {@link CephFSUnderFileSystem}.
+ */
+public final class CephFSUnderFileSystemTest {
+
+  private CephFSUnderFileSystem mCephFSUnderFileSystem;
+  private CephMount mMount;
+
+  @Before
+  public final void before() throws Exception {
+    mMount = Mockito.mock(CephMount.class);
+    mCephFSUnderFileSystem = new CephFSUnderFileSystem(new AlluxioURI("cephfs:///"),
+        mMount, UnderFileSystemConfiguration.defaults());
+  }
+
+  /**
+   * Tests the {@link CephFSUnderFileSystem#getUnderFSType()} method. Confirm the UnderFSType for
+   * CephFSUnderFileSystem.
+   */
+  @Test
+  public void getUnderFSType() throws Exception {
+    Assert.assertEquals("cephfs", mCephFSUnderFileSystem.getUnderFSType());
+  }
+}

--- a/underfs/cephfs/src/test/resources/log4j.properties
+++ b/underfs/cephfs/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.root.logger=INFO, TEST_LOGGER
+alluxio.log.dir=./target/logs
+alluxio.log.file=tests.log
+
+log4j.rootLogger=${alluxio.root.logger}
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+
+#Test Logger
+log4j.appender.TEST_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.TEST_LOGGER.File=${alluxio.log.dir}/${alluxio.log.file}
+log4j.appender.TEST_LOGGER.MaxFileSize=10MB
+log4j.appender.TEST_LOGGER.MaxBackupIndex=100
+log4j.appender.TEST_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.TEST_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -30,6 +30,7 @@
     <module>s3a</module>
     <module>swift</module>
     <module>wasb</module>
+    <module>cephfs</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
this is a patch implements `CephFS` UFS, for early reviews.

Ceph version - latest stable release `Luminous 12.2.1`
tested on Linux dist. - `Ubuntu xenial` and `CentOS 7.3`

Since Ceph did not provide a native Java client, we need to install its Java binding for both building and running.

**preparing**
- preparing build environmen for `Ubuntu xenial`
add apt repository for Ceph and install CephFS java binding:
~$ `sudo vi /etc/apt/sources.list.d/ceph.list`
...
deb http://us.ceph.com/debian-luminous/ xenial main
~$ `sudo apt update`
~$ `sudo apt install libcephfs-java`
install maven dependency to local:
~$ `mvn install:install-file -Dfile=/usr/share/java/libcephfs-12.2.1.jar -DgroupId=com.ceph -DartifactId=libcephfs -Dpackaging=jar -Dversion=12.2.1`

- preparing build environmen for `CentOS 7.x`
add yum repository for Ceph and install CephFS java binding:
~$ `sudo vi /etc/yum.repos.d/ceph.repo`
[ceph]
...
baseurl = http://us.ceph.com/rpm-luminous/el7/x86_64/
~$ `sudo yum updateinfo`
~$ `sudo yum install cephfs-java libcephfs_jni-devel`
install maven dependency to local (the stock maven is a little old, may need to install rh-maven35 from sclo first, then `source /opt/rh/rh-maven35/enable` to use maven 3.5.*):
~$ `mvn install:install-file -Dfile=/usr/share/java/libcephfs.jar -DgroupId=com.ceph -DartifactId=libcephfs -Dpackaging=jar -Dversion=12.2.1`

**building**

~$ `mvn install -DskipTests`

**testing**

_NOTE_: before testing, we must have set up a running Ceph cluster, those `alluxio.underfs.cephfs.*` options are Ceph configuration options.

- Ceph cluster w/o CephX authentication
~$ `mvn test -pl underfs/cephfs -DtestCephFSBaseDir=cephfs:///alluxio_test -Dalluxio.underfs.cephfs.mon.host=10.118.202.195`

- Ceph cluster w/ CephX authentication
~$ `mvn test -pl underfs/cephfs -DtestCephFSBaseDir=cephfs:///alluxio_test -Dalluxio.underfs.cephfs.auth.id=admin -Dalluxio.underfs.cephfs.auth.key=AQD+ZxJatkFdOhAAfYRePpTJFoZDRUbx7I9c9A== -Dalluxio.underfs.cephfs.mon.host=10.118.202.195`

Signed-off-by: luo.runbing <luo.runbing@zte.com.cn>