### PR TITLE
[SMALLFIX] Ignore the fuse tests if the libfuse library is missing

### DIFF
--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -36,6 +36,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,7 +73,12 @@ public class AlluxioFuseFileSystemTest {
         new AlluxioFuseOptions("/doesnt/matter", TEST_ROOT_PATH, false, empty);
 
     mFileSystem = mock(FileSystem.class);
-    mFuseFs = new AlluxioFuseFileSystem(mFileSystem, opts);
+    try {
+      mFuseFs = new AlluxioFuseFileSystem(mFileSystem, opts);
+    } catch (UnsatisfiedLinkError e) {
+      // stop test and ignore if FuseFileSystem fails to create due to missing libfuse library
+      Assume.assumeNoException(e);
+    }
     mFileInfo = allocateNativeFileInfo();
   }
 


### PR DESCRIPTION
So developers won't see test failures on mac if they do not have osxfuse installed.