### PR TITLE
[SMALLFIX] Cache ufs block locations.

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -763,6 +763,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("Time interval to periodically delete the files "
               + "with expired ttl value.")
           .build();
+  public static final PropertyKey MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
+      new Builder(Name.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY)
+          .setDefaultValue(1000000)
+          .setDescription("The capacity of the UFS block locations cache. "
+              + "This cache caches UFS block locations for files that are persisted "
+              + "but not in Alluxio space, so that listing status of these files do not need to "
+              + "repeatedly ask UFS for their block locations. If this is set to 0, the cache "
+              + "will be disabled.")
+          .build();
   public static final PropertyKey MASTER_UFS_PATH_CACHE_CAPACITY =
       new Builder(Name.MASTER_UFS_PATH_CACHE_CAPACITY)
           .setDefaultValue(100000)
@@ -779,15 +788,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "amount of staleness in the async cache, but may impact performance. If this "
               + "is set to 0, the cache will be disabled, and "
               + "`alluxio.user.file.metadata.load.type=Once` will behave like `Always`.")
-          .build();
-  public static final PropertyKey MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
-      new Builder(Name.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY)
-          .setDefaultValue(1000000)
-          .setDescription("The capacity of the UFS block locations cache. "
-              + "This cache caches UFS block locations for files that are persisted "
-              + "but not in Alluxio space, so that listing status of these files do not need to "
-              + "repeatedly ask UFS for their block locations. If this is set to 0, the cache "
-              + "will be disabled.")
           .build();
   public static final PropertyKey MASTER_WEB_BIND_HOST =
       new Builder(Name.MASTER_WEB_BIND_HOST)
@@ -2105,12 +2105,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.tieredstore.global.levels";
     public static final String MASTER_TTL_CHECKER_INTERVAL_MS =
         "alluxio.master.ttl.checker.interval";
+    public static final String MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
+        "alluxio.master.ufs.block.location.cache.capacity";
     public static final String MASTER_UFS_PATH_CACHE_CAPACITY =
         "alluxio.master.ufs.path.cache.capacity";
     public static final String MASTER_UFS_PATH_CACHE_THREADS =
         "alluxio.master.ufs.path.cache.threads";
-    public static final String MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
-        "alluxio.master.ufs.block.location.cache.capacity";
     public static final String MASTER_WEB_BIND_HOST = "alluxio.master.web.bind.host";
     public static final String MASTER_WEB_HOSTNAME = "alluxio.master.web.hostname";
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -786,7 +786,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The capacity of the UFS block locations cache. "
               + "This cache caches UFS block locations for files that are persisted "
               + "but not in Alluxio space, so that listing status of these files do not need to "
-              + "repeatedly ask UFS for their block locations.")
+              + "repeatedly ask UFS for their block locations. If this is set to 0, the cache "
+              + "will be disabled.")
           .build();
   public static final PropertyKey MASTER_WEB_BIND_HOST =
       new Builder(Name.MASTER_WEB_BIND_HOST)

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -780,6 +780,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "is set to 0, the cache will be disabled, and "
               + "`alluxio.user.file.metadata.load.type=Once` will behave like `Always`.")
           .build();
+  public static final PropertyKey MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
+      new Builder(Name.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY)
+          .setDefaultValue(1000000)
+          .setDescription("The capacity of the UFS block locations cache. "
+              + "This cache caches UFS block locations for files that are persisted "
+              + "but not in Alluxio space, so that listing status of these files do not need to "
+              + "repeatedly ask UFS for their block locations.")
+          .build();
   public static final PropertyKey MASTER_WEB_BIND_HOST =
       new Builder(Name.MASTER_WEB_BIND_HOST)
           .setDefaultValue("0.0.0.0")
@@ -2100,6 +2108,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.ufs.path.cache.capacity";
     public static final String MASTER_UFS_PATH_CACHE_THREADS =
         "alluxio.master.ufs.path.cache.threads";
+    public static final String MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
+        "alluxio.master.ufs.block.location.cache.capacity";
     public static final String MASTER_WEB_BIND_HOST = "alluxio.master.web.bind.host";
     public static final String MASTER_WEB_HOSTNAME = "alluxio.master.web.hostname";
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1546,8 +1546,10 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         locs = mUfsBlockLocationCache.process(blockId, inodePath.getUri(),
             FileLocationOptions.defaults().setOffset(fileBlockInfo.getOffset()));
       }
-      for (String loc : locs) {
-        fileBlockInfo.getUfsLocations().add(loc);
+      if (locs != null) {
+        for (String loc : locs) {
+          fileBlockInfo.getUfsLocations().add(loc);
+        }
       }
     }
     return fileBlockInfo;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -108,7 +108,6 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.underfs.options.FileLocationOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.SecurityUtils;
@@ -1542,7 +1541,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // locations from the under storage system.
       long blockId = fileBlockInfo.getBlockInfo().getBlockId();
       List<String> locations = mUfsBlockLocationCache.get(blockId, inodePath.getUri(),
-          FileLocationOptions.defaults().setOffset(fileBlockInfo.getOffset()));
+          fileBlockInfo.getOffset());
       if (locations != null) {
         fileBlockInfo.setUfsLocations(locations);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1543,8 +1543,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       long blockId = fileBlockInfo.getBlockInfo().getBlockId();
       List<String> locs = mUfsBlockLocationCache.get(blockId);
       if (locs == null) {
-        locs = mUfsBlockLocationCache.process(blockId, inodePath.getUri(),
+        mUfsBlockLocationCache.process(blockId, inodePath.getUri(),
             FileLocationOptions.defaults().setOffset(fileBlockInfo.getOffset()));
+        locs = mUfsBlockLocationCache.get(blockId);
       }
       if (locs != null) {
         for (String loc : locs) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1541,16 +1541,10 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // No alluxio locations, but there is a checkpoint in the under storage system. Add the
       // locations from the under storage system.
       long blockId = fileBlockInfo.getBlockInfo().getBlockId();
-      List<String> locs = mUfsBlockLocationCache.get(blockId);
-      if (locs == null) {
-        mUfsBlockLocationCache.process(blockId, inodePath.getUri(),
-            FileLocationOptions.defaults().setOffset(fileBlockInfo.getOffset()));
-        locs = mUfsBlockLocationCache.get(blockId);
-      }
-      if (locs != null) {
-        for (String loc : locs) {
-          fileBlockInfo.getUfsLocations().add(loc);
-        }
+      List<String> locations = mUfsBlockLocationCache.get(blockId, inodePath.getUri(),
+          FileLocationOptions.defaults().setOffset(fileBlockInfo.getOffset()));
+      if (locations != null) {
+        fileBlockInfo.setUfsLocations(locations);
       }
     }
     return fileBlockInfo;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -22,7 +22,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -66,14 +65,15 @@ public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
     MountTable.Resolution resolution = mMountTable.resolve(fileUri);
     String ufsUri = resolution.getUri().toString();
     UnderFileSystem ufs = resolution.getUfs();
-    List<String> locations = new ArrayList<>();
+    List<String> locations;
     try {
-      locations = ufs.getFileLocations(ufsUri,
-          FileLocationOptions.defaults().setOffset(options.getOffset()));
+      locations = ufs.getFileLocations(ufsUri, options);
     } catch (IOException e) {
-      return locations;
+      return null;
     }
-    mCache.put(blockId, locations);
+    if (locations != null) {
+      mCache.put(blockId, locations);
+    }
     return locations;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -26,9 +26,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
  * Lazily cache the block locations only when needed.
  */
+@ThreadSafe
 public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
   private static final Logger LOG = LoggerFactory.getLogger(LazyUfsBlockLocationCache.class);
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -1,0 +1,79 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.meta;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.exception.InvalidPathException;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.FileLocationOptions;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lazily cache the block locations only when needed.
+ *
+ * If {@link #get(long)} returns null, call {@link #process(long, AlluxioURI, FileLocationOptions)}
+ * to synchronously retrieve and cache the block locations.
+ */
+public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
+  /** Number of blocks to cache. */
+  private static final int MAX_BLOCKS =
+      Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
+
+  /** Cache of ufs block locations, key is block ID, value is block locations. */
+  private Cache<Long, List<String>> mCache;
+  private MountTable mMountTable;
+
+  /**
+   * Creates a new instance of {@link UfsBlockLocationCache}.
+   *
+   * @param mountTable the mount table
+   */
+  public LazyUfsBlockLocationCache(MountTable mountTable) {
+    mCache = CacheBuilder.newBuilder().maximumSize(MAX_BLOCKS).build();
+    mMountTable = mountTable;
+  }
+
+  @Override
+  public void invalidate(long blockId) {
+    mCache.invalidate(blockId);
+  }
+
+  @Override
+  public List<String> get(long blockId) {
+    return mCache.getIfPresent(blockId);
+  }
+
+  @Override
+  public List<String> process(long blockId, AlluxioURI fileUri, FileLocationOptions options)
+      throws InvalidPathException {
+    MountTable.Resolution resolution = mMountTable.resolve(fileUri);
+    String ufsUri = resolution.getUri().toString();
+    UnderFileSystem ufs = resolution.getUfs();
+    List<String> locations = new ArrayList<>();
+    try {
+      locations = ufs.getFileLocations(ufsUri,
+          FileLocationOptions.defaults().setOffset(options.getOffset()));
+    } catch (IOException e) {
+      return locations;
+    }
+    mCache.put(blockId, locations);
+    return locations;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -37,7 +37,7 @@ public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
 
   /** Number of blocks to cache. */
   private static final int MAX_BLOCKS =
-      Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
+      Configuration.getInt(PropertyKey.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY);
 
   /** Cache of ufs block locations, key is block ID, value is block locations. */
   private Cache<Long, List<String>> mCache;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -61,7 +61,7 @@ public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
   }
 
   @Override
-  public List<String> get(long blockId, AlluxioURI fileUri, FileLocationOptions options) {
+  public List<String> get(long blockId, AlluxioURI fileUri, long offset) {
     List<String> locations = mCache.getIfPresent(blockId);
     if (locations != null) {
       return locations;
@@ -70,13 +70,14 @@ public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
       MountTable.Resolution resolution = mMountTable.resolve(fileUri);
       String ufsUri = resolution.getUri().toString();
       UnderFileSystem ufs = resolution.getUfs();
-      locations = ufs.getFileLocations(ufsUri, options);
+      locations = ufs.getFileLocations(ufsUri, FileLocationOptions.defaults().setOffset(offset));
       if (locations != null) {
         mCache.put(blockId, locations);
         return locations;
       }
     } catch (InvalidPathException | IOException e) {
-      LOG.warn("Failed to get locations for block {}: ", blockId, e);
+      LOG.warn("Failed to get locations for block {} in file {} with offset {}: {}",
+          blockId, fileUri, offset, e);
     }
     return null;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.InvalidPathException;
 import alluxio.underfs.options.FileLocationOptions;
 
 import java.util.List;
@@ -29,11 +28,8 @@ public interface UfsBlockLocationCache {
    * @param blockId the block ID
    * @param fileUri the URI of the file which contains the block
    * @param options the options for getting file locations from UFS
-   * @return the block locations in UFS or {@code null} if failed to get the locations
-   * @throws InvalidPathException if the fileUri is an invalid path
    */
-  List<String> process(long blockId, AlluxioURI fileUri, FileLocationOptions options)
-      throws InvalidPathException;
+  void process(long blockId, AlluxioURI fileUri, FileLocationOptions options);
 
   /**
    * @param blockId the block ID

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -1,0 +1,61 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.meta;
+
+import alluxio.AlluxioURI;
+import alluxio.exception.InvalidPathException;
+import alluxio.underfs.options.FileLocationOptions;
+
+import java.util.List;
+
+/**
+ * Cache for block locations in the UFS.
+ */
+public interface UfsBlockLocationCache {
+  /**
+   * Retrieves the block locations from UFS, and caches the result.
+   * If failed to get the locations from UFS, an empty list is returned and nothing is cached.
+   * The result will overwrite the existing cached locations for the block.
+   *
+   * @param blockId the block ID
+   * @param fileUri the URI of the file which contains the block
+   * @param options the options for getting file locations from UFS
+   * @return the block locations in UFS
+   * @throws InvalidPathException if the fileUri is an invalid path
+   */
+  List<String> process(long blockId, AlluxioURI fileUri, FileLocationOptions options)
+      throws InvalidPathException;
+
+  /**
+   * @param blockId the block ID
+   * @return the cached block locations or null if there is no cached locations for the block
+   */
+  List<String> get(long blockId);
+
+  /**
+   * Invalidates the UFS locations for the block.
+   *
+   * @param blockId the block ID
+   */
+  void invalidate(long blockId);
+
+  /**
+   * Factory class for {@link UfsBlockLocationCache}.
+   */
+  final class Factory {
+    private Factory() {} // prevent instantiation
+
+    public static UfsBlockLocationCache create(MountTable mountTable) {
+      return new LazyUfsBlockLocationCache(mountTable);
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -23,13 +23,13 @@ import java.util.List;
 public interface UfsBlockLocationCache {
   /**
    * Retrieves the block locations from UFS, and caches the result.
-   * If failed to get the locations from UFS, an empty list is returned and nothing is cached.
+   * If failed to get the locations from UFS, {@code null} is returned and nothing is cached.
    * The result will overwrite the existing cached locations for the block.
    *
    * @param blockId the block ID
    * @param fileUri the URI of the file which contains the block
    * @param options the options for getting file locations from UFS
-   * @return the block locations in UFS
+   * @return the block locations in UFS or {@code null} if failed to get the locations
    * @throws InvalidPathException if the fileUri is an invalid path
    */
   List<String> process(long blockId, AlluxioURI fileUri, FileLocationOptions options)

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.underfs.options.FileLocationOptions;
 
 import java.util.List;
 
@@ -33,10 +32,10 @@ public interface UfsBlockLocationCache {
    *
    * @param blockId the block ID
    * @param fileUri the URI of the file which contains the block
-   * @param options the options for getting file locations from UFS
+   * @param offset the block's offset in the file
    * @return the block locations or null if it fails to get the locations from UFS
    */
-  List<String> get(long blockId, AlluxioURI fileUri, FileLocationOptions options);
+  List<String> get(long blockId, AlluxioURI fileUri, long offset);
 
   /**
    * Invalidates the UFS locations for the block.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -21,21 +21,22 @@ import java.util.List;
  */
 public interface UfsBlockLocationCache {
   /**
-   * Retrieves the block locations from UFS, and caches the result.
-   * If failed to get the locations from UFS, {@code null} is returned and nothing is cached.
-   * The result will overwrite the existing cached locations for the block.
-   *
-   * @param blockId the block ID
-   * @param fileUri the URI of the file which contains the block
-   * @param options the options for getting file locations from UFS
-   */
-  void process(long blockId, AlluxioURI fileUri, FileLocationOptions options);
-
-  /**
    * @param blockId the block ID
    * @return the cached block locations or null if there is no cached locations for the block
    */
   List<String> get(long blockId);
+
+  /**
+   * If the locations exist in the cache, return them, otherwise, retrieves the block locations
+   * from UFS, and caches the result.
+   * If failed to get the locations from UFS, {@code null} is returned and nothing is cached.
+   *
+   * @param blockId the block ID
+   * @param fileUri the URI of the file which contains the block
+   * @param options the options for getting file locations from UFS
+   * @return the block locations or null if it fails to get the locations from UFS
+   */
+  List<String> get(long blockId, AlluxioURI fileUri, FileLocationOptions options);
 
   /**
    * Invalidates the UFS locations for the block.

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -17,7 +17,6 @@ import alluxio.underfs.MasterUfsManager;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.underfs.options.FileLocationOptions;
 import alluxio.util.IdUtils;
 
 import com.google.common.io.Files;
@@ -74,8 +73,7 @@ public class LazyUfsBlockLocationCacheTest {
 
     Assert.assertNull(mUfsBlockLocationCache.get(blockId));
 
-    List<String> locations = mUfsBlockLocationCache.get(blockId, fileUri,
-        FileLocationOptions.defaults().setOffset(0));
+    List<String> locations = mUfsBlockLocationCache.get(blockId, fileUri, 0);
     Assert.assertArrayEquals(ufsLocations.toArray(), locations.toArray());
 
     locations = mUfsBlockLocationCache.get(blockId);

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -62,7 +62,7 @@ public class LazyUfsBlockLocationCacheTest {
   }
 
   @Test
-  public void process() throws Exception {
+  public void get() throws Exception {
     final long blockId = IdUtils.getRandomNonNegativeLong();
     final AlluxioURI fileUri = new AlluxioURI("/mnt/file");
     final String localFilePath = new AlluxioURI(mLocalUfsPath).join("file").getPath();
@@ -74,7 +74,7 @@ public class LazyUfsBlockLocationCacheTest {
 
     Assert.assertNull(mUfsBlockLocationCache.get(blockId));
 
-    List<String> locations = mUfsBlockLocationCache.process(blockId, fileUri,
+    List<String> locations = mUfsBlockLocationCache.get(blockId, fileUri,
         FileLocationOptions.defaults().setOffset(0));
     Assert.assertArrayEquals(ufsLocations.toArray(), locations.toArray());
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -1,0 +1,87 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.meta;
+
+import alluxio.AlluxioURI;
+import alluxio.master.file.options.MountOptions;
+import alluxio.underfs.MasterUfsManager;
+import alluxio.underfs.UfsManager;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.FileLocationOptions;
+import alluxio.util.IdUtils;
+
+import com.google.common.io.Files;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for {@link LazyUfsBlockLocationCache}.
+ */
+public class LazyUfsBlockLocationCacheTest {
+  private String mLocalUfsPath;
+  private UnderFileSystem mLocalUfs;
+  private long mMountId;
+  private UfsManager mUfsManager;
+  private MountTable mMountTable;
+  private LazyUfsBlockLocationCache mUfsBlockLocationCache;
+
+  /**
+   * Sets up a new {@link AsyncUfsAbsentPathCache} before a test runs.
+   */
+  @Before
+  public void before() throws Exception {
+    mLocalUfsPath = Files.createTempDir().getAbsolutePath();
+    mLocalUfs = UnderFileSystem.Factory.create(mLocalUfsPath);
+
+    mMountId = IdUtils.getRandomNonNegativeLong();
+    mUfsManager = new MasterUfsManager();
+    MountOptions options = MountOptions.defaults();
+    mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
+        UnderFileSystemConfiguration.defaults().setReadOnly(options.isReadOnly())
+            .setShared(options.isShared())
+            .setUserSpecifiedConf(Collections.<String, String>emptyMap()));
+
+    mMountTable = new MountTable(mUfsManager);
+    mMountTable.add(new AlluxioURI("/mnt"), new AlluxioURI(mLocalUfsPath), mMountId, options);
+
+    mUfsBlockLocationCache = new LazyUfsBlockLocationCache(mMountTable);
+  }
+
+  @Test
+  public void process() throws Exception {
+    final long blockId = IdUtils.getRandomNonNegativeLong();
+    final AlluxioURI fileUri = new AlluxioURI("/mnt/file");
+    final String localFilePath = new AlluxioURI(mLocalUfsPath).join("file").getPath();
+    mLocalUfs.create(localFilePath);
+    final List<String> ufsLocations = mLocalUfs.getFileLocations(localFilePath);
+    for (String location : ufsLocations) {
+      System.out.println(location);
+    }
+
+    Assert.assertNull(mUfsBlockLocationCache.get(blockId));
+
+    List<String> locations = mUfsBlockLocationCache.process(blockId, fileUri,
+        FileLocationOptions.defaults().setOffset(0));
+    Assert.assertArrayEquals(ufsLocations.toArray(), locations.toArray());
+
+    locations = mUfsBlockLocationCache.get(blockId);
+    Assert.assertArrayEquals(ufsLocations.toArray(), locations.toArray());
+
+    mUfsBlockLocationCache.invalidate(blockId);
+    Assert.assertNull(mUfsBlockLocationCache.get(blockId));
+  }
+}


### PR DESCRIPTION
When listing status of a file, if the file is persisted and has no block cached in Alluxio, and the ufs is not remote, then Alluxio will ask UFS for the block locations of the file so that computation framework can leverage data locality.

This PR caches the ufs locations so that further requests for the ufs locations do not need to send RPCs to UFS again.