### PR TITLE
[SMALLFIX] Exclude netty from zookeeper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,12 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>3.4.6</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
We are using 4.x when zk uses 3.7, this isn't automatically version resolved because netty changes the artifact id from netty to netty-all.