### PR TITLE
[DOCFIX] Update wording for cat command 

### DIFF
--- a/docs/_data/table/en/operation-command.yml
+++ b/docs/_data/table/en/operation-command.yml
@@ -1,5 +1,5 @@
 cat:
-  Print the content of the file to the console.
+  Print the content of a file to the console.
 checkConsistency:
   Check the metadata consistency between Alluxio and the under storage.
 checksum:


### PR DESCRIPTION
changes word "the" to "a"