### PR TITLE
[SMALLFIX] Use static imports for standard test utilities in class FileWorkerMasterSyncExecutorTest

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/file/FileWorkerMasterSyncExecutorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileWorkerMasterSyncExecutorTest.java
@@ -11,6 +11,13 @@
 
 package alluxio.worker.file;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
 import alluxio.exception.status.UnavailableException;
 import alluxio.thrift.FileSystemCommand;
 
@@ -18,7 +25,6 @@ import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -37,8 +43,8 @@ public final class FileWorkerMasterSyncExecutorTest {
 
   @Before
   public void before() {
-    mFileDataManager = Mockito.mock(FileDataManager.class);
-    mFileSystemMasterClient = Mockito.mock(FileSystemMasterClient.class);
+    mFileDataManager = mock(FileDataManager.class);
+    mFileSystemMasterClient = mock(FileSystemMasterClient.class);
     mFileWorkerMasterSyncExecutor = new FileWorkerMasterSyncExecutor(mFileDataManager,
         mFileSystemMasterClient, new AtomicReference<>(10L));
   }
@@ -50,12 +56,12 @@ public final class FileWorkerMasterSyncExecutorTest {
   @Test
   public void heartbeatFailure() throws Exception {
     List<Long> persistedFiles = Lists.newArrayList(1L);
-    Mockito.when(mFileDataManager.getPersistedFiles()).thenReturn(persistedFiles);
+    when(mFileDataManager.getPersistedFiles()).thenReturn(persistedFiles);
     // first time fails, second time passes
-    Mockito.when(mFileSystemMasterClient.heartbeat(Mockito.anyLong(), Mockito.eq(persistedFiles)))
+    when(mFileSystemMasterClient.heartbeat(anyLong(), eq(persistedFiles)))
         .thenThrow(new UnavailableException("failure"));
     mFileWorkerMasterSyncExecutor.heartbeat();
-    Mockito.verify(mFileDataManager, Mockito.never()).clearPersistedFiles(persistedFiles);
+    verify(mFileDataManager, never()).clearPersistedFiles(persistedFiles);
   }
 
   /**
@@ -65,11 +71,11 @@ public final class FileWorkerMasterSyncExecutorTest {
   @Test
   public void heartbeat() throws Exception {
     List<Long> persistedFiles = Lists.newArrayList(1L);
-    Mockito.when(mFileDataManager.getPersistedFiles()).thenReturn(persistedFiles);
+    when(mFileDataManager.getPersistedFiles()).thenReturn(persistedFiles);
     // first time fails, second time passes
-    Mockito.when(mFileSystemMasterClient.heartbeat(Mockito.anyLong(), Mockito.eq(persistedFiles)))
+    when(mFileSystemMasterClient.heartbeat(anyLong(), eq(persistedFiles)))
         .thenReturn(new FileSystemCommand());
     mFileWorkerMasterSyncExecutor.heartbeat();
-    Mockito.verify(mFileDataManager).clearPersistedFiles(persistedFiles);
+    verify(mFileDataManager).clearPersistedFiles(persistedFiles);
   }
 }


### PR DESCRIPTION
…terSyncExecutorTest