### PR TITLE
[SMALLFIX] Use daemon threads for data server.

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -162,10 +162,10 @@ public final class NettyDataServer implements DataServer {
         "data-server-" + ((mSocketAddress instanceof DomainSocketAddress) ? "domain-socket" :
             "tcp-socket");
     final EventLoopGroup bossGroup = NettyUtils
-        .createEventLoop(type, bossThreadCount, dataServerEventLoopNamePrefix + "-boss-%d", false);
+        .createEventLoop(type, bossThreadCount, dataServerEventLoopNamePrefix + "-boss-%d", true);
     final EventLoopGroup workerGroup = NettyUtils
         .createEventLoop(type, workerThreadCount, dataServerEventLoopNamePrefix + "-worker-%d",
-            false);
+            true);
 
     final Class<? extends ServerChannel> socketChannelClass = NettyUtils.getServerChannelClass(type,
          mSocketAddress instanceof DomainSocketAddress);


### PR DESCRIPTION
We block on the thrift server for exiting the worker. Otherwise, we can run into cases where the data server threads prevent the worker from exiting, for example if the data server fails to bind.