### PR TITLE
[SMALLFIX] Format master in docker should never attempt to ssh to workers

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -76,7 +76,7 @@ case ${service,,} in
       exit 1
     fi
     if [[ ${options} != ${NO_FORMAT} ]]; then
-      bin/alluxio format
+      bin/alluxio formatMaster
     fi
     integration/docker/bin/alluxio-master.sh
     ;;


### PR DESCRIPTION
`./bin/alluxio format` tries to ssh to workers and `formatWorker`