### PR TITLE
[SMALLFIX] Tiered identity usability improvements

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/options/CreateFileOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/CreateFileOptions.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 
+import java.lang.reflect.InvocationTargetException;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -62,9 +64,11 @@ public final class CreateFileOptions {
     try {
       mLocationPolicy =
           CommonUtils.createNewClassInstance(Configuration.<FileWriteLocationPolicy>getClass(
-              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[] {}, new Object[] {});
+              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[]{}, new Object[]{});
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e.getCause());
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     mWriteTier = Configuration.getInt(PropertyKey.USER_FILE_WRITE_TIER_DEFAULT);
     mWriteType = Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -22,7 +22,8 @@ import alluxio.client.file.policy.FileWriteLocationPolicy;
 import alluxio.util.CommonUtils;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
+
+import java.lang.reflect.InvocationTargetException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -58,9 +59,11 @@ public final class InStreamOptions {
     try {
       mCacheLocationPolicy = CommonUtils.createNewClassInstance(
           Configuration.<FileWriteLocationPolicy>getClass(
-              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[] {}, new Object[] {});
+              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[]{}, new Object[]{});
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e.getCause());
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     CreateOptions blockLocationPolicyCreateOptions = CreateOptions.defaults()
         .setLocationPolicyClassName(

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OpenFileOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OpenFileOptions.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
+
+import java.lang.reflect.InvocationTargetException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -58,9 +59,11 @@ public final class OpenFileOptions {
     try {
       mCacheLocationPolicy = CommonUtils.createNewClassInstance(
           Configuration.<FileWriteLocationPolicy>getClass(
-              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[] {}, new Object[] {});
+              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[]{}, new Object[]{});
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e.getCause());
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     CreateOptions blockLocationPolicyCreateOptions = CreateOptions.defaults()

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -26,7 +26,8 @@ import alluxio.util.SecurityUtils;
 import alluxio.wire.TtlAction;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
+
+import java.lang.reflect.InvocationTargetException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -63,9 +64,11 @@ public final class OutStreamOptions {
     try {
       mLocationPolicy = CommonUtils.createNewClassInstance(
           Configuration.<FileWriteLocationPolicy>getClass(
-              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[] {}, new Object[] {});
+              PropertyKey.USER_FILE_WRITE_LOCATION_POLICY), new Class[]{}, new Object[]{});
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e.getCause());
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     mWriteTier = Configuration.getInt(PropertyKey.USER_FILE_WRITE_TIER_DEFAULT);
     mWriteType = Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -554,9 +554,9 @@ public final class Configuration {
       if (match.groupCount() > 1) {
         String tierName = match.group(1);
         if (!tiers.contains(tierName)) {
-          throw new IllegalStateException(String.format(
-              "Tier %s is configured by %s, but does not exist in the tier list %s configured by %s",
-              tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
+          throw new IllegalStateException(
+              String.format("Tier %s is configured by %s, but does not exist in the tier list %s "
+                  + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
         }
       }
     }

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1334,6 +1335,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey LOCALITY_SCRIPT =
       new Builder(Name.LOCALITY_SCRIPT)
+          .setDefaultValue(String.format("${%s}/tiered_identity.sh", Name.CONF_DIR))
           .setDescription("A script to determine tiered identity for locality checking")
           .build();
   public static final PropertyKey LOCALITY_TIER_NODE =
@@ -2508,6 +2510,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public boolean matches(String input) {
       Matcher matcher = mPattern.matcher(input);
       return matcher.matches();
+    }
+
+    /**
+     * @param input the input property key string
+     * @return the match result from matching the template to the string
+     */
+    public MatchResult match(String input) {
+      Matcher matcher = mPattern.matcher(input);
+      return matcher.toMatchResult();
     }
   }
 

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2514,11 +2513,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
     /**
      * @param input the input property key string
-     * @return the match result from matching the template to the string
+     * @return the matcher matching the template to the string
      */
-    public MatchResult match(String input) {
-      Matcher matcher = mPattern.matcher(input);
-      return matcher.toMatchResult();
+    public Matcher match(String input) {
+      return mPattern.matcher(input);
     }
   }
 

--- a/core/common/src/main/java/alluxio/network/TieredIdentityFactory.java
+++ b/core/common/src/main/java/alluxio/network/TieredIdentityFactory.java
@@ -22,12 +22,19 @@ import alluxio.wire.TieredIdentity.LocalityTier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -36,6 +43,8 @@ import javax.annotation.concurrent.GuardedBy;
  * Class for getting tiered identity.
  */
 public final class TieredIdentityFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(TieredIdentityFactory.class);
+
   // Synchronize on this lock to modify sInstance.
   private static final Object LOCK = new Object();
   @GuardedBy("LOCK")
@@ -49,6 +58,7 @@ public final class TieredIdentityFactory {
       synchronized (LOCK) {
         if (sInstance == null) {
           sInstance = create();
+          LOG.info("Initialized tiered identity {}", sInstance);
         }
       }
     }
@@ -98,36 +108,49 @@ public final class TieredIdentityFactory {
     if (!Configuration.containsKey(PropertyKey.LOCALITY_SCRIPT)) {
       return null;
     }
-    String script = Configuration.get(PropertyKey.LOCALITY_SCRIPT);
+    Path script = Paths.get(Configuration.get(PropertyKey.LOCALITY_SCRIPT));
+    if (!Files.exists(script)) {
+      return null;
+    }
     String identityString;
     try {
-      identityString = ShellUtils.execCommand(script);
+      identityString = ShellUtils.execCommand(script.toString());
     } catch (IOException e) {
       throw new RuntimeException(
           String.format("Failed to run script %s: %s", script, e.toString()), e);
     }
-    return fromString(identityString);
+    try {
+      return fromString(identityString);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format("Failed to parse output of running %s: %s", script, e.getMessage()), e);
+    }
   }
 
   /**
    * @param identityString tiered identity string to parse
    * @return the parsed tiered identity
    */
-  public static TieredIdentity fromString(String identityString) {
+  public static TieredIdentity fromString(String identityString) throws IOException {
+    Set<String> allTiers = Sets.newHashSet(Configuration.getList(PropertyKey.LOCALITY_ORDER, ","));
     Map<String, String> tiers = new HashMap<>();
     for (String tier : identityString.split(",")) {
       String[] parts = tier.split("=");
       if (parts.length != 2) {
-        throw new RuntimeException(String
+        throw new IOException(String
             .format("Failed to parse tiered identity. The value should be a comma-separated list "
                 + "of key=value pairs, but was %s", identityString));
       }
       String key = parts[0].trim();
       if (tiers.containsKey(key)) {
-        throw new RuntimeException(String.format(
+        throw new IOException(String.format(
             "Encountered repeated tier definition for %s when parsing tiered identity from string "
                 + "%s",
             key, identityString));
+      }
+      if (!allTiers.contains(key)) {
+        throw new IOException(String.format("Unrecognized tier: %s. The tiers defined by %s are %s",
+            key, PropertyKey.LOCALITY_ORDER.toString(), allTiers));
       }
       tiers.put(key, parts[1].trim());
     }

--- a/core/common/src/main/java/alluxio/wire/TieredIdentity.java
+++ b/core/common/src/main/java/alluxio/wire/TieredIdentity.java
@@ -15,6 +15,7 @@ import alluxio.annotation.PublicApi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -130,9 +131,10 @@ public final class TieredIdentity implements Serializable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("tiers", mTiers)
-        .toString();
+    String tiers = Joiner.on(", ").join(mTiers.stream()
+        .map(tier -> tier.getTierName() + "=" + tier.getValue())
+        .collect(Collectors.toList()));
+    return String.format("TieredIdentity(%s)", tiers);
   }
 
   /**

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -483,7 +483,7 @@ public class ConfigurationTest {
       try {
         Configuration.init();
         fail("Expected an exception to be thrown");
-      } catch (IllegalStateException e ) {
+      } catch (IllegalStateException e) {
         assertThat(e.getMessage(), containsString("unknownTier"));
         assertThat(e.getMessage(), containsString("does not exist in the tier list"));
       }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -11,11 +11,15 @@
 
 package alluxio;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import alluxio.PropertyKey.Template;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -466,6 +470,24 @@ public class ConfigurationTest {
     assertTrue(Configuration.containsKey(PropertyKey.USER_FILE_BUFFER_BYTES));
     Configuration.unset(PropertyKey.USER_FILE_BUFFER_BYTES);
     assertFalse(Configuration.containsKey(PropertyKey.USER_FILE_BUFFER_BYTES));
+  }
+
+  @Test
+  public void validateTieredLocality() throws Exception {
+    // Pre-load the Configuration class so that the exception is thrown when we call init(), not
+    // during class loading.
+    Configuration.init();
+    HashMap<String, String> sysProps = new HashMap<>();
+    sysProps.put(Template.LOCALITY_TIER.format("unknownTier").toString(), "val");
+    try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
+      try {
+        Configuration.init();
+        fail("Expected an exception to be thrown");
+      } catch (IllegalStateException e ) {
+        assertThat(e.getMessage(), containsString("unknownTier"));
+        assertThat(e.getMessage(), containsString("does not exist in the tier list"));
+      }
+    }
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
+++ b/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
@@ -106,12 +106,23 @@ public class TieredIdentityFactoryTest {
   }
 
   @Test
+  public void unknownScriptKey() throws Exception {
+    String badOutput = "unknown=x";
+    try {
+      runScriptWithOutput(badOutput);
+      fail("Expected an exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Unrecognized tier: unknown"));
+    }
+  }
+
+  @Test
   public void invalidScriptOutput() throws Exception {
-    for (String badOutput : new String[] {"x", "a=b c=d", "a=b,cd", "a=b,abc,x=y"}) {
+    for (String badOutput : new String[] {"x", "a=b c=d", "node=b,cd", "node=b,abc,x=y"}) {
       try {
         runScriptWithOutput(badOutput);
         fail("Expected an exception to be thrown");
-      } catch (RuntimeException e) {
+      } catch (Exception e) {
         assertThat(e.getMessage(), containsString("Failed to parse"));
         assertThat(e.getMessage(), containsString(badOutput));
       }

--- a/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
+++ b/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
@@ -63,6 +63,13 @@ public class TieredIdentityTest {
     checkEquality(tieredIdentity, other);
   }
 
+  @Test
+  public void string() {
+    TieredIdentity identity = new TieredIdentity(
+        Arrays.asList(new LocalityTier("k1", "v1"), new LocalityTier("k2", "v2")));
+    assertEquals("TieredIdentity(k1=v1, k2=v2)", identity.toString());
+  }
+
   public void checkEquality(TieredIdentity a, TieredIdentity b) {
     assertEquals(a.getTiers(), b.getTiers());
     assertEquals(a, b);


### PR DESCRIPTION
- Throw the causes of `InvocationTargetExceptions`. The exceptions themselves have empty messages, so they give no useful information when only the top-level exception message is shown, as is the case for the shell.
- Check that the user hasn't supplied inconsistent tiered locality configuration, e.g. setting
alluxio.locality.rak=/rack1 instead of alluxio.locality.rack=/rack1
- Specify a default location for the tiered identity script under `conf/tiered_identity.sh`
- Make sure all outputs of the tiered locality script match actual tiers.
- Log the tiered identity when it is initiailized.