### PR TITLE
[SMALLFIX] Remove env vars in alluxio-env.sh.template that have corresponding site properties

### DIFF
--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -22,29 +22,8 @@
 # (http://www.alluxio.org/documentation/en/Configuration-Settings.html),
 # and is respected by both external jobs and Alluxio servers (or shell).
 
-# The directory where Alluxio deployment is installed. (Default: the parent directory of libexec/).
-# ALLUXIO_HOME
-
 # The directory where log files are stored. (Default: ${ALLUXIO_HOME}/logs).
 # ALLUXIO_LOGS_DIR
-
-# Hostname of the master.
-# ALLUXIO_MASTER_HOSTNAME
-
-# This is now deprecated. Support will be removed in v2.0
-# ALLUXIO_MASTER_ADDRESS
-
-# The directory where a worker stores in-memory data. (Default: /mnt/ramdisk).
-# E.g. On linux,  /mnt/ramdisk for ramdisk, /dev/shm for tmpFS; on MacOS, /Volumes/ramdisk for ramdisk
-# ALLUXIO_RAM_FOLDER
-
-# Address of the under filesystem address. (Default: ${ALLUXIO_HOME}/underFSStorage)
-# E.g. "/my/local/path" to use local fs, "hdfs://localhost:9000/alluxio" to use a local hdfs
-# ALLUXIO_UNDERFS_ADDRESS
-
-# How much memory to use per worker. (Default: 1GB)
-# E.g. "1000MB", "2GB"
-# ALLUXIO_WORKER_MEMORY_SIZE
 
 # Config properties set for Alluxio master, worker and shell. (Default: "")
 # E.g. "-Dalluxio.master.port=39999"


### PR DESCRIPTION
- `ALLUXIO_HOME` is not really respected
- `ALLUXIO_MASTER_HOSTNAME`, `ALLUXIO_MASTER_ADDRESS`, `ALLUXIO_RAM_FOLDER`, `ALLUXIO_UNDERFS_ADDRESS`, `ALLUXIO_WORKER_MEMORY_SIZE` should be set by their corresponding Alluxio properties