### PR TITLE
[SMALLFIX] Remove reference of alluxio-env.sh as we recommend alluxio-site.properties

### DIFF
--- a/docs/en/Configuring-Alluxio-with-Ceph.md
+++ b/docs/en/Configuring-Alluxio-with-Ceph.md
@@ -64,10 +64,6 @@ Replace `<container>/<folder>` with an existing Swift container location. Possib
 `true`, `false`. Specify `<swift-auth-model>` as `swiftauth` if using native Ceph RGW authentication and `<swift-auth-url>`
 as `http://<rgw-hostname>:<rgw-port>/auth/1.0`.
 
-Alternatively, these configuration settings can be set in the `conf/alluxio-env.sh` file. More
-details about setting configuration parameters can be found in
-[Configuration Settings](Configuration-Settings.html#environment-variables).
-
 ## Running Alluxio Locally with Ceph
 
 After everything is configured, you can start up Alluxio locally to see that everything works.

--- a/docs/en/Configuring-Alluxio-with-GCS.md
+++ b/docs/en/Configuring-Alluxio-with-GCS.md
@@ -53,10 +53,6 @@ Note: GCS interoperability is disabled by default. Please click on the Interoper
 in [GCS setting](https://console.cloud.google.com/storage/settings) and enable this feature.
 Then click on `Create a new key` to get the Access Key and Secret pair.
 
-Alternatively, these configuration settings can be set in the `conf/alluxio-env.sh` file. More
-details about setting configuration parameters can be found in
-[Configuration Settings](Configuration-Settings.html#environment-variables).
-
 After these changes, Alluxio should be configured to work with GCS as its under storage system, and you can [Run Alluxio Locally with GCS](#running-alluxio-locally-with-gcs).
 
 ### Configuring Application Dependency

--- a/docs/en/Configuring-Alluxio-with-S3.md
+++ b/docs/en/Configuring-Alluxio-with-S3.md
@@ -60,10 +60,6 @@ You can specify credentials in 4 ways, from highest to lowest priority:
 See [Amazon's documentation](http://docs.aws.amazon.com/java-sdk/latest/developer-guide/credentials.html#id6)
 for more details.
 
-Alternatively, these configuration settings can be set in the `conf/alluxio-env.sh` file. More
-details about setting configuration parameters can be found in
-[Configuration Settings](Configuration-Settings.html#environment-variables).
-
 After these changes, Alluxio should be configured to work with S3 as its under storage system, and
 you can try [Running Alluxio Locally with S3](#running-alluxio-locally-with-s3).
 

--- a/docs/en/Configuring-Alluxio-with-secure-HDFS.md
+++ b/docs/en/Configuring-Alluxio-with-secure-HDFS.md
@@ -88,21 +88,21 @@ libraries to specified Kerberos realm and KDC server address.
 If both are set to empty, Kerberos library will respect
 the default Kerberos configuration on the machine. For example:
 
-* If you use Hadoop, you can add to `HADOOP_OPTS` in `{HADOOP_CONF_DIR}/hadoop-env.sh`.
+* If you use Hadoop, you can add to `HADOOP_OPTS` in `${HADOOP_CONF_DIR}/hadoop-env.sh`.
 
 ```bash
 $ export HADOOP_OPTS="$HADOOP_OPTS -Djava.security.krb5.realm=<YOUR_KERBEROS_REALM> -Djava.security.krb5.kdc=<YOUR_KERBEROS_KDC_ADDRESS>"
 ```
 
-* If you use Spark, you can add to `SPARK_JAVA_OPTS` in `{SPARK_CONF_DIR}/spark-env.sh`.
+* If you use Spark, you can add to `SPARK_JAVA_OPTS` in `${SPARK_CONF_DIR}/spark-env.sh`.
 
-```properties
+```bash
 SPARK_JAVA_OPTS+=" -Djava.security.krb5.realm=<YOUR_KERBEROS_REALM> -Djava.security.krb5.kdc=<YOUR_KERBEROS_KDC_ADDRESS>"
 ```
 
 * If you use Alluxio shell, you can add to `ALLUXIO_JAVA_OPTS` in `conf/alluxio-env.sh`.
 
-```properties
+```bash
 ALLUXIO_JAVA_OPTS+=" -Djava.security.krb5.realm=<YOUR_KERBEROS_REALM> -Djava.security.krb5.kdc=<YOUR_KERBEROS_KDC_ADDRESS>"
 ```
 
@@ -116,10 +116,6 @@ alluxio.master.principal=hdfs/<_HOST>@<REALM>
 alluxio.worker.keytab.file=<YOUR_HDFS_KEYTAB_FILE_PATH>
 alluxio.worker.principal=hdfs/<_HOST>@<REALM>
 ```
-
-Alternatively, these configuration settings can be set in the `conf/alluxio-env.sh` file. More
-details about setting configuration parameters can be found in
-[Configuration Settings](Configuration-Settings.html).
 
 ## Running Alluxio Locally with secure HDFS
 

--- a/docs/en/Debugging-Guide.md
+++ b/docs/en/Debugging-Guide.md
@@ -31,7 +31,7 @@ Usually, Alluxio does not run on the development environment, which makes it dif
 
 Java remote debugging technology can make it simple to debug Alluxio in source level without modify any source. You need to append the JVM remote debugging parameters and then start debugging server. There are several ways to append the remote debugging parameters, you can export the properties in shell or `alluxio-env.sh`, add the following configuration properties.
 
-```
+```bash
 export ALLUXIO_WORKER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6606"
 export ALLUXIO_MASTER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6607"
 export ALLUXIO_USER_DEBUG_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=6609"

--- a/docs/en/Remote-Logging.md
+++ b/docs/en/Remote-Logging.md
@@ -27,7 +27,7 @@ run the log server on the same machine as a master.
 
 ### Enable Remote Logging with Environment Variables
 Suppose the hostname of the log server is `AlluxioLogServer`, and the port is `45010`.
-In ./conf/alluxio-env.sh, add the following lines:
+In `conf/alluxio-env.sh`, add the following lines:
 
 ```bash
 ALLUXIO_LOGSERVER_HOSTNAME=AlluxioLogServer

--- a/docs/en/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/en/Running-Alluxio-Fault-Tolerant.md
@@ -97,10 +97,6 @@ with commas, like:
 
     alluxio.zookeeper.address=[zookeeper_hostname1]:2181,[zookeeper_hostname2]:2181,[zookeeper_hostname3]:2181
 
-Alternatively, these configuration settings can be set in the `conf/alluxio-env.sh` file. More
-details about setting configuration parameters can be found in
-[Configuration Settings](Configuration-Settings.html).
-
 ### Master Configuration
 
 In addition to the above configuration settings, Alluxio masters need additional configuration. For

--- a/docs/en/Running-Spark-on-Alluxio.md
+++ b/docs/en/Running-Spark-on-Alluxio.md
@@ -101,8 +101,8 @@ should be an output file `LICENSE2` which doubles each line in the file `LICENSE
 
 Alluxio supports transparently fetching the data from the under storage system, given the exact
 path. Put a file `LICENSE` into HDFS under the folder Alluxio is mounted to, by default this is
-/alluxio, meaning any files in hdfs under this folder will be discoverable by Alluxio. You can
-modify this setting by changing the `ALLUXIO_UNDERFS_ADDRESS` property in alluxio-env.sh on the
+`/alluxio`, meaning any files in HDFS under this folder will be discoverable by Alluxio. You can
+modify this setting by changing the `alluxio.underfs.address` property in `conf/alluxio-site.properties` on the
 server.
 
 Assuming the namenode is running on `localhost` and you are using the default mount directory


### PR DESCRIPTION
To reduce confusion, we recommend to use `alluxio-site.properties` rather than `alluxio-env.sh` to set properties.