### PR TITLE
[SMALLFIX] Remove deprecated java property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -918,7 +918,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.19.1</version>
           <configuration>
-            <argLine>-Djava.net.preferIPv4Stack=true -XX:MaxPermSize=512M</argLine>
+            <argLine>-Djava.net.preferIPv4Stack=true</argLine>
             <forkCount>${surefire.forkCount}</forkCount>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>


### PR DESCRIPTION
Max perm size is no longer supported.