### PR TITLE
[SMALLFIX] Set inode mode if journal entry has mode set

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.file.meta;
 
+import alluxio.Constants;
 import alluxio.collections.FieldIndex;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.UniqueFieldIndex;
@@ -249,6 +250,12 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @return the {@link InodeDirectory} representation
    */
   public static InodeDirectory fromJournalEntry(InodeDirectoryEntry entry) {
+    // If journal entry has no security enabled, set default mode for backwards-compatibility.
+    short mode = Constants.DEFAULT_FILE_SYSTEM_MODE;
+    if (entry.hasMode()) {
+      // Journal entry has security enabled
+      mode = (short) entry.getMode();
+    }
     return new InodeDirectory(entry.getId())
         .setCreationTimeMs(entry.getCreationTimeMs())
         .setName(entry.getName())
@@ -258,7 +265,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
         .setLastModificationTimeMs(entry.getLastModificationTimeMs(), true)
         .setOwner(entry.getOwner())
         .setGroup(entry.getGroup())
-        .setMode((short) entry.getMode())
+        .setMode(mode)
         .setMountPoint(entry.getMountPoint())
         .setTtl(entry.getTtl())
         .setTtlAction(ProtobufUtils.fromProtobuf(entry.getTtlAction()))

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -250,7 +250,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    * @return the {@link InodeDirectory} representation
    */
   public static InodeDirectory fromJournalEntry(InodeDirectoryEntry entry) {
-    // If journal entry has no security enabled, set default mode for backwards-compatibility.
+    // If journal entry has no mode set, set default mode for backwards-compatibility.
     short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
     return new InodeDirectory(entry.getId())
         .setCreationTimeMs(entry.getCreationTimeMs())

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -251,11 +251,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   public static InodeDirectory fromJournalEntry(InodeDirectoryEntry entry) {
     // If journal entry has no security enabled, set default mode for backwards-compatibility.
-    short mode = Constants.DEFAULT_FILE_SYSTEM_MODE;
-    if (entry.hasMode()) {
-      // Journal entry has security enabled
-      mode = (short) entry.getMode();
-    }
+    short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
     return new InodeDirectory(entry.getId())
         .setCreationTimeMs(entry.getCreationTimeMs())
         .setName(entry.getName())

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -263,11 +263,7 @@ public final class InodeFile extends Inode<InodeFile> {
    */
   public static InodeFile fromJournalEntry(InodeFileEntry entry) {
     // If journal entry has no security enabled, set default mode for backwards-compatibility.
-    short mode = Constants.DEFAULT_FILE_SYSTEM_MODE;
-    if (entry.hasMode()) {
-      // Journal entry has security enabled
-      mode = (short) entry.getMode();
-    }
+    short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
     return new InodeFile(BlockId.getContainerId(entry.getId()))
         .setName(entry.getName())
         .setBlockIds(entry.getBlocksList())

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -262,6 +262,12 @@ public final class InodeFile extends Inode<InodeFile> {
    * @return the {@link InodeFile} representation
    */
   public static InodeFile fromJournalEntry(InodeFileEntry entry) {
+    // If journal entry has no security enabled, set default mode for backwards-compatibility.
+    short mode = Constants.DEFAULT_FILE_SYSTEM_MODE;
+    if (entry.hasMode()) {
+      // Journal entry has security enabled
+      mode = (short) entry.getMode();
+    }
     return new InodeFile(BlockId.getContainerId(entry.getId()))
         .setName(entry.getName())
         .setBlockIds(entry.getBlocksList())
@@ -278,7 +284,7 @@ public final class InodeFile extends Inode<InodeFile> {
         .setTtlAction((ProtobufUtils.fromProtobuf(entry.getTtlAction())))
         .setOwner(entry.getOwner())
         .setGroup(entry.getGroup())
-        .setMode((short) entry.getMode());
+        .setMode(mode);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -262,7 +262,7 @@ public final class InodeFile extends Inode<InodeFile> {
    * @return the {@link InodeFile} representation
    */
   public static InodeFile fromJournalEntry(InodeFileEntry entry) {
-    // If journal entry has no security enabled, set default mode for backwards-compatibility.
+    // If journal entry has no mode set, set default mode for backwards-compatibility.
     short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
     return new InodeFile(BlockId.getContainerId(entry.getId()))
         .setName(entry.getName())

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -936,7 +936,7 @@ public class InodeTree implements JournalEntryIterable {
       setRoot(directory);
       // If journal entry has no security enabled, change the replayed inode permission to be 0777
       // for backwards-compatibility.
-      if (SecurityUtils.isSecurityEnabled() && entry.hasMode()) {
+      if (SecurityUtils.isSecurityEnabled() && !entry.hasMode()) {
         mRoot.setMode(Constants.DEFAULT_FILE_SYSTEM_MODE);
       }
     } else {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.collections.FieldIndex;
 import alluxio.collections.IndexDefinition;
@@ -41,7 +40,6 @@ import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.MkdirsOptions;
-import alluxio.util.SecurityUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.TtlAction;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -917,7 +917,7 @@ public class InodeTree implements JournalEntryIterable {
    */
   public void addInodeFileFromJournal(InodeFileEntry entry) {
     InodeFile file = InodeFile.fromJournalEntry(entry);
-    addInodeFromJournalInternal(file);
+    addInodeFromJournalInternal(file, entry.hasMode());
   }
 
   /**
@@ -936,12 +936,11 @@ public class InodeTree implements JournalEntryIterable {
       setRoot(directory);
       // If journal entry has no security enabled, change the replayed inode permission to be 0777
       // for backwards-compatibility.
-      if (SecurityUtils.isSecurityEnabled() && mRoot.getOwner().isEmpty()
-          && mRoot.getGroup().isEmpty()) {
+      if (SecurityUtils.isSecurityEnabled() && entry.hasMode()) {
         mRoot.setMode(Constants.DEFAULT_FILE_SYSTEM_MODE);
       }
     } else {
-      addInodeFromJournalInternal(directory);
+      addInodeFromJournalInternal(directory, entry.hasMode());
     }
   }
 
@@ -966,8 +965,9 @@ public class InodeTree implements JournalEntryIterable {
    * appropriate inode indexes.
    *
    * @param inode the inode to add to the inode tree
+   * @param hasMode if the journal entry has mode set
    */
-  private void addInodeFromJournalInternal(Inode<?> inode) {
+  private void addInodeFromJournalInternal(Inode<?> inode, boolean hasMode) {
     InodeDirectory parentDirectory = mCachedInode;
     if (inode.getParentId() != mCachedInode.getId()) {
       parentDirectory = (InodeDirectory) mInodes.getFirst(inode.getParentId());
@@ -977,8 +977,7 @@ public class InodeTree implements JournalEntryIterable {
     mInodes.add(inode);
     // If journal entry has no security enabled, change the replayed inode permission to be 0777
     // for backwards-compatibility.
-    if (SecurityUtils.isSecurityEnabled() && inode != null && inode.getOwner().isEmpty()
-        && inode.getGroup().isEmpty()) {
+    if (SecurityUtils.isSecurityEnabled() && inode != null && !hasMode) {
       inode.setMode(Constants.DEFAULT_FILE_SYSTEM_MODE);
     }
     // Update indexes.


### PR DESCRIPTION
We lost the mode after a reset if owner/group was empty. To reproduce: when using s3a, with inherit_acl = false.
```
./bin/alluxio format
./bin/alluxio-start.sh
./bin/alluxio fs ls / # discovered objects have mode 0700
./bin/alluxio chmod 600 /file
./bin/alluxio-start.sh
./bin/alluxio fs ls / # objects have mode 0777 since user and group is empty
```

Case where it matters: Initial load from s3 has empty user/group, chmod, restart (chmod lost), chown (now the original chmod matters) #