### PR TITLE
[DOCFIX] Use conf/alluxio-site.properties instead of alluxio-env.sh in docs/cn/Running-Spark-on-Alluxio.md 

### DIFF
--- a/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
+++ b/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
@@ -117,7 +117,7 @@ $ bin/alluxio-start.sh local
 $ bin/alluxio runTests
 ```
 
-为了这个测试能成功运行，你需要保证Alluxio cli登入的用户对挂载到Alluxio的HDFS目录有读/写的访问权限。默认情况下，登入的用户是当前主机OS的用户。要改变默认配置，可以设置`./conf/alluxio-site.properties`文件中的`alluxio.security.login.username`的值为想要的用户名。HDFS的目录通过`alluxio.underfs.address`声明。
+为了这个测试能成功运行，你需要保证Alluxio cli登入的用户对挂载到Alluxio的HDFS目录有读/写的访问权限。默认情况下，登入的用户是当前主机OS的用户。要改变默认配置，可以设置`./conf/alluxio-site.properties`文件中的`alluxio.security.login.username`的值为想要的用户名。
 
 运行成功后，访问HDFS Web UI [http://localhost:50070](http://localhost:50070)，确认其中包含了由Alluxio创建的文件和目录。在该测试中，创建的文件名称应像这样：`/default_tests_files/Basic_CACHE_THROUGH`。
 

--- a/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
+++ b/docs/cn/Configuring-Alluxio-with-secure-HDFS.md
@@ -117,7 +117,7 @@ $ bin/alluxio-start.sh local
 $ bin/alluxio runTests
 ```
 
-为了这个测试能成功运行，你需要保证Alluxio cli登入的用户对挂载到Alluxio的HDFS目录有读/写的访问权限。默认情况下，登入的用户是当前主机OS的用户。要改变默认配置，可以设置`./conf/alluxio-site.properties`文件中的`alluxio.security.login.username`的值为想要的用户名。
+为了这个测试能成功运行，你需要保证Alluxio cli登入的用户对挂载到Alluxio的HDFS目录有读/写的访问权限。默认情况下，登入的用户是当前主机OS的用户。要改变默认配置，可以设置`./conf/alluxio-site.properties`文件中的`alluxio.security.login.username`的值为想要的用户名。HDFS的目录通过`alluxio.underfs.address`声明。
 
 运行成功后，访问HDFS Web UI [http://localhost:50070](http://localhost:50070)，确认其中包含了由Alluxio创建的文件和目录。在该测试中，创建的文件名称应像这样：`/default_tests_files/Basic_CACHE_THROUGH`。
 

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -86,7 +86,7 @@ $ bin/alluxio fs copyFromLocal LICENSE /LICENSE
 
 ### 使用来自HDFS的数据
 
-Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的alluxio.underfs.address属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
+Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties`文件中的`alluxio.underfs.address`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
 
 ```bash
 $ hadoop fs -put -f /alluxio/LICENSE hdfs://localhost:9000/alluxio/LICENSE

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -86,7 +86,7 @@ $ bin/alluxio fs copyFromLocal LICENSE /LICENSE
 
 ### 使用来自HDFS的数据
 
-Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的`alluxio.underfs.address`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
+Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的alluxio.underfs.address属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
 
 ```bash
 $ hadoop fs -put -f /alluxio/LICENSE hdfs://localhost:9000/alluxio/LICENSE

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -86,7 +86,7 @@ $ bin/alluxio fs copyFromLocal LICENSE /LICENSE
 
 ### 使用来自HDFS的数据
 
-Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是/alluxio）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的alluxio-env.sh文件中的 `ALLUXIO_UNDERFS_ADDRESS`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
+Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的 `alluxio.underfs.address`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
 
 ```bash
 $ hadoop fs -put -f /alluxio/LICENSE hdfs://localhost:9000/alluxio/LICENSE

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -86,7 +86,7 @@ $ bin/alluxio fs copyFromLocal LICENSE /LICENSE
 
 ### 使用来自HDFS的数据
 
-Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的 `alluxio.underfs.address`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
+Alluxio支持在给出具体的路径时，透明的从底层文件系统中取数据。将文件`LICENSE`放到Alluxio所挂载的目录下（默认是`/alluxio`）的HDFS中，意味着在这个目录下的HDFS中的任何文件都能被Alluxio发现。通过改变位于Server上的`conf/alluxio-site.properties文件中的`alluxio.underfs.address`属性可以修改这个设置。假定namenode节点运行在`localhost`，并且Alluxio默认的挂载目录是`alluxio`:
 
 ```bash
 $ hadoop fs -put -f /alluxio/LICENSE hdfs://localhost:9000/alluxio/LICENSE


### PR DESCRIPTION
Modify Chinese version of Running-Spark-on-Alluxio.md corresponding to revised english version