### PR TITLE
[ALLUXIO-3077] Add source of different configuration properties to track

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -71,6 +71,6 @@ public final class HadoopConfigurationUtils {
     LOG.info("Loading Alluxio properties from Hadoop configuration: {}", alluxioConfProperties);
     // Merge the relevant Hadoop configuration into Alluxio's configuration.
     // TODO(jiri): support multiple client configurations (ALLUXIO-2034)
-    Configuration.merge(alluxioConfProperties);
+    Configuration.merge(alluxioConfProperties, Configuration.Source.HADOOP_CONF);
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -72,5 +72,6 @@ public final class HadoopConfigurationUtils {
     // Merge the relevant Hadoop configuration into Alluxio's configuration.
     // TODO(jiri): support multiple client configurations (ALLUXIO-2034)
     Configuration.merge(alluxioConfProperties, Configuration.Source.HADOOP_CONF);
+    Configuration.validate();
   }
 }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -117,7 +117,8 @@ public class AbstractFileSystemTest {
     try (Closeable c = new ConfigurationRule(ImmutableMap.of(
         PropertyKey.MASTER_HOSTNAME, uri.getHost(),
         PropertyKey.MASTER_RPC_PORT, Integer.toString(uri.getPort()),
-            PropertyKey.ZOOKEEPER_ENABLED, "true")).toResource()) {
+        PropertyKey.ZOOKEEPER_ENABLED, "true",
+        PropertyKey.ZOOKEEPER_ADDRESS, "ignored")).toResource()) {
       final org.apache.hadoop.fs.FileSystem fs =
           org.apache.hadoop.fs.FileSystem.get(uri, getConf());
       assertTrue(fs instanceof FaultTolerantFileSystem);
@@ -130,7 +131,9 @@ public class AbstractFileSystemTest {
   @Test
   public void loadFaultTolerantSystemWhenUsingNoAuthority() throws Exception {
     URI uri = URI.create(Constants.HEADER_FT + "/tmp/path.txt");
-    try (Closeable c = new ConfigurationRule(PropertyKey.ZOOKEEPER_ENABLED, "true").toResource()) {
+    try (Closeable c = new ConfigurationRule(ImmutableMap.of(
+        PropertyKey.ZOOKEEPER_ENABLED, "true",
+        PropertyKey.ZOOKEEPER_ADDRESS, "ignored")).toResource()) {
       final org.apache.hadoop.fs.FileSystem fs =
           org.apache.hadoop.fs.FileSystem.get(uri, getConf());
       assertTrue(fs instanceof FaultTolerantFileSystem);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -70,11 +70,11 @@ public final class Configuration {
 
   /** The source of a configuration property. */
   public enum Source {
-    UNKNOWN,
     DEFAULT,
+    HADOOP_CONF,
     SITE_PROPERTY,
     SYSTEM_PROPERTY,
-    HADOOP_CONF,
+    UNKNOWN,
   }
 
   /** Regex string to find "${key}" for variable substitution. */

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -85,7 +85,7 @@ public final class Configuration {
   private static final ConcurrentHashMap<String, String> PROPERTIES = new ConcurrentHashMap<>();
   /** Map of property sources. */
   private static final ConcurrentHashMap<PropertyKey, Source> SOURCES = new ConcurrentHashMap<>();
-  private static String SITE_PROPERTIES_FILE;
+  private static String sSitePropertyFile;
 
   static {
     init();
@@ -116,11 +116,11 @@ public final class Configuration {
     if (!getBoolean(PropertyKey.TEST_MODE)) {
       String confPaths = get(PropertyKey.SITE_CONF_DIR);
       String[] confPathList = confPaths.split(",");
-      SITE_PROPERTIES_FILE =
+      sSitePropertyFile =
           ConfigurationUtils.searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
-      if (SITE_PROPERTIES_FILE != null) {
-        Properties siteProps = ConfigurationUtils.loadPropertiesFromFile(SITE_PROPERTIES_FILE);
-        LOG.info("Configuration file {} loaded.", SITE_PROPERTIES_FILE);
+      if (sSitePropertyFile != null) {
+        Properties siteProps = ConfigurationUtils.loadPropertiesFromFile(sSitePropertyFile);
+        LOG.info("Configuration file {} loaded.", sSitePropertyFile);
         // Update site properties and system properties in order
         merge(siteProps, Source.SITE_PROPERTY);
         merge(systemProps, Source.SYSTEM_PROPERTY);
@@ -175,6 +175,7 @@ public final class Configuration {
    * configuration wins if it also appears in the current configuration.
    *
    * @param properties The source {@link Properties} to be merged
+   * @param source The source of the the properties (e.g., system property, default and etc)
    */
   public static void merge(Map<?, ?> properties, Source source) {
     if (properties != null) {
@@ -494,7 +495,7 @@ public final class Configuration {
    */
   @Nullable
   public static String getSitePropertiesFile() {
-    return SITE_PROPERTIES_FILE;
+    return sSitePropertyFile;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
+
 /**
  * Utilities for working with Alluxio configurations.
  */
@@ -84,9 +86,10 @@ public final class ConfigurationUtils {
    *
    * @param propertiesFile the file to load properties
    * @param confPathList a list of paths to search the propertiesFile
-   * @return loaded properties on success, or null if failed
+   * @return the site properties file on success search, or null if failed
    */
-  public static Properties searchPropertiesFile(String propertiesFile,
+  @Nullable
+  public static String searchPropertiesFile(String propertiesFile,
       String[] confPathList) {
     if (propertiesFile == null || confPathList == null) {
       return null;
@@ -96,11 +99,10 @@ public final class ConfigurationUtils {
       Properties properties = loadPropertiesFromFile(file);
       if (properties != null) {
         // If a site conf is successfully loaded, stop trying different paths.
-        LOG.info("Configuration file {} loaded.", file);
-        return properties;
+        return file;
       }
     }
-    return loadPropertiesFromResource(propertiesFile);
+    return null;
   }
 
   /**

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -558,6 +558,7 @@ public class ConfigurationTest {
     sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getAbsolutePath());
     sysProps.put(PropertyKey.TEST_MODE.toString(), "false");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
+      Configuration.init();
       assertEquals(
           Configuration.Source.SYSTEM_PROPERTY, Configuration.getSource(PropertyKey.LOGS_DIR));
       assertEquals("/tmp/logs1", Configuration.get(PropertyKey.LOGS_DIR));

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -438,9 +438,10 @@ public class ConfigurationTest {
 
   @Test
   public void userFileBufferBytesOverFlowException() {
-    mThrown.expect(IllegalStateException.class);
     Configuration.set(PropertyKey.USER_FILE_BUFFER_BYTES,
         String.valueOf(Integer.MAX_VALUE + 1) + "B");
+    mThrown.expect(IllegalStateException.class);
+    Configuration.validate();
   }
 
   @Test
@@ -557,6 +558,8 @@ public class ConfigurationTest {
     sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getAbsolutePath());
     sysProps.put(PropertyKey.TEST_MODE.toString(), "false");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
+      assertEquals(
+          Configuration.Source.SYSTEM_PROPERTY, Configuration.getSource(PropertyKey.LOGS_DIR));
       assertEquals("/tmp/logs1", Configuration.get(PropertyKey.LOGS_DIR));
     }
   }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -62,7 +62,8 @@ public class ConfigurationTest {
 
   @Test
   public void alias() {
-    Configuration.merge(ImmutableMap.of("alluxio.master.worker.timeout.ms", "100"));
+    Configuration.merge(ImmutableMap.of("alluxio.master.worker.timeout.ms", "100"),
+        Configuration.Source.SYSTEM_PROPERTY);
     assertEquals(100, Configuration.getMs(PropertyKey.MASTER_WORKER_TIMEOUT_MS));
   }
 
@@ -399,7 +400,8 @@ public class ConfigurationTest {
   public void variableSubstitution() {
     Configuration.merge(ImmutableMap.of(
         PropertyKey.WORK_DIR, "value",
-        PropertyKey.LOGS_DIR, "${alluxio.work.dir}/logs"));
+        PropertyKey.LOGS_DIR, "${alluxio.work.dir}/logs"),
+        Configuration.Source.SYSTEM_PROPERTY);
     String substitution = Configuration.get(PropertyKey.LOGS_DIR);
     assertEquals("value/logs", substitution);
   }
@@ -409,7 +411,8 @@ public class ConfigurationTest {
     Configuration.merge(ImmutableMap.of(
         PropertyKey.MASTER_HOSTNAME, "value1",
         PropertyKey.MASTER_RPC_PORT, "value2",
-        PropertyKey.MASTER_JOURNAL_FOLDER, "${alluxio.master.hostname}-${alluxio.master.port}"));
+        PropertyKey.MASTER_JOURNAL_FOLDER, "${alluxio.master.hostname}-${alluxio.master.port}"),
+        Configuration.Source.SYSTEM_PROPERTY);
     String substitution = Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     assertEquals("value1-value2", substitution);
   }
@@ -419,7 +422,8 @@ public class ConfigurationTest {
     Configuration.merge(ImmutableMap.of(
         PropertyKey.WORK_DIR, "value",
         PropertyKey.LOGS_DIR, "${alluxio.work.dir}/logs",
-        PropertyKey.SITE_CONF_DIR, "${alluxio.logs.dir}/conf"));
+        PropertyKey.SITE_CONF_DIR, "${alluxio.logs.dir}/conf"),
+        Configuration.Source.SYSTEM_PROPERTY);
     String substitution2 = Configuration.get(PropertyKey.SITE_CONF_DIR);
     assertEquals("value/logs/conf", substitution2);
   }

--- a/core/server/common/src/main/webapp/configuration.jsp
+++ b/core/server/common/src/main/webapp/configuration.jsp
@@ -37,10 +37,16 @@
         <div id="data8" class="accordion-body collapse in">
           <div class="accordion-inner">
             <table class = "table">
+              <tr>
+                <th>Property</th>
+                <th>Value</th>
+                <th>Source</th>
+              </tr>
               <tbody>
-                <% for (ImmutablePair<String, String> entry : (SortedSet<ImmutablePair<String, String>>) request.getAttribute("configuration")) { %>
+                <% for (ImmutableTriple<String, String, String> entry : (SortedSet<ImmutableTriple<String, String, String>>) request.getAttribute("configuration")) { %>
                   <tr>
                     <th><%= entry.getLeft() %></th>
+                    <th><%= entry.getMiddle() %></th>
                     <th><%= entry.getRight() %></th>
                   </tr>
                 <% } %>

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
@@ -16,11 +16,8 @@ import alluxio.PropertyKey;
 import alluxio.master.file.FileSystemMaster;
 
 import com.google.common.collect.Sets;
-
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-
-import com.google.common.collect.Sets;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 
 import java.io.IOException;
 import java.util.Map;
@@ -71,12 +68,20 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
     getServletContext().getRequestDispatcher("/configuration.jsp").forward(request, response);
   }
 
-  private SortedSet<Pair<String, String>> getSortedProperties() {
-    TreeSet<Pair<String, String>> rtn = new TreeSet<>();
+  private SortedSet<Triple<String, String, String>> getSortedProperties() {
+    TreeSet<Triple<String, String, String>> rtn = new TreeSet<>();
     for (Map.Entry<String, String> entry : Configuration.toMap().entrySet()) {
       String key = entry.getKey();
       if (key.startsWith(ALLUXIO_CONF_PREFIX) && !ALLUXIO_CONF_EXCLUDES.contains(key)) {
-        rtn.add(new ImmutablePair<>(key, Configuration.get(PropertyKey.fromString(key))));
+        PropertyKey propertyKey = PropertyKey.fromString(key);
+        Configuration.Source source = Configuration.getSource(propertyKey);
+        String sourceStr;
+        if (source == Configuration.Source.SITE_PROPERTY) {
+          sourceStr = String.format("%s (%s)", source.name(), Configuration.getSitePropertiesFile());
+        } else {
+          sourceStr = source.name();
+        }
+        rtn.add(new ImmutableTriple<>(key, Configuration.get(propertyKey), sourceStr));
       }
     }
     return rtn;

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceConfigurationServlet.java
@@ -77,7 +77,8 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
         Configuration.Source source = Configuration.getSource(propertyKey);
         String sourceStr;
         if (source == Configuration.Source.SITE_PROPERTY) {
-          sourceStr = String.format("%s (%s)", source.name(), Configuration.getSitePropertiesFile());
+          sourceStr =
+              String.format("%s (%s)", source.name(), Configuration.getSitePropertiesFile());
         } else {
           sourceStr = source.name();
         }

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -22,7 +22,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3077

- Change in `getConf` CLI, a new `--source` option is added to show the source of a configuration in the following two cases:

```bash
$ bin/alluxio getConf --source
alluxio.conf.dir=/Users/binfan/Dropbox/Work/alluxio/alluxio/conf (SYSTEM_PROPERTY)
alluxio.debug=true (SITE_PROPERTY: /Users/binfan/Dropbox/Work/alluxio/alluxio/conf/alluxio-site.properties)
alluxio.extensions.dir=${alluxio.home}/extensions (DEFAULT)
...
$ bin/alluxio getConf --source alluxio.debug
SITE_PROPERTY: /Users/binfan/Dropbox/Work/alluxio/alluxio/conf/alluxio-site.properties
```

- Change in Configuration tab of WebUI: add a new column to show the source of each configuration property.

![screen shot 2017-12-14 at 2 48 25 pm](https://user-images.githubusercontent.com/1413748/34018324-309b601c-e0de-11e7-8a51-0a04c65574e0.png)
