### PR TITLE
[SMALLFIX] Eliminate maven build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1003,6 +1003,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <!-- hardcode the version here because maven failed to pick up the dependency-managed version of maven-enforcer-plugin -->
+        <version>1.4</version>
         <executions>
           <execution>
             <id>enforce-versions</id>


### PR DESCRIPTION
Though in dependency management, we already specify the version of maven-enforcer-plugin to be 1.4, we still see the following warning messages with the wrong maven-enforcer-plugin version (1.0 rather than 1.4). This PR avoids warning message by hardcoding the version.

```
[INFO] ------------------------------------------------------------------------
[INFO] Building Alluxio Parent 1.7.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in Alluxio Parent:
[WARNING] org.apache.maven.plugins:maven-enforcer-plugin:1.0
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ alluxio-parent ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-maven) @ alluxio-parent ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-versions) @ alluxio-parent ---
```