### PR TITLE
[SMALLFIX] Allow Alluxio master to shutdown cleanly upon SIGTERM

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -122,7 +122,7 @@ function killAll {
   count=0
   for pid in $(ps -Aww -o pid,command | grep -i "[j]ava" | grep ${keyword} | awk '{print $1}'); do
     kill -15 ${pid} > /dev/null 2>&1
-    local cnt=30
+    local cnt=120
     while kill -0 ${pid} > /dev/null 2>&1; do
       if [[ ${cnt} -gt 1 ]]; then
         # still not dead, wait

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -60,7 +60,7 @@ public final class ProcessUtils {
           process.stop();
         } catch (Exception e) {
           LOG.error("Failed to shutdown process.", e);
-          System.exit(0);
+          System.exit(-1);
         }
       }
     });

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
@@ -50,10 +50,8 @@ public final class AlluxioMaster {
       throw t;
     }
 
-    /**
-     * Register a shutdown hook for master, so that master closes the journal files when it
-     * receives SIGTERM.
-     */
+    // Register a shutdown hook for master, so that master closes the journal files when it
+    // receives SIGTERM.
     ProcessUtils.stopProcessOnShutdown(process);
     ProcessUtils.run(process);
   }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMaster.java
@@ -50,6 +50,11 @@ public final class AlluxioMaster {
       throw t;
     }
 
+    /**
+     * Register a shutdown hook for master, so that master closes the journal files when it
+     * receives SIGTERM.
+     */
+    ProcessUtils.stopProcessOnShutdown(process);
     ProcessUtils.run(process);
   }
 


### PR DESCRIPTION
@aaudiber Could you take a look? Thanks!
When master process receives SIGTERM, the hook will execute to cleanly
close the resources used by the process, e.g. open files.
Without this feature, master will not close the journal files, nor will
it release the lease (lock) held on the journals. Consequently, if HDFS
restarts afterwards, HDFS will not be able to access the journals.