### PR TITLE
[ALLUXIO-3069] Implement RemoteBlockReader for the worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/NettyPacketReader.java
@@ -14,7 +14,6 @@ package alluxio.client.block.stream;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.file.options.InStreamOptions;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.CanceledException;
 import alluxio.exception.status.DeadlineExceededException;
@@ -117,10 +116,9 @@ public final class NettyPacketReader implements PacketReader {
    * @param context the file system context
    * @param address the netty data server address
    * @param readRequest the read request
-   * @param options the in stream options
    */
   private NettyPacketReader(FileSystemContext context, WorkerNetAddress address,
-      Protocol.ReadRequest readRequest, InStreamOptions options) throws IOException {
+      Protocol.ReadRequest readRequest) throws IOException {
     mContext = context;
     mAddress = address;
     mPosToRead = readRequest.getOffset();
@@ -327,7 +325,6 @@ public final class NettyPacketReader implements PacketReader {
     private final FileSystemContext mContext;
     private final WorkerNetAddress mAddress;
     private final Protocol.ReadRequest mReadRequestPartial;
-    private final InStreamOptions mOptions;
 
     /**
      * Creates an instance of {@link NettyPacketReader.Factory} for block reads.
@@ -335,20 +332,18 @@ public final class NettyPacketReader implements PacketReader {
      * @param context the file system context
      * @param address the worker address
      * @param readRequestPartial the partial read request
-     * @param options the in stream options
      */
     public Factory(FileSystemContext context, WorkerNetAddress address,
-        Protocol.ReadRequest readRequestPartial, InStreamOptions options) {
+        Protocol.ReadRequest readRequestPartial) {
       mContext = context;
       mAddress = address;
       mReadRequestPartial = readRequestPartial;
-      mOptions = options;
     }
 
     @Override
     public PacketReader create(long offset, long len) throws IOException {
       return new NettyPacketReader(mContext, mAddress,
-          mReadRequestPartial.toBuilder().setOffset(offset).setLength(len).build(), mOptions);
+          mReadRequestPartial.toBuilder().setOffset(offset).setLength(len).build());
     }
 
     @Override

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
@@ -66,9 +66,7 @@ public final class NettyPacketReaderTest {
     mAddress = Mockito.mock(WorkerNetAddress.class);
     Protocol.ReadRequest readRequest =
         Protocol.ReadRequest.newBuilder().setBlockId(BLOCK_ID).setPacketSize(PACKET_SIZE).build();
-    mFactory =
-        new NettyPacketReader.Factory(mContext, mAddress, readRequest, new InStreamOptions(
-            new URIStatus(new FileInfo())));
+    mFactory = new NettyPacketReader.Factory(mContext, mAddress, readRequest);
 
     mChannel = new EmbeddedChannel();
     PowerMockito.when(mContext.acquireNettyChannel(mAddress)).thenReturn(mChannel);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketReaderTest.java
@@ -13,8 +13,6 @@ package alluxio.client.block.stream;
 
 import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.file.URIStatus;
-import alluxio.client.file.options.InStreamOptions;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.network.protocol.databuffer.DataNettyBufferV2;
@@ -23,7 +21,6 @@ import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.proto.ProtoMessage;
-import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Function;

--- a/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
@@ -13,7 +13,6 @@ package alluxio.worker.block;
 
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.file.FileSystemContext;
-import alluxio.exception.status.AlluxioStatusException;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.io.BlockReader;
@@ -27,7 +26,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
 /**
- * Reads a block from a remote worker node.
+ * Reads a block from a remote worker node. This should only be used for reading entire blocks
+ * and thus only supports the {@link #transferTo(ByteBuf)} API.
  */
 public class RemoteBlockReader implements BlockReader {
   private final long mBlockId;
@@ -74,8 +74,7 @@ public class RemoteBlockReader implements BlockReader {
     if (mInputStream == null || mInputStream.remaining() <= 0) {
       return -1;
     }
-    int bytesToRead =
-        (int) Math.min((long) buf.writableBytes(), mInputStream.remaining());
+    int bytesToRead = (int) Math.min((long) buf.writableBytes(), mInputStream.remaining());
     return buf.writeBytes(mInputStream, bytesToRead);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
@@ -14,7 +14,6 @@ package alluxio.worker.block;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.worker.block.io.BlockReader;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
@@ -26,11 +25,8 @@ import java.nio.channels.ReadableByteChannel;
  * Reads a block from a remote worker node.
  */
 public class RemoteBlockReader implements BlockReader {
-  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private final long mBlockId;
-  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private final InetSocketAddress mDataSource;
-  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private final Protocol.OpenUfsBlockOptions mUfsOptions;
 
   private boolean mClosed;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3069

Some uncleanliness:
* We don't use `InStreamOptions` when doing remote reads and it is not passed to the worker for async caching, so I removed the parameter altogether. This could need to be reverted if for some reason we needed more information from `InStreamOptions` which we could not bundle into the `ReadRequest`
* `RemoteBlockReader` only supports the `transferTo` API and cannot seek/read at arbitrary offsets, that is not necessary for async caching.
* Added a new public constructor to `BlockInStream` because the worker side information is lossy compared to the client side (which reads blocks as part of a file, instead of for the sake of reading a block).
* `WorkerNetAddress` is not a proto object so we only sent the important parts of info over the wire (host/dataport). Only these two are used but we end up recreating a partial `WorkerNetAddress` object which could lead to bugs.