### PR TITLE
[SMALLFIX] Add safe mode manager to file system master

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -16,7 +16,6 @@ import alluxio.Server;
 import alluxio.clock.Clock;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.JournalContext;
-import alluxio.master.journal.JournalSystem;
 import alluxio.util.executor.ExecutorServiceFactory;
 
 import com.google.common.base.Preconditions;
@@ -53,18 +52,22 @@ public abstract class AbstractMaster implements Master {
   /** The clock to use for determining the time. */
   protected final Clock mClock;
 
+  /** The manager for safe mode state */
+  protected final SafeModeManager mSafeModeManager;
+
   /**
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    * @param clock the Clock to use for determining the time
    * @param executorServiceFactory a factory for creating the executor service to use for
    *        running maintenance threads
    */
-  protected AbstractMaster(JournalSystem journalSystem, Clock clock,
+  protected AbstractMaster(MasterContext masterContext, Clock clock,
       ExecutorServiceFactory executorServiceFactory) {
-    mJournal = journalSystem.createJournal(this);
-    mClock = Preconditions.checkNotNull(clock, "clock");
-    mExecutorServiceFactory =
-        Preconditions.checkNotNull(executorServiceFactory, "executorServiceFactory");
+    Preconditions.checkNotNull(masterContext, "masterContext");
+    mJournal = masterContext.getJournalSystem().createJournal(this);
+    mSafeModeManager = masterContext.getmSafeModeManager();
+    mClock = clock;
+    mExecutorServiceFactory = executorServiceFactory;
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -52,7 +52,7 @@ public abstract class AbstractMaster implements Master {
   /** The clock to use for determining the time. */
   protected final Clock mClock;
 
-  /** The manager for safe mode state */
+  /** The manager for safe mode state. */
   protected final SafeModeManager mSafeModeManager;
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/MasterContext.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterContext.java
@@ -1,0 +1,47 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master;
+
+import alluxio.master.journal.JournalSystem;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Stores context information for Alluxio masters.
+ */
+public final class MasterContext {
+  private final JournalSystem mJournalSystem;
+  private final SafeModeManager mSafeModeManager;
+
+  /**
+   * @param journalSystem the journal system to use for tracking master operations
+   * @param safeModeManager the manager for master safe mode
+   */
+  public MasterContext(JournalSystem journalSystem, SafeModeManager safeModeManager) {
+    mJournalSystem = Preconditions.checkNotNull(journalSystem, "journalSystem");
+    mSafeModeManager = Preconditions.checkNotNull(safeModeManager, "safeModeManager");
+  }
+
+  /**
+   * @return the journal system to use for tracking master operations
+   */
+  public JournalSystem getJournalSystem() {
+    return mJournalSystem;
+  }
+
+  /**
+   * @return the manager for master safe mode
+   */
+  public SafeModeManager getmSafeModeManager() {
+    return mSafeModeManager;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterFactory.java
@@ -12,6 +12,7 @@
 package alluxio.master.block;
 
 import alluxio.Constants;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
@@ -50,7 +51,7 @@ public final class BlockMasterFactory implements MasterFactory {
       SafeModeManager safeModeManager) {
     Preconditions.checkArgument(journalFactory != null, "journal");
     LOG.info("Creating {} ", BlockMaster.class.getName());
-    BlockMaster master = new DefaultBlockMaster(journalFactory, safeModeManager);
+    BlockMaster master = new DefaultBlockMaster(new MasterContext(journalFactory, safeModeManager));
     registry.add(BlockMaster.class, master);
     return master;
   }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -29,12 +29,11 @@ import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.AbstractMaster;
-import alluxio.master.SafeModeManager;
+import alluxio.master.MasterContext;
 import alluxio.master.block.meta.MasterBlockInfo;
 import alluxio.master.block.meta.MasterBlockLocation;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.journal.JournalContext;
-import alluxio.master.journal.JournalSystem;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.journal.Block.BlockContainerIdGeneratorEntry;
 import alluxio.proto.journal.Block.BlockInfoEntry;
@@ -165,30 +164,28 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   /** The value of the 'next container id' last journaled. */
   @GuardedBy("mBlockContainerIdGenerator")
   private long mJournaledNextContainerId = 0;
-  private SafeModeManager mSafeModeManager;
 
   /**
    * Creates a new instance of {@link DefaultBlockMaster}.
    *
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    */
-  DefaultBlockMaster(JournalSystem journalSystem, SafeModeManager safeModeManager) {
-    this(journalSystem, new SystemClock(), safeModeManager, ExecutorServiceFactories
+  DefaultBlockMaster(MasterContext masterContext) {
+    this(masterContext, new SystemClock(), ExecutorServiceFactories
         .fixedThreadPoolExecutorServiceFactory(Constants.BLOCK_MASTER_NAME, 2));
   }
 
   /**
    * Creates a new instance of {@link DefaultBlockMaster}.
    *
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    * @param clock the clock to use for determining the time
    * @param executorServiceFactory a factory for creating the executor service to use for running
    *        maintenance threads
    */
-  DefaultBlockMaster(JournalSystem journalSystem, Clock clock, SafeModeManager safeModeManager,
+  DefaultBlockMaster(MasterContext masterContext, Clock clock,
       ExecutorServiceFactory executorServiceFactory) {
-    super(journalSystem, clock, executorServiceFactory);
-    mSafeModeManager = safeModeManager;
+    super(masterContext, clock, executorServiceFactory);
     Metrics.registerGauges(this);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterFactory.java
@@ -12,6 +12,7 @@
 package alluxio.master.file;
 
 import alluxio.Constants;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
@@ -52,8 +53,8 @@ public final class FileSystemMasterFactory implements MasterFactory {
     Preconditions.checkArgument(journalFactory != null, "journal factory may not be null");
     LOG.info("Creating {} ", FileSystemMaster.class.getName());
     BlockMaster blockMaster = registry.get(BlockMaster.class);
-    FileSystemMaster fileSystemMaster = new DefaultFileSystemMaster(blockMaster, journalFactory,
-        safeModeManager);
+    FileSystemMaster fileSystemMaster = new DefaultFileSystemMaster(blockMaster,
+        new MasterContext(journalFactory, safeModeManager));
     registry.add(FileSystemMaster.class, fileSystemMaster);
     return fileSystemMaster;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterFactory.java
@@ -52,7 +52,8 @@ public final class FileSystemMasterFactory implements MasterFactory {
     Preconditions.checkArgument(journalFactory != null, "journal factory may not be null");
     LOG.info("Creating {} ", FileSystemMaster.class.getName());
     BlockMaster blockMaster = registry.get(BlockMaster.class);
-    FileSystemMaster fileSystemMaster = new DefaultFileSystemMaster(blockMaster, journalFactory);
+    FileSystemMaster fileSystemMaster = new DefaultFileSystemMaster(blockMaster, journalFactory,
+        safeModeManager);
     registry.add(FileSystemMaster.class, fileSystemMaster);
     return fileSystemMaster;
   }

--- a/core/server/master/src/main/java/alluxio/master/lineage/DefaultLineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/DefaultLineageMaster.java
@@ -32,10 +32,10 @@ import alluxio.heartbeat.HeartbeatThread;
 import alluxio.job.CommandLineJob;
 import alluxio.job.Job;
 import alluxio.master.AbstractMaster;
+import alluxio.master.MasterContext;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.CreateFileOptions;
 import alluxio.master.journal.JournalContext;
-import alluxio.master.journal.JournalSystem;
 import alluxio.master.lineage.checkpoint.CheckpointPlan;
 import alluxio.master.lineage.checkpoint.CheckpointSchedulingExecutor;
 import alluxio.master.lineage.meta.Lineage;
@@ -89,10 +89,10 @@ public final class DefaultLineageMaster extends AbstractMaster implements Lineag
    * Creates a new instance of {@link LineageMaster}.
    *
    * @param fileSystemMaster the file system master handle
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    */
-  DefaultLineageMaster(FileSystemMaster fileSystemMaster, JournalSystem journalSystem) {
-    this(fileSystemMaster, journalSystem, ExecutorServiceFactories
+  DefaultLineageMaster(FileSystemMaster fileSystemMaster, MasterContext masterContext) {
+    this(fileSystemMaster, masterContext, ExecutorServiceFactories
         .fixedThreadPoolExecutorServiceFactory(Constants.LINEAGE_MASTER_NAME, 2));
   }
 
@@ -100,13 +100,13 @@ public final class DefaultLineageMaster extends AbstractMaster implements Lineag
    * Creates a new instance of {@link LineageMaster}.
    *
    * @param fileSystemMaster the file system master handle
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    * @param executorServiceFactory a factory for creating the executor service to use for running
    *        maintenance threads
    */
-  DefaultLineageMaster(FileSystemMaster fileSystemMaster, JournalSystem journalSystem,
+  DefaultLineageMaster(FileSystemMaster fileSystemMaster, MasterContext masterContext,
                        ExecutorServiceFactory executorServiceFactory) {
-    super(journalSystem, new SystemClock(), executorServiceFactory);
+    super(masterContext, new SystemClock(), executorServiceFactory);
     mLineageIdGenerator = new LineageIdGenerator();
     mLineageStore = new LineageStore(mLineageIdGenerator);
     mFileSystemMaster = fileSystemMaster;

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterFactory.java
@@ -14,6 +14,7 @@ package alluxio.master.lineage;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
@@ -54,7 +55,8 @@ public final class LineageMasterFactory implements MasterFactory {
     Preconditions.checkArgument(journalSystem != null, "journal system may not be null");
     LOG.info("Creating {} ", LineageMaster.class.getName());
     FileSystemMaster fileSystemMaster = registry.get(FileSystemMaster.class);
-    LineageMaster lineageMaster = new DefaultLineageMaster(fileSystemMaster, journalSystem);
+    LineageMaster lineageMaster = new DefaultLineageMaster(fileSystemMaster,
+        new MasterContext(journalSystem, safeModeManager));
     registry.add(LineageMaster.class, lineageMaster);
     return lineageMaster;
   }

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -20,6 +20,7 @@ import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.DefaultSafeModeManager;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
 import alluxio.master.journal.JournalSystem;
@@ -91,8 +92,8 @@ public class BlockMasterTest {
     mClock = new ManualClock();
     mExecutorService =
         Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("TestBlockMaster-%d", true));
-    mBlockMaster = new DefaultBlockMaster(journalSystem, mClock, mSafeModeManager,
-        ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
+    mBlockMaster = new DefaultBlockMaster(new MasterContext(journalSystem, mSafeModeManager),
+        mClock, ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
     mRegistry.add(BlockMaster.class, mBlockMaster);
     mRegistry.start(true);
   }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1902,7 +1902,7 @@ public final class FileSystemMasterTest {
     mBlockMaster = new BlockMasterFactory().create(mRegistry, mJournalSystem, mSafeModeManager);
     mExecutorService = Executors
         .newFixedThreadPool(2, ThreadFactoryUtils.build("DefaultFileSystemMasterTest-%d", true));
-    mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster, mJournalSystem,
+    mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster, mJournalSystem, mSafeModeManager,
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
     mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
     mJournalSystem.start();

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -36,6 +36,7 @@ import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.DefaultSafeModeManager;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMaster;
@@ -1902,7 +1903,8 @@ public final class FileSystemMasterTest {
     mBlockMaster = new BlockMasterFactory().create(mRegistry, mJournalSystem, mSafeModeManager);
     mExecutorService = Executors
         .newFixedThreadPool(2, ThreadFactoryUtils.build("DefaultFileSystemMasterTest-%d", true));
-    mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster, mJournalSystem, mSafeModeManager,
+    mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster,
+        new MasterContext(mJournalSystem, mSafeModeManager),
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
     mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
     mJournalSystem.start();

--- a/core/server/master/src/test/java/alluxio/master/lineage/LineageMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/lineage/LineageMasterTest.java
@@ -19,7 +19,10 @@ import alluxio.exception.LineageDoesNotExistException;
 import alluxio.job.CommandLineJob;
 import alluxio.job.Job;
 import alluxio.job.JobConf;
+import alluxio.master.DefaultSafeModeManager;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterRegistry;
+import alluxio.master.SafeModeManager;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.CompleteFileOptions;
 import alluxio.master.journal.JournalSystem;
@@ -55,6 +58,7 @@ public final class LineageMasterTest {
   private FileSystemMaster mFileSystemMaster;
   private Job mJob;
   private MasterRegistry mRegistry;
+  private SafeModeManager mSafeModeManager;
 
   /** Rule to create a new temporary folder during each test. */
   @Rule
@@ -69,9 +73,11 @@ public final class LineageMasterTest {
     JournalSystem journalSystem = new NoopJournalSystem();
     mFileSystemMaster = Mockito.mock(FileSystemMaster.class);
     mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
+    mSafeModeManager = new DefaultSafeModeManager();
     ThreadFactory threadPool = ThreadFactoryUtils.build("LineageMasterTest-%d", true);
     mExecutorService = Executors.newFixedThreadPool(2, threadPool);
-    mLineageMaster = new DefaultLineageMaster(mFileSystemMaster, journalSystem,
+    mLineageMaster = new DefaultLineageMaster(mFileSystemMaster,
+        new MasterContext(journalSystem, mSafeModeManager),
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
     mRegistry.add(LineageMaster.class, mLineageMaster);
     mJob = new CommandLineJob("test", new JobConf("output"));

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
@@ -22,12 +22,12 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.AbstractMaster;
+import alluxio.master.MasterContext;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.DeleteOptions;
 import alluxio.master.file.options.RenameOptions;
 import alluxio.master.journal.JournalContext;
-import alluxio.master.journal.JournalSystem;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.proto.journal.KeyValue;
 import alluxio.thrift.KeyValueMasterClientService;
@@ -75,10 +75,10 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
 
   /**
    * @param fileSystemMaster the file system master handle
-   * @param journalSystem the journal system to use for tracking master operations
+   * @param masterContext the context for Alluxio master
    */
-  DefaultKeyValueMaster(FileSystemMaster fileSystemMaster, JournalSystem journalSystem) {
-    super(journalSystem, new SystemClock(), ExecutorServiceFactories
+  DefaultKeyValueMaster(FileSystemMaster fileSystemMaster, MasterContext masterContext) {
+    super(masterContext, new SystemClock(), ExecutorServiceFactories
         .fixedThreadPoolExecutorServiceFactory(Constants.KEY_VALUE_MASTER_NAME, 2));
     mFileSystemMaster = fileSystemMaster;
     mCompleteStoreToPartitions = new HashMap<>();

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterFactory.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterFactory.java
@@ -14,6 +14,7 @@ package alluxio.master.keyvalue;
 import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.master.MasterContext;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
@@ -55,7 +56,8 @@ public final class KeyValueMasterFactory implements MasterFactory {
     LOG.info("Creating {} ", KeyValueMaster.class.getName());
     FileSystemMaster fileSystemMaster = registry.get(FileSystemMaster.class);
     DefaultKeyValueMaster keyValueMaster =
-        new DefaultKeyValueMaster(fileSystemMaster, journalSystem);
+        new DefaultKeyValueMaster(fileSystemMaster,
+            new MasterContext(journalSystem, safeModeManager));
     registry.add(KeyValueMaster.class, keyValueMaster);
     return keyValueMaster;
   }


### PR DESCRIPTION
This PR moves safe mode manager to MasterContext which can be used by all masters.