### PR TITLE
[SMALLFIX] Decrease netty packet size in tests.

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -220,7 +220,7 @@ public final class BufferUtils {
    *         sequence of bytes starting at {@code start}
    */
   public static boolean equalIncreasingByteArray(int start, int len, byte[] arr) {
-    if (arr == null || arr.length != len) {
+    if (arr == null) {
       return false;
     }
     for (int k = 0; k < len; k++) {

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -211,7 +211,7 @@ public final class BufferUtils {
 
   /**
    * Checks if the given byte array starts with an increasing sequence of bytes of the given
-   * length, starting from the given value.
+   * length, starting from the given value. The array length must be equal to the length checked.
    *
    * @param start the starting value to use
    * @param len the target length of the sequence
@@ -220,7 +220,7 @@ public final class BufferUtils {
    *         sequence of bytes starting at {@code start}
    */
   public static boolean equalIncreasingByteArray(int start, int len, byte[] arr) {
-    if (arr == null) {
+    if (arr == null || arr.length != len) {
       return false;
     }
     for (int k = 0; k < len; k++) {

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -79,6 +79,7 @@ public final class ConfigurationTestUtils {
 
     conf.put(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "1KB");
     conf.put(PropertyKey.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "64");
+    conf.put(PropertyKey.USER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES, "64");
     conf.put(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "1sec");
     conf.put(PropertyKey.MASTER_WORKER_THREADS_MIN, "1");
     conf.put(PropertyKey.MASTER_WORKER_THREADS_MAX, "100");

--- a/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/FileInStreamIntegrationTest.java
@@ -51,7 +51,8 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource.Builder().build();
+      new LocalAlluxioClusterResource.Builder().setProperty(
+          PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE).build();
   private FileSystem mFileSystem;
   private CreateFileOptions mWriteBoth;
   private CreateFileOptions mWriteAlluxio;
@@ -381,6 +382,7 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
   @LocalAlluxioClusterResource.Config(
       confParams = {PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false",
           PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "16MB",
+          PropertyKey.Name.USER_NETWORK_NETTY_READER_PACKET_SIZE_BYTES, "64KB",
           PropertyKey.Name.WORKER_MEMORY_SIZE, "1GB"})
   public void remoteReadLargeFile() throws Exception {
     // write a file outside of Alluxio

--- a/tests/src/test/java/alluxio/client/RemoteReadIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/RemoteReadIntegrationTest.java
@@ -48,6 +48,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -299,12 +300,9 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
           BlockInStream.create(FileSystemContext.INSTANCE, info.getBlockId(), info.getLength(),
               workerAddr, BlockInStreamSource.REMOTE, null, InStreamOptions.defaults());
       byte[] ret = new byte[k];
-      int start = 0;
-      while (start < k) {
-        int read = is.read(ret);
-        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(start, read, ret));
-        start += read;
-      }
+      int read = is.read(ret);
+      Assert
+          .assertTrue(BufferUtils.equalIncreasingByteArray(read, Arrays.copyOfRange(ret, 0, read)));
       is.close();
       Assert.assertTrue(mFileSystem.getStatus(uri).getInAlluxioPercentage() == 100);
     }
@@ -328,12 +326,11 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
           BlockInStream.create(FileSystemContext.INSTANCE, info.getBlockId(), info.getLength(),
               workerAddr, BlockInStreamSource.REMOTE, null, InStreamOptions.defaults());
       byte[] ret = new byte[k / 2];
-      int start = 0;
-      while (start < k / 2) {
-        int read = is.read(ret, 0, (k / 2) - start);
-        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(start, read, ret));
-        start += read;
+      int read = 0;
+      while (read < k / 2) {
+        read += is.read(ret, read, k / 2 - read);
       }
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(read, ret));
       is.close();
       Assert.assertTrue(mFileSystem.getStatus(uri).getInAlluxioPercentage() == 100);
     }

--- a/tests/src/test/java/alluxio/client/RemoteReadIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/RemoteReadIntegrationTest.java
@@ -578,7 +578,7 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
       Assert.assertFalse(mFileSystem.exists(uri));
       // Look! We can still read the deleted file since we have a lock!
       byte[] ret = new byte[k / 2];
-      Assert.assertEquals(k / 2, is.read(ret, 0, k / 2));
+      Assert.assertTrue(is.read(ret, 0, k / 2) > 0);
       is.close();
       Assert.assertFalse(mFileSystem.exists(uri));
 


### PR DESCRIPTION
If we keep it at 64KB, read requests end up reading 64KB * 16 max packets in flight = 1 MB of data. This leads to weird behavior when checking for Alluxio caching, since even reading 1 byte will lead to 1MB being read, which could potentially be the entire block. It does make some tests slower so we will need to make sure to increase the packet size when necessary.