### PR TITLE
[SMALLFIX] Allow site properties to be loaded from classpath

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -118,9 +118,14 @@ public final class Configuration {
       String[] confPathList = confPaths.split(",");
       sSitePropertyFile =
           ConfigurationUtils.searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
+      Properties siteProps;
       if (sSitePropertyFile != null) {
-        Properties siteProps = ConfigurationUtils.loadPropertiesFromFile(sSitePropertyFile);
+        siteProps = ConfigurationUtils.loadPropertiesFromFile(sSitePropertyFile);
         LOG.info("Configuration file {} loaded.", sSitePropertyFile);
+      } else {
+        siteProps = ConfigurationUtils.loadPropertiesFromResource(Constants.SITE_PROPERTIES);
+      }
+      if (siteProps != null) {
         // Update site properties and system properties in order
         merge(siteProps, Source.SITE_PROPERTY);
         merge(systemProps, Source.SYSTEM_PROPERTY);


### PR DESCRIPTION
We stopped searching the classpath for alluxio-site.properties files in `https://github.com/Alluxio/alluxio/pull/6614`. When the `searchPropertiesFile` method was refactored, we lost the call to `loadPropertiesFromResource`. https://github.com/Alluxio/alluxio/pull/6614/files#diff-5a808cf82f4c0b96b3fe034f313c8b78L103

This PR restores the original behavior