### PR TITLE
[SMALLFIX]Use static imports for standard test utilities for class ResourcePoolTest

### DIFF
--- a/core/common/src/test/java/alluxio/resource/ResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/ResourcePoolTest.java
@@ -11,11 +11,13 @@
 
 package alluxio.resource;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -76,7 +78,7 @@ public final class ResourcePoolTest {
     int resource1 = testPool.acquire();
     testPool.release(resource1);
     int resource2 = testPool.acquire();
-    Assert.assertEquals(resource1, resource2);
+    assertEquals(resource1, resource2);
   }
 
   /**
@@ -87,10 +89,10 @@ public final class ResourcePoolTest {
     mThrown.expect(RuntimeException.class);
     final int POOL_SIZE = 2;
     @SuppressWarnings("unchecked")
-    ConcurrentLinkedQueue<Integer> queue = Mockito.mock(ConcurrentLinkedQueue.class);
+    ConcurrentLinkedQueue<Integer> queue = mock(ConcurrentLinkedQueue.class);
     TestResourcePool testPool = new TestResourcePool(POOL_SIZE, queue);
-    Mockito.when(queue.isEmpty()).thenReturn(true);
-    Mockito.when(queue.poll()).thenThrow(new InterruptedException());
+    when(queue.isEmpty()).thenReturn(true);
+    when(queue.poll()).thenThrow(new InterruptedException());
     for (int i = 0; i < POOL_SIZE + 1; i++) {
       testPool.acquire();
     }


### PR DESCRIPTION
[SMALLFIX]Use static imports for standard test utilities for class ResourcePoolTest