### PR TITLE
[DOCFIX] Some doc fixes

### DIFF
--- a/docs/cn/Clients-Go.md
+++ b/docs/cn/Clients-Go.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 4
 ---
 
+* 内容列表
+{:toc}
+
 Alluxio有一个[Go Client](https://github.com/Alluxio/alluxio-go), 此客户端通过[REST API](Clients-Rest.html)
 和Alluxio进行交互。Go 客户端提供一个和[native Java API](Clients-Java-Native.html)相似的API。
 查看[godoc](http://godoc.org/github.com/Alluxio/alluxio-go)

--- a/docs/cn/Clients-Hadoop.md
+++ b/docs/cn/Clients-Hadoop.md
@@ -10,7 +10,7 @@ priority: 2
 {:toc}
 
 Alluxio通过提供文件系统接口提供对文件的访问方式。Alluxio中的文件提供一次性写的语义：文件在全部写完之后不可修改，并且在全部
-写完之前不可以读。Alluxio提供两种不同的文件系统API,Alluxio文件系统API以及兼容Hadoop的API。Alluxio API提供额外的功能性, 而用户可以直接使用兼容Hadoop的API获取Hadoop原生API的功能，不用修改已有代码。
+写完之前不可以读。Alluxio提供两种不同的文件系统API，Alluxio文件系统API以及兼容Hadoop的API。Alluxio API提供额外的功能性，而用户可以直接使用兼容Hadoop的API获取Hadoop原生API的功能，不用修改已有代码。
 
 Alluxio有[Alluxio客户端](Clients-Alluxio-Java.html)的包装类，可以提供兼容Hadoop的`FileSystem`接口。使用这个客户端时，
 Hadoop文件操作会被翻译为文件系统操作。最新的关于`文件系统`接口的文档可以在[这里](http://hadoop.apache.org/docs/current/api/org/apache/hadoop/fs/FileSystem.html)找到。

--- a/docs/cn/Clients-Python.md
+++ b/docs/cn/Clients-Python.md
@@ -13,7 +13,7 @@ Alluxio有一个Python客户端，这个客户端可以通过它的REST API来�
 
 # Alluxio代理依赖
 这个Python客户端通过由Alluxio代理提供的REST API来和Alluxio相互交流。
-这个代理服务器是一个独立的服务器，可以通过${ALLUXIO_HOME}/bin/alluxio-start.sh proxy来开启它和通过命令${ALLUXIO_HOME}/bin/alluxio-stop.sh proxy来关闭它。默认情况下，可以通过端口39999来使用REST API。
+这个代理服务器是一个独立的服务器，可以通过`${ALLUXIO_HOME}/bin/alluxio-start.sh proxy`来开启它和通过命令`${ALLUXIO_HOME}/bin/alluxio-stop.sh proxy`来关闭它。默认情况下，可以通过端口39999来使用REST API。
 使用HTTP代理服务器有性能上的影响。特别的是，使用这个代理服务器需要一个额外的跳。为了达到最佳性能，运行这个代理服务器的时候推荐在每个计算节点上分配一个Alluxio worker。
 
 # 安装python客户端库
@@ -22,6 +22,7 @@ Alluxio有一个Python客户端，这个客户端可以通过它的REST API来�
 # 使用示例
 下面的程序示例包括了如何在Alluxio创建目录、下载、上传、检查文件是否存在以及文件列表状态。
 
+```python
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
@@ -108,3 +109,5 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+```

--- a/docs/cn/Clients-Python.md
+++ b/docs/cn/Clients-Python.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 5
 ---
 
+* 内容列表
+{:toc}
+
 Alluxio有一个Python客户端，这个客户端可以通过它的REST API来和Alluxio交流。它发布了一个和本地的Java API类似的API。通过看这篇doc来了解有关所有可用方法的详细文档。通过看例子来了解如何在Alluxio上执行基本的文件系统操作。
 
 # Alluxio代理依赖

--- a/docs/cn/Clients-S3.md
+++ b/docs/cn/Clients-S3.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 6
 ---
 
+* 内容列表
+{:toc}
+
 Alluxio支持RESTful API，它和Amazon的基本操作是兼容的[S3 API](http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)。
 
 [REST API 手册](http://www.alluxio.org/restdoc/{{site.ALLUXIO_MAJOR_VERSION}}/proxy/index.html)会在Alluxio构建时生成并且可以通过`${ALLUXIO_HOME}/core/server/proxy/target/miredot/index.html`获得。

--- a/docs/cn/Lineage-API.md
+++ b/docs/cn/Lineage-API.md
@@ -56,7 +56,6 @@ Alluxio提供了Java版本的API来操作和访问世系关系信息。
 
 <table class="table table-striped">
 <tr><th>参数</th><th>默认值</th><th>介绍</th></tr>
-</tr>
 {% for record in site.data.table.LineageParameter %}
 <tr>
   <td>{{record.parameter}}</td>

--- a/docs/cn/Running-Alluxio-On-Docker.md
+++ b/docs/cn/Running-Alluxio-On-Docker.md
@@ -6,6 +6,9 @@ group: Deploying Alluxio
 priority: 3
 ---
 
+* 内容列表
+{:toc}
+
 Alluxio可以运行在一个Docker容器中，本指南介绍如何使用Alluxio Github仓库提供的Dockerfile来将Alluxio运行在Docker之中。
 
 # 基础教程

--- a/docs/cn/Running-Alluxio-Yarn-Standalone.md
+++ b/docs/cn/Running-Alluxio-Yarn-Standalone.md
@@ -6,6 +6,9 @@ group: Deploying Alluxio
 priority: 6
 ---
 
+* 内容列表
+{:toc}
+
 Alluxio应与YARN一起运行，以便所有YARN节点都可以访问本地的Alluxio worker。
 为了YARN和Alluxio能在同一节点上良好地共同运作，应该让YARN知道Alluxio使用的资源。YARN需要知道多少内存和CPU被分配给了Alluxio。
 

--- a/docs/cn/Running-Hadoop-MapReduce-on-Alluxio.md
+++ b/docs/cn/Running-Hadoop-MapReduce-on-Alluxio.md
@@ -14,9 +14,9 @@ priority: 1
 ## 初始化设置
 
 该文档的先决条件包括：
-－ 你已安装了[Java](Java-Setup.html)。
-－ 你已经按照这些文档建立了一个Alluxio集群：[本地模式](Running-Alluxio-Locally.html)或[集群](Running-Alluxio-on-a-Cluster.html)。
-－ 为了运行一些简单的map-reduce实例，我们也推荐你下载根据你的hadoop版本对应的[map-reduce examples jar](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-mapreduce-examples/2.4.1)，或者如果你正在使用Hadoop 1，下载这个[examples jar](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-examples/1.2.1)。
+- 你已安装了[Java](Java-Setup.html)。
+- 你已经按照这些文档建立了一个Alluxio集群：[本地模式](Running-Alluxio-Locally.html)或[集群](Running-Alluxio-on-a-Cluster.html)。
+- 为了运行一些简单的map-reduce实例，我们也推荐你下载根据你的hadoop版本对应的[map-reduce examples jar](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-mapreduce-examples/2.4.1)，或者如果你正在使用Hadoop 1，下载这个[examples jar](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-examples/1.2.1)。
 
 ## 编译Alluxio客户端
 
@@ -61,6 +61,7 @@ $ export HADOOP_CLASSPATH={{site.ALLUXIO_CLIENT_JAR_PATH}}:${HADOOP_CLASSPATH}
 [如何从Cloudera上加入第三方库](http://blog.cloudera.com/blog/2011/01/how-to-include-third-party-libraries-in-your-map-reduce-job/)这篇文档介绍了分发Jar包的多种方式。文档中建议通过使用命令行的`-libjars`选项，使用分布式缓存来分发Alluxio客户端Jar包。另一种分发客户端Jar包的方式就是手动将其分发到Hadoop节点上。下面就是这两种主流方法的介绍：
 
 1.**使用-libjars命令行选项**
+
 你可以在使用`hadoop jar ...`的时候加入-libjars命令行选项，指定`{{site.ALLUXIO_CLIENT_JAR_PATH}}`为`-libjars`的参数。这条命令会把该Jar包放到Hadoop的DistributedCache中，使所有节点都可以访问到。例如，下面的命令就是将Alluxio客户端Jar包添加到`-libjars`选项中。
 
 ```bash
@@ -68,6 +69,7 @@ $ bin/hadoop jar libexec/share/hadoop/mapreduce/hadoop-mapreduce-examples-2.7.3.
 ```
 
 2.**手动将Client Jar包分发到所有节点**
+
 为了在每个节点安装Alluxio,将客户端jar包`{{site.ALLUXIO_CLIENT_JAR_PATH}}`置于每个MapReduce节点的`$HADOOP_HOME/lib`（由于版本不同也可能是`$HADOOP_HOME/share/hadoop/common/lib`），然后重新启动Hadoop。
 另一种选择，在你的Hadoop部署中，把这个jar包添加到`mapreduce.application.classpath`系统属性，确保jar包在classpath上。
 为了在每个节点上安装Alluxio，将客户端Jar包`mapreduce.application.classpath`，该方法要注意的是所有Jar包必须再次安装，因为每个Jar包都更新到了最新版本。另一方面，当该Jar包已经在每个节点上的时候，就没有必要使用`-libjars`命令行选项了。

--- a/docs/cn/Running-Spark-on-Alluxio.md
+++ b/docs/cn/Running-Spark-on-Alluxio.md
@@ -22,7 +22,7 @@ Alluxio直接兼容Spark 1.1或更新版本而无需修改.
 * Alluxio集群根据向导搭建完成(可以是[本地模式](Running-Alluxio-Locally.html)或者[集群模式](Running-Alluxio-on-a-Cluster.html))。
 
 * 我们建议您从Alluxio[下载页面](http://www.alluxio.org/download)下载tarball.
-  另外，高级用户可以选择根据[这里](Building-Alluxio-Master-Branch.html#compute-framework-support)的说明将源代码编译为客户端jar包，并在本文余下部分使用于`{{site.ALLUXIO_CLIENT_JAR_PATH_BUILD}}`路径处生成的jar包。
+  另外，高级用户可以选择根据[这里](Building-Alluxio-Master-Branch.html#compute-framework-support)的说明将源代码编译为客户端jar包，并在本文余下部分使用于`{{site.ALLUXIO_CLIENT_JAR_PATH}}`路径处生成的jar包。
   
 * 请添加如下代码到`spark/conf/spark-defaults.conf`。
 

--- a/docs/cn/Tiered-Locality.md
+++ b/docs/cn/Tiered-Locality.md
@@ -9,12 +9,12 @@ priority: 1
 * Table of Contents
 {:toc}
 
-#分层标识
+# 分层标识
 
 在Alluxio中，每个实体（masters，workers，clients）都有一个*分层标识*。分层标识是一个地址的元组，例如`（node = ...，rack = ...）`。元组中的每一对被称为一个*局部性层（locality tier）*。局部性层从最具体到最不具体进行排列，所以如果两个实体具有相同的节点名称，则假定它们也具有相同的机架名称。 Alluxio使用分层标识优化本地性。例如，当客户端想要从UFS读取文件时，它会倾向于从同一节点上的Alluxio worker进行读取。
 如果第一层（节点）中没有本地worker，则将检查下一层（机架）以优先进行机架本地数据传输。如果没有worker与客户端共享一个节点或机架，将选择一个任意的worker。
 
-#配置
+# 配置
 
 如果用户没有提供任何分层的标识信息，每个实体将会执行本地主机查找来设置其节点级别的标识信息。如果其他局部性层没有设置，他们将不会被用来影响局部性的决定。可以通过设置配置属性来设置局部性层的值
 
@@ -40,7 +40,7 @@ echo "host=$(hostname),rack=/rack1"
 
 如果`alluxio.locality.script`中没有脚本，则该属性将被忽略。 如果该脚本返回一个非零返回值或者是格式错误的输出，Alluxio会发生错误。
 
-##节点位置优先级顺序
+## 节点位置优先级顺序
 
 有多种配置节点位置的方法。这是从最高优先级到最低优先级的顺序：
 
@@ -49,13 +49,13 @@ echo "host=$(hostname),rack=/rack1"
 1. 在worker上设置`alluxio.worker.hostname`，在master上设置`alluxio.master.hostname`，或者在客户端上设置`alluxio.user.hostname`。
 1. 如果以上都未配置，则节点位置由本地主机查找确定。
 
-#什么时候分层局部性会被使用？
+# 什么时候分层局部性会被使用？
 
 1. 当选择一个worker从UFS读取时。
 1. 当多个Alluxio worker拥有一个块，选择一个worker进行读取时。
 1. 如果使用`LocalFirstPolicy`或`LocalFirstAvoidEvictionPolicy`，分层局部性被用于在向Alluxio写入数据时选择要写入的worker。
 
-#自定义局部性层
+# 自定义局部性层
 
 默认情况下，Alluxio有两个局部性层：`node`和`rack`。用户可以自定义一组局部性层来利用更高级的拓扑。要更改可用层集，请设置`alluxio.locality.order`。顺序应该从最具体到最不具体。例如，要将可用区域位置添加到集群，请进行设置
 

--- a/docs/en/Clients-Go.md
+++ b/docs/en/Clients-Go.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 4
 ---
 
+* Table of Contents
+{:toc}
+
 Alluxio has a [Go Client](https://github.com/Alluxio/alluxio-go) for interacting with Alluxio through its
 [REST API](Clients-Rest.html). The Go client exposes an API similar to the [Alluxio Java API](Clients-Alluxio-Java.html).
 See the [godoc](http://godoc.org/github.com/Alluxio/alluxio-go) for detailed documentation about all available

--- a/docs/en/Clients-Python.md
+++ b/docs/en/Clients-Python.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 5
 ---
 
+* Table of Contents
+{:toc}
+
 Alluxio has a [Python Client](https://github.com/Alluxio/alluxio-py) for interacting with Alluxio through its
 [REST API](Clients-Rest.html). The Python client exposes an API similar to the [Alluxio Java API](Clients-Alluxio-Java.html).
 See the [doc](http://alluxio-py.readthedocs.io) for detailed documentation about all available

--- a/docs/en/Clients-S3.md
+++ b/docs/en/Clients-S3.md
@@ -6,6 +6,9 @@ group: Clients
 priority: 6
 ---
 
+* Table of Contents
+{:toc}
+
 Alluxio supports a RESTFul API that is compatible with the basic operations of the Amazon 
 [S3 API](http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html).
 

--- a/docs/en/Lineage-API.md
+++ b/docs/en/Lineage-API.md
@@ -75,7 +75,6 @@ These are the configuration parameters related to Alluxio's lineage feature.
 
 <table class="table table-striped">
 <tr><th>Parameter</th><th>Default Value</th><th>Description</th></tr>
-</tr>
 {% for record in site.data.table.LineageParameter %}
 <tr>
   <td>{{record.parameter}}</td>

--- a/docs/en/Running-Alluxio-On-Docker.md
+++ b/docs/en/Running-Alluxio-On-Docker.md
@@ -6,6 +6,9 @@ group: Deploying Alluxio
 priority: 3
 ---
 
+* Table of Contents
+{:toc}
+
 Alluxio can be run in a Docker container. This guide demonstrates how to run Alluxio
 in Docker using the Dockerfile that comes in the Alluxio Github repository.
 

--- a/docs/en/Running-Alluxio-Yarn-Standalone.md
+++ b/docs/en/Running-Alluxio-Yarn-Standalone.md
@@ -6,6 +6,9 @@ group: Deploying Alluxio
 priority: 6
 ---
 
+* Table of Contents
+{:toc}
+
 Alluxio should be run alongside YARN so that all YARN nodes have access to a local Alluxio worker.
 For YARN and Alluxio to play nicely together on the same nodes, it's important to inform YARN of
 the resources used by Alluxio. YARN needs to know how much memory and cpu to leave for Alluxio.

--- a/docs/en/Running-Hadoop-MapReduce-on-Alluxio.md
+++ b/docs/en/Running-Hadoop-MapReduce-on-Alluxio.md
@@ -78,6 +78,7 @@ Another way to distribute the client jar is to manually distribute it to all the
 Below are instructions for the two main alternatives:
 
 1.**Using the -libjars command line option.**
+
 You can use the `-libjars` command line option when using `hadoop jar ...`,
 specifying `{{site.ALLUXIO_CLIENT_JAR_PATH}}`
 as the argument of `-libjars`. Hadoop will place the jar in the Hadoop DistributedCache, making it
@@ -89,6 +90,7 @@ $ bin/hadoop jar libexec/share/hadoop/mapreduce/hadoop-mapreduce-examples-2.7.3.
 ```
 
 2.**Distributing the client jars to all nodes manually.**
+
 To install Alluxio on each node, place the client jar
 `{{site.ALLUXIO_CLIENT_JAR_PATH}}` in the `$HADOOP_HOME/lib`
 (may be `$HADOOP_HOME/share/hadoop/common/lib` for different versions of Hadoop) directory of every


### PR DESCRIPTION
1. Add blank after hash key and remove redundant label
2. Add Table of Contents and little fix
3. Fix the python example to markdown style
4. Highlight the commands like the en version
5. ALLUXIO_CLIENT_JAR_PATH_BUILD should be ALLUXIO_CLIENT_JAR_PATH

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>