### PR TITLE
[SMALLFIX] Hadoop 1 compatibility.

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -297,7 +297,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
   public UfsStatus getStatus(String path) throws IOException {
     Path tPath = new Path(path);
     FileStatus fs = mFileSystem.getFileStatus(tPath);
-    if (fs.isFile()) {
+    if (!fs.isDir()) {
       // Return file status.
       String contentHash =
           UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());


### PR DESCRIPTION
Hadoop 1 does not have `isFile` or `isDirectory` so we need to use the deprecated `isDir`.