### PR TITLE
[SMALLFIX] Avoid filling logs with getstatus warnings

### DIFF
--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -24,8 +24,10 @@ import java.io.IOException;
  * Utilities for handling RPC calls.
  */
 public final class RpcUtils {
+
   /**
-   * Calls the given {@link RpcCallable} and handles any exceptions thrown.
+   * Calls the given {@link RpcCallable} and handles any exceptions thrown. If the
+   * RPC fails, a warning or error will be logged.
    *
    * @param logger the logger to use for this call
    * @param callable the callable to call
@@ -33,7 +35,23 @@ public final class RpcUtils {
    * @return the return value from calling the callable
    * @throws AlluxioTException if the callable throws an exception
    */
-  public static <T> T call(Logger logger, RpcCallable<T> callable) throws AlluxioTException {
+  public static <T> T call(Logger logger, RpcCallable<T> callable)
+      throws AlluxioTException {
+    return call(logger, callable, true);
+  }
+
+  /**
+   * Calls the given {@link RpcCallable} and handles any exceptions thrown.
+   *
+   * @param logger the logger to use for this call
+   * @param callable the callable to call
+   * @param logAnyFailure whether to log whenever the RPC fails
+   * @param <T> the return type of the callable
+   * @return the return value from calling the callable
+   * @throws AlluxioTException if the callable throws an exception
+   */
+  public static <T> T call(Logger logger, RpcCallable<T> callable, boolean logAnyFailure)
+      throws AlluxioTException {
     try {
       logger.debug("Enter: {}", callable);
       T ret = callable.call();
@@ -41,7 +59,7 @@ public final class RpcUtils {
       return ret;
     } catch (AlluxioException e) {
       logger.debug("Exit (Error): {}", callable, e);
-      if (!logger.isDebugEnabled()) {
+      if (logAnyFailure && !logger.isDebugEnabled()) {
         logger.warn("{}, Error={}", callable, e.getMessage());
       }
       throw AlluxioStatusException.fromAlluxioException(e).toThrift();
@@ -52,7 +70,8 @@ public final class RpcUtils {
   }
 
   /**
-   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown.
+   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown. If the
+   * RPC fails, a warning or error will be logged.
    *
    * @param logger the logger to use for this call
    * @param callable the callable to call
@@ -62,6 +81,21 @@ public final class RpcUtils {
    */
   public static <T> T call(Logger logger, RpcCallableThrowsIOException<T> callable)
       throws AlluxioTException {
+    return call(logger, callable, true);
+  }
+
+  /**
+   * Calls the given {@link RpcCallableThrowsIOException} and handles any exceptions thrown.
+   *
+   * @param logger the logger to use for this call
+   * @param callable the callable to call
+   * @param logAnyFailure whether to log whenever the RPC fails
+   * @param <T> the return type of the callable
+   * @return the return value from calling the callable
+   * @throws AlluxioTException if the callable throws an exception
+   */
+  public static <T> T call(Logger logger, RpcCallableThrowsIOException<T> callable,
+      boolean logAnyFailure) throws AlluxioTException {
     try {
       logger.debug("Enter: {}", callable);
       T ret = callable.call();
@@ -75,7 +109,7 @@ public final class RpcUtils {
       throw AlluxioStatusException.fromAlluxioException(e).toThrift();
     } catch (IOException e) {
       logger.debug("Exit (Error): {}", callable, e);
-      if (!logger.isDebugEnabled()) {
+      if (logAnyFailure && !logger.isDebugEnabled()) {
         logger.warn("{}, Error={}", callable, e.getMessage());
       }
       throw AlluxioStatusException.fromIOException(e).toThrift();

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -236,7 +236,8 @@ public final class FileSystemMasterClientServiceHandler implements
       public String toString() {
         return String.format("GetStatus: path=%s, options=%s", path, options);
       }
-    });
+      // getStatus is often used to check file existence, so we avoid logging all of its failures
+    }, false);
   }
 
   @Override


### PR DESCRIPTION
getStatus is the standard way to check for existence. Before this PR, checking for the existence of a non-existent file would log a warning in the master log. This causes the master log to become unnecessarily full under normal operations. With this change, users will only get RPC tracing for getStatus when they set the log level to debug.