### PR TITLE
[SMALLFIX] Add tarball and work directories to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@
 /deploy/vagrant/vbox/.vagrant/
 /deploy/vagrant/vbox/alluxio-dev.box
 /dev/scripts/*.tar.gz
+/dev/scripts/tarballs
+/dev/scripts/workdir
 /docs/_site/
 /docs/api/
 /docs/serve/


### PR DESCRIPTION
These directories are for tarball generation.