### PR TITLE
[SMALLFIX] Allow user to list available validation tasks

### DIFF
--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -117,8 +117,8 @@ public final class ValidateEnv {
     registerTask("master.ufs.hdfs.security.kerberos",
         "validate kerberos security configurations for masters",
         new SecureHdfsValidationTask("master"), MASTER_TASKS);
-    registerTask("worker.ufs.hdfs.security.kerberos for workers",
-        "validate kerberos security configurations",
+    registerTask("worker.ufs.hdfs.security.kerberos",
+        "validate kerberos security configurations for workers",
         new SecureHdfsValidationTask("worker"), WORKER_TASKS);
 
     // ssh validations


### PR DESCRIPTION
This change added a new option `-l` to `validateEnv` command for user to list validation tasks to run for a given target and prefix. For example `alluxio validateEnv all -l` will list all tasks available to run for each master node and worker node.