### PR TITLE
[SMALLFIX] Fix storage space validation for ramfs

### DIFF
--- a/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
@@ -73,7 +73,7 @@ public final class StorageSpaceValidationTask extends AbstractValidationTask {
         for (int i = 0; i < dirPaths.length; i++) {
           int index = i >= dirQuotas.length ? dirQuotas.length - 1 : i;
           if (Utils.isMountingPoint(dirPaths[i], new String[] {"ramfs"})) {
-            System.out.format("ramfs is mounted at %s which does not report space information,"
+            System.out.format("ramfs mounted at %s does not report space information,"
                 + " skip validation.%n", dirPaths[i]);
             hasRamfsLocation = true;
             break;

--- a/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
@@ -64,10 +64,16 @@ public final class StorageSpaceValidationTask extends AbstractValidationTask {
       try {
         Map<String, MountedStorage> storageMap = new HashMap<>();
         File file = new File(dirPaths[0]);
-        if (dirPaths.length == 1 && alias.equals("MEM") && !file.exists()) {
-          // skip checking if RAM disk is not mounted
-          System.out.format("RAM disk is not mounted at %s, skip validation.%n", dirPaths[0]);
-          continue;
+        if (dirPaths.length == 1 && alias.equals("MEM")) {
+          if (!file.exists()) {
+            System.out.format("RAM disk is not mounted at %s, skip validation.%n", dirPaths[0]);
+            continue;
+          }
+          if (Utils.isMountingPoint(dirPaths[0], new String[] {"ramfs"})) {
+            System.out.format("ramfs is mounted at %s which does not report space information,"
+                + " skip validation.%n", dirPaths[0]);
+            continue;
+          }
         }
 
         for (int i = 0; i < dirPaths.length; i++) {

--- a/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
@@ -13,6 +13,10 @@ package alluxio.cli.validation;
 
 import alluxio.Configuration;
 import alluxio.PropertyKey;
+import alluxio.util.ShellUtils;
+import alluxio.util.UnixMountInfo;
+
+import com.google.common.base.Optional;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,6 +33,7 @@ import java.util.List;
  */
 public final class Utils {
   private static final String LINE_SEPARATOR = System.getProperty("line.separator").toString();
+
   /**
    * Validates whether a network address is reachable.
    * @param hostname host name of the network address
@@ -91,6 +96,30 @@ public final class Utils {
     }
 
     return nodes;
+  }
+
+  /**
+   * Checks whether a path is the mounting point of a RAM disk volume.
+   * @param path  a string represents the path to be checked
+   * @param fsTypes  an array of strings represents expected file system type
+   * @return true if the path is the mounting point of volume with one of the given fsTypes,
+   * false otherwise
+   * @throws IOException if the function fails to get the mount information of the system
+   */
+  public static boolean isMountingPoint(String path, String[] fsTypes) throws IOException {
+    List<UnixMountInfo> infoList = ShellUtils.getUnixMountInfo();
+    for (UnixMountInfo info : infoList) {
+      Optional<String> mountPoint = info.getMountPoint();
+      Optional<String> fsType = info.getFsType();
+      if (mountPoint.isPresent() && mountPoint.get().equals(path) && fsType.isPresent()) {
+        for (String expectedType : fsTypes) {
+          if (fsType.get().equalsIgnoreCase(expectedType)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
@@ -36,6 +36,7 @@ public final class Utils {
 
   /**
    * Validates whether a network address is reachable.
+   *
    * @param hostname host name of the network address
    * @param port port of the network address
    * @return whether the network address is reachable
@@ -50,6 +51,7 @@ public final class Utils {
 
   /**
    * Checks whether an Alluxio service is running.
+   *
    * @param className class name of the Alluxio service
    * @return whether the Alluxio service is running
    */
@@ -100,10 +102,11 @@ public final class Utils {
 
   /**
    * Checks whether a path is the mounting point of a RAM disk volume.
+   *
    * @param path  a string represents the path to be checked
-   * @param fsTypes  an array of strings represents expected file system type
+   * @param fsTypes an array of strings represents expected file system type
    * @return true if the path is the mounting point of volume with one of the given fsTypes,
-   * false otherwise
+   *         false otherwise
    * @throws IOException if the function fails to get the mount information of the system
    */
   public static boolean isMountingPoint(String path, String[] fsTypes) throws IOException {


### PR DESCRIPTION
Currently running validateEnv command on linux with mounted ramfs for worker storage will fail because ramfs does not report correct space information. I am adding a check so we skip checking available space for ramfs.