### PR TITLE
[SMALLFIX] Ignore exceptions on submitting async cache request on worker and make client call nonblocking

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -283,7 +283,7 @@ public class FileInStream extends InputStream implements BoundedStream, Position
           try {
             NettyRPCContext rpcContext =
                 NettyRPCContext.defaults().setChannel(channel).setTimeout(channelTimeout);
-            NettyRPC.callWithoutBlocking(rpcContext, new ProtoMessage(request));
+            NettyRPC.fireAndForget(rpcContext, new ProtoMessage(request));
           } finally {
             mContext.releaseNettyChannel(worker, channel);
           }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -283,7 +283,7 @@ public class FileInStream extends InputStream implements BoundedStream, Position
           try {
             NettyRPCContext rpcContext =
                 NettyRPCContext.defaults().setChannel(channel).setTimeout(channelTimeout);
-            NettyRPC.call(rpcContext, new ProtoMessage(request));
+            NettyRPC.callWithoutBlocking(rpcContext, new ProtoMessage(request));
           } finally {
             mContext.releaseNettyChannel(worker, channel);
           }

--- a/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
+++ b/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
@@ -85,6 +85,8 @@ public final class NettyRPC {
   public static void fireAndForget(final NettyRPCContext context, ProtoMessage request)
       throws IOException {
     Channel channel = Preconditions.checkNotNull(context.getChannel());
+    // Not really using the atomicity of flushed, but use it as a wrapper of boolean that is final,
+    // and can change value.
     final AtomicBoolean flushed = new AtomicBoolean(false);
     channel.writeAndFlush(new RPCProtoMessage(request)).addListener((ChannelFuture future) -> {
       if (future.cause() != null) {

--- a/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
+++ b/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
@@ -83,7 +83,8 @@ public final class NettyRPC {
   public static void callWithoutBlocking(final NettyRPCContext context, ProtoMessage request)
       throws IOException {
     Channel channel = Preconditions.checkNotNull(context.getChannel());
-    channel.writeAndFlush(new RPCProtoMessage(request)).addListener(ChannelFutureListener.CLOSE);
+    channel.writeAndFlush(new RPCProtoMessage(request))
+        .addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
@@ -44,7 +44,8 @@ public class AsyncCacheHandler extends ChannelInboundHandlerAdapter {
       Protocol.AsyncCacheRequest request =
           ((RPCProtoMessage) object).getMessage().asAsyncCacheRequest();
       mRequestManager.submitRequest(request);
-      ctx.writeAndFlush(RPCProtoMessage.createOkResponse(null));
+      // Note that, because the client side of this RPC end point is fireAndForget, thus expecting
+      // no response. No OK response will be returned here.
     } else {
       ctx.fireChannelRead(object);
     }


### PR DESCRIPTION
Aim to:
- Save one roundtrip when client wants to async cache a block on a worker and isolate the result of this async cache on critical path on client
- Catch and ignore the exceptions on worker on submitting async cache --- it is best effort
- the netty service handler of async cache return no response  