### PR TITLE
[SMALLFIX] check at least one in stream is expired and closed

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -177,10 +177,6 @@ public final class UfsInputStreamManagerTest {
         threads.add(new Thread(runnable));
       }
       ConcurrencyUtils.assertConcurrent(threads, 30);
-      for (int i = 0; i < mNumOfInputStreams / 4; i++) {
-        // the first quarter of input streams are closed
-        Mockito.verify(mSeekableInStreams[i], Mockito.timeout(2000)).close();
-      }
     }
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -177,6 +177,8 @@ public final class UfsInputStreamManagerTest {
         threads.add(new Thread(runnable));
       }
       ConcurrencyUtils.assertConcurrent(threads, 30);
+      // ensure at least one expired in stream is closed
+      Mockito.verify(mSeekableInStreams[0], Mockito.timeout(2000)).close();
     }
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -159,7 +159,7 @@ public final class UfsInputStreamManagerTest {
       mManager = new UfsInputStreamManager();
       List<Thread> threads = new ArrayList<>();
       int numCheckOutPerThread = 4;
-      for (int i = 0; i < mNumOfInputStreams / 4; i++) {
+      for (int i = 0; i < mNumOfInputStreams / numCheckOutPerThread; i++) {
         Runnable runnable = () -> {
           for (int j = 0; j < numCheckOutPerThread; j++) {
             InputStream instream;


### PR DESCRIPTION
The purpose of test `testConcurrencyWithExpiration` is to ensure the test can finish without deadlock. So we just check one of the input stream can expire and close, but not an exact amount given that the cache eviction is asynchronous.