### PR TITLE
[SMALLFIX] Reenter safe mode after master become primary again

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/SafeModeManager.java
+++ b/core/server/common/src/main/java/alluxio/master/SafeModeManager.java
@@ -17,6 +17,11 @@ package alluxio.master;
 public interface SafeModeManager {
 
   /**
+   * Notifies {@link SafeModeManager} that the primary master is started.
+   */
+  void notifyPrimaryMasterStarted();
+
+  /**
    * Notifies {@link SafeModeManager} that the RPC server is started.
    */
   void notifyRpcServerStarted();

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -228,6 +228,9 @@ public class AlluxioMasterProcess implements MasterProcess {
    */
   protected void startMasters(boolean isLeader) {
     try {
+      if (isLeader) {
+        mSafeModeManager.notifyPrimaryMasterStarted();
+      }
       mRegistry.start(isLeader);
       LOG.info("All masters started");
     } catch (IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
@@ -53,10 +53,16 @@ public class DefaultSafeModeManager implements SafeModeManager {
   }
 
   @Override
+  public void notifyPrimaryMasterStarted() {
+    LOG.info("Entering safe mode.");
+    mWorkerConnectWaitStartTimeMs.set(null, true);
+  }
+
+  @Override
   public void notifyRpcServerStarted() {
     // updates start time when Alluxio master waits for workers to register
     long waitTime = Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
-    LOG.info(String.format("Entering safe mode. Expect leaving safe mode after %dms", waitTime));
+    LOG.info(String.format("Expect leaving safe mode after %dms", waitTime));
     mWorkerConnectWaitStartTimeMs.set(mClock.millis(), true);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/SafeModeManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/SafeModeManagerTest.java
@@ -56,14 +56,21 @@ public class SafeModeManagerTest {
   }
 
   @Test
-  public void enterSafeMode() throws Exception {
+  public void enterSafeModeOnPrimaryMasterStart() throws Exception {
+    mSafeModeManager.notifyPrimaryMasterStarted();
+
+    assertTrue(mSafeModeManager.isInSafeMode());
+  }
+
+  @Test
+  public void enterSafeModeOnRpcServerStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
 
     assertTrue(mSafeModeManager.isInSafeMode());
   }
 
   @Test
-  public void leaveSafeMode() throws Exception {
+  public void leaveSafeModeAfterRpcServerStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
     mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
 
@@ -71,7 +78,24 @@ public class SafeModeManagerTest {
   }
 
   @Test
-  public void reenterSafeMode() throws Exception {
+  public void stayInSafeModeAfterPrimaryMasterStart() throws Exception {
+    mSafeModeManager.notifyPrimaryMasterStarted();
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+
+    assertTrue(mSafeModeManager.isInSafeMode());
+  }
+
+  @Test
+  public void reenterSafeModeOnPrimaryMasterStart() throws Exception {
+    mSafeModeManager.notifyRpcServerStarted();
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+    mSafeModeManager.notifyPrimaryMasterStarted();
+
+    assertTrue(mSafeModeManager.isInSafeMode());
+  }
+
+  @Test
+  public void reenterSafeModeOnRpcServerStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
     mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
     mSafeModeManager.notifyRpcServerStarted();
@@ -80,7 +104,7 @@ public class SafeModeManagerTest {
   }
 
   @Test
-  public void reenterSafeModeWhileInSafeMode() throws Exception {
+  public void reenterSafeModeOnRpcServerStartWhileInSafeMode() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
 
     // Enters safe mode again while in safe mode.
@@ -92,5 +116,20 @@ public class SafeModeManagerTest {
     assertTrue(mSafeModeManager.isInSafeMode());
     mClock.addTimeMs(20);
     assertFalse(mSafeModeManager.isInSafeMode());
+  }
+
+  @Test
+  public void reenterSafeModeOnPrimaryMasterStartWhileInSafeMode() throws Exception {
+    mSafeModeManager.notifyRpcServerStarted();
+
+    // Enters safe mode again while in safe mode.
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+    mSafeModeManager.notifyPrimaryMasterStarted();
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+
+    // Verifies safe mode timer is cleared.
+    assertTrue(mSafeModeManager.isInSafeMode());
+    mClock.addTimeMs(20);
+    assertTrue(mSafeModeManager.isInSafeMode());
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/TestSafeModeManager.java
+++ b/core/server/master/src/test/java/alluxio/master/TestSafeModeManager.java
@@ -17,6 +17,10 @@ package alluxio.master;
 public class TestSafeModeManager implements SafeModeManager {
 
   @Override
+  public void notifyPrimaryMasterStarted() {
+  }
+
+  @Override
   public void notifyRpcServerStarted() {
   }
 


### PR DESCRIPTION
Currently Alluxio master only reenters safe mode when RPC server starts, leaving safe mode off during the period between a server becomes primary and the RPC server starts. This change adds notification to the safe mode manager so the safe mode will be turned on even when master is starting, preventing services from doing worker dependent tasks.