### PR TITLE
[SMALLFIX] Fix S3/GCS Content-Encoding

### DIFF
--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSOutputStream.java
@@ -120,7 +120,7 @@ public final class GCSOutputStream extends OutputStream {
       obj.setBucketName(mBucketName);
       obj.setDataInputFile(mFile);
       obj.setContentLength(mFile.length());
-      obj.setContentEncoding(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
+      obj.setContentType(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
       if (mHash != null) {
         obj.setMd5Hash(mHash.digest());
       } else {

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -142,7 +142,7 @@ public class S3AOutputStream extends OutputStream {
         meta.setContentMD5(new String(Base64.encode(mHash.digest())));
       }
       meta.setContentLength(mFile.length());
-      meta.setContentEncoding(Mimetypes.MIMETYPE_OCTET_STREAM);
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
 
       // Generate the put request and wait for the transfer manager to complete the upload, then
       // delete the temporary file on the local machine


### PR DESCRIPTION
Currently for S3 and GCS put request we are setting content type value to content encoding. While it works for S3 and GCS, some compatible storage providers will reject it as bad request.