### PR TITLE
[SMALLFIX] Fix ft failure window

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -13,6 +13,7 @@ package alluxio.master;
 
 import alluxio.Constants;
 import alluxio.Server;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.JournalContext;
 import alluxio.util.executor.ExecutorServiceFactory;
@@ -131,7 +132,7 @@ public abstract class AbstractMaster implements Master {
   /**
    * @return new instance of {@link JournalContext}
    */
-  protected JournalContext createJournalContext() {
+  protected JournalContext createJournalContext() throws UnavailableException {
     return mJournal.createJournalContext();
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/Journal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/Journal.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.journal;
 
+import alluxio.exception.status.UnavailableException;
+
 import java.io.Closeable;
 import java.net.URI;
 
@@ -25,6 +27,8 @@ public interface Journal extends Closeable {
 
   /**
    * @return a journal context for appending journal entries
+   * @throws UnavailableException if a context cannot be created because the journal has been
+   *         closed.
    */
-  JournalContext createJournalContext();
+  JournalContext createJournalContext() throws UnavailableException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -99,6 +99,7 @@ public class UfsJournal implements Journal {
   private enum State {
     SECONDARY, PRIMARY, CLOSED;
   }
+
   private State mState;
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -66,7 +66,7 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param blockIds a list of block ids to remove from Alluxio space
    * @param delete whether to delete blocks' metadata in Master
    */
-  void removeBlocks(List<Long> blockIds, boolean delete);
+  void removeBlocks(List<Long> blockIds, boolean delete) throws UnavailableException;
 
   /**
    * Marks a block as committed on a specific worker.
@@ -80,7 +80,7 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    */
   // TODO(binfan): check the logic is correct or not when commitBlock is a retry
   void commitBlock(long workerId, long usedBytesOnTier, String tierAlias, long blockId, long
-      length) throws NoWorkerException;
+      length) throws NoWorkerException, UnavailableException;
 
   /**
    * Marks a block as committed, but without a worker location. This means the block is only in ufs.
@@ -88,7 +88,7 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param blockId the id of the block to commit
    * @param length the length of the block
    */
-  void commitBlockInUFS(long blockId, long length);
+  void commitBlockInUFS(long blockId, long length) throws UnavailableException;
 
   /**
    * @param blockId the block id to get information for

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -33,6 +33,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -80,9 +81,9 @@ public final class BlockMasterWorkerServiceHandler implements BlockMasterWorkerS
   public CommitBlockTResponse commitBlock(final long workerId, final long usedBytesOnTier,
       final String tierAlias, final long blockId, final long length, CommitBlockTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcUtils.RpcCallable<CommitBlockTResponse>() {
+    return RpcUtils.call(LOG, new RpcUtils.RpcCallableThrowsIOException<CommitBlockTResponse>() {
       @Override
-      public CommitBlockTResponse call() throws AlluxioException {
+      public CommitBlockTResponse call() throws AlluxioException, IOException {
         mBlockMaster.commitBlock(workerId, usedBytesOnTier, tierAlias, blockId, length);
         return new CommitBlockTResponse();
       }

--- a/core/server/master/src/main/java/alluxio/master/block/ContainerIdGenerable.java
+++ b/core/server/master/src/main/java/alluxio/master/block/ContainerIdGenerable.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.block;
 
+import alluxio.exception.status.UnavailableException;
+
 /**
  * Provides generation of container IDs.
  */
@@ -18,5 +20,5 @@ public interface ContainerIdGenerable {
   /**
    * @return a unique block container id
    */
-  long getNewContainerId();
+  long getNewContainerId() throws UnavailableException;
 }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -335,7 +335,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   }
 
   @Override
-  public void removeBlocks(List<Long> blockIds, boolean delete) {
+  public void removeBlocks(List<Long> blockIds, boolean delete) throws UnavailableException {
     try (JournalContext journalContext = createJournalContext()) {
       for (long blockId : blockIds) {
         MasterBlockInfo block = mBlocks.get(blockId);
@@ -384,7 +384,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
    * @return a new block container id
    */
   @Override
-  public long getNewContainerId() {
+  public long getNewContainerId() throws UnavailableException {
     synchronized (mBlockContainerIdGenerator) {
       long containerId = mBlockContainerIdGenerator.getNewContainerId();
       if (containerId < mJournaledNextContainerId) {
@@ -425,7 +425,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   // TODO(binfan): check the logic is correct or not when commitBlock is a retry
   @Override
   public void commitBlock(long workerId, long usedBytesOnTier, String tierAlias, long blockId,
-      long length) throws NoWorkerException {
+      long length) throws NoWorkerException, UnavailableException {
     LOG.debug("Commit block from workerId: {}, usedBytesOnTier: {}, blockId: {}, length: {}",
         workerId, usedBytesOnTier, blockId, length);
 
@@ -491,7 +491,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   }
 
   @Override
-  public void commitBlockInUFS(long blockId, long length) {
+  public void commitBlockInUFS(long blockId, long length) throws UnavailableException {
     LOG.debug("Commit block in ufs. blockId: {}, length: {}", blockId, length);
     if (mBlocks.get(blockId) != null) {
       // Block metadata already exists, so do not need to create a new one.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -71,7 +71,7 @@ public interface FileSystemMaster extends Master {
    * @return the file id for a given path, or -1 if there is no file at that path
    * @throws AccessControlException if permission checking fails
    */
-  long getFileId(AlluxioURI path) throws AccessControlException;
+  long getFileId(AlluxioURI path) throws AccessControlException, UnavailableException;
 
   /**
    * Returns the {@link FileInfo} for a given file id. This method is not user-facing but supposed
@@ -200,7 +200,7 @@ public interface FileSystemMaster extends Master {
    */
   // Used by lineage master
   long reinitializeFile(AlluxioURI path, long blockSizeBytes, long ttl, TtlAction ttlAction)
-      throws InvalidPathException, FileDoesNotExistException;
+      throws InvalidPathException, FileDoesNotExistException, UnavailableException;
 
   /**
    * Gets a new block id for the next block of a given file to write to.
@@ -329,7 +329,7 @@ public interface FileSystemMaster extends Master {
   // into RuntimeException on the client.
   void free(AlluxioURI path, FreeOptions options)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      UnexpectedAlluxioException;
+      UnexpectedAlluxioException, UnavailableException;
 
   /**
    * Gets the path of a file with the given id.
@@ -444,7 +444,7 @@ public interface FileSystemMaster extends Master {
   // TODO(binfan): Add permission checking for internal APIs
   void resetFile(long fileId)
       throws UnexpectedAlluxioException, FileDoesNotExistException, InvalidPathException,
-      AccessControlException;
+      AccessControlException, UnavailableException;
 
   /**
    * Sets the file attribute.
@@ -468,7 +468,7 @@ public interface FileSystemMaster extends Master {
    *
    * @param path the path of the file for persistence
    */
-  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
+  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException, UnavailableException;
 
   /**
    * Instructs a worker to persist the files.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -377,18 +377,19 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public ScheduleAsyncPersistenceTResponse scheduleAsyncPersistence(final String path,
       final ScheduleAsyncPersistenceTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<ScheduleAsyncPersistenceTResponse>() {
-      @Override
-      public ScheduleAsyncPersistenceTResponse call() throws AlluxioException, IOException {
-        mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
-        return new ScheduleAsyncPersistenceTResponse();
-      }
+    return RpcUtils.call(LOG,
+        new RpcCallableThrowsIOException<ScheduleAsyncPersistenceTResponse>() {
+          @Override
+          public ScheduleAsyncPersistenceTResponse call() throws AlluxioException, IOException {
+            mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
+            return new ScheduleAsyncPersistenceTResponse();
+          }
 
-      @Override
-      public String toString() {
-        return String.format("ScheduleAsyncPersist: path=%s, options=%s", path, options);
-      }
-    });
+          @Override
+          public String toString() {
+            return String.format("ScheduleAsyncPersist: path=%s, options=%s", path, options);
+          }
+        });
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -184,9 +184,9 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public FreeTResponse free(final String path, final boolean recursive, final FreeTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<FreeTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<FreeTResponse>() {
       @Override
-      public FreeTResponse call() throws AlluxioException {
+      public FreeTResponse call() throws AlluxioException, IOException {
         if (options == null) {
           // For Alluxio client v1.4 or earlier.
           // NOTE, we try to be conservative here so early Alluxio clients will not be able to force
@@ -377,9 +377,9 @@ public final class FileSystemMasterClientServiceHandler implements
   @Override
   public ScheduleAsyncPersistenceTResponse scheduleAsyncPersistence(final String path,
       final ScheduleAsyncPersistenceTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<ScheduleAsyncPersistenceTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<ScheduleAsyncPersistenceTResponse>() {
       @Override
-      public ScheduleAsyncPersistenceTResponse call() throws AlluxioException {
+      public ScheduleAsyncPersistenceTResponse call() throws AlluxioException, IOException {
         mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(path));
         return new ScheduleAsyncPersistenceTResponse();
       }

--- a/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/AsyncPersistHandler.java
@@ -18,6 +18,7 @@ import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.thrift.PersistFile;
 import alluxio.util.CommonUtils;
@@ -64,7 +65,7 @@ public interface AsyncPersistHandler {
    *
    * @param path the path to the file
    */
-  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException;
+  void scheduleAsyncPersistence(AlluxioURI path) throws AlluxioException, UnavailableException;
 
   /**
    * Polls the files for persistence on the given worker.

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -63,7 +63,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
 
   @Override
   public synchronized void scheduleAsyncPersistence(AlluxioURI path)
-      throws AlluxioException {
+      throws AlluxioException, UnavailableException {
     // find the worker
     long workerId = getWorkerStoringFile(path);
 
@@ -88,7 +88,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
    */
   // TODO(calvin): Propagate the exceptions in certain cases
   private long getWorkerStoringFile(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException {
+      throws FileDoesNotExistException, AccessControlException, UnavailableException {
     long fileId = mFileSystemMasterView.getFileId(path);
     try {
       if (mFileSystemMasterView.getFileInfo(fileId).getLength() == 0) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/FileSystemMasterView.java
@@ -85,7 +85,7 @@ public final class FileSystemMasterView {
    * @throws FileDoesNotExistException if file does not exist
    */
   public synchronized long getFileId(AlluxioURI path)
-      throws AccessControlException, FileDoesNotExistException {
+      throws AccessControlException, FileDoesNotExistException, UnavailableException {
     return mFileSystemMaster.getFileId(path);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.file.meta;
 
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.block.BlockId;
 import alluxio.master.block.ContainerIdGenerable;
 import alluxio.master.journal.JournalContext;
@@ -47,7 +48,7 @@ public class InodeDirectoryIdGenerator implements JournalEntryRepresentable {
   /**
    * @return the next directory id
    */
-  synchronized long getNewDirectoryId() {
+  synchronized long getNewDirectoryId() throws UnavailableException {
     return getNewDirectoryId(NoopJournalContext.INSTANCE);
   }
 
@@ -57,7 +58,7 @@ public class InodeDirectoryIdGenerator implements JournalEntryRepresentable {
    * @param journalContext the journal context
    * @return the next directory id
    */
-  synchronized long getNewDirectoryId(JournalContext journalContext) {
+  synchronized long getNewDirectoryId(JournalContext journalContext) throws UnavailableException {
     initialize();
     long directoryId = BlockId.createBlockId(mContainerId, mSequenceNumber);
     if (mSequenceNumber == BlockId.getMaxSequenceNumber()) {
@@ -94,7 +95,7 @@ public class InodeDirectoryIdGenerator implements JournalEntryRepresentable {
     mInitialized = true;
   }
 
-  private void initialize() {
+  private void initialize() throws UnavailableException {
     if (!mInitialized) {
       mContainerId = mContainerIdGenerator.getNewContainerId();
       mSequenceNumber = 0;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -23,6 +23,7 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.block.ContainerIdGenerable;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
@@ -150,7 +151,7 @@ public class InodeTree implements JournalEntryIterable {
    * @param group the root group
    * @param mode the root mode
    */
-  public void initializeRoot(String owner, String group, Mode mode) {
+  public void initializeRoot(String owner, String group, Mode mode) throws UnavailableException {
     if (mRoot == null) {
       InodeDirectory root = InodeDirectory.create(mDirectoryIdGenerator.getNewDirectoryId(),
           NO_PARENT, ROOT_INODE_NAME,

--- a/core/server/master/src/main/java/alluxio/master/lineage/DefaultLineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/DefaultLineageMaster.java
@@ -216,7 +216,7 @@ public final class DefaultLineageMaster extends AbstractMaster implements Lineag
 
   @Override
   public synchronized boolean deleteLineage(long lineageId, boolean cascade)
-      throws LineageDoesNotExistException, LineageDeletionException {
+      throws LineageDoesNotExistException, LineageDeletionException, UnavailableException {
     try (JournalContext journalContext = createJournalContext()) {
       deleteLineageInternal(lineageId, cascade);
       DeleteLineageEntry deleteLineage =
@@ -315,7 +315,7 @@ public final class DefaultLineageMaster extends AbstractMaster implements Lineag
       for (long file : lineage.getOutputFiles()) {
         try {
           mFileSystemMaster.scheduleAsyncPersistence(mFileSystemMaster.getPath(file));
-        } catch (AlluxioException e) {
+        } catch (AlluxioException | UnavailableException e) {
           LOG.error("Failed to persist the file {}.", file, e);
         }
       }

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMaster.java
@@ -67,7 +67,7 @@ public interface LineageMaster extends Master {
    * @throws LineageDeletionException the lineage deletion fails
    */
   boolean deleteLineage(long lineageId, boolean cascade)
-      throws LineageDoesNotExistException, LineageDeletionException;
+      throws LineageDoesNotExistException, LineageDeletionException, UnavailableException;
 
   /**
    * Reinitializes the file when the file is lost or not completed.

--- a/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/LineageMasterClientServiceHandler.java
@@ -101,9 +101,9 @@ public final class LineageMasterClientServiceHandler implements LineageMasterCli
   @Override
   public DeleteLineageTResponse deleteLineage(final long lineageId, final boolean cascade,
       DeleteLineageTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<DeleteLineageTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<DeleteLineageTResponse>() {
       @Override
-      public DeleteLineageTResponse call() throws AlluxioException {
+      public DeleteLineageTResponse call() throws AlluxioException, IOException {
         return new DeleteLineageTResponse(mLineageMaster.deleteLineage(lineageId, cascade));
       }
     });

--- a/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
+++ b/core/server/master/src/main/java/alluxio/master/lineage/recompute/RecomputeExecutor.java
@@ -15,6 +15,7 @@ import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.UnexpectedAlluxioException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.lineage.meta.Lineage;
@@ -115,6 +116,8 @@ public final class RecomputeExecutor implements HeartbeatExecutor {
               LOG.error("the lost file {} is invalid", fileId, e);
             } catch (AccessControlException e) {
               LOG.error("the lost file {} cannot be accessed", fileId, e);
+            } catch (UnavailableException e) {
+              LOG.error("failed to reset file {}", fileId, e);
             }
           }
         } catch (FileDoesNotExistException e) {

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
@@ -21,6 +21,7 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.AbstractMaster;
 import alluxio.master.MasterContext;
 import alluxio.master.file.FileSystemMaster;
@@ -145,7 +146,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
 
   @Override
   public synchronized void completePartition(AlluxioURI path, PartitionInfo info)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+      throws AccessControlException, FileDoesNotExistException, InvalidPathException,
+      UnavailableException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -179,8 +181,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
   }
 
   @Override
-  public synchronized void completeStore(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException {
+  public synchronized void completeStore(AlluxioURI path) throws FileDoesNotExistException,
+      InvalidPathException, AccessControlException, UnavailableException {
     final long fileId = mFileSystemMaster.getFileId(path);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(
@@ -210,8 +212,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
   }
 
   @Override
-  public synchronized void createStore(AlluxioURI path)
-      throws FileAlreadyExistsException, InvalidPathException, AccessControlException {
+  public synchronized void createStore(AlluxioURI path) throws FileAlreadyExistsException,
+      InvalidPathException, AccessControlException, UnavailableException {
     try {
       // Create this dir
       mFileSystemMaster.createDirectory(path, CreateDirectoryOptions.defaults().setRecursive(true));
@@ -270,8 +272,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
     mCompleteStoreToPartitions.remove(fileId);
   }
 
-  private long getFileId(AlluxioURI uri)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException {
+  private long getFileId(AlluxioURI uri) throws AccessControlException, FileDoesNotExistException,
+      InvalidPathException, UnavailableException {
     long fileId = mFileSystemMaster.getFileId(uri);
     if (fileId == IdUtils.INVALID_FILE_ID) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
@@ -349,7 +351,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
 
   @Override
   public synchronized List<PartitionInfo> getPartitionInfo(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException {
+      throws FileDoesNotExistException, AccessControlException, InvalidPathException,
+      UnavailableException {
     long fileId = getFileId(path);
     List<PartitionInfo> partitions = mCompleteStoreToPartitions.get(fileId);
     if (partitions == null) {

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMaster.java
@@ -17,6 +17,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.Master;
 import alluxio.thrift.PartitionInfo;
 
@@ -38,8 +39,8 @@ public interface KeyValueMaster extends Master {
    * @throws FileDoesNotExistException if the key-value store URI does not exists
    * @throws InvalidPathException if the path is invalid
    */
-  void completePartition(AlluxioURI path, PartitionInfo info)
-      throws AccessControlException, FileDoesNotExistException, InvalidPathException;
+  void completePartition(AlluxioURI path, PartitionInfo info) throws AccessControlException,
+      FileDoesNotExistException, InvalidPathException, UnavailableException;
 
   /**
    * Marks a key-value store complete.
@@ -49,8 +50,8 @@ public interface KeyValueMaster extends Master {
    * @throws InvalidPathException if the path is not valid
    * @throws AccessControlException if permission checking fails
    */
-  void completeStore(AlluxioURI path)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException;
+  void completeStore(AlluxioURI path) throws FileDoesNotExistException, InvalidPathException,
+      AccessControlException, UnavailableException;
 
   /**
    * Creates a new key-value store.
@@ -60,8 +61,8 @@ public interface KeyValueMaster extends Master {
    * @throws InvalidPathException if the given path is invalid
    * @throws AccessControlException if permission checking fails
    */
-  void createStore(AlluxioURI path)
-      throws FileAlreadyExistsException, InvalidPathException, AccessControlException;
+  void createStore(AlluxioURI path) throws FileAlreadyExistsException, InvalidPathException,
+      AccessControlException, UnavailableException;
 
   /**
    * Deletes a completed key-value store.
@@ -70,8 +71,8 @@ public interface KeyValueMaster extends Master {
    * @throws InvalidPathException if the uri exists but is not a key-value store
    * @throws FileDoesNotExistException if the uri does not exist
    */
-  void deleteStore(AlluxioURI uri)
-      throws IOException, InvalidPathException, FileDoesNotExistException, AlluxioException;
+  void deleteStore(AlluxioURI uri) throws IOException, InvalidPathException,
+      FileDoesNotExistException, AlluxioException, UnavailableException;
 
   /**
    * Renames one completed key-value store.
@@ -79,7 +80,8 @@ public interface KeyValueMaster extends Master {
    * @param oldUri the old {@link AlluxioURI} to the store
    * @param newUri the {@link AlluxioURI} to the store
    */
-  void renameStore(AlluxioURI oldUri, AlluxioURI newUri) throws IOException, AlluxioException;
+  void renameStore(AlluxioURI oldUri, AlluxioURI newUri)
+      throws IOException, AlluxioException, UnavailableException;
 
   /**
    * Merges one completed key-value store to another completed key-value store.
@@ -89,8 +91,8 @@ public interface KeyValueMaster extends Master {
    * @throws InvalidPathException if the uri exists but is not a key-value store
    * @throws FileDoesNotExistException if the uri does not exist
    */
-  void mergeStore(AlluxioURI fromUri, AlluxioURI toUri)
-      throws IOException, FileDoesNotExistException, InvalidPathException, AlluxioException;
+  void mergeStore(AlluxioURI fromUri, AlluxioURI toUri) throws IOException,
+      FileDoesNotExistException, InvalidPathException, AlluxioException, UnavailableException;
 
   /**
    * Gets a list of partitions of a given key-value store.
@@ -101,6 +103,6 @@ public interface KeyValueMaster extends Master {
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
-  List<PartitionInfo> getPartitionInfo(AlluxioURI path)
-      throws FileDoesNotExistException, AccessControlException, InvalidPathException;
+  List<PartitionInfo> getPartitionInfo(AlluxioURI path) throws FileDoesNotExistException,
+      AccessControlException, InvalidPathException, UnavailableException;
 }

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/KeyValueMasterClientServiceHandler.java
@@ -14,7 +14,6 @@ package alluxio.master.keyvalue;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.RpcUtils;
-import alluxio.RpcUtils.RpcCallable;
 import alluxio.RpcUtils.RpcCallableThrowsIOException;
 import alluxio.exception.AlluxioException;
 import alluxio.thrift.AlluxioTException;
@@ -71,9 +70,9 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public CompletePartitionTResponse completePartition(final String path, final PartitionInfo info,
       CompletePartitionTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<CompletePartitionTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<CompletePartitionTResponse>() {
       @Override
-      public CompletePartitionTResponse call() throws AlluxioException {
+      public CompletePartitionTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.completePartition(new AlluxioURI(path), info);
         return new CompletePartitionTResponse();
       }
@@ -83,9 +82,9 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public CreateStoreTResponse createStore(final String path, CreateStoreTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<CreateStoreTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<CreateStoreTResponse>() {
       @Override
-      public CreateStoreTResponse call() throws AlluxioException {
+      public CreateStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.createStore(new AlluxioURI(path));
         return new CreateStoreTResponse();
       }
@@ -95,9 +94,9 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public CompleteStoreTResponse completeStore(final String path, CompleteStoreTOptions options)
       throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<CompleteStoreTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<CompleteStoreTResponse>() {
       @Override
-      public CompleteStoreTResponse call() throws AlluxioException {
+      public CompleteStoreTResponse call() throws AlluxioException, IOException {
         mKeyValueMaster.completeStore(new AlluxioURI(path));
         return new CompleteStoreTResponse();
       }
@@ -119,9 +118,9 @@ public final class KeyValueMasterClientServiceHandler implements KeyValueMasterC
   @Override
   public GetPartitionInfoTResponse getPartitionInfo(final String path,
       GetPartitionInfoTOptions options) throws AlluxioTException {
-    return RpcUtils.call(LOG, new RpcCallable<GetPartitionInfoTResponse>() {
+    return RpcUtils.call(LOG, new RpcCallableThrowsIOException<GetPartitionInfoTResponse>() {
       @Override
-      public GetPartitionInfoTResponse call() throws AlluxioException {
+      public GetPartitionInfoTResponse call() throws AlluxioException, IOException {
         return new GetPartitionInfoTResponse(
             mKeyValueMaster.getPartitionInfo(new AlluxioURI(path)));
       }

--- a/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalIntegrationTest.java
@@ -29,6 +29,7 @@ import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.NoopMaster;
+import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.options.GetStatusOptions;
 import alluxio.master.file.options.ListStatusOptions;
@@ -489,17 +490,14 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
 
     // Start a standby master, which will replay the mount entry from the journal.
     MasterRegistry registry = MasterTestUtils.createStandbyFileSystemMasterFromJournal();
-    final FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    Assert.assertTrue(registry.get(FileSystemMaster.class) instanceof DefaultFileSystemMaster);
+    final DefaultFileSystemMaster fsMaster =
+        (DefaultFileSystemMaster) registry.get(FileSystemMaster.class);
     try {
-      CommonUtils.waitFor("standby journal checkpoint replay", new Function<Void, Boolean>() {
+      CommonUtils.waitFor("journal checkpoint replay", new Function<Void, Boolean>() {
         @Override
         public Boolean apply(Void input) {
-          try {
-            fsMaster.listStatus(mountUri, ListStatusOptions.defaults());
-            return true;
-          } catch (Exception e) {
-            return false;
-          }
+          return fsMaster.getMountTable().containsKey(mountUri.toString());
         }
       }, WaitForOptions.defaults().setTimeoutMs(60 * Constants.SECOND_MS));
     } finally {

--- a/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalTest.java
+++ b/tests/src/test/java/alluxio/master/journal/ufs/UfsJournalTest.java
@@ -12,6 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.BaseIntegrationTest;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.NoopMaster;
 import alluxio.util.URIUtils;
 
@@ -19,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.net.URI;
@@ -29,6 +31,9 @@ import java.net.URI;
 public final class UfsJournalTest extends BaseIntegrationTest {
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
 
   private UfsJournal mJournal;
 
@@ -71,5 +76,13 @@ public final class UfsJournalTest extends BaseIntegrationTest {
     Assert.assertTrue(snapshot.getCheckpoints().isEmpty());
     Assert.assertTrue(snapshot.getLogs().isEmpty());
     Assert.assertTrue(snapshot.getTemporaryCheckpoints().isEmpty());
+  }
+
+  @Test
+  public void unavailableAfterClose() throws Exception {
+    mJournal.start();
+    mJournal.close();
+    mThrown.expect(UnavailableException.class);
+    mJournal.createJournalContext();
   }
 }


### PR DESCRIPTION
This PR fixes an issue where acked metadata changes could be lost if they happen immediately after the journal is closed. This issue was possible but extremely unlikely in previous versions. It only became a real problem after https://github.com/Alluxio/alluxio/pull/6628 merged two weeks ago.

1. RPC begins
2. Journal is closed, usually by the shutdown hook when stopping the Alluxio master, but possibly because the master loses connection to Zookeeper and steps down as primary.
3. RPC creates a journal context. The context is a NoopContext because the journal is closed.
4. RPC completes without writing a journal entry.
5. RPC is successful, but when master restarts the change is forgotten

To fix this, we should throw UnavailableException instead of returning a NoopContext when the journal is closed.

The interesting changes are in the "Fix bug where closing journal allows RPCs to skip journal write" and "Add test" commits.

  