### PR TITLE
[SMALLFIX] Metrics to track all active UFS writes

### DIFF
--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsSessionManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsSessionManager.java
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.AlluxioURI;
+import alluxio.metrics.MetricsSystem;
+
+import com.codahale.metrics.Counter;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Basic implementation of {@link UfsSessionManager}.
+ */
+@ThreadSafe
+public abstract class AbstractUfsSessionManager implements UfsSessionManager {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractUfsSessionManager.class);
+
+  private UfsManager mUfsManager;
+  private ConcurrentHashMap<Long, Counter> mUfsUriToCounter;
+
+  AbstractUfsSessionManager(UfsManager ufsManager) {
+    mUfsManager = ufsManager;
+    mUfsUriToCounter = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void openSession(long mountId) {
+    mUfsUriToCounter.compute(mountId, (k, v) -> {
+      if (v == null) {
+        try {
+          AlluxioURI key = mUfsManager.get(mountId).getUfsMountPointUri();
+          v = getWriteSessionsCounter(key);
+        } catch (Exception e) {
+          LOG.warn(e.getMessage());
+        }
+      }
+      v.inc();
+      return v;
+    });
+  }
+
+  @Override
+  public void closeSession(long mountId) {
+    mUfsUriToCounter.computeIfPresent(mountId, (k, v) -> {
+      v.dec();
+      if (v.getCount() == 0) {
+        // Remove key
+        return null;
+      }
+      return v;
+    });
+  }
+
+  /**
+   * Get the counter for tracking active writes to the ufs.
+   *
+   * @param ufsUri the ufs being written to
+   * @return the active write counter
+   */
+  private static Counter getWriteSessionsCounter(AlluxioURI ufsUri) {
+    String ufsString = MetricsSystem.escape(ufsUri);
+    String activeWriteMetricName = String.format("ActiveUfsWriteCount-Ufs:%s", ufsString);
+    return MetricsSystem.workerCounter(activeWriteMetricName);
+  }
+}

--- a/core/server/common/src/main/java/alluxio/underfs/UfsSessionManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/UfsSessionManager.java
@@ -1,0 +1,31 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+/**
+ * A class that manages the UFS sessions by different services.
+ */
+public interface UfsSessionManager {
+  /**
+   * Open a session under the given mount id.
+   *
+   * @param mountId the mount id
+   */
+  void openSession(long mountId);
+
+  /**
+   * Close a session under the given mount id.
+   *
+   * @param mountId the mount id
+   */
+  void closeSession(long mountId);
+}

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsSessionManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsSessionManager.java
@@ -1,0 +1,30 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The default implementation of UfsSessionManager to manage the ufs sessions by different worker
+ * services.
+ */
+@ThreadSafe
+public final class WorkerUfsSessionManager extends AbstractUfsSessionManager {
+  /**
+   * Constructs an instance of {@link WorkerUfsSessionManager}.
+   *
+   * @param ufsManager the worker ufs manager
+   */
+  public WorkerUfsSessionManager(UfsManager ufsManager) {
+    super(ufsManager);
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -236,10 +236,8 @@ public final class FileDataManager {
         .setMode(new Mode((short) fileInfo.getMode())));
     final WritableByteChannel outputChannel = Channels.newChannel(outputStream);
 
-    UfsManager.UfsInfo ufsInfo = mUfsManager.get(fileInfo.getMountId());
-    String ufsString = MetricsSystem.escape(ufsInfo.getUfsMountPointUri());
-    String activeWriteMetricName = String.format("ActiveUfsWriteCount-Ufs:%s", ufsString);
-    Counter activeWriteCounter = MetricsSystem.workerCounter(activeWriteMetricName);
+    Counter activeWriteCounter = UnderFileSystemUtils
+        .getActiveWriteCounter(mUfsManager.get(fileInfo.getMountId()).getUfsMountPointUri());
     activeWriteCounter.inc();
 
     List<Throwable> errors = new ArrayList<>();

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileDataManager.java
@@ -20,7 +20,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
-import alluxio.metrics.MetricsSystem;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
@@ -17,9 +17,12 @@ import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
+import alluxio.metrics.MetricsSystem;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.MkdirsOptions;
+
+import com.codahale.metrics.Counter;
 
 import java.io.IOException;
 import java.util.Stack;
@@ -75,6 +78,18 @@ public final class UnderFileSystemUtils {
         }
       }
     }
+  }
+
+  /**
+   * Get the counter for tracking active writes to the ufs.
+   *
+   * @param ufsUri the ufs being written to
+   * @return the active write counter
+   */
+  public static Counter getActiveWriteCounter(AlluxioURI ufsUri) {
+    String ufsString = MetricsSystem.escape(ufsUri);
+    String activeWriteMetricName = String.format("ActiveUfsWriteCount-Ufs:%s", ufsString);
+    return MetricsSystem.workerCounter(activeWriteMetricName);
   }
 
   private UnderFileSystemUtils() {} // prevent instantiation

--- a/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/UnderFileSystemUtils.java
@@ -17,12 +17,9 @@ import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
-import alluxio.metrics.MetricsSystem;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.MkdirsOptions;
-
-import com.codahale.metrics.Counter;
 
 import java.io.IOException;
 import java.util.Stack;
@@ -78,18 +75,6 @@ public final class UnderFileSystemUtils {
         }
       }
     }
-  }
-
-  /**
-   * Get the counter for tracking active writes to the ufs.
-   *
-   * @param ufsUri the ufs being written to
-   * @return the active write counter
-   */
-  public static Counter getActiveWriteCounter(AlluxioURI ufsUri) {
-    String ufsString = MetricsSystem.escape(ufsUri);
-    String activeWriteMetricName = String.format("ActiveUfsWriteCount-Ufs:%s", ufsString);
-    return MetricsSystem.workerCounter(activeWriteMetricName);
   }
 
   private UnderFileSystemUtils() {} // prevent instantiation

--- a/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.exception.status.AlluxioStatusException;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.proto.dataserver.Protocol;

--- a/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
@@ -90,7 +90,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
    */
   public class UfsFilePacketWriter extends PacketWriter {
     private final UfsManager mUfsManager;
-    private final UfsSessionManager mUfsWriteManager;
+    private final UfsSessionManager mUfsSessionManager;
 
     /**
      * @param context context of this packet writer
@@ -101,7 +101,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
         UfsManager ufsManager) {
       super(context, channel);
       mUfsManager = ufsManager;
-      mUfsWriteManager = new WorkerUfsSessionManager(ufsManager);
+      mUfsSessionManager = new WorkerUfsSessionManager(ufsManager);
     }
 
     @Override
@@ -116,7 +116,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
       Preconditions.checkState(context.getOutputStream() != null);
       context.getOutputStream().close();
       context.setOutputStream(null);
-      mUfsWriteManager.openSession(context.getRequest().getCreateUfsFileOptions().getMountId());
+      mUfsSessionManager.closeSession(context.getRequest().getCreateUfsFileOptions().getMountId());
     }
 
     @Override
@@ -131,7 +131,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
         context.getUnderFileSystem().deleteFile(request.getUfsPath());
         context.setOutputStream(null);
       }
-      mUfsWriteManager.closeSession(context.getRequest().getCreateUfsFileOptions().getMountId());
+      mUfsSessionManager.closeSession(context.getRequest().getCreateUfsFileOptions().getMountId());
     }
 
     @Override
@@ -166,7 +166,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
       String metricName = String.format("BytesWrittenUfs-Ufs:%s", ufsString);
       Counter counter = MetricsSystem.workerCounter(metricName);
       context.setCounter(counter);
-      mUfsWriteManager.openSession(context.getRequest().getCreateUfsFileOptions().getMountId());
+      mUfsSessionManager.openSession(context.getRequest().getCreateUfsFileOptions().getMountId());
     }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/UfsFileWriteHandler.java
@@ -20,6 +20,7 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsInfo;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
+import alluxio.worker.file.UnderFileSystemUtils;
 
 import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
@@ -107,12 +108,10 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
         Preconditions.checkNotNull(request);
         Protocol.CreateUfsFileOptions createUfsFileOptions = request.getCreateUfsFileOptions();
         try {
-          UfsInfo ufsInfo = mUfsManager.get(createUfsFileOptions.getMountId());
-          String ufsString = MetricsSystem.escape(ufsInfo.getUfsMountPointUri());
-          String activeWriteMetricName = String.format("ActiveUfsWriteCount-Ufs:%s", ufsString);
-          mActiveWriteCounter = MetricsSystem.workerCounter(activeWriteMetricName);
+          mActiveWriteCounter = UnderFileSystemUtils.getActiveWriteCounter(
+              mUfsManager.get(createUfsFileOptions.getMountId()).getUfsMountPointUri());
         } catch (Exception e) {
-          // Do nothing
+          // Do nothing; unable to find mount id
         }
       }
     }


### PR DESCRIPTION
Context: https://github.com/Alluxio/alluxio/pull/6718 introduces a new CLI to put a ufs in maintenance mode. It, however, does not interrupt any sync or async ufs write operations. The user must wait for all "active" ufs writes to finish before proceeding with maintenance ops. 

This PR introduces a metric to track all active ufs writes (sync and async) on a worker. 