### PR TITLE
[SMALLFIX] Support more MIME types when uploading objects in S3 API.

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -212,7 +212,7 @@ public final class S3RestServiceHandler {
   @PUT
   @Path(OBJECT_PARAM)
   @ReturnType("java.lang.Void")
-  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  @Consumes(MediaType.WILDCARD)
   public Response createObjectOrUploadPart(@HeaderParam("Content-MD5") final String contentMD5,
       @PathParam("bucket") final String bucket,
       @PathParam("object") final String object,


### PR DESCRIPTION
When uploading image, audio, or video, the "Content-Type" is not necessarily "application/octet-stream".