### PR TITLE
[SMALLFIX] Fix vagrant script for S3 ufs

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -71,6 +71,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               alluxio_version: alluxio_version,
               alluxio_version_lessthan_0_8: AlluxioV.v_lt_0_8,
               alluxio_version_lessthan_1_1: AlluxioV.v_lt_1_1,
+              alluxio_version_lessthan_1_2: AlluxioV.v_lt_1_2,
               alluxio_masters: AlluxioV.masters,
               alluxio_platform: alluxio_platform,
 

--- a/deploy/vagrant/conf/ufs.yml
+++ b/deploy/vagrant/conf/ufs.yml
@@ -22,7 +22,7 @@ Hadoop:
 # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html
 S3:
   # The bucket should be the name of an existing bucket (e.g. alluxiodata, not
-  # s3://alluxiodata, s3n://alluxiodata, etc.)
+  # s3://alluxiodata, s3a://alluxiodata, etc.)
   Bucket:
 
 # Doc on accessKeyID and secretAccessKey:

--- a/deploy/vagrant/core/EnvSetup.rb
+++ b/deploy/vagrant/core/EnvSetup.rb
@@ -90,9 +90,11 @@ class AlluxioVersion
     minor = Integer(minor) rescue nil
     @v_lt_0_8 = false
     @v_lt_1_1 = false
+    @v_lt_1_2 = false
     if not major.nil? and not minor.nil?
       @v_lt_0_8 = ((major == 0) and (minor < 8))
       @v_lt_1_1 = ((major < 1) or (major == 1 and minor < 1))
+      @v_lt_1_2 = ((major < 1) or (major == 1 and minor < 2))
     end
 
     @mem = @yml['WorkerMemory']
@@ -121,6 +123,9 @@ class AlluxioVersion
 
   def v_lt_1_1
     return @v_lt_1_1
+  end
+  def v_lt_1_2
+    return @v_lt_1_2
   end
 end
 

--- a/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
+++ b/deploy/vagrant/provision/roles/alluxio/tasks/config.yml
@@ -16,6 +16,7 @@
   script: roles/ufs_{{ ufs }}/files/config_alluxio.sh
   environment:
     ALLUXIO_VERSION_LESSTHAN_1_1: "{{ alluxio_version_lessthan_1_1 }}"
+    ALLUXIO_VERSION_LESSTHAN_1_2: "{{ alluxio_version_lessthan_1_2 }}"
     S3_BUCKET: "{{ s3_bucket }}"
     S3_ID: "{{ s3_id }}"
     S3_KEY: "{{ s3_key }}"

--- a/deploy/vagrant/provision/roles/ufs_s3/files/config_alluxio.sh
+++ b/deploy/vagrant/provision/roles/ufs_s3/files/config_alluxio.sh
@@ -10,7 +10,8 @@ export ALLUXIO_JAVA_OPTS+="
 "
 EOF
 else
-  cat >> /alluxio/conf/alluxio-env.sh << EOF
+  if [[ ${ALLUXIO_VERSION_LESSTHAN_1_2} == true ]]; then
+    cat >> /alluxio/conf/alluxio-env.sh << EOF
 ALLUXIO_UNDERFS_ADDRESS="s3n://${S3_BUCKET}"
 
 ALLUXIO_JAVA_OPTS+="
@@ -18,6 +19,11 @@ ALLUXIO_JAVA_OPTS+="
   -Dfs.s3n.awsAccessKeyId=${S3_ID}
 "
 EOF
+  else
+    echo "alluxio.underfs.address=s3a://${S3_BUCKET}" >> /alluxio/conf/alluxio-site.properties
+    echo "aws.accessKeyId=${S3_ID}" >> /alluxio/conf/alluxio-site.properties
+    echo "aws.secretKey=${S3_KEY}" >> /alluxio/conf/alluxio-site.properties
+  fi
 fi
 
 # For Alluxio version earlier than 0.8, remove schema "s3n" from default prefixes to be handled by HdfsUnderFileSystem.


### PR DESCRIPTION
Updated vagrant script to use s3a protocol for S3 ufs now that we no longer support s3n.