### PR TITLE
[SMALLFIX] Add warnings to validateEnv command

### DIFF
--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -274,7 +274,7 @@ public final class ValidateEnv {
       System.err.format("%d warnings ", results.get(ValidationTask.TaskResult.WARNING));
     }
     if (results.containsKey(ValidationTask.TaskResult.SKIPPED)) {
-      System.err.format("%d skipped ", results.get(ValidationTask.TaskResult.WARNING));
+      System.err.format("%d skipped ", results.get(ValidationTask.TaskResult.SKIPPED));
     }
     System.err.println();
     if (validationCount == 0) {

--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -267,13 +267,13 @@ public final class ValidateEnv {
       System.out.println(Constants.ANSI_RESET);
       validationCount++;
     }
-    if (results.get(ValidationTask.TaskResult.FAILED) != null) {
+    if (results.containsKey(ValidationTask.TaskResult.FAILED)) {
       System.err.format("%d failures ", results.get(ValidationTask.TaskResult.FAILED));
     }
-    if (results.get(ValidationTask.TaskResult.WARNING) != null) {
+    if (results.containsKey(ValidationTask.TaskResult.WARNING)) {
       System.err.format("%d warnings ", results.get(ValidationTask.TaskResult.WARNING));
     }
-    if (results.get(ValidationTask.TaskResult.SKIPPED) != null) {
+    if (results.containsKey(ValidationTask.TaskResult.SKIPPED)) {
       System.err.format("%d skipped ", results.get(ValidationTask.TaskResult.WARNING));
     }
     System.err.println();

--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -12,6 +12,7 @@
 package alluxio.cli;
 
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.cli.validation.HdfsValidationTask;
 import alluxio.cli.validation.PortAvailabilityValidationTask;
@@ -232,7 +233,7 @@ public final class ValidateEnv {
   private static boolean validateLocal(String target, String name, CommandLine cmd)
       throws InterruptedException {
     int validationCount = 0;
-    int failureCount = 0;
+    Map<ValidationTask.TaskResult, Integer> results = new HashMap<>();
     Map<String, String> optionsMap = new HashMap<>();
     for (Option opt : cmd.getOptions()) {
       optionsMap.put(opt.getOpt(), opt.getValue());
@@ -244,23 +245,43 @@ public final class ValidateEnv {
         continue;
       }
       System.out.format("Validating %s...%n", taskName);
-      if (task.shouldSkip()) {
-        continue;
+      ValidationTask.TaskResult result = task.validate(optionsMap);
+      results.put(result, results.getOrDefault(result, 0) + 1);
+      switch (result) {
+        case OK:
+          System.out.print(Constants.ANSI_GREEN);
+          break;
+        case WARNING:
+          System.out.print(Constants.ANSI_YELLOW);
+          break;
+        case FAILED:
+          System.out.print(Constants.ANSI_RED);
+          break;
+        case SKIPPED:
+          System.out.print(Constants.ANSI_PURPLE);
+          break;
+        default:
+          break;
       }
-      if (task.validate(optionsMap)) {
-        System.out.println("OK");
-      } else {
-        System.err.println("Failed");
-        failureCount++;
-      }
+      System.out.print(result.name());
+      System.out.println(Constants.ANSI_RESET);
       validationCount++;
     }
-    if (failureCount > 0) {
-      System.err.format("Validation failed. Total failures: %d.%n", failureCount);
-      return false;
+    if (results.get(ValidationTask.TaskResult.FAILED) != null) {
+      System.err.format("%d failures ", results.get(ValidationTask.TaskResult.FAILED));
     }
+    if (results.get(ValidationTask.TaskResult.WARNING) != null) {
+      System.err.format("%d warnings ", results.get(ValidationTask.TaskResult.WARNING));
+    }
+    if (results.get(ValidationTask.TaskResult.SKIPPED) != null) {
+      System.err.format("%d skipped ", results.get(ValidationTask.TaskResult.WARNING));
+    }
+    System.err.println();
     if (validationCount == 0) {
       System.err.format("No validation task matched name \"%s\".%n", name);
+      return false;
+    }
+    if (results.containsKey(ValidationTask.TaskResult.FAILED)) {
       return false;
     }
     System.out.println("Validation succeeded.");

--- a/core/server/common/src/main/java/alluxio/cli/validation/AbstractValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/AbstractValidationTask.java
@@ -24,9 +24,4 @@ public abstract class AbstractValidationTask implements ValidationTask {
   public List<Option> getOptionList() {
     return new ArrayList<>();
   }
-
-  @Override
-  public boolean shouldSkip() {
-    return false;
-  }
 }

--- a/core/server/common/src/main/java/alluxio/cli/validation/HdfsValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/HdfsValidationTask.java
@@ -47,15 +47,17 @@ public class HdfsValidationTask extends AbstractValidationTask {
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
-    if (!validateHdfsSettingParity(optionsMap)) {
-      return false;
+  public TaskResult validate(Map<String, String> optionsMap) {
+    if (shouldSkip()) {
+      return TaskResult.SKIPPED;
     }
-    return true;
+    if (!validateHdfsSettingParity(optionsMap)) {
+      return TaskResult.FAILED;
+    }
+    return TaskResult.OK;
   }
 
-  @Override
-  public boolean shouldSkip() {
+  protected boolean shouldSkip() {
     String scheme =
         new AlluxioURI(Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS)).getScheme();
     if (scheme == null || !scheme.startsWith("hdfs")) {

--- a/core/server/common/src/main/java/alluxio/cli/validation/PortAvailabilityValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/PortAvailabilityValidationTask.java
@@ -37,17 +37,17 @@ public final class PortAvailabilityValidationTask extends AbstractValidationTask
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
+  public TaskResult validate(Map<String, String> optionsMap) {
     if (Utils.isAlluxioRunning(mOwner)) {
       System.out.format("%s is already running. Skip validation.%n", mOwner);
-      return true;
+      return TaskResult.SKIPPED;
     }
     int port = NetworkAddressUtils.getPort(mServiceType);
     if (!isLocalPortAvailable(port)) {
       System.err.format("%s port %d is not available.%n", mServiceType.getServiceName(), port);
-      return false;
+      return TaskResult.FAILED;
     }
-    return true;
+    return TaskResult.OK;
   }
 
   private static boolean isLocalPortAvailable(int port) {

--- a/core/server/common/src/main/java/alluxio/cli/validation/SecureHdfsValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/SecureHdfsValidationTask.java
@@ -61,18 +61,21 @@ public final class SecureHdfsValidationTask extends HdfsValidationTask {
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
-    if (!super.validate(optionsMap)) {
-      return false;
+  public TaskResult validate(Map<String, String> optionsMap) {
+    if (shouldSkip()) {
+      return TaskResult.SKIPPED;
+    }
+    if (super.validate(optionsMap) == TaskResult.FAILED) {
+      return TaskResult.FAILED;
     }
     if (!validatePrincipalLogin()) {
-      return false;
+      return TaskResult.FAILED;
     }
-    return true;
+    return TaskResult.OK;
   }
 
   @Override
-  public boolean shouldSkip() {
+  protected boolean shouldSkip() {
     if (super.shouldSkip()) {
       return true;
     }

--- a/core/server/common/src/main/java/alluxio/cli/validation/SshValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/SshValidationTask.java
@@ -30,10 +30,10 @@ public final class SshValidationTask extends AbstractValidationTask {
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
+  public TaskResult validate(Map<String, String> optionsMap) {
     List<String> nodes = Utils.readNodeList(mFileName);
     if (nodes == null) {
-      return false;
+      return TaskResult.FAILED;
     }
 
     boolean hasUnreachableNodes = false;
@@ -43,6 +43,6 @@ public final class SshValidationTask extends AbstractValidationTask {
         hasUnreachableNodes = true;
       }
     }
-    return !hasUnreachableNodes;
+    return hasUnreachableNodes ? TaskResult.WARNING : TaskResult.OK;
   }
 }

--- a/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/StorageSpaceValidationTask.java
@@ -38,7 +38,7 @@ public final class StorageSpaceValidationTask extends AbstractValidationTask {
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
+  public TaskResult validate(Map<String, String> optionsMap) {
     int numLevel = Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
     boolean success = true;
 
@@ -56,7 +56,7 @@ public final class StorageSpaceValidationTask extends AbstractValidationTask {
       String rawDirQuota = Configuration.get(tierDirCapacityConf);
       if (rawDirQuota.isEmpty()) {
         System.err.format("Tier %d: Quota cannot be empty.%n", level);
-        return false;
+        return TaskResult.FAILED;
       }
 
       String[] dirQuotas = rawDirQuota.split(",");
@@ -118,7 +118,7 @@ public final class StorageSpaceValidationTask extends AbstractValidationTask {
       }
     }
 
-    return success;
+    return success ? TaskResult.OK : TaskResult.WARNING;
   }
 
   private boolean addDirectoryInfo(String path, long quota, Map<String, MountedStorage> storageMap)

--- a/core/server/common/src/main/java/alluxio/cli/validation/UfsDirectoryValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UfsDirectoryValidationTask.java
@@ -36,19 +36,19 @@ public final class UfsDirectoryValidationTask extends AbstractValidationTask {
   }
 
   @Override
-  public boolean validate(Map<String, String> optionsMap) {
+  public TaskResult validate(Map<String, String> optionsMap) {
     try {
       UfsStatus[] listStatus = mUfs.listStatus(mPath);
       if (listStatus == null) {
         System.err.format("Unable to list under file system path %s.%n", mPath);
-        return false;
+        return TaskResult.FAILED;
       }
 
-      return true;
+      return TaskResult.OK;
     } catch (IOException e) {
       System.err.format("Unable to access under file system path %s: %s.%n", mPath,
           e.getMessage());
-      return false;
+      return TaskResult.FAILED;
     }
   }
 }

--- a/core/server/common/src/main/java/alluxio/cli/validation/ValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/ValidationTask.java
@@ -26,17 +26,20 @@ public interface ValidationTask {
   List<Option> getOptionList();
 
   /**
-   * Checks whether the validation task is applicable.
-   *
-   * @return true if this validation task should be skipped, false otherwise
-   */
-  boolean shouldSkip();
-
-  /**
    * Runs the validation task.
    *
    * @param optionMap contains string representation of <key, value> pairs
-   * @return whether the validation succeeds
+   * @return the result of validation task
    */
-  boolean validate(Map<String, String> optionMap) throws InterruptedException;
+  TaskResult validate(Map<String, String> optionMap) throws InterruptedException;
+
+  /**
+   * Result of a validation task.
+   */
+  enum TaskResult {
+    OK,
+    WARNING,
+    FAILED,
+    SKIPPED
+  }
 }


### PR DESCRIPTION
Some validateEnv tasks report problems that are not fatal. This change adds a new return type for validation tasks to indicate task result to be one of the 4 options: ok, warning, failed and skipped.

Bonus: the task results now have colors!