### PR TITLE
[SMALLFIX] Increase timeout for UfsInputStreamManagerTest.testConcurrency

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -129,9 +129,9 @@ public final class UfsInputStreamManagerTest {
       mManager = new UfsInputStreamManager();
       List<Thread> threads = new ArrayList<>();
       int numCheckOutPerThread = 10;
-      for (int i = 0; i < mNumOfInputStreams / 2; i ++) {
+      for (int i = 0; i < mNumOfInputStreams / 2; i++) {
         Runnable runnable = () -> {
-          for (int j = 0; j < numCheckOutPerThread; j ++) {
+          for (int j = 0; j < numCheckOutPerThread; j++) {
             InputStream instream;
             try {
               instream =

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -120,30 +120,37 @@ public final class UfsInputStreamManagerTest {
    */
   @Test
   public void testConcurrency() throws Exception {
-    mManager = new UfsInputStreamManager();
-    List<Thread> threads = new ArrayList<>();
-    int numCheckOutPerThread = 10;
-    for (int i = 0; i < mNumOfInputStreams / 2; i++) {
-      Runnable runnable = () -> {
-        for (int j = 0; j < numCheckOutPerThread; j++) {
-          InputStream instream;
-          try {
-            instream =
-                mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
-            Thread.sleep(10);
-            mManager.release(instream);
-          } catch (Exception e) {
-            // the input streams created should not be more than mNumOfInputStreams
-            Assert.fail("input stream check in and out failed." + e);
+    try (Closeable r = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        // use very large number
+        put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "200000");
+      }
+    }).toResource()) {
+      mManager = new UfsInputStreamManager();
+      List<Thread> threads = new ArrayList<>();
+      int numCheckOutPerThread = 10;
+      for (int i = 0; i < mNumOfInputStreams / 2; i ++) {
+        Runnable runnable = () -> {
+          for (int j = 0; j < numCheckOutPerThread; j ++) {
+            InputStream instream;
+            try {
+              instream =
+                  mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
+              Thread.sleep(10);
+              mManager.release(instream);
+            } catch (Exception e) {
+              // the input streams created should not be more than mNumOfInputStreams
+              Assert.fail("input stream check in and out failed." + e);
+            }
           }
-        }
-      };
-      threads.add(new Thread(runnable));
+        };
+        threads.add(new Thread(runnable));
+      }
+      ConcurrencyUtils.assertConcurrent(threads, 30);
+      // Each subsequent check out per thread should be a seek operation
+      Mockito.verify(mSeekableInStreams[0], Mockito.times(numCheckOutPerThread - 1))
+          .seek(Mockito.anyLong());
     }
-    ConcurrencyUtils.assertConcurrent(threads, 30);
-    // Each subsequent check out per thread should be a seek operation
-    Mockito.verify(mSeekableInStreams[0], Mockito.times(numCheckOutPerThread - 1))
-        .seek(Mockito.anyLong());
   }
 
   /**


### PR DESCRIPTION
In case the test runs too slowly.