### PR TITLE
[SMALLFIX] Add logging message on Client creation to debug-log conf properties and their sources

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Basic file system interface supporting metadata operations and data operations. Developers
@@ -59,6 +60,7 @@ public interface FileSystem {
    */
   class Factory {
     private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
+    private static final AtomicBoolean CONF_LOGGED = new AtomicBoolean(false);
 
     private Factory() {} // prevent instantiation
 
@@ -67,8 +69,9 @@ public interface FileSystem {
     }
 
     public static FileSystem get(FileSystemContext context) {
-      if (LOG.isDebugEnabled()) {
-        TreeMap<String, String> keyValueSet = new TreeMap<>(Configuration.toMap());
+      if (LOG.isDebugEnabled() && !CONF_LOGGED.getAndSet(true)) {
+        // Store properties in tree map to keep output ordered
+        Map<String, String> keyValueSet = new TreeMap<>(Configuration.toMap());
         for (Map.Entry<String, String> entry : keyValueSet.entrySet()) {
           String key = entry.getKey();
           String value = entry.getValue();

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -37,9 +37,13 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.wire.MountPointInfo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Basic file system interface supporting metadata operations and data operations. Developers
@@ -54,17 +58,29 @@ public interface FileSystem {
    * Factory for {@link FileSystem}.
    */
   class Factory {
+    private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
 
     private Factory() {} // prevent instantiation
 
     public static FileSystem get() {
-      if (Configuration.getBoolean(PropertyKey.USER_LINEAGE_ENABLED)) {
-        return LineageFileSystem.get(FileSystemContext.INSTANCE, LineageContext.INSTANCE);
-      }
-      return BaseFileSystem.get(FileSystemContext.INSTANCE);
+      return get(FileSystemContext.INSTANCE);
     }
 
     public static FileSystem get(FileSystemContext context) {
+      if (LOG.isDebugEnabled()) {
+        TreeMap<String, String> keyValueSet = new TreeMap<>(Configuration.toMap());
+        for (Map.Entry<String, String> entry : keyValueSet.entrySet()) {
+          String key = entry.getKey();
+          String value = entry.getValue();
+          Configuration.Source source = Configuration.getSource(PropertyKey.fromString(key));
+          if (source == Configuration.Source.SITE_PROPERTY) {
+            LOG.debug("{}={} ({}: {})",
+                key, value, source.name(), Configuration.getSitePropertiesFile());
+          } else {
+            LOG.debug("{}={} ({})", key, value, source.name());
+          }
+        }
+      }
       if (Configuration.getBoolean(PropertyKey.USER_LINEAGE_ENABLED)) {
         return LineageFileSystem.get(context, LineageContext.INSTANCE);
       }


### PR DESCRIPTION
example output for user log:

```
2018-01-11 16:19:01,229 DEBUG NetworkAddressUtils - address: localhost/127.0.0.1 isLoopbackAddress: true, with host 127.0.0.1 localhost
2018-01-11 16:19:01,247 DEBUG FileSystem$Factory - alluxio.conf.dir=/Users/binfan/Dropbox/Work/alluxio/alluxio/conf (SYSTEM_PROPERTY)
2018-01-11 16:19:01,247 DEBUG FileSystem$Factory - alluxio.debug=true (SITE_PROPERTY: /Users/binfan/Dropbox/Work/alluxio/alluxio/conf/alluxio-site.properties)
2018-01-11 16:19:01,247 DEBUG FileSystem$Factory - alluxio.extensions.dir=${alluxio.home}/extensions (DEFAULT)
2018-01-11 16:19:01,247 DEBUG FileSystem$Factory - alluxio.fuse.cached.paths.max=500 (DEFAULT)
2018-01-11 16:19:01,247 DEBUG FileSystem$Factory - alluxio.fuse.debug.enabled=false (DEFAULT)
```