### PR TITLE
[SMALLFIX] Update alluxio-start.sh,define ACTION before get_env

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -251,12 +251,6 @@ run_safe() {
 }
 
 main() {
-  # get environment
-  get_env
-
-  # ensure log/data dirs
-  ensure_dirs
-
   while getopts "hNw" o; do
     case "${o}" in
       h)
@@ -285,6 +279,11 @@ main() {
     exit 1
   fi
   shift
+  
+  # get environment
+  get_env
+  # ensure log/data dirs
+  ensure_dirs
 
   MOPT=$1
   # Set MOPT.


### PR DESCRIPTION
as a result that we can  get the value of ACTION in alluxio-env.sh, and make it easier to configure ALLUXIO_MASTER_HOSTNAME in this way:
```
if [[ $ACTION = master ]]; then
    ALLUXIO_MASTER_HOSTNAME=$(hostname)
fi
```