### PR TITLE
[DOCFIX] Upgrade docker integration example to 1.7.0

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM openjdk:8-jdk-alpine
 
-ARG ALLUXIO_TARBALL=http://downloads.alluxio.org/downloads/files/1.6.1/alluxio-1.6.1-bin.tar.gz
+ARG ALLUXIO_TARBALL=http://downloads.alluxio.org/downloads/files/1.7.0/alluxio-1.7.0-bin.tar.gz
 
 RUN apk add --update bash && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Now that 1.7.0 is our the Dockerfile can be updated to get the latest release.