### PR TITLE
[SMALLFIX] Create test failure artifact in-place

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -235,13 +235,12 @@ public final class MultiProcessCluster implements TestRule {
     Preconditions.checkState(mState == State.STARTED,
         "cluster must be started before you can save its work directory");
     ARTIFACTS_DIR.mkdirs();
-    File targetDir = new File(".", mWorkDir.getName());
-    File tarball = new File(targetDir.getPath() + ".tar.gz");
-    // Copy the work directory to "."
-    FileUtils.copyDirectory(mWorkDir, targetDir);
+
+    File tarball = new File(mWorkDir.getParentFile(), mWorkDir.getName() + ".tar.gz");
     // Tar up the work directory.
     ProcessBuilder pb =
-        new ProcessBuilder("tar", "-czf", tarball.getPath(), targetDir.getPath());
+        new ProcessBuilder("tar", "-czf", tarball.getName(), mWorkDir.getName());
+    pb.directory(mWorkDir.getParentFile());
     pb.redirectOutput(TESTS_LOG);
     pb.redirectError(TESTS_LOG);
     Process p = pb.start();
@@ -251,8 +250,6 @@ public final class MultiProcessCluster implements TestRule {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
-    // Delete copied work directory.
-    FileUtils.deleteDirectory(targetDir);
     // Move tarball to artifacts directory.
     File finalTarball = new File(ARTIFACTS_DIR, tarball.getName());
     FileUtils.moveFile(tarball, finalTarball);


### PR DESCRIPTION
Instead of copying the work directory to "."
to tar it up, we now change the tar command's
working directory to the parent of the work
directory. This saves a directory copy and
avoids polluting the java working directory.

It is important to not pollute the java working
directory because if the files there are not
cleaned up, the license check will fail on them.
This has been causing PR build failures in 
https://github.com/Alluxio/alluxio/pull/6795