### PR TITLE
[SMALLFIX] Fix log message

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -532,8 +532,8 @@ public final class Configuration {
     long waitTime = getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
     long retryInterval = getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
     if (waitTime < retryInterval) {
-      LOG.warn("%s=%dms is smaller than %s=%dms. Workers might not have enough time to register. "
-          + "Consider either increasing %s or decreasing %s",
+      LOG.warn("{}={}ms is smaller than {}={}ms. Workers might not have enough time to register. "
+          + "Consider either increasing {} or decreasing {}",
           PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME, waitTime,
           PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS, retryInterval,
           PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME,


### PR DESCRIPTION
This changes the message from

"%s=%dms is smaller than %s=%dms. Workers might not have enough time to register. Consider either increasing %s or decreasing %s"

to something like

"alluxio.master.worker.connect.wait.time=0ms is smaller than alluxio.user.rpc.retry.max.sleep=500ms. Workers might not have enough time to register. Consider either increasing alluxio.master.worker.connect.wait.time or decreasing alluxio.user.rpc.retry.max.sleep"