### PR TITLE
[DOCFIX] update docs/en/Running-Spark-on-Alluxio.md

### DIFF
--- a/docs/en/Running-Spark-on-Alluxio.md
+++ b/docs/en/Running-Spark-on-Alluxio.md
@@ -31,7 +31,11 @@ Alluxio works together with Spark 1.1 or later out-of-the-box.
   by following Follow the instructs [here](Building-Alluxio-Master-Branch.html#compute-framework-support).
   The Alluxio client jar can be found at `{{site.ALLUXIO_CLIENT_JAR_PATH}}`.
 
-* Add the following line to `spark/conf/spark-defaults.conf`.
+* In order for Spark applications to read and write files in Alluxio, the Alluxio client jar must be distributed 
+  on the classpath of the application across different nodes 
+  (each node must have the client jar on the same local path {{site.ALLUXIO_CLIENT_JAR_PATH}}). 
+  
+* Add the following line to `spark/conf/spark-defaults.conf`.  
 
 ```bash
 spark.driver.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH}}


### PR DESCRIPTION
I tested the Running spark cluster on Alluxio, but the spark job did not work.
I found the reason is I only place the client jar in Spark master, but do not put them in Spark slaves so that Spark executors cannot find local Alluxio client jar.