### PR TITLE
[SMALLFIX] Improve test logging

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/Master.java
+++ b/minicluster/src/main/java/alluxio/multi/process/Master.java
@@ -14,6 +14,8 @@ package alluxio.multi.process;
 import alluxio.PropertyKey;
 
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
@@ -27,6 +29,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class Master implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(Master.class);
+
   private final File mLogsDir;
   private final Map<PropertyKey, String> mProperties;
 
@@ -46,6 +50,7 @@ public final class Master implements Closeable {
    */
   public synchronized void start() throws IOException {
     Preconditions.checkState(mProcess == null, "Master is already running");
+    LOG.info("Starting master with port {}", mProperties.get(PropertyKey.MASTER_RPC_PORT));
     mProcess = new ExternalProcess(mProperties, LimitedLifeMasterProcess.class,
         new File(mLogsDir, "master.out"));
     mProcess.start();

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -48,6 +48,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.ProcessBuilder.Redirect;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -126,6 +127,7 @@ public final class MultiProcessCluster implements TestRule {
     mState = State.STARTED;
 
     mMasterAddresses = generateMasterAddresses(mNumMasters);
+    LOG.info("Master addresses: {}", mMasterAddresses);
     switch (mDeployMode) {
       case NON_HA:
         MasterNetAddress masterAddress = mMasterAddresses.get(0);
@@ -241,8 +243,8 @@ public final class MultiProcessCluster implements TestRule {
     ProcessBuilder pb =
         new ProcessBuilder("tar", "-czf", tarball.getName(), mWorkDir.getName());
     pb.directory(mWorkDir.getParentFile());
-    pb.redirectOutput(TESTS_LOG);
-    pb.redirectError(TESTS_LOG);
+    pb.redirectOutput(Redirect.appendTo(TESTS_LOG));
+    pb.redirectError(Redirect.appendTo(TESTS_LOG));
     Process p = pb.start();
     try {
       p.waitFor();

--- a/tests/src/test/java/alluxio/BaseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/BaseIntegrationTest.java
@@ -12,6 +12,8 @@
 package alluxio;
 
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
 import org.junit.runner.Description;
@@ -21,41 +23,65 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Base class used for specifying the maximum time a test should run for.
  */
 public abstract class BaseIntegrationTest {
-
   @Rule
-  public Timeout mGlobalTimeout = Timeout.millis(Constants.MAX_TEST_DURATION_MS);
+  public RuleChain mRules = createRuleChain();
 
-  @Rule
-  public TestWatcher mWatcher = new TestWatcher() {
-    // When tests fail, save the logs.
-    protected void failed(Throwable t, Description description) {
-      try {
-        Files.copy(Paths.get(Constants.TESTS_LOG),
-            Paths.get(Constants.TEST_LOG_DIR, String.format("%s-%s.log",
-                description.getClassName(), description.getMethodName())),
-            StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        if (t != null) {
-          t.addSuppressed(e);
-        } else {
+  private RuleChain createRuleChain() {
+    RuleChain chain = RuleChain.emptyRuleChain();
+    chain = chain.around(logHandler());
+    for (TestRule rule : rules()) {
+      chain = chain.around(rule);
+    }
+    // Make Timeout the innermost rule so that other rules run in the main thread. Everything inside
+    // Timeout is executed in a new thread.
+    chain = chain.around(Timeout.millis(Constants.MAX_TEST_DURATION_MS));
+    return chain;
+  }
+
+  private TestWatcher logHandler() {
+    return new TestWatcher() {
+      // When tests fail, save the logs.
+      protected void failed(Throwable t, Description description) {
+        try {
+          Files.copy(Paths.get(Constants.TESTS_LOG),
+              Paths.get(Constants.TEST_LOG_DIR, String.format("%s-%s.log",
+                  description.getClassName(), description.getMethodName())),
+              StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+          if (t != null) {
+            t.addSuppressed(e);
+          } else {
+            throw new RuntimeException(e);
+          }
+        }
+        return;
+      }
+
+      // Before each test starts, truncate the log file.
+      protected void starting(Description description) {
+        try {
+          new FileWriter(Constants.TESTS_LOG).close();
+        } catch (IOException e) {
           throw new RuntimeException(e);
         }
       }
-      return;
-    }
+    };
+  }
 
-    // Before each test starts, truncate the log file.
-    protected void starting(Description description) {
-      try {
-        new FileWriter(Constants.TESTS_LOG).close();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  };
+  /**
+   * Subclasses should define their rules in this method so that they can be deterministically
+   * ordered and properly nested relative to the global logging and timeout rules.
+   *
+   * @return the list of rules used by the subclass
+   */
+  protected List<TestRule> rules() {
+    return Collections.EMPTY_LIST;
+  }
 }

--- a/tests/src/test/java/alluxio/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/LocalAlluxioClusterResource.java
@@ -139,28 +139,28 @@ public final class LocalAlluxioClusterResource implements TestRule {
 
   @Override
   public Statement apply(final Statement statement, Description description) {
-    try {
-      boolean startCluster = mStartCluster;
-      Annotation configAnnotation = description.getAnnotation(Config.class);
-      if (configAnnotation != null) {
-        Config config = (Config) configAnnotation;
-        // Override the configuration parameters with any configuration params
-        for (int i = 0; i < config.confParams().length; i += 2) {
-          mConfiguration.put(PropertyKey.fromString(config.confParams()[i]),
-              config.confParams()[i + 1]);
-        }
-        // Override startCluster
-        startCluster = config.startCluster();
-      }
-      if (startCluster) {
-        start();
-      }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
+        try {
+          boolean startCluster = mStartCluster;
+          Annotation configAnnotation = description.getAnnotation(Config.class);
+          if (configAnnotation != null) {
+            Config config = (Config) configAnnotation;
+            // Override the configuration parameters with any configuration params
+            for (int i = 0; i < config.confParams().length; i += 2) {
+              mConfiguration.put(PropertyKey.fromString(config.confParams()[i]),
+                  config.confParams()[i + 1]);
+            }
+            // Override startCluster
+            startCluster = config.startCluster();
+          }
+          if (startCluster) {
+            start();
+          }
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
         try {
           statement.evaluate();
         } finally {


### PR DESCRIPTION
This PR uses a RuleChain to enforce an order on rules, allowing us to put a log handling rule at the outermost level and have it capture logs generated by other rules like LocalAlluxioClusterResource.

@calvinjia @apc999 PTAL. If you're on board with the idea, I'll update all integration tests to pass their rules through the `rules()` method