### PR TITLE
[ALLUXIO-3099] Avoid spurious log messages from PrimarySelectorClient

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
@@ -191,7 +191,7 @@ public final class PrimarySelectorClient
         mStateLock.unlock();
       }
     } catch (InterruptedException e) {
-      LOG.error(mName + " was interrupted.", e);
+      LOG.info("{} was interrupted.", mName);
       Thread.currentThread().interrupt();
     } finally {
       LOG.warn("{} relinquishing leadership.", mName);

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
@@ -190,9 +190,6 @@ public final class PrimarySelectorClient
       } finally {
         mStateLock.unlock();
       }
-    } catch (InterruptedException e) {
-      LOG.info("{} was interrupted.", mName);
-      Thread.currentThread().interrupt();
     } finally {
       LOG.warn("{} relinquishing leadership.", mName);
       LOG.info("The current leader is {}", mLeaderSelector.getLeader().getId());


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3099

Otherwise the message gets logged at error level when
we stop the server normally with alluxio-stop.sh