### PR TITLE
[SMALLFIX] Improve handling for the serving thread hanging

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -759,6 +759,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(19998)
           .setDescription("The port that Alluxio master node runs on.")
           .build();
+  public static final PropertyKey MASTER_SERVING_THREAD_TIMEOUT =
+      new Builder(Name.MASTER_SERVING_THREAD_TIMEOUT)
+          .setDefaultValue("5m")
+          .setDescription("When stepping down from being the primary, the master will wait this "
+              + "long for the thrift serving thread to stop before giving up and shutting down "
+              + "the server")
+          .setIsHidden(true)
+          .build();
   public static final PropertyKey MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
       new Builder(Name.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)
           .setDefaultValue(true)
@@ -2222,6 +2230,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_PRINCIPAL = "alluxio.master.principal";
     public static final String MASTER_RETRY = "alluxio.master.retry";
     public static final String MASTER_RPC_PORT = "alluxio.master.port";
+    public static final String MASTER_SERVING_THREAD_TIMEOUT =
+        "alluxio.master.serving.thread.timeout";
     public static final String MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
         "alluxio.master.startup.consistency.check.enabled";
     public static final String MASTER_THRIFT_SHUTDOWN_TIMEOUT =

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -1,0 +1,34 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Utility method for working with threads.
+ */
+public final class ThreadUtils {
+  /**
+   * @param thread a thread
+   * @return a human-readable representation of the thread's stack trace.
+   */
+  public static String formatStackTrace(Thread thread) {
+    Throwable t = new Throwable(String.format("Stack trace for thread %s:", thread.getName()));
+    t.setStackTrace(thread.getStackTrace());
+    StringWriter sw = new StringWriter();
+    t.printStackTrace(new PrintWriter(sw));
+    return sw.toString();
+  }
+
+  private ThreadUtils() {} // prevent instantiation of utils class
+}

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -20,7 +20,7 @@ import java.io.StringWriter;
 public final class ThreadUtils {
   /**
    * @param thread a thread
-   * @return a human-readable representation of the thread's stack trace.
+   * @return a human-readable representation of the thread's stack trace
    */
   public static String formatStackTrace(Thread thread) {
     Throwable t = new Throwable(String.format("Stack trace for thread %s:", thread.getName()));


### PR DESCRIPTION
The serving thread is supposed to be responsive to interrupts such that this will never happen, but in case the thread doesn't die after 5 minutes, we should stop the process and log the stack of the serving thread.

The PropertyKey is added with `isHidden=true` since users should never need to see this configuration, but it could be useful for developer debugging purposes, or to avoid the `System.exit` in case it causes issues.