### PR TITLE
[ALLUXIO-3105] Update evictor to take a best-effort mode to evict blocks

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -313,10 +313,11 @@ public interface BlockStore extends SessionCleanable {
    *
    * @param sessionId the session id
    */
+  @Override
   void cleanupSession(long sessionId);
 
   /**
-   * Frees space to make a specific amount of bytes available in the location.
+   * Frees space to make a specific amount of bytes available in a best-effort way in the location.
    *
    * @param sessionId the session id
    * @param availableBytes the amount of free space in bytes

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -120,7 +120,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
 
   /**
-   * Frees space to make a specific amount of bytes available in the tier.
+   * Frees space to make a specific amount of bytes available in a best-effort way in the tier.
    *
    * @param sessionId the session id
    * @param availableBytes the amount of free space in bytes

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -120,7 +120,9 @@ public interface BlockWorker extends Worker, SessionCleanable {
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
 
   /**
-   * Frees space to make a specific amount of bytes available in a best-effort way in the tier.
+   * Frees space to make a specific amount of bytes available in a best-effort way in the tier. The
+   * implementation should try to free at least 1 byte from the worker, otherwise a
+   * {@link WorkerOutOfSpaceException} should be thrown if no space is available.
    *
    * @param sessionId the session id
    * @param availableBytes the amount of free space in bytes

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -237,7 +237,7 @@ public class TieredBlockStore implements BlockStore {
         // Failed to create a temp block, so trigger Evictor to make some space.
         // NOTE: a successful {@link freeSpaceInternal} here does not ensure the subsequent
         // allocation also successful, because these two operations are not atomic.
-        freeSpaceInternal(sessionId, initialBlockSize, location, Mode.GUUARANTEED);
+        freeSpaceInternal(sessionId, initialBlockSize, location, Mode.GUARANTEED);
       }
       // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
       // other types of exception to indicate this case.
@@ -318,7 +318,7 @@ public class TieredBlockStore implements BlockStore {
         // Failed to create a temp block, so trigger Evictor to make some space.
         // NOTE: a successful {@link freeSpaceInternal} here does not ensure the subsequent
         // allocation also successful, because these two operations are not atomic.
-        freeSpaceInternal(sessionId, additionalBytes, requestResult.getSecond(), Mode.GUUARANTEED);
+        freeSpaceInternal(sessionId, additionalBytes, requestResult.getSecond(), Mode.GUARANTEED);
       }
       // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
       // other types of exception to indicate this case.
@@ -372,7 +372,7 @@ public class TieredBlockStore implements BlockStore {
         // Failed to create a temp block, so trigger Evictor to make some space.
         // NOTE: a successful {@link freeSpaceInternal} here does not ensure the subsequent
         // allocation also successful, because these two operations are not atomic.
-        freeSpaceInternal(sessionId, result.getBlockSize(), newLocation, Mode.GUUARANTEED);
+        freeSpaceInternal(sessionId, result.getBlockSize(), newLocation, Mode.GUARANTEED);
       }
       // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
       // other types of exception to indicate this case.

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -108,7 +108,7 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
     }
 
     // 3. If there is no eligible StorageDirView, return null
-    if (mode == Mode.GUUARANTEED && dirCandidates.candidateSize() < bytesToBeAvailable) {
+    if (mode == Mode.GUARANTEED && dirCandidates.candidateSize() < bytesToBeAvailable) {
       return null;
     }
 
@@ -116,6 +116,9 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
     // there. If allocation fails, the next tier will continue to evict its blocks to free space.
     // Blocks are only evicted from the last tier or it can not be moved to the next tier.
     candidateDirView = dirCandidates.candidateDir();
+    if (candidateDirView == null) {
+      return null;
+    }
     List<Long> candidateBlocks = dirCandidates.candidateBlocks();
     StorageTierView nextTierView = mManagerView.getNextTier(candidateDirView.getParentTierView());
     if (nextTierView == null) {
@@ -168,7 +171,7 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
   @Override
   public EvictionPlan freeSpaceWithView(long bytesToBeAvailable, BlockStoreLocation location,
       BlockMetadataManagerView view) {
-    return freeSpaceWithView(bytesToBeAvailable, location, view, Mode.GUUARANTEED);
+    return freeSpaceWithView(bytesToBeAvailable, location, view, Mode.GUARANTEED);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
@@ -31,7 +31,7 @@ public interface Evictor {
    * The eviction mode.
    */
   enum Mode {
-    BEST_EFFORT, GUUARANTEED
+    BEST_EFFORT, GUARANTEED
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
@@ -28,6 +28,13 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface Evictor {
 
   /**
+   * The eviction mode.
+   */
+  enum Mode {
+    BEST_EFFORT, GUUARANTEED
+  }
+
+  /**
    * Factory for {@link Evictor}.
    */
   @ThreadSafe
@@ -51,19 +58,7 @@ public interface Evictor {
   }
 
   /**
-   * Frees space in the given block store location and with the given view. After eviction, at least
-   * one {@link alluxio.worker.block.meta.StorageDir} in the location has the specific amount of
-   * free space after eviction. The location can be a specific
-   * {@link alluxio.worker.block.meta.StorageDir}, or {@link BlockStoreLocation#anyTier()} or
-   * {@link BlockStoreLocation#anyDirInTier(String)}. The view is generated and passed by the
-   * calling {@link alluxio.worker.block.BlockStore}.
-   * <p>
-   * This method returns null if {@link Evictor} fails to propose a feasible plan to meet the
-   * requirement, or an eviction plan with toMove and toEvict fields to indicate how to free space.
-   * If both toMove and toEvict of the plan are empty, it indicates that {@link Evictor} has no
-   * actions to take and the requirement is already met.
-   *
-   * Throws an {@link IllegalArgumentException} if the given block location is invalid.
+   * Frees space with the guaranteed mode.
    *
    * @param availableBytes the amount of free space in bytes to be ensured after eviction
    * @param location the location in block store
@@ -73,4 +68,34 @@ public interface Evictor {
    */
   EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
       BlockMetadataManagerView view);
+
+  /**
+   * Frees space in the given block store location and with the given view.
+   *
+   * With the GUARANTEED mode, after eviction at least one
+   * {@link alluxio.worker.block.meta.StorageDir} in the location has the specific amount of free
+   * space after eviction. The location can be a specific
+   * {@link alluxio.worker.block.meta.StorageDir}, or {@link BlockStoreLocation#anyTier()} or
+   * {@link BlockStoreLocation#anyDirInTier(String)}. The view is generated and passed by the
+   * calling {@link alluxio.worker.block.BlockStore}. This method returns null if {@link Evictor}
+   * fails to propose a feasible plan to meet the requirement.
+   * <p>
+   * With the BEST_EFFORT mode, the evictor always returns an eviction plan with toMove and toEvict
+   * fields to indicate how to free space. Even if the tier does not have the amount of free space,
+   * the evictor returns the plan to free the max space.
+   * <p>
+   * If both toMove and toEvict of the plan are empty, it indicates that {@link Evictor} has no
+   * actions to take and the requirement is already met.
+   * <p>
+   * Throws an {@link IllegalArgumentException} if the given block location is invalid.
+   *
+   * @param availableBytes the amount of free space in bytes to be ensured after eviction
+   * @param location the location in block store
+   * @param view generated and passed by block store
+   * @param mode the eviction mode
+   * @return an {@link EvictionPlan} (possibly with empty fields) to get the free space, or null if
+   *         no plan is feasible
+   */
+  EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
+      BlockMetadataManagerView view, Mode mode);
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
@@ -50,7 +50,7 @@ public final class GreedyEvictor implements Evictor {
   @Override
   public EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
       BlockMetadataManagerView view) {
-    return freeSpaceWithView(availableBytes, location, view, Mode.GUUARANTEED);
+    return freeSpaceWithView(availableBytes, location, view, Mode.GUARANTEED);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
@@ -50,6 +50,12 @@ public final class GreedyEvictor implements Evictor {
   @Override
   public EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
       BlockMetadataManagerView view) {
+    return freeSpaceWithView(availableBytes, location, view, Mode.GUUARANTEED);
+  }
+
+  @Override
+  public EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
+      BlockMetadataManagerView view, Mode mode) {
     Preconditions.checkNotNull(location, "location");
     Preconditions.checkNotNull(view, "view");
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRFUEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRFUEvictor.java
@@ -35,8 +35,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * This class is used to evict blocks by LRFU. LRFU evict blocks with minimum CRF, where CRF of a
@@ -104,7 +104,7 @@ public final class LRFUEvictor extends AbstractEvictor {
   @Nullable
   @Override
   public EvictionPlan freeSpaceWithView(long bytesToBeAvailable, BlockStoreLocation location,
-      BlockMetadataManagerView view) {
+      BlockMetadataManagerView view, Mode mode) {
     synchronized (mBlockIdToLastUpdateTime) {
       updateCRFValue();
       mManagerView = view;
@@ -112,7 +112,7 @@ public final class LRFUEvictor extends AbstractEvictor {
       List<BlockTransferInfo> toMove = new ArrayList<>();
       List<Pair<Long, BlockStoreLocation>> toEvict = new ArrayList<>();
       EvictionPlan plan = new EvictionPlan(toMove, toEvict);
-      StorageDirView candidateDir = cascadingEvict(bytesToBeAvailable, location, plan);
+      StorageDirView candidateDir = cascadingEvict(bytesToBeAvailable, location, plan, mode);
 
       mManagerView.clearBlockMarks();
       if (candidateDir == null) {

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -426,7 +426,7 @@ public final class TieredBlockStoreTest {
     // session1 locks a block first
     long lockId = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
 
-    // Expect an exception as no eviction plan is feasible
+    // Expect an empty eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);
     mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
     mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes(),

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -12,9 +12,9 @@
 package alluxio.worker.block;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
@@ -294,6 +294,22 @@ public final class TieredBlockStoreTest {
     TieredBlockStoreTestUtils.cache(SESSION_ID1, BLOCK_ID1, BLOCK_SIZE, mTestDir1, mMetaManager,
         mEvictor);
     mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes(),
+        mTestDir1.toBlockStoreLocation());
+    // Expect BLOCK_ID1 to be moved out of mTestDir1
+    assertEquals(mTestDir1.getCapacityBytes(), mTestDir1.getAvailableBytes());
+    assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID1));
+    assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID1)));
+  }
+
+  /**
+   * Tests the {@link TieredBlockStore#freeSpace(long, long, BlockStoreLocation)} method.
+   */
+  @Test
+  public void freeSpaceMoreThanCapacity() throws Exception {
+    TieredBlockStoreTestUtils.cache(SESSION_ID1, BLOCK_ID1, BLOCK_SIZE, mTestDir1, mMetaManager,
+        mEvictor);
+    // this call works because the space is freed in a best-effort way to move BLOCK_ID1 out
+    mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes() * 2,
         mTestDir1.toBlockStoreLocation());
     // Expect BLOCK_ID1 to be moved out of mTestDir1
     assertEquals(mTestDir1.getCapacityBytes(), mTestDir1.getAvailableBytes());

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -28,6 +28,7 @@ import alluxio.test.util.ConcurrencyUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.worker.block.evictor.EvictionPlan;
 import alluxio.worker.block.evictor.Evictor;
+import alluxio.worker.block.evictor.Evictor.Mode;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.TempBlockMeta;
@@ -338,9 +339,9 @@ public final class TieredBlockStoreTest {
     List<Runnable> runnables = new ArrayList<>();
     Evictor evictor = Mockito.mock(Evictor.class);
     Set<Long> set = new HashSet<>();
-    Mockito.when(evictor
-        .freeSpaceWithView(Mockito.any(Long.class), Mockito.any(BlockStoreLocation.class),
-            Mockito.any(BlockMetadataManagerView.class)))
+    Mockito.when(
+        evictor.freeSpaceWithView(Mockito.any(Long.class), Mockito.any(BlockStoreLocation.class),
+            Mockito.any(BlockMetadataManagerView.class), Mockito.any(Mode.class)))
         .thenAnswer((InvocationOnMock invocation) -> {
               for (int i = 0; i < count; i++) {
                 set.add(System.nanoTime());


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3105

The space reserver is invoked asynchronously every heartbeat to free space in a worker. Currently the eviction policy is all-or-nothing, so if there is not enough space to free for a given amount, for example, when too many files are pinned to make space, then the evictor just fails and throws exception.

In this PR, the space reserver is improved to make space in a best-effort way, and lower the watermark as much as possible