### PR TITLE
[SMALLFIX] Remove HdfsUnderFileSystemFactory from service loading in WASB UFS jar

### DIFF
--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -138,6 +138,12 @@
                     <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>


### PR DESCRIPTION
Remove the warning by avoiding having `META-INF/services/alluxio.underfs.UnderFileSystemFactory` to pollute service loading in Wasb UFS
```
2018-01-17 10:03:55,327 INFO  ExtensionsClassLoader - Created ExtensionsClassLoader with jars=file:/Users/binfan/Dropbox/Work/alluxio/alluxio/lib/alluxio-underfs-wasb-1.7.1-SNAPSHOT.jar
**2018-01-17 10:03:55,349 WARN  UnderFileSystemFactoryRegistry - Failed to load jar /Users/binfan/Dropbox/Work/alluxio/alluxio/lib/alluxio-underfs-wasb-1.7.1-SNAPSHOT.jar: alluxio.underfs.UnderFileSystemFactory: Provider alluxio.underfs.hdfs.HdfsUnderFileSystemFactory not found**
```