### PR TITLE
[ALLUXIO-3114] Better attempt to return block locations for blocks not in Alluxio workers

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -11,9 +11,14 @@
 
 package alluxio.hadoop;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
+import alluxio.client.block.AlluxioBlockStore;
+import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
@@ -32,8 +37,8 @@ import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.UnavailableException;
 import alluxio.security.User;
 import alluxio.security.authorization.Mode;
-import alluxio.util.CommonUtils;
 import alluxio.wire.FileBlockInfo;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
@@ -55,8 +60,11 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -273,27 +281,38 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     AlluxioURI path = new AlluxioURI(HadoopUtils.getPathWithoutScheme(file.getPath()));
     List<FileBlockInfo> blocks = getFileBlocks(path);
     List<BlockLocation> blockLocations = new ArrayList<>();
+    Map<String, WorkerNetAddress> workerHosts = null;
     for (FileBlockInfo fileBlockInfo : blocks) {
       long offset = fileBlockInfo.getOffset();
       long end = offset + fileBlockInfo.getBlockInfo().getLength();
       // Check if there is any overlapping between [start, start+len] and [offset, end]
       if (end >= start && offset <= start + len) {
-        ArrayList<String> names = new ArrayList<>();
-        ArrayList<String> hosts = new ArrayList<>();
         // add the existing in-Alluxio block locations
-        for (alluxio.wire.BlockLocation location : fileBlockInfo.getBlockInfo().getLocations()) {
-          HostAndPort address = HostAndPort.fromParts(location.getWorkerAddress().getHost(),
-              location.getWorkerAddress().getDataPort());
-          names.add(address.toString());
-          hosts.add(address.getHostText());
+        Collection<WorkerNetAddress> locations = fileBlockInfo.getBlockInfo().getLocations()
+            .stream().map(alluxio.wire.BlockLocation::getWorkerAddress).collect(toList());
+        if (locations.isEmpty()) {
+          // No in-Alluxio location, fallback to use under file system locations with
+          // co-located workers
+          if (workerHosts == null) {
+            // lazy initialization for rpc call
+            workerHosts = getHostToWorkerMap();
+          }
+          Map<String, WorkerNetAddress> finalWorkerHosts = workerHosts;
+          locations = fileBlockInfo.getUfsLocations().stream()
+              .map(location -> finalWorkerHosts.get(HostAndPort.fromString(location).getHostText()))
+              .filter(Objects::nonNull).collect(toList());
         }
-        // add under file system locations
-        for (String location : fileBlockInfo.getUfsLocations()) {
-          names.add(location);
-          hosts.add(HostAndPort.fromString(location).getHostText());
+        if (locations.isEmpty()) {
+          // Fallback to add all workers to the location so some apps (Impala) won't panic
+          locations = workerHosts.values();
         }
-        blockLocations.add(new BlockLocation(CommonUtils.toStringArray(names),
-            CommonUtils.toStringArray(hosts), offset, fileBlockInfo.getBlockInfo().getLength()));
+        List<HostAndPort> addresses = locations.stream()
+            .map(worker -> HostAndPort.fromParts(worker.getHost(), worker.getDataPort()))
+            .collect(toList());
+        String[] names = addresses.stream().map(HostAndPort::toString).toArray(String[]::new);
+        String[] hosts = addresses.stream().map(HostAndPort::getHostText).toArray(String[]::new);
+        blockLocations.add(
+            new BlockLocation(names, hosts, offset, fileBlockInfo.getBlockInfo().getLength()));
       }
     }
 
@@ -716,5 +735,12 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     } catch (AlluxioException e) {
       throw new IOException(e);
     }
+  }
+
+  private Map<String, WorkerNetAddress> getHostToWorkerMap() throws IOException {
+    List<BlockWorkerInfo> workers = AlluxioBlockStore.create(mContext).getEligibleWorkers();
+    return workers.stream().collect(
+        toMap(worker -> worker.getNetAddress().getHost(), BlockWorkerInfo::getNetAddress,
+            (worker1, worker2) -> worker1));
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -61,6 +61,7 @@ import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -309,6 +310,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
         List<HostAndPort> addresses = locations.stream()
             .map(worker -> HostAndPort.fromParts(worker.getHost(), worker.getDataPort()))
             .collect(toList());
+        Collections.shuffle(addresses);
         String[] names = addresses.stream().map(HostAndPort::toString).toArray(String[]::new);
         String[] hosts = addresses.stream().map(HostAndPort::getHostText).toArray(String[]::new);
         blockLocations.add(

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -292,7 +292,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
             .stream().map(alluxio.wire.BlockLocation::getWorkerAddress).collect(toList());
         if (locations.isEmpty()) {
           // No in-Alluxio location, fallback to use under file system locations with
-          // co-located workers
+          // co-located workers.
           if (workerHosts == null) {
             // lazy initialization for rpc call
             workerHosts = getHostToWorkerMap();
@@ -303,7 +303,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
               .filter(Objects::nonNull).collect(toList());
         }
         if (locations.isEmpty()) {
-          // Fallback to add all workers to the location so some apps (Impala) won't panic
+          // Fallback to add all workers to the location so some apps (Impala) won't panic.
           locations = workerHosts.values();
         }
         List<HostAndPort> addresses = locations.stream()

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -60,7 +60,6 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -289,7 +288,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       // Check if there is any overlapping between [start, start+len] and [offset, end]
       if (end >= start && offset <= start + len) {
         // add the existing in-Alluxio block locations
-        Collection<WorkerNetAddress> locations = fileBlockInfo.getBlockInfo().getLocations()
+        List<WorkerNetAddress> locations = fileBlockInfo.getBlockInfo().getLocations()
             .stream().map(alluxio.wire.BlockLocation::getWorkerAddress).collect(toList());
         if (locations.isEmpty()) {
           // No in-Alluxio location, fallback to use under file system locations with
@@ -305,12 +304,12 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
         }
         if (locations.isEmpty()) {
           // Fallback to add all workers to the location so some apps (Impala) won't panic.
-          locations = workerHosts.values();
+          locations.addAll(workerHosts.values());
+          Collections.shuffle(locations);
         }
         List<HostAndPort> addresses = locations.stream()
             .map(worker -> HostAndPort.fromParts(worker.getHost(), worker.getDataPort()))
             .collect(toList());
-        Collections.shuffle(addresses);
         String[] names = addresses.stream().map(HostAndPort::toString).toArray(String[]::new);
         String[] hosts = addresses.stream().map(HostAndPort::getHostText).toArray(String[]::new);
         blockLocations.add(

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.hadoop;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ArrayUtils.toArray;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -25,14 +28,21 @@ import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.client.block.AlluxioBlockStore;
+import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.status.UnavailableException;
+import alluxio.wire.BlockInfo;
+import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.net.HostAndPort;
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -56,7 +66,9 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 
@@ -64,7 +76,8 @@ import javax.security.auth.Subject;
  * Unit tests for {@link AbstractFileSystem}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FileSystemContext.class, FileSystemMasterClient.class, UserGroupInformation.class})
+@PrepareForTest({AlluxioBlockStore.class, FileSystemContext.class, FileSystemMasterClient.class,
+    UserGroupInformation.class})
 /*
  * [ALLUXIO-1384] Tell PowerMock to defer the loading of javax.security classes to the system
  * classloader in order to avoid linkage error when running this test with CDH.
@@ -359,6 +372,124 @@ public class AbstractFileSystemTest {
     URI uri = URI.create(Constants.HEADER + "host:1");
     org.apache.hadoop.fs.FileSystem.get(uri, conf);
     // FileSystem.get would have thrown an exception if the initialization failed.
+  }
+
+  @Test
+  public void getBlockLocationsOnlyInAlluxio() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList(worker1);
+    List<String> ufsLocations = Arrays.asList();
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker1);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  @Test
+  public void getBlockLocationsInUfs() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList();
+    List<String> ufsLocations = Arrays.asList(worker2.getHost());
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker2);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  @Test
+  public void getBlockLocationsInUfsAndAlluxio() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList(worker1);
+    List<String> ufsLocations = Arrays.asList(worker2.getHost());
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker1);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  @Test
+  public void getBlockLocationsOnlyMatchingWorkers() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList();
+    List<String> ufsLocations = Arrays.asList("worker0", worker2.getHost(), "worker3");
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker2);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  @Test
+  public void getBlockLocationsNoMatchingWorkers() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList();
+    List<String> ufsLocations = Arrays.asList("worker0", "worker3");
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker1, worker2);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  @Test
+  public void getBlockLocationsNoUfsLocations() throws Exception {
+    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1").setDataPort(1234);
+    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2").setDataPort(1234);
+    List<WorkerNetAddress> blockWorkers = Arrays.asList();
+    List<String> ufsLocations = Arrays.asList();
+    List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
+
+    List<WorkerNetAddress> expectedWorkers = Arrays.asList(worker1, worker2);
+
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+  }
+
+  void verifyBlockLocations(List<WorkerNetAddress> blockWorkers, List<String> ufsLocations,
+      List<WorkerNetAddress> allWorkers, List<WorkerNetAddress> expectedWorkers) throws Exception {
+    FileBlockInfo blockInfo = new FileBlockInfo().setBlockInfo(
+        new BlockInfo().setLocations(blockWorkers.stream().map(
+            addr -> new alluxio.wire.BlockLocation().setWorkerAddress(addr)).collect(
+            toList()))).setUfsLocations(ufsLocations);
+    FileInfo fileInfo = new FileInfo()
+        .setLastModificationTimeMs(111L)
+        .setFolder(false)
+        .setOwner("user1")
+        .setGroup("group1")
+        .setMode(00755)
+        .setFileBlockInfos(Arrays.asList(blockInfo));
+    Path path = new Path("/dir/file");
+    alluxio.client.file.FileSystem alluxioFs =
+        mock(alluxio.client.file.FileSystem.class);
+    when(alluxioFs.getStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
+        .thenReturn(new URIStatus(fileInfo));
+    AlluxioBlockStore blockStore = mock(AlluxioBlockStore.class);
+    PowerMockito.mockStatic(AlluxioBlockStore.class);
+    PowerMockito.when(AlluxioBlockStore.create(null)).thenReturn(blockStore);
+    List<BlockWorkerInfo> eligibleWorkerInfos = allWorkers.stream().map(worker ->
+        new BlockWorkerInfo(worker, 0, 0)).collect(toList());
+    PowerMockito.when(blockStore.getEligibleWorkers()).thenReturn(eligibleWorkerInfos);
+    List<HostAndPort> expectedWorkerNames = expectedWorkers.stream()
+        .map(addr -> HostAndPort.fromParts(addr.getHost(), addr.getDataPort())).collect(toList());
+    FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
+    FileStatus file = new FileStatus();
+    file.setPath(path);
+    long start = 0;
+    long len = 100;
+    BlockLocation[] locations = alluxioHadoopFs.getFileBlockLocations(file, start, len);
+    assertEquals(1, locations.length);
+    assertArrayEquals(expectedWorkerNames.stream().map(HostAndPort::toString).toArray(),
+        locations[0].getNames());
+    assertArrayEquals(expectedWorkerNames.stream().map(HostAndPort::getHostText).toArray(),
+        locations[0].getHosts());
+    alluxioHadoopFs.close();
   }
 
   private org.apache.hadoop.conf.Configuration getConf() throws Exception {

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -66,6 +66,8 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.security.auth.Subject;
@@ -483,10 +485,15 @@ public class AbstractFileSystemTest {
     long len = 100;
     BlockLocation[] locations = alluxioHadoopFs.getFileBlockLocations(file, start, len);
     assertEquals(1, locations.length);
+    Collections.sort(expectedWorkerNames, (x, y) -> x.toString().compareTo(y.toString()));
+    String[] actualNames = locations[0].getNames();
+    String[] actualHosts = locations[0].getHosts();
+    Arrays.sort(actualNames);
+    Arrays.sort(actualHosts);
     assertArrayEquals(expectedWorkerNames.stream().map(HostAndPort::toString).toArray(),
-        locations[0].getNames());
+        actualNames);
     assertArrayEquals(expectedWorkerNames.stream().map(HostAndPort::getHostText).toArray(),
-        locations[0].getHosts());
+        actualHosts);
     alluxioHadoopFs.close();
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -67,7 +67,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.security.auth.Subject;

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -12,7 +12,6 @@
 package alluxio.hadoop;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.ArrayUtils.toArray;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -68,7 +67,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3114

Applications like Impala requires block locations to be non-empty for data load to work. Currently Impala could not read from Alluxio Hadoop client when data is not preloaded:

1. For files in HDFS under file system, Alluxio returns HDFS block location hostnames for `BlockLocation::getNames()`, but Impala requires two part `name:port` format which is indicated in javadoc of the method.

2. For files in non-HDFS or remote HDFS under file system, Alluxio returns no `BlockLocation`, this is making Impala skip reading of the file all together.

This change updated the client to return full two-part locations for UFS locations if there is an Alluxio worker co-located. If no worker is colocated with the UFS block location, it will fallback to return all the worker hosts so that applications can just pick from one location to read from.