### PR TITLE
[SMALLFIX] Fix WebUI when UFS is lost

### DIFF
--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -23,6 +23,9 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +42,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @ThreadSafe
 public final class WebInterfaceGeneralServlet extends HttpServlet {
+  private static final Logger LOG = LoggerFactory.getLogger(WebInterfaceGeneralServlet.class);
+
   /**
    * Class to make referencing tiered storage information more intuitive.
    */
@@ -166,7 +171,7 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
    *
    * @param request The {@link HttpServletRequest} object
    */
-  private void populateValues(HttpServletRequest request) throws IOException {
+  private void populateValues(HttpServletRequest request) {
     BlockMaster blockMaster = mMasterProcess.getMaster(BlockMaster.class);
     FileSystemMaster fileSystemMaster = mMasterProcess.getMaster(FileSystemMaster.class);
 
@@ -205,26 +210,41 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
     String ufsRoot = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsRoot);
 
-    long sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_TOTAL);
-    if (sizeBytes >= 0) {
-      request.setAttribute("diskCapacity", FormatUtils.getSizeFromBytes(sizeBytes));
-    } else {
-      request.setAttribute("diskCapacity", "UNKNOWN");
+    String totalSpace = "UNKNOWN";
+    try {
+      long sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_TOTAL);
+      if (sizeBytes >= 0) {
+        totalSpace = FormatUtils.getSizeFromBytes(sizeBytes);
+      }
+    } catch (IOException e) {
+      // Exception may be thrown when UFS connection is lost
+      LOG.warn("Failed to get size of total space of root UFS: {}", e.getMessage());
     }
+    request.setAttribute("diskCapacity", totalSpace);
 
-    sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_USED);
-    if (sizeBytes >= 0) {
-      request.setAttribute("diskUsedCapacity", FormatUtils.getSizeFromBytes(sizeBytes));
-    } else {
-      request.setAttribute("diskUsedCapacity", "UNKNOWN");
+    String usedSpace = "UNKNOWN";
+    try {
+      long sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_USED);
+      if (sizeBytes >= 0) {
+        usedSpace = FormatUtils.getSizeFromBytes(sizeBytes);
+      }
+    } catch (IOException e) {
+      // Exception may be thrown when UFS connection is lost
+      LOG.warn("Failed to get size of used space of root UFS: {}", e.getMessage());
     }
+    request.setAttribute("diskUsedCapacity", usedSpace);
 
-    sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_FREE);
-    if (sizeBytes >= 0) {
-      request.setAttribute("diskFreeCapacity", FormatUtils.getSizeFromBytes(sizeBytes));
-    } else {
-      request.setAttribute("diskFreeCapacity", "UNKNOWN");
+    String freeSpace = "UNKNOWN";
+    try {
+      long sizeBytes = ufs.getSpace(ufsRoot, UnderFileSystem.SpaceType.SPACE_FREE);
+      if (sizeBytes >= 0) {
+        freeSpace = FormatUtils.getSizeFromBytes(sizeBytes);
+      }
+    } catch (IOException e) {
+      // Exception may be thrown when UFS connection is lost
+      LOG.warn("Failed to get size of free space of root UFS: {}", e.getMessage());
     }
+    request.setAttribute("diskFreeCapacity", freeSpace);
 
     StorageTierInfo[] infos = generateOrderedStorageTierInfo();
     request.setAttribute("storageTierInfos", infos);


### PR DESCRIPTION
Before: when UFS is lost, a tracestack is shown on the webUI

```
HTTP ERROR 500
Problem accessing /home. Reason:

    Server Error
Caused by:
java.net.ConnectException: Call From localhost/127.0.0.1 to localhost:9000 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/ConnectionRefused
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:783)
	at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:730)
	at org.apache.hadoop.ipc.Client.call(Client.java:1351)
	at org.apache.hadoop.ipc.Client.call(Client.java:1300)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:206)
	at com.sun.proxy.$Proxy8.getFsStats(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:186)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
	at com.sun.proxy.$Proxy8.getFsStats(Unknown Source)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getStats(ClientNamenodeProtocolTranslatorPB.java:521)
	at org.apache.hadoop.hdfs.DFSClient.getDiskStatus(DFSClient.java:2081)
	at org.apache.hadoop.hdfs.DistributedFileSystem.getDiskStatus(DistributedFileSystem.java:893)
	at alluxio.underfs.hdfs.HdfsUnderFileSystem.getSpace(HdfsUnderFileSystem.java:280)
	at alluxio.underfs.UnderFileSystemWithLogging$16.call(UnderFileSystemWithLogging.java:293)
	at alluxio.underfs.UnderFileSystemWithLogging$16.call(UnderFileSystemWithLogging.java:290)
	at alluxio.underfs.UnderFileSystemWithLogging.call(UnderFileSystemWithLogging.java:556)
	at alluxio.underfs.UnderFileSystemWithLogging.getSpace(UnderFileSystemWithLogging.java:290)
	at alluxio.web.WebInterfaceGeneralServlet.populateValues(WebInterfaceGeneralServlet.java:208)
	at alluxio.web.WebInterfaceGeneralServlet.doGet(WebInterfaceGeneralServlet.java:128)
```

After

![screen shot 2018-02-22 at 4 26 13 pm](https://user-images.githubusercontent.com/1413748/36571791-7321f9a0-17ed-11e8-8f94-ce88e1824630.png)
