### PR TITLE
[SMALL FIX]ALLUXIO-3022 Supply the variable name to Preconditions

### DIFF
--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValuePartitionReader.java
@@ -43,7 +43,7 @@ public interface KeyValuePartitionReader extends Closeable, KeyValueIterable {
      */
     public static KeyValuePartitionReader create(AlluxioURI uri)
         throws AlluxioException, IOException {
-      Preconditions.checkNotNull(uri);
+      Preconditions.checkNotNull(uri, "uri");
       FileSystem fs = FileSystem.Factory.get();
       List<Long> blockIds = fs.getStatus(uri).getBlockIds();
       // Each partition file should only contain one block.


### PR DESCRIPTION
Supply the variable name to Preconditions.checkNotNull for class KeyValuePartitionReader.

Preconditions.checkNotNull(uri); // Do not do this
Preconditions.checkNotNull(uri, "uri") // Do this instead