### PR TITLE
[SMALLFIX] Missing journal log improvement

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -149,8 +149,8 @@ public final class UfsJournalReader implements JournalReader {
         LOG.debug("Skipping duplicate log entry {} (next sequence number: {}).", entry,
             mNextSequenceNumber);
       } else {
-        throw new InvalidJournalEntryException(ExceptionMessage.JOURNAL_ENTRY_MISSING,
-            mNextSequenceNumber, entry.getSequenceNumber());
+        throw new IllegalStateException(ExceptionMessage.JOURNAL_ENTRY_MISSING.getMessage(
+            mNextSequenceNumber, entry.getSequenceNumber()));
       }
     }
   }


### PR DESCRIPTION
Otherwise we will retry in a tight loop, filling the logs
with the same warning.

The exception will be propagated to the top-level handler, and cause the system to exit