### PR TITLE
[SMALLFIX] Log warning instead of throwing exception on channel close.

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -73,7 +73,7 @@ public final class FileSystemContext implements Closeable {
   private volatile BlockMasterClientPool mBlockMasterClientPool;
 
   // Closed flag for debugging information.
-  private AtomicBoolean mClosed;
+  private final AtomicBoolean mClosed;
 
   // The netty data server channel pools.
   private final ConcurrentHashMap<SocketAddress, NettyChannelPool>
@@ -133,6 +133,7 @@ public final class FileSystemContext implements Closeable {
    */
   private FileSystemContext(Subject subject) {
     mParentSubject = subject;
+    mClosed = new AtomicBoolean(false);
   }
 
   /**


### PR DESCRIPTION
This could happen due to the context being closed (ie. from application code), not catastrophic so we can just log a warning instead of crashing.