### PR TITLE
[SMALLFIX] Fix async cache manager: shared among different handlers

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
@@ -14,12 +14,9 @@ package alluxio.worker.netty;
 import alluxio.network.protocol.RPCProtoMessage;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.worker.block.AsyncCacheRequestManager;
-import alluxio.worker.block.BlockWorker;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-
-import java.util.concurrent.ExecutorService;
 
 /**
  * Handler for async cache requests.

--- a/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AsyncCacheHandler.java
@@ -30,11 +30,10 @@ public class AsyncCacheHandler extends ChannelInboundHandlerAdapter {
   /**
    * Constructs a new async cache handler.
    *
-   * @param service the thread pool
-   * @param blockWorker handler to the block worker
+   * @param requestManager the async cache manager
    */
-  public AsyncCacheHandler(ExecutorService service, BlockWorker blockWorker) {
-    mRequestManager = new AsyncCacheRequestManager(service, blockWorker);
+  public AsyncCacheHandler(AsyncCacheRequestManager requestManager) {
+    mRequestManager = requestManager;
   }
 
   @Override


### PR DESCRIPTION
`AsyncCacheRequestManager` instance should be shared for different handlers across channels.