### PR TITLE
[SMALLFIX] Fix LOG.warn without context

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1504,7 +1504,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
               failedToDelete = !ufsDeleter.delete(alluxioUriToDel, delInode);
             }
           } catch (InvalidPathException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn("Failed to delete path from UFS: {}", e.getMessage());
           }
         }
         if (!failedToDelete) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -102,8 +102,8 @@ public class SpaceReserver implements HeartbeatExecutor {
             mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
           } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
               | BlockAlreadyExistsException | InvalidWorkerStateException | IOException e) {
-            LOG.warn("SpaceReserver failed to free tier {} to {} bytes used", tierAlias,
-                reservedSpace, e.getMessage());
+            LOG.warn("SpaceReserver failed to free tier {} to {} bytes used for high watermarks: "
+                + "{}", tierAlias, reservedSpace, e.getMessage());
           }
         }
       } else {
@@ -111,7 +111,8 @@ public class SpaceReserver implements HeartbeatExecutor {
           mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
         } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
             | BlockAlreadyExistsException | InvalidWorkerStateException | IOException e) {
-          LOG.warn(e.getMessage());
+          LOG.warn("SpaceReserver failed to free tier {} to {} bytes used: {}", tierAlias,
+              reservedSpace, e.getMessage());
         }
       }
     }


### PR DESCRIPTION
Logging messages from `LOG.warn(e.getMessage());` will not be able to locate.