### PR TITLE
[SMALLFIX] Improve the error handling of packet writing failure

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
@@ -153,7 +153,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>>
         if (msg.getPayloadDataBuffer() != null) {
           msg.getPayloadDataBuffer().release();
         }
-        LOG.warn("Ignore the request {} dueo the error {} on context", mContext.getRequest(),
+        LOG.warn("Ignore the request {} due to the error {} on context", mContext.getRequest(),
             mContext.getError());
         return;
       } else {

--- a/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
@@ -145,16 +145,21 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>>
         initRequestContext(mContext);
       }
 
-      // If we have seen an error, return early and release the data. This can only
-      // happen for those mis-behaving clients who first sends some invalid requests, then
-      // then some random data. It can leak memory if we do not release buffers here.
+      // If we have seen an error, return early and release the data. This can
+      // happen for (1) those mis-behaving clients who first sends some invalid requests, then
+      // then some random data, or (2) asynchronous requests arrive after the previous request fails
+      // and triggers abortion. It can leak memory if we do not release buffers here.
       if (mContext.getError() != null) {
         if (msg.getPayloadDataBuffer() != null) {
           msg.getPayloadDataBuffer().release();
         }
+        LOG.warn("Ignore the request {} dueo the error {} on context", mContext.getRequest(),
+            mContext.getError());
         return;
       } else {
-        // Validate the write request.
+        // Validate the write request. The validation is performed only when no error is in the
+        // context in order to prevent excessive logging on the subsequent arrived asynchronous
+        // requests after a previous request fails and triggers the abortion
         validateWriteRequest(writeRequest, msg.getPayloadDataBuffer());
       }
 


### PR DESCRIPTION
 - Packet writing failure is bad, so it should be error but not warning. And the stacktrace is necessary to show in the log
 - To prevent too much logging from the write request validation on misbehaving client, we only validate the write request when the context does not have error.