### PR TITLE
[SMALLFIX] Perform retries during catchUp

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -12,6 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.InvalidJournalEntryException;
 import alluxio.exception.status.UnavailableException;
@@ -22,6 +23,8 @@ import alluxio.master.journal.JournalEntryStateMachine;
 import alluxio.master.journal.JournalReader;
 import alluxio.master.journal.MasterJournalContext;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.retry.ExponentialTimeBoundedRetry;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -36,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -334,19 +338,48 @@ public class UfsJournal implements Journal {
    * @return the next sequence number after the final sequence number read
    */
   private synchronized long catchUp(long nextSequenceNumber) {
-    try (JournalReader journalReader = new UfsJournalReader(this, nextSequenceNumber, true)) {
-      JournalEntry entry;
-      while ((entry = journalReader.read()) != null) {
-        mMaster.processJournalEntry(entry);
+    JournalReader journalReader = new UfsJournalReader(this, nextSequenceNumber, true);
+    try {
+      return catchUp(journalReader);
+    } finally {
+      try {
+        journalReader.close();
+      } catch (IOException e) {
+        LOG.warn("Failed to close journal reader: {}", e.toString());
       }
-      return journalReader.getNextSequenceNumber();
-    } catch (IOException e) {
-      LOG.error("{}: Failed to read from journal", mMaster.getName(), e);
-      throw new RuntimeException(e);
-    } catch (InvalidJournalEntryException e) {
-      LOG.error("{}: Invalid journal entry detected.", mMaster.getName(), e);
-      // We found an invalid journal entry, nothing we can do but crash.
-      throw new RuntimeException(e);
+    }
+  }
+
+  private long catchUp(JournalReader journalReader) {
+    RetryPolicy retry =
+        ExponentialTimeBoundedRetry.builder()
+            .withInitialSleep(Duration.ofSeconds(1))
+            .withMaxSleep(Duration.ofSeconds(10))
+            .withMaxDuration(Duration.ofDays(365))
+            .build();
+    while (true) {
+      JournalEntry entry;
+      try {
+        entry = journalReader.read();
+      } catch (IOException e) {
+        LOG.warn("{}: Failed to read from journal: {}", mMaster.getName(), e);
+        if (retry.attemptRetry()) {
+          continue;
+        }
+        throw new RuntimeException(e);
+      } catch (InvalidJournalEntryException e) {
+        LOG.error("{}: Invalid journal entry detected.", mMaster.getName(), e);
+        // We found an invalid journal entry, nothing we can do but crash.
+        throw new RuntimeException(e);
+      }
+      if (entry == null) {
+        return journalReader.getNextSequenceNumber();
+      }
+      try {
+        mMaster.processJournalEntry(entry);
+      } catch (IOException e) {
+        throw new RuntimeException(String.format("Failed to process journal entry %s", entry), e);
+      }
     }
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -12,7 +12,6 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.InvalidJournalEntryException;
 import alluxio.exception.status.UnavailableException;


### PR DESCRIPTION
We usually retry all journal operations in case of temporary journal unavailability, but the journal reads in `catchUp` slipped through the cracks, allowing the master to crash if the journal is unavailable during startup or failover.