### PR TITLE
[ALLUXIO-3127] Creating/loading an Inode does not load ufs metadata for ancestors when recursive is set to true

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -76,14 +76,14 @@ public final class PathUtils {
     Preconditions.checkArgument(paths != null, "Failed to concatPath: a null set of paths");
     List<String> trimmedPathList = new ArrayList<>();
     String trimmedBase =
-        CharMatcher.is(AlluxioURI.SEPARATOR.charAt(0)).trimTrailingFrom(base.toString().trim());
+        CharMatcher.is(AlluxioURI.SEPARATOR.charAt(0)).trimTrailingFrom(base.toString());
     trimmedPathList.add(trimmedBase);
     for (Object path : paths) {
       if (path == null) {
         continue;
       }
       String trimmedPath =
-          CharMatcher.is(AlluxioURI.SEPARATOR.charAt(0)).trimFrom(path.toString().trim());
+          CharMatcher.is(AlluxioURI.SEPARATOR.charAt(0)).trimFrom(path.toString());
       if (!trimmedPath.isEmpty()) {
         trimmedPathList.add(trimmedPath);
       }

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -103,11 +103,6 @@ public final class PathUtilsTest {
     assertEquals("/foo/bar", PathUtils.concatPath("/foo/", "/bar"));
     assertEquals("/foo/bar", PathUtils.concatPath("/foo/", "/bar/"));
 
-    // Whitespace must be trimmed.
-    assertEquals("/foo/bar", PathUtils.concatPath("/foo ", "bar  "));
-    assertEquals("/foo/bar", PathUtils.concatPath("/foo ", "  bar"));
-    assertEquals("/foo/bar", PathUtils.concatPath("/foo ", "  bar  "));
-
     // Redundant separator must be trimmed.
     assertEquals("/foo/bar", PathUtils.concatPath("/foo/", "bar//"));
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1011,7 +1011,7 @@ public class InodeTree implements JournalEntryIterable {
               MkdirsOptions.defaults().setCreateParent(false).setOwner(dir.getOwner())
                   .setGroup(dir.getGroup()).setMode(new Mode(dir.getMode()));
           if (!ufs.mkdirs(ufsUri, mkdirsOptions)) {
-            // Directory already exists. Try loading the status from ufs.
+            // Directory might already exist. Try loading the status from ufs.
             try {
               UfsStatus status = ufs.getStatus(ufsUri);
               if (status.isFile()) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -39,6 +39,7 @@ import alluxio.proto.journal.Journal;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.Mode;
+import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.io.PathUtils;
@@ -49,6 +50,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1008,7 +1010,21 @@ public class InodeTree implements JournalEntryIterable {
           MkdirsOptions mkdirsOptions =
               MkdirsOptions.defaults().setCreateParent(false).setOwner(dir.getOwner())
                   .setGroup(dir.getGroup()).setMode(new Mode(dir.getMode()));
-          ufs.mkdirs(ufsUri, mkdirsOptions);
+          if (!ufs.mkdirs(ufsUri, mkdirsOptions)) {
+            // Directory already exists. Try loading the status from ufs.
+            try {
+              UfsStatus status = ufs.getStatus(ufsUri);
+              if (status.isFile()) {
+                throw new InvalidPathException(String.format(
+                    "Error persisting directory. A file exists at the UFS location %s.", ufsUri));
+              }
+              dir.setOwner(status.getOwner())
+                  .setGroup(status.getGroup())
+                  .setMode(status.getMode());
+            } catch (FileNotFoundException e) {
+              // Ignore exception if file is not found
+            }
+          }
           dir.setPersistenceState(PersistenceState.PERSISTED);
 
           // Append the persist entry to the journal.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1022,7 +1022,9 @@ public class InodeTree implements JournalEntryIterable {
                   .setGroup(status.getGroup())
                   .setMode(status.getMode());
             } catch (FileNotFoundException e) {
-              // Ignore exception if file is not found
+              // Retry creation given that the directory might have just been removed.
+              LOG.warn("Directory {} no longer exists on UFS. Retry creation.", ufsUri);
+              continue;
             }
           }
           dir.setPersistenceState(PersistenceState.PERSISTED);

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -43,7 +43,6 @@ import alluxio.master.file.options.RenameOptions;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UfsDirectoryStatus;
-import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -952,7 +952,9 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void createDirectoryInNestedDirectories() throws Exception {
     String ufs = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    FileUtils.createDir(Paths.get(ufs, "d1", "d2", "d3").toString());
+    String targetPath = Paths.get(ufs, "d1", "d2", "d3").toString();
+    FileUtils.createDir(targetPath);
+    FileUtils.changeLocalFilePermission(targetPath, new Mode((short) 0755).toString());
     String parentPath = Paths.get(ufs, "d1").toString();
     FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 0700).toString());
     AlluxioURI path = new AlluxioURI(Paths.get("/d1", "d2", "d3", "d4").toString());
@@ -974,7 +976,9 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void loadMetadataInNestedDirectories() throws Exception {
     String ufs = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    FileUtils.createDir(Paths.get(ufs, "d1", "d2", "d3").toString());
+    String targetPath = Paths.get(ufs, "d1", "d2", "d3").toString();
+    FileUtils.createDir(targetPath);
+    FileUtils.changeLocalFilePermission(targetPath, new Mode((short) 0755).toString());
     String parentPath = Paths.get(ufs, "d1").toString();
     FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 0700).toString());
     AlluxioURI path = new AlluxioURI(Paths.get("/d1", "d2", "d3").toString());

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -43,6 +43,7 @@ import alluxio.master.file.options.RenameOptions;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
@@ -848,6 +849,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         .thenReturn(new UfsDirectoryStatus("test", "owner", "group", (short) 511));
     Mockito.when(mockUfs.mkdirs(Matchers.eq(ufsBase + "/dir1"), Matchers.any()))
         .thenThrow(new IOException("ufs unavailable"));
+    Mockito.when(mockUfs.getStatus(Matchers.any()))
+        .thenReturn(new UfsDirectoryStatus("test", "test", "test", (short) 0755));
 
     UnderFileSystemFactoryRegistry.register(mockUfsFactory);
 

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -838,6 +838,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         .thenReturn(Boolean.TRUE);
 
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
+    UfsDirectoryStatus ufsStatus = new
+        UfsDirectoryStatus("test", "owner", "group", (short) 511);
     Mockito.when(mockUfsFactory.create(Matchers.eq(ufsBase), Matchers.any())).thenReturn(mockUfs);
     Mockito.when(mockUfs.isDirectory(ufsBase)).thenReturn(true);
     Mockito.when(mockUfs.resolveUri(new AlluxioURI(ufsBase), ""))
@@ -845,11 +847,11 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     Mockito.when(mockUfs.resolveUri(new AlluxioURI(ufsBase), "/dir1"))
         .thenReturn(new AlluxioURI(ufsBase + "/dir1"));
     Mockito.when(mockUfs.getDirectoryStatus(ufsBase))
-        .thenReturn(new UfsDirectoryStatus("test", "owner", "group", (short) 511));
+        .thenReturn(ufsStatus);
     Mockito.when(mockUfs.mkdirs(Matchers.eq(ufsBase + "/dir1"), Matchers.any()))
         .thenThrow(new IOException("ufs unavailable"));
-    Mockito.when(mockUfs.getStatus(Matchers.any()))
-        .thenReturn(new UfsDirectoryStatus("test", "test", "test", (short) 0755));
+    Mockito.when(mockUfs.getStatus(ufsBase))
+        .thenReturn(ufsStatus);
 
     UnderFileSystemFactoryRegistry.register(mockUfsFactory);
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3127