### PR TITLE
[SMALLFIX] Fix broken sync directory retry

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1011,19 +1011,20 @@ public class InodeTree implements JournalEntryIterable {
                   .setGroup(dir.getGroup()).setMode(new Mode(dir.getMode()));
           if (!ufs.mkdirs(ufsUri, mkdirsOptions)) {
             // Directory might already exist. Try loading the status from ufs.
+            UfsStatus status;
             try {
-              UfsStatus status = ufs.getStatus(ufsUri);
-              if (status.isFile()) {
-                throw new InvalidPathException(String.format(
-                    "Error persisting directory. A file exists at the UFS location %s.", ufsUri));
-              }
-              dir.setOwner(status.getOwner())
-                  .setGroup(status.getGroup())
-                  .setMode(status.getMode());
+              status = ufs.getStatus(ufsUri);
             } catch (Exception e) {
-              throw new IOException(String.format("Cannot create or sync UFS directory %s.",
-                  ufsUri), e);
+              throw new IOException(String.format("Cannot sync UFS directory %s: %s.", ufsUri,
+                  e.getMessage()), e);
             }
+            if (status.isFile()) {
+              throw new InvalidPathException(String.format(
+                  "Error persisting directory. A file exists at the UFS location %s.", ufsUri));
+            }
+            dir.setOwner(status.getOwner())
+                .setGroup(status.getGroup())
+                .setMode(status.getMode());
           }
           dir.setPersistenceState(PersistenceState.PERSISTED);
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -50,7 +50,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1021,10 +1021,9 @@ public class InodeTree implements JournalEntryIterable {
               dir.setOwner(status.getOwner())
                   .setGroup(status.getGroup())
                   .setMode(status.getMode());
-            } catch (FileNotFoundException e) {
-              // Retry creation given that the directory might have just been removed.
-              LOG.warn("Directory {} no longer exists on UFS. Retry creation.", ufsUri);
-              continue;
+            } catch (Exception e) {
+              throw new IOException(String.format("Cannot create or sync UFS directory %s: %s.",
+                  ufsUri, e.getMessage()));
             }
           }
           dir.setPersistenceState(PersistenceState.PERSISTED);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1021,8 +1021,8 @@ public class InodeTree implements JournalEntryIterable {
                   .setGroup(status.getGroup())
                   .setMode(status.getMode());
             } catch (Exception e) {
-              throw new IOException(String.format("Cannot create or sync UFS directory %s: %s.",
-                  ufsUri, e.getMessage()));
+              throw new IOException(String.format("Cannot create or sync UFS directory %s.",
+                  ufsUri), e);
             }
           }
           dir.setPersistenceState(PersistenceState.PERSISTED);

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -999,6 +999,45 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
+   * Tests creating nested directories.
+   */
+  @Test
+  public void createNestedDirectories() throws Exception {
+    String ufs = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String parentPath = Paths.get(ufs, "d1").toString();
+    FileUtils.createDir(parentPath);
+    FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 0755).toString());
+    AlluxioURI path = new AlluxioURI(Paths.get("/d1", "d2", "d3", "d4").toString());
+    String ufsPath = Paths.get(ufs, "d1", "d2", "d3", "d4").toString();
+    mFsMaster.createDirectory(path, CreateDirectoryOptions.defaults()
+        .setPersisted(true).setRecursive(true).setMode(new Mode((short) 0700)));
+    long fileId = mFsMaster.getFileId(path);
+    FileInfo fileInfo = mFsMaster.getFileInfo(fileId);
+    Assert.assertEquals("d4", fileInfo.getName());
+    Assert.assertTrue(fileInfo.isFolder());
+    Assert.assertTrue(fileInfo.isPersisted());
+    Assert.assertEquals(0700, (short) fileInfo.getMode());
+    Assert.assertTrue(FileUtils.exists(ufsPath));
+    Assert.assertEquals(0700, FileUtils.getLocalFileMode(ufsPath));
+  }
+
+  /**
+   * Tests creating a directory in a nested directory without execute permission.
+   */
+  @Test(expected = IOException.class)
+  public void createDirectoryInNestedDirectoriesWithoutExecutePermission() throws Exception {
+    String ufs = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String parentPath = Paths.get(ufs, "d1").toString();
+    FileUtils.createDir(parentPath);
+    FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 600).toString());
+    AlluxioURI path = new AlluxioURI(Paths.get("/d1", "d2", "d3", "d4").toString());
+
+    // this should fail
+    mFsMaster.createDirectory(path, CreateDirectoryOptions.defaults()
+        .setPersisted(true).setRecursive(true).setMode(new Mode((short) 0755)));
+  }
+
+  /**
    * This class provides multiple concurrent threads to create all files in one directory.
    */
   class ConcurrentCreator implements Callable<Void> {


### PR DESCRIPTION
Fix infinite retries when a directory cannot be created in UFS due to permission issue.