### PR TITLE
[SMALLFIX] Improve worker side DEBUG logging

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -133,3 +133,6 @@ log4j.appender.FUSE_LOGGER.MaxFileSize=10MB
 log4j.appender.FUSE_LOGGER.MaxBackupIndex=10
 log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
 log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+
+# Disable noisy DEBUG logs
+log4j.logger.org.apache.thrift.transport.TSaslTransport=OFF

--- a/core/server/worker/src/main/java/alluxio/Sessions.java
+++ b/core/server/worker/src/main/java/alluxio/Sessions.java
@@ -58,7 +58,6 @@ public final class Sessions {
    * @return the list of session ids of sessions that timed out
    */
   public List<Long> getTimedOutSessions() {
-    LOG.debug("Worker is checking all sessions' status for timeouts.");
     List<Long> ret = new ArrayList<>();
     synchronized (mSessions) {
       for (Entry<Long, SessionInfo> entry : mSessions.entrySet()) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -147,6 +147,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
+    LOG.debug("lockBlock: sessionId={}, blockId={}", sessionId, blockId);
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);
     boolean hasBlock;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
@@ -162,6 +163,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public long lockBlockNoException(long sessionId, long blockId) {
+    LOG.debug("lockBlockNoException: sessionId={}, blockId={}", sessionId, blockId);
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);
     boolean hasBlock;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
@@ -177,11 +179,13 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public void unlockBlock(long lockId) throws BlockDoesNotExistException {
+    LOG.debug("unlockBlock: lockId={}", lockId);
     mLockManager.unlockBlock(lockId);
   }
 
   @Override
   public boolean unlockBlock(long sessionId, long blockId) {
+    LOG.debug("unlockBlock: sessionId={}, blockId={}", sessionId, blockId);
     return mLockManager.unlockBlock(sessionId, blockId);
   }
 
@@ -189,6 +193,7 @@ public class TieredBlockStore implements BlockStore {
   public BlockWriter getBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       IOException {
+    LOG.debug("getBlockWriter: sessionId={}, blockId={}", sessionId, blockId);
     // NOTE: a temp block is supposed to only be visible by its own writer, unnecessary to acquire
     // block lock here since no sharing
     // TODO(bin): Handle the case where multiple writers compete for the same block.
@@ -202,6 +207,7 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public BlockReader getBlockReader(long sessionId, long blockId, long lockId)
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException {
+    LOG.debug("getBlockReader: sessionId={}, blockId={}, lockId={}", sessionId, blockId, lockId);
     mLockManager.validateLock(sessionId, blockId, lockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       BlockMeta blockMeta = mMetaManager.getBlockMeta(blockId);
@@ -213,6 +219,8 @@ public class TieredBlockStore implements BlockStore {
   public TempBlockMeta createBlock(long sessionId, long blockId, BlockStoreLocation location,
       long initialBlockSize)
           throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException {
+    LOG.debug("createBlock: sessionId={}, blockId={}, location={}, initialBlockSize={}",
+        sessionId, blockId, location, initialBlockSize);
     if (RESERVER_ENABLED) {
       RetryPolicy retryPolicy = new TimeoutRetry(FREE_SPACE_TIMEOUT_MS, EVICTION_INTERVAL_MS);
       while (retryPolicy.attemptRetry()) {
@@ -250,6 +258,7 @@ public class TieredBlockStore implements BlockStore {
   // TODO(bin): Make this method to return a snapshot.
   @Override
   public BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException {
+    LOG.debug("getVolatileBlockMeta: blockId={}", blockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       return mMetaManager.getBlockMeta(blockId);
     }
@@ -258,6 +267,7 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public BlockMeta getBlockMeta(long sessionId, long blockId, long lockId)
       throws BlockDoesNotExistException, InvalidWorkerStateException {
+    LOG.debug("getBlockMeta: sessionId={}, blockId={}, lockId={}", sessionId, blockId, lockId);
     mLockManager.validateLock(sessionId, blockId, lockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       return mMetaManager.getBlockMeta(blockId);
@@ -266,6 +276,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public TempBlockMeta getTempBlockMeta(long sessionId, long blockId) {
+    LOG.debug("getTempBlockMeta: sessionId={}, blockId={}", sessionId, blockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       return mMetaManager.getTempBlockMetaOrNull(blockId);
     }
@@ -274,6 +285,7 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void commitBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+    LOG.debug("commitBlock: sessionId={}, blockId={}", sessionId, blockId);
     BlockStoreLocation loc = commitBlockInternal(sessionId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -285,6 +297,7 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void abortBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       BlockDoesNotExistException, InvalidWorkerStateException, IOException {
+    LOG.debug("abortBlock: sessionId={}, blockId={}", sessionId, blockId);
     abortBlockInternal(sessionId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -296,6 +309,8 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException {
+    LOG.debug("requestSpace: sessionId={}, blockId={}, additionalBytes={}",
+        sessionId, blockId, additionalBytes);
     if (RESERVER_ENABLED) {
       RetryPolicy retryPolicy = new TimeoutRetry(FREE_SPACE_TIMEOUT_MS, EVICTION_INTERVAL_MS);
       while (retryPolicy.attemptRetry()) {
@@ -332,6 +347,8 @@ public class TieredBlockStore implements BlockStore {
   public void moveBlock(long sessionId, long blockId, BlockStoreLocation newLocation)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
+    LOG.debug("moveBlock: sessionId={}, blockId={}, newLocation={}",
+        sessionId, blockId, newLocation);
     moveBlock(sessionId, blockId, BlockStoreLocation.anyTier(), newLocation);
   }
 
@@ -340,6 +357,8 @@ public class TieredBlockStore implements BlockStore {
       BlockStoreLocation newLocation)
           throws BlockDoesNotExistException, BlockAlreadyExistsException,
           InvalidWorkerStateException, WorkerOutOfSpaceException, IOException {
+    LOG.debug("moveBlock: sessionId={}, blockId={}, oldLocation={}, newLocation={}",
+        sessionId, blockId, oldLocation, newLocation);
     if (RESERVER_ENABLED) {
       RetryPolicy retryPolicy = new TimeoutRetry(FREE_SPACE_TIMEOUT_MS, EVICTION_INTERVAL_MS);
       while (retryPolicy.attemptRetry()) {
@@ -384,12 +403,14 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void removeBlock(long sessionId, long blockId)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+    LOG.debug("removeBlock: sessionId={}, blockId={}", sessionId, blockId);
     removeBlock(sessionId, blockId, BlockStoreLocation.anyTier());
   }
 
   @Override
   public void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+    LOG.debug("moveBlock: sessionId={}, blockId={}, location={}", sessionId, blockId, location);
     removeBlockInternal(sessionId, blockId, location);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -400,6 +421,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public void accessBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
+    LOG.debug("accessBlock: sessionId={}, blockId={}", sessionId, blockId);
     boolean hasBlock;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       hasBlock = mMetaManager.hasBlockMeta(blockId);
@@ -417,11 +439,14 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void freeSpace(long sessionId, long availableBytes, BlockStoreLocation location)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException {
+    LOG.debug("freeSpace: sessionId={}, availableBytes={}, location={}",
+        sessionId, availableBytes, location);
     freeSpaceInternal(sessionId, availableBytes, location, Mode.BEST_EFFORT);
   }
 
   @Override
   public void cleanupSession(long sessionId) {
+    LOG.debug("cleanupSession: sessionId={}", sessionId);
     // Release all locks the session is holding.
     mLockManager.cleanupSession(sessionId);
 
@@ -444,6 +469,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public boolean hasBlockMeta(long blockId) {
+    LOG.debug("hasBlockMeta: blockId={}", blockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       return mMetaManager.hasBlockMeta(blockId);
     }
@@ -451,6 +477,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public BlockStoreMeta getBlockStoreMeta() {
+    LOG.debug("getBlockStoreMeta:");
     BlockStoreMeta storeMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       storeMeta = mMetaManager.getBlockStoreMeta();
@@ -460,6 +487,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public BlockStoreMeta getBlockStoreMetaFull() {
+    LOG.debug("getBlockStoreMetaFull:");
     BlockStoreMeta storeMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       storeMeta = mMetaManager.getBlockStoreMetaFull();

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -477,7 +477,6 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public BlockStoreMeta getBlockStoreMeta() {
-    LOG.debug("getBlockStoreMeta:");
     BlockStoreMeta storeMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       storeMeta = mMetaManager.getBlockStoreMeta();
@@ -487,7 +486,6 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public BlockStoreMeta getBlockStoreMetaFull() {
-    LOG.debug("getBlockStoreMetaFull:");
     BlockStoreMeta storeMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       storeMeta = mMetaManager.getBlockStoreMetaFull();


### PR DESCRIPTION
- Remove DEBUG logging from external class TSaslTransport which is too noisy
- Remove DEBUG logging from `Sessions` on routine check which is too noisy
- Add DEBUG logging on tiered block store to assist debug

Before:
```
2018-03-17 17:59:04,084 DEBUG Sessions - Worker is checking all sessions' status for timeouts.
2018-03-17 17:59:04,084 DEBUG TSaslTransport - writing data length: 101
2018-03-17 17:59:04,084 DEBUG TSaslTransport - writing data length: 86
2018-03-17 17:59:04,084 DEBUG TSaslTransport - writing data length: 56
2018-03-17 17:59:04,086 DEBUG TSaslTransport - CLIENT: reading data length: 41
2018-03-17 17:59:04,086 DEBUG TSaslTransport - CLIENT: reading data length: 63
2018-03-17 17:59:04,086 DEBUG TSaslTransport - CLIENT: reading data length: 58
2018-03-17 17:59:04,089 DEBUG BlockMasterSync - Removed block 16777216 due to request from master
2018-03-17 17:59:05,085 DEBUG Sessions - Worker is checking all sessions' status for timeouts.
2018-03-17 17:59:05,085 DEBUG TSaslTransport - writing data length: 56
2018-03-17 17:59:05,085 DEBUG TSaslTransport - writing data length: 109
2018-03-17 17:59:05,085 DEBUG TSaslTransport - writing data length: 86
2018-03-17 17:59:05,086 DEBUG TSaslTransport - CLIENT: reading data length: 41
2018-03-17 17:59:05,086 DEBUG TSaslTransport - CLIENT: reading data length: 63
2018-03-17 17:59:05,086 DEBUG TSaslTransport - CLIENT: reading data length: 50
2018-03-17 17:59:06,085 DEBUG Sessions - Worker is checking all sessions' status for timeouts.
2018-03-17 17:59:06,085 DEBUG TSaslTransport - writing data length: 101
2018-03-17 17:59:06,085 DEBUG TSaslTransport - writing data length: 86
2018-03-17 17:59:06,085 DEBUG TSaslTransport - writing data length: 56
2018-03-17 17:59:06,086 DEBUG TSaslTransport - CLIENT: reading data length: 41
2018-03-17 17:59:06,086 DEBUG TSaslTransport - CLIENT: reading data length: 63
2018-03-17 17:59:06,086 DEBUG TSaslTransport - CLIENT: reading data length: 50
2018-03-17 17:59:07,088 DEBUG Sessions - Worker is checking all sessions' status for timeouts.
2018-03-17 17:59:07,089 DEBUG TSaslTransport - writing data length: 86
2018-03-17 17:59:07,089 DEBUG TSaslTransport - writing data length: 101
2018-03-17 17:59:07,088 DEBUG TSaslTransport - writing data length: 56
2018-03-17 17:59:07,090 DEBUG TSaslTransport - CLIENT: reading data length: 50
2018-03-17 17:59:07,090 DEBUG TSaslTransport - CLIENT: reading data length: 63
2018-03-17 17:59:07,090 DEBUG TSaslTransport - CLIENT: reading data length: 41
```

After:
```
2018-03-17 17:40:47,742 DEBUG TieredBlockStore - lockBlock: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,742 DEBUG BlockReadHandler - Block 33554432 to promote does not exist in Alluxio: blockId 33554432 not found
2018-03-17 17:40:47,742 DEBUG TieredBlockStore - lockBlockNoException: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,742 DEBUG UnderFileSystemWithLogging - Enter: ConnectFromWorker: hostname=10.0.1.37
2018-03-17 17:40:47,742 DEBUG UnderFileSystemWithLogging - Exit (OK): ConnectFromWorker: hostname=10.0.1.37
2018-03-17 17:40:47,742 DEBUG UnderFileSystemWithLogging - Enter: Open: path=/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/output2/part-r-00000, options=OpenOptions{offset=0, length=9223372036854775807, recoverFailedOpen=false}
2018-03-17 17:40:47,742 DEBUG UnderFileSystemWithLogging - Exit (OK): Open: path=/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/output2/part-r-00000, options=OpenOptions{offset=0, length=9223372036854775807, recoverFailedOpen=false}
2018-03-17 17:40:47,742 DEBUG TieredBlockStore - createBlock: sessionId=8155072709129938551, blockId=33554432, location=any dir, tierAlias MEM, initialBlockSize=1048576
2018-03-17 17:40:47,746 DEBUG TieredBlockStore - Created new file block, block path: /Volumes/ramdisk/alluxioworker/.tmp_blocks/631/712ca36be92c2677-2000000
2018-03-17 17:40:47,746 DEBUG TieredBlockStore - getBlockWriter: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - requestSpace: sessionId=8155072709129938551, blockId=33554432, additionalBytes=2865
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - unlockBlock: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - getTempBlockMeta: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - commitBlock: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - lockBlock: sessionId=8155072709129938551, blockId=33554432
2018-03-17 17:40:47,747 DEBUG TieredBlockStore - getBlockMeta: sessionId=8155072709129938551, blockId=33554432, lockId=45
2018-03-17 17:40:47,748 DEBUG TieredBlockStore - unlockBlock: lockId=45
2018-03-17 17:40:47,763 DEBUG TieredBlockStore - lockBlockNoException: sessionId=-7, blockId=33554432
2018-03-17 17:40:47,763 DEBUG TieredBlockStore - unlockBlock: lockId=46
```