### PR TITLE
[SMALLFIX] Fix async evictor with small high/low watermarks

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -97,7 +97,7 @@ public class SpaceReserver implements HeartbeatExecutor {
       long reservedSpace = mReservedSpaces.get(tierAlias);
       if (mHighWatermarks.containsKey(tierAlias)) {
         long highWatermark = mHighWatermarks.get(tierAlias);
-        if (highWatermark > reservedSpace && usedBytesOnTiers.get(tierAlias) >= highWatermark) {
+        if (usedBytesOnTiers.get(tierAlias) >= highWatermark) {
           try {
             mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
           } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
@@ -106,7 +106,7 @@ public class SpaceReserver implements HeartbeatExecutor {
                 + "{}", tierAlias, reservedSpace, e.getMessage());
           }
         }
-      } else {
+      } else if (usedBytesOnTiers.get(tierAlias) >= reservedSpace) {
         try {
           mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
         } catch (WorkerOutOfSpaceException | BlockDoesNotExistException

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpaceReserverTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpaceReserverTest.java
@@ -11,8 +11,7 @@
 
 package alluxio.worker.block;
 
-import alluxio.Configuration;
-import alluxio.ConfigurationTestUtils;
+import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
 import alluxio.Sessions;
 import alluxio.heartbeat.HeartbeatContext;
@@ -27,8 +26,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import java.io.Closeable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,14 +46,13 @@ public class SpaceReserverTest {
   public TemporaryFolder mTempFolder = new TemporaryFolder();
 
   @Rule
-  public ManuallyScheduleHeartbeat mSchedule =
-      new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_SPACE_RESERVER);
+  public ManuallyScheduleHeartbeat mSchedule = new ManuallyScheduleHeartbeat(
+      HeartbeatContext.WORKER_SPACE_RESERVER);
 
   @Before
   public void before() {
     mExecutorService =
         Executors.newFixedThreadPool(1, ThreadFactoryUtils.build("space-reserver-test", true));
-    ConfigurationTestUtils.resetConfiguration();
   }
 
   @After
@@ -75,24 +76,22 @@ public class SpaceReserverTest {
         new String[][]{new String[]{"/a"}, new String[]{"/b"}},
         new long[][]{new long[]{0}, new long[]{0}}, "/");
 
-    PropertyKey reserveRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO.format(0);
-    Configuration.set(reserveRatioProp, "0.2");
-    reserveRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO.format(1);
-    Configuration.set(reserveRatioProp, "0.3");
-    SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
+    try (Closeable c = new ConfigurationRule(ImmutableMap.of(
+        PropertyKey.WORKER_TIERED_STORE_LEVEL0_RESERVED_RATIO, "0.2",
+        PropertyKey.WORKER_TIERED_STORE_LEVEL1_RESERVED_RATIO, "0.3")).toResource()) {
+      SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
 
-    mExecutorService.submit(
-        new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, spaceReserver, 0));
+      mExecutorService.submit(new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER,
+          spaceReserver, 0));
 
-    // Run the space reserver once.
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
+      // Run the space reserver once.
+      HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
 
-    // 400 * 0.2 = 80
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 80L, "MEM");
-    // 400 * 0.2 + 1000 * 0.3 = 380
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 380L, "HDD");
+      // 400 * 0.2 = 80
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 80L, "MEM");
+      // 400 * 0.2 + 1000 * 0.3 = 380
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 380L, "HDD");
+    }
   }
 
   @Test
@@ -114,38 +113,31 @@ public class SpaceReserverTest {
         new int[]{0, 1, 2}, new String[] {"MEM", "SSD", "HDD"},
         new String[][]{new String[]{"/a"}, new String[]{"/b"}, new String[]{"/c"}},
         new long[][]{new long[]{0}, new long[]{0}, new long[]{0}}, "/");
-    PropertyKey highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(0);
-    Configuration.set(highWatermarkRatioProp, "0.9");
-    PropertyKey lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(0);
-    Configuration.set(lowWatermarkRatioProp, "0.8");
-    highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(1);
-    Configuration.set(highWatermarkRatioProp, "0.9");
-    lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(1);
-    Configuration.set(lowWatermarkRatioProp, "0.7");
-    highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(2);
-    Configuration.set(highWatermarkRatioProp, "0.8");
-    lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(2);
-    Configuration.set(lowWatermarkRatioProp, "0.6");
-    SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
+    try (Closeable c = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, "0.9");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_LOW_WATERMARK_RATIO, "0.8");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO, "0.9");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_LOW_WATERMARK_RATIO, "0.7");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO, "0.8");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_LOW_WATERMARK_RATIO, "0.6");
+      }
+    }).toResource()) {
+      SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
 
-    mExecutorService.submit(
-        new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, spaceReserver, 0));
+      mExecutorService.submit(new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER,
+          spaceReserver, 0));
 
-    // Run the space reserver once.
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
+      // Run the space reserver once.
+      HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
 
-    // 1000 * 0.4 + 200 * 0.3 + 100 * 0.2 = 480
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 480L, "HDD");
-    // 200 * 0.3 + 100 * 0.2 = 80
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 80L, "SSD");
-    // 100 * 0.2 = 20
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 20L, "MEM");
+      // 1000 * 0.4 + 200 * 0.3 + 100 * 0.2 = 480
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 480L, "HDD");
+      // 200 * 0.3 + 100 * 0.2 = 80
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 80L, "SSD");
+      // 100 * 0.2 = 20
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 20L, "MEM");
+    }
   }
 
   @Test
@@ -164,42 +156,81 @@ public class SpaceReserverTest {
 
     // Create two tiers named "MEM", "SSD" and "HDD" with aliases 0, 1 and 2.
     TieredBlockStoreTestUtils.setupConfWithMultiTier(tmpFolderPath,
-        new int[]{0, 1, 2}, new String[] {"MEM", "SSD", "HDD"},
+        new int[]{0, 1, 2}, new String[]{"MEM", "SSD", "HDD"},
         new String[][]{new String[]{"/a"}, new String[]{"/b"}, new String[]{"/c"}},
         new long[][]{new long[]{0}, new long[]{0}, new long[]{0}}, "/");
-    PropertyKey highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(0);
-    Configuration.set(highWatermarkRatioProp, "0.9");
-    PropertyKey lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(0);
-    Configuration.set(lowWatermarkRatioProp, "0.8");
-    highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(1);
-    Configuration.set(highWatermarkRatioProp, "0.9");
-    lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(1);
-    Configuration.set(lowWatermarkRatioProp, "0.7");
-    highWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(2);
-    Configuration.set(highWatermarkRatioProp, "0.8");
-    lowWatermarkRatioProp =
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(2);
-    Configuration.set(lowWatermarkRatioProp, "0.6");
-    SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
+    try (Closeable c = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, "0.9");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_LOW_WATERMARK_RATIO, "0.8");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO, "0.9");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_LOW_WATERMARK_RATIO, "0.7");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO, "0.8");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_LOW_WATERMARK_RATIO, "0.6");
+      }
+    }).toResource()) {
+      SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
 
-    mExecutorService.submit(
-        new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, spaceReserver, 0));
+      mExecutorService.submit(new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER,
+          spaceReserver, 0));
 
-    // Run the space reserver once.
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
+      // Run the space reserver once.
+      HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
 
-    // 1000 * 0.4 + 200 * 0.3 + 100 * 0.2 = 480
-    Mockito.verify(blockWorker, Mockito.times(0)).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID,
-        480L, "HDD");
-    // 200 * 0.3 + 100 * 0.2 = 80
-    Mockito.verify(blockWorker, Mockito.times(0)).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID,
-        80L, "SSD");
-    // 100 * 0.2 = 20
-    Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 20L, "MEM");
+      // 1000 * 0.4 + 200 * 0.3 + 100 * 0.2 = 480
+      Mockito.verify(blockWorker, Mockito.never()).freeSpace(
+          Matchers.eq(Sessions.MIGRATE_DATA_SESSION_ID), Matchers.anyLong(), Matchers.eq("HDD"));
+      // 200 * 0.3 + 100 * 0.2 = 80
+      Mockito.verify(blockWorker, Mockito.never()).freeSpace(
+          Matchers.eq(Sessions.MIGRATE_DATA_SESSION_ID), Matchers.anyLong(), Matchers.eq("SSD"));
+      // 100 * 0.2 = 20
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 20L, "MEM");
+    }
+  }
+
+  @Test
+  public void smallWatermarkValues() throws Exception {
+    BlockWorker blockWorker = Mockito.mock(BlockWorker.class);
+    BlockStoreMeta storeMeta = Mockito.mock(BlockStoreMeta.class);
+    Mockito.when(blockWorker.getStoreMeta()).thenReturn(storeMeta);
+    Map<String, Long> capacityBytesOnTiers =
+        ImmutableMap.of("MEM", 100L, "SSD", 200L, "HDD", 1000L);
+    Map<String, Long> usedCapacityBytesOnTiers =
+        ImmutableMap.of("MEM", 100L, "SSD", 100L, "HDD", 0L);
+    Mockito.when(storeMeta.getCapacityBytesOnTiers()).thenReturn(capacityBytesOnTiers);
+    Mockito.when(storeMeta.getUsedBytesOnTiers()).thenReturn(usedCapacityBytesOnTiers);
+
+    String tmpFolderPath = mTempFolder.newFolder().getAbsolutePath();
+    // Create two tiers named "MEM", "SSD" and "HDD" with aliases 0, 1 and 2.
+    TieredBlockStoreTestUtils.setupConfWithMultiTier(tmpFolderPath,
+        new int[]{0, 1, 2}, new String[]{"MEM", "SSD", "HDD"},
+        new String[][]{new String[]{"/a"}, new String[]{"/b"}, new String[]{"/c"}},
+        new long[][]{new long[]{0}, new long[]{0}, new long[]{0}}, "/");
+    try (Closeable c = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, "0.4");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_LOW_WATERMARK_RATIO, "0.3");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO, "0.3");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_LOW_WATERMARK_RATIO, "0.2");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO, "0.2");
+        put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_LOW_WATERMARK_RATIO, "0.1");
+      }
+    }).toResource()) {
+      SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
+
+      mExecutorService.submit(new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER,
+          spaceReserver, 0));
+
+      // Run the space reserver once.
+      HeartbeatScheduler.execute(HeartbeatContext.WORKER_SPACE_RESERVER);
+
+      // 1000 * 0.1 + 200 = 300
+      Mockito.verify(blockWorker, Mockito.never()).freeSpace(
+          Matchers.eq(Sessions.MIGRATE_DATA_SESSION_ID), Matchers.anyLong(), Matchers.eq("HDD"));
+      // 200 * 0.8 + 100 * 0.7 = 230 -> 200
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 200L, "SSD");
+      // 100 * 0.7 = 70
+      Mockito.verify(blockWorker).freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, 70L, "MEM");
+    }
   }
 }


### PR DESCRIPTION
before this fix, async evict will not trigger when low watermark + high watermark < 100%.
Is this intended? I view watermarks [10%, 80%] a valid pair.