### PR TITLE
[ALLUXIO-3134] Use context to delete block ids for deleted files

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemTestUtils.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemTestUtils.java
@@ -139,7 +139,8 @@ public final class FileSystemTestUtils {
    * @param fileName the name of the file to load
    */
   public static void loadFile(FileSystem fs, String fileName) {
-    try (FileInStream is = fs.openFile(new AlluxioURI(fileName))) {
+    try (FileInStream is = fs.openFile(new AlluxioURI(fileName),
+        OpenFileOptions.defaults().setReadType(ReadType.CACHE))) {
       IOUtils.copy(is, ByteStreams.nullOutputStream());
     } catch (IOException | AlluxioException e) {
       throw new RuntimeException(e);

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemTestUtils.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemTestUtils.java
@@ -18,6 +18,9 @@ import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.options.OpenFileOptions;
 import alluxio.exception.AlluxioException;
 
+import com.google.common.io.ByteStreams;
+import org.apache.commons.io.IOUtils;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -124,6 +127,20 @@ public final class FileSystemTestUtils {
         }
       }
       return res;
+    } catch (IOException | AlluxioException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Loads a file into Alluxio by reading it.
+   *
+   * @param fs a {@link FileSystem}
+   * @param fileName the name of the file to load
+   */
+  public static void loadFile(FileSystem fs, String fileName) {
+    try (FileInStream is = fs.openFile(new AlluxioURI(fileName))) {
+      IOUtils.copy(is, ByteStreams.nullOutputStream());
     } catch (IOException | AlluxioException e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
@@ -11,9 +11,8 @@
 
 package alluxio.master.file;
 
-import alluxio.exception.status.UnavailableException;
-
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -34,10 +33,15 @@ public interface BlockDeletionContext extends Closeable {
   void registerBlockForDeletion(long blockId);
 
   /**
-   * @return a list of the blocks scheduled for deletion
+   * Interface for block deletion listeners.
    */
-  List<Long> getBlocks();
-
-  @Override
-  void close() throws UnavailableException;
+  @FunctionalInterface
+  interface BlockDeletionListener {
+    /**
+     * Processes block deletion.
+     *
+     * @param blocks the deleted blocks
+     */
+    void process(List<Long> blocks) throws IOException;
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import alluxio.exception.status.UnavailableException;
+
+import java.io.Closeable;
+import java.util.Collection;
+
+/**
+ * Interface for a class which gathers block deletion requests, then handles them during close.
+ */
+public interface BlockDeletionContext extends Closeable {
+  /**
+   * @param blockIds the blocks to be deleted when the context closes
+   */
+  default void registerBlocksForDeletion(Collection<Long> blockIds) {
+    blockIds.forEach(id -> registerBlockForDeletion(id));
+  }
+
+  /**
+   * @param blockId the block to be deleted when the context closes
+   */
+  void registerBlockForDeletion(long blockId);
+
+  @Override
+  void close() throws UnavailableException;
+}

--- a/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
@@ -15,6 +15,7 @@ import alluxio.exception.status.UnavailableException;
 
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Interface for a class which gathers block deletion requests, then handles them during close.
@@ -31,6 +32,11 @@ public interface BlockDeletionContext extends Closeable {
    * @param blockId the block to be deleted when the context closes
    */
   void registerBlockForDeletion(long blockId);
+
+  /**
+   * @return a list of the blocks scheduled for deletion
+   */
+  List<Long> getBlocks();
 
   @Override
   void close() throws UnavailableException;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
@@ -14,6 +14,8 @@ package alluxio.master.file;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.block.BlockMaster;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,24 +35,25 @@ public final class DefaultBlockDeletionContext implements BlockDeletionContext {
     mBlocks = new ArrayList<>();
   }
 
-  /**
-   * @param blockIds the blocks to be deleted when the context closes
-   */
   @Override
   public void registerBlocksForDeletion(Collection<Long> blockIds) {
     mBlocks.addAll(blockIds);
   }
 
-  /**
-   * @param blockId the block to be deleted when the context closes
-   */
   @Override
   public void registerBlockForDeletion(long blockId) {
     mBlocks.add(blockId);
   }
 
   @Override
+  public List<Long> getBlocks() {
+    return ImmutableList.copyOf(mBlocks);
+  }
+
+  @Override
   public void close() throws UnavailableException {
     mBlockMaster.removeBlocks(mBlocks, true);
+    // In case close gets called multiple times for some reason.
+    mBlocks.clear();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
@@ -1,0 +1,56 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.block.BlockMaster;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Class for tracking which blocks need to be deleted, and deleting them on close.
+ */
+public final class DefaultBlockDeletionContext implements BlockDeletionContext {
+  private final BlockMaster mBlockMaster;
+  private final List<Long> mBlocks;
+
+  /**
+   * @param blockMaster the block master to use for deleting blocks
+   */
+  public DefaultBlockDeletionContext(BlockMaster blockMaster) {
+    mBlockMaster = blockMaster;
+    mBlocks = new ArrayList<>();
+  }
+
+  /**
+   * @param blockIds the blocks to be deleted when the context closes
+   */
+  @Override
+  public void registerBlocksForDeletion(Collection<Long> blockIds) {
+    mBlocks.addAll(blockIds);
+  }
+
+  /**
+   * @param blockId the block to be deleted when the context closes
+   */
+  @Override
+  public void registerBlockForDeletion(long blockId) {
+    mBlocks.add(blockId);
+  }
+
+  @Override
+  public void close() throws UnavailableException {
+    mBlockMaster.removeBlocks(mBlocks, true);
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -100,7 +100,7 @@ public interface FileSystemMaster extends Master {
    */
   FileInfo getFileInfo(AlluxioURI path, GetStatusOptions options)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
-      UnavailableException;
+      UnavailableException, IOException;
 
   /**
    * Returns the persistence state for a file id. This method is used by the lineage master.
@@ -129,7 +129,7 @@ public interface FileSystemMaster extends Master {
    */
   List<FileInfo> listStatus(AlluxioURI path, ListStatusOptions listStatusOptions)
       throws AccessControlException, FileDoesNotExistException, InvalidPathException,
-      UnavailableException;
+      UnavailableException, IOException;
 
   /**
    * @return a read-only view of the file system master

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -228,7 +228,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallableThrowsIOException<GetStatusTResponse>() {
       @Override
-      public GetStatusTResponse call() throws AlluxioException, AlluxioStatusException {
+      public GetStatusTResponse call() throws AlluxioException, IOException {
         return new GetStatusTResponse(ThriftUtils.toThrift(
             mFileSystemMaster.getFileInfo(new AlluxioURI(path), new GetStatusOptions(options))));
       }
@@ -246,7 +246,7 @@ public final class FileSystemMasterClientServiceHandler implements
       throws AlluxioTException {
     return RpcUtils.call(LOG, new RpcCallableThrowsIOException<ListStatusTResponse>() {
       @Override
-      public ListStatusTResponse call() throws AlluxioException, AlluxioStatusException {
+      public ListStatusTResponse call() throws AlluxioException, IOException {
         List<FileInfo> result = new ArrayList<>();
         for (alluxio.wire.FileInfo fileInfo : mFileSystemMaster
             .listStatus(new AlluxioURI(path), new ListStatusOptions(options))) {

--- a/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
@@ -1,0 +1,29 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+/**
+ * Implementation of {@link DefaultBlockDeletionContext} which does nothing.
+ */
+public final class NoopBlockDeletionContext implements BlockDeletionContext {
+  public static final NoopBlockDeletionContext INSTANCE = new NoopBlockDeletionContext();
+
+  @Override
+  public void registerBlockForDeletion(long blockId) {
+    return;
+  }
+
+  @Override
+  public void close() {
+    return;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
@@ -11,9 +11,6 @@
 
 package alluxio.master.file;
 
-import java.util.Collections;
-import java.util.List;
-
 /**
  * Implementation of {@link DefaultBlockDeletionContext} which does nothing.
  */
@@ -23,11 +20,6 @@ public final class NoopBlockDeletionContext implements BlockDeletionContext {
   @Override
   public void registerBlockForDeletion(long blockId) {
     return;
-  }
-
-  @Override
-  public List<Long> getBlocks() {
-    return Collections.emptyList();
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/NoopBlockDeletionContext.java
@@ -11,6 +11,9 @@
 
 package alluxio.master.file;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Implementation of {@link DefaultBlockDeletionContext} which does nothing.
  */
@@ -20,6 +23,11 @@ public final class NoopBlockDeletionContext implements BlockDeletionContext {
   @Override
   public void registerBlockForDeletion(long blockId) {
     return;
+  }
+
+  @Override
+  public List<Long> getBlocks() {
+    return Collections.emptyList();
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -30,6 +30,7 @@ import alluxio.master.MasterRegistry;
 import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
+import alluxio.master.file.NoopBlockDeletionContext;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
 import alluxio.master.file.options.CreatePathOptions;
@@ -803,7 +804,7 @@ public final class InodeTreeTest {
   private static void deleteInodeByPath(InodeTree root, AlluxioURI path) throws Exception {
     try (LockedInodePath inodePath = root.lockFullInodePath(path, InodeTree.LockMode.WRITE)) {
       root.deleteInode(inodePath, System.currentTimeMillis(), DeleteOptions.defaults(),
-          NoopJournalContext.INSTANCE);
+          NoopJournalContext.INSTANCE, NoopBlockDeletionContext.INSTANCE);
     }
   }
 

--- a/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/FileSystemMasterIntegrationTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.file;
 
+import static org.junit.Assert.assertFalse;
+
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.BaseIntegrationTest;
@@ -18,6 +20,11 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.LocalAlluxioClusterResource;
 import alluxio.PropertyKey;
+import alluxio.PropertyKey.Name;
+import alluxio.client.WriteType;
+import alluxio.client.block.BlockMasterClient;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemTestUtils;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyCompletedException;
@@ -27,6 +34,7 @@ import alluxio.exception.InvalidPathException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
+import alluxio.master.MasterClientConfig;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.block.BlockMaster;
@@ -48,7 +56,9 @@ import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
+import alluxio.util.io.PathUtils;
 import alluxio.wire.CommonOptions;
 import alluxio.wire.FileInfo;
 import alluxio.wire.LoadMetadataType;
@@ -148,11 +158,11 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals("testFolder", fileInfo.getName());
     Assert.assertEquals(1, fileInfo.getFileId());
     Assert.assertEquals(0, fileInfo.getLength());
-    Assert.assertFalse(fileInfo.isCacheable());
+    assertFalse(fileInfo.isCacheable());
     Assert.assertTrue(fileInfo.isCompleted());
     Assert.assertTrue(fileInfo.isFolder());
-    Assert.assertFalse(fileInfo.isPersisted());
-    Assert.assertFalse(fileInfo.isPinned());
+    assertFalse(fileInfo.isPersisted());
+    assertFalse(fileInfo.isPinned());
     Assert.assertEquals("", fileInfo.getOwner());
     Assert.assertEquals(0755, (short) fileInfo.getMode());
   }
@@ -168,10 +178,10 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(fileId, fileInfo.getFileId());
     Assert.assertEquals(0, fileInfo.getLength());
     Assert.assertTrue(fileInfo.isCacheable());
-    Assert.assertFalse(fileInfo.isCompleted());
-    Assert.assertFalse(fileInfo.isFolder());
-    Assert.assertFalse(fileInfo.isPersisted());
-    Assert.assertFalse(fileInfo.isPinned());
+    assertFalse(fileInfo.isCompleted());
+    assertFalse(fileInfo.isFolder());
+    assertFalse(fileInfo.isPersisted());
+    assertFalse(fileInfo.isPinned());
     Assert.assertEquals(Constants.NO_TTL, fileInfo.getTtl());
     Assert.assertEquals(TtlAction.DELETE, fileInfo.getTtlAction());
     Assert.assertEquals("", fileInfo.getOwner());
@@ -325,7 +335,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   public void createFile() throws Exception {
     mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileOptions.defaults());
     FileInfo fileInfo = mFsMaster.getFileInfo(mFsMaster.getFileId(new AlluxioURI("/testFile")));
-    Assert.assertFalse(fileInfo.isFolder());
+    assertFalse(fileInfo.isFolder());
     Assert.assertEquals("", fileInfo.getOwner());
     Assert.assertEquals(0644, (short) fileInfo.getMode());
   }
@@ -461,6 +471,31 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         .setRecursive(true));
     Assert.assertEquals(IdUtils.INVALID_FILE_ID,
         mFsMaster.getFileId(new AlluxioURI("/testFolder")));
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {Name.WORKER_MEMORY_SIZE, "10mb", Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "1k"})
+  public void deleteDirectoryRecursive() throws Exception {
+    AlluxioURI dir = new AlluxioURI("/testFolder");
+    mFsMaster.createDirectory(dir, CreateDirectoryOptions.defaults());
+    FileSystem fs = mLocalAlluxioClusterResource.get().getClient();
+    for (int i = 0; i < 3; i++) {
+      FileSystemTestUtils.createByteFile(fs, PathUtils.concatPath(dir, "file" + i), 100,
+          alluxio.client.file.options.CreateFileOptions.defaults()
+              .setWriteType(WriteType.MUST_CACHE));
+    }
+    fs.delete(dir, alluxio.client.file.options.DeleteOptions.defaults().setRecursive(true));
+    assertFalse(fs.exists(dir));
+    // Make sure that the blocks are cleaned up
+    BlockMasterClient blockClient = BlockMasterClient.Factory.create(MasterClientConfig.defaults());
+    CommonUtils.waitFor("data to be deleted", (x) -> {
+      try {
+        return blockClient.getUsedBytes() == 0;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
@@ -1,0 +1,106 @@
+package alluxio.underfs;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import alluxio.AlluxioURI;
+import alluxio.BaseIntegrationTest;
+import alluxio.Constants;
+import alluxio.LocalAlluxioClusterResource;
+import alluxio.PropertyKey;
+import alluxio.UnderFileSystemFactoryRegistryRule;
+import alluxio.client.WriteType;
+import alluxio.client.block.BlockMasterClient;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.options.FreeOptions;
+import alluxio.exception.AlluxioException;
+import alluxio.master.MasterClientConfig;
+import alluxio.underfs.delegating.DelegatingUnderFileSystem;
+import alluxio.underfs.delegating.DelegatingUnderFileSystemFactory;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+
+import com.google.common.io.Files;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
+  private static final String LOCAL_UFS_PATH = Files.createTempDir().getAbsolutePath();
+
+  private FileSystem mFs;
+
+  // An under file system which fails 90% of its renames.
+  private static final UnderFileSystem UFS =
+      new DelegatingUnderFileSystem(UnderFileSystem.Factory.create(LOCAL_UFS_PATH)) {
+        @Override
+        public boolean deleteFile(String path) throws IOException {
+          if (ThreadLocalRandom.current().nextBoolean()) {
+            return mUfs.deleteFile(path);
+          } else {
+            return false;
+          }
+        }
+      };
+
+  @ClassRule
+  public static UnderFileSystemFactoryRegistryRule sUnderfilesystemfactoryregistry =
+      new UnderFileSystemFactoryRegistryRule(new DelegatingUnderFileSystemFactory(UFS));
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
+              DelegatingUnderFileSystemFactory.DELEGATING_SCHEME + "://" + LOCAL_UFS_PATH)
+          .build();
+
+  @Before
+  public void before() throws Exception {
+    mFs = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @Test
+  public void deletePartial() throws Exception {
+    mFs.createDirectory(new AlluxioURI("/dir"));
+    for (int i = 0; i < 100; i++) {
+      FileSystemTestUtils.createByteFile(mFs, "/dir/test" + i, 100,
+          alluxio.client.file.options.CreateFileOptions.defaults()
+              .setWriteType(WriteType.CACHE_THROUGH));
+    }
+    String ufs = LOCAL_UFS_PATH;
+    // This will make the "/dir" directory out of sync so that the files are deleted individually.
+    java.nio.file.Files.createDirectory(Paths.get(ufs, "/dir/testunknown"));
+    try {
+      mFs.delete(new AlluxioURI("/dir"),
+          alluxio.client.file.options.DeleteOptions.defaults().setRecursive(true));
+      fail("Expected an exception to be thrown");
+    } catch (AlluxioException e) {
+      // expected
+    }
+    int deleted = 0;
+    for (int i = 0; i < 100; i++) {
+      if (!mFs.exists(new AlluxioURI("/dir/test" + i))) {
+        deleted++;
+      }
+    }
+    // It's a coin flip whether each delete succeeded. If less than 20 out of 100 succeed, something
+    // is probably wrong.
+    assertThat(deleted, Matchers.greaterThan(20));
+    mFs.free(new AlluxioURI("/"), FreeOptions.defaults().setRecursive(true));
+    BlockMasterClient blockClient = BlockMasterClient.Factory.create(MasterClientConfig.defaults());
+    CommonUtils.waitFor("data to be freed", (x) -> {
+      try {
+        return blockClient.getUsedBytes() == 0;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
+  }
+}

--- a/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
@@ -101,10 +101,10 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
         deleted++;
       }
     }
-    // It's a coin flip whether each delete succeeds. With high likelihood, between 20 and 80
-    // deletes should succeed.
-    assertThat(deleted, Matchers.greaterThan(20));
-    assertThat(deleted, Matchers.lessThan(80));
+    // It's a coin flip whether each delete succeeds. With extremely high likelihood, between 10 and
+    // 90 deletes should succeed.
+    assertThat(deleted, Matchers.greaterThan(10));
+    assertThat(deleted, Matchers.lessThan(90));
     mFs.free(new AlluxioURI("/"), FreeOptions.defaults().setRecursive(true));
     BlockMasterClient blockClient = BlockMasterClient.Factory.create(MasterClientConfig.defaults());
     CommonUtils.waitFor("data to be freed", (x) -> {

--- a/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/underfs/FlakyUfsIntegrationTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.underfs;
 
 import static org.junit.Assert.assertThat;
@@ -90,9 +101,10 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
         deleted++;
       }
     }
-    // It's a coin flip whether each delete succeeded. If less than 20 out of 100 succeed, something
-    // is probably wrong.
+    // It's a coin flip whether each delete succeeds. With high likelihood, between 20 and 80
+    // deletes should succeed.
     assertThat(deleted, Matchers.greaterThan(20));
+    assertThat(deleted, Matchers.lessThan(80));
     mFs.free(new AlluxioURI("/"), FreeOptions.defaults().setRecursive(true));
     BlockMasterClient blockClient = BlockMasterClient.Factory.create(MasterClientConfig.defaults());
     CommonUtils.waitFor("data to be freed", (x) -> {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3134

This PR introduces a context to track which blocks need to be deleted so that we can use try-with-resources to guarantee that they will be removed, even if an RPC throws an exception.

We now have quite a few context-like objects that must be used in a certain order: BlockDeletionContext, LockedInodePath, JournalContext, and AuditContext. In a followup PR to master, I will merge these contexts into a single context that will ensure that the correct order is used, and save us from passing too many arguments to every RPC handler.