### PR TITLE
[SMALLFIX] Improve error logging in masters

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -793,7 +793,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
         synchronized (worker) {
           final long lastUpdate = mClock.millis() - worker.getLastUpdatedTimeMs();
           if (lastUpdate > masterWorkerTimeoutMs) {
-            LOG.error("The worker {} timed out after {}ms without a heartbeat!", worker,
+            LOG.error("The worker {} timed out after {}ms without a heartbeat!", worker.getId(),
                 lastUpdate);
             mLostWorkers.add(worker);
             mWorkers.remove(worker);

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -793,8 +793,8 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
         synchronized (worker) {
           final long lastUpdate = mClock.millis() - worker.getLastUpdatedTimeMs();
           if (lastUpdate > masterWorkerTimeoutMs) {
-            LOG.error("The worker {} timed out after {}ms without a heartbeat!", worker.getId(),
-                lastUpdate);
+            LOG.error("The worker {}({}) timed out after {}ms without a heartbeat!", worker.getId(),
+                worker.getWorkerAddress(), lastUpdate);
             mLostWorkers.add(worker);
             mWorkers.remove(worker);
             processWorkerRemovedBlocks(worker, worker.getBlocks());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -138,7 +138,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.thrift.TProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -476,7 +475,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       } catch (AlluxioException e) {
         // It's possible that rescheduling the async persist calls fails, because the blocks may no
         // longer be in the memory
-        LOG.error(e.getMessage());
+        LOG.error("Failed to process async persist request.", e);
       }
     } else {
       throw new IOException(ExceptionMessage.UNEXPECTED_JOURNAL_ENTRY.getMessage(entry));
@@ -1301,7 +1300,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         ufs = mUfsManager.get(mountInfo.getMountId()).getUfs();
       } catch (UnavailableException | NotFoundException e) {
         // We should never reach here
-        LOG.error(String.format("No UFS cached for %s", info), e);
+        LOG.error("No UFS cached for {}", info, e);
         continue;
       }
       info.setUfsType(ufs.getUnderFSType());
@@ -2474,7 +2473,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         }
       }
     } catch (IOException e) {
-      LOG.error(ExceptionUtils.getStackTrace(e));
+      LOG.error("Failed to loadMetadataAndJournal: inodePath={}, options={}.", inodePath.getUri(),
+          options, e);
       throw e;
     }
   }
@@ -3139,7 +3139,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             deletedInode = true;
           } catch (DirectoryNotEmptyException | IOException e) {
             // Should not happen, since it is an unchecked delete.
-            LOG.error("Unexpected error for unchecked delete. error: {}", e.toString());
+            LOG.error("Unexpected error for unchecked delete.", e);
           }
         }
         if (syncPlan.toLoadMetadata()) {
@@ -3150,8 +3150,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         }
       }
     } catch (Exception e) {
-      LOG.error("Failed to remove out-of-sync metadata for path: {} error: {}", inodePath.getUri(),
-          e.toString());
+      LOG.error("Failed to remove out-of-sync metadata for path: {}", inodePath.getUri(), e);
       return false;
     } finally {
       if (deletedInode) {
@@ -3170,8 +3169,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       } catch (Exception e) {
         // This may be expected. For example, when creating a new file, the UFS file is not
         // expected to exist.
-        LOG.debug("Failed to load metadata for path: {} error: {}", inodePath.getUri(),
-            e.toString());
+        LOG.debug("Failed to load metadata for path: {}", inodePath.getUri(), e);
         return false;
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -475,7 +475,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       } catch (AlluxioException e) {
         // It's possible that rescheduling the async persist calls fails, because the blocks may no
         // longer be in the memory
-        LOG.error("Failed to process async persist request.", e);
+        LOG.error("Failed to process journal entry of async persist request.", e.toString());
       }
     } else {
       throw new IOException(ExceptionMessage.UNEXPECTED_JOURNAL_ENTRY.getMessage(entry));
@@ -2473,7 +2473,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         }
       }
     } catch (IOException e) {
-      LOG.error("Failed to loadMetadataAndJournal: inodePath={}, options={}.", inodePath.getUri(),
+      LOG.debug("Failed to loadMetadataAndJournal: inodePath={}, options={}.", inodePath.getUri(),
           options, e);
       throw e;
     }


### PR DESCRIPTION
- Avoid use `LOG.error(e.getMessage());` --- no way to locate the exception
- on `LOG.error`, avoid using `e.toString()` but `e` directly to have more exception info 
- Fix

```
2018-03-19 10:09:18,126 ERROR DefaultBlockMaster - The worker MasterWorkerInfo{id=5811404141286572521, workerAddress=WorkerNetAddress{host=xxxx, rpcPort=29998, dataPort=29999, webPort=30000, domainSocketPath=, tieredIdentity=TieredIdentity(node=gdc-worker03-uspresto.i.nease.net, rack=null)}, capacityBytes=869730877440, usedBytes=5040223851, lastUpdatedTimeMs=1521425057100, blocks=[101300830208, 1210979450880, 1208328650752, 1208261541888, 1214821433344, 1214452334592, 128664469504, 1235625181184, 1233024712704, 185052692480, 193390968832, 203675402240, 205034356736, 207332835328, 217969590272, 218774896640, 220620390400, 222096785408, 5721215205376, 229612978176, 5736683798528, 5733932335104, 5743579234304, 5743512125440, 5750290120704, 5747437993984, 5754417315840, 5752890589184, 254913019904, 5759383371776, 5759333040128, 5756162146304, 5762352939008, 5761648295936, 5761446969344, 5761010761728, 5760675217408, 5767251886080, 5765272174592, 268485787648, 273988714496, 5775489499136, 5773945995264, 5773140688896, 5772620595200, 5779952238592, 5778274516992, 5777737646080, 5784616304640, 5782972137472, 5782737256448, 5781881618432, 5788374401024, 5787904638976, 5787686535168, 5787032223744, 288987545600, 5793575337984, 5792602259456, 5789867573248, 5789716578304, 297040609280, 5795991257088, 5795018178560, 5801695510528, 5801007644672, 5798340067328, 5805000622080, 5804866404352, 5803104796672, 5806963556352, 5813942878208, 5813674442752, 5812097384448, 5818858602496, 5818153959424, 5823807881216, 5822482481152, 5820804759552, 5827263987712, 5827029106688, 5826207023104, 5824982286336, 5824294420480, 5831760281600, 5831223410688, 5830552322048, 5830116114432, 5828404838400, 5836223021056, 5836105580544, 5833941319680, 5832716582912, 5837447757824, 5845433712640, 5843655327744, 5841323294720, 5841222631424, 1451111743488, 1450088333312, 5846306127872, 5845534375936, 1455020834816, 5853872652288, 5851909718016, 5849896452096, 1454936948736, 5856842219520, 5855802032128, 5854426300416, 1456614670336, 5861623726080, 5860868751360, 5859593682944, 5864660402176, 5864056422400, 5873468440576, 5872277258240, 5871354511360, 5878098952192, 5877511749632]} timed out after 301026ms without a heartbeat!
```
