### PR TITLE
[SMALLFIX] Skip empty block delete

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3643,6 +3643,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   }
 
   private void removeBlocks(List<Long> blocks) throws IOException {
+    if (blocks.isEmpty()) {
+      return;
+    }
     RetryPolicy retry = new CountingRetry(3);
     while (true) {
       try {


### PR DESCRIPTION
Otherwise we can run into unnecessary problems where we can't open/close a journal context due to the journal being closed or unavailable. This also reduces journal locking