### PR TITLE
[ALLUXIO-3139] Fix opts and descriptions of various shell commands

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
@@ -91,7 +91,7 @@ public final class HeadCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "head -c <bytes> <path>";
+    return "head [-c <bytes>] <path>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
@@ -37,6 +37,11 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class HeadCommand extends WithWildCardPathCommand {
+  private static final Option BYTES_OPTION = Option.builder("c")
+      .required(false)
+      .numberOfArgs(1)
+      .desc("number of bytes (e.g., 1024, 4KB)")
+      .build();
 
   /**
    * @param fs the filesystem of Alluxio
@@ -86,7 +91,7 @@ public final class HeadCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "head -c <number of bytes> <path>";
+    return "head -c <bytes> <path>";
   }
 
   @Override
@@ -96,8 +101,6 @@ public final class HeadCommand extends WithWildCardPathCommand {
 
   @Override
   public Options getOptions() {
-    Option bytesOption =
-        Option.builder("c").required(false).numberOfArgs(1).desc("user specified option").build();
-    return new Options().addOption(bytesOption);
+    return new Options().addOption(BYTES_OPTION);
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/HelpCommand.java
@@ -96,7 +96,7 @@ public final class HelpCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "help <command>";
+    return "help [<command>]";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
@@ -92,7 +92,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "persist <alluxioPath1> [alluxioPath2] ... [alluxioPathn]";
+    return "persist <path> [<path> ...]";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -50,7 +50,8 @@ public final class RmCommand extends WithWildCardPathCommand {
           .build();
 
   private static final Option REMOVE_ALLUXIO_ONLY =
-      Option.builder("alluxioOnly")
+      Option.builder()
+          .longOpt("alluxioOnly")
           .required(false)
           .hasArg(false)
           .desc("remove data and metadata from Alluxio space only")
@@ -104,7 +105,7 @@ public final class RmCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "rm [-R] [-U] [-alluxioOnly] <path>";
+    return "rm [-R] [-U] [--alluxioOnly] <path>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -93,7 +93,7 @@ public final class RmCommand extends WithWildCardPathCommand {
     if (cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)) {
       options.setUnchecked(true);
     }
-    boolean isAlluxioOnly = cl.hasOption(REMOVE_ALLUXIO_ONLY.getOpt());
+    boolean isAlluxioOnly = cl.hasOption(REMOVE_ALLUXIO_ONLY.getLongOpt());
     options.setAlluxioOnly(isAlluxioOnly);
     mFileSystem.delete(path, options);
     if (!isAlluxioOnly) {

--- a/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
@@ -42,7 +42,7 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
           .longOpt(TTL_ACTION)
           .required(false)
           .numberOfArgs(1)
-          .desc("Action to take after Ttl expiry. Delete (default) or free the target")
+          .desc("Action to take after TTL expiry. Delete (default) or free the target")
           .build();
 
   private TtlAction mAction = TtlAction.DELETE;
@@ -98,7 +98,7 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Sets a new TTL value for the file at path, "
-        + "performing an action, delete(Default)/free after Ttl expiry. "
+        + "performing an action, delete(Default)/free after TTL expiry. "
         + "The TTL to set can be in one of the unit: ms, millisecond, s, second, m, min, minute, "
         + "h, hour, d, day, default to ms";
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
@@ -98,7 +98,7 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Sets a new TTL value for the file at path, "
-        + "performing an action, delete(Default)/free after TTL expiry. "
+        + "performing an action, delete(default)/free after TTL expiry. "
         + "The TTL to set can be in one of the unit: ms, millisecond, s, second, m, min, minute, "
         + "h, hour, d, day, default to ms";
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
@@ -98,8 +98,8 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Sets a new TTL value for the file at path, "
-        + "performing an action, delete(Default)/free after Ttl expiry."
-        + "The TTL to set can be in any of the unit: ms, millisecond, s, second, m, min, minute, "
-        + "h, hour, d, day.";
+        + "performing an action, delete(Default)/free after Ttl expiry. "
+        + "The TTL to set can be in one of the unit: ms, millisecond, s, second, m, min, minute, "
+        + "h, hour, d, day, default to ms";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/SetTtlCommand.java
@@ -37,8 +37,13 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
 
   private static final String TTL_ACTION = "action";
 
-  private static final Option TTL_ACTION_OPTION = Option.builder(TTL_ACTION).required(false)
-      .numberOfArgs(1).desc("Action to take after Ttl expiry").build();
+  private static final Option TTL_ACTION_OPTION =
+      Option.builder()
+          .longOpt(TTL_ACTION)
+          .required(false)
+          .numberOfArgs(1)
+          .desc("Action to take after Ttl expiry. Delete (default) or free the target")
+          .build();
 
   private TtlAction mAction = TtlAction.DELETE;
 
@@ -87,13 +92,14 @@ public final class SetTtlCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "setTtl [-action delete|free] <path> <time to live>[ms|millisecond|s"
-      + "|second|m|min|minute|h|hour|d|day]";
+    return "setTtl [--action delete|free] <path> <time to live>";
   }
 
   @Override
   public String getDescription() {
     return "Sets a new TTL value for the file at path, "
-        + "performing an action, delete(Default)/free after Ttl expiry.";
+        + "performing an action, delete(Default)/free after Ttl expiry."
+        + "The TTL to set can be in any of the unit: ms, millisecond, s, second, m, min, minute, "
+        + "h, hour, d, day.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/TailCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/TailCommand.java
@@ -37,6 +37,11 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class TailCommand extends WithWildCardPathCommand {
+  private static final Option BYTES_OPTION = Option.builder("c")
+      .required(false)
+      .numberOfArgs(1)
+      .desc("number of bytes (e.g., 1024, 4KB)")
+      .build();
 
   /**
    * @param fs the filesystem of Alluxio
@@ -81,7 +86,7 @@ public final class TailCommand extends WithWildCardPathCommand {
 
   @Override
   public String getUsage() {
-    return "tail -c <number of bytes> <path>";
+    return "tail [-c <bytes>] <path>";
   }
 
   @Override
@@ -96,8 +101,6 @@ public final class TailCommand extends WithWildCardPathCommand {
 
   @Override
   public Options getOptions() {
-    Option bytesOption =
-        Option.builder("c").required(false).numberOfArgs(1).desc("user specified option").build();
-    return new Options().addOption(bytesOption);
+    return new Options().addOption(BYTES_OPTION);
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3139

- Use `--foo` for long opts of fs shell command consistently
- Clean up wrong opt description
- Clean up command usage description