### PR TITLE
[ALLUXIO-3150] Enable UfsFingerprint to partition between content-related vs metadata-related info

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -34,9 +34,9 @@ public final class Fingerprint {
   private static final Tag[] OPTIONAL_TAGS = {Tag.CONTENT_HASH};
 
   /** These tags are all the metadata tags in the fingerprints. */
-  private static final Tag[] METADATA_TAGS = {Tag.TYPE, Tag.UFS, Tag.OWNER, Tag.GROUP, Tag.MODE};
+  private static final Tag[] METADATA_TAGS = {Tag.OWNER, Tag.GROUP, Tag.MODE};
   /** These tags are all the metadata tags in the fingerprints. */
-  private static final Tag[] CONTENT_TAGS = {Tag.CONTENT_HASH};
+  private static final Tag[] CONTENT_TAGS = {Tag.TYPE, Tag.UFS, Tag.CONTENT_HASH};
 
   private static final Pattern SANITIZE_REGEX = Pattern.compile("[ :]");
   private static final String UNDERSCORE = "_";
@@ -143,14 +143,13 @@ public final class Fingerprint {
   /**
    * Returns true if the serialized fingerprint matches the fingerprint in metadata.
    *
-   * @param serializedFP a finger print in string representation
+   * @param fp a parsed fingerprint object
    *
-   * @return true if the serialized fingerprint matches the current fingerprint in metadata
+   * @return true if the given fingerprint matches the current fingerprint in metadata
    */
-  public boolean matchMetadata(String serializedFP) {
-    Fingerprint fp = Fingerprint.parse(serializedFP);
+  public boolean matchMetadata(Fingerprint fp) {
     for (Tag tag : METADATA_TAGS) {
-      if (!this.getTag(tag).equals(fp.getTag(tag))) {
+      if (!getTag(tag).equals(fp.getTag(tag))) {
         return false;
       }
     }
@@ -160,14 +159,13 @@ public final class Fingerprint {
   /**
    * Returns true if the serialized fingerprint matches the fingerprint in the data part.
    *
-   * @param serializedFP a finger print in string representation
+   * @param fp a parsed fingerprint object
    *
-   * @return true if the serialized fingerprint matches the current fingerprint's data
+   * @return true if the given fingerprint matches the current fingerprint's data
    */
-  public boolean matchContent(String serializedFP) {
-    Fingerprint fp = Fingerprint.parse(serializedFP);
+  public boolean matchContent(Fingerprint fp) {
     for (Tag tag : CONTENT_TAGS) {
-      if (!this.getTag(tag).equals(fp.getTag(tag))) {
+      if (!getTag(tag).equals(fp.getTag(tag))) {
         return false;
       }
     }

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -35,6 +35,8 @@ public final class Fingerprint {
 
   /** These tags are all the metadata tags in the fingerprints. */
   private static final Tag[] METADATA_TAGS = {Tag.TYPE, Tag.UFS, Tag.OWNER, Tag.GROUP, Tag.MODE};
+  /** These tags are all the metadata tags in the fingerprints. */
+  private static final Tag[] CONTENT_TAGS = {Tag.CONTENT_HASH};
 
   private static final Pattern SANITIZE_REGEX = Pattern.compile("[ :]");
   private static final String UNDERSCORE = "_";
@@ -148,6 +150,23 @@ public final class Fingerprint {
   public boolean matchMetadata(String serializedFP) {
     Fingerprint fp = Fingerprint.parse(serializedFP);
     for (Tag tag : METADATA_TAGS) {
+      if (!this.getTag(tag).equals(fp.getTag(tag))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if the serialized fingerprint matches the fingerprint in the data part.
+   *
+   * @param serializedFP a finger print in string representation
+   *
+   * @return true if the serialized fingerprint matches the current fingerprint's data
+   */
+  public boolean matchContent(String serializedFP) {
+    Fingerprint fp = Fingerprint.parse(serializedFP);
+    for (Tag tag : CONTENT_TAGS) {
       if (!this.getTag(tag).equals(fp.getTag(tag))) {
         return false;
       }

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -155,7 +155,7 @@ public final class Fingerprint {
   }
 
   /**
-   * Returns true if the serialized fingerprint matches the fingerprint in the data part.
+   * Returns true if the serialized fingerprint matches the fingerprint in the content part.
    *
    * @param fp a parsed fingerprint object
    * @return true if the given fingerprint matches the current fingerprint's content

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -33,6 +33,9 @@ public final class Fingerprint {
   /** These tags are optional, and are serialized after the required tags. */
   private static final Tag[] OPTIONAL_TAGS = {Tag.CONTENT_HASH};
 
+  /** These tags are all the metadata tags in the fingerprints. */
+  private static final Tag[] METADATA_TAGS = {Tag.TYPE, Tag.UFS, Tag.OWNER, Tag.GROUP, Tag.MODE};
+
   private static final Pattern SANITIZE_REGEX = Pattern.compile("[ :]");
   private static final String UNDERSCORE = "_";
 
@@ -133,6 +136,23 @@ public final class Fingerprint {
       }
     }
     return sb.toString();
+  }
+
+  /**
+   * Returns true if the serialized fingerprint matches the fingerprint in metadata.
+   *
+   * @param serializedFP a finger print in string representation
+   *
+   * @return true if the serialized fingerprint matches the current fingerprint in metadata
+   */
+  public boolean matchMetadata(String serializedFP) {
+    Fingerprint fp = Fingerprint.parse(serializedFP);
+    for (Tag tag : METADATA_TAGS) {
+      if (!this.getTag(tag).equals(fp.getTag(tag))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -27,7 +27,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class Fingerprint {
-  // TODO(gpang): partition fingerprint for metadata and content, for more efficient updates.
   /** These tags are required in all fingerprints. */
   private static final Tag[] REQUIRED_TAGS = {Tag.TYPE, Tag.UFS, Tag.OWNER, Tag.GROUP, Tag.MODE};
   /** These tags are optional, and are serialized after the required tags. */
@@ -35,7 +34,7 @@ public final class Fingerprint {
 
   /** These tags are all the metadata tags in the fingerprints. */
   private static final Tag[] METADATA_TAGS = {Tag.OWNER, Tag.GROUP, Tag.MODE};
-  /** These tags are all the metadata tags in the fingerprints. */
+  /** These tags are all the content tags in the fingerprints. */
   private static final Tag[] CONTENT_TAGS = {Tag.TYPE, Tag.UFS, Tag.CONTENT_HASH};
 
   private static final Pattern SANITIZE_REGEX = Pattern.compile("[ :]");
@@ -159,7 +158,7 @@ public final class Fingerprint {
    * Returns true if the serialized fingerprint matches the fingerprint in the data part.
    *
    * @param fp a parsed fingerprint object
-   * @return true if the given fingerprint matches the current fingerprint's data
+   * @return true if the given fingerprint matches the current fingerprint's content
    */
   public boolean matchContent(Fingerprint fp) {
     for (Tag tag : CONTENT_TAGS) {

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -144,7 +144,6 @@ public final class Fingerprint {
    * Returns true if the serialized fingerprint matches the fingerprint in metadata.
    *
    * @param fp a parsed fingerprint object
-   *
    * @return true if the given fingerprint matches the current fingerprint in metadata
    */
   public boolean matchMetadata(Fingerprint fp) {
@@ -160,7 +159,6 @@ public final class Fingerprint {
    * Returns true if the serialized fingerprint matches the fingerprint in the data part.
    *
    * @param fp a parsed fingerprint object
-   *
    * @return true if the given fingerprint matches the current fingerprint's data
    */
   public boolean matchContent(Fingerprint fp) {

--- a/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
+++ b/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
@@ -86,5 +86,6 @@ public final class FingerprintTest {
     assertFalse(fp.matchMetadata(fpMetadataChanged));
     assertTrue(fp.matchContent(fpMetadataChanged));
     assertFalse(fp.matchContent(fpDataChanged));
+    assertTrue(fp.matchMetadata(fpDataChanged));
   }
 }

--- a/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
+++ b/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
@@ -55,4 +55,33 @@ public final class FingerprintTest {
     Assert.assertNotNull(expected);
     Assert.assertEquals(expected, Fingerprint.parse(expected).serialize());
   }
+
+  @Test
+  public void matchMetadataTest() {
+    String name = CommonUtils.randomAlphaNumString(10);
+    String contentHash = CommonUtils.randomAlphaNumString(10);
+    String contentHash2 = CommonUtils.randomAlphaNumString(11);
+    Long contentLength = mRandom.nextLong();
+    Long lastModifiedTimeMs = mRandom.nextLong();
+    String owner = CommonUtils.randomAlphaNumString(10);
+    String group = CommonUtils.randomAlphaNumString(10);
+    short mode = (short) mRandom.nextInt();
+    String ufsName = CommonUtils.randomAlphaNumString(10);
+
+    UfsFileStatus status = new UfsFileStatus(name, contentHash, contentLength, lastModifiedTimeMs,
+        owner, group, mode);
+    UfsFileStatus metadataChangedStatus = new UfsFileStatus(name, contentHash, contentLength,
+        lastModifiedTimeMs, CommonUtils.randomAlphaNumString(10),
+        CommonUtils.randomAlphaNumString(10), mode);
+    UfsFileStatus dataChangedStatus = new UfsFileStatus(name, contentHash2, contentLength,
+        lastModifiedTimeMs, owner, group, mode);
+    Fingerprint fp = Fingerprint.create(ufsName, status);
+    Fingerprint fpMetadataChanged = Fingerprint.create(ufsName, metadataChangedStatus);
+    Fingerprint fpDataChanged = Fingerprint.create(ufsName, dataChangedStatus);
+
+    Assert.assertTrue(fp.matchMetadata(fp.serialize()));
+    Assert.assertFalse(fp.matchMetadata(fpMetadataChanged.serialize()));
+    Assert.assertTrue(fp.matchContent(fpMetadataChanged.serialize()));
+    Assert.assertFalse(fp.matchContent(fpDataChanged.serialize()));
+  }
 }

--- a/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
+++ b/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.underfs;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
 import alluxio.util.CommonUtils;
 
 import org.junit.Assert;
@@ -57,7 +60,7 @@ public final class FingerprintTest {
   }
 
   @Test
-  public void matchMetadataTest() {
+  public void matchMetadataOrContent() {
     String name = CommonUtils.randomAlphaNumString(10);
     String contentHash = CommonUtils.randomAlphaNumString(10);
     String contentHash2 = CommonUtils.randomAlphaNumString(11);
@@ -79,9 +82,9 @@ public final class FingerprintTest {
     Fingerprint fpMetadataChanged = Fingerprint.create(ufsName, metadataChangedStatus);
     Fingerprint fpDataChanged = Fingerprint.create(ufsName, dataChangedStatus);
 
-    Assert.assertTrue(fp.matchMetadata(fp.serialize()));
-    Assert.assertFalse(fp.matchMetadata(fpMetadataChanged.serialize()));
-    Assert.assertTrue(fp.matchContent(fpMetadataChanged.serialize()));
-    Assert.assertFalse(fp.matchContent(fpDataChanged.serialize()));
+    assertTrue(fp.matchMetadata(fp));
+    assertFalse(fp.matchMetadata(fpMetadataChanged));
+    assertTrue(fp.matchContent(fpMetadataChanged));
+    assertFalse(fp.matchContent(fpDataChanged));
   }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3150
Added the notion of Content vs Metadata based tags and some methods to compare fingerprint strictly based on metadata and content. 
