### PR TITLE
[SMALLFIX]change RestUtils.call()

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -140,12 +140,7 @@ public final class AlluxioWorkerRestServiceHandler {
   @ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
-    return RestUtils.call(new RestUtils.RestCallable<Map<String, String>>() {
-      @Override
-      public Map<String, String> call() throws Exception {
-        return getConfigurationInternal(true);
-      }
-    });
+    return RestUtils.call(() -> getMetricsInternal());
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -140,7 +140,12 @@ public final class AlluxioWorkerRestServiceHandler {
   @ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
-    return RestUtils.call(() -> getMetricsInternal());
+    return RestUtils.call(new RestUtils.RestCallable<Map<String, String>>() {
+      @Override
+      public Map<String, String> call() throws Exception {
+        return getConfigurationInternal(true);
+      }
+    });
   }
 
   /**
@@ -320,12 +325,7 @@ public final class AlluxioWorkerRestServiceHandler {
   @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getMetrics() {
-    return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
-      @Override
-      public Map<String, Long> call() throws Exception {
-        return getMetricsInternal();
-      }
-    });
+    return RestUtils.call(() -> getMetricsInternal());
   }
 
   private Capacity getCapacityInternal() {


### PR DESCRIPTION
change

    return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
      @Override
      public Map<String, Long> call() throws Exception {
        return getMetricsInternal();
      }
    });

to

return RestUtils.call(() -> getMetricsInternal());