### PR TITLE
[SMALLFIX]Use static imports for standard test utilities

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/NettyPacketWriterTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.block.stream;
 
+import static org.mockito.Mockito.mock;
+
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.PropertyKey;
@@ -36,7 +38,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -75,7 +76,7 @@ public final class NettyPacketWriterTest {
   @Before
   public void before() throws Exception {
     mContext = PowerMockito.mock(FileSystemContext.class);
-    mAddress = Mockito.mock(WorkerNetAddress.class);
+    mAddress = mock(WorkerNetAddress.class);
 
     mChannel = new EmbeddedChannel();
     PowerMockito.when(mContext.acquireNettyChannel(mAddress)).thenReturn(mChannel);


### PR DESCRIPTION
#177: Use static imports for standard test utilities in alluxio.client.block.stream.NettyPacketWriterTest and resolve some errors.