### PR TITLE
[SMALLFIX] Clarify alluxio.master.startup.block.integrity.check.enabled

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1132,7 +1132,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(false)
           .setDescription("Whether the system should be checked on startup for orphaned blocks "
               + "(blocks having no corresponding files but still taking system resource due to "
-              + "various system failures). Orphaned blocks will be deleted during master starting "
+              + "various system failures). Orphaned blocks will be deleted during master startup "
               + "if this property is true. This property is available since 1.7.1")
           .build();
   public static final PropertyKey MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1130,8 +1130,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED =
       new Builder(Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED)
           .setDefaultValue(false)
-          .setDescription("Whether the system should be checked for orphaned blocks on startup. "
-              + "Orphaned blocks will be deleted.")
+          .setDescription("Whether the system should be checked on startup for orphaned blocks "
+              + "(blocks having no corresponding files but still taking system resource due to "
+              + "various system failures). Orphaned blocks will be deleted during master starting "
+              + "if this property is true. This property is available since 1.7.1")
           .build();
   public static final PropertyKey MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED =
       new Builder(Name.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)

--- a/docs/_data/table/en/master-configuration.yml
+++ b/docs/_data/table/en/master-configuration.yml
@@ -73,7 +73,7 @@ alluxio.master.principal:
 alluxio.master.retry:
   'The number of retries that the client connects to master. (NOTE: this property is deprecated, use `alluxio.user.rpc.retry.max.num.retry` instead).'
 alluxio.master.startup.block.integrity.check.enabled:
-  'Whether the system should be checked for orphaned blocks on startup. Orphaned blocks will be deleted.'
+  'Whether the system should be checked on startup for orphaned blocks (blocks having no corresponding files but still taking system resource due to various system failures). Orphaned blocks will be deleted during master starting if this property is true. This property is available since 1.7.1'
 alluxio.master.startup.consistency.check.enabled:
   'Whether the system should be checked for consistency with the underlying storage on startup. During the time the check is running, Alluxio will be in read only mode. Enabled by default.'
 alluxio.master.thrift.shutdown.timeout:


### PR DESCRIPTION
reason to have this PR is to clarify that `alluxio.master.startup.block.integrity.check.enabled` not available in 1.7.0, which users reported confusion.