### PR TITLE
[SMALLFIX]replace anonymous type with lambda in getMountPoints

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientRestServiceHandler.java
@@ -342,12 +342,7 @@ public final class FileSystemMasterClientRestServiceHandler {
   @Path(GET_MOUNT_POINTS)
   @ReturnType("java.util.SortedMap<java.lang.String, alluxio.wire.MountPointInfo>")
   public Response getMountPoints() {
-    return RestUtils.call(new RestUtils.RestCallable<Map<String, MountPointInfo>>() {
-      @Override
-      public Map<String, MountPointInfo> call() throws Exception {
-        return mFileSystemMaster.getMountTable();
-      }
-    });
+    return RestUtils.call(() -> mFileSystemMaster.getMountTable());
   }
 
   /**


### PR DESCRIPTION
change

    return RestUtils.call(new RestUtils.RestCallable<Map<String, MountPointInfo>>() {
      @Override
      public Map<String, MountPointInfo> call() throws Exception {
        return mFileSystemMaster.getMountTable();
      }
    });
to

return RestUtils.call(() -> mFileSystemMaster.getMountTable());