### PR TITLE
[SMALLFIX] Update safe mode logging

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
@@ -54,7 +54,6 @@ public class DefaultSafeModeManager implements SafeModeManager {
 
   @Override
   public void notifyPrimaryMasterStarted() {
-    LOG.info("Entering safe mode.");
     mWorkerConnectWaitStartTimeMs.set(null, true);
   }
 
@@ -62,7 +61,7 @@ public class DefaultSafeModeManager implements SafeModeManager {
   public void notifyRpcServerStarted() {
     // updates start time when Alluxio master waits for workers to register
     long waitTime = Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
-    LOG.info(String.format("Expect leaving safe mode after %dms", waitTime));
+    LOG.info(String.format("Rpc server started, waiting %dms for workers to register", waitTime));
     mWorkerConnectWaitStartTimeMs.set(mClock.millis(), true);
   }
 
@@ -86,7 +85,7 @@ public class DefaultSafeModeManager implements SafeModeManager {
     }
 
     if (mWorkerConnectWaitStartTimeMs.compareAndSet(startTime, null, true, false)) {
-      LOG.info("Exiting safe mode.");
+      LOG.debug("Exiting safe mode.");
     }
 
     return mWorkerConnectWaitStartTimeMs.isMarked();


### PR DESCRIPTION
This addresses a few minor issues in the log messages surrounding startup safe mode
- It isn't clear to users what we mean by safe mode. It's clearer to say what it means, i.e. that we're waiting to give workers a chance to register.
- Because we exit safe mode lazily, we might log "Expect leaving safe mode after 5000ms", but then wait much more than 5000ms before logging "Exiting safe mode". 