### PR TITLE
[SMALLFIX] Fix placeholder in precondition error message template

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -79,10 +79,10 @@ public class SpaceReserver implements HeartbeatExecutor {
             PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(ordinal);
         double tierHighWatermarkConf = Configuration.getDouble(tierHighWatermarkProp);
         Preconditions.checkArgument(tierHighWatermarkConf > 0,
-            "The high watermark of tier %d should be positive, but is %f", ordinal,
+            "The high watermark of tier %s should be positive, but is %s", ordinal,
             tierHighWatermarkConf);
         Preconditions.checkArgument(tierHighWatermarkConf < 1,
-            "The high watermark of tier %d should be less than 1.0, but is %f", ordinal,
+            "The high watermark of tier %s should be less than 1.0, but is %s", ordinal,
             tierHighWatermarkConf);
         long highWatermark = (long) (tierCapacity * Configuration.getDouble(tierHighWatermarkProp));
         mHighWatermarks.put(tierAlias, highWatermark);
@@ -92,10 +92,10 @@ public class SpaceReserver implements HeartbeatExecutor {
             PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(ordinal);
         double tierLowWatermarkConf = Configuration.getDouble(tierLowWatermarkProp);
         Preconditions.checkArgument(tierLowWatermarkConf >= 0,
-            "The low watermark of tier %d should not be negative, but is %f", ordinal,
+            "The low watermark of tier %s should not be negative, but is %s", ordinal,
             tierLowWatermarkConf);
         Preconditions.checkArgument(tierLowWatermarkConf < tierHighWatermarkConf,
-            "The low watermark (%f) of tier %d should not be smaller than the high watermark (%f)",
+            "The low watermark (%s) of tier %d should not be smaller than the high watermark (%s)",
             tierLowWatermarkConf, ordinal, tierHighWatermarkConf);
         reservedSpace =
             (long) (tierCapacity - tierCapacity * Configuration.getDouble(tierLowWatermarkProp));


### PR DESCRIPTION
Precondition takes only `%s` as the placeholder in the error message template.