### PR TITLE
[ALLUXIO-3159] Sync plan change so that only content change causes delete and reload

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -119,7 +119,7 @@ public final class Fingerprint {
   }
 
   /**
-   * Checking if the fingerprint object was generated from an INVALID_UFS_FINGERPRINT.
+   * Checks if the fingerprint object was generated from an INVALID_UFS_FINGERPRINT.
    *
    * @return returns true if the fingerprint is valid
    */

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -119,6 +119,15 @@ public final class Fingerprint {
   }
 
   /**
+   * Checking if the fingerprint object was generated from an INVALID_UFS_FINGERPRINT.
+   *
+   * @return returns true if the fingerprint is valid
+   */
+  public boolean isValid() {
+    return !mValues.isEmpty();
+  }
+
+  /**
    * @return the serialized string of the fingerprint
    */
   public String serialize() {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3286,12 +3286,15 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();
       String ufsFingerprint = ufs.getFingerprint(ufsUri.toString());
+      Fingerprint ufsFpParsed = Fingerprint.parse(ufsFingerprint);
       boolean containsMountPoint = mMountTable.containsMountPoint(inodePath.getUri());
 
       UfsSyncUtils.SyncPlan syncPlan =
-          UfsSyncUtils.computeSyncPlan(inode, ufsFingerprint, containsMountPoint);
+          UfsSyncUtils.computeSyncPlan(inode, ufsFpParsed, containsMountPoint);
 
-      if (syncPlan.toUpdateDirectory()) {
+      if (syncPlan.toUpdateDirectory() || syncPlan.toUpdateMetaData()) {
+        // Updating directory and updating metadata essentially does the same thing, updating
+        // Owner, Group, Mode
         // Fingerprints only consider permissions for directory inodes.
         UfsStatus ufsStatus = null;
         try {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3171,10 +3171,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     // The high-level process for the syncing is:
     // 1. Find all Alluxio paths which are not consistent with the corresponding UFS path.
     //    This means the UFS path does not exist, or is different from the Alluxio metadata.
-    // 2. If possible, update an Alluxio directory with the corresponding UFS directory.
-    // 3. Delete any Alluxio path not consistent with UFS, or not in UFS. After this step, all
-    //    the paths in Alluxio are consistent with UFS, and there may be additional UFS paths to
-    //    load.
+    // 2. If only the metadata changed for a file or a directory,, update the inode with
+    //    new metadata from the UFS.
+    // 3. Delete any Alluxio path whose content is not consistent with UFS, or not in UFS. After
+    //    this step, all the paths in Alluxio are consistent with UFS, and there may be additional
+    //    UFS paths to load.
     // 4. Load metadata from UFS.
 
     // Set to true if ufs metadata must be loaded.
@@ -3292,10 +3293,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       UfsSyncUtils.SyncPlan syncPlan =
           UfsSyncUtils.computeSyncPlan(inode, ufsFpParsed, containsMountPoint);
 
-      if (syncPlan.toUpdateDirectory() || syncPlan.toUpdateMetaData()) {
-        // Updating directory and updating metadata essentially does the same thing, updating
-        // Owner, Group, Mode
-        // Fingerprints only consider permissions for directory inodes.
+      if (syncPlan.toUpdateMetaData()) {
+        // UpdateMetadata is used when a file or a directory only had metadata change.
+        // It works by calling SetAttributeInternal on the inodePath.
         UfsStatus ufsStatus = null;
         try {
           ufsStatus = ufs.getStatus(ufsUri.toString());

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncUtils.java
@@ -68,6 +68,8 @@ public final class UfsSyncUtils {
     }
 
     // One of metadata or content is not in sync and it is a file
+    // The only way for a directory to reach this point, is that the ufs with the same path is not
+    // a directory. That requires a deletion and reload as well.
     if (!isContentSynced) {
       // update inode, by deleting and then optionally loading metadata
       syncPlan.setDelete();
@@ -111,7 +113,7 @@ public final class UfsSyncUtils {
    */
   public static boolean inodeUfsIsMetadataSynced(Inode inode, Fingerprint ufsFingerprint) {
     Fingerprint inodeFingerprint = Fingerprint.parse(inode.getUfsFingerprint());
-    return inodeFingerprint.matchMetadata(ufsFingerprint);
+    return inodeFingerprint.isValid() && inodeFingerprint.matchMetadata(ufsFingerprint);
   }
 
   /**

--- a/tests/src/test/java/alluxio/master/file/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/file/UfsSyncIntegrationTest.java
@@ -503,9 +503,9 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(
         FileUtils.translatePosixPermissionToMode(PosixFilePermissions.fromString("rwxrwxrwx")),
         status.getMode());
-    long afterFileid = status.getFileId();
+
     // Change the permission of the file and the file id should not change
-    Assert.assertEquals(prevFileid, afterFileid);
+    Assert.assertEquals(prevFileid, status.getFileId());
 
     // Change the content of the file and the file id should change as a result because it is
     // deleted and reloaded.
@@ -513,8 +513,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
     status = mFileSystem.getStatus(new AlluxioURI(alluxioPath(EXISTING_FILE)), options);
     Assert.assertNotNull(status);
-    long afterContentChangeFileid = status.getFileId();
-    Assert.assertNotEquals(prevFileid, afterContentChangeFileid);
+    Assert.assertNotEquals(prevFileid, status.getFileId());
   }
 
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3159

If non-content related attributes have changed in the UFS file, the corresponding Alluxio file should just be updated with that info, and not be deleted if not necessary.