### PR TITLE
[ALLUXIO-3162] Fix default inode permission checking logic.

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultInodePermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultInodePermissionChecker.java
@@ -11,8 +11,6 @@
 
 package alluxio.master.file;
 
-import alluxio.exception.AccessControlException;
-import alluxio.exception.ExceptionMessage;
 import alluxio.master.file.meta.Inode;
 import alluxio.security.authorization.Mode;
 
@@ -23,24 +21,20 @@ import java.util.List;
  */
 public final class DefaultInodePermissionChecker implements InodePermissionChecker {
   @Override
-  public void checkPermission(String user, List<String> groups, String path, Inode<?> inode,
-      Mode.Bits permission) throws AccessControlException {
+  public boolean checkPermission(String user, List<String> groups, Inode<?> inode,
+      Mode.Bits permission) {
     short mode = inode.getMode();
-    if (user.equals(inode.getOwner()) && Mode.extractOwnerBits(mode).imply(permission)) {
-      return;
+    if (user.equals(inode.getOwner())) {
+      return Mode.extractOwnerBits(mode).imply(permission);
     }
-    if (groups.contains(inode.getGroup()) && Mode.extractGroupBits(mode).imply(permission)) {
-      return;
+    if (groups.contains(inode.getGroup())) {
+      return Mode.extractGroupBits(mode).imply(permission);
     }
-    if (Mode.extractOtherBits(mode).imply(permission)) {
-      return;
-    }
-    throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
-        .getMessage(toExceptionMessage(user, permission, path, inode)));
+    return Mode.extractOtherBits(mode).imply(permission);
   }
 
   @Override
-  public Mode.Bits getPermission(String user, List<String> groups, String path, Inode<?> inode) {
+  public Mode.Bits getPermission(String user, List<String> groups, Inode<?> inode) {
     Mode.Bits permission = Mode.Bits.NONE;
     short mode = inode.getMode();
     if (user.equals(inode.getOwner())) {
@@ -51,16 +45,5 @@ public final class DefaultInodePermissionChecker implements InodePermissionCheck
     }
     permission = permission.or(Mode.extractOtherBits(mode));
     return permission;
-  }
-
-  private static String toExceptionMessage(String user, Mode.Bits bits, String path,
-      Inode<?> inode) {
-    StringBuilder sb =
-        new StringBuilder().append("user=").append(user).append(", ").append("access=").append(bits)
-            .append(", ").append("path=").append(path).append(": ").append("failed at ")
-            .append(inode.getName().equals("") ? "/" : inode.getName()).append(", inode owner=")
-            .append(inode.getOwner()).append(", inode group=").append(inode.getGroup())
-            .append(", inode mode=").append(new Mode(inode.getMode()).toString());
-    return sb.toString();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultInodePermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultInodePermissionChecker.java
@@ -35,15 +35,13 @@ public final class DefaultInodePermissionChecker implements InodePermissionCheck
 
   @Override
   public Mode.Bits getPermission(String user, List<String> groups, Inode<?> inode) {
-    Mode.Bits permission = Mode.Bits.NONE;
     short mode = inode.getMode();
     if (user.equals(inode.getOwner())) {
-      permission = permission.or(Mode.extractOwnerBits(mode));
+      return Mode.extractOwnerBits(mode);
     }
     if (groups.contains(inode.getGroup())) {
-      permission = permission.or(Mode.extractGroupBits(mode));
+      return Mode.extractGroupBits(mode);
     }
-    permission = permission.or(Mode.extractOtherBits(mode));
-    return permission;
+    return Mode.extractOtherBits(mode);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/InodePermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodePermissionChecker.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.file;
 
-import alluxio.exception.AccessControlException;
 import alluxio.master.file.meta.Inode;
 import alluxio.security.authorization.Mode;
 
@@ -33,22 +32,19 @@ public interface InodePermissionChecker {
    *
    * @param user the user
    * @param groups the groups that user belongs to
-   * @param path the path
    * @param inode inode of the path
    * @param permission the permissions to check
-   * @throws AccessControlException when user does not have the permission
+   * @return whether the user has the required permission
    */
-  void checkPermission(String user, List<String> groups, String path, Inode<?> inode,
-      Mode.Bits permission) throws AccessControlException;
+  boolean checkPermission(String user, List<String> groups, Inode<?> inode, Mode.Bits permission);
 
   /**
    * Gets the permission the user has for the file or directory at path.
    *
    * @param user the user
    * @param groups the groups that user belongs to
-   * @param path the path
    * @param inode inode of the path
    * @return the permission
    */
-  Mode.Bits getPermission(String user, List<String> groups, String path, Inode<?> inode);
+  Mode.Bits getPermission(String user, List<String> groups, Inode<?> inode);
 }

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -292,6 +292,39 @@ public final class PermissionCheckerTest {
   }
 
   @Test
+  public void checkNoFallThroughFromOwnerToGroup() throws Exception {
+    mThrown.expect(AccessControlException.class);
+    mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
+        toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.READ, TEST_WEIRD_FILE_URI,
+            "testWeirdFile")));
+
+    // user cannot read although group can
+    checkPermission(TEST_USER_1, Mode.Bits.READ, TEST_WEIRD_FILE_URI);
+  }
+
+  @Test
+  public void checkNoFallThroughFromOwnerToOther() throws Exception {
+    mThrown.expect(AccessControlException.class);
+    mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
+        toExceptionMessage(TEST_USER_1.getUser(), Mode.Bits.WRITE, TEST_WEIRD_FILE_URI,
+            "testWeirdFile")));
+
+    // user and group cannot write although other can
+    checkPermission(TEST_USER_1, Mode.Bits.WRITE, TEST_WEIRD_FILE_URI);
+  }
+
+  @Test
+  public void checkNoFallThroughFromGroupToOther() throws Exception {
+    mThrown.expect(AccessControlException.class);
+    mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
+        toExceptionMessage(TEST_USER_3.getUser(), Mode.Bits.WRITE, TEST_WEIRD_FILE_URI,
+            "testWeirdFile")));
+
+    // group cannot write although other can
+    checkPermission(TEST_USER_3, Mode.Bits.WRITE, TEST_WEIRD_FILE_URI);
+  }
+
+  @Test
   public void selfCheckFailByOtherGroup() throws Exception {
     mThrown.expect(AccessControlException.class);
     mThrown.expectMessage(ExceptionMessage.PERMISSION_DENIED.getMessage(
@@ -349,6 +382,32 @@ public final class PermissionCheckerTest {
     try (LockedInodePath inodePath = sTree
         .lockInodePath(new AlluxioURI(""), InodeTree.LockMode.READ)) {
       mPermissionChecker.checkPermission(Mode.Bits.WRITE, inodePath);
+    }
+  }
+
+  @Test
+  public void getPermission() throws Exception {
+    try (LockedInodePath path =
+             sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI), InodeTree.LockMode.READ)) {
+      // user is admin
+      AuthenticatedClientUser.set(TEST_USER_ADMIN.getUser());
+      Mode.Bits perm = mPermissionChecker.getPermission(path);
+      Assert.assertEquals(Mode.Bits.ALL, perm);
+
+      // user is owner
+      AuthenticatedClientUser.set(TEST_USER_1.getUser());
+      perm = mPermissionChecker.getPermission(path);
+      Assert.assertEquals(TEST_WEIRD_MODE.getOwnerBits(), perm);
+
+      // user is not owner but in group
+      AuthenticatedClientUser.set(TEST_USER_3.getUser());
+      perm = mPermissionChecker.getPermission(path);
+      Assert.assertEquals(TEST_WEIRD_MODE.getGroupBits(), perm);
+
+      // user is other
+      AuthenticatedClientUser.set(TEST_USER_2.getUser());
+      perm = mPermissionChecker.getPermission(path);
+      Assert.assertEquals(TEST_WEIRD_MODE.getOtherBits(), perm);
     }
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -314,15 +314,6 @@ public final class PermissionCheckerTest {
   }
 
   @Test
-  public void checkFallThrough() throws Exception {
-    // user can not read, but group can
-    checkPermission(TEST_USER_1, Mode.Bits.READ, TEST_WEIRD_FILE_URI);
-
-    // user and group can not write, but other can
-    checkPermission(TEST_USER_1, Mode.Bits.WRITE, TEST_WEIRD_FILE_URI);
-  }
-
-  @Test
   public void parentCheckSuccess() throws Exception {
     checkParentOrAncestorPermission(TEST_USER_1, Mode.Bits.WRITE, TEST_DIR_FILE_URI);
   }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3162

The default permission checking logic is not POSIX standard. There should be no "fall through" in standard POSIX permission checking.

For example, if a file has permission `r-xrwx---`, and the owning user belongs to the owning group, then the owning user should have no WRITE permission. But in current codebase, since the owning user belongs to the owning group, and the owning group has WRITE permission, the owning user is finally granted the WRITE permission. This is WRONG.