### PR TITLE
[ALLUXIO-3163] Pass -X args to the JVM instead of the shell

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -175,7 +175,7 @@ function runJavaClass {
       case "${arg}" in
           -debug)
               ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
-          -D*)
+          -D* | -X*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
               CLASS_ARGS+=("${arg}")

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import java.util.Arrays;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
@@ -195,7 +196,7 @@ public final class GetConf {
         }
         break;
       default:
-        printHelp("More arguments than expected");
+        printHelp(String.format("More arguments than expected. Args: %s", Arrays.toString(args)));
         return 1;
     }
     return 0;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3163

-Xmx=8g was ending up after the classname when
calling the JVM. This made it an argument to the
CLI instead of a JVM arg.