### PR TITLE
[ALLUXIO-3164] Add ACL data structures to Inode

### DIFF
--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -1,0 +1,294 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import alluxio.proto.journal.File;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Access control list for a file or directory.
+ */
+public final class AccessControlList {
+  /**
+   * Initial capacity for {@link #mUserActions} and {@link #mGroupActions}.
+   * Most of the time, only owning user and owning group exists in {@link #mUserActions} and
+   * {@link #mGroupActions}.
+   */
+  private static final int ACTIONS_MAP_INITIAL_CAPACITY = 1;
+  /** Initial load factor. */
+  private static final int ACTIONS_MAP_INITIAL_LOAD_FACTOR = 1;
+  /** Key representing owning user in {@link #mUserActions}. */
+  private static final String OWNING_USER_KEY = "";
+  /** Key representing owning group in {@link #mGroupActions}. */
+  private static final String OWNING_GROUP_KEY = "";
+
+  private String mOwningUser;
+  private String mOwningGroup;
+  private Map<String, AclActions> mUserActions;
+  private Map<String, AclActions> mGroupActions;
+  private AclActions mMaskActions;
+  private AclActions mOtherActions;
+
+  /**
+   * Creates a new instance where owning user and owning group are initialized to empty strings,
+   * and no action is permitted for any user or group.
+   */
+  public AccessControlList() {
+    mOwningUser = "";
+    mOwningGroup = "";
+    mUserActions = new HashMap<>(ACTIONS_MAP_INITIAL_CAPACITY, ACTIONS_MAP_INITIAL_LOAD_FACTOR);
+    mUserActions.put(OWNING_USER_KEY, new AclActions());
+    mGroupActions = new HashMap<>(ACTIONS_MAP_INITIAL_CAPACITY, ACTIONS_MAP_INITIAL_LOAD_FACTOR);
+    mGroupActions.put(OWNING_GROUP_KEY, new AclActions());
+    mMaskActions = new AclActions();
+    mOtherActions = new AclActions();
+  }
+
+  /**
+   * @return the owning user
+   */
+  public String getOwningUser() {
+    return mOwningUser;
+  }
+
+  /**
+   * @return the owning group
+   */
+  public String getOwningGroup() {
+    return mOwningGroup;
+  }
+
+  private AclActions getOwningUserActions() {
+    return mUserActions.get(OWNING_USER_KEY);
+  }
+
+  private AclActions getOwningGroupActions() {
+    return mGroupActions.get(OWNING_GROUP_KEY);
+  }
+
+  /**
+   * @return the permission mode defined in {@link Mode} for owning user, owning group, and other
+   */
+  public short getMode() {
+    Mode.Bits owner = getOwningUserActions().toModeBits();
+    Mode.Bits group = getOwningGroupActions().toModeBits();
+    Mode.Bits other = mOtherActions.toModeBits();
+    return new Mode(owner, group, other).toShort();
+  }
+
+  /**
+   * Sets owning user.
+   *
+   * @param user the owning user
+   */
+  public void setOwningUser(String user) {
+    mOwningUser = user;
+  }
+
+  /**
+   * Sets owning group.
+   *
+   * @param group the owning group
+   */
+  public void setOwningGroup(String group) {
+    mOwningGroup = group;
+  }
+
+  /**
+   * Sets permitted actions for owning user, owning group, and other based on the mode.
+   * The format of mode is defined in {@link Mode}.
+   * The update logic is defined in {@link AclActions#updateByModeBits(Mode.Bits)}.
+   *
+   * @param mode the mode
+   */
+  public void setMode(short mode) {
+    getOwningUserActions().updateByModeBits(Mode.extractOwnerBits(mode));
+    getOwningGroupActions().updateByModeBits(Mode.extractGroupBits(mode));
+    mOtherActions.updateByModeBits(Mode.extractOtherBits(mode));
+  }
+
+  /**
+   * Sets an entry into the access control list.
+   * If an entry with the same type and subject already exists, overwrites the existing entry;
+   * Otherwise, adds this new entry.
+   *
+   * @param entry the entry to be added or updated
+   */
+  public void setEntry(AclEntry entry) {
+    // TODO(cc): when setting non-mask entries, the mask should be dynamically updated too.
+    switch (entry.getType()) {
+      case OWNING_USER:
+        setOwningUserEntry(entry);
+        return;
+      case NAMED_USER:
+        setNamedUserEntry(entry);
+        return;
+      case OWNING_GROUP:
+        setOwningGroupEntry(entry);
+        return;
+      case NAMED_GROUP:
+        setNamedGroupEntry(entry);
+        return;
+      case MASK:
+        setMaskEntry(entry);
+        return;
+      case OTHER:
+        setOtherEntry(entry);
+        return;
+      default:
+        throw new IllegalStateException("Unknown ACL entry type: " + entry.getType());
+    }
+  }
+
+  /**
+   * Checks whether the user has the permission to perform the action.
+   *
+   * @param user the user
+   * @param groups the groups the user belongs to
+   * @param action the action
+   * @return whether user has the permission to perform the action
+   */
+  public boolean check(String user, List<String> groups, AclAction action) {
+    // TODO(cc): Update the logic to take MASK into consideration.
+    if (user.equals(mOwningUser)) {
+      return getOwningUserActions().contains(action);
+    }
+    if (mUserActions.containsKey(user)) {
+      return mUserActions.get(user).contains(action);
+    }
+
+    boolean isGroupKnown = false;
+    if (groups.contains(mOwningGroup)) {
+      isGroupKnown = true;
+      if (getOwningGroupActions().contains(action)) {
+        return true;
+      }
+    }
+    for (String group : groups) {
+      if (mGroupActions.containsKey(group)) {
+        isGroupKnown = true;
+        if (mGroupActions.get(group).contains(action)) {
+          return true;
+        }
+      }
+    }
+    if (isGroupKnown) {
+      return false;
+    }
+
+    return mOtherActions.contains(action);
+  }
+
+  private void setOwningUserEntry(AclEntry entry) {
+    setOwningUser(entry.getSubject());
+    mUserActions.put(OWNING_USER_KEY, entry.getActions());
+  }
+
+  private void setNamedUserEntry(AclEntry entry) {
+    mUserActions.put(entry.getSubject(), entry.getActions());
+  }
+
+  private void setOwningGroupEntry(AclEntry entry) {
+    setOwningGroup(entry.getSubject());
+    mGroupActions.put(OWNING_GROUP_KEY, entry.getActions());
+  }
+
+  private void setNamedGroupEntry(AclEntry entry) {
+    mGroupActions.put(entry.getSubject(), entry.getActions());
+  }
+
+  private void setMaskEntry(AclEntry entry) {
+    mMaskActions = entry.getActions();
+  }
+
+  private void setOtherEntry(AclEntry entry) {
+    mOtherActions = entry.getActions();
+  }
+
+  /**
+   * @param acl the protobuf representation
+   * @return {@link AccessControlList}
+   */
+  public static AccessControlList fromProtoBuf(File.AccessControlList acl) {
+    AccessControlList ret = new AccessControlList();
+
+    for (File.NamedAclActions namedActions : acl.getUserActionsList()) {
+      String name = namedActions.getName();
+      AclActions actions = AclActions.fromProtoBuf(namedActions.getActions());
+      AclEntry entry;
+      if (name.equals(OWNING_USER_KEY)) {
+        entry = new AclEntry.Builder().setType(AclEntryType.OWNING_USER)
+            .setSubject(acl.getOwningUser()).setActions(actions).build();
+      } else {
+        entry = new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+            .setSubject(name).setActions(actions).build();
+      }
+      ret.setEntry(entry);
+    }
+
+    for (File.NamedAclActions namedActions : acl.getGroupActionsList()) {
+      String name = namedActions.getName();
+      AclActions actions = AclActions.fromProtoBuf(namedActions.getActions());
+      AclEntry entry;
+      if (name.equals(OWNING_GROUP_KEY)) {
+        entry = new AclEntry.Builder().setType(AclEntryType.OWNING_GROUP)
+            .setSubject(acl.getOwningGroup()).setActions(actions).build();
+      } else {
+        entry = new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP)
+            .setSubject(name).setActions(actions).build();
+      }
+      ret.setEntry(entry);
+    }
+
+    AclActions actions = AclActions.fromProtoBuf(acl.getMaskActions());
+    AclEntry entry = new AclEntry.Builder().setType(AclEntryType.MASK)
+        .setActions(actions).build();
+    ret.setEntry(entry);
+
+    actions = AclActions.fromProtoBuf(acl.getOtherActions());
+    entry = new AclEntry.Builder().setType(AclEntryType.OTHER)
+        .setActions(actions).build();
+    ret.setEntry(entry);
+
+    return ret;
+  }
+
+  /**
+   * @param acl {@link AccessControlList}
+   * @return protobuf representation
+   */
+  public static File.AccessControlList toProtoBuf(AccessControlList acl) {
+    File.AccessControlList.Builder builder = File.AccessControlList.newBuilder();
+    builder.setOwningUser(acl.mOwningUser);
+    builder.setOwningGroup(acl.mOwningGroup);
+    builder.setMaskActions(AclActions.toProtoBuf(acl.mMaskActions));
+    builder.setOtherActions(AclActions.toProtoBuf(acl.mOtherActions));
+    for (Map.Entry<String, AclActions> kv : acl.mUserActions.entrySet()) {
+      File.NamedAclActions namedActions = File.NamedAclActions.newBuilder()
+          .setName(kv.getKey())
+          .setActions(AclActions.toProtoBuf(kv.getValue()))
+          .build();
+      builder.addUserActions(namedActions);
+    }
+    for (Map.Entry<String, AclActions> kv : acl.mGroupActions.entrySet()) {
+      File.NamedAclActions namedActions = File.NamedAclActions.newBuilder()
+          .setName(kv.getKey())
+          .setActions(AclActions.toProtoBuf(kv.getValue()))
+          .build();
+      builder.addGroupActions(namedActions);
+    }
+    return builder.build();
+  }
+}

--- a/core/common/src/main/java/alluxio/security/authorization/AclAction.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclAction.java
@@ -1,0 +1,72 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import alluxio.proto.journal.File;
+
+/**
+ * Actions to be controlled in {@link AccessControlList}.
+ */
+public enum AclAction {
+  READ,
+  WRITE,
+  EXECUTE;
+
+  // TODO(cc): Obsolete PrivilegeMaster by supporting Privileges with ACL.
+  // Actions like FREE, PIN, SET_TTL, etc can be added to this enum.
+
+  /** AclAction values. */
+  private static final AclAction[] VALUES = AclAction.values();
+
+  /**
+   * @param ordinal the ordinal of the target action in {@link AclAction}
+   * @return the {@link AclAction} with the specified ordinal
+   * @throws IndexOutOfBoundsException when ordinal is out of range of valid ordinals
+   */
+  public static AclAction ofOrdinal(int ordinal) {
+    return VALUES[ordinal];
+  }
+
+  /**
+   * @param action the protobuf representation of {@link AclAction}
+   * @return the {@link AclAction} decoded from the protobuf representation
+   */
+  public static AclAction fromProtoBuf(File.AclAction action) {
+    switch (action) {
+      case READ:
+        return READ;
+      case WRITE:
+        return WRITE;
+      case EXECUTE:
+        return EXECUTE;
+      default:
+        throw new IllegalStateException("Unknown protobuf acl action: " + action);
+    }
+  }
+
+  /**
+   * @param action the {@link AclAction}
+   * @return the protobuf representation of action
+   */
+  public static File.AclAction toProtoBuf(AclAction action) {
+    switch (action) {
+      case READ:
+        return File.AclAction.READ;
+      case WRITE:
+        return File.AclAction.WRITE;
+      case EXECUTE:
+        return File.AclAction.EXECUTE;
+      default:
+        throw new IllegalStateException("Unknown acl action: " + action);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/security/authorization/AclAction.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclAction.java
@@ -21,9 +21,6 @@ public enum AclAction {
   WRITE,
   EXECUTE;
 
-  // TODO(cc): Obsolete PrivilegeMaster by supporting Privileges with ACL.
-  // Actions like FREE, PIN, SET_TTL, etc can be added to this enum.
-
   /** AclAction values. */
   private static final AclAction[] VALUES = AclAction.values();
 

--- a/core/common/src/main/java/alluxio/security/authorization/AclActions.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclActions.java
@@ -1,0 +1,157 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import alluxio.proto.journal.File;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.BitSet;
+import java.util.Set;
+
+/**
+ * Permitted actions of an entry in {@link AccessControlList}.
+ */
+public final class AclActions {
+  /**
+   * Initial bits of the actions bitset.
+   * Since most of the time, there are at most 3 actions: read, write, and execute,
+   * so it's set to 3.
+   */
+  private static final int ACTIONS_BITSET_INITIAL_BITS = 3;
+
+  /** An index of the bitset equals an ordinal of an action in {@link AclAction}. */
+  private BitSet mActions;
+
+  /**
+   * Creates a new instance where no action is permitted.
+   */
+  public AclActions() {
+    mActions = new BitSet(ACTIONS_BITSET_INITIAL_BITS);
+  }
+
+  /**
+   * Creates a copy of actions.
+   *
+   * @param actions the actions to be copied from
+   */
+  public AclActions(AclActions actions) {
+    mActions = (BitSet) actions.mActions.clone();
+  }
+
+  /**
+   * Creats a new instance with initial permitted actions.
+   *
+   * @param actions the initial setEntry of permitted actions which is copied from
+   */
+  public AclActions(Set<AclAction> actions) {
+    mActions = new BitSet(ACTIONS_BITSET_INITIAL_BITS);
+    for (AclAction action : actions) {
+      mActions.set(action.ordinal());
+    }
+  }
+
+  /**
+   * @return an immutable copy of permitted actions
+   */
+  public Set<AclAction> getActions() {
+    ImmutableSet.Builder<AclAction> builder = ImmutableSet.builder();
+    for (int i = mActions.nextSetBit(0); i >= 0; i = mActions.nextSetBit(i + 1)) {
+      builder.add(AclAction.ofOrdinal(i));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Updates permitted actions based on the mode bits.
+   *
+   * For example, if bits imply READ, then READ is added to permitted actions, otherwise,
+   * READ is removed from permitted actions.
+   * Same logic applies to WRITE and EXECUTE.
+   *
+   * @param bits the mode bits
+   */
+  public void updateByModeBits(Mode.Bits bits) {
+    // Each index equals to corresponding AclAction's ordinal.
+    // E.g. Mode.Bits.READ corresponds to AclAction.READ, the former has index 0 in indexedBits,
+    // the later has ordinal 0 in AclAction.
+    Mode.Bits[] indexedBits = new Mode.Bits[]{
+        Mode.Bits.READ, Mode.Bits.WRITE, Mode.Bits.EXECUTE
+    };
+    for (int i = 0; i < 3; i++) {
+      if (bits.imply(indexedBits[i])) {
+        mActions.set(i);
+      } else {
+        mActions.clear(i);
+      }
+    }
+  }
+
+  /**
+   * Adds a permitted action.
+   *
+   * @param action the permitted action
+   */
+  public void add(AclAction action) {
+    mActions.set(action.ordinal());
+  }
+
+  /**
+   * @param action the action to be checked
+   * @return whether the action is contained in the permitted actions
+   */
+  public boolean contains(AclAction action) {
+    return mActions.get(action.ordinal());
+  }
+
+  /**
+   * @return the representation of the permitted actions in the format of {@link Mode.Bits}
+   */
+  public Mode.Bits toModeBits() {
+    Mode.Bits bits = Mode.Bits.NONE;
+    if (contains(AclAction.READ)) {
+      bits = bits.or(Mode.Bits.READ);
+    }
+    if (contains(AclAction.WRITE)) {
+      bits = bits.or(Mode.Bits.WRITE);
+    }
+    if (contains(AclAction.EXECUTE)) {
+      bits = bits.or(Mode.Bits.EXECUTE);
+    }
+    return bits;
+  }
+
+  /**
+   * @param actions the protobuf representation of {@link AclActions}
+   * @return the {@link AclActions} decoded from the protobuf representation
+   */
+  public static AclActions fromProtoBuf(File.AclActions actions) {
+    AclActions ret = new AclActions();
+    for (File.AclAction action : actions.getActionsList()) {
+      ret.add(AclAction.fromProtoBuf(action));
+    }
+    return ret;
+  }
+
+  /**
+   * @param actions the {@link AclActions}
+   * @return the protobuf representation of {@link AclActions}
+   */
+  public static File.AclActions toProtoBuf(AclActions actions) {
+    File.AclActions.Builder builder = File.AclActions.newBuilder();
+    for (AclAction action : actions.getActions()) {
+      File.AclAction pAction = AclAction.toProtoBuf(action);
+      builder.addActions(pAction);
+    }
+    return builder.build();
+  }
+}

--- a/core/common/src/main/java/alluxio/security/authorization/AclActions.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclActions.java
@@ -22,6 +22,7 @@ import java.util.Set;
  * Permitted actions of an entry in {@link AccessControlList}.
  */
 public final class AclActions {
+  // TODO(ohboring): have a static default AclActions object, and then copy on write.
   /**
    * Initial bits of the actions bitset.
    * Since most of the time, there are at most 3 actions: read, write, and execute,

--- a/core/common/src/main/java/alluxio/security/authorization/AclEntry.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclEntry.java
@@ -1,0 +1,132 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+/**
+ * An entry in {@link AccessControlList}.
+ */
+public final class AclEntry {
+  /**
+   * Type of this entry.
+   */
+  private AclEntryType mType;
+  /**
+   * Name of owning user, owning group, named user, named group.
+   * If the entry is of type MASK or OTHER, this is an empty string.
+   */
+  private String mSubject;
+  /**
+   * Permitted actions.
+   */
+  private AclActions mActions;
+
+  private AclEntry(AclEntryType type, String subject, AclActions actions) {
+    mType = type;
+    mSubject = subject;
+    mActions = actions;
+  }
+
+  /**
+   * @return the type
+   */
+  public AclEntryType getType() {
+    return mType;
+  }
+
+  /**
+   * @return the subject
+   */
+  public String getSubject() {
+    return mSubject;
+  }
+
+  /**
+   * @return a copy of actions
+   */
+  public AclActions getActions() {
+    return new AclActions(mActions);
+  }
+
+  /**
+   * Builder for {@link AclEntry}.
+   */
+  public static final class Builder {
+    private AclEntryType mType;
+    private String mSubject;
+    private AclActions mActions;
+
+    /**
+     * Creates a new builder where type is null, subject is an empty string, and no action is
+     * permitted.
+     */
+    public Builder() {
+      mSubject = "";
+      mActions = new AclActions();
+    }
+
+    /**
+     * Sets the type of the entry.
+     *
+     * @param type the type of the entry
+     * @return the builder
+     */
+    public Builder setType(AclEntryType type) {
+      mType = type;
+      return this;
+    }
+
+    /**
+     * Sets subject of this entry.
+     * If the entry is of type OWNING_USER or NAMED_USER, then the subject is the username.
+     * If the entry is of type OWNING_GROUP or NAMED_GROUP, then the subject is the group name.
+     * For other types, the subject should be an empty string.
+     *
+     * @param subject the subject
+     * @return the builder
+     */
+    public Builder setSubject(String subject) {
+      mSubject = subject;
+      return this;
+    }
+
+    /**
+     * Sets a copy of actions for this entry.
+     *
+     * @param actions the actions to be copied from
+     * @return the builder
+     */
+    public Builder setActions(AclActions actions) {
+      for (AclAction action : actions.getActions()) {
+        mActions.add(action);
+      }
+      return this;
+    }
+
+    /**
+     * Adds a permitted action.
+     *
+     * @param action the permitted action
+     * @return the builder
+     */
+    public Builder addAction(AclAction action) {
+      mActions.add(action);
+      return this;
+    }
+
+    /**
+     * @return a new {@link AclEntry}
+     */
+    public AclEntry build() {
+      return new AclEntry(mType, mSubject, mActions);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/security/authorization/AclEntryParser.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclEntryParser.java
@@ -1,0 +1,19 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+/**
+ * Parser for {@link AclEntry}.
+ */
+public final class AclEntryParser {
+  // TODO(cc)
+}

--- a/core/common/src/main/java/alluxio/security/authorization/AclEntryType.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclEntryType.java
@@ -1,0 +1,24 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+/**
+ * Types of entries in {@link AccessControlList}.
+ */
+public enum AclEntryType {
+  OWNING_USER,
+  NAMED_USER,
+  OWNING_GROUP,
+  NAMED_GROUP,
+  MASK,
+  OTHER
+}

--- a/core/common/src/main/java/alluxio/security/authorization/Mode.java
+++ b/core/common/src/main/java/alluxio/security/authorization/Mode.java
@@ -19,6 +19,9 @@ import alluxio.exception.ExceptionMessage;
 
 import com.google.common.base.Preconditions;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -359,6 +362,23 @@ public final class Mode {
      */
     public Bits not() {
       return SVALS[7 - ordinal()];
+    }
+
+    /**
+     * @return the set of {@link AclAction}s implied by this mode
+     */
+    public Set<AclAction> toAclActions() {
+      Set<AclAction> actions = new HashSet<>();
+      if (imply(READ)) {
+        actions.add(AclAction.READ);
+      }
+      if (imply(WRITE)) {
+        actions.add(AclAction.WRITE);
+      }
+      if (imply(EXECUTE)) {
+        actions.add(AclAction.EXECUTE);
+      }
+      return actions;
     }
   }
 }

--- a/core/common/src/test/java/alluxio/security/authorization/AccessControlListTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/AccessControlListTest.java
@@ -1,0 +1,190 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests the {@link AccessControlList} class.
+ */
+public class AccessControlListTest {
+  private static final String OWNING_USER = "owning_user";
+  private static final String OWNING_GROUP = "owning_group";
+  private static final String NAMED_USER = "named_user";
+  private static final String NAMED_GROUP = "named_group";
+  private static final String OTHER_USER = "other_user";
+  private static final String OTHER_GROUP = "other_group";
+
+  /**
+   * Tests the constructor contract.
+   */
+  @Test
+  public void constructor() {
+    AccessControlList acl = new AccessControlList();
+    Assert.assertEquals("", acl.getOwningUser());
+    Assert.assertEquals("", acl.getOwningGroup());
+  }
+
+  /**
+   * Tests getting and setting owner and group.
+   */
+  @Test
+  public void ownerGroup() {
+    AccessControlList acl = new AccessControlList();
+    acl.setOwningUser(OWNING_USER);
+    acl.setOwningGroup(OWNING_GROUP);
+    Assert.assertEquals(OWNING_USER, acl.getOwningUser());
+    Assert.assertEquals(OWNING_GROUP, acl.getOwningGroup());
+
+    acl = new AccessControlList();
+    acl.setEntry(new AclEntry.Builder()
+        .setType(AclEntryType.OWNING_USER)
+        .setSubject(OWNING_USER)
+        .build());
+    acl.setEntry(new AclEntry.Builder()
+        .setType(AclEntryType.OWNING_GROUP)
+        .setSubject(OWNING_GROUP)
+        .build());
+    Assert.assertEquals(OWNING_USER, acl.getOwningUser());
+    Assert.assertEquals(OWNING_GROUP, acl.getOwningGroup());
+  }
+
+  /**
+   * Tests setting and getting permitted actions.
+   */
+  @Test
+  public void actions() {
+    AccessControlList acl = new AccessControlList();
+    // owning user: rwx
+    // owning group: -rx
+    // other: ---
+    // named user: rwx
+    // named group: w-x
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_USER).setSubject(OWNING_USER)
+        .addAction(AclAction.READ).addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_GROUP).setSubject(OWNING_GROUP)
+        .addAction(AclAction.READ).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OTHER).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_USER).setSubject(NAMED_USER)
+        .addAction(AclAction.READ).addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(NAMED_GROUP)
+        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    // Verify mode.
+    // owning user
+    Assert.assertTrue(checkMode(acl, OWNING_USER, Collections.emptyList(), Mode.Bits.ALL));
+    // owning group
+    Assert.assertTrue(checkMode(acl, OTHER_USER, Lists.newArrayList(OWNING_GROUP),
+        Mode.Bits.READ_EXECUTE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(OWNING_GROUP),
+        Mode.Bits.WRITE));
+    // other
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Collections.emptyList(), Mode.Bits.READ));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Collections.emptyList(), Mode.Bits.WRITE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Collections.emptyList(), Mode.Bits.EXECUTE));
+    // named user
+    Assert.assertTrue(checkMode(acl, NAMED_USER, Collections.emptyList(), Mode.Bits.ALL));
+    // named group
+    Assert.assertTrue(checkMode(acl, OTHER_USER, Lists.newArrayList(NAMED_GROUP),
+        Mode.Bits.WRITE_EXECUTE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(NAMED_GROUP),
+        Mode.Bits.READ));
+  }
+
+  private boolean checkMode(AccessControlList acl, String user, List<String> groups,
+      Mode.Bits mode) {
+    for (AclAction action : mode.toAclActions()) {
+      if (!acl.check(user, groups, action)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Tests {@link AccessControlList#getMode()}.
+   */
+  @Test
+  public void getMode() {
+    AccessControlList acl = new AccessControlList();
+    Assert.assertEquals(0, acl.getMode());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_USER)
+        .addAction(AclAction.READ).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_GROUP)
+        .addAction(AclAction.WRITE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OTHER)
+        .addAction(AclAction.EXECUTE).build());
+    Assert.assertEquals(new Mode(Mode.Bits.READ, Mode.Bits.WRITE, Mode.Bits.EXECUTE).toShort(),
+        acl.getMode());
+  }
+
+  /**
+   * Tests {@link AccessControlList#setMode(short)}.
+   */
+  @Test
+  public void setMode() {
+    AccessControlList acl = new AccessControlList();
+    short mode = new Mode(Mode.Bits.EXECUTE, Mode.Bits.WRITE, Mode.Bits.READ).toShort();
+    acl.setMode(mode);
+    Assert.assertEquals(mode, acl.getMode());
+  }
+
+  /**
+   * Tests {@link AccessControlList#check(String, List, AclAction)}.
+   */
+  @Test
+  public void check() {
+    // owning user: rwx
+    // owning group: r-x
+    // other: --x
+    // named user: r-x
+    // named group: r--
+    AccessControlList acl = new AccessControlList();
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_USER).setSubject(OWNING_USER)
+        .addAction(AclAction.READ).addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OWNING_GROUP).setSubject(OWNING_GROUP)
+        .addAction(AclAction.READ).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.OTHER)
+        .addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_USER).setSubject(NAMED_USER)
+        .addAction(AclAction.READ).addAction(AclAction.EXECUTE).build());
+    acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(NAMED_GROUP)
+        .addAction(AclAction.READ).build());
+
+    Assert.assertTrue(checkMode(acl, OWNING_USER, Collections.emptyList(), Mode.Bits.ALL));
+
+    Assert.assertTrue(checkMode(acl, NAMED_USER, Collections.emptyList(), Mode.Bits.READ_EXECUTE));
+    Assert.assertFalse(checkMode(acl, NAMED_USER, Collections.emptyList(), Mode.Bits.WRITE));
+
+    Assert.assertTrue(checkMode(acl, OTHER_USER, Lists.newArrayList(OWNING_GROUP),
+        Mode.Bits.READ_EXECUTE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(OWNING_GROUP),
+        Mode.Bits.WRITE));
+
+    Assert.assertTrue(checkMode(acl, OTHER_USER, Lists.newArrayList(NAMED_GROUP), Mode.Bits.READ));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(NAMED_GROUP),
+        Mode.Bits.WRITE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(NAMED_GROUP),
+        Mode.Bits.EXECUTE));
+
+    Assert.assertTrue(checkMode(acl, OTHER_USER, Lists.newArrayList(OTHER_GROUP),
+        Mode.Bits.EXECUTE));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(OTHER_GROUP),
+        Mode.Bits.READ));
+    Assert.assertFalse(checkMode(acl, OTHER_USER, Lists.newArrayList(OTHER_GROUP),
+        Mode.Bits.WRITE));
+  }
+}

--- a/core/common/src/test/java/alluxio/security/authorization/AclActionsTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/AclActionsTest.java
@@ -1,0 +1,132 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authorization;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link AclActions} class.
+ */
+public class AclActionsTest {
+  /**
+   * Tests constructor contract.
+   */
+  @Test
+  public void constructor() {
+    AclActions actions = new AclActions();
+    Assert.assertTrue(actions.getActions().isEmpty());
+
+    AclActions copiedActions = new AclActions(actions);
+    copiedActions.add(AclAction.READ);
+    Assert.assertEquals(1, copiedActions.getActions().size());
+    Assert.assertEquals(0, actions.getActions().size());
+  }
+
+  /**
+   * Tests {@link AclActions#toModeBits()}.
+   */
+  @Test
+  public void toModeBits() {
+    AclActions actions = new AclActions();
+    Assert.assertEquals(Mode.Bits.NONE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.READ);
+    Assert.assertEquals(Mode.Bits.READ, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.WRITE);
+    Assert.assertEquals(Mode.Bits.WRITE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.EXECUTE);
+    Assert.assertEquals(Mode.Bits.EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.READ);
+    actions.add(AclAction.WRITE);
+    Assert.assertEquals(Mode.Bits.READ_WRITE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.READ);
+    actions.add(AclAction.EXECUTE);
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.WRITE);
+    actions.add(AclAction.EXECUTE);
+    Assert.assertEquals(Mode.Bits.WRITE_EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.add(AclAction.READ);
+    actions.add(AclAction.WRITE);
+    actions.add(AclAction.EXECUTE);
+    Assert.assertEquals(Mode.Bits.ALL, actions.toModeBits());
+  }
+
+  /**
+   * Tests {@link AclActions#updateByModeBits(Mode.Bits)}.
+   */
+  @Test
+  public void updateByModeBits() {
+    AclActions actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.NONE);
+    Assert.assertEquals(Mode.Bits.NONE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.READ);
+    Assert.assertEquals(Mode.Bits.READ, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.WRITE);
+    Assert.assertEquals(Mode.Bits.WRITE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.EXECUTE);
+    Assert.assertEquals(Mode.Bits.EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.READ_WRITE);
+    Assert.assertEquals(Mode.Bits.READ_WRITE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.READ_EXECUTE);
+    Assert.assertEquals(Mode.Bits.READ_EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.WRITE_EXECUTE);
+    Assert.assertEquals(Mode.Bits.WRITE_EXECUTE, actions.toModeBits());
+
+    actions = new AclActions();
+    actions.updateByModeBits(Mode.Bits.ALL);
+    Assert.assertEquals(Mode.Bits.ALL, actions.toModeBits());
+  }
+
+  /**
+   * Tests {@link AclActions#contains(AclAction)}.
+   */
+  @Test
+  public void contains() {
+    AclActions actions = new AclActions();
+    Assert.assertFalse(actions.contains(AclAction.READ));
+    Assert.assertFalse(actions.contains(AclAction.WRITE));
+    Assert.assertFalse(actions.contains(AclAction.EXECUTE));
+
+    actions.add(AclAction.READ);
+    Assert.assertTrue(actions.contains(AclAction.READ));
+    actions.add(AclAction.WRITE);
+    Assert.assertTrue(actions.contains(AclAction.WRITE));
+    actions.add(AclAction.EXECUTE);
+    Assert.assertTrue(actions.contains(AclAction.EXECUTE));
+  }
+}

--- a/core/common/src/test/java/alluxio/security/authorization/ModeBitsTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeBitsTest.java
@@ -12,9 +12,10 @@
 package alluxio.security.authorization;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -90,5 +91,15 @@ public final class ModeBitsTest {
     assertEquals(Mode.Bits.NONE, Mode.Bits.READ.and(Mode.Bits.WRITE));
     assertEquals(Mode.Bits.READ, Mode.Bits.READ_EXECUTE.and(Mode.Bits.READ));
     assertEquals(Mode.Bits.WRITE, Mode.Bits.READ_WRITE.and(Mode.Bits.WRITE));
+  }
+
+  /**
+   * Tests {@link Mode.Bits#toAclActions()}.
+   */
+  @Test
+  public void toAclActions() {
+    for (Mode.Bits bits : Mode.Bits.values()) {
+      Assert.assertEquals(bits, new AclActions(bits.toAclActions()).toModeBits());
+    }
   }
 }

--- a/core/protobuf/src/main/java/alluxio/proto/journal/File.java
+++ b/core/protobuf/src/main/java/alluxio/proto/journal/File.java
@@ -9,6 +9,101 @@ public final class File {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   /**
+   * Protobuf enum {@code alluxio.proto.journal.AclAction}
+   *
+   * <pre>
+   * next available id: 3
+   * </pre>
+   */
+  public enum AclAction
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>READ = 0;</code>
+     */
+    READ(0, 0),
+    /**
+     * <code>WRITE = 1;</code>
+     */
+    WRITE(1, 1),
+    /**
+     * <code>EXECUTE = 2;</code>
+     */
+    EXECUTE(2, 2),
+    ;
+
+    /**
+     * <code>READ = 0;</code>
+     */
+    public static final int READ_VALUE = 0;
+    /**
+     * <code>WRITE = 1;</code>
+     */
+    public static final int WRITE_VALUE = 1;
+    /**
+     * <code>EXECUTE = 2;</code>
+     */
+    public static final int EXECUTE_VALUE = 2;
+
+
+    public final int getNumber() { return value; }
+
+    public static AclAction valueOf(int value) {
+      switch (value) {
+        case 0: return READ;
+        case 1: return WRITE;
+        case 2: return EXECUTE;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<AclAction>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<AclAction>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<AclAction>() {
+            public AclAction findValueByNumber(int number) {
+              return AclAction.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return alluxio.proto.journal.File.getDescriptor().getEnumTypes().get(0);
+    }
+
+    private static final AclAction[] VALUES = values();
+
+    public static AclAction valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private AclAction(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:alluxio.proto.journal.AclAction)
+  }
+
+  /**
    * Protobuf enum {@code alluxio.proto.journal.PTtlAction}
    */
   public enum PTtlAction
@@ -65,7 +160,7 @@ public final class File {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return alluxio.proto.journal.File.getDescriptor().getEnumTypes().get(0);
+      return alluxio.proto.journal.File.getDescriptor().getEnumTypes().get(1);
     }
 
     private static final PTtlAction[] VALUES = values();
@@ -156,7 +251,7 @@ public final class File {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return alluxio.proto.journal.File.getDescriptor().getEnumTypes().get(1);
+      return alluxio.proto.journal.File.getDescriptor().getEnumTypes().get(2);
     }
 
     private static final UfsMode[] VALUES = values();
@@ -4467,6 +4562,2916 @@ public final class File {
     // @@protoc_insertion_point(class_scope:alluxio.proto.journal.DeleteMountPointEntry)
   }
 
+  public interface AclActionsOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // repeated .alluxio.proto.journal.AclAction actions = 1;
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    java.util.List<alluxio.proto.journal.File.AclAction> getActionsList();
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    int getActionsCount();
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    alluxio.proto.journal.File.AclAction getActions(int index);
+  }
+  /**
+   * Protobuf type {@code alluxio.proto.journal.AclActions}
+   *
+   * <pre>
+   * next available id: 2
+   * </pre>
+   */
+  public static final class AclActions extends
+      com.google.protobuf.GeneratedMessage
+      implements AclActionsOrBuilder {
+    // Use AclActions.newBuilder() to construct.
+    private AclActions(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private AclActions(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final AclActions defaultInstance;
+    public static AclActions getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public AclActions getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AclActions(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              alluxio.proto.journal.File.AclAction value = alluxio.proto.journal.File.AclAction.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  actions_ = new java.util.ArrayList<alluxio.proto.journal.File.AclAction>();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                actions_.add(value);
+              }
+              break;
+            }
+            case 10: {
+              int length = input.readRawVarint32();
+              int oldLimit = input.pushLimit(length);
+              while(input.getBytesUntilLimit() > 0) {
+                int rawValue = input.readEnum();
+                alluxio.proto.journal.File.AclAction value = alluxio.proto.journal.File.AclAction.valueOf(rawValue);
+                if (value == null) {
+                  unknownFields.mergeVarintField(1, rawValue);
+                } else {
+                  if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                    actions_ = new java.util.ArrayList<alluxio.proto.journal.File.AclAction>();
+                    mutable_bitField0_ |= 0x00000001;
+                  }
+                  actions_.add(value);
+                }
+              }
+              input.popLimit(oldLimit);
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          actions_ = java.util.Collections.unmodifiableList(actions_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AclActions_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AclActions_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              alluxio.proto.journal.File.AclActions.class, alluxio.proto.journal.File.AclActions.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<AclActions> PARSER =
+        new com.google.protobuf.AbstractParser<AclActions>() {
+      public AclActions parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AclActions(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AclActions> getParserForType() {
+      return PARSER;
+    }
+
+    // repeated .alluxio.proto.journal.AclAction actions = 1;
+    public static final int ACTIONS_FIELD_NUMBER = 1;
+    private java.util.List<alluxio.proto.journal.File.AclAction> actions_;
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    public java.util.List<alluxio.proto.journal.File.AclAction> getActionsList() {
+      return actions_;
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    public int getActionsCount() {
+      return actions_.size();
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+     */
+    public alluxio.proto.journal.File.AclAction getActions(int index) {
+      return actions_.get(index);
+    }
+
+    private void initFields() {
+      actions_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < actions_.size(); i++) {
+        output.writeEnum(1, actions_.get(i).getNumber());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < actions_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeEnumSizeNoTag(actions_.get(i).getNumber());
+        }
+        size += dataSize;
+        size += 1 * actions_.size();
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AclActions parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static alluxio.proto.journal.File.AclActions parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.AclActions parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(alluxio.proto.journal.File.AclActions prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code alluxio.proto.journal.AclActions}
+     *
+     * <pre>
+     * next available id: 2
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements alluxio.proto.journal.File.AclActionsOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AclActions_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AclActions_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                alluxio.proto.journal.File.AclActions.class, alluxio.proto.journal.File.AclActions.Builder.class);
+      }
+
+      // Construct using alluxio.proto.journal.File.AclActions.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        actions_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AclActions_descriptor;
+      }
+
+      public alluxio.proto.journal.File.AclActions getDefaultInstanceForType() {
+        return alluxio.proto.journal.File.AclActions.getDefaultInstance();
+      }
+
+      public alluxio.proto.journal.File.AclActions build() {
+        alluxio.proto.journal.File.AclActions result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public alluxio.proto.journal.File.AclActions buildPartial() {
+        alluxio.proto.journal.File.AclActions result = new alluxio.proto.journal.File.AclActions(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          actions_ = java.util.Collections.unmodifiableList(actions_);
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.actions_ = actions_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof alluxio.proto.journal.File.AclActions) {
+          return mergeFrom((alluxio.proto.journal.File.AclActions)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(alluxio.proto.journal.File.AclActions other) {
+        if (other == alluxio.proto.journal.File.AclActions.getDefaultInstance()) return this;
+        if (!other.actions_.isEmpty()) {
+          if (actions_.isEmpty()) {
+            actions_ = other.actions_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureActionsIsMutable();
+            actions_.addAll(other.actions_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        alluxio.proto.journal.File.AclActions parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (alluxio.proto.journal.File.AclActions) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .alluxio.proto.journal.AclAction actions = 1;
+      private java.util.List<alluxio.proto.journal.File.AclAction> actions_ =
+        java.util.Collections.emptyList();
+      private void ensureActionsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          actions_ = new java.util.ArrayList<alluxio.proto.journal.File.AclAction>(actions_);
+          bitField0_ |= 0x00000001;
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public java.util.List<alluxio.proto.journal.File.AclAction> getActionsList() {
+        return java.util.Collections.unmodifiableList(actions_);
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public int getActionsCount() {
+        return actions_.size();
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public alluxio.proto.journal.File.AclAction getActions(int index) {
+        return actions_.get(index);
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public Builder setActions(
+          int index, alluxio.proto.journal.File.AclAction value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureActionsIsMutable();
+        actions_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public Builder addActions(alluxio.proto.journal.File.AclAction value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureActionsIsMutable();
+        actions_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public Builder addAllActions(
+          java.lang.Iterable<? extends alluxio.proto.journal.File.AclAction> values) {
+        ensureActionsIsMutable();
+        super.addAll(values, actions_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.AclAction actions = 1;</code>
+       */
+      public Builder clearActions() {
+        actions_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.AclActions)
+    }
+
+    static {
+      defaultInstance = new AclActions(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:alluxio.proto.journal.AclActions)
+  }
+
+  public interface NamedAclActionsOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // optional string name = 1;
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    boolean hasName();
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    java.lang.String getName();
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    // optional .alluxio.proto.journal.AclActions actions = 2;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    boolean hasActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    alluxio.proto.journal.File.AclActions getActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    alluxio.proto.journal.File.AclActionsOrBuilder getActionsOrBuilder();
+  }
+  /**
+   * Protobuf type {@code alluxio.proto.journal.NamedAclActions}
+   *
+   * <pre>
+   * AclActions for a String name.
+   * next available id: 3
+   * </pre>
+   */
+  public static final class NamedAclActions extends
+      com.google.protobuf.GeneratedMessage
+      implements NamedAclActionsOrBuilder {
+    // Use NamedAclActions.newBuilder() to construct.
+    private NamedAclActions(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private NamedAclActions(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final NamedAclActions defaultInstance;
+    public static NamedAclActions getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public NamedAclActions getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private NamedAclActions(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              name_ = input.readBytes();
+              break;
+            }
+            case 18: {
+              alluxio.proto.journal.File.AclActions.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                subBuilder = actions_.toBuilder();
+              }
+              actions_ = input.readMessage(alluxio.proto.journal.File.AclActions.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(actions_);
+                actions_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_NamedAclActions_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_NamedAclActions_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              alluxio.proto.journal.File.NamedAclActions.class, alluxio.proto.journal.File.NamedAclActions.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<NamedAclActions> PARSER =
+        new com.google.protobuf.AbstractParser<NamedAclActions>() {
+      public NamedAclActions parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new NamedAclActions(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<NamedAclActions> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    // optional string name = 1;
+    public static final int NAME_FIELD_NUMBER = 1;
+    private java.lang.Object name_;
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          name_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string name = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional .alluxio.proto.journal.AclActions actions = 2;
+    public static final int ACTIONS_FIELD_NUMBER = 2;
+    private alluxio.proto.journal.File.AclActions actions_;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    public boolean hasActions() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    public alluxio.proto.journal.File.AclActions getActions() {
+      return actions_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+     */
+    public alluxio.proto.journal.File.AclActionsOrBuilder getActionsOrBuilder() {
+      return actions_;
+    }
+
+    private void initFields() {
+      name_ = "";
+      actions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getNameBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(2, actions_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getNameBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, actions_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.NamedAclActions parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(alluxio.proto.journal.File.NamedAclActions prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code alluxio.proto.journal.NamedAclActions}
+     *
+     * <pre>
+     * AclActions for a String name.
+     * next available id: 3
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements alluxio.proto.journal.File.NamedAclActionsOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_NamedAclActions_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_NamedAclActions_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                alluxio.proto.journal.File.NamedAclActions.class, alluxio.proto.journal.File.NamedAclActions.Builder.class);
+      }
+
+      // Construct using alluxio.proto.journal.File.NamedAclActions.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getActionsFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (actionsBuilder_ == null) {
+          actions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+        } else {
+          actionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_NamedAclActions_descriptor;
+      }
+
+      public alluxio.proto.journal.File.NamedAclActions getDefaultInstanceForType() {
+        return alluxio.proto.journal.File.NamedAclActions.getDefaultInstance();
+      }
+
+      public alluxio.proto.journal.File.NamedAclActions build() {
+        alluxio.proto.journal.File.NamedAclActions result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public alluxio.proto.journal.File.NamedAclActions buildPartial() {
+        alluxio.proto.journal.File.NamedAclActions result = new alluxio.proto.journal.File.NamedAclActions(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.name_ = name_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        if (actionsBuilder_ == null) {
+          result.actions_ = actions_;
+        } else {
+          result.actions_ = actionsBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof alluxio.proto.journal.File.NamedAclActions) {
+          return mergeFrom((alluxio.proto.journal.File.NamedAclActions)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(alluxio.proto.journal.File.NamedAclActions other) {
+        if (other == alluxio.proto.journal.File.NamedAclActions.getDefaultInstance()) return this;
+        if (other.hasName()) {
+          bitField0_ |= 0x00000001;
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.hasActions()) {
+          mergeActions(other.getActions());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        alluxio.proto.journal.File.NamedAclActions parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (alluxio.proto.journal.File.NamedAclActions) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // optional string name = 1;
+      private java.lang.Object name_ = "";
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public Builder clearName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 1;</code>
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional .alluxio.proto.journal.AclActions actions = 2;
+      private alluxio.proto.journal.File.AclActions actions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> actionsBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public boolean hasActions() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public alluxio.proto.journal.File.AclActions getActions() {
+        if (actionsBuilder_ == null) {
+          return actions_;
+        } else {
+          return actionsBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public Builder setActions(alluxio.proto.journal.File.AclActions value) {
+        if (actionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          actions_ = value;
+          onChanged();
+        } else {
+          actionsBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public Builder setActions(
+          alluxio.proto.journal.File.AclActions.Builder builderForValue) {
+        if (actionsBuilder_ == null) {
+          actions_ = builderForValue.build();
+          onChanged();
+        } else {
+          actionsBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public Builder mergeActions(alluxio.proto.journal.File.AclActions value) {
+        if (actionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+              actions_ != alluxio.proto.journal.File.AclActions.getDefaultInstance()) {
+            actions_ =
+              alluxio.proto.journal.File.AclActions.newBuilder(actions_).mergeFrom(value).buildPartial();
+          } else {
+            actions_ = value;
+          }
+          onChanged();
+        } else {
+          actionsBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public Builder clearActions() {
+        if (actionsBuilder_ == null) {
+          actions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+          onChanged();
+        } else {
+          actionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public alluxio.proto.journal.File.AclActions.Builder getActionsBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getActionsFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      public alluxio.proto.journal.File.AclActionsOrBuilder getActionsOrBuilder() {
+        if (actionsBuilder_ != null) {
+          return actionsBuilder_.getMessageOrBuilder();
+        } else {
+          return actions_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions actions = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> 
+          getActionsFieldBuilder() {
+        if (actionsBuilder_ == null) {
+          actionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder>(
+                  actions_,
+                  getParentForChildren(),
+                  isClean());
+          actions_ = null;
+        }
+        return actionsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.NamedAclActions)
+    }
+
+    static {
+      defaultInstance = new NamedAclActions(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:alluxio.proto.journal.NamedAclActions)
+  }
+
+  public interface AccessControlListOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // optional string owningUser = 1;
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    boolean hasOwningUser();
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    java.lang.String getOwningUser();
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getOwningUserBytes();
+
+    // optional string owningGroup = 2;
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    boolean hasOwningGroup();
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    java.lang.String getOwningGroup();
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getOwningGroupBytes();
+
+    // repeated .alluxio.proto.journal.NamedAclActions userActions = 3;
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    java.util.List<alluxio.proto.journal.File.NamedAclActions> 
+        getUserActionsList();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    alluxio.proto.journal.File.NamedAclActions getUserActions(int index);
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    int getUserActionsCount();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+        getUserActionsOrBuilderList();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    alluxio.proto.journal.File.NamedAclActionsOrBuilder getUserActionsOrBuilder(
+        int index);
+
+    // repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    java.util.List<alluxio.proto.journal.File.NamedAclActions> 
+        getGroupActionsList();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    alluxio.proto.journal.File.NamedAclActions getGroupActions(int index);
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    int getGroupActionsCount();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+        getGroupActionsOrBuilderList();
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    alluxio.proto.journal.File.NamedAclActionsOrBuilder getGroupActionsOrBuilder(
+        int index);
+
+    // optional .alluxio.proto.journal.AclActions maskActions = 5;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    boolean hasMaskActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    alluxio.proto.journal.File.AclActions getMaskActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    alluxio.proto.journal.File.AclActionsOrBuilder getMaskActionsOrBuilder();
+
+    // optional .alluxio.proto.journal.AclActions otherActions = 6;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    boolean hasOtherActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    alluxio.proto.journal.File.AclActions getOtherActions();
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    alluxio.proto.journal.File.AclActionsOrBuilder getOtherActionsOrBuilder();
+  }
+  /**
+   * Protobuf type {@code alluxio.proto.journal.AccessControlList}
+   *
+   * <pre>
+   * next available id: 7
+   * </pre>
+   */
+  public static final class AccessControlList extends
+      com.google.protobuf.GeneratedMessage
+      implements AccessControlListOrBuilder {
+    // Use AccessControlList.newBuilder() to construct.
+    private AccessControlList(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private AccessControlList(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final AccessControlList defaultInstance;
+    public static AccessControlList getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public AccessControlList getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AccessControlList(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              owningUser_ = input.readBytes();
+              break;
+            }
+            case 18: {
+              bitField0_ |= 0x00000002;
+              owningGroup_ = input.readBytes();
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                userActions_ = new java.util.ArrayList<alluxio.proto.journal.File.NamedAclActions>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              userActions_.add(input.readMessage(alluxio.proto.journal.File.NamedAclActions.PARSER, extensionRegistry));
+              break;
+            }
+            case 34: {
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                groupActions_ = new java.util.ArrayList<alluxio.proto.journal.File.NamedAclActions>();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              groupActions_.add(input.readMessage(alluxio.proto.journal.File.NamedAclActions.PARSER, extensionRegistry));
+              break;
+            }
+            case 42: {
+              alluxio.proto.journal.File.AclActions.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                subBuilder = maskActions_.toBuilder();
+              }
+              maskActions_ = input.readMessage(alluxio.proto.journal.File.AclActions.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(maskActions_);
+                maskActions_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000004;
+              break;
+            }
+            case 50: {
+              alluxio.proto.journal.File.AclActions.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                subBuilder = otherActions_.toBuilder();
+              }
+              otherActions_ = input.readMessage(alluxio.proto.journal.File.AclActions.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(otherActions_);
+                otherActions_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000008;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          userActions_ = java.util.Collections.unmodifiableList(userActions_);
+        }
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+          groupActions_ = java.util.Collections.unmodifiableList(groupActions_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AccessControlList_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AccessControlList_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              alluxio.proto.journal.File.AccessControlList.class, alluxio.proto.journal.File.AccessControlList.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<AccessControlList> PARSER =
+        new com.google.protobuf.AbstractParser<AccessControlList>() {
+      public AccessControlList parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AccessControlList(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AccessControlList> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    // optional string owningUser = 1;
+    public static final int OWNINGUSER_FIELD_NUMBER = 1;
+    private java.lang.Object owningUser_;
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    public boolean hasOwningUser() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    public java.lang.String getOwningUser() {
+      java.lang.Object ref = owningUser_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          owningUser_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string owningUser = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getOwningUserBytes() {
+      java.lang.Object ref = owningUser_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        owningUser_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional string owningGroup = 2;
+    public static final int OWNINGGROUP_FIELD_NUMBER = 2;
+    private java.lang.Object owningGroup_;
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    public boolean hasOwningGroup() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    public java.lang.String getOwningGroup() {
+      java.lang.Object ref = owningGroup_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          owningGroup_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string owningGroup = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getOwningGroupBytes() {
+      java.lang.Object ref = owningGroup_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        owningGroup_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // repeated .alluxio.proto.journal.NamedAclActions userActions = 3;
+    public static final int USERACTIONS_FIELD_NUMBER = 3;
+    private java.util.List<alluxio.proto.journal.File.NamedAclActions> userActions_;
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    public java.util.List<alluxio.proto.journal.File.NamedAclActions> getUserActionsList() {
+      return userActions_;
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    public java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+        getUserActionsOrBuilderList() {
+      return userActions_;
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    public int getUserActionsCount() {
+      return userActions_.size();
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    public alluxio.proto.journal.File.NamedAclActions getUserActions(int index) {
+      return userActions_.get(index);
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+     */
+    public alluxio.proto.journal.File.NamedAclActionsOrBuilder getUserActionsOrBuilder(
+        int index) {
+      return userActions_.get(index);
+    }
+
+    // repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;
+    public static final int GROUPACTIONS_FIELD_NUMBER = 4;
+    private java.util.List<alluxio.proto.journal.File.NamedAclActions> groupActions_;
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    public java.util.List<alluxio.proto.journal.File.NamedAclActions> getGroupActionsList() {
+      return groupActions_;
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    public java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+        getGroupActionsOrBuilderList() {
+      return groupActions_;
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    public int getGroupActionsCount() {
+      return groupActions_.size();
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    public alluxio.proto.journal.File.NamedAclActions getGroupActions(int index) {
+      return groupActions_.get(index);
+    }
+    /**
+     * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+     */
+    public alluxio.proto.journal.File.NamedAclActionsOrBuilder getGroupActionsOrBuilder(
+        int index) {
+      return groupActions_.get(index);
+    }
+
+    // optional .alluxio.proto.journal.AclActions maskActions = 5;
+    public static final int MASKACTIONS_FIELD_NUMBER = 5;
+    private alluxio.proto.journal.File.AclActions maskActions_;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    public boolean hasMaskActions() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    public alluxio.proto.journal.File.AclActions getMaskActions() {
+      return maskActions_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+     */
+    public alluxio.proto.journal.File.AclActionsOrBuilder getMaskActionsOrBuilder() {
+      return maskActions_;
+    }
+
+    // optional .alluxio.proto.journal.AclActions otherActions = 6;
+    public static final int OTHERACTIONS_FIELD_NUMBER = 6;
+    private alluxio.proto.journal.File.AclActions otherActions_;
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    public boolean hasOtherActions() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    public alluxio.proto.journal.File.AclActions getOtherActions() {
+      return otherActions_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+     */
+    public alluxio.proto.journal.File.AclActionsOrBuilder getOtherActionsOrBuilder() {
+      return otherActions_;
+    }
+
+    private void initFields() {
+      owningUser_ = "";
+      owningGroup_ = "";
+      userActions_ = java.util.Collections.emptyList();
+      groupActions_ = java.util.Collections.emptyList();
+      maskActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+      otherActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getOwningUserBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, getOwningGroupBytes());
+      }
+      for (int i = 0; i < userActions_.size(); i++) {
+        output.writeMessage(3, userActions_.get(i));
+      }
+      for (int i = 0; i < groupActions_.size(); i++) {
+        output.writeMessage(4, groupActions_.get(i));
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeMessage(5, maskActions_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeMessage(6, otherActions_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getOwningUserBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getOwningGroupBytes());
+      }
+      for (int i = 0; i < userActions_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, userActions_.get(i));
+      }
+      for (int i = 0; i < groupActions_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, groupActions_.get(i));
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(5, maskActions_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, otherActions_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static alluxio.proto.journal.File.AccessControlList parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(alluxio.proto.journal.File.AccessControlList prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code alluxio.proto.journal.AccessControlList}
+     *
+     * <pre>
+     * next available id: 7
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements alluxio.proto.journal.File.AccessControlListOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AccessControlList_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AccessControlList_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                alluxio.proto.journal.File.AccessControlList.class, alluxio.proto.journal.File.AccessControlList.Builder.class);
+      }
+
+      // Construct using alluxio.proto.journal.File.AccessControlList.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getUserActionsFieldBuilder();
+          getGroupActionsFieldBuilder();
+          getMaskActionsFieldBuilder();
+          getOtherActionsFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        owningUser_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        owningGroup_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        if (userActionsBuilder_ == null) {
+          userActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          userActionsBuilder_.clear();
+        }
+        if (groupActionsBuilder_ == null) {
+          groupActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        } else {
+          groupActionsBuilder_.clear();
+        }
+        if (maskActionsBuilder_ == null) {
+          maskActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+        } else {
+          maskActionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
+        if (otherActionsBuilder_ == null) {
+          otherActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+        } else {
+          otherActionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return alluxio.proto.journal.File.internal_static_alluxio_proto_journal_AccessControlList_descriptor;
+      }
+
+      public alluxio.proto.journal.File.AccessControlList getDefaultInstanceForType() {
+        return alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+      }
+
+      public alluxio.proto.journal.File.AccessControlList build() {
+        alluxio.proto.journal.File.AccessControlList result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public alluxio.proto.journal.File.AccessControlList buildPartial() {
+        alluxio.proto.journal.File.AccessControlList result = new alluxio.proto.journal.File.AccessControlList(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.owningUser_ = owningUser_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.owningGroup_ = owningGroup_;
+        if (userActionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            userActions_ = java.util.Collections.unmodifiableList(userActions_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.userActions_ = userActions_;
+        } else {
+          result.userActions_ = userActionsBuilder_.build();
+        }
+        if (groupActionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+            groupActions_ = java.util.Collections.unmodifiableList(groupActions_);
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.groupActions_ = groupActions_;
+        } else {
+          result.groupActions_ = groupActionsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        if (maskActionsBuilder_ == null) {
+          result.maskActions_ = maskActions_;
+        } else {
+          result.maskActions_ = maskActionsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        if (otherActionsBuilder_ == null) {
+          result.otherActions_ = otherActions_;
+        } else {
+          result.otherActions_ = otherActionsBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof alluxio.proto.journal.File.AccessControlList) {
+          return mergeFrom((alluxio.proto.journal.File.AccessControlList)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(alluxio.proto.journal.File.AccessControlList other) {
+        if (other == alluxio.proto.journal.File.AccessControlList.getDefaultInstance()) return this;
+        if (other.hasOwningUser()) {
+          bitField0_ |= 0x00000001;
+          owningUser_ = other.owningUser_;
+          onChanged();
+        }
+        if (other.hasOwningGroup()) {
+          bitField0_ |= 0x00000002;
+          owningGroup_ = other.owningGroup_;
+          onChanged();
+        }
+        if (userActionsBuilder_ == null) {
+          if (!other.userActions_.isEmpty()) {
+            if (userActions_.isEmpty()) {
+              userActions_ = other.userActions_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensureUserActionsIsMutable();
+              userActions_.addAll(other.userActions_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.userActions_.isEmpty()) {
+            if (userActionsBuilder_.isEmpty()) {
+              userActionsBuilder_.dispose();
+              userActionsBuilder_ = null;
+              userActions_ = other.userActions_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              userActionsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getUserActionsFieldBuilder() : null;
+            } else {
+              userActionsBuilder_.addAllMessages(other.userActions_);
+            }
+          }
+        }
+        if (groupActionsBuilder_ == null) {
+          if (!other.groupActions_.isEmpty()) {
+            if (groupActions_.isEmpty()) {
+              groupActions_ = other.groupActions_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensureGroupActionsIsMutable();
+              groupActions_.addAll(other.groupActions_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.groupActions_.isEmpty()) {
+            if (groupActionsBuilder_.isEmpty()) {
+              groupActionsBuilder_.dispose();
+              groupActionsBuilder_ = null;
+              groupActions_ = other.groupActions_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+              groupActionsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getGroupActionsFieldBuilder() : null;
+            } else {
+              groupActionsBuilder_.addAllMessages(other.groupActions_);
+            }
+          }
+        }
+        if (other.hasMaskActions()) {
+          mergeMaskActions(other.getMaskActions());
+        }
+        if (other.hasOtherActions()) {
+          mergeOtherActions(other.getOtherActions());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        alluxio.proto.journal.File.AccessControlList parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (alluxio.proto.journal.File.AccessControlList) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // optional string owningUser = 1;
+      private java.lang.Object owningUser_ = "";
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public boolean hasOwningUser() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public java.lang.String getOwningUser() {
+        java.lang.Object ref = owningUser_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          owningUser_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getOwningUserBytes() {
+        java.lang.Object ref = owningUser_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          owningUser_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public Builder setOwningUser(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        owningUser_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public Builder clearOwningUser() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        owningUser_ = getDefaultInstance().getOwningUser();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string owningUser = 1;</code>
+       */
+      public Builder setOwningUserBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        owningUser_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional string owningGroup = 2;
+      private java.lang.Object owningGroup_ = "";
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public boolean hasOwningGroup() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public java.lang.String getOwningGroup() {
+        java.lang.Object ref = owningGroup_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          owningGroup_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getOwningGroupBytes() {
+        java.lang.Object ref = owningGroup_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          owningGroup_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public Builder setOwningGroup(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        owningGroup_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public Builder clearOwningGroup() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        owningGroup_ = getDefaultInstance().getOwningGroup();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string owningGroup = 2;</code>
+       */
+      public Builder setOwningGroupBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        owningGroup_ = value;
+        onChanged();
+        return this;
+      }
+
+      // repeated .alluxio.proto.journal.NamedAclActions userActions = 3;
+      private java.util.List<alluxio.proto.journal.File.NamedAclActions> userActions_ =
+        java.util.Collections.emptyList();
+      private void ensureUserActionsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          userActions_ = new java.util.ArrayList<alluxio.proto.journal.File.NamedAclActions>(userActions_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder> userActionsBuilder_;
+
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public java.util.List<alluxio.proto.journal.File.NamedAclActions> getUserActionsList() {
+        if (userActionsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(userActions_);
+        } else {
+          return userActionsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public int getUserActionsCount() {
+        if (userActionsBuilder_ == null) {
+          return userActions_.size();
+        } else {
+          return userActionsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions getUserActions(int index) {
+        if (userActionsBuilder_ == null) {
+          return userActions_.get(index);
+        } else {
+          return userActionsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder setUserActions(
+          int index, alluxio.proto.journal.File.NamedAclActions value) {
+        if (userActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUserActionsIsMutable();
+          userActions_.set(index, value);
+          onChanged();
+        } else {
+          userActionsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder setUserActions(
+          int index, alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (userActionsBuilder_ == null) {
+          ensureUserActionsIsMutable();
+          userActions_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          userActionsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder addUserActions(alluxio.proto.journal.File.NamedAclActions value) {
+        if (userActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUserActionsIsMutable();
+          userActions_.add(value);
+          onChanged();
+        } else {
+          userActionsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder addUserActions(
+          int index, alluxio.proto.journal.File.NamedAclActions value) {
+        if (userActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureUserActionsIsMutable();
+          userActions_.add(index, value);
+          onChanged();
+        } else {
+          userActionsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder addUserActions(
+          alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (userActionsBuilder_ == null) {
+          ensureUserActionsIsMutable();
+          userActions_.add(builderForValue.build());
+          onChanged();
+        } else {
+          userActionsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder addUserActions(
+          int index, alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (userActionsBuilder_ == null) {
+          ensureUserActionsIsMutable();
+          userActions_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          userActionsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder addAllUserActions(
+          java.lang.Iterable<? extends alluxio.proto.journal.File.NamedAclActions> values) {
+        if (userActionsBuilder_ == null) {
+          ensureUserActionsIsMutable();
+          super.addAll(values, userActions_);
+          onChanged();
+        } else {
+          userActionsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder clearUserActions() {
+        if (userActionsBuilder_ == null) {
+          userActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          userActionsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public Builder removeUserActions(int index) {
+        if (userActionsBuilder_ == null) {
+          ensureUserActionsIsMutable();
+          userActions_.remove(index);
+          onChanged();
+        } else {
+          userActionsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder getUserActionsBuilder(
+          int index) {
+        return getUserActionsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActionsOrBuilder getUserActionsOrBuilder(
+          int index) {
+        if (userActionsBuilder_ == null) {
+          return userActions_.get(index);  } else {
+          return userActionsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+           getUserActionsOrBuilderList() {
+        if (userActionsBuilder_ != null) {
+          return userActionsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(userActions_);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder addUserActionsBuilder() {
+        return getUserActionsFieldBuilder().addBuilder(
+            alluxio.proto.journal.File.NamedAclActions.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder addUserActionsBuilder(
+          int index) {
+        return getUserActionsFieldBuilder().addBuilder(
+            index, alluxio.proto.journal.File.NamedAclActions.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions userActions = 3;</code>
+       */
+      public java.util.List<alluxio.proto.journal.File.NamedAclActions.Builder> 
+           getUserActionsBuilderList() {
+        return getUserActionsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+          getUserActionsFieldBuilder() {
+        if (userActionsBuilder_ == null) {
+          userActionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder>(
+                  userActions_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          userActions_ = null;
+        }
+        return userActionsBuilder_;
+      }
+
+      // repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;
+      private java.util.List<alluxio.proto.journal.File.NamedAclActions> groupActions_ =
+        java.util.Collections.emptyList();
+      private void ensureGroupActionsIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          groupActions_ = new java.util.ArrayList<alluxio.proto.journal.File.NamedAclActions>(groupActions_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder> groupActionsBuilder_;
+
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public java.util.List<alluxio.proto.journal.File.NamedAclActions> getGroupActionsList() {
+        if (groupActionsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(groupActions_);
+        } else {
+          return groupActionsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public int getGroupActionsCount() {
+        if (groupActionsBuilder_ == null) {
+          return groupActions_.size();
+        } else {
+          return groupActionsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions getGroupActions(int index) {
+        if (groupActionsBuilder_ == null) {
+          return groupActions_.get(index);
+        } else {
+          return groupActionsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder setGroupActions(
+          int index, alluxio.proto.journal.File.NamedAclActions value) {
+        if (groupActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureGroupActionsIsMutable();
+          groupActions_.set(index, value);
+          onChanged();
+        } else {
+          groupActionsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder setGroupActions(
+          int index, alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (groupActionsBuilder_ == null) {
+          ensureGroupActionsIsMutable();
+          groupActions_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          groupActionsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder addGroupActions(alluxio.proto.journal.File.NamedAclActions value) {
+        if (groupActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureGroupActionsIsMutable();
+          groupActions_.add(value);
+          onChanged();
+        } else {
+          groupActionsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder addGroupActions(
+          int index, alluxio.proto.journal.File.NamedAclActions value) {
+        if (groupActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureGroupActionsIsMutable();
+          groupActions_.add(index, value);
+          onChanged();
+        } else {
+          groupActionsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder addGroupActions(
+          alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (groupActionsBuilder_ == null) {
+          ensureGroupActionsIsMutable();
+          groupActions_.add(builderForValue.build());
+          onChanged();
+        } else {
+          groupActionsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder addGroupActions(
+          int index, alluxio.proto.journal.File.NamedAclActions.Builder builderForValue) {
+        if (groupActionsBuilder_ == null) {
+          ensureGroupActionsIsMutable();
+          groupActions_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          groupActionsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder addAllGroupActions(
+          java.lang.Iterable<? extends alluxio.proto.journal.File.NamedAclActions> values) {
+        if (groupActionsBuilder_ == null) {
+          ensureGroupActionsIsMutable();
+          super.addAll(values, groupActions_);
+          onChanged();
+        } else {
+          groupActionsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder clearGroupActions() {
+        if (groupActionsBuilder_ == null) {
+          groupActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+        } else {
+          groupActionsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public Builder removeGroupActions(int index) {
+        if (groupActionsBuilder_ == null) {
+          ensureGroupActionsIsMutable();
+          groupActions_.remove(index);
+          onChanged();
+        } else {
+          groupActionsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder getGroupActionsBuilder(
+          int index) {
+        return getGroupActionsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActionsOrBuilder getGroupActionsOrBuilder(
+          int index) {
+        if (groupActionsBuilder_ == null) {
+          return groupActions_.get(index);  } else {
+          return groupActionsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public java.util.List<? extends alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+           getGroupActionsOrBuilderList() {
+        if (groupActionsBuilder_ != null) {
+          return groupActionsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(groupActions_);
+        }
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder addGroupActionsBuilder() {
+        return getGroupActionsFieldBuilder().addBuilder(
+            alluxio.proto.journal.File.NamedAclActions.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public alluxio.proto.journal.File.NamedAclActions.Builder addGroupActionsBuilder(
+          int index) {
+        return getGroupActionsFieldBuilder().addBuilder(
+            index, alluxio.proto.journal.File.NamedAclActions.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .alluxio.proto.journal.NamedAclActions groupActions = 4;</code>
+       */
+      public java.util.List<alluxio.proto.journal.File.NamedAclActions.Builder> 
+           getGroupActionsBuilderList() {
+        return getGroupActionsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder> 
+          getGroupActionsFieldBuilder() {
+        if (groupActionsBuilder_ == null) {
+          groupActionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              alluxio.proto.journal.File.NamedAclActions, alluxio.proto.journal.File.NamedAclActions.Builder, alluxio.proto.journal.File.NamedAclActionsOrBuilder>(
+                  groupActions_,
+                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  getParentForChildren(),
+                  isClean());
+          groupActions_ = null;
+        }
+        return groupActionsBuilder_;
+      }
+
+      // optional .alluxio.proto.journal.AclActions maskActions = 5;
+      private alluxio.proto.journal.File.AclActions maskActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> maskActionsBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public boolean hasMaskActions() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public alluxio.proto.journal.File.AclActions getMaskActions() {
+        if (maskActionsBuilder_ == null) {
+          return maskActions_;
+        } else {
+          return maskActionsBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public Builder setMaskActions(alluxio.proto.journal.File.AclActions value) {
+        if (maskActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          maskActions_ = value;
+          onChanged();
+        } else {
+          maskActionsBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public Builder setMaskActions(
+          alluxio.proto.journal.File.AclActions.Builder builderForValue) {
+        if (maskActionsBuilder_ == null) {
+          maskActions_ = builderForValue.build();
+          onChanged();
+        } else {
+          maskActionsBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public Builder mergeMaskActions(alluxio.proto.journal.File.AclActions value) {
+        if (maskActionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) == 0x00000010) &&
+              maskActions_ != alluxio.proto.journal.File.AclActions.getDefaultInstance()) {
+            maskActions_ =
+              alluxio.proto.journal.File.AclActions.newBuilder(maskActions_).mergeFrom(value).buildPartial();
+          } else {
+            maskActions_ = value;
+          }
+          onChanged();
+        } else {
+          maskActionsBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public Builder clearMaskActions() {
+        if (maskActionsBuilder_ == null) {
+          maskActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+          onChanged();
+        } else {
+          maskActionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public alluxio.proto.journal.File.AclActions.Builder getMaskActionsBuilder() {
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return getMaskActionsFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      public alluxio.proto.journal.File.AclActionsOrBuilder getMaskActionsOrBuilder() {
+        if (maskActionsBuilder_ != null) {
+          return maskActionsBuilder_.getMessageOrBuilder();
+        } else {
+          return maskActions_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions maskActions = 5;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> 
+          getMaskActionsFieldBuilder() {
+        if (maskActionsBuilder_ == null) {
+          maskActionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder>(
+                  maskActions_,
+                  getParentForChildren(),
+                  isClean());
+          maskActions_ = null;
+        }
+        return maskActionsBuilder_;
+      }
+
+      // optional .alluxio.proto.journal.AclActions otherActions = 6;
+      private alluxio.proto.journal.File.AclActions otherActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> otherActionsBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public boolean hasOtherActions() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public alluxio.proto.journal.File.AclActions getOtherActions() {
+        if (otherActionsBuilder_ == null) {
+          return otherActions_;
+        } else {
+          return otherActionsBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public Builder setOtherActions(alluxio.proto.journal.File.AclActions value) {
+        if (otherActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          otherActions_ = value;
+          onChanged();
+        } else {
+          otherActionsBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public Builder setOtherActions(
+          alluxio.proto.journal.File.AclActions.Builder builderForValue) {
+        if (otherActionsBuilder_ == null) {
+          otherActions_ = builderForValue.build();
+          onChanged();
+        } else {
+          otherActionsBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public Builder mergeOtherActions(alluxio.proto.journal.File.AclActions value) {
+        if (otherActionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+              otherActions_ != alluxio.proto.journal.File.AclActions.getDefaultInstance()) {
+            otherActions_ =
+              alluxio.proto.journal.File.AclActions.newBuilder(otherActions_).mergeFrom(value).buildPartial();
+          } else {
+            otherActions_ = value;
+          }
+          onChanged();
+        } else {
+          otherActionsBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public Builder clearOtherActions() {
+        if (otherActionsBuilder_ == null) {
+          otherActions_ = alluxio.proto.journal.File.AclActions.getDefaultInstance();
+          onChanged();
+        } else {
+          otherActionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public alluxio.proto.journal.File.AclActions.Builder getOtherActionsBuilder() {
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return getOtherActionsFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      public alluxio.proto.journal.File.AclActionsOrBuilder getOtherActionsOrBuilder() {
+        if (otherActionsBuilder_ != null) {
+          return otherActionsBuilder_.getMessageOrBuilder();
+        } else {
+          return otherActions_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AclActions otherActions = 6;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder> 
+          getOtherActionsFieldBuilder() {
+        if (otherActionsBuilder_ == null) {
+          otherActionsBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              alluxio.proto.journal.File.AclActions, alluxio.proto.journal.File.AclActions.Builder, alluxio.proto.journal.File.AclActionsOrBuilder>(
+                  otherActions_,
+                  getParentForChildren(),
+                  isClean());
+          otherActions_ = null;
+        }
+        return otherActionsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.AccessControlList)
+    }
+
+    static {
+      defaultInstance = new AccessControlList(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:alluxio.proto.journal.AccessControlList)
+  }
+
   public interface InodeDirectoryEntryOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -4629,12 +7634,26 @@ public final class File {
      * <code>optional .alluxio.proto.journal.PTtlAction ttlAction = 14 [default = DELETE];</code>
      */
     alluxio.proto.journal.File.PTtlAction getTtlAction();
+
+    // optional .alluxio.proto.journal.AccessControlList acl = 15;
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    boolean hasAcl();
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    alluxio.proto.journal.File.AccessControlList getAcl();
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder();
   }
   /**
    * Protobuf type {@code alluxio.proto.journal.InodeDirectoryEntry}
    *
    * <pre>
-   * next available id: 15
+   * next available id: 16
    * </pre>
    */
   public static final class InodeDirectoryEntry extends
@@ -4759,6 +7778,19 @@ public final class File {
                 bitField0_ |= 0x00002000;
                 ttlAction_ = value;
               }
+              break;
+            }
+            case 122: {
+              alluxio.proto.journal.File.AccessControlList.Builder subBuilder = null;
+              if (((bitField0_ & 0x00004000) == 0x00004000)) {
+                subBuilder = acl_.toBuilder();
+              }
+              acl_ = input.readMessage(alluxio.proto.journal.File.AccessControlList.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(acl_);
+                acl_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00004000;
               break;
             }
           }
@@ -5133,6 +8165,28 @@ public final class File {
       return ttlAction_;
     }
 
+    // optional .alluxio.proto.journal.AccessControlList acl = 15;
+    public static final int ACL_FIELD_NUMBER = 15;
+    private alluxio.proto.journal.File.AccessControlList acl_;
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    public boolean hasAcl() {
+      return ((bitField0_ & 0x00004000) == 0x00004000);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    public alluxio.proto.journal.File.AccessControlList getAcl() {
+      return acl_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+     */
+    public alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder() {
+      return acl_;
+    }
+
     private void initFields() {
       id_ = 0L;
       parentId_ = 0L;
@@ -5148,6 +8202,7 @@ public final class File {
       directChildrenLoaded_ = false;
       ttl_ = 0L;
       ttlAction_ = alluxio.proto.journal.File.PTtlAction.DELETE;
+      acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -5202,6 +8257,9 @@ public final class File {
       }
       if (((bitField0_ & 0x00002000) == 0x00002000)) {
         output.writeEnum(14, ttlAction_.getNumber());
+      }
+      if (((bitField0_ & 0x00004000) == 0x00004000)) {
+        output.writeMessage(15, acl_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -5267,6 +8325,10 @@ public final class File {
       if (((bitField0_ & 0x00002000) == 0x00002000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(14, ttlAction_.getNumber());
+      }
+      if (((bitField0_ & 0x00004000) == 0x00004000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(15, acl_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5350,7 +8412,7 @@ public final class File {
      * Protobuf type {@code alluxio.proto.journal.InodeDirectoryEntry}
      *
      * <pre>
-     * next available id: 15
+     * next available id: 16
      * </pre>
      */
     public static final class Builder extends
@@ -5380,6 +8442,7 @@ public final class File {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getAclFieldBuilder();
         }
       }
       private static Builder create() {
@@ -5416,6 +8479,12 @@ public final class File {
         bitField0_ = (bitField0_ & ~0x00001000);
         ttlAction_ = alluxio.proto.journal.File.PTtlAction.DELETE;
         bitField0_ = (bitField0_ & ~0x00002000);
+        if (aclBuilder_ == null) {
+          acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+        } else {
+          aclBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00004000);
         return this;
       }
 
@@ -5500,6 +8569,14 @@ public final class File {
           to_bitField0_ |= 0x00002000;
         }
         result.ttlAction_ = ttlAction_;
+        if (((from_bitField0_ & 0x00004000) == 0x00004000)) {
+          to_bitField0_ |= 0x00004000;
+        }
+        if (aclBuilder_ == null) {
+          result.acl_ = acl_;
+        } else {
+          result.acl_ = aclBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -5565,6 +8642,9 @@ public final class File {
         }
         if (other.hasTtlAction()) {
           setTtlAction(other.getTtlAction());
+        }
+        if (other.hasAcl()) {
+          mergeAcl(other.getAcl());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -6220,6 +9300,123 @@ public final class File {
         ttlAction_ = alluxio.proto.journal.File.PTtlAction.DELETE;
         onChanged();
         return this;
+      }
+
+      // optional .alluxio.proto.journal.AccessControlList acl = 15;
+      private alluxio.proto.journal.File.AccessControlList acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder> aclBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public boolean hasAcl() {
+        return ((bitField0_ & 0x00004000) == 0x00004000);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlList getAcl() {
+        if (aclBuilder_ == null) {
+          return acl_;
+        } else {
+          return aclBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public Builder setAcl(alluxio.proto.journal.File.AccessControlList value) {
+        if (aclBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          acl_ = value;
+          onChanged();
+        } else {
+          aclBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00004000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public Builder setAcl(
+          alluxio.proto.journal.File.AccessControlList.Builder builderForValue) {
+        if (aclBuilder_ == null) {
+          acl_ = builderForValue.build();
+          onChanged();
+        } else {
+          aclBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00004000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public Builder mergeAcl(alluxio.proto.journal.File.AccessControlList value) {
+        if (aclBuilder_ == null) {
+          if (((bitField0_ & 0x00004000) == 0x00004000) &&
+              acl_ != alluxio.proto.journal.File.AccessControlList.getDefaultInstance()) {
+            acl_ =
+              alluxio.proto.journal.File.AccessControlList.newBuilder(acl_).mergeFrom(value).buildPartial();
+          } else {
+            acl_ = value;
+          }
+          onChanged();
+        } else {
+          aclBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00004000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public Builder clearAcl() {
+        if (aclBuilder_ == null) {
+          acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+          onChanged();
+        } else {
+          aclBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00004000);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlList.Builder getAclBuilder() {
+        bitField0_ |= 0x00004000;
+        onChanged();
+        return getAclFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder() {
+        if (aclBuilder_ != null) {
+          return aclBuilder_.getMessageOrBuilder();
+        } else {
+          return acl_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 15;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder> 
+          getAclFieldBuilder() {
+        if (aclBuilder_ == null) {
+          aclBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder>(
+                  acl_,
+                  getParentForChildren(),
+                  isClean());
+          acl_ = null;
+        }
+        return aclBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.InodeDirectoryEntry)
@@ -6929,12 +10126,26 @@ public final class File {
      */
     com.google.protobuf.ByteString
         getUfsFingerprintBytes();
+
+    // optional .alluxio.proto.journal.AccessControlList acl = 19;
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    boolean hasAcl();
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    alluxio.proto.journal.File.AccessControlList getAcl();
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder();
   }
   /**
    * Protobuf type {@code alluxio.proto.journal.InodeFileEntry}
    *
    * <pre>
-   * next available id: 19
+   * next available id: 20
    * </pre>
    */
   public static final class InodeFileEntry extends
@@ -7095,6 +10306,19 @@ public final class File {
             case 146: {
               bitField0_ |= 0x00010000;
               ufsFingerprint_ = input.readBytes();
+              break;
+            }
+            case 154: {
+              alluxio.proto.journal.File.AccessControlList.Builder subBuilder = null;
+              if (((bitField0_ & 0x00020000) == 0x00020000)) {
+                subBuilder = acl_.toBuilder();
+              }
+              acl_ = input.readMessage(alluxio.proto.journal.File.AccessControlList.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(acl_);
+                acl_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00020000;
               break;
             }
           }
@@ -7570,6 +10794,28 @@ public final class File {
       }
     }
 
+    // optional .alluxio.proto.journal.AccessControlList acl = 19;
+    public static final int ACL_FIELD_NUMBER = 19;
+    private alluxio.proto.journal.File.AccessControlList acl_;
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    public boolean hasAcl() {
+      return ((bitField0_ & 0x00020000) == 0x00020000);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    public alluxio.proto.journal.File.AccessControlList getAcl() {
+      return acl_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+     */
+    public alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder() {
+      return acl_;
+    }
+
     private void initFields() {
       id_ = 0L;
       parentId_ = 0L;
@@ -7589,6 +10835,7 @@ public final class File {
       mode_ = 0;
       ttlAction_ = alluxio.proto.journal.File.PTtlAction.DELETE;
       ufsFingerprint_ = "";
+      acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -7655,6 +10902,9 @@ public final class File {
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
         output.writeBytes(18, getUfsFingerprintBytes());
+      }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        output.writeMessage(19, acl_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -7742,6 +10992,10 @@ public final class File {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(18, getUfsFingerprintBytes());
       }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(19, acl_);
+      }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
       return size;
@@ -7824,7 +11078,7 @@ public final class File {
      * Protobuf type {@code alluxio.proto.journal.InodeFileEntry}
      *
      * <pre>
-     * next available id: 19
+     * next available id: 20
      * </pre>
      */
     public static final class Builder extends
@@ -7854,6 +11108,7 @@ public final class File {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getAclFieldBuilder();
         }
       }
       private static Builder create() {
@@ -7898,6 +11153,12 @@ public final class File {
         bitField0_ = (bitField0_ & ~0x00010000);
         ufsFingerprint_ = "";
         bitField0_ = (bitField0_ & ~0x00020000);
+        if (aclBuilder_ == null) {
+          acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+        } else {
+          aclBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00040000);
         return this;
       }
 
@@ -7999,6 +11260,14 @@ public final class File {
           to_bitField0_ |= 0x00010000;
         }
         result.ufsFingerprint_ = ufsFingerprint_;
+        if (((from_bitField0_ & 0x00040000) == 0x00040000)) {
+          to_bitField0_ |= 0x00020000;
+        }
+        if (aclBuilder_ == null) {
+          result.acl_ = acl_;
+        } else {
+          result.acl_ = aclBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -8085,6 +11354,9 @@ public final class File {
           bitField0_ |= 0x00020000;
           ufsFingerprint_ = other.ufsFingerprint_;
           onChanged();
+        }
+        if (other.hasAcl()) {
+          mergeAcl(other.getAcl());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -8946,6 +12218,123 @@ public final class File {
         ufsFingerprint_ = value;
         onChanged();
         return this;
+      }
+
+      // optional .alluxio.proto.journal.AccessControlList acl = 19;
+      private alluxio.proto.journal.File.AccessControlList acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder> aclBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public boolean hasAcl() {
+        return ((bitField0_ & 0x00040000) == 0x00040000);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlList getAcl() {
+        if (aclBuilder_ == null) {
+          return acl_;
+        } else {
+          return aclBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public Builder setAcl(alluxio.proto.journal.File.AccessControlList value) {
+        if (aclBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          acl_ = value;
+          onChanged();
+        } else {
+          aclBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00040000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public Builder setAcl(
+          alluxio.proto.journal.File.AccessControlList.Builder builderForValue) {
+        if (aclBuilder_ == null) {
+          acl_ = builderForValue.build();
+          onChanged();
+        } else {
+          aclBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00040000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public Builder mergeAcl(alluxio.proto.journal.File.AccessControlList value) {
+        if (aclBuilder_ == null) {
+          if (((bitField0_ & 0x00040000) == 0x00040000) &&
+              acl_ != alluxio.proto.journal.File.AccessControlList.getDefaultInstance()) {
+            acl_ =
+              alluxio.proto.journal.File.AccessControlList.newBuilder(acl_).mergeFrom(value).buildPartial();
+          } else {
+            acl_ = value;
+          }
+          onChanged();
+        } else {
+          aclBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00040000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public Builder clearAcl() {
+        if (aclBuilder_ == null) {
+          acl_ = alluxio.proto.journal.File.AccessControlList.getDefaultInstance();
+          onChanged();
+        } else {
+          aclBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00040000);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlList.Builder getAclBuilder() {
+        bitField0_ |= 0x00040000;
+        onChanged();
+        return getAclFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      public alluxio.proto.journal.File.AccessControlListOrBuilder getAclOrBuilder() {
+        if (aclBuilder_ != null) {
+          return aclBuilder_.getMessageOrBuilder();
+        } else {
+          return acl_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.AccessControlList acl = 19;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder> 
+          getAclFieldBuilder() {
+        if (aclBuilder_ == null) {
+          aclBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              alluxio.proto.journal.File.AccessControlList, alluxio.proto.journal.File.AccessControlList.Builder, alluxio.proto.journal.File.AccessControlListOrBuilder>(
+                  acl_,
+                  getParentForChildren(),
+                  isClean());
+          acl_ = null;
+        }
+        return aclBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.InodeFileEntry)
@@ -13753,6 +17142,21 @@ public final class File {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_alluxio_proto_journal_DeleteMountPointEntry_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_alluxio_proto_journal_AclActions_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_alluxio_proto_journal_AclActions_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_alluxio_proto_journal_NamedAclActions_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_alluxio_proto_journal_NamedAclActions_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_alluxio_proto_journal_AccessControlList_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_alluxio_proto_journal_AccessControlList_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_alluxio_proto_journal_InodeDirectoryEntry_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -13825,48 +17229,63 @@ public final class File {
       "ry\022\n\n\002id\030\001 \001(\003\022\021\n\trecursive\030\002 \001(\010\022\022\n\nop_" +
       "time_ms\030\003 \001(\003\022\023\n\013alluxioOnly\030\004 \001(\010\"-\n\025De" +
       "leteMountPointEntry\022\024\n\014alluxio_path\030\001 \001(" +
-      "\t\"\326\002\n\023InodeDirectoryEntry\022\n\n\002id\030\001 \001(\003\022\021\n" +
-      "\tparent_id\030\002 \001(\003\022\014\n\004name\030\003 \001(\t\022\031\n\021persis" +
-      "tence_state\030\004 \001(\t\022\016\n\006pinned\030\005 \001(\010\022\030\n\020cre" +
-      "ation_time_ms\030\006 \001(\003\022!\n\031last_modification" +
-      "_time_ms\030\007 \001(\003\022\r\n\005owner\030\010 \001(\t\022\r\n\005group\030\t" +
-      " \001(\t\022\014\n\004mode\030\n \001(\005\022\023\n\013mount_point\030\013 \001(\010\022",
-      "\036\n\026direct_children_loaded\030\014 \001(\010\022\013\n\003ttl\030\r" +
-      " \001(\003\022<\n\tttlAction\030\016 \001(\0162!.alluxio.proto." +
-      "journal.PTtlAction:\006DELETE\"O\n\036InodeDirec" +
-      "toryIdGeneratorEntry\022\024\n\014container_id\030\001 \001" +
-      "(\003\022\027\n\017sequence_number\030\002 \001(\003\"\225\003\n\016InodeFil" +
-      "eEntry\022\n\n\002id\030\001 \001(\003\022\021\n\tparent_id\030\002 \001(\003\022\014\n" +
-      "\004name\030\003 \001(\t\022\031\n\021persistence_state\030\004 \001(\t\022\016" +
-      "\n\006pinned\030\005 \001(\010\022\030\n\020creation_time_ms\030\006 \001(\003" +
-      "\022!\n\031last_modification_time_ms\030\007 \001(\003\022\030\n\020b" +
-      "lock_size_bytes\030\010 \001(\003\022\016\n\006length\030\t \001(\003\022\021\n",
-      "\tcompleted\030\n \001(\010\022\021\n\tcacheable\030\013 \001(\010\022\016\n\006b" +
-      "locks\030\014 \003(\003\022\013\n\003ttl\030\r \001(\003\022\r\n\005owner\030\016 \001(\t\022" +
-      "\r\n\005group\030\017 \001(\t\022\014\n\004mode\030\020 \001(\005\022<\n\tttlActio" +
-      "n\030\021 \001(\0162!.alluxio.proto.journal.PTtlActi" +
-      "on:\006DELETE\022\027\n\017ufs_fingerprint\030\022 \001(\t\"O\n\036I" +
-      "nodeLastModificationTimeEntry\022\n\n\002id\030\001 \001(" +
-      "\003\022!\n\031last_modification_time_ms\030\002 \001(\003\"#\n\025" +
-      "PersistDirectoryEntry\022\n\n\002id\030\001 \001(\003\"B\n\020Per" +
-      "sistFileEntry\022\n\n\002id\030\001 \001(\003\022\016\n\006length\030\002 \001(" +
-      "\003\022\022\n\nop_time_ms\030\003 \001(\003\"\212\001\n\025ReinitializeFi",
-      "leEntry\022\014\n\004path\030\001 \001(\t\022\030\n\020block_size_byte" +
-      "s\030\002 \001(\003\022\013\n\003ttl\030\003 \001(\003\022<\n\tttlAction\030\004 \001(\0162" +
-      "!.alluxio.proto.journal.PTtlAction:\006DELE" +
-      "TE\"?\n\013RenameEntry\022\n\n\002id\030\001 \001(\003\022\020\n\010dst_pat" +
-      "h\030\002 \001(\t\022\022\n\nop_time_ms\030\003 \001(\003\"\354\001\n\021SetAttri" +
-      "buteEntry\022\n\n\002id\030\001 \001(\003\022\022\n\nop_time_ms\030\002 \001(" +
-      "\003\022\016\n\006pinned\030\003 \001(\010\022\013\n\003ttl\030\004 \001(\003\022\021\n\tpersis" +
-      "ted\030\005 \001(\010\022\r\n\005owner\030\006 \001(\t\022\r\n\005group\030\007 \001(\t\022" +
-      "\022\n\npermission\030\010 \001(\005\022<\n\tttlAction\030\t \001(\0162!" +
-      ".alluxio.proto.journal.PTtlAction:\006DELET",
-      "E\022\027\n\017ufs_fingerprint\030\n \001(\t\"b\n\022UpdateUfsM" +
-      "odeEntry\022\017\n\007ufsPath\030\001 \001(\t\022;\n\007ufsMode\030\002 \001" +
-      "(\0162\036.alluxio.proto.journal.UfsMode:\nREAD" +
-      "_WRITE*\"\n\nPTtlAction\022\n\n\006DELETE\020\000\022\010\n\004FREE" +
-      "\020\001*7\n\007UfsMode\022\r\n\tNO_ACCESS\020\000\022\r\n\tREAD_ONL" +
-      "Y\020\001\022\016\n\nREAD_WRITE\020\002"
+      "\t\"?\n\nAclActions\0221\n\007actions\030\001 \003(\0162 .allux" +
+      "io.proto.journal.AclAction\"S\n\017NamedAclAc" +
+      "tions\022\014\n\004name\030\001 \001(\t\0222\n\007actions\030\002 \001(\0132!.a" +
+      "lluxio.proto.journal.AclActions\"\250\002\n\021Acce" +
+      "ssControlList\022\022\n\nowningUser\030\001 \001(\t\022\023\n\013own" +
+      "ingGroup\030\002 \001(\t\022;\n\013userActions\030\003 \003(\0132&.al",
+      "luxio.proto.journal.NamedAclActions\022<\n\014g" +
+      "roupActions\030\004 \003(\0132&.alluxio.proto.journa" +
+      "l.NamedAclActions\0226\n\013maskActions\030\005 \001(\0132!" +
+      ".alluxio.proto.journal.AclActions\0227\n\014oth" +
+      "erActions\030\006 \001(\0132!.alluxio.proto.journal." +
+      "AclActions\"\215\003\n\023InodeDirectoryEntry\022\n\n\002id" +
+      "\030\001 \001(\003\022\021\n\tparent_id\030\002 \001(\003\022\014\n\004name\030\003 \001(\t\022" +
+      "\031\n\021persistence_state\030\004 \001(\t\022\016\n\006pinned\030\005 \001" +
+      "(\010\022\030\n\020creation_time_ms\030\006 \001(\003\022!\n\031last_mod" +
+      "ification_time_ms\030\007 \001(\003\022\r\n\005owner\030\010 \001(\t\022\r",
+      "\n\005group\030\t \001(\t\022\014\n\004mode\030\n \001(\005\022\023\n\013mount_poi" +
+      "nt\030\013 \001(\010\022\036\n\026direct_children_loaded\030\014 \001(\010" +
+      "\022\013\n\003ttl\030\r \001(\003\022<\n\tttlAction\030\016 \001(\0162!.allux" +
+      "io.proto.journal.PTtlAction:\006DELETE\0225\n\003a" +
+      "cl\030\017 \001(\0132(.alluxio.proto.journal.AccessC" +
+      "ontrolList\"O\n\036InodeDirectoryIdGeneratorE" +
+      "ntry\022\024\n\014container_id\030\001 \001(\003\022\027\n\017sequence_n" +
+      "umber\030\002 \001(\003\"\314\003\n\016InodeFileEntry\022\n\n\002id\030\001 \001" +
+      "(\003\022\021\n\tparent_id\030\002 \001(\003\022\014\n\004name\030\003 \001(\t\022\031\n\021p" +
+      "ersistence_state\030\004 \001(\t\022\016\n\006pinned\030\005 \001(\010\022\030",
+      "\n\020creation_time_ms\030\006 \001(\003\022!\n\031last_modific" +
+      "ation_time_ms\030\007 \001(\003\022\030\n\020block_size_bytes\030" +
+      "\010 \001(\003\022\016\n\006length\030\t \001(\003\022\021\n\tcompleted\030\n \001(\010" +
+      "\022\021\n\tcacheable\030\013 \001(\010\022\016\n\006blocks\030\014 \003(\003\022\013\n\003t" +
+      "tl\030\r \001(\003\022\r\n\005owner\030\016 \001(\t\022\r\n\005group\030\017 \001(\t\022\014" +
+      "\n\004mode\030\020 \001(\005\022<\n\tttlAction\030\021 \001(\0162!.alluxi" +
+      "o.proto.journal.PTtlAction:\006DELETE\022\027\n\017uf" +
+      "s_fingerprint\030\022 \001(\t\0225\n\003acl\030\023 \001(\0132(.allux" +
+      "io.proto.journal.AccessControlList\"O\n\036In" +
+      "odeLastModificationTimeEntry\022\n\n\002id\030\001 \001(\003",
+      "\022!\n\031last_modification_time_ms\030\002 \001(\003\"#\n\025P" +
+      "ersistDirectoryEntry\022\n\n\002id\030\001 \001(\003\"B\n\020Pers" +
+      "istFileEntry\022\n\n\002id\030\001 \001(\003\022\016\n\006length\030\002 \001(\003" +
+      "\022\022\n\nop_time_ms\030\003 \001(\003\"\212\001\n\025ReinitializeFil" +
+      "eEntry\022\014\n\004path\030\001 \001(\t\022\030\n\020block_size_bytes" +
+      "\030\002 \001(\003\022\013\n\003ttl\030\003 \001(\003\022<\n\tttlAction\030\004 \001(\0162!" +
+      ".alluxio.proto.journal.PTtlAction:\006DELET" +
+      "E\"?\n\013RenameEntry\022\n\n\002id\030\001 \001(\003\022\020\n\010dst_path" +
+      "\030\002 \001(\t\022\022\n\nop_time_ms\030\003 \001(\003\"\354\001\n\021SetAttrib" +
+      "uteEntry\022\n\n\002id\030\001 \001(\003\022\022\n\nop_time_ms\030\002 \001(\003",
+      "\022\016\n\006pinned\030\003 \001(\010\022\013\n\003ttl\030\004 \001(\003\022\021\n\tpersist" +
+      "ed\030\005 \001(\010\022\r\n\005owner\030\006 \001(\t\022\r\n\005group\030\007 \001(\t\022\022" +
+      "\n\npermission\030\010 \001(\005\022<\n\tttlAction\030\t \001(\0162!." +
+      "alluxio.proto.journal.PTtlAction:\006DELETE" +
+      "\022\027\n\017ufs_fingerprint\030\n \001(\t\"b\n\022UpdateUfsMo" +
+      "deEntry\022\017\n\007ufsPath\030\001 \001(\t\022;\n\007ufsMode\030\002 \001(" +
+      "\0162\036.alluxio.proto.journal.UfsMode:\nREAD_" +
+      "WRITE*-\n\tAclAction\022\010\n\004READ\020\000\022\t\n\005WRITE\020\001\022" +
+      "\013\n\007EXECUTE\020\002*\"\n\nPTtlAction\022\n\n\006DELETE\020\000\022\010" +
+      "\n\004FREE\020\001*7\n\007UfsMode\022\r\n\tNO_ACCESS\020\000\022\r\n\tRE",
+      "AD_ONLY\020\001\022\016\n\nREAD_WRITE\020\002"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -13909,62 +17328,80 @@ public final class File {
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_DeleteMountPointEntry_descriptor,
               new java.lang.String[] { "AlluxioPath", });
-          internal_static_alluxio_proto_journal_InodeDirectoryEntry_descriptor =
+          internal_static_alluxio_proto_journal_AclActions_descriptor =
             getDescriptor().getMessageTypes().get(6);
+          internal_static_alluxio_proto_journal_AclActions_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_alluxio_proto_journal_AclActions_descriptor,
+              new java.lang.String[] { "Actions", });
+          internal_static_alluxio_proto_journal_NamedAclActions_descriptor =
+            getDescriptor().getMessageTypes().get(7);
+          internal_static_alluxio_proto_journal_NamedAclActions_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_alluxio_proto_journal_NamedAclActions_descriptor,
+              new java.lang.String[] { "Name", "Actions", });
+          internal_static_alluxio_proto_journal_AccessControlList_descriptor =
+            getDescriptor().getMessageTypes().get(8);
+          internal_static_alluxio_proto_journal_AccessControlList_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_alluxio_proto_journal_AccessControlList_descriptor,
+              new java.lang.String[] { "OwningUser", "OwningGroup", "UserActions", "GroupActions", "MaskActions", "OtherActions", });
+          internal_static_alluxio_proto_journal_InodeDirectoryEntry_descriptor =
+            getDescriptor().getMessageTypes().get(9);
           internal_static_alluxio_proto_journal_InodeDirectoryEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_InodeDirectoryEntry_descriptor,
-              new java.lang.String[] { "Id", "ParentId", "Name", "PersistenceState", "Pinned", "CreationTimeMs", "LastModificationTimeMs", "Owner", "Group", "Mode", "MountPoint", "DirectChildrenLoaded", "Ttl", "TtlAction", });
+              new java.lang.String[] { "Id", "ParentId", "Name", "PersistenceState", "Pinned", "CreationTimeMs", "LastModificationTimeMs", "Owner", "Group", "Mode", "MountPoint", "DirectChildrenLoaded", "Ttl", "TtlAction", "Acl", });
           internal_static_alluxio_proto_journal_InodeDirectoryIdGeneratorEntry_descriptor =
-            getDescriptor().getMessageTypes().get(7);
+            getDescriptor().getMessageTypes().get(10);
           internal_static_alluxio_proto_journal_InodeDirectoryIdGeneratorEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_InodeDirectoryIdGeneratorEntry_descriptor,
               new java.lang.String[] { "ContainerId", "SequenceNumber", });
           internal_static_alluxio_proto_journal_InodeFileEntry_descriptor =
-            getDescriptor().getMessageTypes().get(8);
+            getDescriptor().getMessageTypes().get(11);
           internal_static_alluxio_proto_journal_InodeFileEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_InodeFileEntry_descriptor,
-              new java.lang.String[] { "Id", "ParentId", "Name", "PersistenceState", "Pinned", "CreationTimeMs", "LastModificationTimeMs", "BlockSizeBytes", "Length", "Completed", "Cacheable", "Blocks", "Ttl", "Owner", "Group", "Mode", "TtlAction", "UfsFingerprint", });
+              new java.lang.String[] { "Id", "ParentId", "Name", "PersistenceState", "Pinned", "CreationTimeMs", "LastModificationTimeMs", "BlockSizeBytes", "Length", "Completed", "Cacheable", "Blocks", "Ttl", "Owner", "Group", "Mode", "TtlAction", "UfsFingerprint", "Acl", });
           internal_static_alluxio_proto_journal_InodeLastModificationTimeEntry_descriptor =
-            getDescriptor().getMessageTypes().get(9);
+            getDescriptor().getMessageTypes().get(12);
           internal_static_alluxio_proto_journal_InodeLastModificationTimeEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_InodeLastModificationTimeEntry_descriptor,
               new java.lang.String[] { "Id", "LastModificationTimeMs", });
           internal_static_alluxio_proto_journal_PersistDirectoryEntry_descriptor =
-            getDescriptor().getMessageTypes().get(10);
+            getDescriptor().getMessageTypes().get(13);
           internal_static_alluxio_proto_journal_PersistDirectoryEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_PersistDirectoryEntry_descriptor,
               new java.lang.String[] { "Id", });
           internal_static_alluxio_proto_journal_PersistFileEntry_descriptor =
-            getDescriptor().getMessageTypes().get(11);
+            getDescriptor().getMessageTypes().get(14);
           internal_static_alluxio_proto_journal_PersistFileEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_PersistFileEntry_descriptor,
               new java.lang.String[] { "Id", "Length", "OpTimeMs", });
           internal_static_alluxio_proto_journal_ReinitializeFileEntry_descriptor =
-            getDescriptor().getMessageTypes().get(12);
+            getDescriptor().getMessageTypes().get(15);
           internal_static_alluxio_proto_journal_ReinitializeFileEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_ReinitializeFileEntry_descriptor,
               new java.lang.String[] { "Path", "BlockSizeBytes", "Ttl", "TtlAction", });
           internal_static_alluxio_proto_journal_RenameEntry_descriptor =
-            getDescriptor().getMessageTypes().get(13);
+            getDescriptor().getMessageTypes().get(16);
           internal_static_alluxio_proto_journal_RenameEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_RenameEntry_descriptor,
               new java.lang.String[] { "Id", "DstPath", "OpTimeMs", });
           internal_static_alluxio_proto_journal_SetAttributeEntry_descriptor =
-            getDescriptor().getMessageTypes().get(14);
+            getDescriptor().getMessageTypes().get(17);
           internal_static_alluxio_proto_journal_SetAttributeEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_SetAttributeEntry_descriptor,
               new java.lang.String[] { "Id", "OpTimeMs", "Pinned", "Ttl", "Persisted", "Owner", "Group", "Permission", "TtlAction", "UfsFingerprint", });
           internal_static_alluxio_proto_journal_UpdateUfsModeEntry_descriptor =
-            getDescriptor().getMessageTypes().get(15);
+            getDescriptor().getMessageTypes().get(18);
           internal_static_alluxio_proto_journal_UpdateUfsModeEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_alluxio_proto_journal_UpdateUfsModeEntry_descriptor,

--- a/core/protobuf/src/proto/journal/file.proto
+++ b/core/protobuf/src/proto/journal/file.proto
@@ -48,7 +48,36 @@ message DeleteMountPointEntry {
   optional string alluxio_path = 1;
 }
 
-// next available id: 15
+// next available id: 3
+enum AclAction {
+  READ = 0;
+  WRITE = 1;
+  EXECUTE = 2;
+}
+
+// next available id: 2
+message AclActions {
+  repeated AclAction actions = 1;
+}
+
+// AclActions for a String name.
+// next available id: 3
+message NamedAclActions {
+  optional string name = 1;
+  optional AclActions actions = 2;
+}
+
+// next available id: 7
+message AccessControlList {
+  optional string owningUser = 1;
+  optional string owningGroup = 2;
+  repeated NamedAclActions userActions = 3;
+  repeated NamedAclActions groupActions = 4;
+  optional AclActions maskActions = 5;
+  optional AclActions otherActions = 6;
+}
+
+// next available id: 16
 message InodeDirectoryEntry {
   optional int64 id = 1;
   optional int64 parent_id = 2;
@@ -64,6 +93,7 @@ message InodeDirectoryEntry {
   optional bool direct_children_loaded = 12;
   optional int64 ttl = 13;
   optional PTtlAction ttlAction = 14 [default = DELETE];
+  optional AccessControlList acl = 15;
 }
 
 // next available id: 3
@@ -77,7 +107,7 @@ enum PTtlAction {
   FREE = 1;
 }
 
-// next available id: 19
+// next available id: 20
 message InodeFileEntry {
   optional int64 id = 1;
   optional int64 parent_id = 2;
@@ -97,6 +127,7 @@ message InodeFileEntry {
   optional int32 mode = 16;
   optional PTtlAction ttlAction = 17 [default = DELETE];
   optional string ufs_fingerprint = 18;
+  optional AccessControlList acl = 19;
 }
 
 // next available id: 3

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -20,6 +20,7 @@ import alluxio.master.ProtobufUtils;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.proto.journal.File.InodeDirectoryEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.security.authorization.AccessControlList;
 import alluxio.wire.FileInfo;
 
 import com.google.common.collect.ImmutableSet;
@@ -255,21 +256,29 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
    */
   public static InodeDirectory fromJournalEntry(InodeDirectoryEntry entry) {
     // If journal entry has no mode set, set default mode for backwards-compatibility.
-    short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
-    return new InodeDirectory(entry.getId())
+    InodeDirectory ret = new InodeDirectory(entry.getId())
         .setCreationTimeMs(entry.getCreationTimeMs())
         .setName(entry.getName())
         .setParentId(entry.getParentId())
         .setPersistenceState(PersistenceState.valueOf(entry.getPersistenceState()))
         .setPinned(entry.getPinned())
         .setLastModificationTimeMs(entry.getLastModificationTimeMs(), true)
-        .setOwner(entry.getOwner())
-        .setGroup(entry.getGroup())
-        .setMode(mode)
         .setMountPoint(entry.getMountPoint())
         .setTtl(entry.getTtl())
         .setTtlAction(ProtobufUtils.fromProtobuf(entry.getTtlAction()))
         .setDirectChildrenLoaded(entry.getDirectChildrenLoaded());
+    if (entry.hasAcl()) {
+      ret.mAcl = AccessControlList.fromProtoBuf(entry.getAcl());
+    } else {
+      // Backward compatibility.
+      AccessControlList acl = new AccessControlList();
+      acl.setOwningUser(entry.getOwner());
+      acl.setOwningGroup(entry.getGroup());
+      short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
+      acl.setMode(mode);
+      ret.mAcl = acl;
+    }
+    return ret;
   }
 
   /**
@@ -308,7 +317,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
         .setTtl(getTtl())
         .setTtlAction(ProtobufUtils.toProtobuf(getTtlAction()))
         .setDirectChildrenLoaded(isDirectChildrenLoaded())
-        .setOwner(getOwner()).setGroup(getGroup()).setMode(getMode())
+        .setAcl(AccessControlList.toProtoBuf(mAcl))
         .build();
     return JournalEntry.newBuilder().setInodeDirectory(inodeDirectory).build();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -20,6 +20,7 @@ import alluxio.master.block.BlockId;
 import alluxio.master.file.options.CreateFileOptions;
 import alluxio.proto.journal.File.InodeFileEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.security.authorization.AccessControlList;
 import alluxio.wire.FileInfo;
 
 import com.google.common.base.Preconditions;
@@ -264,8 +265,7 @@ public final class InodeFile extends Inode<InodeFile> {
    */
   public static InodeFile fromJournalEntry(InodeFileEntry entry) {
     // If journal entry has no mode set, set default mode for backwards-compatibility.
-    short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
-    return new InodeFile(BlockId.getContainerId(entry.getId()))
+    InodeFile ret = new InodeFile(BlockId.getContainerId(entry.getId()))
         .setName(entry.getName())
         .setBlockIds(entry.getBlocksList())
         .setBlockSizeBytes(entry.getBlockSizeBytes())
@@ -279,11 +279,20 @@ public final class InodeFile extends Inode<InodeFile> {
         .setPinned(entry.getPinned())
         .setTtl(entry.getTtl())
         .setTtlAction((ProtobufUtils.fromProtobuf(entry.getTtlAction())))
-        .setOwner(entry.getOwner())
-        .setGroup(entry.getGroup())
-        .setMode(mode)
         .setUfsFingerprint(entry.hasUfsFingerprint() ? entry.getUfsFingerprint() :
             Constants.INVALID_UFS_FINGERPRINT);
+    if (entry.hasAcl()) {
+      ret.mAcl = AccessControlList.fromProtoBuf(entry.getAcl());
+    } else {
+      // Backward compatibility.
+      AccessControlList acl = new AccessControlList();
+      acl.setOwningUser(entry.getOwner());
+      acl.setOwningGroup(entry.getGroup());
+      short mode = entry.hasMode() ? (short) entry.getMode() : Constants.DEFAULT_FILE_SYSTEM_MODE;
+      acl.setMode(mode);
+      ret.mAcl = acl;
+    }
+    return ret;
   }
 
   /**
@@ -321,21 +330,18 @@ public final class InodeFile extends Inode<InodeFile> {
         .setCacheable(isCacheable())
         .setCompleted(isCompleted())
         .setCreationTimeMs(getCreationTimeMs())
-        .setGroup(getGroup())
         .setId(getId())
         .setLastModificationTimeMs(getLastModificationTimeMs())
         .setLength(getLength())
-        .setMode(getMode())
         .setName(getName())
-        .setOwner(getOwner())
         .setParentId(getParentId())
         .setPersistenceState(getPersistenceState().name())
         .setPinned(isPinned())
         .setTtl(getTtl())
         .setTtlAction(ProtobufUtils.toProtobuf(getTtlAction()))
         .setUfsFingerprint(getUfsFingerprint())
+        .setAcl(AccessControlList.toProtoBuf(mAcl))
         .build();
     return JournalEntry.newBuilder().setInodeFile(inodeFile).build();
   }
-
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3164

This PR:

1. adds data structures to represent access control list
2. replaces owner, group, and mode in Inode with AccessControlList
3. updates journal entries for InodeFile and InodeDirectory to include AccessControlList
4. adds unit tests to test the newly added data structures