### PR TITLE
[SMALLFIX] Revert basename change

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -410,8 +410,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   public UfsDirectoryStatus getDirectoryStatus(String path) throws IOException {
     if (isDirectory(path)) {
       ObjectPermissions permissions = getPermissions();
-      return new UfsDirectoryStatus(PathUtils.basename(path), permissions.getOwner(),
-          permissions.getGroup(), permissions.getMode());
+      return new UfsDirectoryStatus(path, permissions.getOwner(), permissions.getGroup(),
+          permissions.getMode());
     }
     LOG.warn("Error fetching directory status, assuming directory {} does not exist", path);
     throw new FileNotFoundException(path);
@@ -445,9 +445,9 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     ObjectStatus details = getObjectStatus(stripPrefixIfPresent(path));
     if (details != null) {
       ObjectPermissions permissions = getPermissions();
-      return new UfsFileStatus(PathUtils.basename(path), details.getContentHash(),
-          details.getContentLength(), details.getLastModifiedTimeMs(), permissions.getOwner(),
-          permissions.getGroup(), permissions.getMode());
+      return new UfsFileStatus(path, details.getContentHash(), details.getContentLength(),
+          details.getLastModifiedTimeMs(), permissions.getOwner(), permissions.getGroup(),
+          permissions.getMode());
     } else {
       LOG.warn("Error fetching file status, assuming file {} does not exist", path);
       throw new FileNotFoundException(path);
@@ -462,9 +462,9 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     ObjectStatus details = getObjectStatus(stripPrefixIfPresent(path));
     if (details != null) {
       ObjectPermissions permissions = getPermissions();
-      return new UfsFileStatus(PathUtils.basename(path), details.getContentHash(),
-          details.getContentLength(), details.getLastModifiedTimeMs(), permissions.getOwner(),
-          permissions.getGroup(), permissions.getMode());
+      return new UfsFileStatus(path, details.getContentHash(), details.getContentLength(),
+          details.getLastModifiedTimeMs(), permissions.getOwner(), permissions.getGroup(),
+          permissions.getMode());
     }
     return getDirectoryStatus(path);
   }

--- a/core/common/src/main/java/alluxio/underfs/UfsDirectoryStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsDirectoryStatus.java
@@ -21,7 +21,7 @@ public class UfsDirectoryStatus extends UfsStatus {
   /**
    * Creates new instance of {@link UfsDirectoryStatus} without providing last modified time.
    *
-   * @param name basename of directory
+   * @param name relative path of directory
    * @param owner of the directory
    * @param group of the directory
    * @param mode of the directory
@@ -33,7 +33,7 @@ public class UfsDirectoryStatus extends UfsStatus {
   /**
    * Creates new instance of {@link UfsDirectoryStatus}.
    *
-   * @param name basename of directory
+   * @param name relative path of directory
    * @param owner of the directory
    * @param group of the directory
    * @param mode of the directory

--- a/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
@@ -26,7 +26,7 @@ public class UfsFileStatus extends UfsStatus {
   /**
    * Creates new instance of {@link UfsFileStatus}.
    *
-   * @param name basename of the file
+   * @param name relative path of file
    * @param contentHash hash of the file contents
    * @param contentLength in bytes
    * @param lastModifiedTimeMs UTC time

--- a/core/common/src/main/java/alluxio/underfs/UfsStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsStatus.java
@@ -11,11 +11,7 @@
 
 package alluxio.underfs;
 
-import alluxio.util.io.PathUtils;
-
 import com.google.common.base.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -26,8 +22,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class UfsStatus {
-  private static final Logger LOG = LoggerFactory.getLogger(UfsStatus.class);
-
   protected final boolean mIsDirectory;
   /** Last modified epoch time in ms, or null if it is not available. */
   protected final Long mLastModifiedTimeMs;
@@ -41,7 +35,7 @@ public abstract class UfsStatus {
   /**
    * Creates new instance of {@link UfsStatus}.
    *
-   * @param name basename of file or directory
+   * @param name relative path of file or directory
    * @param isDirectory whether the path is a directory
    * @param owner of the file
    * @param group of the file
@@ -51,12 +45,7 @@ public abstract class UfsStatus {
   protected UfsStatus(String name, boolean isDirectory, String owner, String group, short mode,
       Long lastModifiedTimeMs) {
     mIsDirectory = isDirectory;
-    String basename = PathUtils.basename(name);
-    if (!basename.equals(name)) {
-      LOG.debug("UfsStatus expected a basename, but got {}. Changing to {} and continuing.", name,
-          basename);
-    }
-    mName = basename;
+    mName = name;
     mOwner = owner;
     mGroup = group;
     mMode = mode;
@@ -147,7 +136,7 @@ public abstract class UfsStatus {
   }
 
   /**
-   * @return basename of file or directory
+   * @return name of file or directory
    */
   public String getName() {
     return mName;
@@ -168,7 +157,7 @@ public abstract class UfsStatus {
   }
 
   /**
-   * Set the basename of file or directory.
+   * Set the name of file or directory.
    *
    * @param name of entry
    * @return this object

--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -38,43 +38,6 @@ public final class PathUtils {
       String.format(TEMPORARY_SUFFIX_FORMAT, 0).length();
 
   /**
-   * Returns the basename of the path, consistent with the Unix basename command.
-   *
-   * Examples:
-   *
-   * <pre>
-   *   basename("/") => "/"
-   *   basename("/abc") => "abc"
-   *   basename("///") => "/"
-   *   basename("abc/)" => "abc"
-   *   basename("") => ""
-   *   basename("/a/b/c/d") => "d"
-   *   basename("//a///b/c//d//") => "d"
-   *   basename("/a.txt") => "a.txt"
-   * </pre>
-   *
-   * @param path the path
-   * @return the basename of the path
-   */
-  public static String basename(String path) {
-    if (path.isEmpty()) {
-      return "";
-    }
-    while (!path.isEmpty() && path.charAt(path.length() - 1) == '/') {
-      path = path.substring(0, path.length() - 1);
-    }
-    int lastSlash = path.lastIndexOf("/");
-    if (lastSlash >= 0) {
-      path = path.substring(lastSlash + 1);
-    }
-    if (path.isEmpty()) {
-      // Must have only had slashes in the path.
-      return "/";
-    }
-    return path;
-  }
-
-  /**
    * Checks and normalizes the given path.
    *
    * @param path The path to clean up

--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -269,7 +269,6 @@ public abstract class AbstractUnderFileSystemContractTest {
     mUfs.mkdirs(testDir);
 
     UfsStatus status = mUfs.getStatus(testDir);
-    assertEquals("testDir", status.getName());
     assertTrue(status instanceof UfsDirectoryStatus);
   }
 
@@ -289,7 +288,6 @@ public abstract class AbstractUnderFileSystemContractTest {
     createEmptyFile(testFile);
 
     UfsStatus status = mUfs.getStatus(testFile);
-    assertEquals("testFile", status.getName());
     assertTrue(status instanceof UfsFileStatus);
   }
 

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -11,52 +11,38 @@
 
 package alluxio.util.io;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
  * Tests for the {@link PathUtils} class.
  */
 public final class PathUtilsTest {
 
+  /**
+   * The expected exception thrown during a test.
+   */
   @Rule
   public final ExpectedException mException = ExpectedException.none();
 
-  @Test
-  public void basename() {
-    Map<String, String> tests = ImmutableMap.<String, String>builder()
-        .put("/", "/")
-        .put("/abc", "abc")
-        .put("///", "/")
-        .put("abc/", "abc")
-        .put("", "")
-        .put("/a/b/c/d", "d")
-        .put("//a///b/c//d//", "d")
-        .put("//a///b/c//d//////", "d")
-        .put("/a.txt", "a.txt")
-        .build();
-    for (String testCase : tests.keySet()) {
-      assertEquals(tests.get(testCase), PathUtils.basename(testCase));
-    }
-  }
-
+  /**
+   * Tests the {@link PathUtils#cleanPath(String)} method.
+   */
   @Test
   public void cleanPathNoException() throws InvalidPathException {
     // test clean path
@@ -82,12 +68,19 @@ public final class PathUtilsTest {
     assertNull(PathUtils.cleanPath("/foo/bar/../../.."));
   }
 
+  /**
+   * Tests the {@link PathUtils#cleanPath(String)} method to thrown an exception in case an invalid
+   * path is provided.
+   */
   @Test
   public void cleanPathException() throws InvalidPathException {
     mException.expect(InvalidPathException.class);
     PathUtils.cleanPath("");
   }
 
+  /**
+   * Tests the {@link PathUtils#concatPath(Object, Object...)} method.
+   */
   @Test
   public void concatPath() {
     assertEquals("/", PathUtils.concatPath("/"));
@@ -126,6 +119,9 @@ public final class PathUtilsTest {
         PathUtils.concatPath(Constants.HEADER + "host:port", "/foo", "bar"));
   }
 
+  /**
+   * Tests the {@link PathUtils#getParent(String)} method.
+   */
   @Test
   public void getParent() throws InvalidPathException {
     // get a parent that is non-root
@@ -145,6 +141,9 @@ public final class PathUtilsTest {
     assertEquals("/", PathUtils.getParent("/foo/../bar/../"));
   }
 
+  /**
+   * Tests the {@link PathUtils#getPathComponents(String)} method.
+   */
   @Test
   public void getPathComponentsNoException() throws InvalidPathException {
     assertArrayEquals(new String[] {""}, PathUtils.getPathComponents("/"));
@@ -159,12 +158,19 @@ public final class PathUtilsTest {
         PathUtils.getPathComponents("/foo//bar/a/b/c"));
   }
 
+  /**
+   * Tests the {@link PathUtils#getPathComponents(String)} method to thrown an exception in case the
+   * path is invalid.
+   */
   @Test
   public void getPathComponentsException() throws InvalidPathException {
     mException.expect(InvalidPathException.class);
     PathUtils.getPathComponents("");
   }
 
+  /**
+   * Tests the {@link PathUtils#subtractPaths(String, String)} method.
+   */
   @Test
   public void subtractPaths() throws InvalidPathException {
     assertEquals("b/c", PathUtils.subtractPaths("/a/b/c", "/a"));
@@ -177,6 +183,10 @@ public final class PathUtilsTest {
     assertEquals("", PathUtils.subtractPaths("/a/b", "/a/b"));
   }
 
+  /**
+   * Tests {@link PathUtils#subtractPaths(String, String)} throws the right exception if an input
+   * path is invalid or the second argument isn't a prefix of the first.
+   */
   @Test
   public void subtractPathsException() throws InvalidPathException {
     try {
@@ -200,6 +210,9 @@ public final class PathUtilsTest {
     }
   }
 
+  /**
+   * Tests the {@link PathUtils#hasPrefix(String, String)} method.
+   */
   @Test
   public void hasPrefix() throws InvalidPathException {
     assertTrue(PathUtils.hasPrefix("/", "/"));
@@ -220,6 +233,9 @@ public final class PathUtilsTest {
     assertFalse(PathUtils.hasPrefix("/a/b/cc", "/a/b/c"));
   }
 
+  /**
+   * Tests the {@link PathUtils#isRoot(String)} method.
+   */
   @Test
   public void isRoot() throws InvalidPathException {
     // check a path that is non-root
@@ -239,6 +255,9 @@ public final class PathUtilsTest {
     assertTrue(PathUtils.isRoot("/foo/../"));
   }
 
+  /**
+   * Tests the {@link PathUtils#temporaryFileName(long, String)} method.
+   */
   @Test
   public void temporaryFileName() {
     assertEquals(PathUtils.temporaryFileName(1, "/"),
@@ -259,6 +278,9 @@ public final class PathUtilsTest {
             "/foo.alluxio.0x0123456789ABCDEF.tmp")));
   }
 
+  /**
+   * Test the {@link PathUtils#isTemporaryFileName(String)} method.
+   */
   @Test
   public void isTemporaryFileName() {
     assertTrue(PathUtils.isTemporaryFileName(PathUtils.temporaryFileName(0, "/")));
@@ -272,11 +294,19 @@ public final class PathUtilsTest {
     assertFalse(PathUtils.isTemporaryFileName("alluxio.0x0123456789ABCDEFG"));
   }
 
+  /**
+   * Tests the {@link PathUtils#uniqPath()} method.
+   */
   @Test
   public void uniqPath() {
     assertNotEquals(PathUtils.uniqPath(), PathUtils.uniqPath());
   }
 
+  /**
+   * Tests the {@link PathUtils#validatePath(String)} method.
+   *
+   * @throws InvalidPathException thrown if the path is invalid
+   */
   @Test
   public void validatePath() throws InvalidPathException {
     // check valid paths
@@ -301,6 +331,9 @@ public final class PathUtilsTest {
     }
   }
 
+  /**
+   * Tests the {@link PathUtils#normalizePath(String, String)} method.
+   */
   @Test
   public void normalizePath() throws Exception {
     assertEquals("/", PathUtils.normalizePath("", "/"));

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -31,7 +31,6 @@ import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.UnderFileSystemUtils;
-import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -235,7 +234,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
     Path tPath = new Path(path);
     FileSystem hdfs = getFs();
     FileStatus fs = hdfs.getFileStatus(tPath);
-    return new UfsDirectoryStatus(PathUtils.basename(path), fs.getOwner(), fs.getGroup(),
+    return new UfsDirectoryStatus(path, fs.getOwner(), fs.getGroup(),
         fs.getPermission().toShort(), fs.getModificationTime());
   }
 
@@ -282,7 +281,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
     FileStatus fs = hdfs.getFileStatus(tPath);
     String contentHash =
         UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
-    return new UfsFileStatus(PathUtils.basename(path), contentHash, fs.getLen(),
+    return new UfsFileStatus(path, contentHash, fs.getLen(),
         fs.getModificationTime(), fs.getOwner(), fs.getGroup(), fs.getPermission().toShort());
   }
 
@@ -333,12 +332,12 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
       // Return file status.
       String contentHash =
           UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
-      return new UfsFileStatus(PathUtils.basename(path), contentHash, fs.getLen(),
-          fs.getModificationTime(), fs.getOwner(), fs.getGroup(), fs.getPermission().toShort());
+      return new UfsFileStatus(path, contentHash, fs.getLen(), fs.getModificationTime(),
+          fs.getOwner(), fs.getGroup(), fs.getPermission().toShort());
     }
     // Return directory status.
-    return new UfsDirectoryStatus(PathUtils.basename(path), fs.getOwner(), fs.getGroup(),
-        fs.getPermission().toShort(), fs.getModificationTime());
+    return new UfsDirectoryStatus(path, fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(),
+        fs.getModificationTime());
   }
 
   @Override

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -174,9 +174,8 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
     File file = new File(tpath);
     PosixFileAttributes attr =
         Files.readAttributes(Paths.get(file.getPath()), PosixFileAttributes.class);
-    return new UfsDirectoryStatus(PathUtils.basename(path), attr.owner().getName(),
-        attr.group().getName(), FileUtils.translatePosixPermissionToMode(attr.permissions()),
-        file.lastModified());
+    return new UfsDirectoryStatus(path, attr.owner().getName(), attr.group().getName(),
+        FileUtils.translatePosixPermissionToMode(attr.permissions()), file.lastModified());
   }
 
   @Override
@@ -200,7 +199,7 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
         Files.readAttributes(Paths.get(file.getPath()), PosixFileAttributes.class);
     String contentHash =
         UnderFileSystemUtils.approximateContentHash(file.length(), file.lastModified());
-    return new UfsFileStatus(PathUtils.basename(path), contentHash, file.length(),
+    return new UfsFileStatus(path, contentHash, file.length(),
         file.lastModified(), attr.owner().getName(), attr.group().getName(),
         FileUtils.translatePosixPermissionToMode(attr.permissions()));
   }
@@ -231,14 +230,13 @@ public class LocalUnderFileSystem extends BaseUnderFileSystem
       // Return file status.
       String contentHash =
           UnderFileSystemUtils.approximateContentHash(file.length(), file.lastModified());
-      return new UfsFileStatus(PathUtils.basename(path), contentHash, file.length(),
-          file.lastModified(), attr.owner().getName(), attr.group().getName(),
+      return new UfsFileStatus(path, contentHash, file.length(), file.lastModified(),
+          attr.owner().getName(), attr.group().getName(),
           FileUtils.translatePosixPermissionToMode(attr.permissions()));
     }
     // Return directory status.
-    return new UfsDirectoryStatus(PathUtils.basename(path), attr.owner().getName(),
-        attr.group().getName(), FileUtils.translatePosixPermissionToMode(attr.permissions()),
-        file.lastModified());
+    return new UfsDirectoryStatus(path, attr.owner().getName(), attr.group().getName(),
+        FileUtils.translatePosixPermissionToMode(attr.permissions()), file.lastModified());
   }
 
   @Override


### PR DESCRIPTION
This reverts commit c8de9a7de11aaea4d66c0faa1287a3212bae2df7.

This is necessary because recursive listStatus requires that status
names be relative to the listed path, and for nested directories
this means the names can't always be base names.