### PR TITLE
[SMALLFIX] Add nullable annotation for function fromThrift

### DIFF
--- a/core/common/src/main/java/alluxio/wire/TieredIdentity.java
+++ b/core/common/src/main/java/alluxio/wire/TieredIdentity.java
@@ -78,6 +78,7 @@ public final class TieredIdentity implements Serializable {
    * @param tieredIdentity a Thrift tiered identity
    * @return the corresponding wire type tiered identity
    */
+  @Nullable
   public static TieredIdentity fromThrift(alluxio.thrift.TieredIdentity tieredIdentity) {
     if (tieredIdentity == null) {
       return null;


### PR DESCRIPTION
 add "@Nullable" before the function
 “public static TieredIdentity fromThrift(alluxio.thrift.TieredIdentity tieredIdentity)”