### PR TITLE
[SMALLFIX]Improve Naming for FileSystemAclIntegrationTest 

### DIFF
--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
@@ -535,7 +535,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
   public void swiftGetPermission() throws Exception {
     Assume.assumeTrue(UnderFileSystemUtils.isSwift(sUfs));
 
-    Path fileA = new Path("/objectfileA");
+    Path fileA = new Path("/swiftGetPermissionFile");
     create(sTFS, fileA);
     Assert.assertTrue(sUfs.isFile(PathUtils.concatPath(sUfsRoot, fileA)));
 


### PR DESCRIPTION
In the test swiftGetPermission, rename the file /objectfileA to /swiftGetPermissionFile