### PR TITLE
[ALLUXIO-3168] Web UI and CLI master configuration broken

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -61,7 +61,7 @@ public final class HadoopConfigurationUtilsTest {
     long beforeSize = Configuration.toMap().size();
     HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
     long afterSize = Configuration.toMap().size();
-    Assert.assertEquals(beforeSize, afterSize);
+    Assert.assertEquals(beforeSize + 2, afterSize);
     Assert.assertEquals(TEST_S3_ACCCES_KEY, Configuration.get(PropertyKey.S3A_ACCESS_KEY));
     Assert.assertEquals(TEST_S3_SECRET_KEY, Configuration.get(PropertyKey.S3A_SECRET_KEY));
   }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -40,7 +40,6 @@ public final class HadoopConfigurationUtilsTest {
   @Test
   public void mergeEmptyHadoopConfiguration() {
     org.apache.hadoop.conf.Configuration hadoopConfig = new org.apache.hadoop.conf.Configuration();
-
     long beforeSize = Configuration.toMap().size();
     HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
     long afterSize = Configuration.toMap().size();
@@ -59,7 +58,6 @@ public final class HadoopConfigurationUtilsTest {
 
     // This hadoop config will not be loaded into Alluxio configuration.
     hadoopConfig.set("hadoop.config.parameter", "hadoop config value");
-
     long beforeSize = Configuration.toMap().size();
     HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
     long afterSize = Configuration.toMap().size();

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -61,7 +61,7 @@ public final class HadoopConfigurationUtilsTest {
     long beforeSize = Configuration.toMap().size();
     HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
     long afterSize = Configuration.toMap().size();
-    Assert.assertEquals(beforeSize + 2, afterSize);
+    Assert.assertEquals(beforeSize, afterSize);
     Assert.assertEquals(TEST_S3_ACCCES_KEY, Configuration.get(PropertyKey.S3A_ACCESS_KEY));
     Assert.assertEquals(TEST_S3_SECRET_KEY, Configuration.get(PropertyKey.S3A_SECRET_KEY));
   }

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -408,7 +408,7 @@ public final class Configuration {
 
   /**
    * @return a view of the resolved properties represented by this configuration,
-   * including all default properties
+   *         including all default properties
    */
   public static Map<String, String> toMap() {
     Map<String, String> map = toRawMap();
@@ -423,7 +423,7 @@ public final class Configuration {
 
   /**
    * @return a map of the raw properties represented by this configuration,
-   * including all default properties
+   *         including all default properties
    */
   public static Map<String, String> toRawMap() {
     Map<String, String> map = new HashMap<>(PROPERTIES);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -407,16 +407,14 @@ public final class Configuration {
   }
 
   /**
-   * @return a map of the resolved properties represented by this configuration,
+   * @return a view of the resolved properties represented by this configuration,
    * including all default properties
    */
   public static Map<String, String> toMap() {
     Map<String, String> map = toRawMap();
-    // Resolve values with ${VALUE} format
-    String nestedPropIdentifier = "$";
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String value = entry.getValue();
-      if (value != null && value.contains(nestedPropIdentifier)) {
+      if (value != null) {
         map.put(entry.getKey(), lookup(value));
       }
     }
@@ -430,10 +428,10 @@ public final class Configuration {
   public static Map<String, String> toRawMap() {
     Map<String, String> map = new HashMap<>(PROPERTIES);
     for (PropertyKey key : PropertyKey.defaultKeys()) {
-      String propName = key.getName();
+      String keyName = key.getName();
       String defaultValue = key.getDefaultValue();
-      if (!map.containsKey(propName) && defaultValue != null) {
-        map.put(propName, defaultValue);
+      if (!map.containsKey(keyName) && defaultValue != null) {
+        map.put(keyName, defaultValue);
       }
     }
     return map;

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -101,6 +100,7 @@ public final class Configuration {
 
     // Now lets combine, order matters here
     PROPERTIES.clear();
+    SOURCES.clear();
     merge(systemProps, Source.SYSTEM_PROPERTY);
 
     // Load site specific properties file if not in test mode. Note that we decide whether in test
@@ -611,7 +611,7 @@ public final class Configuration {
    * @throws IllegalStateException if invalid configuration is encountered
    */
   public static void validate() {
-    for (Map.Entry<String, String> entry : Collections.unmodifiableMap(PROPERTIES).entrySet()) {
+    for (Map.Entry<String, String> entry : toMap().entrySet()) {
       String propertyName = entry.getKey();
       Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
       PropertyKey propertyKey = PropertyKey.fromString(propertyName);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -407,17 +407,18 @@ public final class Configuration {
   }
 
   /**
-   * @return a view of the internal {@link Properties} and default properties of as an immutable map
+   * @return a view of the properties(include default properties) of as an immutable map
    */
   public static Map<String, String> toMap() {
-    Map<String, String> includeDefaultProperties = new HashMap<>(PROPERTIES);
+    Map<String, String> map = new HashMap<>(PROPERTIES);
     for (PropertyKey key : PropertyKey.defaultKeys()) {
       String propName = key.getName();
-      if (!includeDefaultProperties.containsKey(propName)) {
-        includeDefaultProperties.put(propName, key.getDefaultValue());
+      String defaultValue = key.getDefaultValue();
+      if (!map.containsKey(propName) && defaultValue != null) {
+        map.put(propName, defaultValue);
       }
     }
-    return Collections.unmodifiableMap(includeDefaultProperties);
+    return Collections.unmodifiableMap(map);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -22,6 +22,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -418,7 +419,17 @@ public final class Configuration {
         map.put(propName, defaultValue);
       }
     }
-    return Collections.unmodifiableMap(map);
+
+    // Resolve values with ${VALUE} format
+    String nestedPropIdentifier = "$";
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String value = entry.getValue();
+      if (value.contains(nestedPropIdentifier)) {
+        value = StrSubstitutor.replace(value, map);
+        map.put(entry.getKey(), value);
+      }
+    }
+    return map;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -406,10 +407,17 @@ public final class Configuration {
   }
 
   /**
-   * @return a view of the internal {@link Properties} of as an immutable map
+   * @return a view of the internal {@link Properties} and default properties of as an immutable map
    */
   public static Map<String, String> toMap() {
-    return Collections.unmodifiableMap(PROPERTIES);
+    Map<String, String> includeDefaultProperties = new HashMap<>(PROPERTIES);
+    for (PropertyKey key : PropertyKey.defaultKeys()) {
+      String propName = key.getName();
+      if (!includeDefaultProperties.containsKey(propName)) {
+        includeDefaultProperties.put(propName, key.getDefaultValue());
+      }
+    }
+    return Collections.unmodifiableMap(includeDefaultProperties);
   }
 
   /**
@@ -586,7 +594,7 @@ public final class Configuration {
    * @throws IllegalStateException if invalid configuration is encountered
    */
   public static void validate() {
-    for (Map.Entry<String, String> entry : toMap().entrySet()) {
+    for (Map.Entry<String, String> entry : Collections.unmodifiableMap(PROPERTIES).entrySet()) {
       String propertyName = entry.getKey();
       Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
       PropertyKey propertyKey = PropertyKey.fromString(propertyName);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -22,7 +22,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -411,14 +410,13 @@ public final class Configuration {
    * @return a map of the resolved properties(include default properties)
    */
   public static Map<String, String> toMap() {
-    // Resolve values with ${VALUE} format
     Map<String, String> map = toRawMap();
+    // Resolve values with ${VALUE} format
     String nestedPropIdentifier = "$";
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String value = entry.getValue();
       if (value.contains(nestedPropIdentifier)) {
-        value = StrSubstitutor.replace(value, map);
-        map.put(entry.getKey(), value);
+        map.put(entry.getKey(), lookup(value));
       }
     }
     return map;

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -408,25 +408,32 @@ public final class Configuration {
   }
 
   /**
-   * @return a view of the properties(include default properties) of as an immutable map
+   * @return a map of the resolved properties(include default properties)
    */
   public static Map<String, String> toMap() {
-    Map<String, String> map = new HashMap<>(PROPERTIES);
-    for (PropertyKey key : PropertyKey.defaultKeys()) {
-      String propName = key.getName();
-      String defaultValue = key.getDefaultValue();
-      if (!map.containsKey(propName) && defaultValue != null) {
-        map.put(propName, defaultValue);
-      }
-    }
-
     // Resolve values with ${VALUE} format
+    Map<String, String> map = toRawMap();
     String nestedPropIdentifier = "$";
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String value = entry.getValue();
       if (value.contains(nestedPropIdentifier)) {
         value = StrSubstitutor.replace(value, map);
         map.put(entry.getKey(), value);
+      }
+    }
+    return map;
+  }
+
+  /**
+   * @return a map of the raw properties(include default properties)
+   */
+  public static Map<String, String> toRawMap() {
+    Map<String, String> map = new HashMap<>(PROPERTIES);
+    for (PropertyKey key : PropertyKey.defaultKeys()) {
+      String propName = key.getName();
+      String defaultValue = key.getDefaultValue();
+      if (!map.containsKey(propName) && defaultValue != null) {
+        map.put(propName, defaultValue);
       }
     }
     return map;

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -95,16 +95,12 @@ public final class Configuration {
    * default property values.
    */
   static void init() {
-    // Load default
-    Properties defaultProps = createDefaultProps();
-
     // Load system properties
     Properties systemProps = new Properties();
     systemProps.putAll(System.getProperties());
 
     // Now lets combine, order matters here
     PROPERTIES.clear();
-    merge(defaultProps, Source.DEFAULT);
     merge(systemProps, Source.SYSTEM_PROPERTY);
 
     // Load site specific properties file if not in test mode. Note that we decide whether in test
@@ -130,21 +126,6 @@ public final class Configuration {
     }
 
     validate();
-  }
-
-  /**
-   * @return default properties
-   */
-  private static Properties createDefaultProps() {
-    Properties defaultProps = new Properties();
-    // Load compile-time default
-    for (PropertyKey key : PropertyKey.defaultKeys()) {
-      String value = key.getDefaultValue();
-      if (value != null) {
-        defaultProps.setProperty(key.toString(), value);
-      }
-    }
-    return defaultProps;
   }
 
   /**
@@ -426,26 +407,36 @@ public final class Configuration {
   }
 
   /**
-   * @return a map of the resolved properties represented by this configuration
+   * @return a map of the resolved properties represented by this configuration,
+   * including all default properties
    */
   public static Map<String, String> toMap() {
-    Map<String, String> map =  new HashMap<>(PROPERTIES);
+    Map<String, String> map = toRawMap();
     // Resolve values with ${VALUE} format
     String nestedPropIdentifier = "$";
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String value = entry.getValue();
-      if (value.contains(nestedPropIdentifier)) {
+      if (value != null && value.contains(nestedPropIdentifier)) {
         map.put(entry.getKey(), lookup(value));
       }
     }
-    return Collections.unmodifiableMap(map);
+    return map;
   }
 
   /**
-   * @return a map of the raw properties represented by this configuration
+   * @return a map of the raw properties represented by this configuration,
+   * including all default properties
    */
   public static Map<String, String> toRawMap() {
-    return Collections.unmodifiableMap(PROPERTIES);
+    Map<String, String> map = new HashMap<>(PROPERTIES);
+    for (PropertyKey key : PropertyKey.defaultKeys()) {
+      String propName = key.getName();
+      String defaultValue = key.getDefaultValue();
+      if (!map.containsKey(propName) && defaultValue != null) {
+        map.put(propName, defaultValue);
+      }
+    }
+    return map;
   }
 
   /**
@@ -622,7 +613,7 @@ public final class Configuration {
    * @throws IllegalStateException if invalid configuration is encountered
    */
   public static void validate() {
-    for (Map.Entry<String, String> entry : toRawMap().entrySet()) {
+    for (Map.Entry<String, String> entry : Collections.unmodifiableMap(PROPERTIES).entrySet()) {
       String propertyName = entry.getKey();
       Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
       PropertyKey propertyKey = PropertyKey.fromString(propertyName);

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -407,7 +407,8 @@ public final class Configuration {
   }
 
   /**
-   * @return a map of the resolved properties(include default properties)
+   * @return a map of the resolved properties represented by this configuration,
+   * including all default properties
    */
   public static Map<String, String> toMap() {
     Map<String, String> map = toRawMap();
@@ -423,7 +424,8 @@ public final class Configuration {
   }
 
   /**
-   * @return a map of the raw properties(include default properties)
+   * @return a map of the raw properties represented by this configuration,
+   * including all default properties
    */
   public static Map<String, String> toRawMap() {
     Map<String, String> map = new HashMap<>(PROPERTIES);

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 /**
  * Unit tests for the {@link Configuration} class.
@@ -723,8 +724,9 @@ public class ConfigurationTest {
     assertEquals(testValue, rawMap.get(testKey.toString()));
 
     // Test if some values in raw map is of ${VALUE} format
-    String nestedPropertyIdentifier = "$";
-    assertTrue(rawMap.get("alluxio.locality.script").contains(nestedPropertyIdentifier));
-    assertTrue(rawMap.get("alluxio.logs.dir").contains(nestedPropertyIdentifier));
+    String regexString = "(\\$\\{([^{}]*)\\})";
+    Pattern confRegex = Pattern.compile(regexString);
+    assertTrue(confRegex.matcher(rawMap.get("alluxio.locality.script")).find());
+    assertTrue(confRegex.matcher(rawMap.get("alluxio.logs.dir")).find());
   }
 }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -675,4 +675,45 @@ public class ConfigurationTest {
     x.set(20);
     assertEquals(20, Configuration.getInt(key));
   }
+
+  @Test
+  public void toMap() throws Exception {
+    // Create a nested property to test
+    String extensionsDirKeyName = "alluxio.extensions.dir";
+    String testValue = String.format("${%s}.test", extensionsDirKeyName);
+    PropertyKey testKey = PropertyKey.SECURITY_LOGIN_USERNAME;
+    Configuration.set(testKey, testValue);
+
+    Map<String, String> resolvedMap = Configuration.toMap();
+    Map<String, String> rawMap = Configuration.toRawMap();
+
+    // Test if the value of the created nested property is correct in both maps
+    String testKeyName = testKey.toString();
+    assertEquals(resolvedMap.get(testKeyName),
+        resolvedMap.get(extensionsDirKeyName) + ".test");
+    assertEquals(rawMap.get(testKeyName), testValue);
+
+    // Test if the values in the resolvedMap is resolved
+    assertEquals(resolvedMap.get(extensionsDirKeyName),
+        String.format("%s/extensions", resolvedMap.get("alluxio.home")));
+    assertEquals(resolvedMap.get("alluxio.logs.dir"),
+        String.format("%s/logs", resolvedMap.get("alluxio.work.dir")));
+    assertEquals(resolvedMap.get(extensionsDirKeyName),
+        Configuration.get(PropertyKey.fromString(extensionsDirKeyName)));
+
+    // Test if some values in raw map is of ${VALUE} format
+    String nestedPropertyIdentifier = "$";
+    assertTrue(rawMap.get("alluxio.locality.script").contains(nestedPropertyIdentifier));
+    assertTrue(rawMap.get("alluxio.logs.dir").contains(nestedPropertyIdentifier));
+
+    // Test if the resolvedMap include all kinds of properties
+    assertTrue(resolvedMap.containsKey("alluxio.debug"));
+    assertTrue(resolvedMap.containsKey("alluxio.fuse.fs.name"));
+    assertTrue(resolvedMap.containsKey("alluxio.logserver.logs.dir"));
+    assertTrue(resolvedMap.containsKey("alluxio.master.journal.folder"));
+    assertTrue(resolvedMap.containsKey("alluxio.proxy.web.port"));
+    assertTrue(resolvedMap.containsKey("alluxio.security.authentication.type"));
+    assertTrue(resolvedMap.containsKey("alluxio.user.block.master.client.threads"));
+    assertTrue(resolvedMap.containsKey("alluxio.worker.bind.host"));
+  }
 }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -679,21 +679,22 @@ public class ConfigurationTest {
   @Test
   public void toMap() throws Exception {
     // Create a nested property to test
-    String testKey = "alluxio.extensions.dir";
+    String testKeyName = "alluxio.extensions.dir";
     PropertyKey nestedKey = PropertyKey.SECURITY_LOGIN_USERNAME;
-    String nestedValue = String.format("${%s}.test", testKey);
+    String nestedValue = String.format("${%s}.test", testKeyName);
     Configuration.set(nestedKey, nestedValue);
 
     Map<String, String> resolvedMap = Configuration.toMap();
 
     // Test if the value of the created nested property is correct
-    assertEquals(Configuration.get(PropertyKey.fromString(testKey)), resolvedMap.get(testKey));
-    String nestedResolvedValue = String.format("${%s}.test", resolvedMap.get(testKey));
-    assertEquals(nestedResolvedValue, resolvedMap.get(nestedKey));
+    assertEquals(Configuration.get(PropertyKey.fromString(testKeyName)),
+        resolvedMap.get(testKeyName));
+    String nestedResolvedValue = String.format("%s.test", resolvedMap.get(testKeyName));
+    assertEquals(nestedResolvedValue, resolvedMap.get(nestedKey.toString()));
 
     // Test if the values in the resolvedMap is resolved
     String resolvedValue1 = String.format("%s/extensions", resolvedMap.get("alluxio.home"));
-    assertEquals(resolvedValue1, resolvedMap.get(testKey));
+    assertEquals(resolvedValue1, resolvedMap.get(testKeyName));
 
     String resolvedValue2 =  String.format("%s/logs", resolvedMap.get("alluxio.work.dir"));
     assertEquals(resolvedValue2, resolvedMap.get("alluxio.logs.dir"));

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -208,7 +208,8 @@ public class AlluxioMasterProcess implements MasterProcess {
     String alluxioConfPrefix = "alluxio";
     for (Map.Entry<String, String> entry : Configuration.toMap().entrySet()) {
       String key = entry.getKey();
-      if (key.startsWith(alluxioConfPrefix)) {
+      String value = entry.getValue();
+      if (key.startsWith(alluxioConfPrefix) && value != null) {
         PropertyKey propertyKey = PropertyKey.fromString(key);
         Configuration.Source source = Configuration.getSource(propertyKey);
         String sourceStr;

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterRestServiceHandler.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -420,19 +419,11 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Map<String, String> getConfigurationInternal(boolean raw) {
-    Set<Map.Entry<String, String>> properties = Configuration.toMap().entrySet();
-    SortedMap<String, String> configuration = new TreeMap<>();
-    for (Map.Entry<String, String> entry : properties) {
-      String key = entry.getKey();
-      if (PropertyKey.isValid(key)) {
-        if (raw) {
-          configuration.put(key, entry.getValue());
-        } else {
-          configuration.put(key, Configuration.get(PropertyKey.fromString(key)));
-        }
-      }
+    if (raw) {
+      return new TreeMap<>(Configuration.toRawMap());
+    } else {
+      return new TreeMap<>(Configuration.toMap());
     }
-    return configuration;
   }
 
   private Map<String, Long> getMetricsInternal() {

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/ConfigurationCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/ConfigurationCommand.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Prints runtime configuration information.
  */
 public class ConfigurationCommand {
-  private static final String CONFIG_INFO_FORMAT = "%s (value = %s, source = %s)%n";
+  private static final String CONFIG_INFO_FORMAT = "%s = %s (source = %s)%n";
   private MetaMasterClient mMetaMasterClient;
   private PrintStream mPrintStream;
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/ConfigurationCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/ConfigurationCommand.java
@@ -24,6 +24,7 @@ import java.util.List;
  * Prints runtime configuration information.
  */
 public class ConfigurationCommand {
+  private static final String CONFIG_INFO_FORMAT = "%s (value = %s, source = %s)%n";
   private MetaMasterClient mMetaMasterClient;
   private PrintStream mPrintStream;
 
@@ -46,35 +47,13 @@ public class ConfigurationCommand {
   public int run() throws IOException {
     List<ConfigProperty> configList = mMetaMasterClient.getConfiguration();
     Collections.sort(configList, Comparator.comparing(ConfigProperty::getSource));
-    String configInfoFormat = getConfigInfoFormat(configList);
 
     mPrintStream.print("Alluxio configuration information: \n");
-    mPrintStream.print(String.format(configInfoFormat,
-        "Property", "Value", "Source"));
 
     for (ConfigProperty info : configList) {
-      mPrintStream.print(String.format(configInfoFormat,
+      mPrintStream.print(String.format(CONFIG_INFO_FORMAT,
           info.getName(), info.getValue(), info.getSource()));
     }
     return 0;
-  }
-
-  /**
-   * Gets config info format based on the max length of each column.
-   *
-   * @param configList the config property list to find the max length of each column
-   * @return a config info format string
-   */
-  private String getConfigInfoFormat(List<ConfigProperty> configList) {
-    int nameSize = 15; // Default value is 15 to maintain basic column width
-    int valueSize = 15;
-    int sourceSize = 15;
-    for (ConfigProperty property : configList) {
-      nameSize = Math.max(nameSize, property.getName().length());
-      valueSize = Math.max(valueSize, property.getValue().length());
-      sourceSize = Math.max(sourceSize, property.getSource().length());
-    }
-    return new StringBuilder("%-").append(nameSize).append("s  %-")
-        .append(valueSize).append("s  %-").append(sourceSize).append("s%n").toString();
   }
 }

--- a/shell/src/test/java/alluxio/cli/fsadmin/command/ConfigurationCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/command/ConfigurationCommandTest.java
@@ -50,13 +50,12 @@ public class ConfigurationCommandTest {
       String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
       // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
       List<String> expectedOutput = Arrays.asList("Alluxio configuration information: ",
-          "Property                          Value                  Source                                               ",
-          "alluxio.master.port               19998                  DEFAULT                                              ",
-          "alluxio.master.web.port           19999                  DEFAULT                                              ",
-          "alluxio.master.hostname           localhost              SITE_PROPERTY (/alluxio/conf/alluxio-site.properties)",
-          "alluxio.underfs.address           hdfs://localhost:9000  SITE_PROPERTY (/alluxio/conf/alluxio-site.properties)",
-          "alluxio.logger.type               MASTER_LOGGER          SYSTEM_PROPERTY                                      ",
-          "alluxio.master.audit.logger.type  MASTER_AUDIT_LOGGER    SYSTEM_PROPERTY                                      ");
+          "alluxio.master.port (value = 19998, source = DEFAULT)",
+          "alluxio.master.web.port (value = 19999, source = DEFAULT)",
+          "alluxio.master.hostname (value = localhost, source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
+          "alluxio.underfs.address (value = hdfs://localhost:9000, source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
+          "alluxio.logger.type (value = MASTER_LOGGER, source = SYSTEM_PROPERTY)",
+          "alluxio.master.audit.logger.type (value = MASTER_AUDIT_LOGGER, source = SYSTEM_PROPERTY)");
       // CHECKSTYLE.ON: LineLengthExceed
       List<String> testOutput = Arrays.asList(output.split("\n"));
       Assert.assertThat(testOutput,

--- a/shell/src/test/java/alluxio/cli/fsadmin/command/ConfigurationCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/command/ConfigurationCommandTest.java
@@ -50,12 +50,12 @@ public class ConfigurationCommandTest {
       String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
       // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
       List<String> expectedOutput = Arrays.asList("Alluxio configuration information: ",
-          "alluxio.master.port (value = 19998, source = DEFAULT)",
-          "alluxio.master.web.port (value = 19999, source = DEFAULT)",
-          "alluxio.master.hostname (value = localhost, source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
-          "alluxio.underfs.address (value = hdfs://localhost:9000, source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
-          "alluxio.logger.type (value = MASTER_LOGGER, source = SYSTEM_PROPERTY)",
-          "alluxio.master.audit.logger.type (value = MASTER_AUDIT_LOGGER, source = SYSTEM_PROPERTY)");
+          "alluxio.master.port = 19998 (source = DEFAULT)",
+          "alluxio.master.web.port = 19999 (source = DEFAULT)",
+          "alluxio.master.hostname = localhost (source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
+          "alluxio.underfs.address = hdfs://localhost:9000 (source = SITE_PROPERTY (/alluxio/conf/alluxio-site.properties))",
+          "alluxio.logger.type = MASTER_LOGGER (source = SYSTEM_PROPERTY)",
+          "alluxio.master.audit.logger.type = MASTER_AUDIT_LOGGER (source = SYSTEM_PROPERTY)");
       // CHECKSTYLE.ON: LineLengthExceed
       List<String> testOutput = Arrays.asList(output.split("\n"));
       Assert.assertThat(testOutput,

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportCommandIntegrationTest.java
@@ -22,6 +22,9 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Tests for report command.
  */
@@ -55,8 +58,10 @@ public final class ReportCommandIntegrationTest extends AbstractFsAdminShellTest
         CoreMatchers.containsString("Alluxio configuration information:"));
 
     // Output should not contain raw values with ${VALUE} format
-    Assert.assertFalse(output.contains("$")
-        || output.contains("{") || output.contains("}"));
+    String regexString = "(\\$\\{([^{}]*)\\})";
+    Pattern confRegex = Pattern.compile(regexString);
+    Matcher matcher = confRegex.matcher(output);
+    Assert.assertFalse(matcher.find());
 
     // Output should contain all kinds of properties.
     Assert.assertTrue(output.contains("alluxio.debug"));

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportCommandIntegrationTest.java
@@ -53,8 +53,20 @@ public final class ReportCommandIntegrationTest extends AbstractFsAdminShellTest
     String output = mOutput.toString();
     Assert.assertThat(output,
         CoreMatchers.containsString("Alluxio configuration information:"));
-    Assert.assertThat(output,
-        CoreMatchers.containsString("alluxio.test.mode"));
+
+    // Output should not contain raw values with ${VALUE} format
+    Assert.assertFalse(output.contains("$")
+        || output.contains("{") || output.contains("}"));
+
+    // Output should contain all kinds of properties.
+    Assert.assertTrue(output.contains("alluxio.debug"));
+    Assert.assertTrue(output.contains("alluxio.fuse.fs.name"));
+    Assert.assertTrue(output.contains("alluxio.logserver.logs.dir"));
+    Assert.assertTrue(output.contains("alluxio.master.journal.folder"));
+    Assert.assertTrue(output.contains("alluxio.proxy.web.port"));
+    Assert.assertTrue(output.contains("alluxio.security.authentication.type"));
+    Assert.assertTrue(output.contains("alluxio.user.block.master.client.threads"));
+    Assert.assertTrue(output.contains("alluxio.worker.bind.host"));
   }
 
   @Test


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3168
# Issue:
- Web UI and CLI can only get a small set of configurations from Alluxio leader master in 1.8.0-SNAPSHOT.
- Web UI should be able to show all alluxio-related configurations and fsadmin report configuration should be able to show all configurations.

# Reason:
- In the ```Configuration.java```, we use a ```ConcurrentHashMap<String, String> PROPERTIES``` to record property keys and values.
- We have a merge function to merge ```defaultProperties/systemProperties/siteProperties``` to our ```PROPERTIES``` map.
- However, ```PROPERTIES``` map actually do not need to store default property key value pairs, so someone delete the codes to merge ```defaultProperties``` to ```PROPERTIES``` map. The ```Configuration.get(PropertyKey key)``` can use ```PropertyKey.fromString(property).getDefaultValue()``` to get default value of this key. ```Configuration.containsKey(PropertyKey key)``` can use ```key.getDefaultValue() != null``` to know that this key exists.
- ```PROPERTIES``` map now only store systemProperties, siteProperties and some of the properties that we set by using ```Configuration.set(Properkey key, Object value)``` function. The disappeared properties on alluxio web UI are those **default properties** that do not set via ```Configuration.set()```.