### PR TITLE
[SMALLFIX] Catch IOException on socket close

### DIFF
--- a/logserver/src/main/java/alluxio/logserver/AlluxioLogServerProcess.java
+++ b/logserver/src/main/java/alluxio/logserver/AlluxioLogServerProcess.java
@@ -147,7 +147,7 @@ public class AlluxioLogServerProcess implements Process {
       try {
         mServerSocket.close();
       } catch (IOException e) {
-        LOG.warn("Exception in closing server socket.", e);
+        LOG.warn("Exception in closing server socket: {}", e);
       }
     }
     mThreadPool.shutdownNow();
@@ -156,7 +156,11 @@ public class AlluxioLogServerProcess implements Process {
     // close them all.
     synchronized (mClientSockets) {
       for (Socket socket : mClientSockets) {
-        socket.close();
+        try {
+          socket.close();
+        } catch (IOException e) {
+          LOG.warn("Exception in closing client socket: {}", e);
+        }
       }
     }
     boolean ret = mThreadPool.awaitTermination(THREAD_KEEP_ALIVE_TIME_MS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Otherwise if closing one socket fails, we will exit with exit code `-1` instead without gracefully closing other sockets. With this change, we will try to close all sockets, and only log warning messages if some of the closes fail.