### PR TITLE
[SMALLFIX] Avoid spamming logs when there are a lot of orphan blocks

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -452,16 +452,26 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   @Override
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
-    List<Long> invalidBlocks = new ArrayList<>();
-    for (long blockId : mBlocks.keySet()) {
-      if (!validator.apply(blockId)) {
-        invalidBlocks.add(blockId);
+    List<Long> invalidBlocks = mBlocks.keySet().stream()
+        .filter((blockId) -> !validator.apply(blockId)).collect(Collectors.toList());
+    if (!invalidBlocks.isEmpty()) {
+      long maxSize = 100;
+      List<Long> loggedBlocks = invalidBlocks.stream().limit(maxSize).collect(Collectors.toList());
+      if (repair) {
+        LOG.warn(
+            "Blocks including {} (in total {} blocks) have no corresponding file metadata. " +
+                "Attempting to repair by deleting all invalid blocks.",
+            loggedBlocks, invalidBlocks.size());
+        removeBlocks(invalidBlocks, true);
+      } else {
+        LOG.warn(
+            "Blocks including {} (in total {} blocks) have no corresponding file metadata. " +
+                "Restart Alluxio master with {}=true to delete the block and repair the system.",
+            loggedBlocks, invalidBlocks.size(),
+            PropertyKey.Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED);
       }
     }
-    if (repair && !invalidBlocks.isEmpty()) {
-      LOG.warn("Deleting {} invalid blocks.", invalidBlocks.size());
-      removeBlocks(invalidBlocks, true);
-    }
+
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -452,26 +452,23 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   @Override
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
-    List<Long> invalidBlocks = mBlocks.keySet().stream()
-        .filter((blockId) -> !validator.apply(blockId)).collect(Collectors.toList());
+    List<Long> invalidBlocks = mBlocks.keySet()
+        .stream()
+        .filter((blockId) -> !validator.apply(blockId))
+        .collect(Collectors.toList());
     if (!invalidBlocks.isEmpty()) {
       long maxSize = 100;
       List<Long> loggedBlocks = invalidBlocks.stream().limit(maxSize).collect(Collectors.toList());
+      LOG.warn("Found {} blocks (including {}) have no corresponding file metadata.",
+          invalidBlocks.size(), loggedBlocks);
       if (repair) {
-        LOG.warn(
-            "Blocks including {} (in total {} blocks) have no corresponding file metadata. "
-                + "Attempting to repair by deleting all invalid blocks.",
-            loggedBlocks, invalidBlocks.size());
+        LOG.warn("Deleting {} invalid blocks.", invalidBlocks.size());
         removeBlocks(invalidBlocks, true);
       } else {
-        LOG.warn(
-            "Blocks including {} (in total {} blocks) have no corresponding file metadata. "
-                + "Restart Alluxio master with {}=true to delete the block and repair the system.",
-            loggedBlocks, invalidBlocks.size(),
+        LOG.warn("Restart Alluxio master with {}=true to delete the blocks and repair the system.",
             PropertyKey.Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED);
       }
     }
-
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -452,14 +452,12 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   @Override
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
-    List<Long> invalidBlocks = mBlocks.keySet()
-        .stream()
-        .filter((blockId) -> !validator.apply(blockId))
-        .collect(Collectors.toList());
+    List<Long> invalidBlocks =
+        mBlocks.keySet().stream().filter((blockId) -> !validator.apply(blockId))
+            .collect(Collectors.toList());
     if (!invalidBlocks.isEmpty()) {
-      long maxSize = 100;
-      List<Long> loggedBlocks = invalidBlocks.stream().limit(maxSize).collect(Collectors.toList());
-      LOG.warn("Found {} blocks (including {}) have no corresponding file metadata.",
+      List<Long> loggedBlocks = invalidBlocks.stream().limit(100).collect(Collectors.toList());
+      LOG.warn("Found {} blocks without corresponding file metadata. Blocks include {}.",
           invalidBlocks.size(), loggedBlocks);
       if (repair) {
         LOG.warn("Deleting {} invalid blocks.", invalidBlocks.size());

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -456,11 +456,16 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
         mBlocks.keySet().stream().filter((blockId) -> !validator.apply(blockId))
             .collect(Collectors.toList());
     if (!invalidBlocks.isEmpty()) {
-      List<Long> loggedBlocks = invalidBlocks.stream().limit(100).collect(Collectors.toList());
-      LOG.warn("Found {} blocks without corresponding file metadata. Blocks include {}.",
-          invalidBlocks.size(), loggedBlocks);
+      long limit = 100;
+      List<Long> loggedBlocks = invalidBlocks.stream().limit(limit).collect(Collectors.toList());
+      LOG.warn("Found {} orphan blocks without corresponding file metadata.", invalidBlocks.size());
+      if (invalidBlocks.size() > limit) {
+        LOG.warn("The first {} orphan blocks include {}.", limit, loggedBlocks);
+      } else {
+        LOG.warn("The orphan blocks include {}.", loggedBlocks);
+      }
       if (repair) {
-        LOG.warn("Deleting {} invalid blocks.", invalidBlocks.size());
+        LOG.warn("Deleting {} orphan blocks.", invalidBlocks.size());
         removeBlocks(invalidBlocks, true);
       } else {
         LOG.warn("Restart Alluxio master with {}=true to delete the blocks and repair the system.",

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -459,14 +459,14 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
       List<Long> loggedBlocks = invalidBlocks.stream().limit(maxSize).collect(Collectors.toList());
       if (repair) {
         LOG.warn(
-            "Blocks including {} (in total {} blocks) have no corresponding file metadata. " +
-                "Attempting to repair by deleting all invalid blocks.",
+            "Blocks including {} (in total {} blocks) have no corresponding file metadata. "
+                + "Attempting to repair by deleting all invalid blocks.",
             loggedBlocks, invalidBlocks.size());
         removeBlocks(invalidBlocks, true);
       } else {
         LOG.warn(
-            "Blocks including {} (in total {} blocks) have no corresponding file metadata. " +
-                "Restart Alluxio master with {}=true to delete the block and repair the system.",
+            "Blocks including {} (in total {} blocks) have no corresponding file metadata. "
+                + "Restart Alluxio master with {}=true to delete the block and repair the system.",
             loggedBlocks, invalidBlocks.size(),
             PropertyKey.Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -631,17 +631,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   public void validateInodeBlocks(boolean repair) throws UnavailableException {
     mBlockMaster.validateBlocks((blockId) -> {
       long fileId = IdUtils.fileIdFromBlockId(blockId);
-      boolean exists = mInodeTree.inodeIdExists(fileId);
-      if (!exists) {
-        if (repair) {
-          LOG.warn("Block {} has no corresponding file metadata. Attempting to repair.", blockId);
-        } else {
-          LOG.warn("Block {} has no corresponding file metadata. Restart Alluxio master with "
-              + "{}=true to delete the block and repair the system.",
-              blockId, PropertyKey.Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED);
-        }
-      }
-      return exists;
+      return mInodeTree.inodeIdExists(fileId);
     }, repair);
   }
 


### PR DESCRIPTION
Only show the first 100 invalid blocks in logs