### PR TITLE
 [SMALLFIX]Improve Naming in FileSystemAclIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
@@ -501,7 +501,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
     Assume.assumeTrue(UnderFileSystemUtils.isS3(sUfs));
 
     alluxio.Configuration.set(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "");
-    Path fileA = new Path("/objectfileA");
+    Path fileA = new Path("/s3GetPermissionFile");
     create(sTFS, fileA);
     Assert.assertTrue(sUfs.isFile(PathUtils.concatPath(sUfsRoot, fileA)));
 


### PR DESCRIPTION
Improve Naming in FileSystemAclIntegrationTest,in the test s3GetPermission, rename the file /objectFileA to /s3GetPermissionFile.

