### PR TITLE
[ALLUXIO-3200] JournalTool failed to read binary journal entries

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalTool.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalTool.java
@@ -177,8 +177,8 @@ public final class JournalTool {
     }
     sHelp = cmd.hasOption("help");
     sMaster = cmd.getOptionValue("master", "FileSystemMaster");
-    sStart = Long.parseLong(cmd.getOptionValue("start", "0"));
-    sEnd = Long.parseLong(cmd.getOptionValue("end", Long.valueOf(Long.MAX_VALUE).toString()));
+    sStart = Long.decode(cmd.getOptionValue("start", "0"));
+    sEnd = Long.decode(cmd.getOptionValue("end", Long.valueOf(Long.MAX_VALUE).toString()));
     sJournalFile = cmd.getOptionValue("journalFile", "");
     return true;
   }


### PR DESCRIPTION
JournalTool can't read binary journal entries since it parses input arguments improperly.