### PR TITLE
[SMALLFIX] generalize extension factory registry

### DIFF
--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
@@ -24,7 +24,7 @@ public interface ExtensionFactory<T, S> {
    * thrown if this factory does not support extension for the given path or if the configuration
    * provided is insufficient to create a client.
    *
-   * @param path file path
+   * @param path file path for which the extension will be created
    * @param conf optional configuration object for the extension, may be null
    * @return the client
    */
@@ -34,7 +34,7 @@ public interface ExtensionFactory<T, S> {
    * Gets whether this factory supports the given path and thus whether calling the
    * {@link #create(String, S)} can succeed for this path.
    *
-   * @param path file path
+   * @param path file path for which the extension will be created
    * @param conf optional configuration object for the extension, may be null
    * @return true if the path is supported, false otherwise
    */

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.extensions;
+
+import javax.annotation.Nullable;
+
+public interface ExtensionFactory<T, S> {
+  /**
+   * Creates a new extension for the given path. An {@link IllegalArgumentException} is
+   * thrown if this factory does not support extension for the given path or if the configuration
+   * provided is insufficient to create a client.
+   *
+   * @param path file path
+   * @param conf optional configuration object for the extension, may be null
+   * @return the client
+   */
+  T create(String path, @Nullable S conf);
+
+  /**
+   * Gets whether this factory supports the given path and thus whether calling the
+   * {@link #create(String, S)} can succeed for this path.
+   *
+   * @param path file path
+   * @param conf optional configuration object for the extension, may be null
+   * @return true if the path is supported, false otherwise
+   */
+  boolean supportsPath(String path, @Nullable S conf);
+}

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
@@ -24,7 +24,7 @@ public interface ExtensionFactory<T, S> {
    * thrown if this factory does not support extension for the given path or if the configuration
    * provided is insufficient to create a client.
    *
-   * @param path file path for which the extension will be created
+   * @param path file path with scheme for which the extension will be created
    * @param conf optional configuration object for the extension, may be null
    * @return the client
    */
@@ -34,7 +34,7 @@ public interface ExtensionFactory<T, S> {
    * Gets whether this factory supports the given path and thus whether calling the
    * {@link #create(String, S)} can succeed for this path.
    *
-   * @param path file path for which the extension will be created
+   * @param path file path with scheme for which the extension will be created
    * @param conf optional configuration object for the extension, may be null
    * @return true if the path is supported, false otherwise
    */

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
@@ -13,6 +13,11 @@ package alluxio.extensions;
 
 import javax.annotation.Nullable;
 
+/**
+ * A factory class for creating instance of {@link T} based on configuration {@link S}.
+ * @param <T> The type of instance to be created
+ * @param <S> the type of configuration to be used when creating the extension
+ */
 public interface ExtensionFactory<T, S> {
   /**
    * Creates a new extension for the given path. An {@link IllegalArgumentException} is

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactory.java
@@ -22,11 +22,11 @@ public interface ExtensionFactory<T, S> {
   /**
    * Creates a new extension for the given path. An {@link IllegalArgumentException} is
    * thrown if this factory does not support extension for the given path or if the configuration
-   * provided is insufficient to create a client.
+   * provided is insufficient to create an extension.
    *
    * @param path file path with scheme for which the extension will be created
    * @param conf optional configuration object for the extension, may be null
-   * @return the client
+   * @return the new extension
    */
   T create(String path, @Nullable S conf);
 

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -1,0 +1,270 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.extensions;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.util.ExtensionUtils;
+import alluxio.util.io.PathUtils;
+
+/**
+ * <p>
+ * An extension registry that uses the {@link ServiceLoader} mechanism to automatically discover
+ * available factories and provides a central place for obtaining actual extension instances.
+ * </p>
+ * <h3>Registering New Factories</h3>
+ * <p>
+ * New factories can be registered either using the {@linkplain ServiceLoader} based automatic
+ * discovery mechanism or manually using the static {@link #register(T)}
+ * method. The down-side of the automatic discovery mechanism is that the discovery order is not
+ * controllable. As a result if your implementation is designed as a replacement for one of the
+ * standard implementations, depending on the order in which the JVM discovers the services your own
+ * implementation may not take priority. You can enable {@code DEBUG} level logging for this class
+ * to see the order in which factories are discovered and which is selected when obtaining a
+ * {@link T} instance for a path. If this shows that your implementation is not
+ * getting discovered or used, you may wish to use the manual registration approach.
+ * </p>
+ * <h4>Automatic Discovery</h4>
+ * <p>
+ * To use the {@linkplain ServiceLoader} based mechanism you need to have a file with the same name
+ * as the factory class {@code T} placed in the {@code META-INF\services} directory
+ * of your project. This file should contain the full name of your factory types (one per line),
+ * your factory types must have a public unparameterised constructor available (see
+ * {@link ServiceLoader} for more detail on this). You can enable {@code DEBUG} level logging to see
+ * factories as they are discovered if you wish to check that your implementation gets discovered.
+ * </p>
+ * <h4>Manual Registration</h4>
+ * <p>
+ * To manually register a factory, simply pass an instance of your factory to the
+ * {@link #register(T)} method. This can be useful when your factory cannot be
+ * instantiated without arguments or in cases where automatic discovery does not give your factory
+ * priority. Factories registered this way will be registered at the start of the factories list so
+ * will have the first opportunity to indicate whether they support a requested path.
+ * </p>
+ */
+@NotThreadSafe
+public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
+  private static final Logger LOG = LoggerFactory.getLogger(ExtensionFactoryRegistry.class);
+
+  public static final String LIB_DIR =
+      PathUtils.concatPath(Configuration.get(PropertyKey.HOME), "lib");
+
+  /**
+   * The base list of factories, which does not include any lib or extension factories. The only
+   * factories in the base list will be built-in factories, and any additional factories
+   * registered by tests. All other factories will be discovered and service loaded when extension
+   * creation occurs.
+   */
+  private final List<T> mFactories = new CopyOnWriteArrayList<>();
+  private final String mExtensionPattern;
+  private final Class<T> mFactoryClass;
+  private boolean mInit = false;
+
+  public ExtensionFactoryRegistry(Class<T> factoryClass, String extensionPattern) {
+    mFactoryClass = Preconditions.checkNotNull(factoryClass, "factoryClass");
+    mExtensionPattern = extensionPattern;
+    init();
+  }
+
+  private synchronized void init() {
+    // Discover and register the available base factories
+    ServiceLoader<T> discoveredFactories =
+        ServiceLoader.load(mFactoryClass, mFactoryClass.getClassLoader());
+    for (T factory : discoveredFactories) {
+      LOG.debug("Discovered base extension factory implementation {} - {}",
+          factory.getClass(), factory.toString());
+      register(factory);
+    }
+  }
+
+  /**
+   * Returns a read-only view of the available base factories.
+   *
+   * @return Read-only view of the available base factories
+   */
+  public List<T> getAvailable() {
+    return Collections.unmodifiableList(mFactories);
+  }
+
+  /**
+   * Finds all the factories that support the given path.
+   *
+   * @param path path
+   * @param conf configuration of the extension
+   * @return list of factories that support the given path which may be an empty list
+   */
+  public List<T> findAll(String path, S conf) {
+    Preconditions.checkArgument(path != null, "path may not be null");
+
+    List<T> factories = new ArrayList<>(mFactories);
+    scanLibs(factories);
+    scanExtensions(factories);
+
+    List<T> eligibleFactories = new ArrayList<>();
+    for (T factory : factories) {
+      if (factory.supportsPath(path, conf)) {
+        LOG.debug("factory implementation {} is eligible for path {}",
+            factory.getClass(), path);
+        eligibleFactories.add(factory);
+      }
+    }
+
+    if (eligibleFactories.isEmpty()) {
+      LOG.warn("factory implementation supports the path {}", path);
+    }
+    return eligibleFactories;
+  }
+
+  /**
+   * Finds all factory from the extensions directory.
+   *
+   * @param factories list of factories to add to
+   */
+  private void scanExtensions(List<T> factories) {
+    LOG.info("Loading extension jars from {}", Configuration.get(PropertyKey.EXTENSIONS_DIR));
+    scan(Arrays.asList(ExtensionUtils.listExtensions()), factories);
+  }
+
+  /**
+   * Finds all factory from the lib directory.
+   *
+   * @param factories list of factories to add to
+   */
+  private void scanLibs(List<T> factories) {
+    LOG.info("Loading core jars from {}", LIB_DIR);
+    List<File> files = new ArrayList<>();
+    try (DirectoryStream<Path> stream =
+        Files.newDirectoryStream(Paths.get(LIB_DIR), mExtensionPattern)) {
+      for (Path entry : stream) {
+        if (entry.toFile().isFile()) {
+          files.add(entry.toFile());
+        }
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to load libs: {}", e.getMessage());
+    }
+    scan(files, factories);
+  }
+
+  /**
+   * Class-loads jar files that have not been loaded.
+   *
+   * @param files jar files to class-load
+   * @param factories list of factories to add to
+   */
+  private void scan(List<File> files, List<T> factories) {
+    for (File jar : files) {
+      try {
+        URL extensionURL = jar.toURI().toURL();
+        String jarPath = extensionURL.toString();
+
+        ClassLoader extensionsClassLoader = new ExtensionsClassLoader(new URL[] {extensionURL},
+            ClassLoader.getSystemClassLoader());
+        ServiceLoader<T> extensionServiceLoader =
+            ServiceLoader.load(mFactoryClass, extensionsClassLoader);
+        for (T factory : extensionServiceLoader) {
+          LOG.debug("Discovered a factory implementation {} - {} in jar {}",
+              factory.getClass(), factory.toString(), jarPath);
+          register(factory, factories);
+        }
+      } catch (Throwable t) {
+        LOG.warn("Failed to load jar {}: {}", jar, t.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Registers a new factory.
+   * <p>
+   * Factories are registered at the start of the factories list so they can override the existing
+   * automatically discovered factories. Generally if you use the {@link ServiceLoader} mechanism
+   * properly it should be unnecessary to call this, however since ServiceLoader discovery order
+   * may be susceptible to class loader behavioral differences there may be rare cases when you
+   * need to manually register the desired factory.
+   * </p>
+   *
+   * @param factory factory to register
+   */
+  public void register(T factory) {
+    register(factory, mFactories);
+  }
+
+  private void register(T factory, List<T> factories) {
+    if (factory == null) {
+      return;
+    }
+
+    LOG.debug("Registered factory implementation {} - {}", factory.getClass(),
+        factory.toString());
+
+    // Insert at start of list so it will take precedence over automatically discovered and
+    // previously registered factories
+    factories.add(0, factory);
+  }
+
+  /**
+   * Resets the registry to its default state
+   * <p>
+   * This clears the registry as it stands and rediscovers the available factories.
+   * </p>
+   */
+  public synchronized void reset() {
+    if (mInit) {
+      // Reset state
+      mInit = false;
+      mFactories.clear();
+    }
+
+    // Reinitialise
+    init();
+  }
+
+  /**
+   * Unregisters an existing factory.
+   *
+   * @param factory factory to unregister
+   */
+  public void unregister(T factory) {
+    unregister(factory, mFactories);
+  }
+
+  private void unregister(T factory, List<T> factories) {
+    if (factory == null) {
+      return;
+    }
+
+    LOG.debug("Unregistered factory implementation {} - {}", factory.getClass(),
+        factory.toString());
+    factories.remove(factory);
+  }
+}

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -11,6 +11,16 @@
 
 package alluxio.extensions;
 
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.util.ExtensionUtils;
+import alluxio.util.io.PathUtils;
+
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -26,16 +36,6 @@ import java.util.ServiceLoader;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.concurrent.NotThreadSafe;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
-
-import alluxio.Configuration;
-import alluxio.PropertyKey;
-import alluxio.util.ExtensionUtils;
-import alluxio.util.io.PathUtils;
 
 /**
  * <p>
@@ -71,6 +71,8 @@ import alluxio.util.io.PathUtils;
  * priority. Factories registered this way will be registered at the start of the factories list so
  * will have the first opportunity to indicate whether they support a requested path.
  * </p>
+ * @param <T> The type of extension factory
+ * @param <S> the type of configuration to be used when creating the extension
  */
 @NotThreadSafe
 public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
@@ -90,6 +92,11 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
   private final Class<T> mFactoryClass;
   private boolean mInit = false;
 
+  /**
+   * Constructs a registry for loading extension of a particular type.
+   * @param factoryClass the type of the extension factory
+   * @param extensionPattern the pattern used to select libraries to be loaded
+   */
   public ExtensionFactoryRegistry(Class<T> factoryClass, String extensionPattern) {
     mFactoryClass = Preconditions.checkNotNull(factoryClass, "factoryClass");
     mExtensionPattern = extensionPattern;

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactory.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactory.java
@@ -11,12 +11,15 @@
 
 package alluxio.underfs;
 
+import alluxio.extensions.ExtensionFactory;
+
 import javax.annotation.Nullable;
 
 /**
  * Interface for under file system factories.
  */
-public interface UnderFileSystemFactory {
+public interface UnderFileSystemFactory
+    extends ExtensionFactory<UnderFileSystem, UnderFileSystemConfiguration> {
 
   /**
    * Creates a new client for accessing the given path. An {@link IllegalArgumentException} is

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -39,9 +39,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class UnderFileSystemFactoryRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemFactoryRegistry.class);
-  private static final String EXTENSION_PATTERN = "alluxio-underfs-*.jar";
+  private static final String UFS_EXTENSION_PATTERN = "alluxio-underfs-*.jar";
   private static ExtensionFactoryRegistry<UnderFileSystemFactory, UnderFileSystemConfiguration>
-      sInstance;
+      sRegistryInstance;
 
   // prevent instantiation
   private UnderFileSystemFactoryRegistry() {}
@@ -57,7 +57,7 @@ public final class UnderFileSystemFactoryRegistry {
    * @return Read-only view of the available base factories
    */
   public static List<UnderFileSystemFactory> available() {
-    return sInstance.getAvailable();
+    return sRegistryInstance.getAvailable();
   }
 
   /**
@@ -101,12 +101,13 @@ public final class UnderFileSystemFactoryRegistry {
    */
   public static List<UnderFileSystemFactory> findAll(String path,
       UnderFileSystemConfiguration ufsConf) {
-    return sInstance.findAll(path, ufsConf);
+    return sRegistryInstance.findAll(path, ufsConf);
   }
 
   private static synchronized void init() {
-    if (sInstance == null) {
-      sInstance = new ExtensionFactoryRegistry<>(UnderFileSystemFactory.class, EXTENSION_PATTERN);
+    if (sRegistryInstance == null) {
+      sRegistryInstance = new ExtensionFactoryRegistry<>(UnderFileSystemFactory.class,
+          UFS_EXTENSION_PATTERN);
     }
   }
 
@@ -123,7 +124,7 @@ public final class UnderFileSystemFactoryRegistry {
    * @param factory factory to register
    */
   public static void register(UnderFileSystemFactory factory) {
-    sInstance.register(factory);
+    sRegistryInstance.register(factory);
   }
 
   /**
@@ -133,7 +134,7 @@ public final class UnderFileSystemFactoryRegistry {
    * </p>
    */
   public static synchronized void reset() {
-    sInstance.reset();
+    sRegistryInstance.reset();
   }
 
   /**
@@ -142,6 +143,6 @@ public final class UnderFileSystemFactoryRegistry {
    * @param factory factory to unregister
    */
   public static void unregister(UnderFileSystemFactory factory) {
-    sInstance.unregister(factory);
+    sRegistryInstance.unregister(factory);
   }
 }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -11,29 +11,13 @@
 
 package alluxio.underfs;
 
-import alluxio.Configuration;
-import alluxio.PropertyKey;
-import alluxio.extensions.ExtensionsClassLoader;
-import alluxio.util.ExtensionUtils;
-import alluxio.util.io.PathUtils;
+import alluxio.extensions.ExtensionFactoryRegistry;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -44,58 +28,20 @@ import javax.annotation.concurrent.NotThreadSafe;
  * {@link ServiceLoader} mechanism to automatically discover available factories and provides a
  * central place for obtaining actual {@link UnderFileSystem} instances.
  * </p>
- * <h3>Registering New Factories</h3>
- * <p>
- * New factories can be registered either using the {@linkplain ServiceLoader} based automatic
- * discovery mechanism or manually using the static {@link #register(UnderFileSystemFactory)}
- * method. The down-side of the automatic discovery mechanism is that the discovery order is not
- * controllable. As a result if your implementation is designed as a replacement for one of the
- * standard implementations, depending on the order in which the JVM discovers the services your own
- * implementation may not take priority. You can enable {@code DEBUG} level logging for this class
- * to see the order in which factories are discovered and which is selected when obtaining a
- * {@link UnderFileSystem} instance for a path. If this shows that your implementation is not
- * getting discovered or used, you may wish to use the manual registration approach.
- * </p>
- * <h4>Automatic Discovery</h4>
- * <p>
- * To use the {@linkplain ServiceLoader} based mechanism you need to have a file named
- * {@code alluxio.underfs.UnderFileSystemFactory} placed in the {@code META-INF\services} directory
- * of your project. This file should contain the full name of your factory types (one per line),
- * your factory types must have a public unparameterised constructor available (see
- * {@link ServiceLoader} for more detail on this). You can enable {@code DEBUG} level logging to see
- * factories as they are discovered if you wish to check that your implementation gets discovered.
- * </p>
  * <p>
  * Note that if you are bundling Alluxio plus your code in a shaded JAR using Maven, make sure to
  * use the {@code ServicesResourceTransformer} as otherwise your services file will override the
  * core provided services file and leave the standard factories and under file system
  * implementations unavailable.
  * </p>
- * <h4>Manual Registration</h4>
- * <p>
- * To manually register a factory, simply pass an instance of your factory to the
- * {@link #register(UnderFileSystemFactory)} method. This can be useful when your factory cannot be
- * instantiated without arguments or in cases where automatic discovery does not give your factory
- * priority. Factories registered this way will be registered at the start of the factories list so
- * will have the first opportunity to indicate whether they support a requested path.
- * </p>
+ * @see ExtensionFactoryRegistry
  */
 @NotThreadSafe
 public final class UnderFileSystemFactoryRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemFactoryRegistry.class);
-
-  /**
-   * The base list of factories, which does not include any lib or extension factories. The only
-   * factories in the base list will be the LocalUFS factory, and any additional factories
-   * registered by tests. All other UFS factories will be discovered and service loaded when ufs
-   * creation occurs.
-   */
-  private static final List<UnderFileSystemFactory> FACTORIES = new CopyOnWriteArrayList<>();
-
-  public static final String LIB_DIR =
-      PathUtils.concatPath(Configuration.get(PropertyKey.HOME), "lib");
-
-  private static boolean sInit = false;
+  private static final String EXTENSION_PATTERN = "alluxio-underfs-*.jar";
+  private static ExtensionFactoryRegistry<UnderFileSystemFactory, UnderFileSystemConfiguration>
+      sInstance;
 
   // prevent instantiation
   private UnderFileSystemFactoryRegistry() {}
@@ -111,7 +57,7 @@ public final class UnderFileSystemFactoryRegistry {
    * @return Read-only view of the available base factories
    */
   public static List<UnderFileSystemFactory> available() {
-    return Collections.unmodifiableList(FACTORIES);
+    return sInstance.getAvailable();
   }
 
   /**
@@ -155,101 +101,13 @@ public final class UnderFileSystemFactoryRegistry {
    */
   public static List<UnderFileSystemFactory> findAll(String path,
       UnderFileSystemConfiguration ufsConf) {
-    Preconditions.checkArgument(path != null, "path may not be null");
-
-    List<UnderFileSystemFactory> factories = new ArrayList<>(FACTORIES);
-    scanLibs(factories);
-    scanExtensions(factories);
-
-    List<UnderFileSystemFactory> eligibleFactories = new ArrayList<>();
-    for (UnderFileSystemFactory factory : factories) {
-      if (factory.supportsPath(path, ufsConf)) {
-        LOG.debug("Under File System Factory implementation {} is eligible for path {}",
-            factory.getClass(), path);
-        eligibleFactories.add(factory);
-      }
-    }
-
-    if (eligibleFactories.isEmpty()) {
-      LOG.warn("No Under File System Factory implementation supports the path {}", path);
-    }
-    return eligibleFactories;
-  }
-
-  /**
-   * Finds all {@link UnderFileSystemFactory} from the extensions directory.
-   *
-   * @param factories list of factories to add to
-   */
-  private static void scanExtensions(List<UnderFileSystemFactory> factories) {
-    LOG.info("Loading extension UFS jars from {}", Configuration.get(PropertyKey.EXTENSIONS_DIR));
-    scan(Arrays.asList(ExtensionUtils.listExtensions()), factories);
-  }
-
-  /**
-   * Finds all {@link UnderFileSystemFactory} from the lib directory.
-   *
-   * @param factories list of factories to add to
-   */
-  private static void scanLibs(List<UnderFileSystemFactory> factories) {
-    LOG.info("Loading core UFS jars from {}", LIB_DIR);
-    List<File> files = new ArrayList<>();
-    try (DirectoryStream<Path> stream =
-        Files.newDirectoryStream(Paths.get(LIB_DIR), "alluxio-underfs-*.jar")) {
-      for (Path entry : stream) {
-        if (entry.toFile().isFile()) {
-          files.add(entry.toFile());
-        }
-      }
-    } catch (IOException e) {
-      LOG.warn("Failed to load UFS libs: {}", e.getMessage());
-    }
-    scan(files, factories);
-  }
-
-  /**
-   * Class-loads jar files that have not been loaded.
-   *
-   * @param files jar files to class-load
-   * @param factories list of factories to add to
-   */
-  private static void scan(List<File> files, List<UnderFileSystemFactory> factories) {
-    for (File jar : files) {
-      try {
-        URL extensionURL = jar.toURI().toURL();
-        String jarPath = extensionURL.toString();
-
-        ClassLoader extensionsClassLoader = new ExtensionsClassLoader(new URL[] {extensionURL},
-            ClassLoader.getSystemClassLoader());
-        ServiceLoader<UnderFileSystemFactory> extensionServiceLoader =
-            ServiceLoader.load(UnderFileSystemFactory.class, extensionsClassLoader);
-        for (UnderFileSystemFactory factory : extensionServiceLoader) {
-          LOG.debug("Discovered an Under File System Factory implementation {} - {} in jar {}",
-              factory.getClass(), factory.toString(), jarPath);
-          register(factory, factories);
-        }
-      } catch (Throwable t) {
-        LOG.warn("Failed to load jar {}: {}", jar, t.getMessage());
-      }
-    }
+    return sInstance.findAll(path, ufsConf);
   }
 
   private static synchronized void init() {
-    if (sInit) {
-      return;
+    if (sInstance == null) {
+      sInstance = new ExtensionFactoryRegistry<>(UnderFileSystemFactory.class, EXTENSION_PATTERN);
     }
-
-    // Discover and register the available base factories
-    ServiceLoader<UnderFileSystemFactory> discoveredFactories =
-        ServiceLoader.load(UnderFileSystemFactory.class,
-            UnderFileSystemFactory.class.getClassLoader());
-    for (UnderFileSystemFactory factory : discoveredFactories) {
-      LOG.debug("Discovered base Under File System Factory implementation {} - {}",
-          factory.getClass(), factory.toString());
-      register(factory);
-    }
-
-    sInit = true;
   }
 
   /**
@@ -265,21 +123,7 @@ public final class UnderFileSystemFactoryRegistry {
    * @param factory factory to register
    */
   public static void register(UnderFileSystemFactory factory) {
-    register(factory, FACTORIES);
-  }
-
-  private static void register(UnderFileSystemFactory factory,
-      List<UnderFileSystemFactory> factories) {
-    if (factory == null) {
-      return;
-    }
-
-    LOG.debug("Registered Under File System Factory implementation {} - {}", factory.getClass(),
-        factory.toString());
-
-    // Insert at start of list so it will take precedence over automatically discovered and
-    // previously registered factories
-    factories.add(0, factory);
+    sInstance.register(factory);
   }
 
   /**
@@ -289,14 +133,7 @@ public final class UnderFileSystemFactoryRegistry {
    * </p>
    */
   public static synchronized void reset() {
-    if (sInit) {
-      // Reset state
-      sInit = false;
-      FACTORIES.clear();
-    }
-
-    // Reinitialise
-    init();
+    sInstance.reset();
   }
 
   /**
@@ -305,17 +142,6 @@ public final class UnderFileSystemFactoryRegistry {
    * @param factory factory to unregister
    */
   public static void unregister(UnderFileSystemFactory factory) {
-    unregister(factory, FACTORIES);
-  }
-
-  private static void unregister(UnderFileSystemFactory factory,
-      List<UnderFileSystemFactory> factories) {
-    if (factory == null) {
-      return;
-    }
-
-    LOG.debug("Unregistered Under File System Factory implementation {} - {}", factory.getClass(),
-        factory.toString());
-    factories.remove(factory);
+    sInstance.unregister(factory);
   }
 }


### PR DESCRIPTION
Extract extension loading logic from UnderFileSystemFactoryRegistry and put it in a reusable generic class.