### PR TITLE
[SMALLFIX] Timestamps comparison can overflow

### DIFF
--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -333,6 +333,8 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
         }
         long currTimeMs = mClock.millis();
         try {
+          // one should use t1-t0<0, not t1<t0, because of the possibility of numerical overflow.
+          // For further detail see: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html
           if (endTimeMs - currTimeMs <= 0 || !mNotEmpty
               .await(endTimeMs - currTimeMs, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Acquire resource times out.");

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -333,7 +333,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
         }
         long currTimeMs = mClock.millis();
         try {
-          if (currTimeMs >= endTimeMs || !mNotEmpty
+          if (endTimeMs - currTimeMs <= 0 || !mNotEmpty
               .await(endTimeMs - currTimeMs, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException("Acquire resource times out.");
           }

--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -120,7 +120,7 @@ public abstract class ResourcePool<T> implements Pool<T> {
           }
           if (time > 0) {
             long currTimeMs = System.currentTimeMillis();
-            if (currTimeMs >= endTimeMs) {
+            if (endTimeMs - currTimeMs <= 0) {
               return null;
             }
             if (!mNotEmpty.await(endTimeMs - currTimeMs, TimeUnit.MILLISECONDS)) {

--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -120,6 +120,8 @@ public abstract class ResourcePool<T> implements Pool<T> {
           }
           if (time > 0) {
             long currTimeMs = System.currentTimeMillis();
+            // one should use t1-t0<0, not t1<t0, because of the possibility of numerical overflow.
+            // For further detail see: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html
             if (endTimeMs - currTimeMs <= 0) {
               return null;
             }


### PR DESCRIPTION
Some comparisons with timestamp values are not safe. This comparisons can trigger errors that were found in some other projects, e.g. apache kafka with the issue id KAFKA-4290.
I changed those comparisons according to what the Java documentation recommends to help preventing such errors. 