### PR TITLE
[SMALLFIX] Only register metrics shutdown hook in non-test mode.

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -195,8 +195,10 @@ public final class FileSystemContext implements Closeable {
       mExecutorService
           .submit(new HeartbeatThread(HeartbeatContext.MASTER_METRICS_SYNC, mClientMasterSync,
               (int) Configuration.getMs(PropertyKey.USER_METRICS_HEARTBEAT_INTERVAL_MS)));
-      // register the shutdown hook
-      Runtime.getRuntime().addShutdownHook(new MetricsMasterSyncShutDownHook());
+      // register the shutdown hook if we are not running tests
+      if (!Configuration.getBoolean(PropertyKey.TEST_MODE)) {
+        Runtime.getRuntime().addShutdownHook(new MetricsMasterSyncShutDownHook());
+      }
     }
   }
 


### PR DESCRIPTION
This should stop each of our tests from hanging at the end, greatly increasing test speeds.