### PR TITLE
[SMALLFIX] Fix web UI fail to load issue

### DIFF
--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceGeneralServlet.java
@@ -208,7 +208,7 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
     }
 
     String ufsRoot = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsRoot);
+    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot();
 
     String totalSpace = "UNKNOWN";
     try {


### PR DESCRIPTION
Web UI might fail to load if anything given under `alluxio.master.mount.table.root.option` prefix is required to load the under file system.

Will port to 1.7 branch once approved.