### PR TITLE
[ALLUXIO-3211] Make metrics heartbeat retry-less on individual heartbeats.

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -185,7 +185,8 @@ public final class FileSystemContext implements Closeable {
     mBlockMasterClientPool = new BlockMasterClientPool(mParentSubject, mMasterInquireClient);
     mClosed.set(false);
 
-    if (Configuration.getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED)
+        && Configuration.getInt(PropertyKey.MASTER_RPC_PORT) != 0) {
       // setup metrics master client sync
       mMetricsMasterClient = new MetricsMasterClient(MasterClientConfig.defaults()
           .withSubject(mParentSubject).withMasterInquireClient(mMasterInquireClient));
@@ -220,7 +221,7 @@ public final class FileSystemContext implements Closeable {
     mNettyChannelPools.clear();
 
     synchronized (this) {
-      if (Configuration.getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED)) {
+      if (mMetricsMasterClient != null) {
         ThreadUtils.shutdownAndAwaitTermination(mExecutorService);
         mMetricsMasterClient.close();
         mMetricsMasterClient = null;

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -185,6 +185,7 @@ public final class FileSystemContext implements Closeable {
     mBlockMasterClientPool = new BlockMasterClientPool(mParentSubject, mMasterInquireClient);
     mClosed.set(false);
 
+    // Only send metrics if enabled and the port is set (can be zero when tests are setting up).
     if (Configuration.getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED)
         && Configuration.getInt(PropertyKey.MASTER_RPC_PORT) != 0) {
       // setup metrics master client sync

--- a/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
@@ -81,9 +81,7 @@ public class MetricsMasterClient extends AbstractMasterClient {
    * @param metrics a list of client metrics
    */
   public synchronized void heartbeat(final List<Metric> metrics) throws IOException {
-    if (!mConnected) {
-      connect();
-    }
+    connect();
     try {
       mClient.metricsHeartbeat(Long.toString(FileSystemContext.get().getId()),
           NetworkAddressUtils.getClientHostName(), new MetricsHeartbeatTOptions(metrics));

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -48,6 +48,14 @@ import javax.security.auth.Subject;
 public abstract class AbstractClient implements Client {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractClient.class);
 
+  private static Supplier<RetryPolicy> defaultRetry() {
+    Duration maxRetryDuration = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_DURATION);
+    Duration baseSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS);
+    Duration maxSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
+    return () -> ExponentialTimeBoundedRetry.builder().withMaxDuration(maxRetryDuration)
+        .withInitialSleep(baseSleepMs).withMaxSleep(maxSleepMs).build();
+  }
+
   private final Supplier<RetryPolicy> mRetryPolicySupplier;
 
   protected InetSocketAddress mAddress;
@@ -80,14 +88,6 @@ public abstract class AbstractClient implements Client {
    */
   public AbstractClient(Subject subject, InetSocketAddress address) {
     this(subject, address, defaultRetry());
-  }
-
-  private static Supplier<RetryPolicy> defaultRetry() {
-    Duration maxRetryDuration = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_DURATION);
-    Duration baseSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS);
-    Duration maxSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
-    return () -> ExponentialTimeBoundedRetry.builder().withMaxDuration(maxRetryDuration)
-        .withInitialSleep(baseSleepMs).withMaxSleep(maxSleepMs).build();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -14,8 +14,10 @@ package alluxio;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterClientConfig;
 import alluxio.master.MasterInquireClient;
+import alluxio.retry.RetryPolicy;
 
 import java.net.InetSocketAddress;
+import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -34,6 +36,17 @@ public abstract class AbstractMasterClient extends AbstractClient {
    */
   public AbstractMasterClient(MasterClientConfig conf) {
     super(conf.getSubject(), null);
+    mMasterInquireClient = conf.getMasterInquireClient();
+  }
+
+  /**
+   * Creates a new master client base.
+   *
+   * @param conf master client configuration
+   */
+  public AbstractMasterClient(MasterClientConfig conf, InetSocketAddress address,
+      Supplier<RetryPolicy> retryPolicySupplier) {
+    super(conf.getSubject(), address, retryPolicySupplier);
     mMasterInquireClient = conf.getMasterInquireClient();
   }
 

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -43,6 +43,8 @@ public abstract class AbstractMasterClient extends AbstractClient {
    * Creates a new master client base.
    *
    * @param conf master client configuration
+   * @param address address to connect to
+   * @param retryPolicySupplier retry policy to use
    */
   public AbstractMasterClient(MasterClientConfig conf, InetSocketAddress address,
       Supplier<RetryPolicy> retryPolicySupplier) {

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -74,7 +74,7 @@ public final class HeartbeatThread implements Runnable {
         mExecutor.heartbeat();
       }
     } catch (InterruptedException e) {
-      LOG.info("Hearbeat is interrupted.");
+      LOG.info("Hearbeat {} is interrupted.", mThreadName);
     } catch (Exception e) {
       LOG.error("Uncaught exception in heartbeat executor, Heartbeat Thread shutting down", e);
     } finally {

--- a/core/common/src/main/java/alluxio/retry/CountingRetry.java
+++ b/core/common/src/main/java/alluxio/retry/CountingRetry.java
@@ -30,7 +30,7 @@ public class CountingRetry implements RetryPolicy {
    * @param maxRetries max number of retries
    */
   public CountingRetry(int maxRetries) {
-    Preconditions.checkArgument(maxRetries >= 0, "Max retries must be a positive number");
+    Preconditions.checkArgument(maxRetries >= 0, "Max retries must be a non-negative number");
     mMaxRetries = maxRetries;
   }
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3210

Issues with testing w/ Metrics Heartbeat
* When initially starting up, port is 0, there is no point to try and heartbeat (fixed)
* Retrying metrics is not good because the heartbeat automatically does so, also it makes the shutdown hook hang if the master is not available (fixed)
* When stopping the LocalAlluxioCluster, we actually reset the client instead of stopping it, this leads to a heartbeat failure on each test because we stop the master (not fixed)