### PR TITLE
[SMALLFIX] ignore JournalShutdownIntegerationTest for now

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
  * Test master journal for cluster terminating. Assert that test can replay the log and reproduce
  * the correct state. Test both the single master and multi masters.
  */
+@Ignore
 public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   @ClassRule
   public static SystemPropertyRule sDisableHdfsCacheRule =


### PR DESCRIPTION
Since it times out after 2 hours