### PR TITLE
[ALLUXIO-3216] Instanced config

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -67,8 +67,6 @@
 
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">
-    <!-- Checks that a class which has only private constructors is declared as final. -->
-    <module name="FinalClass"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -77,7 +77,7 @@ public interface FileSystem {
           String key = entry.getKey();
           String value = entry.getValue();
           Source source = Configuration.getSource(PropertyKey.fromString(key));
-          LOG.debug("{}={} ({})", key, value, source.toString());
+          LOG.debug("{}={} ({})", key, value, source);
         }
       }
       if (Configuration.getBoolean(PropertyKey.USER_LINEAGE_ENABLED)) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -77,7 +77,7 @@ public interface FileSystem {
           String key = entry.getKey();
           String value = entry.getValue();
           Source source = Configuration.getSource(PropertyKey.fromString(key));
-          LOG.debug("{}={} ({}: {})", key, value, source.toString());
+          LOG.debug("{}={} ({})", key, value, source.toString());
         }
       }
       if (Configuration.getBoolean(PropertyKey.USER_LINEAGE_ENABLED)) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -77,12 +77,7 @@ public interface FileSystem {
           String key = entry.getKey();
           String value = entry.getValue();
           Source source = Configuration.getSource(PropertyKey.fromString(key));
-          if (source == Source.SITE_PROPERTY) {
-            LOG.debug("{}={} ({}: {})",
-                key, value, source.name(), Configuration.getSitePropertiesFile());
-          } else {
-            LOG.debug("{}={} ({})", key, value, source.name());
-          }
+          LOG.debug("{}={} ({}: {})", key, value, source.toString());
         }
       }
       if (Configuration.getBoolean(PropertyKey.USER_LINEAGE_ENABLED)) {

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -17,7 +17,7 @@ import static java.util.stream.Collectors.toMap;
 import alluxio.AlluxioConfiguration;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.InstancedConfiguration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.PropertyKey;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -14,8 +14,10 @@ package alluxio.hadoop;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import alluxio.AlluxioConfiguration;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
+import alluxio.InstancedConfiguration;
 import alluxio.PropertyKey;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
@@ -495,7 +497,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system. These
     // modifications to ClientContext are global, affecting all Alluxio clients in this JVM.
     // We assume here that all clients use the same configuration.
-    HadoopConfigurationUtils.mergeHadoopConfiguration(conf);
+    HadoopConfigurationUtils.mergeHadoopConfiguration(conf, Configuration.global());
     Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, isZookeeperMode());
     // When using zookeeper we get the leader master address from the alluxio.zookeeper.address
     // configuration property, so the user doesn't need to specify the authority.
@@ -532,21 +534,11 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   private boolean connectDetailsMatch(URI uri, org.apache.hadoop.conf.Configuration conf) {
     // Create the master inquire client that we would have after merging the hadoop conf into
     // Alluxio Configuration.
-    MasterInquireClient.Factory.Config inquireClientConf =
-        MasterInquireClient.Factory.Config.defaults();
-    inquireClientConf.setZookeeperEnabled(conf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED.getName(),
-        inquireClientConf.isZookeeperEnabled()));
-    inquireClientConf.setZookeeperAddress(
-        conf.get(PropertyKey.ZOOKEEPER_ADDRESS.getName(), inquireClientConf.getZookeeperAddress()));
-    inquireClientConf.setElectionPath(conf.get(PropertyKey.ZOOKEEPER_ELECTION_PATH.getName(),
-        inquireClientConf.getElectionPath()));
-    inquireClientConf.setLeaderPath(
-        conf.get(PropertyKey.ZOOKEEPER_ELECTION_PATH.getName(), inquireClientConf.getLeaderPath()));
-    inquireClientConf.setConnectHost(mUri.getHost());
-    inquireClientConf.setConnectPort(mUri.getPort());
-    MasterInquireClient configClient = MasterInquireClient.Factory.create(inquireClientConf);
-    MasterInquireClient contextClient = FileSystemContext.get().getMasterInquireClient();
-    return configClient.equals(contextClient);
+    AlluxioConfiguration alluxioConf = new InstancedConfiguration(Configuration.global());
+    HadoopConfigurationUtils.mergeHadoopConfiguration(conf, alluxioConf);
+    MasterInquireClient configClient = MasterInquireClient.Factory.create(alluxioConf);
+
+    return configClient.equals(FileSystemContext.get().getMasterInquireClient());
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -536,9 +536,9 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     // Alluxio Configuration.
     AlluxioConfiguration alluxioConf = new InstancedConfiguration(Configuration.global());
     HadoopConfigurationUtils.mergeHadoopConfiguration(conf, alluxioConf);
-    MasterInquireClient configClient = MasterInquireClient.Factory.create(alluxioConf);
+    MasterInquireClient confClient = MasterInquireClient.Factory.create(alluxioConf);
 
-    return configClient.equals(FileSystemContext.get().getMasterInquireClient());
+    return confClient.equals(FileSystemContext.get().getMasterInquireClient());
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -11,6 +11,7 @@
 
 package alluxio.hadoop;
 
+import alluxio.AlluxioConfiguration;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.conf.Source;
@@ -54,11 +55,13 @@ public final class HadoopConfigurationUtils {
   }
 
   /**
-   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} into the Alluxio configuration.
+   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} into the Alluxio properties.
    *
    * @param source the {@link org.apache.hadoop.conf.Configuration} to merge
+   * @param alluxioConfiguration the Alluxio configuration to merge to
    */
-  public static void mergeHadoopConfiguration(org.apache.hadoop.conf.Configuration source) {
+  public static void mergeHadoopConfiguration(org.apache.hadoop.conf.Configuration source,
+      AlluxioConfiguration alluxioConfiguration) {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system
     // Push Alluxio configuration to the Job configuration
     Properties alluxioConfProperties = new Properties();
@@ -72,7 +75,7 @@ public final class HadoopConfigurationUtils {
     LOG.info("Loading Alluxio properties from Hadoop configuration: {}", alluxioConfProperties);
     // Merge the relevant Hadoop configuration into Alluxio's configuration.
     // TODO(jiri): support multiple client configurations (ALLUXIO-2034)
-    Configuration.merge(alluxioConfProperties, Source.RUNTIME);
-    Configuration.validate();
+    alluxioConfiguration.merge(alluxioConfProperties, Source.RUNTIME);
+    alluxioConfiguration.validate();
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -55,7 +55,7 @@ public final class HadoopConfigurationUtils {
   }
 
   /**
-   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} into the Alluxio properties.
+   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} into the Alluxio configuration.
    *
    * @param source the {@link org.apache.hadoop.conf.Configuration} to merge
    * @param alluxioConfiguration the Alluxio configuration to merge to

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -42,7 +42,7 @@ public final class HadoopConfigurationUtilsTest {
   public void mergeEmptyHadoopConfiguration() {
     org.apache.hadoop.conf.Configuration hadoopConfig = new org.apache.hadoop.conf.Configuration();
     long beforeSize = Configuration.toMap().size();
-    HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
+    HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, Configuration.global());
     long afterSize = Configuration.toMap().size();
     Assert.assertEquals(beforeSize, afterSize);
   }
@@ -59,7 +59,7 @@ public final class HadoopConfigurationUtilsTest {
 
     // This hadoop config will not be loaded into Alluxio configuration.
     hadoopConfig.set("hadoop.config.parameter", "hadoop config value");
-    HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig);
+    HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, Configuration.global());
     Assert.assertEquals(TEST_S3_ACCCES_KEY, Configuration.get(PropertyKey.S3A_ACCESS_KEY));
     Assert.assertEquals(TEST_S3_SECRET_KEY, Configuration.get(PropertyKey.S3A_SECRET_KEY));
     Assert.assertEquals(Source.RUNTIME, Configuration.getSource(PropertyKey.S3A_ACCESS_KEY));

--- a/core/common/src/main/java/alluxio/AlluxioConfiguration.java
+++ b/core/common/src/main/java/alluxio/AlluxioConfiguration.java
@@ -1,0 +1,498 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.PropertyKey.Template;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.Source;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.PreconditionMessage;
+import alluxio.util.FormatUtils;
+import alluxio.wire.ConfigProperty;
+import alluxio.wire.Scope;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+public class AlluxioConfiguration {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
+
+  /** Regex string to find "${key}" for variable substitution. */
+  private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
+  /** Regex to find ${key} for variable substitution. */
+  private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
+  /** Source of the truth of all property values (default or customized). */
+  private final AlluxioProperties mProperties;
+
+  public AlluxioConfiguration(AlluxioProperties properties) {
+    mProperties = properties;
+  }
+
+  /**
+   * Gets the value for the given key in the {@link Properties}; if this key is not found, a
+   * RuntimeException is thrown.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key
+   */
+  public String get(PropertyKey key) {
+    String rawValue = mProperties.get(key);
+    if (rawValue == null) {
+      // if key is not found among the default properties
+      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
+    }
+    return lookup(rawValue);
+  }
+
+  /**
+   * Checks if the configuration contains value for the given key.
+   *
+   * @param key the key to check
+   * @return true if there is value for the key, false otherwise
+   */
+  public boolean containsKey(PropertyKey key) {
+    return mProperties.hasValueSet(key);
+  }
+
+  /**
+   * Gets the integer representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as an {@code int}
+   */
+  public int getInt(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Integer.parseInt(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_INTEGER.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the long representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code long}
+   */
+  public long getLong(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Long.parseLong(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_LONG.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the double representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code double}
+   */
+  public double getDouble(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Double.parseDouble(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_DOUBLE.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the float representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code float}
+   */
+  public float getFloat(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Float.parseFloat(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_FLOAT.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the boolean representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code boolean}
+   */
+  public boolean getBoolean(PropertyKey key) {
+    String rawValue = get(key);
+
+    if (rawValue.equalsIgnoreCase("true")) {
+      return true;
+    } else if (rawValue.equalsIgnoreCase("false")) {
+      return false;
+    } else {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_BOOLEAN.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the value for the given key as a list.
+   *
+   * @param key the key to get the value for
+   * @param delimiter the delimiter to split the values
+   * @return the list of values for the given key
+   */
+  public List<String> getList(PropertyKey key, String delimiter) {
+    Preconditions.checkArgument(delimiter != null,
+        "Illegal separator for Alluxio properties as list");
+    String rawValue = get(key);
+
+    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
+        .split(rawValue));
+  }
+
+  /**
+   * Gets the value for the given key as an enum value.
+   *
+   * @param key the key to get the value for
+   * @param enumType the type of the enum
+   * @param <T> the type of the enum
+   * @return the value for the given key as an enum value
+   */
+  public <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType) {
+    String rawValue = get(key);
+
+    try {
+      return Enum.valueOf(enumType, rawValue);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException(ExceptionMessage.UNKNOWN_ENUM.getMessage(rawValue,
+          Arrays.toString(enumType.getEnumConstants())));
+    }
+  }
+
+  /**
+   * Gets the bytes of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the bytes of the value for the given key
+   */
+  public long getBytes(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return FormatUtils.parseSpaceSize(rawValue);
+    } catch (Exception ex) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_BYTES.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the time of key in millisecond unit.
+   *
+   * @param key the key to get the value for
+   * @return the time of key in millisecond unit
+   */
+  public long getMs(PropertyKey key) {
+    String rawValue = get(key);
+    try {
+      return FormatUtils.parseTimeSize(rawValue);
+    } catch (Exception e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_MS.getMessage(key));
+    }
+  }
+
+  /**
+   * Gets the time of the key as a duration.
+   *
+   * @param key the key to get the value for
+   * @return the value of the key represented as a duration
+   */
+  public Duration getDuration(PropertyKey key) {
+    return Duration.ofMillis(getMs(key));
+  }
+
+  /**
+   * Gets the value for the given key as a class.
+   *
+   * @param key the key to get the value for
+   * @param <T> the type of the class
+   * @return the value for the given key as a class
+   */
+  public <T> Class<T> getClass(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      @SuppressWarnings("unchecked")
+      Class<T> clazz = (Class<T>) Class.forName(rawValue);
+      return clazz;
+    } catch (Exception e) {
+      LOG.error("requested class could not be loaded: {}", rawValue, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets a set of properties that share a given common prefix key as a map. E.g., if A.B=V1 and
+   * A.C=V2, calling this method with prefixKey=A returns a map of {B=V1, C=V2}, where B and C are
+   * also valid properties. If no property shares the prefix, an empty map is returned.
+   *
+   * @param prefixKey the prefix key
+   * @return a map from nested properties aggregated by the prefix
+   */
+  public Map<String, String> getNestedProperties(PropertyKey prefixKey) {
+    Map<String, String> ret = Maps.newHashMap();
+    for (Map.Entry<PropertyKey, String> entry: mProperties.entrySet()) {
+      String key = entry.getKey().getName();
+      if (prefixKey.isNested(key)) {
+        String suffixKey = key.substring(prefixKey.length() + 1);
+        ret.put(suffixKey, entry.getValue());
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * @return a view of the resolved properties represented by this configuration,
+   *         including all default properties
+   */
+  public Map<String, String> toMap() {
+    Map<String, String> map = toRawMap();
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        map.put(entry.getKey(), lookup(value));
+      } else {
+        map.put(entry.getKey(), value);
+      }
+    }
+    return map;
+  }
+
+  /**
+   * @return a map of the raw properties represented by this configuration,
+   *         including all default properties
+   */
+  public Map<String, String> toRawMap() {
+    Map<String, String> rawMap = new HashMap<>();
+    mProperties.forEach((key, value) -> rawMap.put(key.getName(), value));
+    return rawMap;
+  }
+
+  /**
+   * Lookup key names to handle ${key} stuff.
+   *
+   * @param base the String to look for
+   * @return resolved String value
+   */
+  private String lookup(final String base) {
+    return lookupRecursively(base, new HashSet<>());
+  }
+
+  /**
+   * Actual recursive lookup replacement.
+   *
+   * @param base the string to resolve
+   * @param seen strings already seen during this lookup, used to prevent unbound recursion
+   * @return the resolved string
+   */
+  @Nullable
+  private String lookupRecursively(String base, Set<String> seen) {
+    // check argument
+    if (base == null) {
+      return null;
+    }
+
+    String resolved = base;
+    // Lets find pattern match to ${key}.
+    // TODO(hsaputra): Consider using Apache Commons StrSubstitutor.
+    Matcher matcher = CONF_REGEX.matcher(base);
+    while (matcher.find()) {
+      String match = matcher.group(2).trim();
+      if (!seen.add(match)) {
+        throw new RuntimeException("Circular dependency found while resolving " + match);
+      }
+      if (!PropertyKey.isValid(match)) {
+        throw new RuntimeException("Invalid property key " + match);
+      }
+      String value = lookupRecursively(mProperties.get(PropertyKey.fromString(match)), seen);
+      seen.remove(match);
+      if (value == null) {
+        throw new RuntimeException("No value specified for configuration property " + match);
+      }
+      LOG.debug("Replacing {} with {}", matcher.group(1), value);
+      resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
+    }
+    return resolved;
+  }
+
+  /**
+   * @param key the property key
+   * @return the source for the given key
+   */
+  public Source getSource(PropertyKey key) {
+    return mProperties.getSource(key);
+  }
+
+  /**
+   * Validates worker port configuration.
+   *
+   * @throws IllegalStateException if invalid worker port configuration is encountered
+   */
+  private void checkWorkerPorts() {
+    int maxWorkersPerHost = getInt(PropertyKey.INTEGRATION_YARN_WORKERS_PER_HOST_MAX);
+    if (maxWorkersPerHost > 1) {
+      String message = "%s cannot be specified when allowing multiple workers per host with "
+          + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_DATA_PORT) == null,
+          String.format(message, PropertyKey.WORKER_DATA_PORT));
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
+          String.format(message, PropertyKey.WORKER_RPC_PORT));
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
+          String.format(message, PropertyKey.WORKER_WEB_PORT));
+    }
+  }
+
+  /**
+   * Validates timeout related configuration.
+   */
+  private void checkTimeouts() {
+    long waitTime = getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
+    long retryInterval = getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
+    if (waitTime < retryInterval) {
+      LOG.warn("{}={}ms is smaller than {}={}ms. Workers might not have enough time to register. "
+              + "Consider either increasing {} or decreasing {}",
+          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME, waitTime,
+          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS, retryInterval,
+          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME,
+          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS);
+    }
+  }
+
+  /**
+   * Validates the user file buffer size is a non-negative number.
+   *
+   * @throws IllegalStateException if invalid user file buffer size configuration is encountered
+   */
+  private void checkUserFileBufferBytes() {
+    if (!containsKey(PropertyKey.USER_FILE_BUFFER_BYTES)) { // load from hadoop conf
+      return;
+    }
+    long usrFileBufferBytes = getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
+    Preconditions.checkState((usrFileBufferBytes & Integer.MAX_VALUE) == usrFileBufferBytes,
+        PreconditionMessage.INVALID_USER_FILE_BUFFER_BYTES.toString(),
+        PropertyKey.Name.USER_FILE_BUFFER_BYTES, usrFileBufferBytes);
+  }
+
+  /**
+   * Validates Zookeeper-related configuration and prints warnings for possible sources of error.
+   *
+   * @throws IllegalStateException if invalid Zookeeper configuration is encountered
+   */
+  private void checkZkConfiguration() {
+    Preconditions.checkState(
+        containsKey(PropertyKey.ZOOKEEPER_ADDRESS) == getBoolean(PropertyKey.ZOOKEEPER_ENABLED),
+        PreconditionMessage.INCONSISTENT_ZK_CONFIGURATION.toString(),
+        PropertyKey.Name.ZOOKEEPER_ADDRESS, PropertyKey.Name.ZOOKEEPER_ENABLED);
+  }
+
+  /**
+   * Checks that tiered locality configuration is consistent.
+   *
+   * @throws IllegalStateException if invalid tiered locality configuration is encountered
+   */
+  private void checkTieredLocality() {
+    // Check that any custom tiers set by alluxio.locality.{custom_tier}=value are also defined in
+    // the tier ordering defined by alluxio.locality.order.
+    Set<String> tiers = Sets.newHashSet(getList(PropertyKey.LOCALITY_ORDER, ","));
+    Set<PropertyKey> predefinedKeys = new HashSet<>(PropertyKey.defaultKeys());
+    for (PropertyKey key : mProperties.keySet()) {
+      if (predefinedKeys.contains(key)) {
+        // Skip non-templated keys.
+        continue;
+      }
+      Matcher matcher = Template.LOCALITY_TIER.match(key.toString());
+      if (matcher.matches() && matcher.group(1) != null) {
+        String tierName = matcher.group(1);
+        if (!tiers.contains(tierName)) {
+          throw new IllegalStateException(
+              String.format("Tier %s is configured by %s, but does not exist in the tier list %s "
+                  + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
+        }
+      }
+    }
+  }
+
+  /**
+   * Validates the configuration.
+   *
+   * @throws IllegalStateException if invalid configuration is encountered
+   */
+  public void validate() {
+    for (Map.Entry<String, String> entry : toMap().entrySet()) {
+      String propertyName = entry.getKey();
+      Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
+      PropertyKey propertyKey = PropertyKey.fromString(propertyName);
+      Preconditions.checkState(
+          getSource(propertyKey).getType() != Source.Type.SITE_PROPERTY
+              || !propertyKey.isIgnoredSiteProperty(),
+          "%s is not accepted in alluxio-site.properties, "
+              + "and must be specified as a JVM property. "
+              + "If no JVM property is present, Alluxio will use default value '%s'.", propertyName,
+          propertyKey.getDefaultValue());
+    }
+    checkTimeouts();
+    checkWorkerPorts();
+    checkUserFileBufferBytes();
+    checkZkConfiguration();
+    checkTieredLocality();
+  }
+
+  /**
+   * Gets the raw configuration of a given scope.
+   *
+   * @param scope the property key scope
+   * @return a list of raw configurations inside the property scope
+   */
+  public List<ConfigProperty> getConfiguration(Scope scope) {
+    List<ConfigProperty> list = new ArrayList<>();
+    for (Map.Entry<String, String> entry : toRawMap().entrySet()) {
+      PropertyKey key = PropertyKey.fromString(entry.getKey());
+      if (key.getScope().contains(scope) && containsKey(key)) {
+        ConfigProperty configProperty = new ConfigProperty().setName(key.getName())
+            .setValue(get(key)).setSource(Configuration.getSource(key).toString());
+        list.add(configProperty);
+      }
+    }
+    return list;
+  }
+}

--- a/core/common/src/main/java/alluxio/AlluxioConfiguration.java
+++ b/core/common/src/main/java/alluxio/AlluxioConfiguration.java
@@ -11,52 +11,19 @@
 
 package alluxio;
 
-import alluxio.PropertyKey.Template;
-import alluxio.conf.AlluxioProperties;
 import alluxio.conf.Source;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.PreconditionMessage;
-import alluxio.util.FormatUtils;
 import alluxio.wire.ConfigProperty;
 import alluxio.wire.Scope;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
-public class AlluxioConfiguration {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
-
-  /** Regex string to find "${key}" for variable substitution. */
-  private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
-  /** Regex to find ${key} for variable substitution. */
-  private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
-  /** Source of the truth of all property values (default or customized). */
-  private final AlluxioProperties mProperties;
-
-  public AlluxioConfiguration(AlluxioProperties properties) {
-    mProperties = properties;
-  }
-
+/**
+ * Alluxio configuration.
+ */
+public interface AlluxioConfiguration {
   /**
    * Gets the value for the given key in the {@link Properties}; if this key is not found, a
    * RuntimeException is thrown.
@@ -64,14 +31,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key
    */
-  public String get(PropertyKey key) {
-    String rawValue = mProperties.get(key);
-    if (rawValue == null) {
-      // if key is not found among the default properties
-      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
-    }
-    return lookup(rawValue);
-  }
+  String get(PropertyKey key);
 
   /**
    * Checks if the configuration contains value for the given key.
@@ -79,9 +39,7 @@ public class AlluxioConfiguration {
    * @param key the key to check
    * @return true if there is value for the key, false otherwise
    */
-  public boolean containsKey(PropertyKey key) {
-    return mProperties.hasValueSet(key);
-  }
+  boolean containsKey(PropertyKey key);
 
   /**
    * Gets the integer representation of the value for the given key.
@@ -89,15 +47,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key as an {@code int}
    */
-  public int getInt(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Integer.parseInt(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_INTEGER.getMessage(key));
-    }
-  }
+  int getInt(PropertyKey key);
 
   /**
    * Gets the long representation of the value for the given key.
@@ -105,15 +55,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key as a {@code long}
    */
-  public long getLong(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Long.parseLong(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_LONG.getMessage(key));
-    }
-  }
+  long getLong(PropertyKey key);
 
   /**
    * Gets the double representation of the value for the given key.
@@ -121,15 +63,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key as a {@code double}
    */
-  public double getDouble(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Double.parseDouble(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_DOUBLE.getMessage(key));
-    }
-  }
+  double getDouble(PropertyKey key);
 
   /**
    * Gets the float representation of the value for the given key.
@@ -137,15 +71,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key as a {@code float}
    */
-  public float getFloat(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Float.parseFloat(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_FLOAT.getMessage(key));
-    }
-  }
+  float getFloat(PropertyKey key);
 
   /**
    * Gets the boolean representation of the value for the given key.
@@ -153,17 +79,8 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value for the given key as a {@code boolean}
    */
-  public boolean getBoolean(PropertyKey key) {
-    String rawValue = get(key);
+  boolean getBoolean(PropertyKey key);
 
-    if (rawValue.equalsIgnoreCase("true")) {
-      return true;
-    } else if (rawValue.equalsIgnoreCase("false")) {
-      return false;
-    } else {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_BOOLEAN.getMessage(key));
-    }
-  }
 
   /**
    * Gets the value for the given key as a list.
@@ -172,14 +89,8 @@ public class AlluxioConfiguration {
    * @param delimiter the delimiter to split the values
    * @return the list of values for the given key
    */
-  public List<String> getList(PropertyKey key, String delimiter) {
-    Preconditions.checkArgument(delimiter != null,
-        "Illegal separator for Alluxio properties as list");
-    String rawValue = get(key);
+  List<String> getList(PropertyKey key, String delimiter);
 
-    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
-        .split(rawValue));
-  }
 
   /**
    * Gets the value for the given key as an enum value.
@@ -189,16 +100,7 @@ public class AlluxioConfiguration {
    * @param <T> the type of the enum
    * @return the value for the given key as an enum value
    */
-  public <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType) {
-    String rawValue = get(key);
-
-    try {
-      return Enum.valueOf(enumType, rawValue);
-    } catch (IllegalArgumentException e) {
-      throw new RuntimeException(ExceptionMessage.UNKNOWN_ENUM.getMessage(rawValue,
-          Arrays.toString(enumType.getEnumConstants())));
-    }
-  }
+  <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType);
 
   /**
    * Gets the bytes of the value for the given key.
@@ -206,15 +108,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the bytes of the value for the given key
    */
-  public long getBytes(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return FormatUtils.parseSpaceSize(rawValue);
-    } catch (Exception ex) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_BYTES.getMessage(key));
-    }
-  }
+  long getBytes(PropertyKey key);
 
   /**
    * Gets the time of key in millisecond unit.
@@ -222,14 +116,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the time of key in millisecond unit
    */
-  public long getMs(PropertyKey key) {
-    String rawValue = get(key);
-    try {
-      return FormatUtils.parseTimeSize(rawValue);
-    } catch (Exception e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_MS.getMessage(key));
-    }
-  }
+  long getMs(PropertyKey key);
 
   /**
    * Gets the time of the key as a duration.
@@ -237,9 +124,7 @@ public class AlluxioConfiguration {
    * @param key the key to get the value for
    * @return the value of the key represented as a duration
    */
-  public Duration getDuration(PropertyKey key) {
-    return Duration.ofMillis(getMs(key));
-  }
+  Duration getDuration(PropertyKey key);
 
   /**
    * Gets the value for the given key as a class.
@@ -248,18 +133,7 @@ public class AlluxioConfiguration {
    * @param <T> the type of the class
    * @return the value for the given key as a class
    */
-  public <T> Class<T> getClass(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      @SuppressWarnings("unchecked")
-      Class<T> clazz = (Class<T>) Class.forName(rawValue);
-      return clazz;
-    } catch (Exception e) {
-      LOG.error("requested class could not be loaded: {}", rawValue, e);
-      throw new RuntimeException(e);
-    }
-  }
+  <T> Class<T> getClass(PropertyKey key);
 
   /**
    * Gets a set of properties that share a given common prefix key as a map. E.g., if A.B=V1 and
@@ -269,213 +143,25 @@ public class AlluxioConfiguration {
    * @param prefixKey the prefix key
    * @return a map from nested properties aggregated by the prefix
    */
-  public Map<String, String> getNestedProperties(PropertyKey prefixKey) {
-    Map<String, String> ret = Maps.newHashMap();
-    for (Map.Entry<PropertyKey, String> entry: mProperties.entrySet()) {
-      String key = entry.getKey().getName();
-      if (prefixKey.isNested(key)) {
-        String suffixKey = key.substring(prefixKey.length() + 1);
-        ret.put(suffixKey, entry.getValue());
-      }
-    }
-    return ret;
-  }
+  Map<String, String> getNestedProperties(PropertyKey prefixKey);
 
   /**
    * @return a view of the resolved properties represented by this configuration,
    *         including all default properties
    */
-  public Map<String, String> toMap() {
-    Map<String, String> map = toRawMap();
-    for (Map.Entry<String, String> entry : map.entrySet()) {
-      String value = entry.getValue();
-      if (value != null) {
-        map.put(entry.getKey(), lookup(value));
-      } else {
-        map.put(entry.getKey(), value);
-      }
-    }
-    return map;
-  }
+  Map<String, String> toMap();
 
   /**
    * @return a map of the raw properties represented by this configuration,
    *         including all default properties
    */
-  public Map<String, String> toRawMap() {
-    Map<String, String> rawMap = new HashMap<>();
-    mProperties.forEach((key, value) -> rawMap.put(key.getName(), value));
-    return rawMap;
-  }
-
-  /**
-   * Lookup key names to handle ${key} stuff.
-   *
-   * @param base the String to look for
-   * @return resolved String value
-   */
-  private String lookup(final String base) {
-    return lookupRecursively(base, new HashSet<>());
-  }
-
-  /**
-   * Actual recursive lookup replacement.
-   *
-   * @param base the string to resolve
-   * @param seen strings already seen during this lookup, used to prevent unbound recursion
-   * @return the resolved string
-   */
-  @Nullable
-  private String lookupRecursively(String base, Set<String> seen) {
-    // check argument
-    if (base == null) {
-      return null;
-    }
-
-    String resolved = base;
-    // Lets find pattern match to ${key}.
-    // TODO(hsaputra): Consider using Apache Commons StrSubstitutor.
-    Matcher matcher = CONF_REGEX.matcher(base);
-    while (matcher.find()) {
-      String match = matcher.group(2).trim();
-      if (!seen.add(match)) {
-        throw new RuntimeException("Circular dependency found while resolving " + match);
-      }
-      if (!PropertyKey.isValid(match)) {
-        throw new RuntimeException("Invalid property key " + match);
-      }
-      String value = lookupRecursively(mProperties.get(PropertyKey.fromString(match)), seen);
-      seen.remove(match);
-      if (value == null) {
-        throw new RuntimeException("No value specified for configuration property " + match);
-      }
-      LOG.debug("Replacing {} with {}", matcher.group(1), value);
-      resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
-    }
-    return resolved;
-  }
+  Map<String, String> toRawMap();
 
   /**
    * @param key the property key
    * @return the source for the given key
    */
-  public Source getSource(PropertyKey key) {
-    return mProperties.getSource(key);
-  }
-
-  /**
-   * Validates worker port configuration.
-   *
-   * @throws IllegalStateException if invalid worker port configuration is encountered
-   */
-  private void checkWorkerPorts() {
-    int maxWorkersPerHost = getInt(PropertyKey.INTEGRATION_YARN_WORKERS_PER_HOST_MAX);
-    if (maxWorkersPerHost > 1) {
-      String message = "%s cannot be specified when allowing multiple workers per host with "
-          + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_DATA_PORT) == null,
-          String.format(message, PropertyKey.WORKER_DATA_PORT));
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
-          String.format(message, PropertyKey.WORKER_RPC_PORT));
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
-          String.format(message, PropertyKey.WORKER_WEB_PORT));
-    }
-  }
-
-  /**
-   * Validates timeout related configuration.
-   */
-  private void checkTimeouts() {
-    long waitTime = getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
-    long retryInterval = getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
-    if (waitTime < retryInterval) {
-      LOG.warn("{}={}ms is smaller than {}={}ms. Workers might not have enough time to register. "
-              + "Consider either increasing {} or decreasing {}",
-          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME, waitTime,
-          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS, retryInterval,
-          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME,
-          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS);
-    }
-  }
-
-  /**
-   * Validates the user file buffer size is a non-negative number.
-   *
-   * @throws IllegalStateException if invalid user file buffer size configuration is encountered
-   */
-  private void checkUserFileBufferBytes() {
-    if (!containsKey(PropertyKey.USER_FILE_BUFFER_BYTES)) { // load from hadoop conf
-      return;
-    }
-    long usrFileBufferBytes = getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
-    Preconditions.checkState((usrFileBufferBytes & Integer.MAX_VALUE) == usrFileBufferBytes,
-        PreconditionMessage.INVALID_USER_FILE_BUFFER_BYTES.toString(),
-        PropertyKey.Name.USER_FILE_BUFFER_BYTES, usrFileBufferBytes);
-  }
-
-  /**
-   * Validates Zookeeper-related configuration and prints warnings for possible sources of error.
-   *
-   * @throws IllegalStateException if invalid Zookeeper configuration is encountered
-   */
-  private void checkZkConfiguration() {
-    Preconditions.checkState(
-        containsKey(PropertyKey.ZOOKEEPER_ADDRESS) == getBoolean(PropertyKey.ZOOKEEPER_ENABLED),
-        PreconditionMessage.INCONSISTENT_ZK_CONFIGURATION.toString(),
-        PropertyKey.Name.ZOOKEEPER_ADDRESS, PropertyKey.Name.ZOOKEEPER_ENABLED);
-  }
-
-  /**
-   * Checks that tiered locality configuration is consistent.
-   *
-   * @throws IllegalStateException if invalid tiered locality configuration is encountered
-   */
-  private void checkTieredLocality() {
-    // Check that any custom tiers set by alluxio.locality.{custom_tier}=value are also defined in
-    // the tier ordering defined by alluxio.locality.order.
-    Set<String> tiers = Sets.newHashSet(getList(PropertyKey.LOCALITY_ORDER, ","));
-    Set<PropertyKey> predefinedKeys = new HashSet<>(PropertyKey.defaultKeys());
-    for (PropertyKey key : mProperties.keySet()) {
-      if (predefinedKeys.contains(key)) {
-        // Skip non-templated keys.
-        continue;
-      }
-      Matcher matcher = Template.LOCALITY_TIER.match(key.toString());
-      if (matcher.matches() && matcher.group(1) != null) {
-        String tierName = matcher.group(1);
-        if (!tiers.contains(tierName)) {
-          throw new IllegalStateException(
-              String.format("Tier %s is configured by %s, but does not exist in the tier list %s "
-                  + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
-        }
-      }
-    }
-  }
-
-  /**
-   * Validates the configuration.
-   *
-   * @throws IllegalStateException if invalid configuration is encountered
-   */
-  public void validate() {
-    for (Map.Entry<String, String> entry : toMap().entrySet()) {
-      String propertyName = entry.getKey();
-      Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
-      PropertyKey propertyKey = PropertyKey.fromString(propertyName);
-      Preconditions.checkState(
-          getSource(propertyKey).getType() != Source.Type.SITE_PROPERTY
-              || !propertyKey.isIgnoredSiteProperty(),
-          "%s is not accepted in alluxio-site.properties, "
-              + "and must be specified as a JVM property. "
-              + "If no JVM property is present, Alluxio will use default value '%s'.", propertyName,
-          propertyKey.getDefaultValue());
-    }
-    checkTimeouts();
-    checkWorkerPorts();
-    checkUserFileBufferBytes();
-    checkZkConfiguration();
-    checkTieredLocality();
-  }
+  Source getSource(PropertyKey key);
 
   /**
    * Gets the raw configuration of a given scope.
@@ -483,16 +169,22 @@ public class AlluxioConfiguration {
    * @param scope the property key scope
    * @return a list of raw configurations inside the property scope
    */
-  public List<ConfigProperty> getConfiguration(Scope scope) {
-    List<ConfigProperty> list = new ArrayList<>();
-    for (Map.Entry<String, String> entry : toRawMap().entrySet()) {
-      PropertyKey key = PropertyKey.fromString(entry.getKey());
-      if (key.getScope().contains(scope) && containsKey(key)) {
-        ConfigProperty configProperty = new ConfigProperty().setName(key.getName())
-            .setValue(get(key)).setSource(Configuration.getSource(key).toString());
-        list.add(configProperty);
-      }
-    }
-    return list;
-  }
+  List<ConfigProperty> getConfiguration(Scope scope);
+
+  /**
+   * Merges the current configuration properties with new properties. If a property exists
+   * both in the new and current configuration, the one from the new configuration wins if
+   * its priority is higher or equal than the existing one.
+   *
+   * @param properties the source {@link Properties} to be merged
+   * @param source the source of the the properties (e.g., system property, default and etc)
+   */
+  void merge(Map<?, ?> properties, Source source);
+
+  /**
+   * Validates the configuration.
+   *
+   * @throws IllegalStateException if invalid configuration is encountered
+   */
+  void validate();
 }

--- a/core/common/src/main/java/alluxio/AlluxioConfiguration.java
+++ b/core/common/src/main/java/alluxio/AlluxioConfiguration.java
@@ -81,7 +81,6 @@ public interface AlluxioConfiguration {
    */
   boolean getBoolean(PropertyKey key);
 
-
   /**
    * Gets the value for the given key as a list.
    *
@@ -90,7 +89,6 @@ public interface AlluxioConfiguration {
    * @return the list of values for the given key
    */
   List<String> getList(PropertyKey key, String delimiter);
-
 
   /**
    * Gets the value for the given key as an enum value.

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -18,14 +18,11 @@ import alluxio.wire.ConfigProperty;
 import alluxio.wire.Scope;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -50,15 +47,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class Configuration {
-  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
-
-  /** Regex string to find "${key}" for variable substitution. */
-  private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
-  /** Regex to find ${key} for variable substitution. */
-  private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
-
   private static final AlluxioProperties PROPERTIES = new AlluxioProperties();
-  private static final AlluxioConfiguration CONF = new AlluxioConfiguration(PROPERTIES);
+  private static final InstancedConfiguration CONF = new InstancedConfiguration(PROPERTIES);
 
   static {
     reset();
@@ -318,6 +308,13 @@ public final class Configuration {
    */
   public static List<ConfigProperty> getConfiguration(Scope scope) {
     return CONF.getConfiguration(scope);
+  }
+
+  /**
+   * @return the {@link InstancedConfiguration} object backing the global configuration
+   */
+  public static InstancedConfiguration global() {
+    return CONF;
   }
 
   private Configuration() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -12,6 +12,7 @@
 package alluxio;
 
 import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.Source;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.ConfigProperty;

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -11,37 +11,22 @@
 
 package alluxio;
 
-import alluxio.PropertyKey.Template;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.Source;
-import alluxio.exception.ExceptionMessage;
-import alluxio.exception.PreconditionMessage;
 import alluxio.util.ConfigurationUtils;
-import alluxio.util.FormatUtils;
 import alluxio.wire.ConfigProperty;
 import alluxio.wire.Scope;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -71,10 +56,9 @@ public final class Configuration {
   private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
   /** Regex to find ${key} for variable substitution. */
   private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
-  /** Source of the truth of all property values (default or customized). */
+
   private static final AlluxioProperties PROPERTIES = new AlluxioProperties();
-  /** Path of site properties file. */
-  private static String sSitePropertyFile;
+  private static final AlluxioConfiguration CONF = new AlluxioConfiguration(PROPERTIES);
 
   static {
     reset();
@@ -100,14 +84,14 @@ public final class Configuration {
     // we are not in test mode, load site properties
     String confPaths = Configuration.get(PropertyKey.SITE_CONF_DIR);
     String[] confPathList = confPaths.split(",");
-    sSitePropertyFile =
+    String sitePropertyFile =
         ConfigurationUtils.searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
-    if (sSitePropertyFile != null) {
-      siteProps = ConfigurationUtils.loadPropertiesFromFile(sSitePropertyFile);
+    if (sitePropertyFile != null) {
+      siteProps = ConfigurationUtils.loadPropertiesFromFile(sitePropertyFile);
     } else {
       siteProps = ConfigurationUtils.loadPropertiesFromResource(Constants.SITE_PROPERTIES);
     }
-    PROPERTIES.merge(siteProps, Source.SITE_PROPERTY);
+    PROPERTIES.merge(siteProps, Source.siteProperty(sitePropertyFile));
     validate();
   }
 
@@ -154,12 +138,7 @@ public final class Configuration {
    * @return the value for the given key
    */
   public static String get(PropertyKey key) {
-    String rawValue = PROPERTIES.get(key);
-    if (rawValue == null) {
-      // if key is not found among the default properties
-      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
-    }
-    return lookup(rawValue);
+    return CONF.get(key);
   }
 
   /**
@@ -169,7 +148,7 @@ public final class Configuration {
    * @return true if there is value for the key, false otherwise
    */
   public static boolean containsKey(PropertyKey key) {
-    return PROPERTIES.hasValueSet(key);
+    return CONF.containsKey(key);
   }
 
   /**
@@ -179,13 +158,7 @@ public final class Configuration {
    * @return the value for the given key as an {@code int}
    */
   public static int getInt(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Integer.parseInt(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_INTEGER.getMessage(key));
-    }
+    return CONF.getInt(key);
   }
 
   /**
@@ -195,13 +168,7 @@ public final class Configuration {
    * @return the value for the given key as a {@code long}
    */
   public static long getLong(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Long.parseLong(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_LONG.getMessage(key));
-    }
+    return CONF.getLong(key);
   }
 
   /**
@@ -211,13 +178,7 @@ public final class Configuration {
    * @return the value for the given key as a {@code double}
    */
   public static double getDouble(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Double.parseDouble(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_DOUBLE.getMessage(key));
-    }
+    return CONF.getDouble(key);
   }
 
   /**
@@ -227,13 +188,7 @@ public final class Configuration {
    * @return the value for the given key as a {@code float}
    */
   public static float getFloat(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return Float.parseFloat(lookup(rawValue));
-    } catch (NumberFormatException e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_FLOAT.getMessage(key));
-    }
+    return CONF.getFloat(key);
   }
 
   /**
@@ -243,15 +198,7 @@ public final class Configuration {
    * @return the value for the given key as a {@code boolean}
    */
   public static boolean getBoolean(PropertyKey key) {
-    String rawValue = get(key);
-
-    if (rawValue.equalsIgnoreCase("true")) {
-      return true;
-    } else if (rawValue.equalsIgnoreCase("false")) {
-      return false;
-    } else {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_BOOLEAN.getMessage(key));
-    }
+    return CONF.getBoolean(key);
   }
 
   /**
@@ -262,12 +209,7 @@ public final class Configuration {
    * @return the list of values for the given key
    */
   public static List<String> getList(PropertyKey key, String delimiter) {
-    Preconditions.checkArgument(delimiter != null,
-        "Illegal separator for Alluxio properties as list");
-    String rawValue = get(key);
-
-    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
-        .split(rawValue));
+    return CONF.getList(key, delimiter);
   }
 
   /**
@@ -279,14 +221,7 @@ public final class Configuration {
    * @return the value for the given key as an enum value
    */
   public static <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType) {
-    String rawValue = get(key);
-
-    try {
-      return Enum.valueOf(enumType, rawValue);
-    } catch (IllegalArgumentException e) {
-      throw new RuntimeException(ExceptionMessage.UNKNOWN_ENUM.getMessage(rawValue,
-          Arrays.toString(enumType.getEnumConstants())));
-    }
+    return CONF.getEnum(key, enumType);
   }
 
   /**
@@ -296,13 +231,7 @@ public final class Configuration {
    * @return the bytes of the value for the given key
    */
   public static long getBytes(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      return FormatUtils.parseSpaceSize(rawValue);
-    } catch (Exception ex) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_BYTES.getMessage(key));
-    }
+    return CONF.getBytes(key);
   }
 
   /**
@@ -312,12 +241,7 @@ public final class Configuration {
    * @return the time of key in millisecond unit
    */
   public static long getMs(PropertyKey key) {
-    String rawValue = get(key);
-    try {
-      return FormatUtils.parseTimeSize(rawValue);
-    } catch (Exception e) {
-      throw new RuntimeException(ExceptionMessage.KEY_NOT_MS.getMessage(key));
-    }
+    return CONF.getMs(key);
   }
 
   /**
@@ -327,7 +251,7 @@ public final class Configuration {
    * @return the value of the key represented as a duration
    */
   public static Duration getDuration(PropertyKey key) {
-    return Duration.ofMillis(getMs(key));
+    return CONF.getDuration(key);
   }
 
   /**
@@ -338,16 +262,7 @@ public final class Configuration {
    * @return the value for the given key as a class
    */
   public static <T> Class<T> getClass(PropertyKey key) {
-    String rawValue = get(key);
-
-    try {
-      @SuppressWarnings("unchecked")
-      Class<T> clazz = (Class<T>) Class.forName(rawValue);
-      return clazz;
-    } catch (Exception e) {
-      LOG.error("requested class could not be loaded: {}", rawValue, e);
-      throw new RuntimeException(e);
-    }
+    return CONF.getClass(key);
   }
 
   /**
@@ -359,15 +274,7 @@ public final class Configuration {
    * @return a map from nested properties aggregated by the prefix
    */
   public static Map<String, String> getNestedProperties(PropertyKey prefixKey) {
-    Map<String, String> ret = Maps.newHashMap();
-    for (Map.Entry<PropertyKey, String> entry: PROPERTIES.entrySet()) {
-      String key = entry.getKey().getName();
-      if (prefixKey.isNested(key)) {
-        String suffixKey = key.substring(prefixKey.length() + 1);
-        ret.put(suffixKey, entry.getValue());
-      }
-    }
-    return ret;
+    return CONF.getNestedProperties(prefixKey);
   }
 
   /**
@@ -375,16 +282,7 @@ public final class Configuration {
    *         including all default properties
    */
   public static Map<String, String> toMap() {
-    Map<String, String> map = toRawMap();
-    for (Map.Entry<String, String> entry : map.entrySet()) {
-      String value = entry.getValue();
-      if (value != null) {
-        map.put(entry.getKey(), lookup(value));
-      } else {
-        map.put(entry.getKey(), value);
-      }
-    }
-    return map;
+    return CONF.toMap();
   }
 
   /**
@@ -392,56 +290,7 @@ public final class Configuration {
    *         including all default properties
    */
   public static Map<String, String> toRawMap() {
-    Map<String, String> rawMap = new HashMap<>();
-    PROPERTIES.forEach((key, value) -> rawMap.put(key.getName(), value));
-    return rawMap;
-  }
-
-  /**
-   * Lookup key names to handle ${key} stuff.
-   *
-   * @param base the String to look for
-   * @return resolved String value
-   */
-  private static String lookup(final String base) {
-    return lookupRecursively(base, new HashSet<>());
-  }
-
-  /**
-   * Actual recursive lookup replacement.
-   *
-   * @param base the string to resolve
-   * @param seen strings already seen during this lookup, used to prevent unbound recursion
-   * @return the resolved string
-   */
-  @Nullable
-  private static String lookupRecursively(String base, Set<String> seen) {
-    // check argument
-    if (base == null) {
-      return null;
-    }
-
-    String resolved = base;
-    // Lets find pattern match to ${key}.
-    // TODO(hsaputra): Consider using Apache Commons StrSubstitutor.
-    Matcher matcher = CONF_REGEX.matcher(base);
-    while (matcher.find()) {
-      String match = matcher.group(2).trim();
-      if (!seen.add(match)) {
-        throw new RuntimeException("Circular dependency found while resolving " + match);
-      }
-      if (!PropertyKey.isValid(match)) {
-        throw new RuntimeException("Invalid property key " + match);
-      }
-      String value = lookupRecursively(PROPERTIES.get(PropertyKey.fromString(match)), seen);
-      seen.remove(match);
-      if (value == null) {
-        throw new RuntimeException("No value specified for configuration property " + match);
-      }
-      LOG.debug("Replacing {} with {}", matcher.group(1), value);
-      resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
-    }
-    return resolved;
+    return CONF.toRawMap();
   }
 
   /**
@@ -449,123 +298,7 @@ public final class Configuration {
    * @return the source for the given key
    */
   public static Source getSource(PropertyKey key) {
-    return PROPERTIES.getSource(key);
-  }
-
-  /**
-   * @param key the property key
-   * @return the formatted source for the given key
-   */
-  public static String getFormattedSource(PropertyKey key) {
-    Source source = getSource(key);
-    String sourceStr;
-    if (source == Source.SITE_PROPERTY) {
-      sourceStr =
-          String.format("%s (%s)", source.name(), getSitePropertiesFile());
-    } else {
-      sourceStr = source.name();
-    }
-    return sourceStr;
-  }
-
-  /**
-   * @return the path of the site property file
-   */
-  @Nullable
-  public static String getSitePropertiesFile() {
-    return sSitePropertyFile;
-  }
-
-  /**
-   * Validates worker port configuration.
-   *
-   * @throws IllegalStateException if invalid worker port configuration is encountered
-   */
-  private static void checkWorkerPorts() {
-    int maxWorkersPerHost = getInt(PropertyKey.INTEGRATION_YARN_WORKERS_PER_HOST_MAX);
-    if (maxWorkersPerHost > 1) {
-      String message = "%s cannot be specified when allowing multiple workers per host with "
-          + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_DATA_PORT) == null,
-          String.format(message, PropertyKey.WORKER_DATA_PORT));
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
-          String.format(message, PropertyKey.WORKER_RPC_PORT));
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
-          String.format(message, PropertyKey.WORKER_WEB_PORT));
-      set(PropertyKey.WORKER_DATA_PORT, "0");
-      set(PropertyKey.WORKER_RPC_PORT, "0");
-      set(PropertyKey.WORKER_WEB_PORT, "0");
-    }
-  }
-
-  /**
-   * Validates timeout related configuration.
-   */
-  private static void checkTimeouts() {
-    long waitTime = getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
-    long retryInterval = getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
-    if (waitTime < retryInterval) {
-      LOG.warn("{}={}ms is smaller than {}={}ms. Workers might not have enough time to register. "
-          + "Consider either increasing {} or decreasing {}",
-          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME, waitTime,
-          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS, retryInterval,
-          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME,
-          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS);
-    }
-  }
-
-  /**
-   * Validates the user file buffer size is a non-negative number.
-   *
-   * @throws IllegalStateException if invalid user file buffer size configuration is encountered
-   */
-  private static void checkUserFileBufferBytes() {
-    if (!containsKey(PropertyKey.USER_FILE_BUFFER_BYTES)) { // load from hadoop conf
-      return;
-    }
-    long usrFileBufferBytes = getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
-    Preconditions.checkState((usrFileBufferBytes & Integer.MAX_VALUE) == usrFileBufferBytes,
-        PreconditionMessage.INVALID_USER_FILE_BUFFER_BYTES.toString(),
-        PropertyKey.Name.USER_FILE_BUFFER_BYTES, usrFileBufferBytes);
-  }
-
-  /**
-   * Validates Zookeeper-related configuration and prints warnings for possible sources of error.
-   *
-   * @throws IllegalStateException if invalid Zookeeper configuration is encountered
-   */
-  private static void checkZkConfiguration() {
-    Preconditions.checkState(
-        containsKey(PropertyKey.ZOOKEEPER_ADDRESS) == getBoolean(PropertyKey.ZOOKEEPER_ENABLED),
-        PreconditionMessage.INCONSISTENT_ZK_CONFIGURATION.toString(),
-        PropertyKey.Name.ZOOKEEPER_ADDRESS, PropertyKey.Name.ZOOKEEPER_ENABLED);
-  }
-
-  /**
-   * Checks that tiered locality configuration is consistent.
-   *
-   * @throws IllegalStateException if invalid tiered locality configuration is encountered
-   */
-  private static void checkTieredLocality() {
-    // Check that any custom tiers set by alluxio.locality.{custom_tier}=value are also defined in
-    // the tier ordering defined by alluxio.locality.order.
-    Set<String> tiers = Sets.newHashSet(getList(PropertyKey.LOCALITY_ORDER, ","));
-    Set<PropertyKey> predefinedKeys = new HashSet<>(PropertyKey.defaultKeys());
-    for (PropertyKey key : PROPERTIES.keySet()) {
-      if (predefinedKeys.contains(key)) {
-        // Skip non-templated keys.
-        continue;
-      }
-      Matcher matcher = Template.LOCALITY_TIER.match(key.toString());
-      if (matcher.matches() && matcher.group(1) != null) {
-        String tierName = matcher.group(1);
-        if (!tiers.contains(tierName)) {
-          throw new IllegalStateException(
-              String.format("Tier %s is configured by %s, but does not exist in the tier list %s "
-                  + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
-        }
-      }
-    }
+    return CONF.getSource(key);
   }
 
   /**
@@ -574,22 +307,7 @@ public final class Configuration {
    * @throws IllegalStateException if invalid configuration is encountered
    */
   public static void validate() {
-    for (Map.Entry<String, String> entry : toMap().entrySet()) {
-      String propertyName = entry.getKey();
-      Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
-      PropertyKey propertyKey = PropertyKey.fromString(propertyName);
-      Preconditions.checkState(
-          getSource(propertyKey) != Source.SITE_PROPERTY || !propertyKey.isIgnoredSiteProperty(),
-          "%s is not accepted in alluxio-site.properties, "
-              + "and must be specified as a JVM property. "
-              + "If no JVM property is present, Alluxio will use default value '%s'.", propertyName,
-          propertyKey.getDefaultValue());
-    }
-    checkTimeouts();
-    checkWorkerPorts();
-    checkUserFileBufferBytes();
-    checkZkConfiguration();
-    checkTieredLocality();
+    CONF.validate();
   }
 
   /**
@@ -599,16 +317,7 @@ public final class Configuration {
    * @return a list of raw configurations inside the property scope
    */
   public static List<ConfigProperty> getConfiguration(Scope scope) {
-    List<ConfigProperty> list = new ArrayList<>();
-    for (Map.Entry<String, String> entry : toRawMap().entrySet()) {
-      PropertyKey key = PropertyKey.fromString(entry.getKey());
-      if (key.getScope().contains(scope) && containsKey(key)) {
-        ConfigProperty configProperty = new ConfigProperty()
-            .setName(key.getName()).setValue(get(key)).setSource(getFormattedSource(key));
-        list.add(configProperty);
-      }
-    }
-    return list;
+    return CONF.getConfiguration(scope);
   }
 
   private Configuration() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -28,8 +28,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * <p>
- * All the runtime configuration properties of Alluxio. This class works like a dictionary and
- * serves each Alluxio configuration property as a key-value pair.
+ * Global configuration properties of Alluxio. This class works like a dictionary and serves each
+ * Alluxio configuration property as a key-value pair.
  *
  * <p>
  * Alluxio configuration properties are loaded into this class in the following order with
@@ -44,6 +44,11 @@ import javax.annotation.concurrent.NotThreadSafe;
  * The default properties are defined in the {@link PropertyKey} class in the codebase. Alluxio
  * users can override values of these default properties by creating {@code alluxio-site.properties}
  * and putting it under java {@code CLASSPATH} when running Alluxio (e.g., ${ALLUXIO_HOME}/conf/)
+ *
+ * <p>
+ * This class defines many convenient static methods which delegate to an internal
+ * {@link InstancedConfiguration}. To use this global configuration in a method that takes
+ * {@link AlluxioConfiguration} as an argument, pass {@link Configuration#global()}.
  */
 @NotThreadSafe
 public final class Configuration {

--- a/core/common/src/main/java/alluxio/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/InstancedConfiguration.java
@@ -1,0 +1,426 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.PropertyKey.Template;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.Source;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.PreconditionMessage;
+import alluxio.util.FormatUtils;
+import alluxio.wire.ConfigProperty;
+import alluxio.wire.Scope;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+/**
+ * Alluxio configuration.
+ */
+public class InstancedConfiguration implements AlluxioConfiguration {
+  private static final Logger LOG = LoggerFactory.getLogger(InstancedConfiguration.class);
+
+  /** Regex string to find "${key}" for variable substitution. */
+  private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
+  /** Regex to find ${key} for variable substitution. */
+  private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
+  /** Source of the truth of all property values (default or customized). */
+  private final AlluxioProperties mProperties;
+
+  /**
+   * @param properties alluxio properties underlying this configuration
+   */
+  public InstancedConfiguration(AlluxioProperties properties) {
+    mProperties = properties;
+  }
+
+  /**
+   * @param conf configuration to copy
+   */
+  public InstancedConfiguration(InstancedConfiguration conf) {
+    mProperties = new AlluxioProperties(conf.mProperties);
+  }
+
+  /**
+   * @return the properties backing this configuration
+   */
+  public AlluxioProperties getProperties() {
+    return mProperties;
+  }
+
+  @Override
+  public String get(PropertyKey key) {
+    String rawValue = mProperties.get(key);
+    if (rawValue == null) {
+      // if key is not found among the default properties
+      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
+    }
+    return lookup(rawValue);
+  }
+
+  @Override
+  public boolean containsKey(PropertyKey key) {
+    return mProperties.hasValueSet(key);
+  }
+
+  @Override
+  public int getInt(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Integer.parseInt(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_INTEGER.getMessage(key));
+    }
+  }
+
+  @Override
+  public long getLong(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Long.parseLong(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_LONG.getMessage(key));
+    }
+  }
+
+  @Override
+  public double getDouble(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Double.parseDouble(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_DOUBLE.getMessage(key));
+    }
+  }
+
+  @Override
+  public float getFloat(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Float.parseFloat(lookup(rawValue));
+    } catch (NumberFormatException e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_FLOAT.getMessage(key));
+    }
+  }
+
+  @Override
+  public boolean getBoolean(PropertyKey key) {
+    String rawValue = get(key);
+
+    if (rawValue.equalsIgnoreCase("true")) {
+      return true;
+    } else if (rawValue.equalsIgnoreCase("false")) {
+      return false;
+    } else {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_BOOLEAN.getMessage(key));
+    }
+  }
+
+  @Override
+  public List<String> getList(PropertyKey key, String delimiter) {
+    Preconditions.checkArgument(delimiter != null,
+        "Illegal separator for Alluxio properties as list");
+    String rawValue = get(key);
+
+    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
+        .split(rawValue));
+  }
+
+  @Override
+  public <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType) {
+    String rawValue = get(key);
+
+    try {
+      return Enum.valueOf(enumType, rawValue);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException(ExceptionMessage.UNKNOWN_ENUM.getMessage(rawValue,
+          Arrays.toString(enumType.getEnumConstants())));
+    }
+  }
+
+  @Override
+  public long getBytes(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return FormatUtils.parseSpaceSize(rawValue);
+    } catch (Exception ex) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_BYTES.getMessage(key));
+    }
+  }
+
+  @Override
+  public long getMs(PropertyKey key) {
+    String rawValue = get(key);
+    try {
+      return FormatUtils.parseTimeSize(rawValue);
+    } catch (Exception e) {
+      throw new RuntimeException(ExceptionMessage.KEY_NOT_MS.getMessage(key));
+    }
+  }
+
+  @Override
+  public Duration getDuration(PropertyKey key) {
+    return Duration.ofMillis(getMs(key));
+  }
+
+  @Override
+  public <T> Class<T> getClass(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      @SuppressWarnings("unchecked")
+      Class<T> clazz = (Class<T>) Class.forName(rawValue);
+      return clazz;
+    } catch (Exception e) {
+      LOG.error("requested class could not be loaded: {}", rawValue, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Map<String, String> getNestedProperties(PropertyKey prefixKey) {
+    Map<String, String> ret = Maps.newHashMap();
+    for (Map.Entry<PropertyKey, String> entry: mProperties.entrySet()) {
+      String key = entry.getKey().getName();
+      if (prefixKey.isNested(key)) {
+        String suffixKey = key.substring(prefixKey.length() + 1);
+        ret.put(suffixKey, entry.getValue());
+      }
+    }
+    return ret;
+  }
+
+  @Override
+  public Map<String, String> toMap() {
+    Map<String, String> map = toRawMap();
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        map.put(entry.getKey(), lookup(value));
+      } else {
+        map.put(entry.getKey(), value);
+      }
+    }
+    return map;
+  }
+
+  @Override
+  public Map<String, String> toRawMap() {
+    Map<String, String> rawMap = new HashMap<>();
+    mProperties.forEach((key, value) -> rawMap.put(key.getName(), value));
+    return rawMap;
+  }
+
+  @Override
+  public Source getSource(PropertyKey key) {
+    return mProperties.getSource(key);
+  }
+
+  @Override
+  public List<ConfigProperty> getConfiguration(Scope scope) {
+    List<ConfigProperty> list = new ArrayList<>();
+    for (Map.Entry<String, String> entry : toRawMap().entrySet()) {
+      PropertyKey key = PropertyKey.fromString(entry.getKey());
+      if (key.getScope().contains(scope) && containsKey(key)) {
+        ConfigProperty configProperty = new ConfigProperty().setName(key.getName())
+            .setValue(get(key)).setSource(Configuration.getSource(key).toString());
+        list.add(configProperty);
+      }
+    }
+    return list;
+  }
+
+  @Override
+  public void merge(Map<?, ?> properties, Source source) {
+    mProperties.merge(properties, source);
+  }
+
+  @Override
+  public void validate() {
+    for (Map.Entry<String, String> entry : toMap().entrySet()) {
+      String propertyName = entry.getKey();
+      Preconditions.checkState(PropertyKey.isValid(propertyName), propertyName);
+      PropertyKey propertyKey = PropertyKey.fromString(propertyName);
+      Preconditions.checkState(
+          getSource(propertyKey).getType() != Source.Type.SITE_PROPERTY
+              || !propertyKey.isIgnoredSiteProperty(),
+          "%s is not accepted in alluxio-site.properties, "
+              + "and must be specified as a JVM property. "
+              + "If no JVM property is present, Alluxio will use default value '%s'.", propertyName,
+          propertyKey.getDefaultValue());
+    }
+    checkTimeouts();
+    checkWorkerPorts();
+    checkUserFileBufferBytes();
+    checkZkConfiguration();
+    checkTieredLocality();
+  }
+
+  /**
+   * Lookup key names to handle ${key} stuff.
+   *
+   * @param base the String to look for
+   * @return resolved String value
+   */
+  private String lookup(final String base) {
+    return lookupRecursively(base, new HashSet<>());
+  }
+
+  /**
+   * Actual recursive lookup replacement.
+   *
+   * @param base the string to resolve
+   * @param seen strings already seen during this lookup, used to prevent unbound recursion
+   * @return the resolved string
+   */
+  @Nullable
+  private String lookupRecursively(String base, Set<String> seen) {
+    // check argument
+    if (base == null) {
+      return null;
+    }
+
+    String resolved = base;
+    // Lets find pattern match to ${key}.
+    // TODO(hsaputra): Consider using Apache Commons StrSubstitutor.
+    Matcher matcher = CONF_REGEX.matcher(base);
+    while (matcher.find()) {
+      String match = matcher.group(2).trim();
+      if (!seen.add(match)) {
+        throw new RuntimeException("Circular dependency found while resolving " + match);
+      }
+      if (!PropertyKey.isValid(match)) {
+        throw new RuntimeException("Invalid property key " + match);
+      }
+      String value = lookupRecursively(mProperties.get(PropertyKey.fromString(match)), seen);
+      seen.remove(match);
+      if (value == null) {
+        throw new RuntimeException("No value specified for configuration property " + match);
+      }
+      LOG.debug("Replacing {} with {}", matcher.group(1), value);
+      resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
+    }
+    return resolved;
+  }
+
+  /**
+   * Validates worker port configuration.
+   *
+   * @throws IllegalStateException if invalid worker port configuration is encountered
+   */
+  private void checkWorkerPorts() {
+    int maxWorkersPerHost = getInt(PropertyKey.INTEGRATION_YARN_WORKERS_PER_HOST_MAX);
+    if (maxWorkersPerHost > 1) {
+      String message = "%s cannot be specified when allowing multiple workers per host with "
+          + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_DATA_PORT) == null,
+          String.format(message, PropertyKey.WORKER_DATA_PORT));
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
+          String.format(message, PropertyKey.WORKER_RPC_PORT));
+      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
+          String.format(message, PropertyKey.WORKER_WEB_PORT));
+    }
+  }
+
+  /**
+   * Validates timeout related configuration.
+   */
+  private void checkTimeouts() {
+    long waitTime = getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
+    long retryInterval = getMs(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
+    if (waitTime < retryInterval) {
+      LOG.warn("{}={}ms is smaller than {}={}ms. Workers might not have enough time to register. "
+              + "Consider either increasing {} or decreasing {}",
+          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME, waitTime,
+          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS, retryInterval,
+          PropertyKey.Name.MASTER_WORKER_CONNECT_WAIT_TIME,
+          PropertyKey.Name.USER_RPC_RETRY_MAX_SLEEP_MS);
+    }
+  }
+
+  /**
+   * Validates the user file buffer size is a non-negative number.
+   *
+   * @throws IllegalStateException if invalid user file buffer size configuration is encountered
+   */
+  private void checkUserFileBufferBytes() {
+    if (!containsKey(PropertyKey.USER_FILE_BUFFER_BYTES)) { // load from hadoop conf
+      return;
+    }
+    long usrFileBufferBytes = getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
+    Preconditions.checkState((usrFileBufferBytes & Integer.MAX_VALUE) == usrFileBufferBytes,
+        PreconditionMessage.INVALID_USER_FILE_BUFFER_BYTES.toString(),
+        PropertyKey.Name.USER_FILE_BUFFER_BYTES, usrFileBufferBytes);
+  }
+
+  /**
+   * Validates Zookeeper-related configuration and prints warnings for possible sources of error.
+   *
+   * @throws IllegalStateException if invalid Zookeeper configuration is encountered
+   */
+  private void checkZkConfiguration() {
+    Preconditions.checkState(
+        containsKey(PropertyKey.ZOOKEEPER_ADDRESS) == getBoolean(PropertyKey.ZOOKEEPER_ENABLED),
+        PreconditionMessage.INCONSISTENT_ZK_CONFIGURATION.toString(),
+        PropertyKey.Name.ZOOKEEPER_ADDRESS, PropertyKey.Name.ZOOKEEPER_ENABLED);
+  }
+
+  /**
+   * Checks that tiered locality configuration is consistent.
+   *
+   * @throws IllegalStateException if invalid tiered locality configuration is encountered
+   */
+  private void checkTieredLocality() {
+    // Check that any custom tiers set by alluxio.locality.{custom_tier}=value are also defined in
+    // the tier ordering defined by alluxio.locality.order.
+    Set<String> tiers = Sets.newHashSet(getList(PropertyKey.LOCALITY_ORDER, ","));
+    Set<PropertyKey> predefinedKeys = new HashSet<>(PropertyKey.defaultKeys());
+    for (PropertyKey key : mProperties.keySet()) {
+      if (predefinedKeys.contains(key)) {
+        // Skip non-templated keys.
+        continue;
+      }
+      Matcher matcher = Template.LOCALITY_TIER.match(key.toString());
+      if (matcher.matches() && matcher.group(1) != null) {
+        String tierName = matcher.group(1);
+        if (!tiers.contains(tierName)) {
+          throw new IllegalStateException(
+              String.format("Tier %s is configured by %s, but does not exist in the tier list %s "
+                  + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
+        }
+      }
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -65,6 +65,14 @@ public class AlluxioProperties {
   public AlluxioProperties() {}
 
   /**
+   * @param alluxioProperties properties to copy
+   */
+  public AlluxioProperties(AlluxioProperties alluxioProperties) {
+    mUserProps.putAll(alluxioProperties.mUserProps);
+    mSources.putAll(alluxioProperties.mSources);
+  }
+
+  /**
    * @param key the key to query
    * @return the value, or null if the key has no value set
    */

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -9,11 +9,12 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio;
+package alluxio.conf;
 
+import alluxio.AlluxioConfiguration;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.PropertyKey.Template;
-import alluxio.conf.AlluxioProperties;
-import alluxio.conf.Source;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.FormatUtils;

--- a/core/common/src/main/java/alluxio/conf/Source.java
+++ b/core/common/src/main/java/alluxio/conf/Source.java
@@ -14,7 +14,7 @@ package alluxio.conf;
 /**
  * The source of a configuration property.
  */
-public final class Source implements Comparable<Source> {
+public class Source implements Comparable<Source> {
   public static final Source UNKNOWN = new Source(Type.UNKNOWN);
   public static final Source DEFAULT = new Source(Type.DEFAULT);
   public static final Source SYSTEM_PROPERTY = new Source(Type.SYSTEM_PROPERTY);

--- a/core/common/src/main/java/alluxio/conf/Source.java
+++ b/core/common/src/main/java/alluxio/conf/Source.java
@@ -14,12 +14,15 @@ package alluxio.conf;
 /**
  * The source of a configuration property.
  */
-public class Source implements Comparable<Source> {
+public final class Source implements Comparable<Source> {
   public static final Source UNKNOWN = new Source(Type.UNKNOWN);
   public static final Source DEFAULT = new Source(Type.DEFAULT);
   public static final Source SYSTEM_PROPERTY = new Source(Type.SYSTEM_PROPERTY);
   public static final Source RUNTIME = new Source(Type.RUNTIME);
 
+  /**
+   * Source type.
+   */
   public enum Type {
     /**
      * The unknown source which has the lowest priority.

--- a/core/common/src/main/java/alluxio/conf/Source.java
+++ b/core/common/src/main/java/alluxio/conf/Source.java
@@ -14,26 +14,80 @@ package alluxio.conf;
 /**
  * The source of a configuration property.
  */
-public enum Source {
+public class Source implements Comparable<Source> {
+  public static final Source UNKNOWN = new Source(Type.UNKNOWN);
+  public static final Source DEFAULT = new Source(Type.DEFAULT);
+  public static final Source SYSTEM_PROPERTY = new Source(Type.SYSTEM_PROPERTY);
+  public static final Source RUNTIME = new Source(Type.RUNTIME);
+
+  public enum Type {
+    /**
+     * The unknown source which has the lowest priority.
+     */
+    UNKNOWN,
+    /**
+     * The default property value from <code>PropertyKey</code> on compile time.
+     */
+    DEFAULT,
+    /**
+     * The property value is specified in site properties file (alluxio-site.properties).
+     */
+    SITE_PROPERTY,
+    /**
+     * The property value is specified with JVM -D options before passed to Alluxio.
+     */
+    SYSTEM_PROPERTY,
+    /**
+     * The property value is set by user during runtime (e.g., Configuration.set or through
+     * HadoopConf). This source has the highest priority.
+     */
+    RUNTIME,
+  }
+
+  protected final Type mType;
+
+  private Source(Type type) {
+    mType = type;
+  }
+
   /**
-   * The unknown source which has the lowest priority.
+   * @return the type of the source
    */
-  UNKNOWN,
+  public Type getType() {
+    return mType;
+  }
+
   /**
-   * The default property value from <code>PropertyKey</code> on compile time.
+   * Creates a site property source with the specified filename.
+   *
+   * @param filename the filename
+   * @return the source
    */
-  DEFAULT,
-  /**
-   * The property value is specified in site properties file (alluxio-site.properties).
-   */
-  SITE_PROPERTY,
-  /**
-   * The property value is specified with JVM -D options before passed to Alluxio.
-   */
-  SYSTEM_PROPERTY,
-  /**
-   * The property value is set by user during runtime (e.g., Configuration.set or through
-   * HadoopConf). This source has the highest priority.
-   */
-  RUNTIME,
+  public static Source siteProperty(String filename) {
+    return new SitePropertySource(filename);
+  }
+
+  @Override
+  public int compareTo(Source other) {
+    return mType.compareTo(other.mType);
+  }
+
+  @Override
+  public String toString() {
+    return mType.name();
+  }
+
+  private static final class SitePropertySource extends Source {
+    private final String mFilename;
+
+    private SitePropertySource(String filename) {
+      super(Type.SITE_PROPERTY);
+      mFilename = filename;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s (%s)", mType, mFilename);
+    }
+  }
 }

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -56,17 +56,17 @@ public interface MasterInquireClient {
     }
 
     /**
-     * @param config configuration for creating the master inquire client
+     * @param conf configuration for creating the master inquire client
      * @return a master inquire client
      */
-    public static MasterInquireClient create(AlluxioConfiguration config) {
-      if (config.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
-        return ZkMasterInquireClient.getClient(config.get(PropertyKey.ZOOKEEPER_ADDRESS),
-            config.get(PropertyKey.ZOOKEEPER_ELECTION_PATH),
-            config.get(PropertyKey.ZOOKEEPER_LEADER_PATH));
+    public static MasterInquireClient create(AlluxioConfiguration conf) {
+      if (conf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
+        return ZkMasterInquireClient.getClient(conf.get(PropertyKey.ZOOKEEPER_ADDRESS),
+            conf.get(PropertyKey.ZOOKEEPER_ELECTION_PATH),
+            conf.get(PropertyKey.ZOOKEEPER_LEADER_PATH));
       } else {
         return new SingleMasterInquireClient(
-            NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, config));
+            NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf));
       }
     }
 

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -11,6 +11,7 @@
 
 package alluxio.master;
 
+import alluxio.AlluxioConfiguration;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.exception.status.UnavailableException;
@@ -51,156 +52,25 @@ public interface MasterInquireClient {
      * @return a master inquire client
      */
     public static MasterInquireClient create() {
-      return create(Config.defaults());
+      return create(Configuration.global());
     }
 
     /**
      * @param config configuration for creating the master inquire client
      * @return a master inquire client
      */
-    public static MasterInquireClient create(Config config) {
-      if (config.isZookeeperEnabled()) {
-        return ZkMasterInquireClient.getClient(config.getZookeeperAddress(),
-            config.getElectionPath(), config.getLeaderPath());
+    public static MasterInquireClient create(AlluxioConfiguration config) {
+      if (config.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
+        return ZkMasterInquireClient.getClient(config.get(PropertyKey.ZOOKEEPER_ADDRESS),
+            config.get(PropertyKey.ZOOKEEPER_ELECTION_PATH),
+            config.get(PropertyKey.ZOOKEEPER_LEADER_PATH));
       } else {
         return new SingleMasterInquireClient(
-            new InetSocketAddress(config.getConnectHost(), config.getConnectPort()));
+            NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, config));
       }
     }
 
-    private Factory() {} // Not intended for instantiation.
-
-    /**
-     * Configuration for building a {@link MasterInquireClient} from a
-     * {@link MasterInquireClient.Factory}.
-     */
-    public static final class Config {
-      // HA connect with Zookeeper.
-      private boolean mZookeeperEnabled;
-      private String mZookeeperAddress;
-      private String mElectionPath;
-      private String mLeaderPath;
-
-      // Non-HA connect.
-      private String mConnectHost;
-      private int mConnectPort;
-
-      // Use Config.defaults() instead.
-      private Config() {}
-
-      /**
-       * @return the default master inquire configuration based on {@link Configuration}
-       */
-      public static Config defaults() {
-        String zkAddress = Configuration.containsKey(PropertyKey.ZOOKEEPER_ADDRESS)
-            ? Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS)
-            : null;
-        return new Config()
-            .setZookeeperEnabled(Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED))
-            .setZookeeperAddress(zkAddress)
-            .setElectionPath(Configuration.get(PropertyKey.ZOOKEEPER_ELECTION_PATH))
-            .setLeaderPath(Configuration.get(PropertyKey.ZOOKEEPER_LEADER_PATH))
-            .setConnectHost(
-                NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC).getHostName())
-            .setConnectPort(
-                NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC).getPort());
-      }
-
-      /**
-       * @param zookeeperEnabled whether zookeeper is enabled
-       * @return this
-       */
-      public Config setZookeeperEnabled(boolean zookeeperEnabled) {
-        mZookeeperEnabled = zookeeperEnabled;
-        return this;
-      }
-
-      /**
-       * @param zookeeperAddress zookeeper address
-       * @return this
-       */
-      public Config setZookeeperAddress(String zookeeperAddress) {
-        mZookeeperAddress = zookeeperAddress;
-        return this;
-      }
-
-      /**
-       * @param electionPath election path
-       * @return this
-       */
-      public Config setElectionPath(String electionPath) {
-        mElectionPath = electionPath;
-        return this;
-      }
-
-      /**
-       * @param leaderPath leader path
-       * @return this
-       */
-      public Config setLeaderPath(String leaderPath) {
-        mLeaderPath = leaderPath;
-        return this;
-      }
-
-      /**
-       * @param host master connect host
-       * @return this
-       */
-      public Config setConnectHost(String host) {
-        mConnectHost = host;
-        return this;
-      }
-
-      /**
-       * @param port master connect port
-       * @return this
-       */
-      public Config setConnectPort(int port) {
-        mConnectPort = port;
-        return this;
-      }
-
-      /**
-       * @return whether zookeeper is enabled
-       */
-      public boolean isZookeeperEnabled() {
-        return mZookeeperEnabled;
-      }
-
-      /**
-       * @return the zookeeper address
-       */
-      public String getZookeeperAddress() {
-        return mZookeeperAddress;
-      }
-
-      /**
-       * @return the election path
-       */
-      public String getElectionPath() {
-        return mElectionPath;
-      }
-
-      /**
-       * @return the leader path
-       */
-      public String getLeaderPath() {
-        return mLeaderPath;
-      }
-
-      /**
-       * @return the connect host
-       */
-      public String getConnectHost() {
-        return mConnectHost;
-      }
-
-      /**
-       * @return the connect port
-       */
-      public int getConnectPort() {
-        return mConnectPort;
-      }
-    }
+    private Factory() {
+    } // Not intended for instantiation.
   }
 }

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -267,13 +267,15 @@ public final class NetworkAddressUtils {
    * is wildcard, Alluxio will automatically determine an appropriate hostname from local machine.
    * The various possibilities shown in the following table:
    * <table>
-   * <caption>Hostname Scenarios</caption> <thead>
+   * <caption>Hostname Scenarios</caption>
+   * <thead>
    * <tr>
    * <th>Specified Hostname</th>
    * <th>Specified Bind Host</th>
    * <th>Returned Connect Host</th>
    * </tr>
-   * </thead> <tbody>
+   * </thead>
+   * <tbody>
    * <tr>
    * <td>hostname</td>
    * <td>hostname</td>

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -208,13 +208,13 @@ public final class NetworkAddressUtils {
    * service.
    *
    * @param service the service name used to connect
-   * @param config the configuration to use for looking up the connect address
+   * @param conf the configuration to use for looking up the connect address
    * @return the service address that a client (typically outside the service machine) uses to
    *         communicate with service.
    */
   public static InetSocketAddress getConnectAddress(ServiceType service,
-      AlluxioConfiguration config) {
-    return new InetSocketAddress(getConnectHost(service, config), getPort(service, config));
+      AlluxioConfiguration conf) {
+    return new InetSocketAddress(getConnectHost(service, conf), getPort(service, conf));
   }
 
   /**
@@ -300,19 +300,19 @@ public final class NetworkAddressUtils {
    * </table>
    *
    * @param service Service type used to connect
-   * @param config configuration
+   * @param conf configuration
    * @return the externally resolvable hostname that the client can use to communicate with the
    *         service.
    */
-  public static String getConnectHost(ServiceType service, AlluxioConfiguration config) {
-    if (config.containsKey(service.mHostNameKey)) {
-      String connectHost = config.get(service.mHostNameKey);
+  public static String getConnectHost(ServiceType service, AlluxioConfiguration conf) {
+    if (conf.containsKey(service.mHostNameKey)) {
+      String connectHost = conf.get(service.mHostNameKey);
       if (!connectHost.isEmpty() && !connectHost.equals(WILDCARD_ADDRESS)) {
         return connectHost;
       }
     }
-    if (config.containsKey(service.mBindHostKey)) {
-      String bindHost = config.get(service.mBindHostKey);
+    if (conf.containsKey(service.mBindHostKey)) {
+      String bindHost = conf.get(service.mBindHostKey);
       if (!bindHost.isEmpty() && !bindHost.equals(WILDCARD_ADDRESS)) {
         return bindHost;
       }

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -658,8 +658,8 @@ public class ConfigurationTest {
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
       Configuration.reset();
       // set only in site prop
-      assertEquals(Source.SITE_PROPERTY,
-          Configuration.getSource(PropertyKey.MASTER_HOSTNAME));
+      assertEquals(Source.Type.SITE_PROPERTY,
+          Configuration.getSource(PropertyKey.MASTER_HOSTNAME).getType());
       // set both in site and system prop
       assertEquals(Source.SYSTEM_PROPERTY,
           Configuration.getSource(PropertyKey.MASTER_WEB_PORT));

--- a/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
+++ b/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
@@ -76,7 +76,7 @@ public class AlluxioPropertiesTest {
     assertEquals("value1", mProperties.get(mKeyWithValue));
     assertEquals("value2", mProperties.get(mKeyWithoutValue));
 
-    mProperties.put(mKeyWithValue, "valueLowerPriority", Source.SITE_PROPERTY);
+    mProperties.put(mKeyWithValue, "valueLowerPriority", Source.siteProperty(""));
     assertEquals("value1", mProperties.get(mKeyWithValue));
     mProperties.put(mKeyWithValue, "valueSamePriority", Source.SYSTEM_PROPERTY);
     assertEquals("valueSamePriority", mProperties.get(mKeyWithValue));

--- a/core/common/src/test/java/alluxio/conf/SourceTest.java
+++ b/core/common/src/test/java/alluxio/conf/SourceTest.java
@@ -22,8 +22,8 @@ public class SourceTest {
   @Test
   public void compareTo() {
     assertEquals(-1, Source.UNKNOWN.compareTo(Source.DEFAULT));
-    assertEquals(-1, Source.DEFAULT.compareTo(Source.SITE_PROPERTY));
-    assertEquals(-1, Source.SITE_PROPERTY.compareTo(Source.SYSTEM_PROPERTY));
+    assertEquals(-1, Source.DEFAULT.compareTo(Source.siteProperty("")));
+    assertEquals(-1, Source.Type.SITE_PROPERTY.compareTo(Source.Type.SYSTEM_PROPERTY));
     assertEquals(-1, Source.SYSTEM_PROPERTY.compareTo(Source.RUNTIME));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -232,7 +232,7 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
       String key = entry.getKey();
       if (key.startsWith(alluxioConfPrefix)) {
         PropertyKey propertyKey = PropertyKey.fromString(key);
-        String source = Configuration.getFormattedSource(propertyKey);
+        String source = Configuration.getSource(propertyKey).toString();
         configInfoList.add(new ConfigProperty()
             .setName(key).setValue(entry.getValue()).setSource(source));
       }

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
@@ -169,7 +169,8 @@ public class AlluxioScheduler implements Scheduler {
                             .addVariables(
                                 Protos.Environment.Variable.newBuilder()
                                     .setName("ALLUXIO_MESOS_SITE_PROPERTIES_CONTENT")
-                                    .setValue(Configuration.getSitePropertiesFile())
+                                    // TODO(andrew): set the site properties here
+                                    .setValue("")
                                     .build())
                             .build()));
         // pre-build resource list here, then use it to build Protos.Task later.
@@ -214,7 +215,8 @@ public class AlluxioScheduler implements Scheduler {
                             .addVariables(
                                 Protos.Environment.Variable.newBuilder()
                                     .setName("ALLUXIO_MESOS_SITE_PROPERTIES_CONTENT")
-                                    .setValue(Configuration.getSitePropertiesFile())
+                                    // TODO(andrew): set the site properties here
+                                    .setValue("")
                                     .build())
                             .build()));
         // pre-build resource list here, then use it to build Protos.Task later.

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -161,7 +161,7 @@ public final class GetConf {
         } else {
           if (cmd.hasOption(SOURCE_OPTION_NAME)) {
             Source source = Configuration.getSource(key);
-            System.out.println(String.format("%s", source));
+            System.out.println(source);
           } else if (cmd.hasOption(UNIT_OPTION_NAME)) {
             String arg = cmd.getOptionValue(UNIT_OPTION_NAME).toUpperCase();
             try {

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -144,12 +144,7 @@ public final class GetConf {
           output.append(String.format("%s=%s", key, value));
           if (cmd.hasOption(SOURCE_OPTION_NAME)) {
             Source source = Configuration.getSource(PropertyKey.fromString(key));
-            if (source == Source.SITE_PROPERTY) {
-              output.append(String.format(" (%s: %s)", source.name(),
-                  Configuration.getSitePropertiesFile()));
-            } else {
-              output.append(String.format(" (%s)", source.name()));
-            }
+            output.append(String.format(" (%s)", source));
           }
           output.append("\n");
         }
@@ -166,12 +161,7 @@ public final class GetConf {
         } else {
           if (cmd.hasOption(SOURCE_OPTION_NAME)) {
             Source source = Configuration.getSource(key);
-            if (source == Source.SITE_PROPERTY) {
-              System.out.println(String.format("%s: %s", source.name(),
-                  Configuration.getSitePropertiesFile()));
-            } else {
-              System.out.println(String.format("%s", source.name()));
-            }
+            System.out.println(String.format("%s", source));
           } else if (cmd.hasOption(UNIT_OPTION_NAME)) {
             String arg = cmd.getOptionValue(UNIT_OPTION_NAME).toUpperCase();
             try {


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3216

This moves most functionality of `Configuration` to `InstancedConfiguration`, then has `Configuration` delegate to an internal instance of `InstancedConfiguration`. The only logic left in `Configuration` is the logic for setting/clearing values, and the logic for initializing itself in `reset`.

`Configuration.global()` returns an instance object that acts the same as `Configuration`.

The methods needed by `AbstractFileSystem` were updated to accept both instanced and non-instanced configuration. In the long term they will probably take only instanced configuration, but in the short and medium terms we can make incremental progress by keeping both versions.

The only functionality change in the move from `Configuration` to `InstancedConfiguration` was to attach the site properties file name to the `SITE_PROPERTIES` source so that `Configuration` doesn't need to worry about it. Then `getFormattedSource` can be replaced by `getSource.toString()`. I think this is a cleaner design.