### PR TITLE
[SMALLFIX] add null check to configuration value getter

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -85,6 +85,10 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   @Override
   public String get(PropertyKey key, ConfigurationValueOptions options) {
     String value = mProperties.get(key);
+    if (value == null) {
+      // if value or default value is not set in configuration for the given key
+      throw new RuntimeException(ExceptionMessage.UNDEFINED_CONFIGURATION_KEY.getMessage(key));
+    }
     if (!options.shouldUseRawValue()) {
       value = lookup(value);
     }
@@ -245,7 +249,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   public Map<String, String> toMap(ConfigurationValueOptions options) {
     Map<String, String> map = new HashMap<>();
     mProperties.forEach((key, value) ->
-        map.put(key.getName(), get(key, options)));
+        map.put(key.getName(), containsKey(key) ? get(key, options) : null));
     return map;
   }
 

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -386,6 +386,12 @@ public class ConfigurationTest {
   }
 
   @Test
+  public void getUnsetValueThrowsException() {
+    mThrown.expect(RuntimeException.class);
+    Configuration.get(PropertyKey.S3A_ACCESS_KEY);
+  }
+
+  @Test
   public void getNestedProperties() {
     Configuration.set(
         PropertyKey.Template.MASTER_MOUNT_TABLE_OPTION_PROPERTY.format("foo",


### PR DESCRIPTION
Adding null check back to keep the non-nullable contract of configuration getter.