### PR TITLE
[SMALLFIX] Fix meta master master service version

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterMasterServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterMasterServiceHandler.java
@@ -53,7 +53,7 @@ public final class MetaMasterMasterServiceHandler implements MetaMasterMasterSer
 
   @Override
   public GetServiceVersionTResponse getServiceVersion(GetServiceVersionTOptions options) {
-    return new GetServiceVersionTResponse(Constants.META_MASTER_CLIENT_SERVICE_VERSION);
+    return new GetServiceVersionTResponse(Constants.META_MASTER_MASTER_SERVICE_VERSION);
   }
 
   @Override


### PR DESCRIPTION
Simple bug, causes 

2018-06-15 13:20:36,902 WARN  alluxio.AbstractClient (AbstractClient.java:connect) - Failed to connect (1) with MetaMasterMaster @ 192.168.1.34/192.168.1.34:53018: MetaMasterMaster client version 1 is not compatible with server version 2

in the logs