### PR TITLE
[SMALLFIX] Config checker improvements

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -446,19 +446,18 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
   }
 
   /**
-   * Periodic log config check report.
+   * Periodically log the config check report.
    */
   private final class LogConfigReportHeartbeatExecutor implements HeartbeatExecutor {
-
-    /**
-     * Constructs a new {@link LogConfigReportHeartbeatExecutor}.
-     */
-    public LogConfigReportHeartbeatExecutor() {
-    }
+    private boolean mFirst = true;
 
     @Override
     public void heartbeat() {
-      mConfigChecker.logConfigReport();
+      // Skip the first heartbeat since it happens before servers have time to register their
+      // configurations.
+      if (!mFirst) {
+        mConfigChecker.logConfigReport();
+      }
     }
 
     @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -455,7 +455,9 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
     public void heartbeat() {
       // Skip the first heartbeat since it happens before servers have time to register their
       // configurations.
-      if (!mFirst) {
+      if (mFirst) {
+        mFirst = false;
+      } else {
         mConfigChecker.logConfigReport();
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -449,7 +449,7 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
    * Periodically log the config check report.
    */
   private final class LogConfigReportHeartbeatExecutor implements HeartbeatExecutor {
-    private boolean mFirst = true;
+    private volatile boolean mFirst = true;
 
     @Override
     public void heartbeat() {

--- a/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
@@ -36,7 +36,7 @@ public class ServerConfigurationChecker {
   private static final Logger LOG = LoggerFactory.getLogger(ServerConfigurationChecker.class);
   private static final int LOG_CONF_SIZE = 5;
   private static final String CONSISTENT_CONFIGURATION_INFO
-      = "All server-side configuration is consistent.";
+      = "All server-side configurations are consistent.";
   private static final String INCONSISTENT_CONFIGURATION_INFO
       = "Inconsistent configuration detected. "
       + "Only a limited set of inconsistent configuration will be shown here. "
@@ -109,7 +109,7 @@ public class ServerConfigurationChecker {
    * @return the configuration checker report
    */
   public synchronized ConfigCheckReport getConfigCheckReport() {
-    if (mConfigDirty == true) {
+    if (mConfigDirty) {
       mConfigDirty = false;
       regenerateReport();
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
@@ -110,6 +110,9 @@ public class ServerConfigurationChecker {
    */
   public synchronized ConfigCheckReport getConfigCheckReport() {
     if (mConfigDirty) {
+      // Reset mConfigDirty *before* calling regenerateReport so that if the configuration changes
+      // during report regeneration, the change will be reflected in the next call to
+      // getConfigCheckReport.
       mConfigDirty = false;
       regenerateReport();
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
@@ -36,7 +36,7 @@ public class ServerConfigurationChecker {
   private static final Logger LOG = LoggerFactory.getLogger(ServerConfigurationChecker.class);
   private static final int LOG_CONF_SIZE = 5;
   private static final String CONSISTENT_CONFIGURATION_INFO
-      = "All server-side configuration are consistent.";
+      = "All server-side configuration is consistent.";
   private static final String INCONSISTENT_CONFIGURATION_INFO
       = "Inconsistent configuration detected. "
       + "Only a limited set of inconsistent configuration will be shown here. "
@@ -48,6 +48,8 @@ public class ServerConfigurationChecker {
   private final ServerConfigurationStore mWorkerStore;
   /** Contain the checker results. */
   private ConfigCheckReport mConfigCheckReport;
+  /** Whether the configuration has been changed since the last time the report was generated. */
+  private volatile boolean mConfigDirty = true;
 
   /**
    * Constructs a new {@link ServerConfigurationChecker}.
@@ -60,8 +62,8 @@ public class ServerConfigurationChecker {
     mMasterStore = masterStore;
     mWorkerStore = workerStore;
     mConfigCheckReport = new ConfigCheckReport();
-    mMasterStore.registerChangeListener(this::regenerateReport);
-    mWorkerStore.registerChangeListener(this::regenerateReport);
+    mMasterStore.registerChangeListener(() -> mConfigDirty = true);
+    mWorkerStore.registerChangeListener(() -> mConfigDirty = true);
   }
 
   /**
@@ -107,6 +109,10 @@ public class ServerConfigurationChecker {
    * @return the configuration checker report
    */
   public synchronized ConfigCheckReport getConfigCheckReport() {
+    if (mConfigDirty == true) {
+      mConfigDirty = false;
+      regenerateReport();
+    }
     return mConfigCheckReport;
   }
 


### PR DESCRIPTION
This PR addresses https://alluxio.atlassian.net/browse/ALLUXIO-3221 and includes a few more small fixes around the configuration checker.

The root cause for the deadlock was
```java
mMasterStore.registerChangeListener(this::regenerateReport);
mWorkerStore.registerChangeListener(this::regenerateReport);
```
`regenerateReport` makes calls into `mMasterStore`, and `mWorkerStore`, but `mWorkerStore` and `mMasterStore` both call `regenerateReport` synchronously while holding `ConfigurationStore`-level locks. This leads to an issue where `mMasterStore` and `mWorkerStore` each try to grab a lock on the other.