### PR TITLE
[SMALLFIX] Fix unset test

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -34,6 +34,7 @@ import alluxio.thrift.GetServiceVersionTOptions;
 import alluxio.thrift.MetaMasterClientService;
 import alluxio.util.SecurityUtils;
 import alluxio.wire.ConfigProperty;
+import alluxio.wire.Scope;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
@@ -228,6 +229,10 @@ public abstract class AbstractClient implements Client {
         // TODO(binfan): support propagating unsetting properties from master
         if (PropertyKey.isValid(name) && property.getValue() != null) {
           PropertyKey key = PropertyKey.fromString(name);
+          if (!key.getScope().contains(Scope.CLIENT)) {
+            // Only propagate client properties.
+            continue;
+          }
           String value = property.getValue();
           clusterProps.put(key, value);
           LOG.debug("Loading cluster default: {} ({}) -> {}", key, key.getScope(), value);

--- a/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
@@ -114,7 +114,10 @@ public class ServerConfigurationChecker {
       // during report regeneration, the change will be reflected in the next call to
       // getConfigCheckReport.
       mConfigDirty = false;
+      LOG.debug("Regenerating config check report");
       regenerateReport();
+    } else {
+      LOG.debug("Skipping regenerating config check report");
     }
     return mConfigCheckReport;
   }


### PR DESCRIPTION
Test setup: Set a master-only property on master1 but not on master2
Expected: Configuration checker reports the inconsistency

Actual:
1. Secondary master gets ID from primary master, triggering handshake
2. Handshake sends the primary master's version of the property to secondary master, and overrides the secondary master's configuration
3. Secondary master reports its configuration, but it's actually reporting the configuration that the primary master sent it
4. The test fails.

There's actually a 50% chance that the test passes because the handshake doesn't propagate unset values, so if the master which left the property unset becomes primary, the handshake won't break the test.