### PR TITLE
[SMALLFIX] Relax time requirements to prevent flakiness under stress

### DIFF
--- a/minicluster/src/main/java/alluxio/master/TestUtils.java
+++ b/minicluster/src/main/java/alluxio/master/TestUtils.java
@@ -18,7 +18,7 @@ import alluxio.util.ThreadUtils;
  * Test utilities.
  */
 public class TestUtils {
-  private static final int SERVER_START_TIMEOUT_MS = 10 * Constants.SECOND_MS;
+  private static final int SERVER_START_TIMEOUT_MS = Constants.MINUTE_MS;
 
   /**
    * @param process the process to wait for

--- a/tests/src/test/java/alluxio/client/fs/ConcurrentFileSystemMasterCreateTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ConcurrentFileSystemMasterCreateTest.java
@@ -100,7 +100,7 @@ public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
   public void concurrentCreate() throws Exception {
     final int numThreads = CONCURRENCY_FACTOR;
     // 7 nested components to create (2 seconds each).
-    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 10;
+    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 2;
     AlluxioURI[] paths = new AlluxioURI[numThreads];
 
     for (int i = 0; i < numThreads; i++) {
@@ -123,7 +123,7 @@ public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
   public void concurrentCreateExistingDir() throws Exception {
     final int numThreads = CONCURRENCY_FACTOR;
     // 7 nested components to create (2 seconds each).
-    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 10;
+    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 2;
     AlluxioURI[] paths = new AlluxioURI[numThreads];
 
     // Create the existing path with CACHE_THROUGH that it will be persisted.
@@ -150,7 +150,7 @@ public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
   public void concurrentCreateNonPersistedDir() throws Exception {
     final int numThreads = CONCURRENCY_FACTOR;
     // 7 nested components to create (2 seconds each).
-    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 10;
+    final long limitMs = 14 * SLEEP_MS * CONCURRENCY_FACTOR / 2;
     AlluxioURI[] paths = new AlluxioURI[numThreads];
 
     // Create the existing path with MUST_CACHE, so subsequent creates have to persist the dirs.


### PR DESCRIPTION
When the testing system is under a high load, some tests
start failing due to overly strict time requirements.