### PR TITLE
[ALLUXIO-3229] Rename formatMaster to formatMasters

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -175,13 +175,26 @@ function runJavaClass {
       case "${arg}" in
           -debug)
               ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
-          -D* | -X*)
+          -D* | -X* | -agentlib*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
               CLASS_ARGS+=("${arg}")
       esac
   done
   "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+}
+
+function formatJournal {
+  echo "Formatting Alluxio Master @ $(hostname -f)"
+  CLASS="alluxio.cli.Format"
+  CLASSPATH=${ALLUXIO_SERVER_CLASSPATH}
+  PARAMETER="master"
+  ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
+  runJavaClass "$@"
+}
+
+function formatMasters {
+  formatJournal "$@"
 }
 
 function main {
@@ -245,12 +258,7 @@ function main {
 
     ${LAUNCHER} ${BIN}/alluxio-workers.sh ${BIN}/alluxio formatWorker
 
-    echo "Formatting Alluxio Master @ $(hostname -f)"
-    CLASS="alluxio.cli.Format"
-    CLASSPATH=${ALLUXIO_SERVER_CLASSPATH}
-    PARAMETER="master"
-    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
-    runJavaClass "$@"
+    formatMasters
   ;;
   "formatWorker")
     echo "Formatting Alluxio Worker @ $(hostname -f)"
@@ -260,13 +268,15 @@ function main {
     ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
     runJavaClass "$@"
   ;;
+  "formatJournal")
+    formatJournal
+  ;;
   "formatMaster")
-    echo "Formatting Alluxio Master @ $(hostname -f)"
-    CLASS="alluxio.cli.Format"
-    CLASSPATH=${ALLUXIO_SERVER_CLASSPATH}
-    PARAMETER="master"
-    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
-    runJavaClass "$@"
+    echo "formatMaster is deprecated - use formatMasters instead"
+    formatJournal
+  ;;
+  "formatMasters")
+    formatMasters
   ;;
   "fs")
     CLASS="alluxio.cli.fs.FileSystemShell"


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3229

It formats all masters, so formatMasters seems
like a better name.

Also includes a smallfix to pass -agentlib to the jvm instead of shell commands like format. Otherwise running format with the -agentlib java arg will fail because it thinks -agentlib is an argument to format