### PR TITLE
[SMALLFIX] more efficient locking for listStatus

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -999,7 +999,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
           listStatusInternal(childInodePath, auditContext,
               nextDescendantType, statusList);
         } catch (InvalidPathException e) {
-          LOG.warn("ListStatus encountered an invalid path {}", child.getName(), e);
+          LOG.warn("ListStatus encountered an invalid path {}",
+              currInodePath.getUri().join(child.getName()), e);
         }
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -146,7 +146,6 @@ import com.google.common.io.Closer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.thrift.TProcessor;
-import org.omg.CORBA.DynAnyPackage.Invalid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
before this change, listStatusInternal was locking from the root to the child node, now we lock from the parent node to the child node.  