### PR TITLE
[SMALLFIX] Fix build for hadoop 1

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -102,6 +102,10 @@ func getCommonMvnArgs(hadoopVersion version) []string {
 	if includeYarnIntegration(hadoopVersion) {
 		args = append(args, "-Pyarn")
 	}
+	if hadoopVersion.major == 1 {
+		// checker requires hadoop 2+ to compile.
+		args = append(args, "-Dchecker.hadoop.version=2.2.0")
+	}
 	return args
 }
 

--- a/integration/checker/pom.xml
+++ b/integration/checker/pom.xml
@@ -27,6 +27,7 @@
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
     <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
+    <checker.hadoop.version>${hadoop.version}</checker.hadoop.version>
   </properties>
 
   <dependencies>
@@ -41,7 +42,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.2.0</version>
+      <version>${checker.hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-client</artifactId>
+      <version>${checker.hadoop.version}</version>
     </dependency>
 
     <!-- We pick a particular Hive version here for convenience, but this checker


### PR DESCRIPTION
Checker couldn't build with the hadoop-1 profile because its `hadoop-yarn-client` dependency does not exist until hadoop 2.

Now we can build in these ways:
`mvn install` - build alluxio and checker with the default hadoop version (2.2.0)
`mvn install -Phadoop-2.7` - build alluxio and checker with hadoop 2.7
`mvn install -Phadoop-1 -Dchecker.hadoop.version=2.2.0` - build alluxio with hadoop 1.0.4, build the checker with hadoop 2.2.0