### PR TITLE
[SMALLFIX] Add support for generating default tarballs

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
@@ -34,6 +34,8 @@ var hadoopDistributions = map[string]version{
 	"hadoop-2.6": parseVersion("2.6.5"),
 	"hadoop-2.7": parseVersion("2.7.3"),
 	"hadoop-2.8": parseVersion("2.8.0"),
+	// This distribution type is built with 2.2.0, but doesn't include the hadoop version in the name.
+	"default": parseVersion("2.2.0"),
 }
 
 func validHadoopDistributions() []string {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
@@ -55,7 +55,11 @@ func release(_ *cmdline.Env, _ []string) error {
 
 func generateTarballs() error {
 	for _, distribution := range strings.Split(hadoopDistributionsFlag, ",") {
-		targetFlag = fmt.Sprintf("alluxio-%v-%v.tar.gz", versionMarker, distribution)
+		if distribution == "default" {
+			targetFlag = fmt.Sprintf("alluxio-%v-bin.tar.gz", versionMarker)
+		} else {
+			targetFlag = fmt.Sprintf("alluxio-%v-%v.tar.gz", versionMarker, distribution)
+		}
 		fmt.Printf("Generating distribution for %v at %v", distribution, targetFlag)
 		if err := generateTarball(distribution); err != nil {
 			return err

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -244,6 +244,7 @@ func generateTarball(hadoopDistribution string) error {
 
 	tarball := strings.Replace(targetFlag, versionMarker, version, 1)
 	dstDir := strings.TrimSuffix(filepath.Base(tarball), ".tar.gz")
+	dstDir = strings.TrimSuffix(dstDir, "-bin")
 	dstPath := filepath.Join(cwd, dstDir)
 	run(fmt.Sprintf("removing any existing %v", dstPath), "rm", "-rf", dstPath)
 	fmt.Printf("Creating %s:\n", tarball)


### PR DESCRIPTION
We traditionally distribute a tarball named `alluxio-${VERSION}-bin.tar.gz` which is built with the default hadoop version, and untars to a directory named `alluxio-${VERSION}`. This PR adds support for generating this tarball automatically by specifying the "default" hadoop-distribution