### PR TITLE
[SMALLFIX] Fix NPE

### DIFF
--- a/core/common/src/main/java/alluxio/network/thrift/SocketTrackingTServerSocket.java
+++ b/core/common/src/main/java/alluxio/network/thrift/SocketTrackingTServerSocket.java
@@ -76,16 +76,18 @@ public class SocketTrackingTServerSocket extends TServerSocket {
    * Shuts down the executor service.
    */
   private void shutdownExecutor() {
-    if (mExecutor != null) {
-      mExecutor.shutdownNow();
-      try {
-        if (!mExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-          LOG.warn("Failed to stop socket cleanup thread.");
-        }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return;
+    // Possible since super constructor can call close().
+    if (mExecutor == null) {
+      return;
+    }
+    mExecutor.shutdownNow();
+    try {
+      if (!mExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+        LOG.warn("Failed to stop socket cleanup thread.");
       }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
     }
   }
 
@@ -93,6 +95,10 @@ public class SocketTrackingTServerSocket extends TServerSocket {
    * Closes all socket connections that have been accepted by this server socket.
    */
   private void closeClientSockets() throws IOException {
+    // Possible since super constructor can call close().
+    if (mSockets == null) {
+      return;
+    }
     Closer closer = Closer.create();
     int count = 0;
     for (Socket s : mSockets) {


### PR DESCRIPTION
Fixes this happening when the superclass fails to bind the socket and tries to call `close()` before finishing the constructor.
```
java.lang.RuntimeException: java.lang.NullPointerException
	at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:172)
	at alluxio.master.MasterProcess$Factory.create(MasterProcess.java:45)
	at alluxio.master.AlluxioMaster.main(AlluxioMaster.java:45)
	at alluxio.multi.process.LimitedLifeMasterProcess.main(LimitedLifeMasterProcess.java:26)
Caused by: java.lang.NullPointerException
	at alluxio.network.thrift.SocketTrackingTServerSocket.closeClientSockets(SocketTrackingTServerSocket.java:98)
	at alluxio.network.thrift.SocketTrackingTServerSocket.close(SocketTrackingTServerSocket.java:68)
	at org.apache.thrift.transport.TServerSocket.<init>(TServerSocket.java:108)
	at alluxio.network.thrift.SocketTrackingTServerSocket.<init>(SocketTrackingTServerSocket.java:50)
	at alluxio.network.thrift.ThriftUtils.createThriftServerSocket(ThriftUtils.java:84)
	at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:151)
	... 3 more
```