### PR TITLE
[DOCFIX] improve NFS docs

### DIFF
--- a/docs/en/Configuring-Alluxio-with-NFS.md
+++ b/docs/en/Configuring-Alluxio-with-NFS.md
@@ -38,12 +38,11 @@ alluxio.underfs.address=/mnt/nfs
 
 ## Running Alluxio with NFS
 
-After everything is configured, you can start up Alluxio locally to see that everything works.
+Simply run the following command to start Alluxio filesystem.
 
 {% include Configuring-Alluxio-with-NFS/start-alluxio.md %}
 
-This should start an Alluxio master and an Alluxio worker. You can see the master UI at
-[http://localhost:19999](http://localhost:19999).
+To verify that Alluxio is running, you can visit http://localhost:19999, or see the log in the logs folder.
 
 Next, you can run a simple example program:
 
@@ -54,6 +53,6 @@ by Alluxio exist. For this test, you should see files named like:
 
 {% include Configuring-Alluxio-with-NFS/nfs-file.md %}
 
-To stop Alluxio, you can run:
+You can stop Alluxio any time by running:
 
 {% include Configuring-Alluxio-with-NFS/stop-alluxio.md %}

--- a/docs/en/Configuring-Alluxio-with-NFS.md
+++ b/docs/en/Configuring-Alluxio-with-NFS.md
@@ -42,7 +42,8 @@ Simply run the following command to start Alluxio filesystem.
 
 {% include Configuring-Alluxio-with-NFS/start-alluxio.md %}
 
-To verify that Alluxio is running, you can visit http://localhost:19999, or see the log in the logs folder.
+To verify that Alluxio is running, you can visit
+**[http://localhost:19999](http://localhost:19999)**, or see the log in the `logs` folder.
 
 Next, you can run a simple example program:
 

--- a/docs/en/Configuring-Alluxio-with-NFS.md
+++ b/docs/en/Configuring-Alluxio-with-NFS.md
@@ -32,7 +32,7 @@ directory `/mnt/nfs`, the following environment variable assignment needs to be 
 `conf/alluxio-site.properties`:
 
 ```
-properties
+alluxio.master.hostname=localhost
 alluxio.underfs.address=/mnt/nfs
 ```
 


### PR DESCRIPTION
It looks strange to say ```properties``` should be added to ```conf/alluxio-site.properties``` file for me. People that are not familiar with Alluxio or not have much coding experience before may think the word ```properties``` should be directly added to conf files.

The fix is to make the docs easier to follow.