### PR TITLE
[SMALLFIX] Fix using object storage for UFS journal

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -376,7 +376,6 @@ final class UfsJournalLogWriter implements JournalWriter {
     private final UfsJournalFile mCurrentLog;
 
     JournalOutputStream(UfsJournalFile currentLog, OutputStream stream) throws IOException {
-      Preconditions.checkState(mUfs.exists(currentLog.getLocation().getPath()));
       mOutputStream = wrapDataOutputStream(stream);
       mCurrentLog = currentLog;
     }


### PR DESCRIPTION
In object stores, successful return from `createFile()` doesn't imply that `exists()` will return true, so we need to remove this precondition check.

Tested locally, before this change master can't start up with journal pointed to an S3 folder. After the change runTests passes.