### PR TITLE
[SMALLFIX] Track source for alluxio-site.properties loaded from classpath

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -18,6 +18,7 @@ import alluxio.util.ConfigurationUtils;
 
 import com.google.common.base.Preconditions;
 
+import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,11 @@ public final class Configuration {
     if (sitePropertyFile != null) {
       siteProps = ConfigurationUtils.loadPropertiesFromFile(sitePropertyFile);
     } else {
-      siteProps = ConfigurationUtils.loadPropertiesFromResource(Constants.SITE_PROPERTIES);
+      URL resource = Configuration.class.getClassLoader().getResource(Constants.SITE_PROPERTIES);
+      siteProps = ConfigurationUtils.loadPropertiesFromResource(resource);
+      if (siteProps != null) {
+        sitePropertyFile = resource.getPath();
+      }
     }
     PROPERTIES.merge(siteProps, Source.siteProperty(sitePropertyFile));
     validate();

--- a/core/common/src/main/java/alluxio/conf/Source.java
+++ b/core/common/src/main/java/alluxio/conf/Source.java
@@ -11,6 +11,8 @@
 
 package alluxio.conf;
 
+import com.google.common.base.Objects;
+
 /**
  * The source of a configuration property.
  */
@@ -91,6 +93,23 @@ public class Source implements Comparable<Source> {
     private SitePropertySource(String filename) {
       super(Type.SITE_PROPERTY);
       mFilename = filename;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SitePropertySource)) {
+        return false;
+      }
+      SitePropertySource that = (SitePropertySource) o;
+      return Objects.equal(mFilename, that.mFilename);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mFilename);
     }
 
     @Override

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -27,6 +27,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.List;
 import java.util.Properties;
 
@@ -41,25 +42,27 @@ public final class ConfigurationUtils {
   private ConfigurationUtils() {} // prevent instantiation
 
   /**
-   * Loads properties from resource. This method will search Classpath for the properties file with
-   * the given resourceName.
+   * Loads properties from a resource.
    *
-   * @param resourceName filename of the properties file
+   * @param resource url of the properties file
    * @return a set of properties on success, or null if failed
    */
-  public static Properties loadPropertiesFromResource(String resourceName) {
-    Properties properties = new Properties();
-
-    InputStream inputStream =
-        Configuration.class.getClassLoader().getResourceAsStream(resourceName);
+  public static Properties loadPropertiesFromResource(URL resource) {
+    InputStream inputStream;
+    try {
+      inputStream = resource.openStream();
+    } catch (IOException e) {
+      return null;
+    }
     if (inputStream == null) {
       return null;
     }
 
+    Properties properties = new Properties();
     try {
       properties.load(inputStream);
     } catch (IOException e) {
-      LOG.warn("Unable to load default Alluxio properties file {} : {}", resourceName,
+      LOG.warn("Unable to load default Alluxio properties file {} : {}", resource,
           e.getMessage());
       return null;
     }

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -47,45 +47,45 @@ public final class ConfigurationUtils {
    * @param resource url of the properties file
    * @return a set of properties on success, or null if failed
    */
+  @Nullable
   public static Properties loadPropertiesFromResource(URL resource) {
-    InputStream inputStream;
     try {
-      inputStream = resource.openStream();
+      return loadProperties(resource.openStream());
     } catch (IOException e) {
+      LOG.warn("Failed to read properties from {}: {}", resource, e.toString());
       return null;
     }
-    if (inputStream == null) {
-      return null;
-    }
-
-    Properties properties = new Properties();
-    try {
-      properties.load(inputStream);
-    } catch (IOException e) {
-      LOG.warn("Unable to load default Alluxio properties file {} : {}", resource,
-          e.getMessage());
-      return null;
-    }
-    return properties;
   }
 
   /**
-   * Loads properties from the given file. This method will search Classpath for the properties
-   * file.
+   * Loads properties from the given file.
    *
    * @param filePath the absolute path of the file to load properties
    * @return a set of properties on success, or null if failed
    */
   @Nullable
   public static Properties loadPropertiesFromFile(String filePath) {
-    Properties properties = new Properties();
-
     try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
-      properties.load(fileInputStream);
+      return loadProperties(fileInputStream);
     } catch (FileNotFoundException e) {
       return null;
     } catch (IOException e) {
-      LOG.warn("Unable to load properties file {} : {}", filePath, e.getMessage());
+      LOG.warn("Failed to close property input stream from {}: {}", filePath, e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * @param stream the stream to read properties from
+   * @return a properties object populated from the stream
+   */
+  @Nullable
+  public static Properties loadProperties(InputStream stream) {
+    Properties properties = new Properties();
+    try {
+      properties.load(stream);
+    } catch (IOException e) {
+      LOG.warn("Unable to load properties: {}", e.toString());
       return null;
     }
     return properties;

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -28,10 +28,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.powermock.reflect.Whitebox;
 
+import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -865,5 +868,23 @@ public class ConfigurationTest {
     PropertyKey fakeExtensionKey = new PropertyKey.Builder(fakeKeyName).build();
     assertEquals("value", Configuration.get(fakeExtensionKey));
     assertTrue(PropertyKey.fromString(fakeKeyName).isBuiltIn());
+  }
+
+  @Test
+  public void findPropertiesFileClasspath() throws Exception {
+    try (Closeable p =
+        new SystemPropertyRule(PropertyKey.TEST_MODE.toString(), "false").toResource()) {
+      File dir = AlluxioTestDirectory.createTemporaryDirectory("findPropertiesFileClasspath");
+      Whitebox.invokeMethod(ClassLoader.getSystemClassLoader(), "addURL", dir.toURI().toURL());
+      File props = new File(dir, "alluxio-site.properties");
+      try (BufferedWriter writer = Files.newBufferedWriter(props.toPath())) {
+        writer.write(String.format("%s=%s", PropertyKey.MASTER_HOSTNAME, "test_hostname"));
+      }
+      Configuration.reset();
+      assertEquals("test_hostname", Configuration.get(PropertyKey.MASTER_HOSTNAME));
+      assertEquals(Source.siteProperty(props.getPath()),
+          Configuration.getSource(PropertyKey.MASTER_HOSTNAME));
+      props.delete();
+    }
   }
 }


### PR DESCRIPTION
Otherwise the site properties source will show up as `null` when it's loaded from the classpath