### PR TITLE
[SMALLFIX] Improve extension factory logging

### DIFF
--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -17,7 +17,6 @@ import alluxio.util.ExtensionUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,8 +107,8 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
     ServiceLoader<T> discoveredFactories =
         ServiceLoader.load(mFactoryClass, mFactoryClass.getClassLoader());
     for (T factory : discoveredFactories) {
-      LOG.debug("Discovered base extension factory implementation {} - {}",
-          factory.getClass(), factory.toString());
+      LOG.debug("Discovered base extension factory implementation {} - {}", factory.getClass(),
+          factory);
       register(factory);
     }
   }
@@ -140,14 +139,13 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
     List<T> eligibleFactories = new ArrayList<>();
     for (T factory : factories) {
       if (factory.supportsPath(path, conf)) {
-        LOG.debug("factory implementation {} is eligible for path {}",
-            factory.getClass(), path);
+        LOG.debug("Factory implementation {} is eligible for path {}", factory, path);
         eligibleFactories.add(factory);
       }
     }
 
     if (eligibleFactories.isEmpty()) {
-      LOG.warn("factory implementation supports the path {}", path);
+      LOG.warn("No factory implementation supports the path {}", path);
     }
     return eligibleFactories;
   }
@@ -178,7 +176,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
         }
       }
     } catch (IOException e) {
-      LOG.warn("Failed to load libs: {}", e.getMessage());
+      LOG.warn("Failed to load libs: {}", e.toString());
     }
     scan(files, factories);
   }
@@ -200,12 +198,12 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
         ServiceLoader<T> extensionServiceLoader =
             ServiceLoader.load(mFactoryClass, extensionsClassLoader);
         for (T factory : extensionServiceLoader) {
-          LOG.debug("Discovered a factory implementation {} - {} in jar {}",
-              factory.getClass(), factory.toString(), jarPath);
+          LOG.debug("Discovered a factory implementation {} - {} in jar {}", factory.getClass(),
+              factory, jarPath);
           register(factory, factories);
         }
       } catch (Throwable t) {
-        LOG.warn("Failed to load jar {}: {}", jar, t.getMessage());
+        LOG.warn("Failed to load jar {}: {}", jar, t.toString());
       }
     }
   }
@@ -231,8 +229,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
       return;
     }
 
-    LOG.debug("Registered factory implementation {} - {}", factory.getClass(),
-        factory.toString());
+    LOG.debug("Registered factory implementation {} - {}", factory.getClass(), factory);
 
     // Insert at start of list so it will take precedence over automatically discovered and
     // previously registered factories
@@ -270,8 +267,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>, S> {
       return;
     }
 
-    LOG.debug("Unregistered factory implementation {} - {}", factory.getClass(),
-        factory.toString());
+    LOG.debug("Unregistered factory implementation {} - {}", factory.getClass(), factory);
     factories.remove(factory);
   }
 }


### PR DESCRIPTION
Mostly style changes, the only functional change is changing from
```java
LOG.debug("factory implementation {} is eligible for path {}", factory.getClass(), path);
```
to
```java
LOG.debug("Factory implementation {} is eligible for path {}", factory, path)
```
This is because `factory` shows the specific reference for the ufs factory (e.g. `alluxio.underfs.hdfs.HdfsUnderFileSystemFactory@4dfcb41e`) instead of just the class name (`alluxio.underfs.hdfs.HdfsUnderFileSystemFactory`)

This helps with identifying which specific jar was used to instantiate a UFS