### PR TITLE
[SMALLFIX] make a couple things more reusable

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
 
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -353,7 +353,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
 
   @Override
   public List<WorkerInfo> getWorkerInfoList() throws UnavailableException {
-    if (mSafeModeManager.isInSafeMode()) {
+    if (mMasterContext.getSafeModeManager().isInSafeMode()) {
       throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
     }
     List<WorkerInfo> workerInfoList = new ArrayList<>(mWorkers.size());
@@ -367,7 +367,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
 
   @Override
   public List<WorkerInfo> getLostWorkersInfoList() throws UnavailableException {
-    if (mSafeModeManager.isInSafeMode()) {
+    if (mMasterContext.getSafeModeManager().isInSafeMode()) {
       throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
     }
     List<WorkerInfo> workerInfoList = new ArrayList<>(mLostWorkers.size());
@@ -383,7 +383,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   @Override
   public List<WorkerInfo> getWorkerReport(GetWorkerReportOptions options)
       throws UnavailableException, InvalidArgumentException {
-    if (mSafeModeManager.isInSafeMode()) {
+    if (mMasterContext.getSafeModeManager().isInSafeMode()) {
       throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
     }
 
@@ -890,7 +890,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
    */
   @GuardedBy("masterBlockInfo")
   private BlockInfo generateBlockInfo(MasterBlockInfo masterBlockInfo) throws UnavailableException {
-    if (mSafeModeManager.isInSafeMode()) {
+    if (mMasterContext.getSafeModeManager().isInSafeMode()) {
       throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
     }
     // "Join" to get all the addresses of the workers.

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -28,7 +28,6 @@ import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.AbstractMaster;
 import alluxio.master.MasterClientConfig;
 import alluxio.master.MasterContext;
-import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.meta.checkconf.ServerConfigurationChecker;
 import alluxio.master.meta.checkconf.ServerConfigurationStore;
@@ -130,12 +129,6 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
   private final InetSocketAddress mRpcConnectAddress
       = NetworkAddressUtils.getConnectAddress(NetworkAddressUtils.ServiceType.MASTER_RPC);
 
-  /** The manager of safe mode state. */
-  private final SafeModeManager mSafeModeManager;
-
-  /** The start time for when the master started serving the RPC server. */
-  private final long mStartTimeMs;
-
   /** The address of this master. */
   private Address mMasterAddress;
 
@@ -161,8 +154,6 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
   DefaultMetaMaster(BlockMaster blockMaster, MasterContext masterContext,
       ExecutorServiceFactory executorServiceFactory) {
     super(masterContext, new SystemClock(), executorServiceFactory);
-    mSafeModeManager = masterContext.getSafeModeManager();
-    mStartTimeMs = masterContext.getStartTimeMs();
     mMasterAddress =
         new Address().setHost(Configuration.getOrDefault(PropertyKey.MASTER_HOSTNAME, "localhost"))
             .setRpcPort(masterContext.getPort());
@@ -259,7 +250,7 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
       }
     }
     String backupFilePath;
-    try (LockResource lr = new LockResource(mPauseStateLock)) {
+    try (LockResource lr = new LockResource(mMasterContext.pauseStateLock())) {
       Instant now = Instant.now();
       String backupFileName = String.format("alluxio-backup-%s-%s.gz",
           DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneId.of("UTC")).format(now),
@@ -267,7 +258,7 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
       backupFilePath = PathUtils.concatPath(dir, backupFileName);
       OutputStream ufsStream = ufs.create(backupFilePath);
       try {
-        mBackupManager.backup(ufsStream);
+        mMasterContext.getBackupManager().backup(ufsStream);
       } catch (Throwable t) {
         try {
           ufsStream.close();
@@ -367,12 +358,12 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
 
   @Override
   public long getStartTimeMs() {
-    return mStartTimeMs;
+    return mMasterContext.getStartTimeMs();
   }
 
   @Override
   public long getUptimeMs() {
-    return System.currentTimeMillis() - mStartTimeMs;
+    return System.currentTimeMillis() - mMasterContext.getStartTimeMs();
   }
 
   @Override
@@ -382,7 +373,7 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
 
   @Override
   public boolean isInSafeMode() {
-    return mSafeModeManager.isInSafeMode();
+    return mMasterContext.getSafeModeManager().isInSafeMode();
   }
 
   @Override

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -197,6 +197,18 @@ public final class MultiProcessCluster implements TestRule {
    * @return the ID of the killed master
    */
   public synchronized int waitForAndKillPrimaryMaster(int timeoutMs) {
+    int index = getPrimaryMasterIndex(timeoutMs);
+    mMasters.get(index).close();
+    return index;
+  }
+
+  /**
+   * Gets the index of the primary master.
+   *
+   * @param timeoutMs maximum amount of time to wait, in milliseconds
+   * @return the index of the primary master
+   */
+  public synchronized int getPrimaryMasterIndex(int timeoutMs) {
     final FileSystem fs = getFileSystemClient();
     final MasterInquireClient inquireClient = getMasterInquireClient();
     CommonUtils.waitFor("a primary master to be serving", new Function<Void, Boolean>() {
@@ -219,10 +231,9 @@ public final class MultiProcessCluster implements TestRule {
     } catch (UnavailableException e) {
       throw new RuntimeException(e);
     }
-    // Destroy the master whose RPC port matches the primary RPC port.
+    // Returns the master whose RPC port matches the primary RPC port.
     for (int i = 0; i < mMasterAddresses.size(); i++) {
       if (mMasterAddresses.get(i).getRpcPort() == primaryRpcPort) {
-        mMasters.get(i).close();
         return i;
       }
     }


### PR DESCRIPTION
- Replace individual members in `AbstractMaster` in favor of storing and using `MasterContext` directly.

- Add getPrimaryIndex in MultiProcessCluster for determining primary master.