### PR TITLE
[SMALLFIX] Slight performance optimizations.

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -214,7 +214,7 @@ public final class MetricsSystem {
    * @return the metric registry name
    */
   private static String getMasterMetricName(String name) {
-    return Joiner.on(".").join(MetricsSystem.InstanceType.MASTER, name);
+    return InstanceType.MASTER + "." + name;
   }
 
   /**
@@ -266,8 +266,7 @@ public final class MetricsSystem {
    * @return the metric registry name
    */
   private static String getMetricNameWithUniqueId(InstanceType instance, String name) {
-    return Joiner.on(".").join(instance, NetworkAddressUtils.getLocalHostName().replace('.', '_'),
-        name);
+    return instance + "." + NetworkAddressUtils.getLocalHostMetricName() + "." + name;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -60,6 +60,7 @@ public final class NetworkAddressUtils {
   public static final boolean WINDOWS = OSUtils.isWindows();
 
   private static String sLocalHost;
+  private static String sLocalHostMetricName;
   private static String sLocalIP;
 
   private NetworkAddressUtils() {}
@@ -450,6 +451,20 @@ public final class NetworkAddressUtils {
     } catch (UnknownHostException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Gets a local hostname for the host this JVM is running on with '.' replaced with '_' for
+   * metrics usage.
+   *
+   * @return the metrics system friendly local host name
+   */
+  public static synchronized String getLocalHostMetricName() {
+    if (sLocalHostMetricName != null) {
+      return sLocalHostMetricName;
+    }
+    sLocalHostMetricName = getLocalHostName().replace('.', '_');
+    return sLocalHostMetricName;
   }
 
   /**


### PR DESCRIPTION
`+` is faster than `Joiner` for few elements. Caching the metric hostname to avoid expensive string replace.

@yuzhu the performance is better but still not as good as if we did not do the instance type string construction.