### PR TITLE
[SMALLFIX] Check for null when searching classpath for alluxio-site.properties

### DIFF
--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -76,7 +76,7 @@ public final class Configuration {
 
     // Step2: Load site specific properties file if not in test mode. Note that we decide whether in
     // test mode by default properties and system properties (via getBoolean).
-    Properties siteProps;
+    Properties siteProps = null;
     // we are not in test mode, load site properties
     String confPaths = Configuration.get(PropertyKey.SITE_CONF_DIR);
     String[] confPathList = confPaths.split(",");
@@ -86,9 +86,11 @@ public final class Configuration {
       siteProps = ConfigurationUtils.loadPropertiesFromFile(sitePropertyFile);
     } else {
       URL resource = Configuration.class.getClassLoader().getResource(Constants.SITE_PROPERTIES);
-      siteProps = ConfigurationUtils.loadPropertiesFromResource(resource);
-      if (siteProps != null) {
-        sitePropertyFile = resource.getPath();
+      if (resource != null) {
+        siteProps = ConfigurationUtils.loadPropertiesFromResource(resource);
+        if (siteProps != null) {
+          sitePropertyFile = resource.getPath();
+        }
       }
     }
     PROPERTIES.merge(siteProps, Source.siteProperty(sitePropertyFile));

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -92,7 +92,7 @@ public final class ConfigurationUtils {
   }
 
   /**
-   * Searches the given properties file from a list of paths as well as the classpath.
+   * Searches the given properties file from a list of paths.
    *
    * @param propertiesFile the file to load properties
    * @param confPathList a list of paths to search the propertiesFile

--- a/core/common/src/test/java/alluxio/ConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTest.java
@@ -886,4 +886,14 @@ public class ConfigurationTest {
       props.delete();
     }
   }
+
+  @Test
+  public void noPropertiesAnywhere() throws Exception {
+    try (Closeable p =
+             new SystemPropertyRule(PropertyKey.TEST_MODE.toString(), "false").toResource()) {
+      Configuration.set(PropertyKey.SITE_CONF_DIR, "");
+      Configuration.reset();
+      assertEquals("0.0.0.0", Configuration.get(PropertyKey.PROXY_WEB_BIND_HOST));
+    }
+  }
 }


### PR DESCRIPTION
The NPE is triggered if no alluxio-site.properties file can be found anywhere