### PR TITLE
[SMALLFIX] Use a heartbeat thread to update metrics.

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -958,6 +958,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_CLUSTER_METRICS_UPDATE_INTERVAL =
+      new Builder(Name.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL)
+          .setDefaultValue("1m")
+          .setDescription("The interval for periodically updating the cluster level metrics.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_CONNECTION_TIMEOUT_MS =
       new Builder(Name.MASTER_CONNECTION_TIMEOUT_MS)
           .setAlias(new String[]{"alluxio.master.connection.timeout.ms"})
@@ -3198,6 +3205,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_BIND_HOST = "alluxio.master.bind.host";
     public static final String MASTER_CLIENT_SOCKET_CLEANUP_INTERVAL =
         "alluxio.master.client.socket.cleanup.interval";
+    public static final String MASTER_CLUSTER_METRICS_UPDATE_INTERVAL =
+        "alluxio.master.cluster.metrics.update.interval";
     public static final String MASTER_CONNECTION_TIMEOUT_MS =
         "alluxio.master.connection.timeout";
     public static final String MASTER_FILE_ASYNC_PERSIST_HANDLER =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -964,6 +964,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The interval for periodically updating the cluster level metrics.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
+          .setIsHidden(true)
           .build();
   public static final PropertyKey MASTER_CONNECTION_TIMEOUT_MS =
       new Builder(Name.MASTER_CONNECTION_TIMEOUT_MS)

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -30,6 +30,7 @@ public final class HeartbeatContext {
 
   // Names of different heartbeat executors.
   public static final String MASTER_BLOCK_INTEGRITY_CHECK = "Master Block Integrity Check";
+  public static final String MASTER_CLUSTER_METRICS_UPDATER = "Master Cluster Metrics Updater";
   public static final String MASTER_CHECKPOINT_SCHEDULING = "Master Checkpoint Scheduling";
   public static final String MASTER_FILE_RECOMPUTATION = "Master File Recomputation";
   public static final String MASTER_LOG_CONFIG_REPORT_SCHEDULING
@@ -49,6 +50,7 @@ public final class HeartbeatContext {
   static {
     sTimerClasses = new HashMap<>();
     sTimerClasses.put(MASTER_BLOCK_INTEGRITY_CHECK, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_CLUSTER_METRICS_UPDATER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_CHECKPOINT_SCHEDULING, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_FILE_RECOMPUTATION, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_LOG_CONFIG_REPORT_SCHEDULING, SLEEPING_TIMER_CLASS);

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -60,21 +60,6 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   private final HeartbeatThread mClusterMetricsUpdater;
 
   /**
-   * Heartbeat executor that updates the cluster metrics.
-   */
-  private class ClusterMetricsUpdater implements HeartbeatExecutor {
-    @Override
-    public void heartbeat() throws InterruptedException {
-      updateMultiValueMetrics();
-    }
-
-    @Override
-    public void close() {
-      // nothing to clean up
-    }
-  }
-
-  /**
    * Creates a new instance of {@link MetricsMaster}.
    *
    * @param masterContext the context for metrics master
@@ -230,4 +215,20 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   public void workerHeartbeat(String hostname, List<Metric> metrics) {
     mMetricsStore.putWorkerMetrics(hostname, metrics);
   }
+
+  /**
+   * Heartbeat executor that updates the cluster metrics.
+   */
+  private class ClusterMetricsUpdater implements HeartbeatExecutor {
+    @Override
+    public void heartbeat() throws InterruptedException {
+      updateMultiValueMetrics();
+    }
+
+    @Override
+    public void close() {
+      // nothing to clean up
+    }
+  }
+
 }

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -11,8 +11,12 @@
 
 package alluxio.master.metrics;
 
+import alluxio.Configuration;
 import alluxio.Constants;
+import alluxio.PropertyKey;
 import alluxio.clock.SystemClock;
+import alluxio.heartbeat.HeartbeatExecutor;
+import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.AbstractMaster;
 import alluxio.master.MasterContext;
 import alluxio.metrics.ClientMetrics;
@@ -53,6 +57,22 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   private final Set<MultiValueMetricsAggregator> mMultiValueMetricsAggregatorRegistry =
       new HashSet<>();
   private final MetricsStore mMetricsStore;
+  private final HeartbeatThread mClusterMetricsUpdater;
+
+  /**
+   * Heartbeat executor that updates the cluster metrics.
+   */
+  private class ClusterMetricsUpdater implements HeartbeatExecutor {
+    @Override
+    public void heartbeat() throws InterruptedException {
+      updateMultiValueMetrics();
+    }
+
+    @Override
+    public void close() {
+      // nothing to clean up
+    }
+  }
 
   /**
    * Creates a new instance of {@link MetricsMaster}.
@@ -77,6 +97,9 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
     super(masterContext, clock, executorServiceFactory);
     mMetricsStore = new MetricsStore();
     registerAggregators();
+    mClusterMetricsUpdater =
+        new HeartbeatThread("MultiValueMetricsUpdate", new ClusterMetricsUpdater(),
+            Configuration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL));
   }
 
   @VisibleForTesting
@@ -188,12 +211,14 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   @Override
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
+    if (isLeader) {
+      getExecutorService().submit(mClusterMetricsUpdater);
+    }
   }
 
   @Override
   public void clientHeartbeat(String clientId, String hostname, List<Metric> metrics) {
     mMetricsStore.putClientMetrics(hostname, clientId, metrics);
-    updateMultiValueMetrics();
   }
 
   @Override
@@ -204,6 +229,5 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   @Override
   public void workerHeartbeat(String hostname, List<Metric> metrics) {
     mMetricsStore.putWorkerMetrics(hostname, metrics);
-    updateMultiValueMetrics();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -15,6 +15,7 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.clock.SystemClock;
+import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.AbstractMaster;
@@ -83,7 +84,8 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
     mMetricsStore = new MetricsStore();
     registerAggregators();
     mClusterMetricsUpdater =
-        new HeartbeatThread("MultiValueMetricsUpdate", new ClusterMetricsUpdater(),
+        new HeartbeatThread(HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER,
+            new ClusterMetricsUpdater(),
             Configuration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL));
   }
 

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -14,6 +14,9 @@ package alluxio.master.metrics;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.clock.ManualClock;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.HeartbeatScheduler;
+import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.metrics.Metric;
@@ -26,6 +29,7 @@ import alluxio.util.executor.ExecutorServiceFactories;
 import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -36,6 +40,10 @@ import java.util.concurrent.Executors;
  * Unit tests for {@link MetricsMaster}.
  */
 public class MetricsMasterTest {
+  @ClassRule
+  public static ManuallyScheduleHeartbeat sManuallyScheduleRule = new ManuallyScheduleHeartbeat(
+      HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER);
+
   private DefaultMetricsMaster mMetricsMaster;
   private MasterRegistry mRegistry;
   private ManualClock mClock;
@@ -83,7 +91,7 @@ public class MetricsMasterTest {
   }
 
   @Test
-  public void testMultiValueAggregator() {
+  public void testMultiValueAggregator() throws Exception {
     mMetricsMaster.addAggregator(
         new SingleTagValueAggregator("metric", MetricsSystem.InstanceType.WORKER, "metric", "tag"));
     List<Metric> metrics1 = Lists.newArrayList(Metric.from("worker.192_1_1_1.metric.tag:v1", 10),
@@ -92,6 +100,7 @@ public class MetricsMasterTest {
     List<Metric> metrics2 = Lists.newArrayList(Metric.from("worker.192_1_1_2.metric.tag:v1", 1),
         Metric.from("worker.192_1_1_2.metric.tag:v2", 2));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics2);
+    HeartbeatScheduler.execute(HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER);
     assertEquals(11L, getGauge("metric", "tag", "v1"));
     assertEquals(22L, getGauge("metric", "tag", "v2"));
   }


### PR DESCRIPTION
Calling `MultiValueMetricsUpdate` incurs some costs, such as querying ufs for available space. Also, this gets call on each heartbeat which can be very frequent. Instead, do this on a best effort basis periodically.