### PR TITLE
[SMALLFIX] Optimize metric name construction

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/Metric.java
+++ b/core/common/src/main/java/alluxio/metrics/Metric.java
@@ -31,7 +31,7 @@ public final class Metric implements Serializable {
 
   private static final String ID_SEPARATOR = "-id:";
   public static final String TAG_SEPARATOR = ":";
-  private static final ConcurrentHashMap<UserKey, String> CACHED_METRICS =
+  private static final ConcurrentHashMap<UserMetricKey, String> CACHED_METRICS =
       new ConcurrentHashMap<>();
 
   private final MetricsSystem.InstanceType mInstanceType;
@@ -219,7 +219,7 @@ public final class Metric implements Serializable {
    * @return a metric name with the user tagged
    */
   public static String getMetricNameWithUserTag(String metricName, String userName) {
-    UserKey k = new UserKey(metricName, userName);
+    UserMetricKey k = new UserMetricKey(metricName, userName);
     String result = CACHED_METRICS.get(k);
     if (result != null) {
       return result;
@@ -300,11 +300,11 @@ public final class Metric implements Serializable {
   /**
    * Data structure representing a metric name and user name.
    */
-  private static class UserKey {
+  private static class UserMetricKey {
     private String mMetric;
     private String mUser;
 
-    private UserKey(String metricName, String userName) {
+    private UserMetricKey(String metricName, String userName) {
       mMetric = metricName;
       mUser = userName;
     }
@@ -314,10 +314,10 @@ public final class Metric implements Serializable {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof UserKey)) {
+      if (!(o instanceof UserMetricKey)) {
         return false;
       }
-      UserKey that = (UserKey) o;
+      UserMetricKey that = (UserMetricKey) o;
       return Objects.equal(mMetric, that.mMetric)
           && Objects.equal(mUser, that.mUser);
     }

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -52,6 +52,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class MetricsSystem {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsSystem.class);
 
+  private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
+
   /**
    * An enum of supported instance type.
    */
@@ -208,8 +210,6 @@ public final class MetricsSystem {
     }
   }
 
-  private static ConcurrentHashMap<String, String> sCachedMetrics = new ConcurrentHashMap<>();
-
   /**
    * Builds metric registry names for master instance. The pattern is instance.metricName.
    *
@@ -217,11 +217,11 @@ public final class MetricsSystem {
    * @return the metric registry name
    */
   private static String getMasterMetricName(String name) {
-    String result = sCachedMetrics.get(name);
+    String result = CACHED_METRICS.get(name);
     if (result != null) {
       return result;
     }
-    return sCachedMetrics.computeIfAbsent(name, n -> InstanceType.MASTER.toString() + "." + name);
+    return CACHED_METRICS.computeIfAbsent(name, n -> InstanceType.MASTER.toString() + "." + name);
   }
 
   /**
@@ -231,11 +231,11 @@ public final class MetricsSystem {
    * @return the metric registry name
    */
   private static String getWorkerMetricName(String name) {
-    String result = sCachedMetrics.get(name);
+    String result = CACHED_METRICS.get(name);
     if (result != null) {
       return result;
     }
-    return sCachedMetrics.computeIfAbsent(name,
+    return CACHED_METRICS.computeIfAbsent(name,
         n -> getMetricNameWithUniqueId(InstanceType.WORKER, name));
   }
 
@@ -246,11 +246,11 @@ public final class MetricsSystem {
    * @return the metric registry name
    */
   private static String getClientMetricName(String name) {
-    String result = sCachedMetrics.get(name);
+    String result = CACHED_METRICS.get(name);
     if (result != null) {
       return result;
     }
-    return sCachedMetrics.computeIfAbsent(name,
+    return CACHED_METRICS.computeIfAbsent(name,
         n -> getMetricNameWithUniqueId(InstanceType.CLIENT, name));
   }
 

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -60,6 +60,13 @@ public final class AuthenticatedClientUser {
   }
 
   /**
+   * @return the user or null if the user is not set.
+   */
+  public static User getOrNull() {
+    return sUserThreadLocal.get();
+  }
+
+  /**
    * Gets the user name from the {@link ThreadLocal} variable.
    *
    * @return the client user in string

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -60,7 +60,7 @@ public final class AuthenticatedClientUser {
   }
 
   /**
-   * @return the user or null if the user is not set.
+   * @return the user or null if the user is not set
    */
   public static User getOrNull() {
     return sUserThreadLocal.get();

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -11,17 +11,14 @@
 
 package alluxio;
 
-import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InternalException;
-import alluxio.metrics.CommonMetrics;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.thrift.AlluxioTException;
-import alluxio.util.SecurityUtils;
 
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -18,6 +18,7 @@ import alluxio.exception.status.InternalException;
 import alluxio.metrics.CommonMetrics;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
+import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.thrift.AlluxioTException;
 import alluxio.util.SecurityUtils;
@@ -305,13 +306,9 @@ public final class RpcUtils {
   }
 
   private static String getQualifiedMetricNameInternal(String name) {
-    try {
-      if (SecurityUtils.isAuthenticationEnabled() && AuthenticatedClientUser.get() != null) {
-        return Metric.getMetricNameWithTags(name, CommonMetrics.TAG_USER,
-            AuthenticatedClientUser.getClientUser());
-      }
-    } catch (IOException | AccessControlException e) {
-      // fall through
+    User user = AuthenticatedClientUser.getOrNull();
+    if (user != null) {
+      return Metric.getMetricNameWithUserTag(name, user.getName());
     }
     return name;
   }


### PR DESCRIPTION
Since metrics will often be reported multiple times, we reduce the overhead of string construction by caching the metric names.

Also change the user name call to be much more lightweight as accessing the configuration is relatively expensive.