### PR TITLE
[DOCFIX] Update doc for cloning Alluxio to get deploy module

### DIFF
--- a/docs/en/Running-Alluxio-on-EC2.md
+++ b/docs/en/Running-Alluxio-on-EC2.md
@@ -23,7 +23,7 @@ Install AWS Vagrant plugin:
 
 **Install Alluxio**
 
-[Download Alluxio](https://alluxio.org/download) to your local machine, and unzip it:
+[Clone Alluxio Repository](https://github.com/Alluxio/alluxio) to your local machine.
 
 **Install python library dependencies**
 


### PR DESCRIPTION
We updated all the other vagrant docs to recommend cloning instead of download, this is the last one