### PR TITLE
[SMALLFIX] Fix exception when sending unknown conf to master

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -253,7 +253,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
      *
      * @return the created property key instance
      */
-    private PropertyKey buildUnregistered() {
+    public PropertyKey buildUnregistered() {
       DefaultSupplier defaultSupplier = mDefaultSupplier;
       if (defaultSupplier == null) {
         String defaultString = String.valueOf(mDefaultValue);

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -136,6 +136,7 @@ public final class ConfigurationUtils {
         ConfigurationValueOptions.defaults().useDisplayValue(true).useRawValue(true);
     return Configuration.keySet().stream()
         .filter(key -> key.getScope().contains(scope))
+        .filter(key -> key.isValid(key.getName()))
         .map(key -> new ConfigProperty()
             .setName(key.getName())
             .setSource(Configuration.getSource(key).toString()).setValue(

--- a/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationStoreTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.meta.checkconf;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -59,6 +60,18 @@ public class ServerConfigurationStoreTest {
 
     assertTrue(confMap.containsKey(mAddressOne));
     assertTrue(confMap.containsKey(mAddressTwo));
+  }
+
+  @Test
+  public void registerNewConfUnknownProperty() {
+    Address testAddress = new Address("test", 0);
+    ServerConfigurationStore configStore = new ServerConfigurationStore();
+    configStore.registerNewConf(testAddress, Arrays.asList(
+        new ConfigProperty().setName("unknown.property")
+    ));
+    Map<Address, List<ConfigRecord>> confMap = configStore.getConfMap();
+    assertTrue(confMap.containsKey(testAddress));
+    assertEquals("unknown.property", confMap.get(testAddress).get(0).getKey().getName());
   }
 
   @Test


### PR DESCRIPTION
Previously, sending an unknown property to master
would cause an exception which prevents the worker
from joining. Now, the worker will filter out
invalid properties before sending its configuration
to master, and the master will also tolerate unknown
properties for the purpose of configuration checking.