### PR TITLE
[SMALLFIX] remove optional in server configuration checker logs and doctor CLI

### DIFF
--- a/core/common/src/main/java/alluxio/wire/InconsistentProperty.java
+++ b/core/common/src/main/java/alluxio/wire/InconsistentProperty.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 /**
@@ -104,8 +105,23 @@ public final class InconsistentProperty {
   public String toString() {
     return Objects.toStringHelper(this)
         .add("key", mName)
-        .add("values", mValues)
+        .add("values", getValuesWithoutOptionalKeyword())
         .toString();
+  }
+
+  /**
+   * @return the string of mValues without Optional keyword
+   */
+  private String getValuesWithoutOptionalKeyword() {
+    String readableNullValue = "no value set";
+    String valueFormat = "%s (%s)";
+    StringJoiner stringJoiner = new StringJoiner(", ");
+    for (Map.Entry<Optional<String>, List<String>> entry : mValues.entrySet()) {
+      stringJoiner.add(String.format(valueFormat,
+          entry.getKey().map(String::toString).orElse(readableNullValue),
+          String.join(", ", entry.getValue())));
+    }
+    return stringJoiner.toString();
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fsadmin/doctor/ConfigurationCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/doctor/ConfigurationCommand.java
@@ -78,11 +78,13 @@ public class ConfigurationCommand {
    */
   private void printInconsistentProperties(
       Map<Scope, List<InconsistentProperty>> inconsistentProperties) {
+    String readableNullValue = "no value set";
     for (List<InconsistentProperty> list : inconsistentProperties.values()) {
       for (InconsistentProperty prop : list) {
         mPrintStream.println("key: " + prop.getName());
         for (Map.Entry<Optional<String>, List<String>> entry : prop.getValues().entrySet()) {
-          mPrintStream.println("    value: " + String.format("%s (%s)", entry.getKey(),
+          mPrintStream.println("    value: " + String.format("%s (%s)",
+              entry.getKey().orElse(readableNullValue),
               String.join(", ", entry.getValue())));
         }
       }


### PR DESCRIPTION
Now the CLI and doctor CLI will not show **Optional** 
$ /bin/alluxio fsadmin doctor configuration
Server-side configuration errors (those properties are required to be identical):
key: key1
    value: hdfs://name2:port2 (masterHostname3:masterPort, masterHostname4:masterPort)
    value: hdfs://name1:port1 (masterHostname1:masterPort, masterHostname2:masterPort)
key: key2
    value: ErrorValue2 (masterHostname1:masterPort, masterHostname3:masterPort)
    value: ErrorValue1 (masterHostname4:masterPort, masterHostname2:masterPort)

Server-side configuration warnings (those properties are recommended to be identical):
key: key3
    value: /a/b/c (workerHostname1:workerPort, workerHostname2:workerPort)
    value: /d/e/f (masterHostname1:port1, masterHostname2:port2)
key: key4
    value: WarnValue2 (workerHostName1:workerPort, workerHostname2:workerPort)
    value: WarnValue1 (workerHostname1:workerPort, workerHostName3:workerPort)


2018-06-29 13:46:07,368 ERROR ServerConfigurationChecker - Inconsistent configuration detected. Only a limited set of inconsistent configuration will be shown here. For details, please visit Alluxio web UI or run fsadmin doctor CLI.
Errors: [InconsistentProperty{key=key1, values=hdfs://name2:port2 (masterHostname3:masterPort, masterHostname4:masterPort), hdfs://name1:port1 (masterHostname1:masterPort, masterHostname2:masterPort)}, InconsistentProperty{key=key2, values=ErrorValue2 (masterHostname1:masterPort, masterHostname3:masterPort), ErrorValue1 (masterHostname4:masterPort, masterHostname2:masterPort)}]
Warnings: [InconsistentProperty{key=key4, values=WarnValue2 (workerHostName1:workerPort, workerHostname2:workerPort), WarnValue1 (workerHostname1:workerPort, workerHostName3:workerPort)}], [InconsistentProperty{key=key3, values=/a/b/c (workerHostname1:workerPort, workerHostname2:workerPort), /d/e/f (masterHostname1:port1, masterHostname2:port2)}]
