### PR TITLE
[SMALLFIX] fix report metrics null issue

### DIFF
--- a/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
@@ -54,7 +54,6 @@ public class MetricsCommand {
    */
   public int run() throws IOException {
     Map<String, MetricValue> metricsMap = new TreeMap<>(mMetaMasterClient.getMetrics());
-
     Set<String> operations = new HashSet<>();
     operations.add("DirectoriesCreated");
     operations.add("FileBlockInfosGot");
@@ -71,8 +70,6 @@ public class MetricsCommand {
     operations.add("PathsUnmounted");
 
     mPrintStream.println("Alluxio logical operations: ");
-    metricsMap.put("FilesPinned", metricsMap.get("master.FilesPinned"));
-    metricsMap.remove("master.FilesPinned");
     for (Map.Entry<String, MetricValue> entry : metricsMap.entrySet()) {
       String key = entry.getKey();
       if (operations.contains(key)) {

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli.fsadmin.report;
 
-import alluxio.cli.fsadmin.report.MetricsCommand;
 import alluxio.client.MetaMasterClient;
 import alluxio.wire.MetricValue;
 
@@ -73,7 +72,6 @@ public class MetricsCommandTest {
     map.put("FilesCreated", MetricValue.forLong(534L));
     map.put("FilesFreed", MetricValue.forLong(2141L));
     map.put("FilesPersisted", MetricValue.forLong(4171L));
-    map.put("master.FilesPinned", MetricValue.forLong(2354239L));
     map.put("NewBlocksGot", MetricValue.forLong(4L));
     map.put("PathsDeleted", MetricValue.forLong(583L));
     map.put("PathsMounted", MetricValue.forLong(3635L));
@@ -118,7 +116,6 @@ public class MetricsCommandTest {
         "    FilesCreated                               534",
         "    FilesFreed                               2,141",
         "    FilesPersisted                           4,171",
-        "    FilesPinned                          2,354,239",
         "    NewBlocksGot                                 4",
         "    PathsDeleted                               583",
         "    PathsMounted                             3,635",

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
@@ -48,7 +48,6 @@ public final class MetricsCommandIntegrationTest extends AbstractFsAdminShellTes
         "    FilesCreated                                 0",
         "    FilesFreed                                   0",
         "    FilesPersisted                               0",
-        "    FilesPinned                                  0",
         "    NewBlocksGot                                 0",
         "    PathsDeleted                                 0",
         "    PathsMounted                                 0",
@@ -69,14 +68,7 @@ public final class MetricsCommandIntegrationTest extends AbstractFsAdminShellTes
         "    SetAttributeOps                              0",
         "    UnmountOps                                   0",
         "",
-        "Other metrics information: ",
-        "    AsyncCacheDuplicateRequests  (0)",
-        "    AsyncCacheFailedBlocks  (0)",
-        "    AsyncCacheRemoteBlocks  (0)",
-        "    AsyncCacheRequests  (0)",
-        "    AsyncCacheSucceededBlocks  (0)",
-        "    AsyncCacheUfsBlocks  (0)",
-        "    BlocksAccessed  (0)");
+        "Other metrics information: ");
     List<String> testOutput = Arrays.asList(output.split("\n")).subList(0, expectedOutput.size());
     Assert.assertThat(testOutput,
         IsIterableContainingInOrder.contains(expectedOutput.toArray()));


### PR DESCRIPTION
The issue occurs because the metrics name has changed from "master.FilesPinned" to "Master.FilesPinned". Remove this case sensitive info from "Alluxio logical operations:" to "other metrics information: Master.FilesPinned  (0)" .

In the future, we can see how to improve the report metrics to make it sync with the web UI.