### PR TITLE
[SMALLFIX] make default filesystem metrics name constants

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -169,5 +169,36 @@ public final class Constants {
   // Ufs fingerprint
   public static final String INVALID_UFS_FINGERPRINT = "";
 
+  // Metrics-related constants
+  public static final String DIRECTORIES_CREATED_METRICS_NAME = "DirectoriesCreated";
+  public static final String FILE_BLOCK_INFOS_GOT_METRICS_NAME = "FileBlockInfosGot";
+  public static final String FILE_INFOS_GOT_METRICS_NAME = "FileInfosGot";
+  public static final String FILES_COMPLETED_METRICS_NAME = "FilesCompleted";
+  public static final String FILES_CREATED_METRICS_NAME = "FilesCreated";
+  public static final String FILES_FREED_METRICS_NAME = "FilesFreed";
+  public static final String FILES_PERSISTED_METRICS_NAME = "FilesPersisted";
+  public static final String NEW_BLOCKS_GOT_METRICS_NAME = "NewBlocksGot";
+  public static final String PATHS_DELETED_METRICS_NAME = "PathsDeleted";
+  public static final String PATHS_MOUNTED_METRICS_NAME = "PathsMounted";
+  public static final String PATHS_RENAMED_METRICS_NAME = "PathsRenamed";
+  public static final String PATHS_UNMOUNTED_METRICS_NAME = "PathsUnmounted";
+  public static final String COMPLETE_FILE_OPS_METRICS_NAME = "CompleteFileOps";
+  public static final String CREATE_DIRECTORIES_OPS_METRICS_NAME = "CreateDirectoryOps";
+  public static final String CREATE_FILES_OPS_METRICS_NAME = "CreateFileOps";
+  public static final String DELETE_PATHS_OPS_METRICS_NAME = "DeletePathOps";
+  public static final String FREE_FILE_OPS_METRICS_NAME = "FreeFileOps";
+  public static final String GET_FILE_BLOCK_INFO_OPS_METRICS_NAME = "GetFileBlockInfoOps";
+  public static final String GET_FILE_INFO_OPS_METRICS_NAME = "GetFileInfoOps";
+  public static final String GET_NEW_BLOCK_OPS_METRICS_NAME = "GetNewBlockOps";
+  public static final String MOUNT_OPS_METRICS_NAME = "MountOps";
+  public static final String RENAME_PATH_OPS_METRICS_NAME = "RenamePathOps";
+  public static final String SET_ATTRIBUTE_OPS_METRICS_NAME = "SetAttributeOps";
+  public static final String UNMOUNT_OPS_METRICS_NAME = "UnmountOps";
+  public static final String FILES_PINNED_METRICS_NAME = "FilesPinned";
+  public static final String PATHS_TOTAL_METRICS_NAME = "PathsTotal";
+  public static final String UFS_CAPACITY_TOTAL_METRICS_NAME = "UfsCapacityTotal";
+  public static final String UFS_CAPACITY_USED_METRICS_NAME = "UfsCapacityUsed";
+  public static final String UFS_CAPACITY_FREE_METRICS_NAME = "UfsCapacityFree";
+
   private Constants() {} // prevent instantiation
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3814,40 +3814,56 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * {@link alluxio.web.WebInterfaceMasterMetricsServlet}.
    */
   public static final class Metrics {
-    private static final Counter DIRECTORIES_CREATED = MetricsSystem.counter("DirectoriesCreated");
-    private static final Counter FILE_BLOCK_INFOS_GOT = MetricsSystem.counter("FileBlockInfosGot");
-    private static final Counter FILE_INFOS_GOT = MetricsSystem.counter("FileInfosGot");
-    private static final Counter FILES_COMPLETED = MetricsSystem.counter("FilesCompleted");
-    private static final Counter FILES_CREATED = MetricsSystem.counter("FilesCreated");
-    private static final Counter FILES_FREED = MetricsSystem.counter("FilesFreed");
-    private static final Counter FILES_PERSISTED = MetricsSystem.counter("FilesPersisted");
-    private static final Counter NEW_BLOCKS_GOT = MetricsSystem.counter("NewBlocksGot");
-    private static final Counter PATHS_DELETED = MetricsSystem.counter("PathsDeleted");
-    private static final Counter PATHS_MOUNTED = MetricsSystem.counter("PathsMounted");
-    private static final Counter PATHS_RENAMED = MetricsSystem.counter("PathsRenamed");
-    private static final Counter PATHS_UNMOUNTED = MetricsSystem.counter("PathsUnmounted");
+    private static final Counter DIRECTORIES_CREATED
+        = MetricsSystem.counter(Constants.DIRECTORIES_CREATED_METRICS_NAME);
+    private static final Counter FILE_BLOCK_INFOS_GOT
+        = MetricsSystem.counter(Constants.FILE_BLOCK_INFOS_GOT_METRICS_NAME);
+    private static final Counter FILE_INFOS_GOT
+        = MetricsSystem.counter(Constants.FILE_INFOS_GOT_METRICS_NAME);
+    private static final Counter FILES_COMPLETED
+        = MetricsSystem.counter(Constants.FILES_COMPLETED_METRICS_NAME);
+    private static final Counter FILES_CREATED
+        = MetricsSystem.counter(Constants.FILES_CREATED_METRICS_NAME);
+    private static final Counter FILES_FREED
+        = MetricsSystem.counter(Constants.FILES_FREED_METRICS_NAME);
+    private static final Counter FILES_PERSISTED
+        = MetricsSystem.counter(Constants.FILES_PERSISTED_METRICS_NAME);
+    private static final Counter NEW_BLOCKS_GOT
+        = MetricsSystem.counter(Constants.NEW_BLOCKS_GOT_METRICS_NAME);
+    private static final Counter PATHS_DELETED
+        = MetricsSystem.counter(Constants.PATHS_DELETED_METRICS_NAME);
+    private static final Counter PATHS_MOUNTED
+        = MetricsSystem.counter(Constants.PATHS_MOUNTED_METRICS_NAME);
+    private static final Counter PATHS_RENAMED
+        = MetricsSystem.counter(Constants.PATHS_RENAMED_METRICS_NAME);
+    private static final Counter PATHS_UNMOUNTED
+        = MetricsSystem.counter(Constants.PATHS_UNMOUNTED_METRICS_NAME);
 
     // TODO(peis): Increment the RPCs OPs at the place where we receive the RPCs.
-    private static final Counter COMPLETE_FILE_OPS = MetricsSystem.counter("CompleteFileOps");
-    private static final Counter CREATE_DIRECTORIES_OPS =
-        MetricsSystem.counter("CreateDirectoryOps");
-    private static final Counter CREATE_FILES_OPS = MetricsSystem.counter("CreateFileOps");
-    private static final Counter DELETE_PATHS_OPS = MetricsSystem.counter("DeletePathOps");
-    private static final Counter FREE_FILE_OPS = MetricsSystem.counter("FreeFileOps");
-    private static final Counter GET_FILE_BLOCK_INFO_OPS =
-        MetricsSystem.counter("GetFileBlockInfoOps");
-    private static final Counter GET_FILE_INFO_OPS = MetricsSystem.counter("GetFileInfoOps");
-    private static final Counter GET_NEW_BLOCK_OPS = MetricsSystem.counter("GetNewBlockOps");
-    private static final Counter MOUNT_OPS = MetricsSystem.counter("MountOps");
-    private static final Counter RENAME_PATH_OPS = MetricsSystem.counter("RenamePathOps");
-    private static final Counter SET_ATTRIBUTE_OPS = MetricsSystem.counter("SetAttributeOps");
-    private static final Counter UNMOUNT_OPS = MetricsSystem.counter("UnmountOps");
-
-    public static final String FILES_PINNED = "FilesPinned";
-    public static final String PATHS_TOTAL = "PathsTotal";
-    public static final String UFS_CAPACITY_TOTAL = "UfsCapacityTotal";
-    public static final String UFS_CAPACITY_USED = "UfsCapacityUsed";
-    public static final String UFS_CAPACITY_FREE = "UfsCapacityFree";
+    private static final Counter COMPLETE_FILE_OPS
+        = MetricsSystem.counter(Constants.COMPLETE_FILE_OPS_METRICS_NAME);
+    private static final Counter CREATE_DIRECTORIES_OPS
+        = MetricsSystem.counter(Constants.CREATE_DIRECTORIES_OPS_METRICS_NAME);
+    private static final Counter CREATE_FILES_OPS
+        = MetricsSystem.counter(Constants.CREATE_FILES_OPS_METRICS_NAME);
+    private static final Counter DELETE_PATHS_OPS
+        = MetricsSystem.counter(Constants.DELETE_PATHS_OPS_METRICS_NAME);
+    private static final Counter FREE_FILE_OPS
+        = MetricsSystem.counter(Constants.FREE_FILE_OPS_METRICS_NAME);
+    private static final Counter GET_FILE_BLOCK_INFO_OPS
+        = MetricsSystem.counter(Constants.GET_FILE_BLOCK_INFO_OPS_METRICS_NAME);
+    private static final Counter GET_FILE_INFO_OPS
+        = MetricsSystem.counter(Constants.GET_FILE_INFO_OPS_METRICS_NAME);
+    private static final Counter GET_NEW_BLOCK_OPS
+        = MetricsSystem.counter(Constants.GET_NEW_BLOCK_OPS_METRICS_NAME);
+    private static final Counter MOUNT_OPS
+        = MetricsSystem.counter(Constants.MOUNT_OPS_METRICS_NAME);
+    private static final Counter RENAME_PATH_OPS
+        = MetricsSystem.counter(Constants.RENAME_PATH_OPS_METRICS_NAME);
+    private static final Counter SET_ATTRIBUTE_OPS
+        = MetricsSystem.counter(Constants.SET_ATTRIBUTE_OPS_METRICS_NAME);
+    private static final Counter UNMOUNT_OPS
+        = MetricsSystem.counter(Constants.UNMOUNT_OPS_METRICS_NAME);
 
     /**
      * Register some file system master related gauges.
@@ -3858,7 +3874,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     @VisibleForTesting
     public static void registerGauges(
         final FileSystemMaster master, final UfsManager ufsManager) {
-      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(FILES_PINNED),
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem
+              .getMetricName(Constants.FILES_PINNED_METRICS_NAME),
           new Gauge<Integer>() {
             @Override
             public Integer getValue() {
@@ -3866,12 +3883,14 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             }
           });
 
-      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(PATHS_TOTAL),
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem
+              .getMetricName(Constants.PATHS_TOTAL_METRICS_NAME),
           () -> master.getNumberOfPaths());
 
       final String ufsDataFolder = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 
-      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(UFS_CAPACITY_TOTAL),
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem
+              .getMetricName(Constants.UFS_CAPACITY_TOTAL_METRICS_NAME),
           () -> {
             try (CloseableResource<UnderFileSystem> ufsResource =
                 ufsManager.getRoot().acquireUfsResource()) {
@@ -3883,7 +3902,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             }
           });
 
-      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(UFS_CAPACITY_USED),
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem
+              .getMetricName(Constants.UFS_CAPACITY_USED_METRICS_NAME),
           () -> {
             try (CloseableResource<UnderFileSystem> ufsResource =
                 ufsManager.getRoot().acquireUfsResource()) {
@@ -3895,7 +3915,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             }
           });
 
-      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(UFS_CAPACITY_FREE),
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem
+              .getMetricName(Constants.UFS_CAPACITY_FREE_METRICS_NAME),
           new Gauge<Long>() {
             @Override
             public Long getValue() {

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -14,13 +14,13 @@ package alluxio.master.meta;
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.ConfigurationValueOptions;
+import alluxio.Constants;
 import alluxio.MasterStorageTierAssoc;
 import alluxio.PropertyKey;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterProcess;
 import alluxio.master.block.BlockMaster;
-import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.StartupConsistencyCheck;
 import alluxio.metrics.MetricsSystem;
@@ -429,7 +429,7 @@ public final class AlluxioMasterRestServiceHandler {
     // free/used
     // spaces, those statistics can be gotten via other REST apis.
     String filesPinnedProperty =
-        MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.FILES_PINNED);
+        MetricsSystem.getMetricName(Constants.FILES_PINNED_METRICS_NAME);
     @SuppressWarnings("unchecked") Gauge<Integer> filesPinned =
         (Gauge<Integer>) MetricsSystem.METRIC_REGISTRY.getGauges().get(filesPinnedProperty);
 

--- a/core/server/master/src/main/java/alluxio/web/WebInterfaceMasterMetricsServlet.java
+++ b/core/server/master/src/main/java/alluxio/web/WebInterfaceMasterMetricsServlet.java
@@ -11,8 +11,8 @@
 
 package alluxio.web;
 
+import alluxio.Constants;
 import alluxio.master.block.DefaultBlockMaster;
-import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.metrics.ClientMetrics;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
@@ -89,10 +89,10 @@ public final class WebInterfaceMasterMetricsServlet extends WebInterfaceAbstract
     request.setAttribute("masterCapacityFreePercentage", 100 - masterCapacityUsedPercentage);
 
     Long masterUnderfsCapacityTotal = (Long) mr.getGauges()
-        .get(MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.UFS_CAPACITY_TOTAL))
+        .get(MetricsSystem.getMetricName(Constants.UFS_CAPACITY_TOTAL_METRICS_NAME))
         .getValue();
     Long masterUnderfsCapacityUsed = (Long) mr.getGauges()
-        .get(MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.UFS_CAPACITY_USED))
+        .get(MetricsSystem.getMetricName(Constants.UFS_CAPACITY_USED_METRICS_NAME))
         .getValue();
 
     int masterUnderfsCapacityUsedPercentage = (masterUnderfsCapacityTotal > 0)
@@ -124,7 +124,7 @@ public final class WebInterfaceMasterMetricsServlet extends WebInterfaceAbstract
       operations.put(MetricsSystem.stripInstanceAndHost(entry.getKey()), entry.getValue());
     }
     String filesPinnedProperty =
-        MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.FILES_PINNED);
+        MetricsSystem.getMetricName(Constants.FILES_PINNED_METRICS_NAME);
     operations.put(MetricsSystem.stripInstanceAndHost(filesPinnedProperty),
         mr.getGauges().get(filesPinnedProperty));
 

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import alluxio.Configuration;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.master.file.DefaultFileSystemMaster.Metrics;
 import alluxio.metrics.MetricsSystem;
@@ -44,13 +45,13 @@ public class FileSystemMasterMetricsTest {
   @Test
   public void testMetricsFilesPinned() {
     when(mFileSystemMaster.getNumberOfPinnedFiles()).thenReturn(100);
-    assertEquals(100, getGauge(Metrics.FILES_PINNED));
+    assertEquals(100, getGauge(Constants.FILES_PINNED_METRICS_NAME));
   }
 
   @Test
   public void testMetricsPathsTotal() {
     when(mFileSystemMaster.getNumberOfPaths()).thenReturn(90);
-    assertEquals(90, getGauge(Metrics.PATHS_TOTAL));
+    assertEquals(90, getGauge(Constants.PATHS_TOTAL_METRICS_NAME));
   }
 
   @Test
@@ -66,9 +67,9 @@ public class FileSystemMasterMetricsTest {
       public void close() {}
     });
     when(mUfsManager.getRoot()).thenReturn(client);
-    assertEquals(1000L, getGauge(Metrics.UFS_CAPACITY_TOTAL));
-    assertEquals(200L, getGauge(Metrics.UFS_CAPACITY_USED));
-    assertEquals(800L, getGauge(Metrics.UFS_CAPACITY_FREE));
+    assertEquals(1000L, getGauge(Constants.UFS_CAPACITY_TOTAL_METRICS_NAME));
+    assertEquals(200L, getGauge(Constants.UFS_CAPACITY_USED_METRICS_NAME));
+    assertEquals(800L, getGauge(Constants.UFS_CAPACITY_FREE_METRICS_NAME));
   }
 
   private Object getGauge(String name) {

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationRule;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterContext;
@@ -30,7 +31,6 @@ import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
-import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.metrics.MetricsSystem;
@@ -110,7 +110,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     String filesPinnedProperty =
-        MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.FILES_PINNED);
+        MetricsSystem.getMetricName(Constants.FILES_PINNED_METRICS_NAME);
     MetricsSystem.METRIC_REGISTRY.remove(filesPinnedProperty);
   }
 
@@ -196,7 +196,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
   public void getMetrics() {
     final int FILES_PINNED_TEST_VALUE = 100;
     String filesPinnedProperty =
-        MetricsSystem.getMetricName(DefaultFileSystemMaster.Metrics.FILES_PINNED);
+        MetricsSystem.getMetricName(Constants.FILES_PINNED_METRICS_NAME);
     Gauge<Integer> filesPinnedGauge = new Gauge<Integer>() {
       @Override
       public Integer getValue() {

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
@@ -11,6 +11,7 @@
 
 package alluxio.cli.fsadmin.report;
 
+import alluxio.Constants;
 import alluxio.client.MetaMasterClient;
 import alluxio.wire.MetricValue;
 
@@ -55,19 +56,18 @@ public class MetricsCommand {
   public int run() throws IOException {
     Map<String, MetricValue> metricsMap = new TreeMap<>(mMetaMasterClient.getMetrics());
     Set<String> operations = new HashSet<>();
-    operations.add("DirectoriesCreated");
-    operations.add("FileBlockInfosGot");
-    operations.add("FileInfosGot");
-    operations.add("FilesCompleted");
-    operations.add("FilesCreated");
-    operations.add("FilesFreed");
-    operations.add("FilesPersisted");
-    operations.add("FilesPinned");
-    operations.add("NewBlocksGot");
-    operations.add("PathsDeleted");
-    operations.add("PathsMounted");
-    operations.add("PathsRenamed");
-    operations.add("PathsUnmounted");
+    operations.add(Constants.DIRECTORIES_CREATED_METRICS_NAME);
+    operations.add(Constants.FILE_BLOCK_INFOS_GOT_METRICS_NAME);
+    operations.add(Constants.FILE_INFOS_GOT_METRICS_NAME);
+    operations.add(Constants.FILES_COMPLETED_METRICS_NAME);
+    operations.add(Constants.FILES_CREATED_METRICS_NAME);
+    operations.add(Constants.FILES_FREED_METRICS_NAME);
+    operations.add(Constants.FILES_PERSISTED_METRICS_NAME);
+    operations.add(Constants.NEW_BLOCKS_GOT_METRICS_NAME);
+    operations.add(Constants.PATHS_DELETED_METRICS_NAME);
+    operations.add(Constants.PATHS_MOUNTED_METRICS_NAME);
+    operations.add(Constants.PATHS_RENAMED_METRICS_NAME);
+    operations.add(Constants.PATHS_UNMOUNTED_METRICS_NAME);
 
     mPrintStream.println("Alluxio logical operations: ");
     for (Map.Entry<String, MetricValue> entry : metricsMap.entrySet()) {
@@ -78,18 +78,18 @@ public class MetricsCommand {
     }
 
     Set<String> rpcInvocations = new HashSet<>();
-    rpcInvocations.add("CompleteFileOps");
-    rpcInvocations.add("CreateDirectoryOps");
-    rpcInvocations.add("CreateFileOps");
-    rpcInvocations.add("DeletePathOps");
-    rpcInvocations.add("FreeFileOps");
-    rpcInvocations.add("GetFileBlockInfoOps");
-    rpcInvocations.add("GetFileInfoOps");
-    rpcInvocations.add("GetNewBlockOps");
-    rpcInvocations.add("MountOps");
-    rpcInvocations.add("RenamePathOps");
-    rpcInvocations.add("SetAttributeOps");
-    rpcInvocations.add("UnmountOps");
+    rpcInvocations.add(Constants.COMPLETE_FILE_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.CREATE_DIRECTORIES_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.CREATE_FILES_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.DELETE_PATHS_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.FREE_FILE_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.GET_FILE_BLOCK_INFO_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.GET_FILE_INFO_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.GET_NEW_BLOCK_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.MOUNT_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.RENAME_PATH_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.SET_ATTRIBUTE_OPS_METRICS_NAME);
+    rpcInvocations.add(Constants.UNMOUNT_OPS_METRICS_NAME);
 
     mPrintStream.println("\nAlluxio RPC invocations: ");
     for (Map.Entry<String, MetricValue> entry : metricsMap.entrySet()) {

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.cli.fsadmin.report;
 
+import alluxio.Constants;
 import alluxio.client.MetaMasterClient;
 import alluxio.wire.MetricValue;
 
@@ -65,31 +66,31 @@ public class MetricsCommandTest {
    */
   private Map<String, MetricValue> generateMetricsMap() {
     Map<String, MetricValue> map = new HashMap<>();
-    map.put("DirectoriesCreated", MetricValue.forLong(121L));
-    map.put("FileBlockInfosGot", MetricValue.forLong(31243412L));
-    map.put("FileInfosGot", MetricValue.forLong(12312321434276L));
-    map.put("FilesCompleted", MetricValue.forLong(0L));
-    map.put("FilesCreated", MetricValue.forLong(534L));
-    map.put("FilesFreed", MetricValue.forLong(2141L));
-    map.put("FilesPersisted", MetricValue.forLong(4171L));
-    map.put("NewBlocksGot", MetricValue.forLong(4L));
-    map.put("PathsDeleted", MetricValue.forLong(583L));
-    map.put("PathsMounted", MetricValue.forLong(3635L));
-    map.put("PathsRenamed", MetricValue.forLong(382L));
-    map.put("PathsUnmounted", MetricValue.forLong(975L));
+    map.put(Constants.DIRECTORIES_CREATED_METRICS_NAME, MetricValue.forLong(121L));
+    map.put(Constants.FILE_BLOCK_INFOS_GOT_METRICS_NAME, MetricValue.forLong(31243412L));
+    map.put(Constants.FILE_INFOS_GOT_METRICS_NAME, MetricValue.forLong(12312321434276L));
+    map.put(Constants.FILES_COMPLETED_METRICS_NAME, MetricValue.forLong(0L));
+    map.put(Constants.FILES_CREATED_METRICS_NAME, MetricValue.forLong(534L));
+    map.put(Constants.FILES_FREED_METRICS_NAME, MetricValue.forLong(2141L));
+    map.put(Constants.FILES_PERSISTED_METRICS_NAME, MetricValue.forLong(4171L));
+    map.put(Constants.NEW_BLOCKS_GOT_METRICS_NAME, MetricValue.forLong(4L));
+    map.put(Constants.PATHS_DELETED_METRICS_NAME, MetricValue.forLong(583L));
+    map.put(Constants.PATHS_MOUNTED_METRICS_NAME, MetricValue.forLong(3635L));
+    map.put(Constants.PATHS_RENAMED_METRICS_NAME, MetricValue.forLong(382L));
+    map.put(Constants.PATHS_UNMOUNTED_METRICS_NAME, MetricValue.forLong(975L));
 
-    map.put("CompleteFileOps", MetricValue.forLong(813L));
-    map.put("CreateDirectoryOps", MetricValue.forLong(325728397L));
-    map.put("CreateFileOps", MetricValue.forLong(89L));
-    map.put("DeletePathOps", MetricValue.forLong(21L));
-    map.put("FreeFileOps", MetricValue.forLong(5213L));
-    map.put("GetFileBlockInfoOps", MetricValue.forLong(798L));
-    map.put("GetFileInfoOps", MetricValue.forLong(32L));
-    map.put("GetNewBlockOps", MetricValue.forLong(912572136653L));
-    map.put("MountOps", MetricValue.forLong(953795L));
-    map.put("RenamePathOps", MetricValue.forLong(29L));
-    map.put("SetAttributeOps", MetricValue.forLong(0L));
-    map.put("UnmountOps", MetricValue.forLong(1L));
+    map.put(Constants.COMPLETE_FILE_OPS_METRICS_NAME, MetricValue.forLong(813L));
+    map.put(Constants.CREATE_DIRECTORIES_OPS_METRICS_NAME, MetricValue.forLong(325728397L));
+    map.put(Constants.CREATE_FILES_OPS_METRICS_NAME, MetricValue.forLong(89L));
+    map.put(Constants.DELETE_PATHS_OPS_METRICS_NAME, MetricValue.forLong(21L));
+    map.put(Constants.FREE_FILE_OPS_METRICS_NAME, MetricValue.forLong(5213L));
+    map.put(Constants.GET_FILE_BLOCK_INFO_OPS_METRICS_NAME, MetricValue.forLong(798L));
+    map.put(Constants.GET_FILE_INFO_OPS_METRICS_NAME, MetricValue.forLong(32L));
+    map.put(Constants.GET_NEW_BLOCK_OPS_METRICS_NAME, MetricValue.forLong(912572136653L));
+    map.put(Constants.MOUNT_OPS_METRICS_NAME, MetricValue.forLong(953795L));
+    map.put(Constants.RENAME_PATH_OPS_METRICS_NAME, MetricValue.forLong(29L));
+    map.put(Constants.SET_ATTRIBUTE_OPS_METRICS_NAME, MetricValue.forLong(0L));
+    map.put(Constants.UNMOUNT_OPS_METRICS_NAME, MetricValue.forLong(1L));
 
     map.put("UfsSessionCount-Ufs:_alluxio_underFSStorage",
         MetricValue.forLong(8535L));


### PR DESCRIPTION
The same metrics names hard-coded in many places, better to make them constants.