### PR TITLE
[SMALLFIX] Test improvement in zk failure test

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -67,7 +67,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void zkFailure() throws Exception {
-    final AlluxioOperationThread thread =
+    AlluxioOperationThread thread =
         new AlluxioOperationThread(mCluster.getFileSystemClient());
     thread.start();
     CommonUtils.waitFor("a successful operation to be performed", () -> thread.successes() > 0);
@@ -83,6 +83,8 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
     long zkStartTime = System.currentTimeMillis();
     CommonUtils.waitFor("another successful operation to be performed",
         () -> thread.successes() > successes);
+    thread.interrupt();
+    thread.join();
     LOG.info("Recovered after {}ms", System.currentTimeMillis() - zkStartTime);
     mCluster.notifySuccess();
   }


### PR DESCRIPTION
This prevents the logs from getting spammed by NPEs when we shut down the cluster without stopping the operation thread.