### PR TITLE
[SMALLFIX] Enforce loading cluster-default conf on worker process starting up

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
@@ -17,8 +17,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterClientConfig;
-import alluxio.retry.CountingRetry;
-import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
 import alluxio.thrift.AlluxioService.Client;
 import alluxio.thrift.AlluxioTException;
 import alluxio.thrift.Metric;
@@ -30,7 +29,6 @@ import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -39,11 +37,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class MetricsMasterClient extends AbstractMasterClient {
-  // No retry for metrics since they are best effort and automatically retried with the heartbeat.
-  private static Supplier<RetryPolicy> defaultMetricsRetry() {
-    return () -> new CountingRetry(0);
-  }
-
   private MetricsMasterClientService.Client mClient = null;
 
   /**
@@ -52,7 +45,7 @@ public class MetricsMasterClient extends AbstractMasterClient {
    * @param conf master client configuration
    */
   public MetricsMasterClient(MasterClientConfig conf) {
-    super(conf, null, defaultMetricsRetry());
+    super(conf, null, RetryUtils::defaultMetricsClientRetry);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -11,7 +11,6 @@
 
 package alluxio;
 
-import alluxio.conf.Source;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.AlluxioStatusException;
@@ -21,26 +20,20 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.metrics.CommonMetrics;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
-import alluxio.network.thrift.BootstrapClientTransport;
 import alluxio.network.thrift.ThriftUtils;
-import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
 import alluxio.security.LoginUser;
 import alluxio.security.authentication.TransportProvider;
 import alluxio.thrift.AlluxioService;
 import alluxio.thrift.AlluxioTException;
-import alluxio.thrift.GetConfigurationTOptions;
 import alluxio.thrift.GetServiceVersionTOptions;
-import alluxio.thrift.MetaMasterClientService;
 import alluxio.util.SecurityUtils;
-import alluxio.wire.ConfigProperty;
-import alluxio.wire.Scope;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -48,12 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.time.Duration;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.security.auth.Subject;
@@ -66,24 +54,10 @@ import javax.security.auth.Subject;
 public abstract class AbstractClient implements Client {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractClient.class);
 
-  private static Supplier<RetryPolicy> defaultRetry() {
-    Duration maxRetryDuration = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_DURATION);
-    Duration baseSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS);
-    Duration maxSleepMs = Configuration.getDuration(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS);
-    return () -> ExponentialTimeBoundedRetry.builder().withMaxDuration(maxRetryDuration)
-        .withInitialSleep(baseSleepMs).withMaxSleep(maxSleepMs).build();
-  }
-
   private final Supplier<RetryPolicy> mRetryPolicySupplier;
 
   protected InetSocketAddress mAddress;
   protected TProtocol mProtocol;
-
-  /** Whether the client needs to handshake with master first. */
-  private static final boolean HANDSHAKE_NEEDED =
-      Configuration.getBoolean(PropertyKey.USER_CONF_CLUSTER_DEFAULT_ENABLED);
-  /** Whether the handshake is complete. */
-  private static AtomicBoolean sHandshakeComplete = new AtomicBoolean(false);
 
   /** Is true if this client is currently connected. */
   protected boolean mConnected = false;
@@ -111,7 +85,7 @@ public abstract class AbstractClient implements Client {
    * @param address the address
    */
   public AbstractClient(Subject subject, InetSocketAddress address) {
-    this(subject, address, defaultRetry());
+    this(subject, address, RetryUtils::defaultClientRetry);
   }
 
   /**
@@ -189,70 +163,6 @@ public abstract class AbstractClient implements Client {
     // Empty implementation.
   }
 
-  /**
-   * Handshakes with meta master.
-   */
-  private void doHandshake() throws AlluxioStatusException {
-    synchronized (AbstractClient.class) {
-      if (isConnected() || sHandshakeComplete.get()) {
-        return;
-      }
-      LOG.info("Alluxio client (version {}) is trying to bootstrap-connect with {}",
-          RuntimeConstants.VERSION, mAddress);
-      // A plain socket transport to bootstrap
-      TSocket socket = ThriftUtils.createThriftSocket(mAddress);
-      TTransport bootstrapTransport = new BootstrapClientTransport(socket);
-      TProtocol protocol = ThriftUtils.createThriftProtocol(bootstrapTransport,
-          Constants.META_MASTER_CLIENT_SERVICE_NAME);
-      List<ConfigProperty> clusterConfig;
-      try {
-        bootstrapTransport.open();
-        // We didn't use RetryHandlingMetaMasterClient because it inherits AbstractClient.
-        MetaMasterClientService.Client client = new MetaMasterClientService.Client(protocol);
-        // The credential configuration properties use displayValue
-        clusterConfig = client.getConfiguration(new GetConfigurationTOptions().setRawValue(true))
-            .getConfigList()
-            .stream()
-            .map(ConfigProperty::fromThrift)
-            .collect(Collectors.toList());
-      } catch (TException e) {
-        throw new UnavailableException(String.format(
-            "Failed to handshake with master %s to load cluster default configuration values",
-            mAddress), e);
-      } finally {
-        bootstrapTransport.close();
-      }
-      // merge conf returned by master as the cluster default into Configuration
-      Properties clusterProps = new Properties();
-      for (ConfigProperty property : clusterConfig) {
-        String name = property.getName();
-        // TODO(binfan): support propagating unsetting properties from master
-        if (PropertyKey.isValid(name) && property.getValue() != null) {
-          PropertyKey key = PropertyKey.fromString(name);
-          if (!key.getScope().contains(Scope.CLIENT)) {
-            // Only propagate client properties.
-            continue;
-          }
-          String value = property.getValue();
-          clusterProps.put(key, value);
-          LOG.debug("Loading cluster default: {} ({}) -> {}", key, key.getScope(), value);
-        }
-      }
-      String clientVersion = Configuration.get(PropertyKey.VERSION);
-      String clusterVersion = clusterProps.get(PropertyKey.VERSION).toString();
-      if (!clientVersion.equals(clusterVersion)) {
-        LOG.warn("Alluxio client version ({}) does not match Alluxio cluster version ({})",
-            clientVersion, clusterVersion);
-        clusterProps.remove(PropertyKey.VERSION);
-      }
-      Configuration.merge(clusterProps, Source.CLUSTER_DEFAULT);
-      Configuration.validate();
-      // This needs to be the last
-      sHandshakeComplete.set(true);
-      LOG.info("Alluxio client has bootstrap-connected with {}", mAddress);
-    }
-  }
-
   private void doConnect() throws IOException, TTransportException {
     LOG.info("Alluxio client (version {}) is trying to connect with {} @ {}",
         RuntimeConstants.VERSION, getServiceName(), mAddress);
@@ -291,10 +201,10 @@ public abstract class AbstractClient implements Client {
             getServiceName(), retryPolicy.getAttemptCount(), e.toString());
         continue;
       }
-      // Bootstrap once
-      if (HANDSHAKE_NEEDED && !sHandshakeComplete.get()) {
+      // Bootstrap once for clients
+      if (!isConnected()) {
         try {
-          doHandshake();
+          Configuration.loadClusterDefault(mAddress);
         } catch (UnavailableException e) {
           LOG.warn("Failed to handshake ({}) with {} @ {}: {}", retryPolicy.getAttemptCount(),
               getServiceName(), mAddress, e.getMessage());

--- a/core/common/src/main/java/alluxio/Configuration.java
+++ b/core/common/src/main/java/alluxio/Configuration.java
@@ -14,16 +14,33 @@ package alluxio;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.Source;
+import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.UnavailableException;
+import alluxio.network.thrift.BootstrapClientTransport;
+import alluxio.network.thrift.ThriftUtils;
+import alluxio.thrift.GetConfigurationTOptions;
+import alluxio.thrift.MetaMasterClientService;
 import alluxio.util.ConfigurationUtils;
+import alluxio.wire.ConfigProperty;
+import alluxio.wire.Scope;
 
 import com.google.common.base.Preconditions;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -53,6 +70,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class Configuration {
+  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
+
   private static final AlluxioProperties PROPERTIES = new AlluxioProperties();
   private static final InstancedConfiguration CONF = new InstancedConfiguration(PROPERTIES);
 
@@ -380,6 +399,80 @@ public final class Configuration {
    */
   public static InstancedConfiguration global() {
     return CONF;
+  }
+
+  /** Whether the cluster-default is loaded. */
+  private static final AtomicBoolean CLUSTER_DEFAULT_LOADED = new AtomicBoolean(false);
+
+  /**
+   * Loads cluster default values from the meta master.
+   *
+   * @param address the master address
+   */
+  public static void loadClusterDefault(InetSocketAddress address) throws AlluxioStatusException {
+    if (!Configuration.getBoolean(PropertyKey.USER_CONF_CLUSTER_DEFAULT_ENABLED)
+        || CLUSTER_DEFAULT_LOADED.get()) {
+      return;
+    }
+    synchronized (Configuration.class) {
+      if (CLUSTER_DEFAULT_LOADED.get()) {
+        return;
+      }
+      LOG.info("Alluxio client (version {}) is trying to bootstrap-connect with {}",
+          RuntimeConstants.VERSION, address);
+      // A plain socket transport to bootstrap
+      TSocket socket = ThriftUtils.createThriftSocket(address);
+      TTransport bootstrapTransport = new BootstrapClientTransport(socket);
+      TProtocol protocol = ThriftUtils.createThriftProtocol(bootstrapTransport,
+          Constants.META_MASTER_CLIENT_SERVICE_NAME);
+      List<ConfigProperty> clusterConfig;
+      try {
+        bootstrapTransport.open();
+        // We didn't use RetryHandlingMetaMasterClient because it inherits AbstractClient,
+        // and AbstractClient uses Configuration.loadClusterDefault inside.
+        MetaMasterClientService.Client client = new MetaMasterClientService.Client(protocol);
+        // The credential configuration properties use displayValue
+        clusterConfig = client.getConfiguration(new GetConfigurationTOptions().setRawValue(true))
+            .getConfigList()
+            .stream()
+            .map(ConfigProperty::fromThrift)
+            .collect(Collectors.toList());
+      } catch (TException e) {
+        throw new UnavailableException(String.format(
+            "Failed to handshake with master %s to load cluster default configuration values",
+            address), e);
+      } finally {
+        bootstrapTransport.close();
+      }
+      // merge conf returned by master as the cluster default into Configuration
+      Properties clusterProps = new Properties();
+      for (ConfigProperty property : clusterConfig) {
+        String name = property.getName();
+        // TODO(binfan): support propagating unsetting properties from master
+        if (PropertyKey.isValid(name) && property.getValue() != null) {
+          PropertyKey key = PropertyKey.fromString(name);
+          if (!key.getScope().contains(Scope.CLIENT)) {
+            // Only propagate client properties.
+            continue;
+          }
+          String value = property.getValue();
+          clusterProps.put(key, value);
+          LOG.debug("Loading cluster default: {} ({}) -> {}", key, key.getScope(), value);
+        }
+      }
+      String clientVersion = Configuration.get(PropertyKey.VERSION);
+      String clusterVersion = clusterProps.get(PropertyKey.VERSION).toString();
+      if (!clientVersion.equals(clusterVersion)) {
+        LOG.warn("Alluxio client version ({}) does not match Alluxio cluster version ({})",
+            clientVersion, clusterVersion);
+        clusterProps.remove(PropertyKey.VERSION);
+      }
+      Configuration.merge(clusterProps, Source.CLUSTER_DEFAULT);
+      Configuration.validate();
+      // This needs to be the last
+      CLUSTER_DEFAULT_LOADED.set(true);
+      LOG.info("Alluxio client has bootstrap-connected with {}", address);
+    }
   }
 
   private Configuration() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -549,8 +550,8 @@ public final class CommonUtils {
    * NOTE: This will only be set by main methods of Alluxio processes. It will not be set properly
    * for tests. Avoid using this field if at all possible.
    */
-  public static final java.util.concurrent.atomic.AtomicReference<ProcessType> PROCESS_TYPE =
-      new java.util.concurrent.atomic.AtomicReference<>(ProcessType.CLIENT);
+  public static final AtomicReference<ProcessType> PROCESS_TYPE =
+      new AtomicReference<>(ProcessType.CLIENT);
 
   /**
    * Unwraps a {@link alluxio.proto.dataserver.Protocol.Response}.

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -11,15 +11,21 @@
 
 package alluxio.worker;
 
+import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.ProcessUtils;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
+import alluxio.master.MasterInquireClient;
+import alluxio.retry.RetryUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -52,6 +58,16 @@ public final class AlluxioWorker {
     }
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.WORKER);
+    MasterInquireClient masterInquireClient = MasterInquireClient.Factory.create();
+    try {
+      RetryUtils.retry("load cluster default configuration with master", () -> {
+        InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();
+        Configuration.loadClusterDefault(masterAddress);
+      }, RetryUtils.defaultWorkerMasterClientRetry());
+    } catch (IOException e) {
+      ProcessUtils.fatalError(LOG,
+          "Failed to load cluster default configuration for worker: %s", e.getMessage());
+    }
     WorkerProcess process = WorkerProcess.Factory.create();
     ProcessUtils.run(process);
   }


### PR DESCRIPTION
- Move `loadClusterDefault` to `Configuration`.
- Refactor a bunch of retry policies.