### PR TITLE
[SMALLFIX] Update metrics command to include set_acl_ops

### DIFF
--- a/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/MetricsCommand.java
@@ -131,6 +131,7 @@ public class MetricsCommand {
     printMetric(MasterMetrics.GET_NEW_BLOCK_OPS, "Get New Block Operations", false);
     printMetric(MasterMetrics.MOUNT_OPS, "Mount Operations", false);
     printMetric(MasterMetrics.RENAME_PATH_OPS, "Rename Path Operations", false);
+    printMetric(MasterMetrics.SET_ACL_OPS, "Set ACL Operations", false);
     printMetric(MasterMetrics.SET_ATTRIBUTE_OPS, "Set Attribute Operations", false);
     printMetric(MasterMetrics.UNMOUNT_OPS, "Unmount Operations", false);
 

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/MetricsCommandTest.java
@@ -114,6 +114,7 @@ public class MetricsCommandTest {
     map.put(MasterMetrics.GET_NEW_BLOCK_OPS, MetricValue.forLong(912572136653L));
     map.put(MasterMetrics.MOUNT_OPS, MetricValue.forLong(953795L));
     map.put(MasterMetrics.RENAME_PATH_OPS, MetricValue.forLong(29L));
+    map.put(MasterMetrics.SET_ACL_OPS, MetricValue.forLong(316L));
     map.put(MasterMetrics.SET_ATTRIBUTE_OPS, MetricValue.forLong(0L));
     map.put(MasterMetrics.UNMOUNT_OPS, MetricValue.forLong(1L));
 
@@ -179,6 +180,7 @@ public class MetricsCommandTest {
         "    Get New Block Operations            912,572,136,653",
         "    Mount Operations                            953,795",
         "    Rename Path Operations                           29",
+        "    Set ACL Operations                              316",
         "    Set Attribute Operations                          0",
         "    Unmount Operations                                1",
         "",

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
@@ -83,6 +83,7 @@ public final class MetricsCommandIntegrationTest extends AbstractFsAdminShellTes
         "    Get New Block Operations                          0",
         "    Mount Operations                                  0",
         "    Rename Path Operations                            0",
+        "    Set ACL Operations                                0",
         "    Set Attribute Operations                          0",
         "    Unmount Operations                                0",
         "",


### PR DESCRIPTION
There's probably a better way to do this so that we don't need to manually remember to update this whenever we add a new metric. Will leave this to a future PR. @calvinjia does anything similar need to be done for the web UI metrics?