### PR TITLE
[SMALLFIX] Fix flakiness in zk failure test

### DIFF
--- a/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
+++ b/core/common/src/main/java/alluxio/network/netty/NettyRPC.java
@@ -60,6 +60,7 @@ public final class NettyRPC {
       CommonUtils.closeChannel(channel);
       throw new IOException(e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       CommonUtils.closeChannel(channel);
       throw new RuntimeException(e);
     } finally {


### PR DESCRIPTION
The test was getting stuck trying to `Thread.join` the operation thread after interrupting it. Turns out that our Netty client was wrapping `InterruptedException` without resetting the interrupted flag. Haven't been able to get the test to fail since fixing this.