### PR TITLE
[SMALLFIX] Audit interrupted exception handling

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -443,6 +443,7 @@ public final class FileSystemContext implements Closeable {
           mClientMasterSync.heartbeat();
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOG.error("Failed to heartbeat to the metrics master before exit");
       }
     }

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatThread.java
@@ -74,7 +74,7 @@ public final class HeartbeatThread implements Runnable {
         mExecutor.heartbeat();
       }
     } catch (InterruptedException e) {
-      LOG.info("Hearbeat {} is interrupted.", mThreadName);
+      // Allow thread to exit.
     } catch (Exception e) {
       LOG.error("Uncaught exception in heartbeat executor, Heartbeat Thread shutting down", e);
     } finally {

--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -136,6 +136,7 @@ public abstract class ResourcePool<T> implements Pool<T> {
         mTakeLock.unlock();
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -341,10 +341,10 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
         try {
           result.addAll(list.get());
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           // If operation was interrupted do not add to successfully deleted list
           LOG.warn("Interrupted while waiting for the result of batch delete. UFS and Alluxio "
               + "state may be inconsistent. Error: {}", e.getMessage());
-          Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
           // If operation failed to execute do not add to successfully deleted list
           LOG.warn("A batch delete failed. UFS and Alluxio state may be inconsistent. Error: {}",

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -188,10 +188,10 @@ public final class CommonUtils {
     try {
       Thread.sleep(timeMs);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       if (logger != null) {
         logger.warn(e.getMessage(), e);
       }
-      Thread.currentThread().interrupt();
     }
   }
 
@@ -477,8 +477,8 @@ public final class CommonUtils {
         throw new IllegalStateException("Failed to shutdown service");
       }
     } catch (InterruptedException e) {
-      service.shutdownNow();
       Thread.currentThread().interrupt();
+      service.shutdownNow();
       throw new RuntimeException(e);
     }
   }

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -70,10 +70,9 @@ public final class ThreadUtils {
         }
       }
     } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
       // (Re-)Cancel if current thread also interrupted
       pool.shutdownNow();
-      // Preserve interrupt status
-      Thread.currentThread().interrupt();
     }
   }
 

--- a/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/Utils.java
@@ -159,8 +159,8 @@ public final class Utils {
       System.err.println("Failed to execute command.");
       return new ProcessExecutionResult(1, "", e.getMessage());
     } catch (InterruptedException e) {
-      System.err.println("Interrupted.");
       Thread.currentThread().interrupt();
+      System.err.println("Interrupted.");
       return new ProcessExecutionResult(1, "", e.getMessage());
     }
   }

--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -114,6 +114,7 @@ public abstract class AbstractMaster implements Master {
             LOG.warn("Timed out " + awaitFailureMessage, this.getClass().getSimpleName());
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           LOG.warn("Interrupted while " + awaitFailureMessage, this.getClass().getSimpleName());
         }
       } finally {

--- a/core/server/common/src/main/java/alluxio/master/audit/AsyncUserAccessAuditLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/audit/AsyncUserAccessAuditLogWriter.java
@@ -97,8 +97,6 @@ public final class AsyncUserAccessAuditLogWriter {
     try {
       mAuditLogEntries.put(context);
     } catch (InterruptedException e) {
-      // Reset the interrupted flag and return because some other thread has
-      // told us not to wait any more.
       Thread.currentThread().interrupt();
       return false;
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -103,12 +103,8 @@ public final class ClientRWLock implements ReadWriteLock {
     }
 
     @Override
-    public boolean tryLock(long time, TimeUnit unit) {
-      try {
-        return mAvailable.tryAcquire(mPermits, time, unit);
-      } catch (InterruptedException e) {
-        return false;
-      }
+    public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+      return mAvailable.tryAcquire(mPermits, time, unit);
     }
 
     @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -256,6 +256,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
         try {
           return getExecutorService().awaitTermination(100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       });

--- a/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/DefaultFileSystemWorker.java
@@ -126,6 +126,7 @@ public final class DefaultFileSystemWorker extends AbstractWorker implements Fil
         try {
           return getExecutorService().awaitTermination(100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       });

--- a/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/NettyDataServer.java
@@ -18,7 +18,6 @@ import alluxio.util.network.NettyUtils;
 import alluxio.worker.DataServer;
 import alluxio.worker.WorkerProcess;
 
-import com.google.common.base.Throwables;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
@@ -64,7 +63,8 @@ public final class NettyDataServer implements DataServer {
     try {
       mChannelFuture = mBootstrap.bind(address).sync();
     } catch (InterruptedException e) {
-      throw Throwables.propagate(e);
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Update code to follow a general practice of
immediately resetting the interrupt status
if the handling of an InterruptedException
is not going to exit the thread or propagate
the exception as an InterruptedException.