### PR TITLE
[SMALLFIX] Remove CpCommandIntegrationTest#copyToLocalLarge

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -419,11 +419,6 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   }
 
   @Test
-  public void copyToLocalLarge() throws Exception {
-    copyToLocalWithBytes(SIZE_BYTES);
-  }
-
-  @Test
   public void copyToLocal() throws Exception {
     copyToLocalWithBytes(10);
   }


### PR DESCRIPTION
The test is flaky, and the functionality is already
covered by CopyToLocalCommandIntegrationTest.