### PR TITLE
[SMALLFIX] fix tiered locality script location

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -2131,7 +2131,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey LOCALITY_SCRIPT =
       new Builder(Name.LOCALITY_SCRIPT)
-          .setDefaultValue(Constants.ALLUXIO_LOCALITY_SCRIPT)
+          .setDefaultValue(String.format("${%s}/conf/%s", Name.HOME, Constants.ALLUXIO_LOCALITY_SCRIPT))
           .setDescription("A script to determine tiered identity for locality checking")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();

--- a/docs/en/Tiered-Locality.md
+++ b/docs/en/Tiered-Locality.md
@@ -28,15 +28,30 @@ perform a localhost lookup to set its node-level identity info. If other localit
 are left unset, they will not be used to inform locality decisions. To set
 the value for a locality tier, set the configuration property
 
+By default, the locality order is set to node,rack.
+
+```
+alluxio.locality.order=node,rack
+```
+
+To set the values for locality tiers, set the configuration properties
+
 ```
 alluxio.locality.[tiername]=...
+```
+
+For example, set the node and rack locality values
+
+```
+alluxio.locality.node=localhost
+alluxio.locality.rack=rack1
 ```
 
 See the [Configuration-Settings](Configuration-Settings.html) page for details on how
 to set configuration properties.
 
 It is also possible to configure tiered identity info via script. By default Alluxio looks
-for a script at `${ALLUXIO_HOME}/conf/tiered_identity.sh`. You can override this location
+for a script at `${ALLUXIO_HOME}/conf/alluxio-locality.sh`. You can override this location
 by setting
 
 ```
@@ -49,7 +64,7 @@ pairs. Here is an example script for reference:
 ```bash
 #!/bin/bash
 
-echo "host=$(hostname),rack=/rack1"
+echo "node=$(hostname),rack=/rack1"
 ```
 
 If the no script exists at `alluxio.locality.script`, the property will be ignored. If

--- a/docs/en/Tiered-Locality.md
+++ b/docs/en/Tiered-Locality.md
@@ -25,8 +25,7 @@ arbitrary worker will be chosen.
 
 If the user does nothing to provide tiered identity info, each entity will
 perform a localhost lookup to set its node-level identity info. If other locality tiers
-are left unset, they will not be used to inform locality decisions. To set
-the value for a locality tier, set the configuration property
+are left unset, they will not be used to inform locality decisions. 
 
 By default, the locality order is set to node,rack.
 


### PR DESCRIPTION
The current locality script name and path in docs are wrong.

public static final String ALLUXIO_LOCALITY_SCRIPT = "alluxio-locality.sh";
and path should be set to ${ALLUXIO_HOME}/conf/ALLUXIO_LOCALITY_SCRIPT

This needs to cherry pick to 1.8 branch