### PR TITLE
[ALLUXIO-3164] Improve facl serialization/deserialization perf

### DIFF
--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -12,6 +12,8 @@
 package alluxio.client.file;
 
 import alluxio.annotation.PublicApi;
+import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
 import alluxio.wire.TtlAction;
@@ -45,15 +47,15 @@ public class URIStatus {
   /**
    * @return the ACL entries for this path, mutable
    */
-  public List<String> getAclEntries() {
-    return mInfo.convertAclToStringEntries();
+  public AccessControlList getAcl() {
+    return mInfo.getAcl();
   }
 
   /**
    * @return the default ACL entries for this path, mutable
    */
-  public List<String> getDefaultAclEntries() {
-    return mInfo.convertDefaultAclToStringEntries();
+  public DefaultAccessControlList getDefaultAcl() {
+    return mInfo.getDefaultAcl();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -46,14 +46,14 @@ public class URIStatus {
    * @return the ACL entries for this path, mutable
    */
   public List<String> getAclEntries() {
-    return mInfo.getAclEntries();
+    return mInfo.convertAclToStringEntries();
   }
 
   /**
    * @return the default ACL entries for this path, mutable
    */
   public List<String> getDefaultAclEntries() {
-    return mInfo.getDefaultAclEntries();
+    return mInfo.convertDefaultAclToStringEntries();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -621,6 +621,8 @@ public class AccessControlList implements Serializable {
    * This is a custom json serializer for AccessControlList class.
    */
   public static class AccessControlListSerializer extends StdSerializer<AccessControlList> {
+    private static final long serialVersionUID = -8523910728069876504L;
+
     /**
      * Creates a AccessControlListSerializer.
      */
@@ -650,6 +652,8 @@ public class AccessControlList implements Serializable {
    * This is a custom json deserializer for AccessControlList class.
    */
   public static class AccessControlListDeserializer extends StdDeserializer<AccessControlList> {
+    private static final long serialVersionUID = 5524283318028333563L;
+
     /**
      * Creates a AccessControlListDeserializer.
      */

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -65,6 +65,12 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class AccessControlList implements Serializable {
   private static final long serialVersionUID = 106023217076996L;
 
+  public static final AccessControlList EMPTY_ACL = new AccessControlList();
+
+  public static final String OWNER_FIELD = "owner";
+  public static final String OWNING_GROUP_FIELD = "owningGroup";
+  public static final String STRING_ENTRY_FIELD = "stringEntries";
+
   /** Key representing owning user in {@link #mUserActions}. */
   protected static final String OWNING_USER_KEY = "";
   /** Key representing owning group in {@link #mGroupActions}. */
@@ -641,9 +647,9 @@ public class AccessControlList implements Serializable {
     public void serialize(AccessControlList accessControlList, JsonGenerator jsonGenerator,
         SerializerProvider serializerProvider) throws IOException {
       jsonGenerator.writeStartObject();
-      jsonGenerator.writeStringField("owner", accessControlList.getOwningUser());
-      jsonGenerator.writeStringField("owningGroup", accessControlList.getOwningGroup());
-      jsonGenerator.writeObjectField("stringEntries", accessControlList.toStringEntries());
+      jsonGenerator.writeStringField(OWNER_FIELD, accessControlList.getOwningUser());
+      jsonGenerator.writeStringField(OWNING_GROUP_FIELD, accessControlList.getOwningGroup());
+      jsonGenerator.writeObjectField(STRING_ENTRY_FIELD, accessControlList.toStringEntries());
       jsonGenerator.writeEndObject();
     }
   }
@@ -673,10 +679,10 @@ public class AccessControlList implements Serializable {
     public AccessControlList deserialize(JsonParser jsonParser,
         DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
       JsonNode node = jsonParser.getCodec().readTree(jsonParser);
-      String owner = node.get("owner").asText();
-      String owningGroup = node.get("owningGroup").asText();
+      String owner = node.get(OWNER_FIELD).asText();
+      String owningGroup = node.get(OWNING_GROUP_FIELD).asText();
       List<String> stringEntries = new ArrayList<>();
-      Iterator<JsonNode> nodeIterator = node.get("stringEntries").elements();
+      Iterator<JsonNode> nodeIterator = node.get(STRING_ENTRY_FIELD).elements();
       while (nodeIterator.hasNext()) {
         stringEntries.add(nodeIterator.next().asText());
       }

--- a/core/common/src/main/java/alluxio/security/authorization/AclActions.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclActions.java
@@ -16,6 +16,7 @@ import alluxio.proto.journal.File;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 
+import java.io.Serializable;
 import java.util.BitSet;
 import java.util.Set;
 
@@ -25,7 +26,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Permitted actions of an entry in {@link AccessControlList}.
  */
 @NotThreadSafe
-public final class AclActions {
+public final class AclActions implements Serializable {
+  private static final long serialVersionUID = 4500558548535992938L;
+
   // TODO(ohboring): have a static default AclActions object, and then copy on write.
   /**
    * Initial bits of the actions bitset.

--- a/core/common/src/main/java/alluxio/security/authorization/AclEntry.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclEntry.java
@@ -17,6 +17,7 @@ import alluxio.thrift.TAclEntry;
 
 import com.google.common.base.Objects;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,7 +25,8 @@ import java.util.stream.Collectors;
 /**
  * An entry in {@link AccessControlList}.
  */
-public final class AclEntry {
+public final class AclEntry implements Serializable {
+  private static final long serialVersionUID = -738692910777661243L;
 
   private static final String DEFAULT_KEYWORD = "default";
   private static final String DEFAULT_PREFIX = DEFAULT_KEYWORD + ":";

--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class DefaultAccessControlList extends AccessControlList {
   private static final long serialVersionUID = 8649647787531425489L;
-  
+
   /**
    * a reference to the access ACL associated with the same inode so that we can fill the default
    * value for OWNING_USER, OWNING_GROUP and OTHER.

--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -26,6 +26,8 @@ import java.util.List;
 public class DefaultAccessControlList extends AccessControlList {
   private static final long serialVersionUID = 8649647787531425489L;
 
+  public static final DefaultAccessControlList EMPTY_DEFAULT_ACL = new DefaultAccessControlList();
+
   /**
    * a reference to the access ACL associated with the same inode so that we can fill the default
    * value for OWNING_USER, OWNING_GROUP and OTHER.

--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -24,6 +24,8 @@ import java.util.List;
  * Default Access control list for a directory.
  */
 public class DefaultAccessControlList extends AccessControlList {
+  private static final long serialVersionUID = 8649647787531425489L;
+  
   /**
    * a reference to the access ACL associated with the same inode so that we can fill the default
    * value for OWNING_USER, OWNING_GROUP and OTHER.

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -15,8 +15,8 @@ import static alluxio.util.StreamUtils.map;
 
 import alluxio.Constants;
 import alluxio.security.authorization.AccessControlList;
-
 import alluxio.security.authorization.DefaultAccessControlList;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -30,6 +30,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * The file information.
  */
 @NotThreadSafe
+
 // TODO(jiri): Consolidate with URIStatus.
 public final class FileInfo implements Serializable {
   private static final long serialVersionUID = 7119966306934831779L;
@@ -252,16 +253,30 @@ public final class FileInfo implements Serializable {
   }
 
   /**
-   * @return the ACL entries for this file
+   * @return the ACL object for this file
    */
-  public List<String> getAclEntries() {
+  public AccessControlList getAcl() {
+    return mAcl;
+  }
+
+  /**
+   * @return the default ACL object for this file
+   */
+  public DefaultAccessControlList getDefaultAcl() {
+    return mDefaultAcl;
+  }
+
+  /**
+   * @return the ACL as string entries for this file
+   */
+  public List<String> convertAclToStringEntries() {
     return (mAcl == null) ? new ArrayList<>() : mAcl.toStringEntries();
   }
 
   /**
-   * @return the default ACL entries for this file
+   * @return the default ACL as string entries for this file
    */
-  public List<String> getDefaultAclEntries() {
+  public List<String> convertDefaultAclToStringEntries() {
     return (mDefaultAcl == null) ? new ArrayList<>() : mDefaultAcl.toStringEntries();
   }
 
@@ -510,7 +525,7 @@ public final class FileInfo implements Serializable {
    * @param acl the ACL entries to use
    * @return the file information
    */
-  public FileInfo setAclEntries(AccessControlList acl) {
+  public FileInfo setAcl(AccessControlList acl) {
     mAcl = acl;
     return this;
   }
@@ -519,7 +534,7 @@ public final class FileInfo implements Serializable {
    * @param defaultAcl the ACL entries to use
    * @return the file information
    */
-  public FileInfo setDefaultAclEntries(DefaultAccessControlList defaultAcl) {
+  public FileInfo setDefaultAcl(DefaultAccessControlList defaultAcl) {
     mDefaultAcl = defaultAcl;
     return this;
   }
@@ -582,9 +597,9 @@ public final class FileInfo implements Serializable {
         .setInAlluxioPercentage(info.getInAlluxioPercentage())
         .setUfsFingerprint(info.isSetUfsFingerprint() ? info.getUfsFingerprint()
             : Constants.INVALID_UFS_FINGERPRINT)
-        .setAclEntries(info.isSetAcl()
+        .setAcl(info.isSetAcl()
             ? (AccessControlList.fromThrift(info.getAcl())) : new AccessControlList())
-        .setDefaultAclEntries(info.isSetDefaultAcl()
+        .setDefaultAcl(info.isSetDefaultAcl()
             ? ((DefaultAccessControlList) AccessControlList.fromThrift(info.getDefaultAcl()))
             : new DefaultAccessControlList());
   }

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -62,8 +62,8 @@ public final class FileInfo implements Serializable {
   private int mInAlluxioPercentage;
   private String mUfsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
 
-  private AccessControlList mAcl = new AccessControlList();
-  private DefaultAccessControlList mDefaultAcl = new DefaultAccessControlList();
+  private AccessControlList mAcl = AccessControlList.EMPTY_ACL;
+  private DefaultAccessControlList mDefaultAcl = DefaultAccessControlList.EMPTY_DEFAULT_ACL;
 
   /**
    * Creates a new instance of {@link FileInfo}.

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -270,6 +270,7 @@ public final class FileInfo implements Serializable {
    * @return the ACL as string entries for this file
    */
   public List<String> convertAclToStringEntries() {
+    // do not use getX as the name of the method, otherwise it will be used by json serialization
     return (mAcl == null) ? new ArrayList<>() : mAcl.toStringEntries();
   }
 
@@ -277,6 +278,7 @@ public final class FileInfo implements Serializable {
    * @return the default ACL as string entries for this file
    */
   public List<String> convertDefaultAclToStringEntries() {
+    // do not use getX as the name of the method, otherwise it will be used by json serialization
     return (mDefaultAcl == null) ? new ArrayList<>() : mDefaultAcl.toStringEntries();
   }
 

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -62,8 +62,8 @@ public final class FileInfo implements Serializable {
   private int mInAlluxioPercentage;
   private String mUfsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
 
-  private AccessControlList mAcl = null;
-  private DefaultAccessControlList mDefaultAcl = null;
+  private AccessControlList mAcl = new AccessControlList();
+  private DefaultAccessControlList mDefaultAcl = new DefaultAccessControlList();
 
   /**
    * Creates a new instance of {@link FileInfo}.
@@ -651,8 +651,8 @@ public final class FileInfo implements Serializable {
         .add("fileBlockInfos", mFileBlockInfos)
         .add("mountId", mMountId).add("inAlluxioPercentage", mInAlluxioPercentage)
         .add("ufsFingerprint", mUfsFingerprint)
-        .add("aclEntries", mAcl.toString())
-        .add("defaultAclEntries", mDefaultAcl.toString())
+        .add("acl", mAcl.toString())
+        .add("defaultAcl", mDefaultAcl.toString())
         .toString();
   }
 }

--- a/core/common/src/test/java/alluxio/wire/FileInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/FileInfoTest.java
@@ -135,8 +135,8 @@ public class FileInfoTest {
     result.setUfsPath(ufsPath);
     result.setInAlluxioPercentage(inAlluxioPercentage);
     AccessControlList acl = new AccessControlList();
-    result.setAclEntries(acl.toStringEntries());
-    result.setDefaultAclEntries(new DefaultAccessControlList().toStringEntries());
+    result.setAclEntries(acl);
+    result.setDefaultAclEntries(new DefaultAccessControlList());
     return result;
   }
 }

--- a/core/common/src/test/java/alluxio/wire/FileInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/FileInfoTest.java
@@ -86,6 +86,7 @@ public class FileInfoTest {
     Assert.assertEquals(a.isPinned(), b.isPinned());
     Assert.assertEquals(a.getInAlluxioPercentage(), b.getInAlluxioPercentage());
     Assert.assertEquals(a.getAcl(), b.getAcl());
+    Assert.assertEquals(a.getDefaultAcl(), b.getDefaultAcl());
     Assert.assertEquals(a, b);
   }
 

--- a/core/server/common/src/main/java/alluxio/web/UIFileInfo.java
+++ b/core/server/common/src/main/java/alluxio/web/UIFileInfo.java
@@ -109,8 +109,8 @@ public final class UIFileInfo {
   public UIFileInfo(URIStatus status) {
     // detect the extended acls
     AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAclEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAclEntries().isEmpty();
+        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
+    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
 
     mId = status.getFileId();
     mName = status.getName();

--- a/core/server/common/src/main/java/alluxio/web/UIFileInfo.java
+++ b/core/server/common/src/main/java/alluxio/web/UIFileInfo.java
@@ -14,7 +14,6 @@ package alluxio.web;
 import alluxio.AlluxioURI;
 import alluxio.client.file.URIStatus;
 import alluxio.master.file.meta.PersistenceState;
-import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
@@ -108,9 +107,7 @@ public final class UIFileInfo {
    */
   public UIFileInfo(URIStatus status) {
     // detect the extended acls
-    AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
+    boolean hasExtended = status.getAcl().hasExtended() || !status.getDefaultAcl().isEmpty();
 
     mId = status.getFileId();
     mName = status.getName();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -274,11 +274,11 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     ret.setPersistenceState(getPersistenceState().toString());
     ret.setMountPoint(isMountPoint());
     ret.setUfsFingerprint(Constants.INVALID_UFS_FINGERPRINT);
-    ret.setAclEntries(mAcl.toStringEntries());
+    ret.setAclEntries(mAcl);
     if (!mDefaultAcl.isEmpty()) {
-      ret.setDefaultAclEntries(mDefaultAcl.toStringEntries());
+      ret.setDefaultAclEntries(mDefaultAcl);
     } else {
-      ret.setDefaultAclEntries(Collections.emptyList());
+      ret.setDefaultAclEntries(new DefaultAccessControlList());
     }
     return ret;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -26,7 +26,6 @@ import alluxio.wire.FileInfo;
 
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -274,11 +273,11 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     ret.setPersistenceState(getPersistenceState().toString());
     ret.setMountPoint(isMountPoint());
     ret.setUfsFingerprint(Constants.INVALID_UFS_FINGERPRINT);
-    ret.setAclEntries(mAcl);
+    ret.setAcl(mAcl);
     if (!mDefaultAcl.isEmpty()) {
-      ret.setDefaultAclEntries(mDefaultAcl);
+      ret.setDefaultAcl(mDefaultAcl);
     } else {
-      ret.setDefaultAclEntries(new DefaultAccessControlList());
+      ret.setDefaultAcl(new DefaultAccessControlList());
     }
     return ret;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -274,11 +274,7 @@ public final class InodeDirectory extends Inode<InodeDirectory> {
     ret.setMountPoint(isMountPoint());
     ret.setUfsFingerprint(Constants.INVALID_UFS_FINGERPRINT);
     ret.setAcl(mAcl);
-    if (!mDefaultAcl.isEmpty()) {
-      ret.setDefaultAcl(mDefaultAcl);
-    } else {
-      ret.setDefaultAcl(new DefaultAccessControlList());
-    }
+    ret.setDefaultAcl(mDefaultAcl);
     return ret;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -90,7 +90,7 @@ public final class InodeFile extends Inode<InodeFile> {
     ret.setPersistenceState(getPersistenceState().toString());
     ret.setMountPoint(false);
     ret.setUfsFingerprint(getUfsFingerprint());
-    ret.setAclEntries(mAcl);
+    ret.setAcl(mAcl);
     return ret;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -90,7 +90,7 @@ public final class InodeFile extends Inode<InodeFile> {
     ret.setPersistenceState(getPersistenceState().toString());
     ret.setMountPoint(false);
     ret.setUfsFingerprint(getUfsFingerprint());
-    ret.setAclEntries(mAcl.toStringEntries());
+    ret.setAclEntries(mAcl);
     return ret;
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1185,8 +1185,8 @@ public final class FileSystemMasterTest {
   public void setDefaultAcl() throws Exception {
     SetAclOptions options = SetAclOptions.defaults();
     createFileWithSingleBlock(NESTED_FILE_URI);
-    Set<String> entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    Set<String> entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertEquals(0, entries.size());
 
     // replace
@@ -1195,16 +1195,16 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.REPLACE,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // replace
     newEntries = Sets.newHashSet("default:user::rw-", "default:group::r--", "default:other::r--");
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.REPLACE,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // modify existing
@@ -1212,8 +1212,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // modify add
@@ -1222,8 +1222,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
     assertTrue(entries.containsAll(newEntries));
 
@@ -1233,16 +1233,16 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertTrue(entries.containsAll(newEntries));
 
     // remove default
     mFileSystemMaster
         .setAcl(NESTED_URI, SetAclAction.REMOVE_DEFAULT, Collections.emptyList(), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertEquals(0, entries.size());
 
     // remove
@@ -1253,8 +1253,8 @@ public final class FileSystemMasterTest {
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
     oldEntries = new HashSet<>(entries);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
 
     Set<String> deleteEntries = Sets.newHashSet("default:user:userb:rwx",
@@ -1262,8 +1262,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.REMOVE,
         deleteEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).getDefaultAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     Set<String> remainingEntries = new HashSet<>(newEntries);
     assertTrue(remainingEntries.removeAll(deleteEntries));
     assertTrue(entries.containsAll(remainingEntries));
@@ -1277,8 +1277,8 @@ public final class FileSystemMasterTest {
     SetAclOptions options = SetAclOptions.defaults();
     createFileWithSingleBlock(NESTED_FILE_URI);
 
-    Set<String> entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    Set<String> entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertEquals(3, entries.size());
 
     // replace
@@ -1286,8 +1286,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.REPLACE,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // replace
@@ -1295,8 +1295,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.REPLACE,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // modify existing
@@ -1304,8 +1304,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertEquals(newEntries, entries);
 
     // modify add
@@ -1314,8 +1314,8 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
     assertTrue(entries.containsAll(newEntries));
 
@@ -1324,16 +1324,16 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertTrue(entries.containsAll(newEntries));
 
     // remove all
     mFileSystemMaster
         .setAcl(NESTED_FILE_URI, SetAclAction.REMOVE_ALL, Collections.emptyList(), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertEquals(3, entries.size());
 
     // remove
@@ -1343,16 +1343,16 @@ public final class FileSystemMasterTest {
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
     oldEntries = new HashSet<>(entries);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
 
     Set<String> deleteEntries = Sets.newHashSet("user:userb:rwx", "group:groupa:--x");
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.REMOVE,
         deleteEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
-    entries = Sets.newHashSet(
-        mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).getAclEntries());
+    entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     Set<String> remainingEntries = new HashSet<>(newEntries);
     assertTrue(remainingEntries.removeAll(deleteEntries));
     assertTrue(entries.containsAll(remainingEntries));
@@ -1389,7 +1389,7 @@ public final class FileSystemMasterTest {
         .setLoadMetadataType(LoadMetadataType.Once).setRecursive(true));
     assertEquals(files * 3 + 3, infos.size());
     for (FileInfo info : infos) {
-      assertEquals(newEntries, Sets.newHashSet(info.getAclEntries()));
+      assertEquals(newEntries, Sets.newHashSet(info.convertAclToStringEntries()));
     }
   }
 
@@ -2382,7 +2382,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.loadMetadata(uri,
         LoadMetadataOptions.defaults().setCreateAncestors(true));
     FileInfo info = mFileSystemMaster.getFileInfo(uri, GetStatusOptions.defaults());
-    Assert.assertTrue(info.getAclEntries().contains("user::rw-"));
+    Assert.assertTrue(info.convertAclToStringEntries().contains("user::rw-"));
 
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/GetFaclCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/GetFaclCommand.java
@@ -49,10 +49,10 @@ public final class GetFaclCommand extends AbstractFileSystemCommand {
     System.out.println("# file: " + status.getPath());
     System.out.println("# owner: " + status.getOwner());
     System.out.println("# group: " + status.getGroup());
-    for (String entry : status.getAclEntries()) {
+    for (String entry : status.getAcl().toStringEntries()) {
       System.out.println(entry);
     }
-    List<String> defaultAclEntries = status.getDefaultAclEntries();
+    List<String> defaultAclEntries = status.getDefaultAcl().toStringEntries();
     for (String entry: defaultAclEntries) {
       System.out.println(entry);
     }

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -19,7 +19,6 @@ import alluxio.client.file.options.ListStatusOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.InvalidArgumentException;
-import alluxio.security.authorization.AccessControlList;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.SecurityUtils;
@@ -170,9 +169,8 @@ public final class LsCommand extends AbstractFileSystemCommand {
 
   private void printLsString(URIStatus status, boolean hSize) {
     // detect the extended acls
-    AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
+    boolean hasExtended = status.getAcl().hasExtended()
+        || !status.getDefaultAcl().isEmpty();
 
     System.out.print(formatLsString(hSize, SecurityUtils.isSecurityEnabled(), status.isFolder(),
         FormatUtils.formatMode((short) status.getMode(), status.isFolder(), hasExtended),

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -171,8 +171,8 @@ public final class LsCommand extends AbstractFileSystemCommand {
   private void printLsString(URIStatus status, boolean hSize) {
     // detect the extended acls
     AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAclEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAclEntries().isEmpty();
+        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
+    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
 
     System.out.print(formatLsString(hSize, SecurityUtils.isSecurityEnabled(), status.isFolder(),
         FormatUtils.formatMode((short) status.getMode(), status.isFolder(), hasExtended),

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
@@ -49,8 +49,8 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
     URIStatus status = mFileSystem.getStatus(uri);
     // detect the extended acls
     AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAclEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAclEntries().isEmpty();
+        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
+    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
 
     return getLsResultStr(uri.getPath(), status.getLastModificationTimeMs(), size,
         STATE_FILE_IN_ALLUXIO, testUser, testGroup, status.getMode(), hasExtended,

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
@@ -23,7 +23,6 @@ import alluxio.exception.AlluxioException;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.master.file.meta.PersistenceState;
-import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
@@ -48,9 +47,8 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
       throws IOException, AlluxioException {
     URIStatus status = mFileSystem.getStatus(uri);
     // detect the extended acls
-    AccessControlList acl = AccessControlList
-        .fromStringEntries(status.getOwner(), status.getGroup(), status.getAcl().toStringEntries());
-    boolean hasExtended = acl.hasExtended() || !status.getDefaultAcl().toStringEntries().isEmpty();
+    boolean hasExtended = status.getAcl().hasExtended()
+        || !status.getDefaultAcl().isEmpty();
 
     return getLsResultStr(uri.getPath(), status.getLastModificationTimeMs(), size,
         STATE_FILE_IN_ALLUXIO, testUser, testGroup, status.getMode(), hasExtended,


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3164

Instead of keeping a list of string entries in the file info, we keep acl object in the `FileInfo` object. This results in fewer conversions to/ from object when we convert to Thrift 