### PR TITLE
[SMALLFIX] Set cancel mark in FileOutStream to true if exception caught on write failures

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -274,6 +274,7 @@ public class FileOutStream extends AbstractOutStream {
   private void handleCacheWriteException(Exception e) throws IOException {
     LOG.warn("Failed to write into AlluxioStore, canceling write attempt.", e);
     if (!mUnderStorageType.isSyncPersist()) {
+      mCanceled = true;
       throw new IOException(ExceptionMessage.FAILED_CACHE.getMessage(e.getMessage()), e);
     }
 

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -91,11 +91,16 @@ public enum ExceptionMessage {
   BLOCK_NOT_FOUND_AT_LOCATION("blockId {0,number,#} not found at location: {1}"),
   MOVE_UNCOMMITTED_BLOCK("Cannot move uncommitted blockId {0,number,#}"),
   NO_BLOCK_ID_FOUND("blockId {0,number,#} not found"),
-  NO_EVICTION_PLAN_TO_FREE_SPACE("No eviction plan by evictor to free space"),
+  NO_EVICTION_PLAN_TO_FREE_SPACE(
+      "Failed to find an eviction plan to free {0,number,#} bytes space at location {1}"),
   NO_SPACE_FOR_BLOCK_ALLOCATION_TIMEOUT(
-      "Failed to allocate {0,number,#} bytes after {1}ms for blockId {2,number,#}"),
+      "Failed to allocate {0,number,#} bytes on {1} after {2}ms to create blockId {3,number,#}"),
   NO_SPACE_FOR_BLOCK_ALLOCATION_RETRIES_EXCEEDED(
-      "Failed to allocate {0,number,#} bytes after {1} attempts for blockId {2,number,#}"),
+      "Failed to allocate {0,number,#} bytes on {1} after {2} attempts for blockId {3,number,#}"),
+  NO_SPACE_FOR_BLOCK_REQUEST_SPACE_TIMEOUT(
+      "Failed to request {0,number,#} bytes after {1}ms to create blockId {2,number,#}"),
+  NO_SPACE_FOR_BLOCK_REQUEST_SPACE_RETRIES_EXCEEDED(
+      "Failed to request {0,number,#} bytes after {1} attempts for blockId {2,number,#}"),
   NO_SPACE_FOR_BLOCK_MOVE_TIMEOUT(
       "Failed to find space in {0} to move blockId {1,number,#} after {2}ms"),
   NO_SPACE_FOR_BLOCK_MOVE_RETRIES_EXCEEDED(

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -120,8 +120,8 @@ public class SpaceReserver implements HeartbeatExecutor {
             mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
           } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
               | BlockAlreadyExistsException | InvalidWorkerStateException | IOException e) {
-            LOG.warn("SpaceReserver failed to free tier {} to {} bytes used for high watermarks: "
-                + "{}", tierAlias, reservedSpace, e.getMessage());
+            LOG.warn("SpaceReserver failed to free {} bytes on tier {} for high watermarks: {}",
+                reservedSpace, tierAlias, e.getMessage());
           }
         }
       } else {
@@ -129,8 +129,8 @@ public class SpaceReserver implements HeartbeatExecutor {
           mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
         } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
             | BlockAlreadyExistsException | InvalidWorkerStateException | IOException e) {
-          LOG.warn("SpaceReserver failed to free tier {} to {} bytes used: {}", tierAlias,
-              reservedSpace, e.getMessage());
+          LOG.warn("SpaceReserver failed to free {} bytes on tier {}: {}", reservedSpace,
+              tierAlias, e.getMessage());
         }
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -232,7 +232,7 @@ public class TieredBlockStore implements BlockStore {
         }
       }
       throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION_TIMEOUT,
-          initialBlockSize, FREE_SPACE_TIMEOUT_MS, blockId);
+          initialBlockSize, location, FREE_SPACE_TIMEOUT_MS, blockId);
     } else {
       RetryPolicy retryPolicy = new CountingRetry(MAX_RETRIES);
       while (retryPolicy.attempt()) {
@@ -251,7 +251,7 @@ public class TieredBlockStore implements BlockStore {
       // other types of exception to indicate this case.
       throw new WorkerOutOfSpaceException(
           ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION_RETRIES_EXCEEDED, initialBlockSize,
-          MAX_RETRIES, blockId);
+          location, MAX_RETRIES, blockId);
     }
   }
 
@@ -320,7 +320,7 @@ public class TieredBlockStore implements BlockStore {
           return;
         }
       }
-      throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION_TIMEOUT,
+      throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_REQUEST_SPACE_TIMEOUT,
           additionalBytes, FREE_SPACE_TIMEOUT_MS, blockId);
     } else {
       RetryPolicy retryPolicy = new CountingRetry(MAX_RETRIES);
@@ -338,7 +338,7 @@ public class TieredBlockStore implements BlockStore {
       // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
       // other types of exception to indicate this case.
       throw new WorkerOutOfSpaceException(
-          ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION_RETRIES_EXCEEDED, additionalBytes,
+          ExceptionMessage.NO_SPACE_FOR_BLOCK_REQUEST_SPACE_RETRIES_EXCEEDED, additionalBytes,
           MAX_RETRIES, blockId);
     }
   }
@@ -710,7 +710,8 @@ public class TieredBlockStore implements BlockStore {
       plan = mEvictor.freeSpaceWithView(availableBytes, location, getUpdatedView(), mode);
       // Absent plan means failed to evict enough space.
       if (plan == null) {
-        throw new WorkerOutOfSpaceException(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE);
+        throw new WorkerOutOfSpaceException(
+            ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE, availableBytes, location.tierAlias());
       }
     }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -428,7 +428,9 @@ public final class TieredBlockStoreTest {
 
     // Expect an exception because no eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);
-    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
+    mThrown.expectMessage(
+        ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage(mTestDir1.getCapacityBytes(),
+            mTestDir1.toBlockStoreLocation().tierAlias()));
     mBlockStore.createBlock(SESSION_ID1, TEMP_BLOCK_ID, mTestDir1.toBlockStoreLocation(),
         mTestDir1.getCapacityBytes());
 
@@ -458,7 +460,8 @@ public final class TieredBlockStoreTest {
 
     // Expect an exception because no eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);
-    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage(
+        BLOCK_SIZE, mTestDir2.toBlockStoreLocation().tierAlias()));
     mBlockStore.moveBlock(SESSION_ID1, BLOCK_ID1, mTestDir2.toBlockStoreLocation());
 
     // Expect createBlockMeta to succeed after unlocking this block.
@@ -484,7 +487,8 @@ public final class TieredBlockStoreTest {
 
     // Expect an empty eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);
-    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage(
+        mTestDir1.getCapacityBytes(), mTestDir1.toBlockStoreLocation().tierAlias()));
     mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes(),
         mTestDir1.toBlockStoreLocation());
 


### PR DESCRIPTION
- Set cancel mark in FileOutStream to true if exception caught on write failures

- Improve exception messages