### PR TITLE
[ALLUXIO-3278] Enforce no unshaded protobuf and thrift classes in the output

### DIFF
--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -156,6 +156,9 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
+                    <!-- Enforce no unshaded protobuf and thrift classes in the output. -->
+                    <exclude>com/google/protobuf/*</exclude>
+                    <exclude>org/apache/thrift/*</exclude>
                     <exclude>LICENSE</exclude>
                     <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3278

Before this fix:
- When building Alluxio from the root dir of the source tree, the protobuf still shows as a dependency of alluxio-core-protobuf, which introduces unshaded protobuf in the final uber client jar.
- When building Alluxio from `core/client/runtime`, the output is correct

This fix corrects the output by enforcing the output having no thrift and protobuf classes in filters.