### PR TITLE
[ALLUXIO-3264]Use static imports for standard test utilities for class UnderFileSystemUtilsTest

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/file/UnderFileSystemUtilsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/UnderFileSystemUtilsTest.java
@@ -24,7 +24,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -71,7 +76,7 @@ public final class UnderFileSystemUtilsTest {
     mFileSystem = PowerMockito.mock(FileSystem.class);
     mUnderFileSystem = PowerMockito.mock(UnderFileSystem.class);
 
-    Mockito.when(mUnderFileSystem.mkdirs(Mockito.anyString(), Mockito.any(MkdirsOptions.class)))
+    when(mUnderFileSystem.mkdirs(anyString(), any(MkdirsOptions.class)))
         .thenReturn(true);
   }
 
@@ -81,27 +86,27 @@ public final class UnderFileSystemUtilsTest {
   @Test
   public void prepareFilePath1() throws Exception {
     // Alluxio root is mount point
-    Mockito.when(mFileSystem.getStatus(mAlluxioRoot))
+    when(mFileSystem.getStatus(mAlluxioRoot))
         .thenReturn(createStatus(mOwnerRoot, mGroup, mMode, true));
-    Mockito.when(mFileSystem.getStatus(mAlluxioA))
+    when(mFileSystem.getStatus(mAlluxioA))
         .thenReturn(createStatus(mOwnerA, mGroup, mMode, false));
-    Mockito.when(mFileSystem.getStatus(mAlluxioB))
+    when(mFileSystem.getStatus(mAlluxioB))
         .thenReturn(createStatus(mOwnerB, mGroup, mMode, false));
 
     // Parent directories 'a' and 'b' do not exist in UFS
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(false);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
+    when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
+    when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(false);
+    when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
 
     UnderFileSystemUtils.prepareFilePath(mAlluxioFile, mUfsFile, mFileSystem, mUnderFileSystem);
 
     // Verify getStatus is called for all non-existent directories
-    Mockito.verify(mFileSystem, Mockito.times(2)).getStatus(Mockito.any(AlluxioURI.class));
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(mAlluxioA);
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(mAlluxioA);
+    verify(mFileSystem, times(2)).getStatus(any(AlluxioURI.class));
+    verify(mFileSystem, times(1)).getStatus(mAlluxioA);
+    verify(mFileSystem, times(1)).getStatus(mAlluxioA);
     // Verify mkdir is called with the correct permissions
-    Mockito.verify(mUnderFileSystem, Mockito.times(1)).mkdirs(mUfsA, createMkdirsOptions(mOwnerA));
-    Mockito.verify(mUnderFileSystem, Mockito.times(1)).mkdirs(mUfsB, createMkdirsOptions(mOwnerB));
+    verify(mUnderFileSystem, times(1)).mkdirs(mUfsA, createMkdirsOptions(mOwnerA));
+    verify(mUnderFileSystem, times(1)).mkdirs(mUfsB, createMkdirsOptions(mOwnerB));
   }
 
   /**
@@ -110,26 +115,26 @@ public final class UnderFileSystemUtilsTest {
   @Test
   public void prepareFilePath2() throws Exception {
     // Alluxio 'a' is mount point
-    Mockito.when(mFileSystem.getStatus(mAlluxioRoot))
+    when(mFileSystem.getStatus(mAlluxioRoot))
         .thenReturn(createStatus(mOwnerRoot, mGroup, mMode, true));
-    Mockito.when(mFileSystem.getStatus(mAlluxioA))
+    when(mFileSystem.getStatus(mAlluxioA))
         .thenReturn(createStatus(mOwnerA, mGroup, mMode, true));
-    Mockito.when(mFileSystem.getStatus(mAlluxioB))
+    when(mFileSystem.getStatus(mAlluxioB))
         .thenReturn(createStatus(mOwnerB, mGroup, mMode, false));
 
     // Parent directory 'b' does not exist in UFS
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(true);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
+    when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
+    when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(true);
+    when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
 
     UnderFileSystemUtils.prepareFilePath(mAlluxioFile, mUfsFile, mFileSystem, mUnderFileSystem);
 
     // Verify getStatus is called for all non-existent directories
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(Mockito.any(AlluxioURI.class));
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(mAlluxioB);
+    verify(mFileSystem, times(1)).getStatus(any(AlluxioURI.class));
+    verify(mFileSystem, times(1)).getStatus(mAlluxioB);
 
     // Verify mkdir is called with the correct permissions
-    Mockito.verify(mUnderFileSystem, Mockito.times(1)).mkdirs(mUfsB, createMkdirsOptions(mOwnerB));
+    verify(mUnderFileSystem, times(1)).mkdirs(mUfsB, createMkdirsOptions(mOwnerB));
   }
 
   /**
@@ -142,26 +147,26 @@ public final class UnderFileSystemUtilsTest {
     mThrown.expect(IOException.class);
 
     // Alluxio 'a' is mount point
-    Mockito.when(mFileSystem.getStatus(mAlluxioRoot))
+    when(mFileSystem.getStatus(mAlluxioRoot))
         .thenReturn(createStatus(mOwnerRoot, mGroup, mMode, true));
-    Mockito.when(mFileSystem.getStatus(mAlluxioA))
+    when(mFileSystem.getStatus(mAlluxioA))
         .thenReturn(createStatus(mOwnerA, mGroup, mMode, true));
-    Mockito.when(mFileSystem.getStatus(mAlluxioB))
+    when(mFileSystem.getStatus(mAlluxioB))
         .thenReturn(createStatus(mOwnerB, mGroup, mMode, false));
 
     // Parent directories 'a' and 'b' do not exist in UFS
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(false);
-    Mockito.when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
+    when(mUnderFileSystem.isDirectory(mUfsRoot)).thenReturn(true);
+    when(mUnderFileSystem.isDirectory(mUfsA)).thenReturn(false);
+    when(mUnderFileSystem.isDirectory(mUfsB)).thenReturn(false);
 
     UnderFileSystemUtils.prepareFilePath(mAlluxioFile, mUfsFile, mFileSystem, mUnderFileSystem);
 
     // Verify getStatus is called for all non-existent directories
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(Mockito.any(AlluxioURI.class));
-    Mockito.verify(mFileSystem, Mockito.times(1)).getStatus(mAlluxioB);
+    verify(mFileSystem, times(1)).getStatus(any(AlluxioURI.class));
+    verify(mFileSystem, times(1)).getStatus(mAlluxioB);
     // Verify no directories are created in UFS
-    Mockito.verify(mUnderFileSystem, Mockito.times(0)).mkdirs(Mockito.anyString(),
-        Mockito.any(MkdirsOptions.class));
+    verify(mUnderFileSystem, times(0)).mkdirs(anyString(),
+        any(MkdirsOptions.class));
   }
 
   private MkdirsOptions createMkdirsOptions(String owner) {

--- a/core/server/worker/src/test/java/alluxio/worker/file/UnderFileSystemUtilsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/UnderFileSystemUtilsTest.java
@@ -11,6 +11,12 @@
 
 package alluxio.worker.file;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
@@ -24,12 +30,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3264
change Mockito.verify(...) to verify(...) for all function of class alluxio.worker.file.UnderFileSystemUtilsTest and change import org.mockito.Mockito; to import static org.mockito.Mockito.verify;
Mockito.mock(...),Mockito.when(...), Mockito.times(...) ,Mockito.any(...) and Mockito.anyString() are the same.