### PR TITLE
[ALLUXIO-3270] Use static imports for standard test utilities for class UfsInputStreamManagerTest

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -11,6 +11,15 @@
 
 package alluxio.worker.block;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
+
 import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
 import alluxio.test.util.ConcurrencyUtils;
@@ -21,7 +30,6 @@ import alluxio.underfs.options.OpenOptions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.mockito.invocation.Invocation;
 
 import java.io.Closeable;
@@ -46,14 +54,14 @@ public final class UfsInputStreamManagerTest {
   @Before
   public void before() throws Exception {
     mSeekableInStreams = new SeekableUnderFileInputStream[mNumOfInputStreams];
-    mUfs = Mockito.mock(UnderFileSystem.class);
-    Mockito.when(mUfs.isSeekable()).thenReturn(true);
+    mUfs = mock(UnderFileSystem.class);
+    when(mUfs.isSeekable()).thenReturn(true);
     for (int i = 0; i < mNumOfInputStreams; i++) {
-      SeekableUnderFileInputStream instream = Mockito.mock(SeekableUnderFileInputStream.class);
+      SeekableUnderFileInputStream instream = mock(SeekableUnderFileInputStream.class);
       mSeekableInStreams[i] = instream;
     }
-    Mockito.when(mUfs.open(Mockito.eq(FILE_NAME), Mockito.any(OpenOptions.class))).thenReturn(
-        mSeekableInStreams[0], Arrays.copyOfRange(mSeekableInStreams, 1, mNumOfInputStreams));
+    when(mUfs.open(eq(FILE_NAME), any(OpenOptions.class))).thenReturn(
+            mSeekableInStreams[0], Arrays.copyOfRange(mSeekableInStreams, 1, mNumOfInputStreams));
     mManager = new UfsInputStreamManager();
   }
 
@@ -62,22 +70,22 @@ public final class UfsInputStreamManagerTest {
    */
   @Test
   public void testAcquireAndRelease() throws Exception {
-    SeekableUnderFileInputStream mockedStrem = Mockito.mock(SeekableUnderFileInputStream.class);
-    Mockito.when(mUfs.open(Mockito.eq(FILE_NAME), Mockito.any(OpenOptions.class)))
-        .thenReturn(mockedStrem).thenThrow(new IllegalStateException("Should only be called once"));
+    SeekableUnderFileInputStream mockedStrem = mock(SeekableUnderFileInputStream.class);
+    when(mUfs.open(eq(FILE_NAME), any(OpenOptions.class)))
+            .thenReturn(mockedStrem).thenThrow(new IllegalStateException("Should only be called once"));
 
     // acquire a stream
     InputStream instream1 =
-        mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
+            mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
     // release
     mManager.release(instream1);
     // acquire a stream again
     InputStream instream2 =
-        mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
+            mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
 
     Assert.assertEquals(instream1, instream2);
     // ensure the second time the released instream is the same one but repositioned
-    Mockito.verify(mockedStrem).seek(4);
+    verify(mockedStrem).seek(4);
   }
 
   /**
@@ -89,8 +97,8 @@ public final class UfsInputStreamManagerTest {
     mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
     mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(6));
     // 3 different input streams are acquired
-    Mockito.verify(mUfs, Mockito.times(3)).open(Mockito.eq(FILE_NAME),
-        Mockito.any(OpenOptions.class));
+    verify(mUfs, times(3)).open(eq(FILE_NAME),
+            any(OpenOptions.class));
   }
 
   /**
@@ -106,13 +114,13 @@ public final class UfsInputStreamManagerTest {
       mManager = new UfsInputStreamManager();
       // check out a stream
       InputStream instream =
-          mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
+              mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
       // check in back
       mManager.release(instream);
       Thread.sleep(10);
       // check out another stream should trigger the timeout
       mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
-      Mockito.verify(mSeekableInStreams[0], Mockito.timeout(2000).times(1)).close();
+      verify(mSeekableInStreams[0], timeout(2000).times(1)).close();
     }
   }
 
@@ -136,7 +144,7 @@ public final class UfsInputStreamManagerTest {
             InputStream instream;
             try {
               instream =
-                  mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
+                      mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
               Thread.sleep(10);
               mManager.release(instream);
             } catch (Exception e) {
@@ -151,8 +159,8 @@ public final class UfsInputStreamManagerTest {
       // Each subsequent check out per thread should be a seek operation
       int numSeek = 0;
       for (int i = 0; i < mNumOfInputStreams; i++) {
-        for (Invocation invocation : Mockito.mockingDetails(mSeekableInStreams[i])
-            .getInvocations()) {
+        for (Invocation invocation : mockingDetails(mSeekableInStreams[i])
+                .getInvocations()) {
           if (invocation.getMethod().getName().equals("seek")) {
             numSeek++;
           }
@@ -181,7 +189,7 @@ public final class UfsInputStreamManagerTest {
             InputStream instream;
             try {
               instream =
-                  mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
+                      mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
               mManager.release(instream);
               Thread.sleep(200);
             } catch (Exception e) {
@@ -194,7 +202,7 @@ public final class UfsInputStreamManagerTest {
       }
       ConcurrencyUtils.assertConcurrent(threads, 30);
       // ensure at least one expired in stream is closed
-      Mockito.verify(mSeekableInStreams[0], Mockito.timeout(2000)).close();
+      verify(mSeekableInStreams[0], timeout(2000)).close();
     }
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -11,14 +11,14 @@
 
 package alluxio.worker.block;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamManagerTest.java
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
[https://alluxio.atlassian.net/browse/ALLUXIO-3270](https://alluxio.atlassian.net/browse/ALLUXIO-3270)
change Mockito.mock(...) to mock(...) for all function of class alluxio.worker.block.UfsInputStreamManagerTest and change import org.mockito.Mockito; to import static org.mockito.Mockito.mock; Mockito.when(...) and Mockito.eq(...) Mockito.any(...) Mockito.verify(..) are the same.