### PR TITLE
[ALLUXIO-3272] Use static imports for standard test utilities for class SummaryCommandTest

### DIFF
--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -11,6 +11,10 @@
 
 package alluxio.cli.fsadmin.report;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import alluxio.cli.fsadmin.report.SummaryCommand;
 import alluxio.client.MetaMasterClient;
 import alluxio.client.block.BlockMasterClient;
@@ -32,10 +36,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SummaryCommandTest {
   private MetaMasterClient mMetaMasterClient;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3272
change Mockito.mock(...) to mock(...) for all function of class alluxio.cli.fsadmin.report.SummaryCommandTest and change import org.mockito.Mockito; to import static org.mockito.Mockito.mock;
Mockito.when(...) Mockito.any(...) are the same.