### PR TITLE
[ALLUXIO-3268] Use static imports for standard test utilities for class GCSUnderFileSystemTest

### DIFF
--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -22,7 +22,7 @@ import org.jets3t.service.impl.rest.httpclient.GoogleStorageService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
-import static org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3268
change Mockito.mock(...) to mock(...) for all function of class alluxio.underfs.gcs.GCSUnderFileSystemTest and change import org.mockito.Mockito; to import static org.mockito.Mockito.mock;
Mockito.when(...) is the same.