### PR TITLE
[ALLUXIO-3269] Use static imports for standard test utilities for class MasterTestUtilster test utils

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
@@ -11,10 +11,10 @@
 
 package alluxio.master;
 
+import static org.mockito.Mockito.mock;
+
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * Util methods to help with master testing.

--- a/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;
 
-import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
 
 /**
  * Util methods to help with master testing.
@@ -34,7 +34,7 @@ public final class MasterTestUtils {
    */
   public static MasterContext testMasterContext(JournalSystem journalSystem) {
     return new MasterContext(journalSystem, new TestSafeModeManager(),
-        Mockito.mock(BackupManager.class), -1, -1);
+        mock(BackupManager.class), -1, -1);
   }
 
   private MasterTestUtils() {} // Not intended for instatiation.


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3269
change Mockito.mock(...) to mock(...) for all function of class alluxio.master.MasterTestUtils and change import org.mockito.Mockito; to import static org.mockito.Mockito.mock;