### PR TITLE
[SMALLFIX] Avoid potential exception when terminal type can not be decided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
       <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
-        <version>2.14.2</version>
+        <version>2.14.6</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>

--- a/shell/src/main/java/alluxio/cli/fs/command/HelpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/HelpCommand.java
@@ -47,7 +47,12 @@ public final class HelpCommand extends AbstractFileSystemCommand {
   public static void printCommandInfo(Command command, PrintWriter pw) {
     String description =
         String.format("%s: %s", command.getCommandName(), command.getDescription());
-    int width = TerminalFactory.get().getWidth();
+    int width = 80;
+    try {
+      width = TerminalFactory.get().getWidth();
+    } catch (Exception e) {
+      // In case the terminal factory failed to decide terminal type, use default width
+    }
 
     HELP_FORMATTER.printWrapped(pw, width, description);
     HELP_FORMATTER.printUsage(pw, width, command.getUsage());


### PR DESCRIPTION
Fix the following issue that may happen on certain terminals:

```bash
$ bin/alluxio fs help ls
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.valueOf(Integer.java:766)
	at jline.internal.InfoCmp.parseInfoCmp(InfoCmp.java:59)
	at jline.UnixTerminal.parseInfoCmp(UnixTerminal.java:242)
	at jline.UnixTerminal.<init>(UnixTerminal.java:65)
	at jline.UnixTerminal.<init>(UnixTerminal.java:50)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
	at jline.TerminalFactory.create(TerminalFactory.java:102)
	at jline.TerminalFactory.get(TerminalFactory.java:186)
	at jline.TerminalFactory.get(TerminalFactory.java:192)
	at alluxio.cli.fs.command.HelpCommand.printCommandInfo(HelpCommand.java:50)
	at alluxio.cli.fs.command.HelpCommand.run(HelpCommand.java:88)
	at alluxio.cli.AbstractShell.run(AbstractShell.java:100)
	at alluxio.cli.fs.FileSystemShell.main(FileSystemShell.java:65)
```

This is a bug in jline [link](https://github.com/jline/jline2/commit/c1b1676de1803278289af0622ad202f1c7a526ec)
So I also bumped the jline version. However, when I cherry-pick to 1.8 branch, I will keep the same jline version to avoid complicating the test.