### PR TITLE
[SMALLFIX] Coordinate test ports

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -132,7 +132,7 @@ public final class MultiProcessCluster {
     mDeployMode = mode;
     mMasters = new ArrayList<>();
     mWorkers = new ArrayList<>();
-    mPorts = ports;
+    mPorts = new ArrayList<>(ports);
     mCloser = Closer.create();
     mState = State.NOT_STARTED;
     mSuccess = false;

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -121,9 +121,9 @@ public final class MultiProcessCluster {
     if (System.getenv(ALLUXIO_USE_FIXED_TEST_PORTS) != null) {
       Preconditions.checkState(
           ports.size() == numMasters * PORTS_PER_MASTER + numWorkers * PORTS_PER_WORKER,
-          "Require 2 ports per master and 3 ports per worker, but there are %s masters, "
+          "We require %s ports per master and %s ports per worker, but there are %s masters, "
               + "%s workers, and %s ports",
-          numMasters, numWorkers, ports.size());
+          PORTS_PER_MASTER, PORTS_PER_WORKER, numMasters, numWorkers, ports.size());
     }
     mProperties = properties;
     mMasterProperties = masterProperties;

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -81,6 +81,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class MultiProcessCluster {
   public static final String ALLUXIO_USE_FIXED_TEST_PORTS = "ALLUXIO_USE_FIXED_TEST_PORTS";
+  public static final int PORTS_PER_MASTER = 2;
+  public static final int PORTS_PER_WORKER = 3;
 
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File(Constants.TEST_ARTIFACTS_DIR);
@@ -117,7 +119,8 @@ public final class MultiProcessCluster {
       Map<Integer, Map<PropertyKey, String>> workerProperties, int numMasters, int numWorkers,
       String clusterName, DeployMode mode, List<PortCoordination.ReservedPort> ports) {
     if (System.getenv(ALLUXIO_USE_FIXED_TEST_PORTS) != null) {
-      Preconditions.checkState(ports.size() == numMasters * 2 + numWorkers * 3,
+      Preconditions.checkState(
+          ports.size() == numMasters * PORTS_PER_MASTER + numWorkers * PORTS_PER_WORKER,
           "Require 2 ports per master and 3 ports per worker, but there are %s masters, "
               + "%s workers, and %s ports",
           numMasters, numWorkers, ports.size());

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -30,6 +30,7 @@ import alluxio.master.MasterClientConfig;
 import alluxio.master.MasterInquireClient;
 import alluxio.master.SingleMasterInquireClient;
 import alluxio.master.ZkMasterInquireClient;
+import alluxio.multi.process.PortCoordination.ReservedPort;
 import alluxio.network.PortUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
@@ -42,9 +43,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +79,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * The synchronization strategy for this class is to synchronize all public methods.
  */
 @ThreadSafe
-public final class MultiProcessCluster implements TestRule {
+public final class MultiProcessCluster {
+  public static final String ALLUXIO_USE_FIXED_TEST_PORTS = "ALLUXIO_USE_FIXED_TEST_PORTS";
+
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File(Constants.TEST_ARTIFACTS_DIR);
   private static final File TESTS_LOG = new File(Constants.TESTS_LOG);
@@ -96,6 +96,7 @@ public final class MultiProcessCluster implements TestRule {
   private final Closer mCloser;
   private final List<Master> mMasters;
   private final List<Worker> mWorkers;
+  private final List<ReservedPort> mPorts;
 
   private DeployMode mDeployMode;
 
@@ -113,8 +114,14 @@ public final class MultiProcessCluster implements TestRule {
 
   private MultiProcessCluster(Map<PropertyKey, String> properties,
       Map<Integer, Map<PropertyKey, String>> masterProperties,
-      Map<Integer, Map<PropertyKey, String>> workerProperties,
-      int numMasters, int numWorkers, String clusterName, DeployMode mode) {
+      Map<Integer, Map<PropertyKey, String>> workerProperties, int numMasters, int numWorkers,
+      String clusterName, DeployMode mode, List<PortCoordination.ReservedPort> ports) {
+    if (System.getenv(ALLUXIO_USE_FIXED_TEST_PORTS) != null) {
+      Preconditions.checkState(ports.size() == numMasters * 2 + numWorkers * 3,
+          "Require 2 ports per master and 3 ports per worker, but there are %s masters, "
+              + "%s workers, and %s ports",
+          numMasters, numWorkers, ports.size());
+    }
     mProperties = properties;
     mMasterProperties = masterProperties;
     mWorkerProperties = workerProperties;
@@ -125,6 +132,7 @@ public final class MultiProcessCluster implements TestRule {
     mDeployMode = mode;
     mMasters = new ArrayList<>();
     mWorkers = new ArrayList<>();
+    mPorts = ports;
     mCloser = Closer.create();
     mState = State.NOT_STARTED;
     mSuccess = false;
@@ -469,9 +477,9 @@ public final class MultiProcessCluster implements TestRule {
     File ramdisk = new File(mWorkDir, "ramdisk" + i);
     logsDir.mkdirs();
     ramdisk.mkdirs();
-    int rpcPort = PortUtils.getFreePort();
-    int dataPort = PortUtils.getFreePort();
-    int webPort = PortUtils.getFreePort();
+    int rpcPort = getNewPort();
+    int dataPort = getNewPort();
+    int webPort = getNewPort();
 
     Map<PropertyKey, String> conf = new HashMap<>();
     conf.put(PropertyKey.LOGGER_TYPE, "WORKER_LOGGER");
@@ -535,33 +543,12 @@ public final class MultiProcessCluster implements TestRule {
     }
   }
 
-  @Override
-  public Statement apply(final Statement base, Description description) {
-    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-      public void run() {
-        try {
-          destroy();
-        } catch (IOException e) {
-          LOG.warn("Failed to clean up test cluster processes: {}", e.toString());
-        }
-      }
-    }));
-    return new Statement() {
-      @Override
-      public void evaluate() throws Throwable {
-        try {
-          start();
-          waitForAllNodesRegistered(5 * Constants.MINUTE_MS);
-          base.evaluate();
-        } finally {
-          try {
-            destroy();
-          } catch (Throwable t) {
-            LOG.error("Failed to destroy cluster", t);
-          }
-        }
-      }
-    };
+  private int getNewPort() throws IOException {
+    if (System.getenv(ALLUXIO_USE_FIXED_TEST_PORTS) == null) {
+      return PortUtils.getFreePort();
+    }
+    Preconditions.checkState(!mPorts.isEmpty(), "Out of ports to reserve");
+    return mPorts.remove(mPorts.size() - 1).getPort();
   }
 
   /**
@@ -590,11 +577,11 @@ public final class MultiProcessCluster implements TestRule {
     }
   }
 
-  private static List<MasterNetAddress> generateMasterAddresses(int numMasters) throws IOException {
+  private List<MasterNetAddress> generateMasterAddresses(int numMasters) throws IOException {
     List<MasterNetAddress> addrs = new ArrayList<>();
     for (int i = 0; i < numMasters; i++) {
-      addrs.add(new MasterNetAddress(NetworkAddressUtils.getLocalHostName(),
-          PortUtils.getFreePort(), PortUtils.getFreePort()));
+      addrs.add(
+          new MasterNetAddress(NetworkAddressUtils.getLocalHostName(), getNewPort(), getNewPort()));
     }
     return addrs;
   }
@@ -614,6 +601,8 @@ public final class MultiProcessCluster implements TestRule {
    * Builder for {@link MultiProcessCluster}.
    */
   public static final class Builder {
+    private final List<ReservedPort> mReservedPorts;
+
     private Map<PropertyKey, String> mProperties = new HashMap<>();
     private Map<Integer, Map<PropertyKey, String>> mMasterProperties = new HashMap<>();
     private Map<Integer, Map<PropertyKey, String>> mWorkerProperties = new HashMap<>();
@@ -622,7 +611,10 @@ public final class MultiProcessCluster implements TestRule {
     private String mClusterName = "AlluxioMiniCluster";
     private DeployMode mDeployMode = DeployMode.NON_HA;
 
-    private Builder() {} // Should only be instantiated by newBuilder().
+    // Should only be instantiated by newBuilder().
+    private Builder(List<ReservedPort> reservedPorts) {
+      mReservedPorts = reservedPorts;
+    }
 
     /**
      * @param key the property key to set
@@ -722,14 +714,15 @@ public final class MultiProcessCluster implements TestRule {
           "The worker indexes in worker properties should be bigger or equal to zero "
               + "and small than %s", mNumWorkers);
       return new MultiProcessCluster(mProperties, mMasterProperties, mWorkerProperties,
-          mNumMasters, mNumWorkers, mClusterName, mDeployMode);
+          mNumMasters, mNumWorkers, mClusterName, mDeployMode, mReservedPorts);
     }
   }
 
   /**
+   * @param reservedPorts ports reserved for usage by this cluster
    * @return a new builder for an {@link MultiProcessCluster}
    */
-  public static Builder newBuilder() {
-    return new Builder();
+  public static Builder newBuilder(List<ReservedPort> reservedPorts) {
+    return new Builder(reservedPorts);
   }
 }

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -26,6 +26,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Using the same ports every time improves build stability when using Docker.
  */
 public class PortCoordination {
+  // Start at 11000 to stay within the non-ephemeral port range and hopefully dodge most other
+  // processes.
+  private static final AtomicInteger NEXT_PORT = new AtomicInteger(11000);
+  private static final Set<Integer> SKIP_PORTS = new HashSet(Arrays.asList(
+      // add ports here to avoid conflicting with other processes on those ports.
+  ));
+
   public static final List<ReservedPort> CONFIG_CHECKER_MULTI_WORKERS = allocate(1, 2);
   public static final List<ReservedPort> CONFIG_CHECKER_MULTI_NODES = allocate(2, 2);
   public static final List<ReservedPort> CONFIG_CHECKER_UNSET_VS_SET = allocate(2, 0);
@@ -41,14 +48,6 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_RESTORE_SINGLE = allocate(1, 1);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(1, 1);
-
-  // Start at 11000 to stay within the non-ephemeral port range and hopefully dodge most other
-  // processes.
-  private static final AtomicInteger NEXT_PORT = new AtomicInteger(11000);
-
-  private static final Set<Integer> SKIP_PORTS = new HashSet(Arrays.asList(
-      // add ports here to avoid conflicting with other processes on those ports.
-  ));
 
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
     int needed = 2 * numMasters + 3 * numWorkers;

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.multi.process;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Class for coordinating between test suites so that they don't conflict in ports.
+ *
+ * Using the same ports every time improves build stability when using Docker.
+ */
+public class PortCoordination {
+  public static List<ReservedPort> sConfigCheckerMultiWorkersTest = allocate(1, 2);
+  public static List<ReservedPort> sConfigCheckerMultiNodesTest = allocate(2, 2);
+  public static List<ReservedPort> sConfigCheckerUnsetVsSet = allocate(2, 0);
+  public static List<ReservedPort> sConfigCheckerMultiMastersTest = allocate(2, 0);
+
+  public static List<ReservedPort> sMultiProcessSimpleCluster = allocate(1, 1);
+  public static List<ReservedPort> sMultiProcessZookeeper = allocate(3, 2);
+
+  public static List<ReservedPort> sSingleMasterJournalStopIntegration = allocate(1, 0);
+  public static List<ReservedPort> sMultiMasterJournalStopIntegration = allocate(3, 0);
+
+  public static List<ReservedPort> sBackupRestoreZk = allocate(3, 1);
+  public static List<ReservedPort> sBackupRestoreSingle = allocate(1, 1);
+
+  public static List<ReservedPort> sZookeeperFailure = allocate(1, 1);
+
+  // Start at 11000 to stay within the non-ephemeral port range and hopefully dodge most other
+  // processes.
+  private static AtomicInteger sNextPort = new AtomicInteger(11000);
+
+  private static final Set<Integer> SKIP_PORTS = new HashSet(Arrays.asList(
+      // add ports here to avoid conflicting with other processes on those ports.
+  ));
+
+  private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
+    int needed = 2 * numMasters + 3 * numWorkers;
+    List<ReservedPort> ports = new ArrayList();
+    for (int i = 0; i < needed; i++) {
+      ports.add(new ReservedPort());
+    }
+    return ports;
+  }
+
+  // This is intended for usage in a Docker environment where there won't be random processes using
+  // these ports. If we find a process using one of these ports, we can remove the port from here
+  // and replace it with a new one.
+  public static class ReservedPort {
+    private int mPort;
+
+    private ReservedPort() {
+      int port = sNextPort.getAndIncrement();
+      while (SKIP_PORTS.contains(port)) {
+        port = sNextPort.getAndIncrement();
+      }
+      mPort = port;
+    }
+
+    public int getPort() {
+      return mPort;
+    }
+  }
+}

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -57,9 +57,9 @@ public class PortCoordination {
     return ports;
   }
 
-  // This is intended for usage in a Docker environment where there won't be random processes using
-  // these ports. If we find a process using one of these ports, we can remove the port from here
-  // and replace it with a new one.
+  /**
+   * A port that has been reserved for the purposes of a single test.
+   */
   public static class ReservedPort {
     private int mPort;
 
@@ -71,6 +71,9 @@ public class PortCoordination {
       mPort = port;
     }
 
+    /**
+     * @return the port number
+     */
     public int getPort() {
       return mPort;
     }

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -11,7 +11,9 @@
 
 package alluxio.multi.process;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -24,25 +26,25 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Using the same ports every time improves build stability when using Docker.
  */
 public class PortCoordination {
-  public static List<ReservedPort> sConfigCheckerMultiWorkersTest = allocate(1, 2);
-  public static List<ReservedPort> sConfigCheckerMultiNodesTest = allocate(2, 2);
-  public static List<ReservedPort> sConfigCheckerUnsetVsSet = allocate(2, 0);
-  public static List<ReservedPort> sConfigCheckerMultiMastersTest = allocate(2, 0);
+  public static final List<ReservedPort> CONFIG_CHECKER_MULTI_WORKERS = allocate(1, 2);
+  public static final List<ReservedPort> CONFIG_CHECKER_MULTI_NODES = allocate(2, 2);
+  public static final List<ReservedPort> CONFIG_CHECKER_UNSET_VS_SET = allocate(2, 0);
+  public static final List<ReservedPort> CONFIG_CHECKER_MULTI_MASTERS = allocate(2, 0);
 
-  public static List<ReservedPort> sMultiProcessSimpleCluster = allocate(1, 1);
-  public static List<ReservedPort> sMultiProcessZookeeper = allocate(3, 2);
+  public static final List<ReservedPort> MULTI_PROCESS_SIMPLE_CLUSTER = allocate(1, 1);
+  public static final List<ReservedPort> MULTI_PROCESS_ZOOKEEPER = allocate(3, 2);
 
-  public static List<ReservedPort> sSingleMasterJournalStopIntegration = allocate(1, 0);
-  public static List<ReservedPort> sMultiMasterJournalStopIntegration = allocate(3, 0);
+  public static final List<ReservedPort> JOURNAL_STOP_SINGLE_MASTER = allocate(1, 0);
+  public static final List<ReservedPort> JOURNAL_STOP_MULTI_MASTER = allocate(3, 0);
 
-  public static List<ReservedPort> sBackupRestoreZk = allocate(3, 1);
-  public static List<ReservedPort> sBackupRestoreSingle = allocate(1, 1);
+  public static final List<ReservedPort> BACKUP_RESTORE_ZK = allocate(3, 1);
+  public static final List<ReservedPort> BACKUP_RESTORE_SINGLE = allocate(1, 1);
 
-  public static List<ReservedPort> sZookeeperFailure = allocate(1, 1);
+  public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(1, 1);
 
   // Start at 11000 to stay within the non-ephemeral port range and hopefully dodge most other
   // processes.
-  private static AtomicInteger sNextPort = new AtomicInteger(11000);
+  private static final AtomicInteger NEXT_PORT = new AtomicInteger(11000);
 
   private static final Set<Integer> SKIP_PORTS = new HashSet(Arrays.asList(
       // add ports here to avoid conflicting with other processes on those ports.
@@ -50,11 +52,11 @@ public class PortCoordination {
 
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
     int needed = 2 * numMasters + 3 * numWorkers;
-    List<ReservedPort> ports = new ArrayList();
+    Builder<ReservedPort> ports = ImmutableList.builder();
     for (int i = 0; i < needed; i++) {
       ports.add(new ReservedPort());
     }
-    return ports;
+    return ports.build();
   }
 
   /**
@@ -64,9 +66,9 @@ public class PortCoordination {
     private int mPort;
 
     private ReservedPort() {
-      int port = sNextPort.getAndIncrement();
+      int port = NEXT_PORT.getAndIncrement();
       while (SKIP_PORTS.contains(port)) {
-        port = sNextPort.getAndIncrement();
+        port = NEXT_PORT.getAndIncrement();
       }
       mPort = port;
     }

--- a/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
+++ b/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
@@ -34,7 +34,7 @@ public final class MultiProcessClusterTest {
 
   @Test
   public void simpleCluster() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sMultiProcessSimpleCluster)
         .setClusterName("simpleCluster")
         .setNumMasters(1)
         .setNumWorkers(1)
@@ -51,7 +51,7 @@ public final class MultiProcessClusterTest {
 
   @Test
   public void zookeeper() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sMultiProcessZookeeper)
         .setClusterName("zookeeper")
         .setDeployMode(DeployMode.ZOOKEEPER_HA)
         .setNumMasters(3)

--- a/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
+++ b/minicluster/src/test/java/alluxio/multi/process/MultiProcessClusterTest.java
@@ -34,7 +34,7 @@ public final class MultiProcessClusterTest {
 
   @Test
   public void simpleCluster() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sMultiProcessSimpleCluster)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.MULTI_PROCESS_SIMPLE_CLUSTER)
         .setClusterName("simpleCluster")
         .setNumMasters(1)
         .setNumWorkers(1)
@@ -51,7 +51,7 @@ public final class MultiProcessClusterTest {
 
   @Test
   public void zookeeper() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sMultiProcessZookeeper)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.MULTI_PROCESS_ZOOKEEPER)
         .setClusterName("zookeeper")
         .setDeployMode(DeployMode.ZOOKEEPER_HA)
         .setNumMasters(3)

--- a/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
@@ -21,6 +21,7 @@ import alluxio.PropertyKey;
 import alluxio.client.MetaMasterClient;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.MultiProcessCluster.DeployMode;
+import alluxio.multi.process.PortCoordination;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.wire.ConfigCheckReport;
 import alluxio.wire.ConfigCheckReport.ConfigStatus;
@@ -58,7 +59,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     PropertyKey key = PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS;
     Map<Integer, Map<PropertyKey, String>> masterProperties
         = generatePropertyWithDifferentValues(TEST_NUM_MASTERS, key);
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiMastersTest)
         .setClusterName("ConfigCheckerMultiMastersTest")
         .setNumMasters(TEST_NUM_MASTERS)
         .setNumWorkers(0)
@@ -78,7 +79,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     PropertyKey key = PropertyKey.WORKER_FREE_SPACE_TIMEOUT;
     Map<Integer, Map<PropertyKey, String>> workerProperties
         = generatePropertyWithDifferentValues(TEST_NUM_WORKERS, key);
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiWorkersTest)
         .setClusterName("ConfigCheckerMultiWorkersTest")
         .setNumMasters(1)
         .setNumWorkers(TEST_NUM_WORKERS)
@@ -105,7 +106,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
         .filter(entry -> (entry.getKey() >= TEST_NUM_MASTERS))
         .collect(Collectors.toMap(entry -> entry.getKey() - TEST_NUM_MASTERS, Map.Entry::getValue));
 
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiNodesTest)
         .setClusterName("ConfigCheckerMultiNodesTest")
         .setNumMasters(TEST_NUM_MASTERS)
         .setNumWorkers(TEST_NUM_WORKERS)
@@ -126,7 +127,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     Map<Integer, Map<PropertyKey, String>> masterProperties = ImmutableMap.of(
         1, ImmutableMap.of(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION, "option"));
 
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerUnsetVsSet)
         .setClusterName("ConfigCheckerUnsetVsSet")
         .setNumMasters(2)
         .setNumWorkers(0)

--- a/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
@@ -59,7 +59,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     PropertyKey key = PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS;
     Map<Integer, Map<PropertyKey, String>> masterProperties
         = generatePropertyWithDifferentValues(TEST_NUM_MASTERS, key);
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiMastersTest)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.CONFIG_CHECKER_MULTI_MASTERS)
         .setClusterName("ConfigCheckerMultiMastersTest")
         .setNumMasters(TEST_NUM_MASTERS)
         .setNumWorkers(0)
@@ -79,7 +79,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     PropertyKey key = PropertyKey.WORKER_FREE_SPACE_TIMEOUT;
     Map<Integer, Map<PropertyKey, String>> workerProperties
         = generatePropertyWithDifferentValues(TEST_NUM_WORKERS, key);
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiWorkersTest)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.CONFIG_CHECKER_MULTI_WORKERS)
         .setClusterName("ConfigCheckerMultiWorkersTest")
         .setNumMasters(1)
         .setNumWorkers(TEST_NUM_WORKERS)
@@ -106,7 +106,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
         .filter(entry -> (entry.getKey() >= TEST_NUM_MASTERS))
         .collect(Collectors.toMap(entry -> entry.getKey() - TEST_NUM_MASTERS, Map.Entry::getValue));
 
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerMultiNodesTest)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.CONFIG_CHECKER_MULTI_NODES)
         .setClusterName("ConfigCheckerMultiNodesTest")
         .setNumMasters(TEST_NUM_MASTERS)
         .setNumWorkers(TEST_NUM_WORKERS)
@@ -127,7 +127,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     Map<Integer, Map<PropertyKey, String>> masterProperties = ImmutableMap.of(
         1, ImmutableMap.of(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION, "option"));
 
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sConfigCheckerUnsetVsSet)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.CONFIG_CHECKER_UNSET_VS_SET)
         .setClusterName("ConfigCheckerUnsetVsSet")
         .setNumMasters(2)
         .setNumWorkers(0)

--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -76,6 +76,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
         .setNumMasters(1)
         .setNumWorkers(1)
         .build();
+    mCluster.start();
 
     AlluxioOperationThread thread =
         new AlluxioOperationThread(mCluster.getFileSystemClient());

--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -70,7 +70,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void zkFailure() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sZookeeperFailure)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_FAILURE)
         .setClusterName("ZookeeperFailure")
         .setDeployMode(DeployMode.ZOOKEEPER_HA)
         .setNumMasters(1)

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -64,7 +64,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
   // This test needs to stop and start master many times, so it can take up to a minute to complete.
   @Test
   public void backupRestoreZk() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sBackupRestoreZk)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.BACKUP_RESTORE_ZK)
         .setClusterName("backupRestoreZk")
         .setDeployMode(DeployMode.ZOOKEEPER_HA)
         .setNumMasters(3)
@@ -75,7 +75,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void backupRestoreSingleMaster() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sBackupRestoreSingle)
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.BACKUP_RESTORE_SINGLE)
         .setClusterName("backupRestoreSingle")
         .setNumMasters(1).build();
     backupRestoreTest(false);

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -27,6 +27,7 @@ import alluxio.client.file.options.CreateDirectoryOptions;
 import alluxio.master.MasterClientConfig;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.MultiProcessCluster.DeployMode;
+import alluxio.multi.process.PortCoordination;
 import alluxio.testutils.AlluxioOperationThread;
 import alluxio.testutils.BaseIntegrationTest;
 
@@ -63,7 +64,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
   // This test needs to stop and start master many times, so it can take up to a minute to complete.
   @Test
   public void backupRestoreZk() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sBackupRestoreZk)
         .setClusterName("backupRestoreZk")
         .setDeployMode(DeployMode.ZOOKEEPER_HA)
         .setNumMasters(3)
@@ -74,7 +75,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void backupRestoreSingleMaster() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder()
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.sBackupRestoreSingle)
         .setClusterName("backupRestoreSingle")
         .setNumMasters(1).build();
     backupRestoreTest(false);

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -103,7 +103,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   @Test
   public void singleMasterJournalStopIntegration() throws Exception {
     MultiProcessCluster cluster =
-        MultiProcessCluster.newBuilder(PortCoordination.sSingleMasterJournalStopIntegration)
+        MultiProcessCluster.newBuilder(PortCoordination.JOURNAL_STOP_SINGLE_MASTER)
             .setClusterName("singleMasterJournalStopIntegration")
             .setNumWorkers(0)
             .setNumMasters(1)
@@ -132,7 +132,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   @Test
   public void multiMasterJournalStopIntegration() throws Exception {
     MultiProcessCluster cluster =
-        MultiProcessCluster.newBuilder(PortCoordination.sMultiMasterJournalStopIntegration)
+        MultiProcessCluster.newBuilder(PortCoordination.JOURNAL_STOP_MULTI_MASTER)
             .setClusterName("multiMasterJournalStopIntegration")
             .setNumWorkers(0)
             .setNumMasters(TEST_NUM_MASTERS)

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -33,6 +33,7 @@ import alluxio.master.MasterRegistry;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.MultiProcessCluster.DeployMode;
+import alluxio.multi.process.PortCoordination;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.master.MasterTestUtils;
 import alluxio.testutils.underfs.sleeping.SleepingUnderFileSystem;
@@ -101,11 +102,12 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void singleMasterJournalStopIntegration() throws Exception {
-    MultiProcessCluster cluster = MultiProcessCluster.newBuilder()
-        .setClusterName("singleMasterJournalStopIntegration")
-        .setNumWorkers(0)
-        .setNumMasters(1)
-        .build();
+    MultiProcessCluster cluster =
+        MultiProcessCluster.newBuilder(PortCoordination.sSingleMasterJournalStopIntegration)
+            .setClusterName("singleMasterJournalStopIntegration")
+            .setNumWorkers(0)
+            .setNumMasters(1)
+            .build();
     try {
       cluster.start();
       FileSystem fs = cluster.getFileSystemClient();
@@ -129,15 +131,16 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void multiMasterJournalStopIntegration() throws Exception {
-    MultiProcessCluster cluster = MultiProcessCluster.newBuilder()
-        .setClusterName("multiMasterJournalStopIntegration")
-        .setNumWorkers(0)
-        .setNumMasters(TEST_NUM_MASTERS)
-        .setDeployMode(DeployMode.ZOOKEEPER_HA)
-        // Cannot go lower than 2x the tick time. Curator testing cluster tick time is 3s and cannot
-        // be overridden until later versions of Curator.
-        .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "6s")
-        .build();
+    MultiProcessCluster cluster =
+        MultiProcessCluster.newBuilder(PortCoordination.sMultiMasterJournalStopIntegration)
+            .setClusterName("multiMasterJournalStopIntegration")
+            .setNumWorkers(0)
+            .setNumMasters(TEST_NUM_MASTERS)
+            .setDeployMode(DeployMode.ZOOKEEPER_HA)
+            // Cannot go lower than 2x the tick time. Curator testing cluster tick time is 3s and
+            // cannot be overridden until later versions of Curator.
+            .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "6s")
+            .build();
     try {
       cluster.start();
       FileSystem fs = cluster.getFileSystemClient();


### PR DESCRIPTION
This PR adds support for running tests with fixed ports. Previously, we would choose a random currently-available ephemeral port. The problem with ephemeral ports is that multiple processes may choose to run with the same ephemeral port, causing the second test to fail if the first is still using the port. There can be a long delay between when the port is chosen and when it gets bound. Secondary master doesn't bind its RPC port until it is promoted to primary, so it could be many seconds during a failover test between when we select the RPC port and when it finally gets bound. During this time another test could choose to use the port and have a conflict.

With fixed ports, every test will use different ports from every other tests. A central `PortCoordination` class enforces this, and `MultiProcessCluster` requires the user to supply it with the available ports that it should use.

Ports will be allocated starting from port `11000` and counting upwards. If we discover ports that are used by other processes besides tests, we can add those ports to the `PortCoordination#SKIP_PORTS` list to avoid allocating those ports.

To get the original behavior, users can leave the `ALLUXIO_USE_FIXED_TEST_PORTS` environment variable unset. After this PR merges, we can update the jenkins build to set `ALLUXIO_USE_FIXED_TEST_PORTS` to address all test flakiness due to port conflicts.