### PR TITLE
[SMALLFIX] Improve type safety for indexed set

### DIFF
--- a/core/common/src/main/java/alluxio/collections/FieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/FieldIndex.java
@@ -20,9 +20,10 @@ import java.util.Set;
  * must use the same instance of the implementation of this interface as the parameter in all
  * methods of {@link IndexedSet} to represent the same index.
  *
- * @param <T> type of objects in {@link IndexedSet}
+ * @param <T> type of objects in this index
+ * @param <V> type of the field used for indexing
  */
-public interface FieldIndex<T> extends Iterable<T> {
+public interface FieldIndex<T, V> extends Iterable<T> {
   /**
    * Adds an object o to the index.
    *
@@ -50,7 +51,7 @@ public interface FieldIndex<T> extends Iterable<T> {
    * @param fieldValue the field value to be satisfied
    * @return true if there is one such object, otherwise false
    */
-  boolean containsField(Object fieldValue);
+  boolean containsField(V fieldValue);
 
   /**
    * Returns whether there is an object in the set.
@@ -67,7 +68,7 @@ public interface FieldIndex<T> extends Iterable<T> {
    * @param value the field value to be satisfied
    * @return the set of objects or an empty set if no such object exists
    */
-  Set<T> getByField(Object value);
+  Set<T> getByField(V value);
 
   /**
    * Gets an object from the set of objects with the specified field value.
@@ -75,7 +76,7 @@ public interface FieldIndex<T> extends Iterable<T> {
    * @param value the field value to be satisfied
    * @return the object or null if there is no such object
    */
-  T getFirst(Object value);
+  T getFirst(V value);
 
   /**
    * Returns an iterator over the elements in this index. The elements are returned in no particular

--- a/core/common/src/main/java/alluxio/collections/IndexDefinition.java
+++ b/core/common/src/main/java/alluxio/collections/IndexDefinition.java
@@ -14,17 +14,26 @@ package alluxio.collections;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A class representing the definition of an index for this {@link IndexedSet}. Each instance of
- * this class must implement the method to define how to get the value of the field chosen as
- * the index key. Users use this indexDefinition class as the parameter in all methods of
- * {@link IndexedSet} to represent an index.
+ * A class representing an index for an {@link IndexedSet}.
  *
- * @param <T> type of objects in this {@link IndexedSet}
+ * For example, if an indexed set stores inodes, and we want to be able to look them up by their
+ * "id" field, we would define an index like so:
+ *
+ * <pre>
+ * public class IndexDefinition<Inode, Long>() {
+ *   @Override
+ *   Long getFieldValue(Inode) {
+ *     return Inode.getId();
+ *   }
+ * }
+ * </pre>
+ *
+ * @param <T> the type that this is an index for
+ * @param <V> the type of the value used for indexing
  */
 @ThreadSafe
-public abstract class IndexDefinition<T> {
+public abstract class IndexDefinition<T, V> {
   /** Whether it is a unique index. */
-  //TODO(lei): change the mIsUnique to mIndexType enum
   private final boolean mIsUnique;
 
   /**
@@ -51,5 +60,5 @@ public abstract class IndexDefinition<T> {
    * @param o the instance to get the field value from
    * @return the field value
    */
-  public abstract Object getFieldValue(T o);
+  public abstract V getFieldValue(T o);
 }

--- a/core/common/src/main/java/alluxio/collections/IndexedSet.java
+++ b/core/common/src/main/java/alluxio/collections/IndexedSet.java
@@ -104,12 +104,12 @@ public class IndexedSet<T> extends AbstractSet<T> {
    * The first index of the indexed set. This index is used to guarantee uniqueness of objects,
    * support iterator and provide quick lookup.
    */
-  private final FieldIndex<T> mPrimaryIndex;
+  private final FieldIndex<T, ?> mPrimaryIndex;
   /**
    * Map from index definition to the index. An index is a map from index value to one or a set of
    * objects with that index value.
    */
-  private final Map<IndexDefinition<T>, FieldIndex<T>> mIndices;
+  private final Map<IndexDefinition<T, ?>, FieldIndex<T, ?>> mIndices;
 
   /**
    * Constructs a new {@link IndexedSet} instance with at least one field as the index.
@@ -120,17 +120,17 @@ public class IndexedSet<T> extends AbstractSet<T> {
    * @param otherIndexDefinitions other index definitions to index the set
    */
   @SafeVarargs
-  public IndexedSet(IndexDefinition<T> primaryIndexDefinition,
-      IndexDefinition<T>... otherIndexDefinitions) {
-    Iterable<IndexDefinition<T>> indexDefinitions =
+  public IndexedSet(IndexDefinition<T, ?> primaryIndexDefinition,
+      IndexDefinition<T, ?>... otherIndexDefinitions) {
+    Iterable<IndexDefinition<T, ?>> indexDefinitions =
         Iterables.concat(Collections.singletonList(primaryIndexDefinition),
             Arrays.asList(otherIndexDefinitions));
 
     // initialization
-    Map<IndexDefinition<T>, FieldIndex<T>> indices = new HashMap<>();
+    Map<IndexDefinition<T, ?>, FieldIndex<T, ?>> indices = new HashMap<>();
 
-    for (IndexDefinition<T> indexDefinition : indexDefinitions) {
-      FieldIndex<T> index;
+    for (IndexDefinition<T, ?> indexDefinition : indexDefinitions) {
+      FieldIndex<T, ?> index;
       if (indexDefinition.isUnique()) {
         index = new UniqueFieldIndex<>(indexDefinition);
       } else {
@@ -177,7 +177,7 @@ public class IndexedSet<T> extends AbstractSet<T> {
         return false;
       }
 
-      for (FieldIndex<T> fieldIndex : mIndices.values()) {
+      for (FieldIndex<T, ?> fieldIndex : mIndices.values()) {
         fieldIndex.add(object);
       }
     }
@@ -241,10 +241,11 @@ public class IndexedSet<T> extends AbstractSet<T> {
    *
    * @param indexDefinition the field index definition
    * @param value the field value
+   * @param <V> the field type
    * @return true if there is one such object, otherwise false
    */
-  public boolean contains(IndexDefinition<T> indexDefinition, Object value) {
-    FieldIndex<T> index = mIndices.get(indexDefinition);
+  public <V> boolean contains(IndexDefinition<T, V> indexDefinition, V value) {
+    FieldIndex<T, V> index = (FieldIndex<T, V>) mIndices.get(indexDefinition);
     if (index == null) {
       throw new IllegalStateException("the given index isn't defined for this IndexedSet");
     }
@@ -257,10 +258,11 @@ public class IndexedSet<T> extends AbstractSet<T> {
    *
    * @param indexDefinition the field index definition
    * @param value the field value to be satisfied
+   * @param <V> the field type
    * @return the set of objects or an empty set if no such object exists
    */
-  public Set<T> getByField(IndexDefinition<T> indexDefinition, Object value) {
-    FieldIndex<T> index = mIndices.get(indexDefinition);
+  public <V> Set<T> getByField(IndexDefinition<T, V> indexDefinition, V value) {
+    FieldIndex<T, V> index = (FieldIndex<T, V>) mIndices.get(indexDefinition);
     if (index == null) {
       throw new IllegalStateException("the given index isn't defined for this IndexedSet");
     }
@@ -272,10 +274,11 @@ public class IndexedSet<T> extends AbstractSet<T> {
    *
    * @param indexDefinition the field index definition
    * @param value the field value
+   * @param <V> the field type
    * @return the object or null if there is no such object
    */
-  public T getFirstByField(IndexDefinition<T> indexDefinition, Object value) {
-    FieldIndex<T> index = mIndices.get(indexDefinition);
+  public <V> T getFirstByField(IndexDefinition<T, V> indexDefinition, V value) {
+    FieldIndex<T, V> index = (FieldIndex<T, V>) mIndices.get(indexDefinition);
     if (index == null) {
       throw new IllegalStateException("the given index isn't defined for this IndexedSet");
     }
@@ -316,7 +319,7 @@ public class IndexedSet<T> extends AbstractSet<T> {
    * @param object the object to be removed
    */
   private void removeFromIndices(T object) {
-    for (FieldIndex<T> fieldValue : mIndices.values()) {
+    for (FieldIndex<T, ?> fieldValue : mIndices.values()) {
       fieldValue.remove(object);
     }
   }
@@ -326,9 +329,10 @@ public class IndexedSet<T> extends AbstractSet<T> {
    *
    * @param indexDefinition the field index
    * @param value the field value
+   * @param <V> the field type
    * @return the number of objects removed
    */
-  public int removeByField(IndexDefinition<T> indexDefinition, Object value) {
+  public <V> int removeByField(IndexDefinition<T, V> indexDefinition, V value) {
     Set<T> toRemove = getByField(indexDefinition, value);
 
     int removed = 0;

--- a/core/common/src/main/java/alluxio/collections/UniqueFieldIndex.java
+++ b/core/common/src/main/java/alluxio/collections/UniqueFieldIndex.java
@@ -23,25 +23,26 @@ import javax.annotation.concurrent.ThreadSafe;
  * where each index value only maps to one object.
  *
  * @param <T> type of objects in this index
+ * @param <V> type of the field used for indexing
  */
 @ThreadSafe
-public class UniqueFieldIndex<T> implements FieldIndex<T> {
-  private final IndexDefinition<T> mIndexDefinition;
-  private final ConcurrentHashMap<Object, T> mIndexMap;
+public class UniqueFieldIndex<T, V> implements FieldIndex<T, V> {
+  private final IndexDefinition<T, V> mIndexDefinition;
+  private final ConcurrentHashMap<V, T> mIndexMap;
 
   /**
    * Constructs a new {@link UniqueFieldIndex} instance.
    *
    * @param indexDefinition definition of index
    */
-  public UniqueFieldIndex(IndexDefinition<T> indexDefinition) {
+  public UniqueFieldIndex(IndexDefinition<T, V> indexDefinition) {
     mIndexMap = new ConcurrentHashMap<>(8, 0.95f, 8);
     mIndexDefinition = indexDefinition;
   }
 
   @Override
   public boolean add(T object) {
-    Object fieldValue = mIndexDefinition.getFieldValue(object);
+    V fieldValue = mIndexDefinition.getFieldValue(object);
     T previousObject = mIndexMap.putIfAbsent(fieldValue, object);
 
     if (previousObject != null && previousObject != object) {
@@ -52,7 +53,7 @@ public class UniqueFieldIndex<T> implements FieldIndex<T> {
 
   @Override
   public boolean remove(T object) {
-    Object fieldValue = mIndexDefinition.getFieldValue(object);
+    V fieldValue = mIndexDefinition.getFieldValue(object);
     return mIndexMap.remove(fieldValue, object);
   }
 
@@ -62,13 +63,13 @@ public class UniqueFieldIndex<T> implements FieldIndex<T> {
   }
 
   @Override
-  public boolean containsField(Object fieldValue) {
+  public boolean containsField(V fieldValue) {
     return mIndexMap.containsKey(fieldValue);
   }
 
   @Override
   public boolean containsObject(T object) {
-    Object fieldValue = mIndexDefinition.getFieldValue(object);
+    V fieldValue = mIndexDefinition.getFieldValue(object);
     T res = mIndexMap.get(fieldValue);
     if (res == null) {
       return false;
@@ -77,7 +78,7 @@ public class UniqueFieldIndex<T> implements FieldIndex<T> {
   }
 
   @Override
-  public Set<T> getByField(Object value) {
+  public Set<T> getByField(V value) {
     T res = mIndexMap.get(value);
     if (res != null) {
       return Collections.singleton(res);
@@ -86,7 +87,7 @@ public class UniqueFieldIndex<T> implements FieldIndex<T> {
   }
 
   @Override
-  public T getFirst(Object value) {
+  public T getFirst(V value) {
     return mIndexMap.get(value);
   }
 

--- a/core/common/src/test/java/alluxio/collections/IndexedSetConcurrencyTest.java
+++ b/core/common/src/test/java/alluxio/collections/IndexedSetConcurrencyTest.java
@@ -234,19 +234,21 @@ public class IndexedSetConcurrencyTest {
     }
   }
 
-  private final IndexDefinition<TestInfo> mIdIndex = new IndexDefinition<TestInfo>(true) {
-    @Override
-    public Object getFieldValue(TestInfo o) {
-      return o.getId();
-    }
-  };
+  private final IndexDefinition<TestInfo, Long> mIdIndex =
+      new IndexDefinition<TestInfo, Long>(true) {
+        @Override
+        public Long getFieldValue(TestInfo o) {
+          return o.getId();
+        }
+      };
 
-  private final IndexDefinition<TestInfo> mSizeIndex = new IndexDefinition<TestInfo>(false) {
-    @Override
-    public Object getFieldValue(TestInfo o) {
-      return o.getSize();
-    }
-  };
+  private final IndexDefinition<TestInfo, Integer> mSizeIndex =
+      new IndexDefinition<TestInfo, Integer>(false) {
+        @Override
+        public Integer getFieldValue(TestInfo o) {
+          return o.getSize();
+        }
+      };
 
   @Before
   public void before() throws Exception {

--- a/core/common/src/test/java/alluxio/collections/IndexedSetTest.java
+++ b/core/common/src/test/java/alluxio/collections/IndexedSetTest.java
@@ -49,24 +49,24 @@ public final class IndexedSetTest {
   }
 
   private IndexedSet<Pair> mSet;
-  private IndexDefinition<Pair> mNonUniqueIntIndex;
-  private IndexDefinition<Pair> mUniqueLongIndex;
+  private IndexDefinition<Pair, Integer> mNonUniqueIntIndex;
+  private IndexDefinition<Pair, Long> mUniqueLongIndex;
 
   /**
    * Sets up the fields before running a test.
    */
   @Before
   public void before() {
-    mNonUniqueIntIndex = new IndexDefinition<Pair>(false) {
+    mNonUniqueIntIndex = new IndexDefinition<Pair, Integer>(false) {
       @Override
-      public Object getFieldValue(Pair o) {
+      public Integer getFieldValue(Pair o) {
         return o.intValue();
       }
     };
 
-    mUniqueLongIndex = new IndexDefinition<Pair>(true) {
+    mUniqueLongIndex = new IndexDefinition<Pair, Long>(true) {
       @Override
-      public Object getFieldValue(Pair o) {
+      public Long getFieldValue(Pair o) {
         return o.longValue();
       }
     };
@@ -127,9 +127,7 @@ public final class IndexedSetTest {
   @Test
   public void uniqueGet() {
     for (int i = 0; i < 9; i++) {
-      Set<Pair> set = mSet.getByField(mUniqueLongIndex, i);
-      assertEquals(0, set.size()); // i is integer, must be in the same type
-      set = mSet.getByField(mUniqueLongIndex, (long) i);
+      Set<Pair> set = mSet.getByField(mUniqueLongIndex, (long) i);
       assertEquals(1, set.size());
       assertEquals(i / 3, set.iterator().next().intValue());
     }
@@ -170,8 +168,6 @@ public final class IndexedSetTest {
     assertTrue(mSet.remove(toRemove));
     assertFalse("Element should not be in the NonUniqueIntIndex",
         mSet.contains(mNonUniqueIntIndex, toRemove.intValue()));
-    assertFalse("Element should not be in the mNonUniqueIntIndex",
-        mSet.contains(mNonUniqueIntIndex, toRemove.longValue()));
 
     toRemove = mSet.getFirstByField(mNonUniqueIntIndex, 2);
     assertTrue(toRemove == null);

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -113,18 +113,18 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
   private static final long CONTAINER_ID_RESERVATION_SIZE = 1000;
 
   // Worker metadata management.
-  private static final IndexDefinition<MasterWorkerInfo> ID_INDEX =
-      new IndexDefinition<MasterWorkerInfo>(true) {
+  private static final IndexDefinition<MasterWorkerInfo, Long> ID_INDEX =
+      new IndexDefinition<MasterWorkerInfo, Long>(true) {
         @Override
-        public Object getFieldValue(MasterWorkerInfo o) {
+        public Long getFieldValue(MasterWorkerInfo o) {
           return o.getId();
         }
       };
 
-  private static final IndexDefinition<MasterWorkerInfo> ADDRESS_INDEX =
-      new IndexDefinition<MasterWorkerInfo>(true) {
+  private static final IndexDefinition<MasterWorkerInfo, WorkerNetAddress> ADDRESS_INDEX =
+      new IndexDefinition<MasterWorkerInfo, WorkerNetAddress>(true) {
         @Override
-        public Object getFieldValue(MasterWorkerInfo o) {
+        public WorkerNetAddress getFieldValue(MasterWorkerInfo o) {
           return o.getWorkerAddress();
         }
       };

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -38,15 +38,16 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class InodeDirectory extends Inode<InodeDirectory> {
-  private static final IndexDefinition<Inode<?>> NAME_INDEX = new IndexDefinition<Inode<?>>(true) {
-    @Override
-    public Object getFieldValue(Inode<?> o) {
-      return o.getName();
-    }
-  };
+  private static final IndexDefinition<Inode<?>, String> NAME_INDEX =
+      new IndexDefinition<Inode<?>, String>(true) {
+        @Override
+        public String getFieldValue(Inode<?> o) {
+          return o.getName();
+        }
+      };
 
   /** Use UniqueFieldIndex directly for name index rather than using IndexedSet. */
-  private final FieldIndex<Inode<?>> mChildren = new UniqueFieldIndex<>(NAME_INDEX);
+  private final FieldIndex<Inode<?>, String> mChildren = new UniqueFieldIndex<>(NAME_INDEX);
 
   private boolean mMountPoint;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -84,12 +84,13 @@ public class InodeTree implements JournalEntryIterable {
   /** Value to be used for an inode with no parent. */
   public static final long NO_PARENT = -1;
 
-  private static final IndexDefinition<Inode<?>> ID_INDEX = new IndexDefinition<Inode<?>>(true) {
-    @Override
-    public Object getFieldValue(Inode<?> o) {
-      return o.getId();
-    }
-  };
+  private static final IndexDefinition<Inode<?>, Long> ID_INDEX =
+      new IndexDefinition<Inode<?>, Long>(true) {
+        @Override
+        public Long getFieldValue(Inode<?> o) {
+          return o.getId();
+        }
+      };
 
   /**
    * The type of lock to lock inode paths with.
@@ -115,7 +116,7 @@ public class InodeTree implements JournalEntryIterable {
   private final MountTable mMountTable;
 
   /** Use UniqueFieldIndex directly for ID index rather than using IndexedSet. */
-  private final FieldIndex<Inode<?>> mInodes = new UniqueFieldIndex<>(ID_INDEX);
+  private final FieldIndex<Inode<?>, Long> mInodes = new UniqueFieldIndex<>(ID_INDEX);
   /** A set of inode ids representing pinned inode files. */
   private final Set<Long> mPinnedInodeFileIds = new ConcurrentHashSet<>(64, 0.90f, 64);
 

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -88,18 +88,18 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
       ImmutableSet.<Class<? extends Server>>of(BlockMaster.class);
 
   // Master metadata management.
-  private static final IndexDefinition<MasterInfo> ID_INDEX =
-      new IndexDefinition<MasterInfo>(true) {
+  private static final IndexDefinition<MasterInfo, Long> ID_INDEX =
+      new IndexDefinition<MasterInfo, Long>(true) {
         @Override
-        public Object getFieldValue(MasterInfo o) {
+        public Long getFieldValue(MasterInfo o) {
           return o.getId();
         }
       };
 
-  private static final IndexDefinition<MasterInfo> ADDRESS_INDEX =
-      new IndexDefinition<MasterInfo>(true) {
+  private static final IndexDefinition<MasterInfo, Address> ADDRESS_INDEX =
+      new IndexDefinition<MasterInfo, Address>(true) {
         @Override
-        public Object getFieldValue(MasterInfo o) {
+        public Address getFieldValue(MasterInfo o) {
           return o.getAddress();
         }
       };

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -32,24 +32,26 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class MetricsStore {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsStore.class);
-  private static final IndexDefinition<Metric> FULL_NAME_INDEX = new IndexDefinition<Metric>(true) {
-    @Override
-    public Object getFieldValue(Metric o) {
-      return o.getFullMetricName();
-    }
-  };
-
-  private static final IndexDefinition<Metric> NAME_INDEX = new IndexDefinition<Metric>(false) {
-    @Override
-    public Object getFieldValue(Metric o) {
-      return o.getName();
-    }
-  };
-
-  private static final IndexDefinition<Metric> ID_INDEX =
-      new IndexDefinition<Metric>(false) {
+  private static final IndexDefinition<Metric, String> FULL_NAME_INDEX =
+      new IndexDefinition<Metric, String>(true) {
         @Override
-        public Object getFieldValue(Metric o) {
+        public String getFieldValue(Metric o) {
+          return o.getFullMetricName();
+        }
+      };
+
+  private static final IndexDefinition<Metric, String> NAME_INDEX =
+      new IndexDefinition<Metric, String>(false) {
+        @Override
+        public String getFieldValue(Metric o) {
+          return o.getName();
+        }
+      };
+
+  private static final IndexDefinition<Metric, String> ID_INDEX =
+      new IndexDefinition<Metric, String>(false) {
+        @Override
+        public String getFieldValue(Metric o) {
           return getFullInstanceId(o.getHostname(), o.getInstanceId());
         }
       };


### PR DESCRIPTION
This PR improves type safety by specifying the type of values returned by indices. Previously we just called everything `Object`. Now usages like
```java
  int x = indexedSet.getFirst(ID_INDEX, "notAnId");
```
will be caught at compile time instead of at runtime.