### PR TITLE
[SMALLFIX] make masks auto update, and make permission checking respect ACL mask

### DIFF
--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -228,7 +228,7 @@ public class AccessControlList implements Serializable {
 
   /**
    * Update the mask to be the union of owning group entry, named user entry and named group entry.
-   * This method should be called when the aforementioned entries are modified.
+   * This method must be called when the aforementioned entries are modified.
    */
   public void updateMask() {
     if (hasExtended()) {

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -226,6 +226,9 @@ public class AccessControlList implements Serializable {
     mMode = mode;
   }
 
+  /**
+   * Update the mask to be the union of owning group entry, named user entry and named group entry.
+   */
   public void updateMask() {
     if (hasExtended()) {
       AclActions actions = getOwningGroupActions();

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -228,6 +228,7 @@ public class AccessControlList implements Serializable {
 
   /**
    * Update the mask to be the union of owning group entry, named user entry and named group entry.
+   * This method should be called when the aforementioned entries are modified.
    */
   public void updateMask() {
     if (hasExtended()) {
@@ -240,11 +241,11 @@ public class AccessControlList implements Serializable {
    * Sets an entry into the access control list.
    * If an entry with the same type and subject already exists, overwrites the existing entry;
    * Otherwise, adds this new entry.
+   * After we modify entries for NAMED_GROUP, OWNING_GROUP, NAMED_USER, we need to update the mask.
    *
    * @param entry the entry to be added or updated
    */
   public void setEntry(AclEntry entry) {
-    // TODO(cc): when setting non-mask entries, the mask should be dynamically updated too.
     switch (entry.getType()) {
       case NAMED_USER:  // fall through
       case NAMED_GROUP: // fall through
@@ -258,7 +259,6 @@ public class AccessControlList implements Serializable {
         Mode modeOwner = new Mode(mMode);
         modeOwner.setOwnerBits(entry.getActions().toModeBits());
         mMode = modeOwner.toShort();
-
         return;
       case OWNING_GROUP:
         Mode modeGroup = new Mode(mMode);

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -354,7 +354,9 @@ public class AccessControlList implements Serializable {
       }
     }
     if (isGroupKnown) {
-      groupActions.mask(mExtendedEntries.mMaskActions);
+      if (hasExtended()) {
+        groupActions.mask(mExtendedEntries.mMaskActions);
+      }
       return groupActions;
     }
 

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -247,13 +247,7 @@ public class AccessControlList implements Serializable {
     // TODO(cc): when setting non-mask entries, the mask should be dynamically updated too.
     switch (entry.getType()) {
       case NAMED_USER:  // fall through
-      case NAMED_GROUP:
-        if (mExtendedEntries == null) {
-          mExtendedEntries = new ExtendedACLEntries();
-        }
-        mExtendedEntries.setEntry(entry);
-        updateMask();
-        return;
+      case NAMED_GROUP: // fall through
       case MASK:
         if (mExtendedEntries == null) {
           mExtendedEntries = new ExtendedACLEntries();
@@ -270,7 +264,6 @@ public class AccessControlList implements Serializable {
         Mode modeGroup = new Mode(mMode);
         modeGroup.setGroupBits(entry.getActions().toModeBits());
         mMode = modeGroup.toShort();
-        updateMask();
         return;
       case OTHER:
         Mode modeOther = new Mode(mMode);

--- a/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AccessControlList.java
@@ -226,6 +226,13 @@ public class AccessControlList implements Serializable {
     mMode = mode;
   }
 
+  public void updateMask() {
+    if (hasExtended()) {
+      AclActions actions = getOwningGroupActions();
+      mExtendedEntries.updateMask(actions);
+    }
+  }
+
   /**
    * Sets an entry into the access control list.
    * If an entry with the same type and subject already exists, overwrites the existing entry;
@@ -237,7 +244,12 @@ public class AccessControlList implements Serializable {
     // TODO(cc): when setting non-mask entries, the mask should be dynamically updated too.
     switch (entry.getType()) {
       case NAMED_USER:  // fall through
-      case NAMED_GROUP: // fall through
+      case NAMED_GROUP:
+        if (mExtendedEntries == null) {
+          mExtendedEntries = new ExtendedACLEntries();
+        }
+        mExtendedEntries.setEntry(entry);
+        return;
       case MASK:
         if (mExtendedEntries == null) {
           mExtendedEntries = new ExtendedACLEntries();

--- a/core/common/src/main/java/alluxio/security/authorization/AclActions.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclActions.java
@@ -122,6 +122,10 @@ public final class AclActions implements Serializable {
     mActions.or(actions.mActions);
   }
 
+  public void mask(AclActions actions)  {
+    mActions.and(actions.mActions);
+  }
+
   /**
    * @param action the action to be checked
    * @return whether the action is contained in the permitted actions

--- a/core/common/src/main/java/alluxio/security/authorization/AclActions.java
+++ b/core/common/src/main/java/alluxio/security/authorization/AclActions.java
@@ -114,7 +114,7 @@ public final class AclActions implements Serializable {
   }
 
   /**
-   * Merges the actions.
+   * Merges the actions. (Or operation)
    *
    * @param actions the actions to be merged from
    */
@@ -122,6 +122,10 @@ public final class AclActions implements Serializable {
     mActions.or(actions.mActions);
   }
 
+  /**
+   * Mask the actions. (And operation)
+   * @param actions the acl mask
+   */
   public void mask(AclActions actions)  {
     mActions.and(actions.mActions);
   }

--- a/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -206,6 +207,23 @@ public class ExtendedACLEntries {
     return actions;
   }
 
+  public void updateMask(AclActions groupActions) {
+    AclActions result = new AclActions(groupActions);
+    Set<Map.Entry<String, AclActions>> kvSet = mNamedUserActions.entrySet();
+    kvSet.addAll(mNamedGroupActions.entrySet());
+
+    for (Map.Entry<String, AclActions> kv : kvSet) {
+      AclActions userAction = kv.getValue();
+      for (AclAction action : AclAction.values()) {
+        if (result.contains(action) || userAction.contains(action)) {
+          result.add(action);
+        }
+      }
+    }
+
+    mMaskActions = result;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -224,4 +242,6 @@ public class ExtendedACLEntries {
   public int hashCode() {
     return Objects.hashCode(mNamedUserActions, mNamedGroupActions, mMaskActions);
   }
+
+
 }

--- a/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -209,11 +210,14 @@ public class ExtendedACLEntries {
 
   public void updateMask(AclActions groupActions) {
     AclActions result = new AclActions(groupActions);
-    Set<Map.Entry<String, AclActions>> kvSet = mNamedUserActions.entrySet();
+    Set<Map.Entry<String, AclActions>> kvSet = new HashSet<>();
+    kvSet.addAll(mNamedUserActions.entrySet());
     kvSet.addAll(mNamedGroupActions.entrySet());
 
     for (Map.Entry<String, AclActions> kv : kvSet) {
       AclActions userAction = kv.getValue();
+      result.merge(userAction);
+
       for (AclAction action : AclAction.values()) {
         if (result.contains(action) || userAction.contains(action)) {
           result.add(action);

--- a/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
@@ -18,10 +18,8 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import javax.annotation.concurrent.NotThreadSafe;

--- a/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
@@ -208,6 +208,10 @@ public class ExtendedACLEntries {
     return actions;
   }
 
+  /**
+   * Update the mask to be the union of owning group entry, named user entry and named group entry.
+   * @param groupActions the group entry to be integrated into the mask
+   */
   public void updateMask(AclActions groupActions) {
     AclActions result = new AclActions(groupActions);
     Set<Map.Entry<String, AclActions>> kvSet = new HashSet<>();
@@ -246,6 +250,4 @@ public class ExtendedACLEntries {
   public int hashCode() {
     return Objects.hashCode(mNamedUserActions, mNamedGroupActions, mMaskActions);
   }
-
-
 }

--- a/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
+++ b/core/common/src/main/java/alluxio/security/authorization/ExtendedACLEntries.java
@@ -214,11 +214,19 @@ public class ExtendedACLEntries {
    */
   public void updateMask(AclActions groupActions) {
     AclActions result = new AclActions(groupActions);
-    Set<Map.Entry<String, AclActions>> kvSet = new HashSet<>();
-    kvSet.addAll(mNamedUserActions.entrySet());
-    kvSet.addAll(mNamedGroupActions.entrySet());
 
-    for (Map.Entry<String, AclActions> kv : kvSet) {
+    for (Map.Entry<String, AclActions> kv : mNamedUserActions.entrySet()) {
+      AclActions userAction = kv.getValue();
+      result.merge(userAction);
+
+      for (AclAction action : AclAction.values()) {
+        if (result.contains(action) || userAction.contains(action)) {
+          result.add(action);
+        }
+      }
+    }
+
+    for (Map.Entry<String, AclActions> kv : mNamedGroupActions.entrySet()) {
       AclActions userAction = kv.getValue();
       result.merge(userAction);
 

--- a/core/common/src/test/java/alluxio/security/authorization/AccessControlListTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/AccessControlListTest.java
@@ -74,6 +74,7 @@ public class AccessControlListTest {
         .addAction(AclAction.READ).addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
     acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(NAMED_GROUP)
         .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    acl.updateMask();
     // Verify mode.
     // owning user
     Assert.assertTrue(checkMode(acl, OWNING_USER, Collections.emptyList(), Mode.Bits.ALL));
@@ -154,6 +155,7 @@ public class AccessControlListTest {
         .addAction(AclAction.READ).build());
     acl.setEntry(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(NAMED_GROUP2)
         .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    acl.updateMask();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3245,15 +3245,12 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       case REPLACE:
         // fully replace the acl for the path
         targetInode.replaceAcl(entries);
-        targetInode.updateMask(entries);
         break;
       case MODIFY:
         targetInode.setAcl(entries);
-        targetInode.updateMask(entries);
         break;
       case REMOVE:
         targetInode.removeAcl(entries);
-        targetInode.updateMask(entries);
         break;
       case REMOVE_ALL:
         targetInode.removeExtendedAcl();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3245,12 +3245,15 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       case REPLACE:
         // fully replace the acl for the path
         targetInode.replaceAcl(entries);
+        targetInode.updateMask(entries);
         break;
       case MODIFY:
         targetInode.setAcl(entries);
+        targetInode.updateMask(entries);
         break;
       case REMOVE:
         targetInode.removeAcl(entries);
+        targetInode.updateMask(entries);
         break;
       case REMOVE_ALL:
         targetInode.removeExtendedAcl();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -237,6 +237,7 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
         mAcl.removeEntry(entry);
       }
     }
+    updateMask(entries);
     return getThis();
   }
 
@@ -265,6 +266,7 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
 
   /**
    * Update Mask for the Inode.
+   * This method should be called after updates to ACL and defaultACL.
    *
    * @param entries the list of ACL entries
    * @return the updated object
@@ -464,6 +466,7 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
         mAcl.setEntry(entry);
       }
     }
+    updateMask(entries);
     return getThis();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -19,6 +19,7 @@ import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclAction;
 import alluxio.security.authorization.AclActions;
 import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.AclEntryType;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileInfo;
 import alluxio.wire.TtlAction;
@@ -260,6 +261,41 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
       mAcl.clearEntries();
     }
     return setAcl(entries);
+  }
+
+  /**
+   * Update Mask for the Inode.
+   *
+   * @param entries the list of ACL entries
+   * @return the updated object
+   */
+  public T updateMask(List<AclEntry> entries) {
+    boolean needToUpdateACL = false;
+    boolean needToUpdateDefaultACL = false;
+
+    for (AclEntry entry : entries) {
+      if (entry.getType().equals(AclEntryType.NAMED_USER)
+          || entry.getType().equals(AclEntryType.NAMED_GROUP)
+          || entry.getType().equals(AclEntryType.OWNING_GROUP)) {
+        if (entry.isDefault()) {
+          needToUpdateDefaultACL = true;
+        } else {
+          needToUpdateACL = true;
+        }
+      }
+      if (entry.getType().equals(AclEntryType.MASK)) {
+        // If mask is explicitly set or removed then we don't need to update the mask
+        return getThis();
+      }
+    }
+    if (needToUpdateACL) {
+      mAcl.updateMask();
+    }
+
+    if (needToUpdateDefaultACL) {
+      getDefaultACL().updateMask();
+    }
+    return getThis();
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1226,6 +1226,7 @@ public final class FileSystemMasterTest {
         .getFileInfo(NESTED_URI, GET_STATUS_OPTIONS).convertDefaultAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
     assertTrue(entries.containsAll(newEntries));
+    assertTrue(entries.contains("default:mask::rwx"));
 
     // modify existing and add
     newEntries = Sets.newHashSet("default:user:usera:---", "default:group:groupa:--x",
@@ -1300,7 +1301,7 @@ public final class FileSystemMasterTest {
     assertEquals(newEntries, entries);
 
     // modify existing
-    newEntries = Sets.newHashSet("user::rwx", "group::rw-", "other::r-x");
+    newEntries = Sets.newHashSet("user::rwx", "group::r--", "other::r-x");
     mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.MODIFY,
         newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
 
@@ -1318,6 +1319,8 @@ public final class FileSystemMasterTest {
         .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
     assertTrue(entries.containsAll(oldEntries));
     assertTrue(entries.containsAll(newEntries));
+    // check if the mask got updated correctly
+    assertTrue(entries.contains("mask::r-x"));
 
     // modify existing and add
     newEntries = Sets.newHashSet("user:usera:---", "group:groupa:--x", "other::r-x");

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
@@ -60,7 +60,7 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
 
     List<String> stringEntries = new ArrayList<>(FACL_STRING_ENTRIES);
     stringEntries.add("user:testuser:rwx");
-    stringEntries.add("mask::---");
+    stringEntries.add("mask::rwx");
     expected += getFaclResultStr(testOwner, testOwner, "/testRoot/testFileA", stringEntries);
 
     Assert.assertEquals(expected, mOutput.toString());
@@ -95,7 +95,7 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     List<String> stringEntries = new ArrayList<>(DIR_FACL_STRING_ENTRIES);
     stringEntries.addAll(DEFAULT_FACL_STRING_ENTRIES);
     stringEntries.add("default:user:testuser:rwx");
-    stringEntries.add("default:mask::---");
+    stringEntries.add("default:mask::rwx");
     String expected = getFaclResultStr(testOwner, testOwner, "/testRoot/testDir", stringEntries);
 
     Assert.assertEquals(expected, mOutput.toString());
@@ -106,10 +106,10 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     mFsShell.run("getfacl", "/testRoot/testDir/testDir2");
     stringEntries = new ArrayList<>(DIR_FACL_STRING_ENTRIES);
     stringEntries.add("user:testuser:rwx");
-    stringEntries.add("mask::---");
+    stringEntries.add("mask::rwx");
     stringEntries.addAll(DEFAULT_FACL_STRING_ENTRIES);
     stringEntries.add("default:user:testuser:rwx");
-    stringEntries.add("default:mask::---");
+    stringEntries.add("default:mask::rwx");
     expected += getFaclResultStr(testOwner, testOwner,
         "/testRoot/testDir/testDir2", stringEntries);
 
@@ -118,7 +118,7 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     mFsShell.run("getfacl", "/testRoot/testDir/testDir2/testFileD");
     stringEntries = new ArrayList<>(DIR_FACL_STRING_ENTRIES);
     stringEntries.add("user:testuser:rwx");
-    stringEntries.add("mask::---");
+    stringEntries.add("mask::rwx");
     expected += getFaclResultStr(testOwner, testOwner,
         "/testRoot/testDir/testDir2/testFileD", stringEntries);
     Assert.assertEquals(expected, mOutput.toString());


### PR DESCRIPTION
Before this change, we were ignoring ACL masks. After this change, we will take ACL masks into consideration when we do permission checking. Also we automatically sets masks when updating other relevant entries. 