### PR TITLE
[SMALLFIX] Reduce test flakiness

### DIFF
--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -474,22 +474,19 @@ public class CommonUtilsTest {
     List<Callable<Void>> tasks = new ArrayList<>();
     final Exception testException = new Exception("test message");
     for (int i = 0; i < numTasks; i++) {
-      tasks.add(new Callable<Void>() {
-        @Override
-        public Void call() throws Exception {
-          int myId = id.incrementAndGet();
-          // The 3rd task throws an exception, other tasks sleep.
-          if (myId == 3) {
-            throw testException;
-          } else {
-            Thread.sleep(10 * Constants.SECOND_MS);
-          }
-          return null;
+      tasks.add(() -> {
+        int myId = id.incrementAndGet();
+        // The 3rd task throws an exception, other tasks sleep.
+        if (myId == 3) {
+          throw testException;
+        } else {
+          Thread.sleep(10 * Constants.SECOND_MS);
         }
+        return null;
       });
     }
     try {
-      CommonUtils.invokeAll(tasks, 50, TimeUnit.MILLISECONDS);
+      CommonUtils.invokeAll(tasks, 500, TimeUnit.MILLISECONDS);
       fail("Expected an exception to be thrown");
     } catch (Exception e) {
       assertSame(testException, e);


### PR DESCRIPTION
The test will fail if it times out before the third task throws its exception. Increase the timeout to 500ms to be safe. Not increasing it higher because the method always waits for the timeout to elapse before checking for exceptions