### PR TITLE
[SMALLFIX] exclude one package in Hive checker

### DIFF
--- a/integration/checker/pom.xml
+++ b/integration/checker/pom.xml
@@ -56,6 +56,12 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
       <version>2.3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jamon</groupId>
+          <artifactId>jamon-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- We pick a particular Spark version here for convenience, but this checker


### PR DESCRIPTION
Remove the dependency on jamon-runtime package.