### PR TITLE
[ALLUXIO-3288] skip conf validation for getConf

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -291,7 +291,7 @@ function main {
   "getConf")
     CLASS="alluxio.cli.GetConf"
     CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
-    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.skip.conf.validation"
+    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.conf.validation.enabled=false"
     runJavaClass "$@"
   ;;
   "loadufs")

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -291,6 +291,7 @@ function main {
   "getConf")
     CLASS="alluxio.cli.GetConf"
     CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
+    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.skip.conf.validation"
     runJavaClass "$@"
   ;;
   "loadufs")

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -139,6 +139,8 @@ public final class Constants {
   public static final String LOCALITY_RACK = "rack";
   public static final String MESOS_LOCAL_INSTALL = "LOCAL";
 
+  public static final String SKIP_CONF_VALIDATION = "alluxio.skip.conf.validation";
+
   /**
    * Maximum number of seconds to wait for thrift servers to stop on shutdown. Tests use a value of
    * 0 instead of this value so that they can run faster.

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -139,8 +139,6 @@ public final class Constants {
   public static final String LOCALITY_RACK = "rack";
   public static final String MESOS_LOCAL_INSTALL = "LOCAL";
 
-  public static final String SKIP_CONF_VALIDATION = "alluxio.skip.conf.validation";
-
   /**
    * Maximum number of seconds to wait for thrift servers to stop on shutdown. Tests use a value of
    * 0 instead of this value so that they can run faster.

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -284,6 +284,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIgnoredSiteProperty(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
+  public static final PropertyKey CONF_VALIDATION_ENABLED =
+      new Builder(Name.CONF_VALIDATION_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("Whether to validate the configuration properties when initializing " +
+              "Alluxio clients or server process.")
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   public static final PropertyKey DEBUG =
       new Builder(Name.DEBUG)
           .setDefaultValue(false)
@@ -3027,6 +3035,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   @ThreadSafe
   public static final class Name {
     public static final String CONF_DIR = "alluxio.conf.dir";
+    public static final String CONF_VALIDATION_ENABLED = "alluxio.conf.validation.enabled";
     public static final String DEBUG = "alluxio.debug";
     public static final String EXTENSIONS_DIR = "alluxio.extensions.dir";
     public static final String HOME = "alluxio.home";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -287,8 +287,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey CONF_VALIDATION_ENABLED =
       new Builder(Name.CONF_VALIDATION_ENABLED)
           .setDefaultValue(true)
-          .setDescription("Whether to validate the configuration properties when initializing " +
-              "Alluxio clients or server process.")
+          .setDescription("Whether to validate the configuration properties when initializing "
+              + "Alluxio clients or server process.")
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -13,6 +13,7 @@ package alluxio.conf;
 
 import alluxio.AlluxioConfiguration;
 import alluxio.ConfigurationValueOptions;
+import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.PropertyKey.Template;
 import alluxio.exception.ExceptionMessage;
@@ -266,6 +267,9 @@ public class InstancedConfiguration implements AlluxioConfiguration {
 
   @Override
   public void validate() {
+    if (System.getProperty(Constants.SKIP_CONF_VALIDATION) != null) {
+      return;
+    }
     for (PropertyKey key : keySet()) {
       Preconditions.checkState(
           getSource(key).getType() != Source.Type.SITE_PROPERTY || !key.isIgnoredSiteProperty(),

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -13,7 +13,6 @@ package alluxio.conf;
 
 import alluxio.AlluxioConfiguration;
 import alluxio.ConfigurationValueOptions;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.PropertyKey.Template;
 import alluxio.exception.ExceptionMessage;
@@ -267,7 +266,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
 
   @Override
   public void validate() {
-    if (System.getProperty(Constants.SKIP_CONF_VALIDATION) != null) {
+    if (!getBoolean(PropertyKey.CONF_VALIDATION_ENABLED)) {
       return;
     }
     for (PropertyKey key : keySet()) {

--- a/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
@@ -14,7 +14,6 @@ package alluxio.client.cli.fs;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.Configuration;
-import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.SystemOutRule;
 import alluxio.SystemPropertyRule;
@@ -111,7 +110,7 @@ public final class GetConfTest {
   @Test
   public void getConfWithInvalidConf() throws Exception {
     try (Closeable p = new SystemPropertyRule(ImmutableMap.of(
-        Constants.SKIP_CONF_VALIDATION, "true",
+        PropertyKey.CONF_VALIDATION_ENABLED.toString(), "false",
         PropertyKey.ZOOKEEPER_ENABLED.toString(), "true")).toResource()) {
       Configuration.reset();
       assertEquals(0, GetConf.getConf(PropertyKey.ZOOKEEPER_ENABLED.toString()));


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3288

If I set `alluxio.zookeeper.enabled=true` alone in `alluxio-site.properties` without setting `alluxio.zookeeper.address`, this error shows before this patch:

```
$ bin/alluxio getConf alluxio.zookeeper.enabled
Exception in thread "main" java.lang.ExceptionInInitializerError
	at alluxio.cli.GetConf.getConfImpl(GetConf.java:176)
	at alluxio.cli.GetConf.getConf(GetConf.java:141)
	at alluxio.cli.GetConf.main(GetConf.java:261)
Caused by: java.lang.IllegalStateException: Inconsistent Zookeeper configuration; alluxio.zookeeper.address should be set if and only if alluxio.zookeeper.enabled is true
	at com.google.common.base.Preconditions.checkState(Preconditions.java:176)
	at alluxio.conf.InstancedConfiguration.checkZkConfiguration(InstancedConfiguration.java:405)
	at alluxio.conf.InstancedConfiguration.validate(InstancedConfiguration.java:280)
	at alluxio.Configuration.validate(Configuration.java:375)
	at alluxio.Configuration.reset(Configuration.java:97)
	at alluxio.Configuration.<clinit>(Configuration.java:60)
	... 3 more
```

After this change:
```
$ bin/alluxio getConf alluxio.zookeeper.enabled
false
```