### PR TITLE
[SMALLFIX] The release package is missing bin/alluxio-monitor.sh (#7752)

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -128,6 +128,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 	pathsToCopy := []string{
 		"bin/alluxio",
 		"bin/alluxio-masters.sh",
+		"bin/alluxio-monitor.sh",
 		"bin/alluxio-mount.sh",
 		"bin/alluxio-start.sh",
 		"bin/alluxio-stop.sh",


### PR DESCRIPTION
cherry-pick from 1.9-SNAPSHOT to 1.8 branch