### PR TITLE
[ALLUXIO-3291] make worker not crush if a storage location cannot be accessed (#7751)

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -82,8 +82,14 @@ public final class StorageTier {
     for (int i = 0; i < dirPaths.length; i++) {
       int index = i >= dirQuotas.length ? dirQuotas.length - 1 : i;
       long capacity = FormatUtils.parseSpaceSize(dirQuotas[index]);
-      totalCapacity += capacity;
-      mDirs.add(StorageDir.newStorageDir(this, i, capacity, dirPaths[i]));
+      try {
+        StorageDir dir = StorageDir.newStorageDir(this, i, capacity, dirPaths[i]);
+        totalCapacity += capacity;
+        mDirs.add(dir);
+      } catch (IOException e) {
+        LOG.error("Unable to initialize storage directory at {}: {}", dirPaths[i], e.getMessage());
+        continue;
+      }
 
       // Delete tmp directory.
       String tmpDirPath = PathUtils.concatPath(dirPaths[i], tmpDir);

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
@@ -145,4 +145,15 @@ public class StorageTierTest {
     mThrown.expectMessage(PreconditionMessage.ERR_TIER_QUOTA_BLANK.toString());
     mTier = StorageTier.newStorageTier("MEM");
   }
+
+  @Test
+  public void tolerantFailureInStorageDir() throws Exception {
+    PropertyKey tierDirPathConf =
+        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0);
+    Configuration.set(tierDirPathConf, "/dev/null/invalid," + mTestDirPath1);
+    mTier = StorageTier.newStorageTier("MEM");
+    List<StorageDir> dirs = mTier.getStorageDirs();
+    Assert.assertEquals(1, dirs.size());
+    Assert.assertEquals(mTestDirPath1, dirs.get(0).getDirPath());
+  }
 }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3291

Cherry-pick https://github.com/Alluxio/alluxio/pull/7751 for `branch-1.8`