### PR TITLE
[SMALLFIX] Fix mount check for alluxio-start.sh

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -392,13 +392,17 @@ main() {
   case "${ACTION}" in
     all|worker|workers|local)
       if [[ -z "${MOPT}" ]]; then
+        echo  "Assuming NoMount by default."
         MOPT="NoMount"
       elif [[ "${MOPT}" == "-f" ]]; then
+        echo  "Assuming SudoMount given -f option."
         MOPT="SudoMount"
       else
         shift
       fi
-      check_mount_mode "${MOPT}"
+      if [[ "${ACTION}" = "worker" ]] || [[ "${ACTION}" = "local" ]]; then
+        check_mount_mode "${MOPT}"
+      fi
       ;;
     *)
       MOPT=""


### PR DESCRIPTION
Right now alluxio-start.sh will check ramdisk if the action is one of local, worker, workers, all. It should only happen if a local worker will be started.