### PR TITLE
[ALLUXIO-3263]Use static imports for standard test utilities for class SpaceReserverTest

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -291,7 +291,7 @@ public interface BlockStore extends SessionCleanable {
   BlockStoreMeta getBlockStoreMeta();
 
   /**
-   * Similar as {@link BlockStoreMeta.Factory#getBlockStoreMeta} except that this includes
+   * Similar as {@link #getBlockStoreMeta} except that this includes
    * more information about the block store (e.g. blockId list). This is an expensive operation.
    *
    * @return full store metadata

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -22,7 +22,7 @@ import org.jets3t.service.impl.rest.httpclient.GoogleStorageService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
-import org.mockito.Mockito;
+import static org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -46,7 +46,7 @@ public class GCSUnderFileSystemTest {
    */
   @Before
   public void before() throws InterruptedException, ServiceException {
-    mClient = Mockito.mock(GoogleStorageService.class);
+    mClient = mock(GoogleStorageService.class);
 
     mGCSUnderFileSystem = new GCSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
         BUCKET_MODE, ACCOUNT_OWNER, UnderFileSystemConfiguration.defaults());
@@ -57,7 +57,7 @@ public class GCSUnderFileSystemTest {
    */
   @Test
   public void deleteNonRecursiveOnServiceException() throws IOException, ServiceException {
-    Mockito.when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
+    when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
@@ -71,7 +71,7 @@ public class GCSUnderFileSystemTest {
    */
   @Test
   public void deleteRecursiveOnServiceException() throws IOException, ServiceException {
-    Mockito.when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
+    when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 
@@ -85,7 +85,7 @@ public class GCSUnderFileSystemTest {
    */
   @Test
   public void renameOnServiceException() throws IOException, ServiceException {
-    Mockito.when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
+    when(mClient.listObjectsChunked(Matchers.anyString(), Matchers.anyString(),
         Matchers.anyString(), Matchers.anyLong(), Matchers.anyString()))
         .thenThrow(ServiceException.class);
 


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3263
change Mockito.verify(...) _to verify(...) _for all function of class alluxio.worker.block.SpaceReserverTestand change import org.mockito.Mockito; to import static org.mockito.Mockito.verify;