### PR TITLE
[ALLUXIO-3298] Avoid creating transport of metrics client before cluster conf loaded

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
@@ -63,7 +63,7 @@ public final class ClientMasterSync implements HeartbeatExecutor {
       mMasterClient.heartbeat(metrics);
     } catch (IOException e) {
       // An error occurred, log and ignore it or error if heartbeat timeout is reached
-      LOG.error("Failed to heartbeat to the metrics master: {}", e);
+      LOG.error("Failed to heartbeat to the metrics master:", e);
       mMasterClient.disconnect();
     }
   }

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -73,9 +73,6 @@ public abstract class AbstractClient implements Client {
    */
   protected long mServiceVersion;
 
-  /** Handler to the transport provider according to the authentication type. */
-  protected final TransportProvider mTransportProvider;
-
   private final Subject mParentSubject;
 
   /**
@@ -101,7 +98,6 @@ public abstract class AbstractClient implements Client {
     mParentSubject = subject;
     mRetryPolicySupplier = retryPolicySupplier;
     mServiceVersion = Constants.UNKNOWN_SERVICE_VERSION;
-    mTransportProvider = TransportProvider.Factory.create();
   }
 
   /**
@@ -177,6 +173,7 @@ public abstract class AbstractClient implements Client {
   /**
    * Connects with the remote.
    */
+  @Override
   public synchronized void connect() throws AlluxioStatusException {
     if (mConnected) {
       return;
@@ -204,7 +201,7 @@ public abstract class AbstractClient implements Client {
             RuntimeConstants.VERSION, getServiceName(), mAddress);
         // The wrapper transport
         TTransport clientTransport =
-            mTransportProvider.getClientTransport(mParentSubject, mAddress);
+            TransportProvider.Factory.create().getClientTransport(mParentSubject, mAddress);
         mProtocol = ThriftUtils.createThriftProtocol(clientTransport, getServiceName());
         mProtocol.getTransport().open();
         LOG.info("Client registered with {} @ {}", getServiceName(), mAddress);


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3298

- `TransportProvider.Factory.create()` is using `Configuration.get` inside, which should be after `beforeConnect`
- I will cherry-pick this to branch-1.8