### PR TITLE
[ALLUXIO-3298] Avoid setting transport of metrics client earlier than cluster conf loaded (#7795) 

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
@@ -63,7 +63,7 @@ public final class ClientMasterSync implements HeartbeatExecutor {
       mMasterClient.heartbeat(metrics);
     } catch (IOException e) {
       // An error occurred, log and ignore it or error if heartbeat timeout is reached
-      LOG.error("Failed to heartbeat to the metrics master: {}", e);
+      LOG.error("Failed to heartbeat to the metrics master:", e);
       mMasterClient.disconnect();
     }
   }

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -99,9 +99,6 @@ public abstract class AbstractClient implements Client {
    */
   protected long mServiceVersion;
 
-  /** Handler to the transport provider according to the authentication type. */
-  protected final TransportProvider mTransportProvider;
-
   private final Subject mParentSubject;
 
   /**
@@ -127,7 +124,6 @@ public abstract class AbstractClient implements Client {
     mParentSubject = subject;
     mRetryPolicySupplier = retryPolicySupplier;
     mServiceVersion = Constants.UNKNOWN_SERVICE_VERSION;
-    mTransportProvider = TransportProvider.Factory.create();
   }
 
   /**
@@ -258,7 +254,7 @@ public abstract class AbstractClient implements Client {
         RuntimeConstants.VERSION, getServiceName(), mAddress);
     // The wrapper transport
     TTransport clientTransport =
-        mTransportProvider.getClientTransport(mParentSubject, mAddress);
+        TransportProvider.Factory.create().getClientTransport(mParentSubject, mAddress);
     mProtocol = ThriftUtils.createThriftProtocol(clientTransport, getServiceName());
     mProtocol.getTransport().open();
     LOG.info("Client registered with {} @ {}", getServiceName(), mAddress);
@@ -270,6 +266,7 @@ public abstract class AbstractClient implements Client {
   /**
    * Connects with the remote.
    */
+  @Override
   public synchronized void connect() throws AlluxioStatusException {
     if (mConnected) {
       return;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3298

Cherry-pick from 1.9 snapshot to 1.8 branch