### PR TITLE
[SMALLFIX] improve Authority regrex and add tests

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -155,18 +155,18 @@ public class AbstractFileSystemTest {
   @Test
   public void hadoopShouldLoadFileSystemWithMultipleZkUri() throws Exception {
     org.apache.hadoop.conf.Configuration conf = getConf();
-    URI uri = URI.create(Constants.HEADER + "zk@host1:port1,host2:port2,host3:port3/tmp/path.txt");
+    URI uri = URI.create(Constants.HEADER + "zk@host1:2181,host2:2181,host3:2181/tmp/path.txt");
     org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
 
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
-    assertEquals("host1:port1,host2:port2,host3:port3",
+    assertEquals("host1:2181,host2:2181,host3:2181",
         alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
     assertTrue(fs instanceof FileSystem);
 
-    uri = URI.create(Constants.HEADER + "zk@host1:port1;host2:port2;host3:port3/tmp/path.txt");
+    uri = URI.create(Constants.HEADER + "zk@host1:2181;host2:2181;host3:2181/tmp/path.txt");
     fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
-    assertEquals("host1:port1,host2:port2,host3:port3",
+    assertEquals("host1:2181,host2:2181,host3:2181",
         alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
     assertTrue(fs instanceof FileSystem);
   }
@@ -260,17 +260,17 @@ public class AbstractFileSystemTest {
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
     assertEquals("zkHost:2181", alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
 
-    uri = URI.create(Constants.HEADER + "zk@host1:port1,host2:port2,host3:port3/tmp/path.txt");
+    uri = URI.create(Constants.HEADER + "zk@host1:2181,host2:2181,host3:2181/tmp/path.txt");
     org.apache.hadoop.fs.FileSystem.get(uri, getConf());
 
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
-    assertEquals("host1:port1,host2:port2,host3:port3",
+    assertEquals("host1:2181,host2:2181,host3:2181",
         alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
 
-    uri = URI.create(Constants.HEADER + "zk@host1:port1;host2:port2;host3:port3/tmp/path.txt");
+    uri = URI.create(Constants.HEADER + "zk@host1:2181;host2:2181;host3:2181/tmp/path.txt");
     org.apache.hadoop.fs.FileSystem.get(uri, getConf());
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
-    assertEquals("host1:port1,host2:port2,host3:port3",
+    assertEquals("host1:2181,host2:2181,host3:2181",
         alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
 
     verify(mMockFileSystemContext, times(3)).reset(alluxio.Configuration.global());
@@ -279,10 +279,10 @@ public class AbstractFileSystemTest {
   @Test
   public void resetContextFromZkUriToNonZkUri() throws Exception {
     org.apache.hadoop.conf.Configuration conf = getConf();
-    URI uri = URI.create(Constants.HEADER + "zk@zkHost:zkPort/tmp/path.txt");
+    URI uri = URI.create(Constants.HEADER + "zk@zkHost:2181/tmp/path.txt");
     org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
     assertTrue(alluxio.Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
-    assertEquals("zkHost:zkPort", alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
+    assertEquals("zkHost:2181", alluxio.Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
 
     URI otherUri = URI.create(Constants.HEADER + "alluxioHost:19998/tmp/path.txt");
     org.apache.hadoop.fs.FileSystem otherFs = org.apache.hadoop.fs.FileSystem.get(otherUri, conf);

--- a/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -124,45 +124,45 @@ public class AlluxioURITest {
   @Test
   public void basicZookeeperUri() {
     AlluxioURI uri =
-        new AlluxioURI("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z/a b c");
+        new AlluxioURI("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z/a b c");
     assertEquals(uri,
-        new AlluxioURI("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z/a b c"));
+        new AlluxioURI("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z/a b c"));
     assertEquals("alluxio", uri.getScheme());
 
-    assertEquals("zk@host1:port1,host2:port2,host3:port3", uri.getAuthority().toString());
+    assertEquals("zk@host1:2181,host2:2181,host3:2181", uri.getAuthority().toString());
     assertTrue(uri.getAuthority() instanceof ZookeeperAuthority);
     ZookeeperAuthority zkAuthority = (ZookeeperAuthority) uri.getAuthority();
-    assertEquals("host1:port1,host2:port2,host3:port3", zkAuthority.getZookeeperAddress());
+    assertEquals("host1:2181,host2:2181,host3:2181", zkAuthority.getZookeeperAddress());
 
     assertEquals(2, uri.getDepth());
     assertEquals("a b c", uri.getName());
-    assertEquals("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z",
+    assertEquals("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z",
         uri.getParent().toString());
-    assertEquals("alluxio://zk@host1:port1,host2:port2,host3:port3/",
+    assertEquals("alluxio://zk@host1:2181,host2:2181,host3:2181/",
         uri.getParent().getParent().toString());
     assertEquals("/xy z/a b c", uri.getPath());
     assertTrue(uri.hasAuthority());
     assertTrue(uri.hasScheme());
     assertTrue(uri.isAbsolute());
     assertTrue(uri.isPathAbsolute());
-    assertEquals("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z/a b c/d",
+    assertEquals("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z/a b c/d",
         uri.join("/d").toString());
-    assertEquals("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z/a b c/d",
+    assertEquals("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z/a b c/d",
         uri.join(new AlluxioURI("/d"))
         .toString());
-    assertEquals("alluxio://zk@host1:port1,host2:port2,host3:port3/xy z/a b c",
+    assertEquals("alluxio://zk@host1:2181,host2:2181,host3:2181/xy z/a b c",
         uri.toString());
   }
 
   @Test
   public void semicolonZookeeperUri() {
     AlluxioURI uri =
-        new AlluxioURI("alluxio://zk@host1:port1;host2:port2;host3:port3/xy z/a b c");
+        new AlluxioURI("alluxio://zk@host1:2181;host2:2181;host3:2181/xy z/a b c");
     assertTrue(uri.hasAuthority());
-    assertEquals("zk@host1:port1;host2:port2;host3:port3", uri.getAuthority().toString());
+    assertEquals("zk@host1:2181;host2:2181;host3:2181", uri.getAuthority().toString());
     assertTrue(uri.getAuthority() instanceof ZookeeperAuthority);
     ZookeeperAuthority zkAuthority = (ZookeeperAuthority) uri.getAuthority();
-    assertEquals("host1:port1,host2:port2,host3:port3", zkAuthority.getZookeeperAddress());
+    assertEquals("host1:2181,host2:2181,host3:2181", zkAuthority.getZookeeperAddress());
   }
 
   /**
@@ -486,7 +486,7 @@ public class AlluxioURITest {
     assertTrue(new AlluxioURI("file", Authority.fromString("localhost:8080"), "/b/c").getAuthority()
         instanceof SingleMasterAuthority);
 
-    assertTrue(new AlluxioURI("file", Authority.fromString("zk@host:port"), "/b/c").getAuthority()
+    assertTrue(new AlluxioURI("file", Authority.fromString("zk@host:2181"), "/b/c").getAuthority()
         instanceof ZookeeperAuthority);
     assertTrue(new AlluxioURI("alluxio://zk@host1:2181,host2:2181,host3:2181/b/c").getAuthority()
         instanceof ZookeeperAuthority);

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -24,9 +24,10 @@ public class AuthorityTest {
   @Test
   public void authorityFromStringTest() {
     assertTrue(Authority.fromString("localhost:19998") instanceof SingleMasterAuthority);
+    assertTrue(Authority.fromString("127.0.0.1:19998") instanceof SingleMasterAuthority);
 
-    assertTrue(Authority.fromString("zk@host:port") instanceof ZookeeperAuthority);
-    assertTrue(Authority.fromString("zk@host1:2181,host2:2181,host3:2181")
+    assertTrue(Authority.fromString("zk@host:2181") instanceof ZookeeperAuthority);
+    assertTrue(Authority.fromString("zk@host1:2181,127.0.0.2:2181,12.43.214.53:2181")
         instanceof ZookeeperAuthority);
     assertTrue(Authority.fromString("zk@host1:2181;host2:2181;host3:2181")
         instanceof ZookeeperAuthority);
@@ -35,8 +36,21 @@ public class AuthorityTest {
     assertTrue(Authority.fromString(null) instanceof NoAuthority);
 
     assertTrue(Authority.fromString("localhost") instanceof UnknownAuthority);
-    assertTrue(Authority.fromString("localhost:19998:8080") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("f3,321:sad") instanceof UnknownAuthority);
     assertTrue(Authority.fromString("localhost:") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("127.0.0.1:19998,") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("localhost:19998:8080") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("localhost:asdsad") instanceof UnknownAuthority);
+
+    assertTrue(Authority.fromString("zk@") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("zk@;") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("zk@localhost") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("zk@127.0.0.1:port") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("zk@127.0.0.1:2181,") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString("zk@127.0.0.1:2181,localhost") instanceof UnknownAuthority);
+
+    assertTrue(Authority.fromString(",,,") instanceof UnknownAuthority);
+    assertTrue(Authority.fromString(";;;") instanceof UnknownAuthority);
   }
 
   @Test
@@ -50,13 +64,14 @@ public class AuthorityTest {
 
   @Test
   public void zookeeperAuthorityTest() {
-    ZookeeperAuthority authority = (ZookeeperAuthority) Authority.fromString("zk@host:port");
-    assertEquals("zk@host:port", authority.toString());
-    assertEquals("host:port", authority.getZookeeperAddress());
+    ZookeeperAuthority authority = (ZookeeperAuthority) Authority.fromString("zk@host:2181");
+    assertEquals("zk@host:2181", authority.toString());
+    assertEquals("host:2181", authority.getZookeeperAddress());
 
-    authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181,host2:2181,host3:2181");
-    assertEquals("zk@host1:2181,host2:2181,host3:2181", authority.toString());
-    assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
+    authority = (ZookeeperAuthority) Authority
+        .fromString("zk@127.0.0.1:2181,127.0.0.2:2181,127.0.0.3:2181");
+    assertEquals("zk@127.0.0.1:2181,127.0.0.2:2181,127.0.0.3:2181", authority.toString());
+    assertEquals("127.0.0.1:2181,127.0.0.2:2181,127.0.0.3:2181", authority.getZookeeperAddress());
 
     authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181;host2:2181;host3:2181");
     assertEquals("zk@host1:2181;host2:2181;host3:2181", authority.toString());

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemUriIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemUriIntegrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.hadoop;
+
+import alluxio.Constants;
+import alluxio.hadoop.FileSystem;
+import alluxio.master.ZkMasterInquireClient.ZkMasterConnectDetails;
+import alluxio.multi.process.MultiProcessCluster;
+import alluxio.multi.process.MultiProcessCluster.DeployMode;
+import alluxio.multi.process.PortCoordination;
+import alluxio.testutils.BaseIntegrationTest;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * Integration tests for using URIs with connect details in authorities to connect to
+ * Alluxio clusters through {@link FileSystem}.
+ */
+public class FileSystemUriIntegrationTest extends BaseIntegrationTest {
+  private static final int WAIT_TIMEOUT_MS = 60 * Constants.SECOND_MS;
+  public MultiProcessCluster mCluster;
+
+  @After
+  public void after() throws Exception {
+    mCluster.destroy();
+  }
+
+  @Test
+  public void zookeeperUriTest() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.MULTI_PROCESS_ZOOKEEPER)
+        .setClusterName("ZookeeperUriFileSystemIntegrationTest")
+        .setNumMasters(3)
+        .setNumWorkers(2)
+        .setDeployMode(DeployMode.ZOOKEEPER_HA)
+        .build();
+    mCluster.start();
+    // Get the zookeeper address
+    ZkMasterConnectDetails connectDetails =
+        (ZkMasterConnectDetails) mCluster.getMasterInquireClient().getConnectDetails();
+    String zkAddress = connectDetails.getZkAddress();
+
+    Configuration conf = new Configuration();
+    conf.set("fs.alluxio.impl", FileSystem.class.getName());
+
+    URI uri = URI.create("alluxio://zk@" + zkAddress + "/tmp/path.txt");
+    org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
+
+    mCluster.waitForAllNodesRegistered(WAIT_TIMEOUT_MS);
+
+    Path file = new Path("/testFile-Zookeeper");
+    FsPermission permission = FsPermission.createImmutable((short) 0666);
+    FSDataOutputStream o = fs.create(file, permission, false /* ignored */, 10 /* ignored */,
+        (short) 1 /* ignored */, 512 /* ignored */, null /* ignored */);
+    o.writeBytes("Test Bytes");
+    o.close();
+    // with mark of delete-on-exit, the close method will try to delete it
+    fs.deleteOnExit(file);
+    fs.close();
+    mCluster.notifySuccess();
+  }
+}


### PR DESCRIPTION
Change the SingleMasterAuthority and ZookeeperAuthority to be more concrete check.
add integration tests for using Alluxio on Zookeeper Uri in HDFS API to connect to Alluxio on Zookeeper cluster.