### PR TITLE
[SMALLFIX]Replace Properties with HashMap in HadoopConfigurationUtils#mergeHadoopConfiguration.

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -19,8 +19,8 @@ import alluxio.conf.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -43,7 +43,7 @@ public final class HadoopConfigurationUtils {
       AlluxioConfiguration alluxioConfiguration) {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system
     // Push Alluxio configuration to the Job configuration
-    Properties alluxioConfProperties = new Properties();
+    Map<String, String> alluxioConfProperties = new HashMap<String, String>();
     // Load any Alluxio configuration parameters existing in the Hadoop configuration.
     for (Map.Entry<String, String> entry : source) {
       String propertyName = entry.getKey();


### PR DESCRIPTION
Spark executor process output the following log:

```

2018-08-31 11:10:32,723 | INFO  | [Executor task launch worker for task 2515] | Loading Alluxio properties from Hadoop configuration: {spark.network.timeoutInterval=60, spark.rpc.io.numConnectionsPerPeer=1, spark.ssl.ui.protocol=TLSv1.1,TLSv1.2, spark.ssl.historyServer.enabled=true, spark.rpc.retry.wait=3s, spark.shuffle.service.port=27338, spark.rpc.numRetries=3, spark.yarn.app.container.log.dir=/opt/UQuery/data2/hadoop/log/application_1535677093711_0010/container_e403_1535677093711_0010_01_000001, spark.ui.port=0, alluxio.zookeeper.leader.path=/cluster007/alluxioLeader, alluxio.zookeeper.address=192.168.1.197:2181,192.168.1.200:2181,192.168.1.148:2181, alluxio.zookeeper.session.timeout=5s, spark.rpc.message.maxSize=128, spark.network.timeout=240s, spark.rpc.lookupTimeout=120s, spark.random.port.min=22600, spark.rpc.io.threads=0, alluxio.zookeeper.enabled=true, spark.random.port.max=22899, spark.authenticate=false, spark.rpc.connect.threads=64, spark.port.maxRetries=16, alluxio.zookeeper.election.path=/cluster007/alluxioElection, spark.ssl.ui.enabledAlgorithms=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, spark.driver.port=22788, spark.rpc.askTimeout=120s} | alluxio.hadoop.HadoopConfigurationUtils.mergeHadoopConfiguration(HadoopConfigurationUtils.java:54)

```