### PR TITLE
[ALLUXIO-3305] Fix loadMetadata bug related to ACL  

### DIFF
--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -59,7 +59,7 @@ public class DefaultAccessControlList extends AccessControlList {
 
   /**
    * create a child file 's accessACL based on the default ACL.
-   * @param mode file's initial mode based on umask
+   * @param mode file's umask
    * @return child file's access ACL
    */
   public AccessControlList generateChildFileACL(Short mode) {
@@ -94,7 +94,7 @@ public class DefaultAccessControlList extends AccessControlList {
 
   /**
    * Creates a child directory's access ACL and default ACL based on the default ACL.
-   * @param mode child's initial mode based on umask
+   * @param mode child's umask
    * @return child directory's access ACL and default ACL
    */
   public Pair<AccessControlList, DefaultAccessControlList> generateChildDirACL(Short mode) {

--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -59,11 +59,11 @@ public class DefaultAccessControlList extends AccessControlList {
 
   /**
    * create a child file 's accessACL based on the default ACL.
-   * @param mode file's umask
+   * @param umask file's umask
    * @return child file's access ACL
    */
-  public AccessControlList generateChildFileACL(Short mode) {
-    Mode defaultMode = new Mode(mode);
+  public AccessControlList generateChildFileACL(Short umask) {
+    Mode defaultMode = new Mode(umask);
     AccessControlList acl = new AccessControlList();
     acl.mOwningUser = mOwningUser;
     acl.mOwningGroup = mOwningGroup;
@@ -77,13 +77,13 @@ public class DefaultAccessControlList extends AccessControlList {
       // permission to be filtered by the defaultMode
       acl.mExtendedEntries = new ExtendedACLEntries(mExtendedEntries);
 
-      // mask is filtered by the group bits from the mode parameter
+      // mask is filtered by the group bits from the umask parameter
       AclActions mask = acl.mExtendedEntries.getMask();
       AclActions groupAction = new AclActions();
       groupAction.updateByModeBits(defaultMode.getGroupBits());
       mask.mask(groupAction);
-      // user is filtered by the user bits from the mode parameter
-      // other is filtered by the other bits from the mode parameter
+      // user is filtered by the user bits from the umask parameter
+      // other is filtered by the other bits from the umask parameter
       Mode updateMode = new Mode(mMode);
       updateMode.setOwnerBits(updateMode.getOwnerBits().and(defaultMode.getOwnerBits()));
       updateMode.setOtherBits(updateMode.getOtherBits().and(defaultMode.getOtherBits()));
@@ -94,11 +94,11 @@ public class DefaultAccessControlList extends AccessControlList {
 
   /**
    * Creates a child directory's access ACL and default ACL based on the default ACL.
-   * @param mode child's umask
+   * @param umask child's umask
    * @return child directory's access ACL and default ACL
    */
-  public Pair<AccessControlList, DefaultAccessControlList> generateChildDirACL(Short mode) {
-    AccessControlList acl = generateChildFileACL(mode);
+  public Pair<AccessControlList, DefaultAccessControlList> generateChildDirACL(Short umask) {
+    AccessControlList acl = generateChildFileACL(umask);
     DefaultAccessControlList dAcl = new DefaultAccessControlList(acl);
     dAcl.setEmpty(false);
     dAcl.mOwningUser = mOwningUser;

--- a/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
+++ b/core/common/src/main/java/alluxio/security/authorization/DefaultAccessControlList.java
@@ -15,8 +15,6 @@ import alluxio.collections.Pair;
 import alluxio.thrift.TAcl;
 
 import com.google.common.base.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +24,6 @@ import java.util.List;
  */
 public class DefaultAccessControlList extends AccessControlList {
   private static final long serialVersionUID = 8649647787531425489L;
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultAccessControlList.class);
   public static final DefaultAccessControlList EMPTY_DEFAULT_ACL = new DefaultAccessControlList();
 
   /**
@@ -66,7 +63,6 @@ public class DefaultAccessControlList extends AccessControlList {
    * @return child file's access ACL
    */
   public AccessControlList generateChildFileACL(Short mode) {
-    LOG.info("short mode {}", mode);
     Mode defaultMode = new Mode(mode);
     AccessControlList acl = new AccessControlList();
     acl.mOwningUser = mOwningUser;

--- a/core/common/src/main/java/alluxio/security/authorization/Mode.java
+++ b/core/common/src/main/java/alluxio/security/authorization/Mode.java
@@ -105,6 +105,18 @@ public final class Mode {
   }
 
   /**
+   * @param mode1 first mode of the and operation
+   * @param mode2 second mode of the and operation
+   * @return the AND result of the two Modes
+   */
+  public static Mode and(Mode mode1, Mode mode2) {
+    Bits u = mode1.mOwnerBits.and(mode2.mOwnerBits);
+    Bits g = mode1.mGroupBits.and(mode2.mGroupBits);
+    Bits o = mode1.mOtherBits.and(mode2.mOtherBits);
+    return new Mode(u, g, o);
+  }
+
+  /**
    * @return the owner {@link Bits}
    */
   public Bits getOwnerBits() {

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -81,7 +81,8 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path)
+      throws IOException {
     return null;
   }
 
@@ -92,7 +93,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
 
   @Override
   public String getFingerprint(String path) {
-    // TODO (yuzhu): include default ACL in the fingerprint
+    // TODO(yuzhu): include default ACL in the fingerprint
     try {
       UfsStatus status = getStatus(path);
       Pair<AccessControlList, DefaultAccessControlList> aclPair = getAclPair(path);

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
@@ -79,7 +80,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public AccessControlList getAcl(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException {
     return null;
   }
 
@@ -90,13 +91,15 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
 
   @Override
   public String getFingerprint(String path) {
+    // TODO (yuzhu): include default ACL in the fingerprint
     try {
       UfsStatus status = getStatus(path);
-      AccessControlList acl = getAcl(path);
-      if (acl == null || !acl.hasExtended()) {
+      Pair<AccessControlList, DefaultAccessControlList> aclPair = getAcl(path);
+
+      if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
         return Fingerprint.create(getUnderFSType(), status).serialize();
       } else {
-        return Fingerprint.create(getUnderFSType(), status, acl).serialize();
+        return Fingerprint.create(getUnderFSType(), status, aclPair.getFirst()).serialize();
       }
 
     } catch (Exception e) {

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
@@ -80,12 +81,12 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
     return null;
   }
 
   @Override
-  public void setAcl(String path, AccessControlList acl) throws IOException{
+  public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException{
     // Noop here by default
   }
 
@@ -94,7 +95,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
     // TODO (yuzhu): include default ACL in the fingerprint
     try {
       UfsStatus status = getStatus(path);
-      Pair<AccessControlList, DefaultAccessControlList> aclPair = getAcl(path);
+      Pair<AccessControlList, DefaultAccessControlList> aclPair = getAclPair(path);
 
       if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
         return Fingerprint.create(getUnderFSType(), status).serialize();

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -15,7 +15,9 @@ import alluxio.AlluxioURI;
 import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.annotation.PublicApi;
+import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
@@ -261,13 +263,14 @@ public interface UnderFileSystem extends Closeable {
   boolean exists(String path) throws IOException;
 
   /**
-   * Gets the access control list of a file or directory in under file system.
+   * Gets the ACL and the Default ACL of a file or directory in under file system.
    *
    * @param path the path to the file or directory
-   * @return the access control list, or null if ACL is unsupported or disabled
+   * @return the access control list, along with a Default ACL if it is a directory
+   *         return null if ACL is unsupported or disabled
    * @throws IOException if ACL is supported and enabled but cannot be retrieved
    */
-  AccessControlList getAcl(String path) throws IOException;
+  Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException;
 
   /**
    * Gets the block size of a file in under file system, in bytes.

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.annotation.PublicApi;
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
@@ -270,7 +271,7 @@ public interface UnderFileSystem extends Closeable {
    *         return null if ACL is unsupported or disabled
    * @throws IOException if ACL is supported and enabled but cannot be retrieved
    */
-  Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException;
+  Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException;
 
   /**
    * Gets the block size of a file in under file system, in bytes.
@@ -519,11 +520,12 @@ public interface UnderFileSystem extends Closeable {
   /**
    * Sets the access control list of a file or directory in under file system.
    * if the ufs does not support acls, this is a noop.
+   * This will overwrite the ACL and defaultACL in the UFS.
    *
    * @param path the path to the file or directory
-   * @param acl the access control list
+   * @param aclEntries the access control list + default acl represented in a list of acl entries
    */
-  void setAcl(String path, AccessControlList acl) throws IOException;
+  void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException;
 
   /**
    * Changes posix file mode.

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -565,7 +565,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
 
       @Override
       public String toString() {
-        return String.format("SetAcl: path=%s, ACL=%s", path, aclEntries);
+        return String.format("SetAcl: path=%s, ACLEntries=%s", path, aclEntries);
       }
     });
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -20,6 +20,7 @@ import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
 import alluxio.security.authentication.AuthenticatedClientUser;
+import alluxio.security.authorization.AclEntry;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
@@ -207,11 +208,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public AccessControlList getAcl(String path) throws IOException, UnimplementedException {
+  public AccessControlList getAclPair(String path) throws IOException, UnimplementedException {
     return call(new UfsCallable<AccessControlList>() {
       @Override
       public AccessControlList call() throws IOException {
-        return mUnderFileSystem.getAcl(path);
+        return mUnderFileSystem.getAclPair(path);
       }
 
       @Override
@@ -551,17 +552,17 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public void setAcl(String path, AccessControlList acl) throws IOException {
+  public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
     call(new UfsCallable<Void>() {
       @Override
       public Void call() throws IOException {
-        mUnderFileSystem.setAcl(path, acl);
+        mUnderFileSystem.setAclEntries(path, aclEntries);
         return null;
       }
 
       @Override
       public String toString() {
-        return String.format("SetAcl: path=%s, ACL=%s", path, acl);
+        return String.format("SetAcl: path=%s, ACL=%s", path, aclEntries);
       }
     });
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -13,6 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.collections.Pair;
 import alluxio.exception.status.UnimplementedException;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.metrics.CommonMetrics;
@@ -21,6 +22,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
@@ -208,10 +210,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public AccessControlList getAclPair(String path) throws IOException, UnimplementedException {
-    return call(new UfsCallable<AccessControlList>() {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path)
+      throws IOException, UnimplementedException {
+    return call(new UfsCallable<Pair<AccessControlList, DefaultAccessControlList>>() {
       @Override
-      public AccessControlList call() throws IOException {
+      public Pair<AccessControlList, DefaultAccessControlList> call() throws IOException {
         return mUnderFileSystem.getAclPair(path);
       }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2311,7 +2311,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       ufsLength = ufsStatus.getContentLength();
 
       if (isAclEnabled()) {
-        Pair<AccessControlList, DefaultAccessControlList> aclPair = ufs.getAcl(ufsUri.toString());
+        Pair<AccessControlList, DefaultAccessControlList> aclPair = ufs.getAclPair(ufsUri.toString());
         if (aclPair != null) {
           acl = aclPair.getFirst();
           // DefaultACL should be null, because it is a file
@@ -2403,7 +2403,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         ufsStatus = ufs.getDirectoryStatus(ufsUri.toString());
       }
       Pair<AccessControlList, DefaultAccessControlList> aclPair =
-          ufs.getAcl(ufsUri.toString());
+          ufs.getAclPair(ufsUri.toString());
       if (aclPair != null) {
         acl = aclPair.getFirst();
         defaultAcl = aclPair.getSecond();
@@ -2727,11 +2727,12 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             + "UFS: " + ufsUri + ". This has no effect on the underlying object.");
       } else {
         try {
-          ufs.setAcl(ufsUri, inode.getACL());
+          List<AclEntry> entries = inode.getACL().getEntries();
           if (inode.isDirectory()) {
             InodeDirectoryView inodeDirectory = (InodeDirectoryView) inode;
-            ufs.setAcl(ufsUri, inodeDirectory.getDefaultACL());
+            entries.addAll(inodeDirectory.getDefaultACL().getEntries());
           }
+          ufs.setAclEntries(ufsUri, entries);
         } catch (IOException e) {
           throw new AccessControlException("Could not setAcl for UFS file: " + ufsUri);
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2317,7 +2317,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       ufsLength = ufsStatus.getContentLength();
 
       if (isAclEnabled()) {
-        Pair<AccessControlList, DefaultAccessControlList> aclPair = ufs.getAclPair(ufsUri.toString());
+        Pair<AccessControlList, DefaultAccessControlList> aclPair
+            = ufs.getAclPair(ufsUri.toString());
         if (aclPair != null) {
           acl = aclPair.getFirst();
           // DefaultACL should be null, because it is a file
@@ -2476,7 +2477,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       try {
         loadMetadataInternal(rpcContext, inodePath, options);
       } catch (IOException | InvalidPathException | FileDoesNotExistException | BlockInfoException
-          | FileAlreadyCompletedException | InvalidFileSizeException |AccessControlException e) {
+          | FileAlreadyCompletedException | InvalidFileSizeException | AccessControlException e) {
         // NOTE, this may be expected when client tries to get info (e.g. exists()) for a file
         // existing neither in Alluxio nor UFS.
         LOG.debug("Failed to load metadata for path from UFS: {}", inodePath.getUri());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -815,6 +815,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       } else {
         checkLoadMetadataOptions(listStatusOptions.getLoadMetadataType(), inodePath.getUri());
       }
+
       loadMetadataIfNotExist(rpcContext, inodePath, loadMetadataOptions);
       ensureFullPathAndUpdateCache(inodePath);
       inode = inodePath.getInode();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2735,7 +2735,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             + "UFS: " + ufsUri + ". This has no effect on the underlying object.");
       } else {
         try {
-          List<AclEntry> entries = inode.getACL().getEntries();
+          List<AclEntry> entries = new ArrayList<>();
+          entries.addAll(inode.getACL().getEntries());
           if (inode.isDirectory()) {
             InodeDirectoryView inodeDirectory = (InodeDirectoryView) inode;
             entries.addAll(inodeDirectory.getDefaultACL().getEntries());

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -415,6 +415,9 @@ public abstract class Inode<T> implements InodeView {
    * @return the updated object
    */
   public T setAcl(List<AclEntry> entries) {
+    if (entries == null || entries.isEmpty()) {
+      return getThis();
+    }
     for (AclEntry entry : entries) {
       if (entry.isDefault()) {
         getDefaultACL().setEntry(entry);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -402,6 +402,7 @@ public abstract class Inode<T> implements InodeView {
   /**
    * @param acl set the default ACL associated with this inode
    * @throws UnsupportedOperationException if the inode is a file
+   * @return the updated object
    */
   public abstract T setDefaultACL(DefaultAccessControlList acl)
       throws UnsupportedOperationException;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -403,7 +403,7 @@ public abstract class Inode<T> implements InodeView {
    * @param acl set the default ACL associated with this inode
    * @throws UnsupportedOperationException if the inode is a file
    */
-  public abstract void setDefaultACL(DefaultAccessControlList acl)
+  public abstract T setDefaultACL(DefaultAccessControlList acl)
       throws UnsupportedOperationException;
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectory.java
@@ -216,8 +216,9 @@ public final class InodeDirectory extends Inode<InodeDirectory> implements Inode
   }
 
   @Override
-  public void setDefaultACL(DefaultAccessControlList acl) {
+  public InodeDirectory setDefaultACL(DefaultAccessControlList acl) {
     mDefaultAcl = acl;
+    return getThis();
   }
 
   /**
@@ -336,6 +337,8 @@ public final class InodeDirectory extends Inode<InodeDirectory> implements Inode
         .setGroup(options.getGroup())
         .setMode(options.getMode().toShort())
         .setAcl(options.getAcl())
+        // SetAcl call is also setting default AclEntries
+        .setAcl(options.getDefaultAcl())
         .setMountPoint(options.isMountPoint());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -109,7 +109,7 @@ public final class InodeFile extends Inode<InodeFile> implements InodeFileView {
   }
 
   @Override
-  public void setDefaultACL(DefaultAccessControlList acl) throws UnsupportedOperationException {
+  public InodeFile setDefaultACL(DefaultAccessControlList acl) throws UnsupportedOperationException {
     throw new UnsupportedOperationException("setDefaultACL: File does not have default ACL");
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -109,7 +109,8 @@ public final class InodeFile extends Inode<InodeFile> implements InodeFileView {
   }
 
   @Override
-  public InodeFile setDefaultACL(DefaultAccessControlList acl) throws UnsupportedOperationException {
+  public InodeFile setDefaultACL(DefaultAccessControlList acl)
+      throws UnsupportedOperationException {
     throw new UnsupportedOperationException("setDefaultACL: File does not have default ACL");
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -666,7 +666,9 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         newDir.setPinned(currentInodeDirectory.isPinned());
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
-        // and access acl, take into account of the directory's initial mode (umask)
+        // and access acl, ANDed with the umask
+        // if it is part of a metadata load operation, we ignore the umask and simply inherit
+        // the default ACL as the directory's new default and access ACL
         short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
             : newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
@@ -765,8 +767,9 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         extensibleInodePath.getLockList().lockWriteAndCheckNameAndParent(newDir,
             currentInodeDirectory, name);
 
-        // if the parent has default ACL, copy that default ACL as the new directory's default
-        // and access acl, taking into account the creation umask of the dir.
+        // if the parent has default ACL, take the default ACL ANDed with the umask as the new
+        // directory's default and access acl
+        // WHen it is a metadata load operation, do not take the umask into account
         short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
             : newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
@@ -805,7 +808,9 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         extensibleInodePath.getLockList().lockWriteAndCheckNameAndParent(newFile,
             currentInodeDirectory, name);
 
-        // if the parent has a default ACL, copy that default ACL as the new file's access ACL.
+        // if the parent has a default ACL, copy that default ACL ANDed with the umask as the new
+        // file's access ACL.
+        // If it is a metadata load operation, do not consider the umask.
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
             : newFile.getMode();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -667,7 +667,8 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
         // and access acl, take into account of the directory's initial mode (umask)
-        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() : newDir.getMode();
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
+            : newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
           Pair<AccessControlList, DefaultAccessControlList> pair =
@@ -766,7 +767,8 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
         // and access acl, taking into account the creation umask of the dir.
-        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() :newDir.getMode();
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
+            : newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
           Pair<AccessControlList, DefaultAccessControlList> pair =
@@ -805,7 +807,8 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has a default ACL, copy that default ACL as the new file's access ACL.
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
-        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() : newFile.getMode();
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort()
+            : newFile.getMode();
         if (!dAcl.isEmpty()) {
           AccessControlList acl = dAcl.generateChildFileACL(mode);
           newFile.setInternalAcl(acl);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -667,13 +667,11 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
         // and access acl.
-        if (!options.isMetadataLoad()) {
-          DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
-          if (!dAcl.isEmpty()) {
-            Pair<AccessControlList, DefaultAccessControlList> pair = dAcl.generateChildDirACL();
-            newDir.setInternalAcl(pair.getFirst());
-            newDir.setDefaultACL(pair.getSecond());
-          }
+        DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
+        if (!dAcl.isEmpty()) {
+          Pair<AccessControlList, DefaultAccessControlList> pair = dAcl.generateChildDirACL();
+          newDir.setInternalAcl(pair.getFirst());
+          newDir.setDefaultACL(pair.getSecond());
         }
 
         if (mState.applyAndJournal(rpcContext, newDir)) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -666,10 +666,11 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         newDir.setPinned(currentInodeDirectory.isPinned());
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
-        // and access acl.
+        // and access acl, take into account of the directory's initial mode (umask)
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
-          Pair<AccessControlList, DefaultAccessControlList> pair = dAcl.generateChildDirACL();
+          Pair<AccessControlList, DefaultAccessControlList> pair =
+              dAcl.generateChildDirACL(newDir.getMode());
           newDir.setInternalAcl(pair.getFirst());
           newDir.setDefaultACL(pair.getSecond());
         }
@@ -766,7 +767,8 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         // and access acl.
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
-          Pair<AccessControlList, DefaultAccessControlList> pair = dAcl.generateChildDirACL();
+          Pair<AccessControlList, DefaultAccessControlList> pair =
+              dAcl.generateChildDirACL(newDir.getMode());
           newDir.setInternalAcl(pair.getFirst());
           newDir.setDefaultACL(pair.getSecond());
         }
@@ -802,7 +804,7 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         // if the parent has a default ACL, copy that default ACL as the new file's access ACL.
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
-          AccessControlList acl = dAcl.generateChildFileACL();
+          AccessControlList acl = dAcl.generateChildFileACL(newFile.getMode());
           newFile.setInternalAcl(acl);
         }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -667,10 +667,11 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
         // and access acl, take into account of the directory's initial mode (umask)
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() : newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
           Pair<AccessControlList, DefaultAccessControlList> pair =
-              dAcl.generateChildDirACL(newDir.getMode());
+              dAcl.generateChildDirACL(mode);
           newDir.setInternalAcl(pair.getFirst());
           newDir.setDefaultACL(pair.getSecond());
         }
@@ -764,11 +765,12 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
             currentInodeDirectory, name);
 
         // if the parent has default ACL, copy that default ACL as the new directory's default
-        // and access acl.
+        // and access acl, taking into account the creation umask of the dir.
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() :newDir.getMode();
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
         if (!dAcl.isEmpty()) {
           Pair<AccessControlList, DefaultAccessControlList> pair =
-              dAcl.generateChildDirACL(newDir.getMode());
+              dAcl.generateChildDirACL(mode);
           newDir.setInternalAcl(pair.getFirst());
           newDir.setDefaultACL(pair.getSecond());
         }
@@ -803,8 +805,9 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
 
         // if the parent has a default ACL, copy that default ACL as the new file's access ACL.
         DefaultAccessControlList dAcl = currentInodeDirectory.getDefaultACL();
+        short mode = options.isMetadataLoad() ? Mode.createFullAccess().toShort() : newFile.getMode();
         if (!dAcl.isEmpty()) {
-          AccessControlList acl = dAcl.generateChildFileACL(newFile.getMode());
+          AccessControlList acl = dAcl.generateChildFileACL(mode);
           newFile.setInternalAcl(acl);
         }
 

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.options;
 
 import alluxio.security.authorization.AclEntry;
-import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.thrift.CreateDirectoryTOptions;
 import alluxio.underfs.UfsStatus;
@@ -86,10 +85,18 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     return mAllowExists;
   }
 
+  /**
+   * @return the default ACL in the form of a list of default ACL Entries
+   */
   public List<AclEntry> getDefaultAcl() {
     return mDefaultAcl;
   }
 
+  /**
+   * Sets the default ACL in the option.
+   * @param defaultAcl a list of default ACL Entries
+   * @return the updated options object
+   */
   public CreateDirectoryOptions setDefaultAcl(List<AclEntry> defaultAcl) {
     mDefaultAcl = ImmutableList.copyOf(defaultAcl);
     return getThis();
@@ -152,6 +159,4 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     return toStringHelper().add("allowExists", mAllowExists)
         .add("ufsStatus", mUfsStatus).toString();
   }
-
-
 }

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -74,6 +75,7 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     mAllowExists = false;
     mMode.applyDirectoryUMask();
     mUfsStatus = null;
+    mDefaultAcl = Collections.emptyList();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.file.options;
 
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.thrift.CreateDirectoryTOptions;
 import alluxio.underfs.UfsStatus;
@@ -18,8 +20,10 @@ import alluxio.util.SecurityUtils;
 import alluxio.wire.CommonOptions;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.List;
 
 /**
  * Method options for creating a directory.
@@ -28,6 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirectoryOptions> {
   private boolean mAllowExists;
   private UfsStatus mUfsStatus;
+  private List<AclEntry> mDefaultAcl;
 
   /**
    * @return the default {@link CreateDirectoryOptions}
@@ -77,6 +82,15 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
    */
   public boolean isAllowExists() {
     return mAllowExists;
+  }
+
+  public List<AclEntry> getDefaultAcl() {
+    return mDefaultAcl;
+  }
+
+  public CreateDirectoryOptions setDefaultAcl(List<AclEntry> defaultAcl) {
+    mDefaultAcl = ImmutableList.copyOf(defaultAcl);
+    return getThis();
   }
 
   /**
@@ -136,4 +150,6 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     return toStringHelper().add("allowExists", mAllowExists)
         .add("ufsStatus", mUfsStatus).toString();
   }
+
+
 }

--- a/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/CreateDirectoryOptions.java
@@ -146,17 +146,19 @@ public final class CreateDirectoryOptions extends CreatePathOptions<CreateDirect
     }
     CreateDirectoryOptions that = (CreateDirectoryOptions) o;
     return Objects.equal(mAllowExists, that.mAllowExists)
-        && Objects.equal(mUfsStatus, that.mUfsStatus);
+        && Objects.equal(mUfsStatus, that.mUfsStatus)
+        && Objects.equal(mDefaultAcl, that.mDefaultAcl);
   }
 
   @Override
   public int hashCode() {
-    return super.hashCode() + Objects.hashCode(mAllowExists, mUfsStatus);
+    return super.hashCode() + Objects.hashCode(mAllowExists, mUfsStatus, mDefaultAcl);
   }
 
   @Override
   public String toString() {
     return toStringHelper().add("allowExists", mAllowExists)
-        .add("ufsStatus", mUfsStatus).toString();
+        .add("ufsStatus", mUfsStatus)
+        .add("defaultAcl", mDefaultAcl).toString();
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -2470,7 +2470,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.loadMetadata(uri,
         LoadMetadataOptions.defaults().setCreateAncestors(true));
     FileInfo info = mFileSystemMaster.getFileInfo(uri, GetStatusOptions.defaults());
-    Assert.assertTrue(info.convertAclToStringEntries().contains("user::rw-"));
+    Assert.assertTrue(info.convertAclToStringEntries().contains("user::r-x"));
 
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -245,7 +245,7 @@ public final class InodeTreeTest {
    * Tests the createPath method, specifically for ACLs and default ACLs.
    */
   @Test
-  public void createPathAclTest() throws Exception {
+  public void createPathNonExtendedAclTest() throws Exception {
     CreateDirectoryOptions dirOptions = CreateDirectoryOptions.defaults().setOwner(TEST_OWNER)
         .setGroup(TEST_GROUP).setMode(TEST_DIR_MODE).setRecursive(true);
     // create nested directory
@@ -299,6 +299,59 @@ public final class InodeTreeTest {
           .collect(Collectors.toList()), dAcl.toStringEntries());
     }
 
+  }
+
+  /**
+   * Tests the createPath method, specifically for ACLs and default ACLs.
+   */
+  @Test
+  public void createPathExtendedAclTest() throws Exception {
+    CreateDirectoryOptions dirOptions = CreateDirectoryOptions.defaults().setOwner(TEST_OWNER)
+        .setGroup(TEST_GROUP).setMode(TEST_DIR_MODE).setRecursive(true);
+    // create nested directory /nested/test
+    InodeTree.CreatePathResult createResult = createPath(mTree, NESTED_URI, dirOptions);
+    List<InodeView> created = createResult.getCreated();
+    // 2 created directories
+    assertEquals(2, created.size());
+    assertEquals("nested", created.get(0).getName());
+    assertEquals("test", created.get(1).getName());
+
+    ((Inode<?>) created.get(1)).setAcl(Arrays.asList(
+        (AclEntry.fromCliString("default:user:testuser:r-x"))));
+    DefaultAccessControlList dAcl = ((InodeDirectory) created.get(1)).getDefaultACL();
+
+    // create nested directory
+    createResult = createPath(mTree, NESTED_DIR_URI, dirOptions);
+    created = createResult.getCreated();
+    // the new directory should have the same ACL as its parent
+    // 1 created directories
+    assertEquals(1, created.size());
+    assertEquals("dir", created.get(0).getName());
+    DefaultAccessControlList childDefaultAcl =  created.get(0).getDefaultACL();
+    AccessControlList childAcl = created.get(0).getACL();
+    assertEquals(dAcl, childDefaultAcl);
+
+    assertEquals(childAcl.toStringEntries().stream().map(AclEntry::toDefault)
+        .collect(Collectors.toList()), dAcl.toStringEntries());
+    // create nested file
+    CreateFileOptions fileOptions = CreateFileOptions.defaults()
+        .setOwner(TEST_OWNER).setGroup(TEST_GROUP).setMode(TEST_FILE_MODE)
+        .setRecursive(true);
+    createResult = createPath(mTree, NESTED_FILE_URI, fileOptions);
+    created = createResult.getCreated();
+    // the new file should have the same ACL as its parent's default ACL
+    // 1 created file
+    assertEquals(1, created.size());
+    assertEquals("file", created.get(0).getName());
+    childAcl = created.get(0).getACL();
+    // Because default mode for file is 644, the file's permission is not going to match default
+    // Acl's permission, but rather have all the execute permissions removed.
+    dAcl.setEntry(AclEntry.fromCliString("default:user::rw-"));
+    dAcl.setEntry(AclEntry.fromCliString("default:other::r--"));
+    dAcl.setEntry(AclEntry.fromCliString("default:mask::r--"));
+    assertEquals(dAcl.toStringEntries(),
+        childAcl.toStringEntries().stream().map(AclEntry::toDefault)
+        .collect(Collectors.toList()));
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
@@ -36,6 +36,8 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
       = Arrays.asList("user::rw-", "group::r--", "other::r--");
   private static final List<String> DIR_FACL_STRING_ENTRIES
       = Arrays.asList("user::rwx", "group::r-x", "other::r-x");
+  private static final List<String> FILE_FACL_STRING_ENTRIES
+      = Arrays.asList("user::rw-", "group::r-x", "other::r--");
   private static final List<String> DEFAULT_FACL_STRING_ENTRIES
       = Arrays.asList("default:user::rwx", "default:group::r-x", "default:other::r-x");
 
@@ -106,7 +108,7 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     mFsShell.run("getfacl", "/testRoot/testDir/testDir2");
     stringEntries = new ArrayList<>(DIR_FACL_STRING_ENTRIES);
     stringEntries.add("user:testuser:rwx");
-    stringEntries.add("mask::rwx");
+    stringEntries.add("mask::r-x");
     stringEntries.addAll(DEFAULT_FACL_STRING_ENTRIES);
     stringEntries.add("default:user:testuser:rwx");
     stringEntries.add("default:mask::rwx");
@@ -116,9 +118,9 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     Assert.assertEquals(expected, mOutput.toString());
 
     mFsShell.run("getfacl", "/testRoot/testDir/testDir2/testFileD");
-    stringEntries = new ArrayList<>(DIR_FACL_STRING_ENTRIES);
+    stringEntries = new ArrayList<>(FILE_FACL_STRING_ENTRIES);
     stringEntries.add("user:testuser:rwx");
-    stringEntries.add("mask::rwx");
+    stringEntries.add("mask::r--");
     expected += getFaclResultStr(testOwner, testOwner,
         "/testRoot/testDir/testDir2/testFileD", stringEntries);
     Assert.assertEquals(expected, mOutput.toString());

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -12,7 +12,10 @@
 package alluxio.testutils.underfs.delegating;
 
 import alluxio.AlluxioURI;
+import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.UfsDirectoryStatus;
 import alluxio.underfs.UfsFileStatus;
 import alluxio.underfs.UfsStatus;
@@ -89,8 +92,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public AccessControlList getAcl(String path) throws IOException {
-    return mUfs.getAcl(path);
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
+    return mUfs.getAclPair(path);
   }
 
   @Override
@@ -215,8 +218,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public void setAcl(String path, AccessControlList acl) throws IOException {
-    mUfs.setAcl(path, acl);
+  public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
+    mUfs.setAclEntries(path, aclEntries);
   }
 
   @Override

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -92,7 +92,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path)
+      throws IOException {
     return mUfs.getAclPair(path);
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
@@ -14,10 +14,12 @@ package alluxio.underfs.hdfs;
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
 
+import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -42,8 +44,9 @@ public interface HdfsAclProvider {
    *
    * @param hdfs the HDFS client
    * @param path the path to set the ACL for
-   * @param acl the {@link AccessControlList} representation
+   * @param aclEntries list of AclEntries, could be a representation of {@link AccessControlList}
+   *                   or {@link DefaultAccessControlList}
    * @throws IOException if ACL can not be set
    */
-  void setAcl(FileSystem hdfs, String path, AccessControlList acl) throws IOException;
+  void setAclEntries(FileSystem hdfs, String path, List<AclEntry> aclEntries) throws IOException;
 }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
@@ -32,7 +32,9 @@ public interface HdfsAclProvider {
    *
    * @param hdfs the HDFS client
    * @param path the path to retrieve the ACL for
-   * @return the {@link AccessControlList} representation, or null if ACL is unsupported/disabled
+   * @return a Pair object containing the {@link AccessControlList} representation and
+   *         the  {@link DefaultAccessControlList} representation or null if ACL is
+   *         unsupported/disabled
    * @throws IOException if ACL is supported but cannot be retrieved
    */
   @Nullable
@@ -40,10 +42,10 @@ public interface HdfsAclProvider {
       throws IOException;
 
   /**
-   * Sets the ACL for an hdfs path.
+   * Sets the ACL and default ACL for an hdfs path using ACL entries.
    *
    * @param hdfs the HDFS client
-   * @param path the path to set the ACL for
+   * @param path the path to set the ACL entries for
    * @param aclEntries list of AclEntries, could be a representation of {@link AccessControlList}
    *                   or {@link DefaultAccessControlList}
    * @throws IOException if ACL can not be set

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
@@ -11,8 +11,10 @@
 
 package alluxio.underfs.hdfs;
 
+import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
 
+import alluxio.security.authorization.DefaultAccessControlList;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
@@ -32,7 +34,8 @@ public interface HdfsAclProvider {
    * @throws IOException if ACL is supported but cannot be retrieved
    */
   @Nullable
-  AccessControlList getAcl(FileSystem hdfs, String path) throws IOException;
+  Pair<AccessControlList, DefaultAccessControlList> getAcl(FileSystem hdfs, String path)
+      throws IOException;
 
   /**
    * Sets the ACL for an hdfs path.

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsAclProvider.java
@@ -13,9 +13,9 @@ package alluxio.underfs.hdfs;
 
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
-
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
+
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -14,9 +14,11 @@ package alluxio.underfs.hdfs;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.PropertyKey;
+import alluxio.collections.Pair;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.AtomicFileOutputStream;
 import alluxio.underfs.AtomicFileOutputStreamCallback;
 import alluxio.underfs.BaseUnderFileSystem;
@@ -244,7 +246,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
   }
 
   @Override
-  public AccessControlList getAcl(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException {
     return mHdfsAclProvider.getAcl(getFs(), path);
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -18,6 +18,7 @@ import alluxio.collections.Pair;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authorization.AccessControlList;
+import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.AtomicFileOutputStream;
 import alluxio.underfs.AtomicFileOutputStreamCallback;
@@ -246,13 +247,13 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
   }
 
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAcl(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
     return mHdfsAclProvider.getAcl(getFs(), path);
   }
 
   @Override
-  public void setAcl(String path, AccessControlList acl) throws IOException {
-    mHdfsAclProvider.setAcl(getFs(), path, acl);
+  public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
+    mHdfsAclProvider.setAclEntries(getFs(), path, aclEntries);
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -253,7 +254,9 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
 
   @Override
   public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
+    LOG.info("setAclEntry {}", path);
     mHdfsAclProvider.setAclEntries(getFs(), path, aclEntries);
+    LOG.info("setAclEntry over {}", path);
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -254,9 +254,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
 
   @Override
   public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
-    LOG.info("setAclEntry {}", path);
     mHdfsAclProvider.setAclEntries(getFs(), path, aclEntries);
-    LOG.info("setAclEntry over {}", path);
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -59,7 +59,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +247,8 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
   }
 
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path)
+      throws IOException {
     return mHdfsAclProvider.getAcl(getFs(), path);
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
@@ -13,9 +13,9 @@ package alluxio.underfs.hdfs;
 
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
-
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
+
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
@@ -26,12 +26,14 @@ import java.util.List;
  */
 public class NoopHdfsAclProvider implements HdfsAclProvider {
   @Override
-  public Pair<AccessControlList, DefaultAccessControlList> getAcl(FileSystem hdfs, String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAcl(FileSystem hdfs, String path)
+      throws IOException {
     return null;
   }
 
   @Override
-  public void setAclEntries(FileSystem hdfs, String path, List<AclEntry> aclEntries) throws IOException {
+  public void setAclEntries(FileSystem hdfs, String path, List<AclEntry> aclEntries)
+      throws IOException {
     // Noop for setAclEntries
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
@@ -11,8 +11,10 @@
 
 package alluxio.underfs.hdfs;
 
+import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
 
+import alluxio.security.authorization.DefaultAccessControlList;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
@@ -22,7 +24,7 @@ import java.io.IOException;
  */
 public class NoopHdfsAclProvider implements HdfsAclProvider {
   @Override
-  public AccessControlList getAcl(FileSystem hdfs, String path) throws IOException {
+  public Pair<AccessControlList, DefaultAccessControlList> getAcl(FileSystem hdfs, String path) throws IOException {
     return null;
   }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
@@ -14,10 +14,12 @@ package alluxio.underfs.hdfs;
 import alluxio.collections.Pair;
 import alluxio.security.authorization.AccessControlList;
 
+import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import org.apache.hadoop.fs.FileSystem;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The noop HDFS ACL provider.
@@ -29,8 +31,8 @@ public class NoopHdfsAclProvider implements HdfsAclProvider {
   }
 
   @Override
-  public void setAcl(FileSystem hdfs, String path, AccessControlList acl) throws IOException {
-    // Noop for setAcl
+  public void setAclEntries(FileSystem hdfs, String path, List<AclEntry> aclEntries) throws IOException {
+    // Noop for setAclEntries
   }
 
 }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/acl/SupportedHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/acl/SupportedHdfsAclProvider.java
@@ -89,11 +89,12 @@ public class SupportedHdfsAclProvider implements HdfsAclProvider {
   }
 
   @Override
-  public void setAcl(FileSystem hdfs, String path, AccessControlList acl) throws IOException {
+  public void setAclEntries(FileSystem hdfs, String path,
+      List<alluxio.security.authorization.AclEntry> aclEntries) throws IOException {
     // convert AccessControlList into hdfsAcl
     List<AclEntry> aclSpecs = new ArrayList<>();
 
-    for (alluxio.security.authorization.AclEntry entry : acl.getEntries()) {
+    for (alluxio.security.authorization.AclEntry entry : aclEntries) {
       AclEntry hdfsAclEntry = getHdfsAclEntry(entry);
       aclSpecs.add(hdfsAclEntry);
     }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/acl/SupportedHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/acl/SupportedHdfsAclProvider.java
@@ -64,7 +64,7 @@ public class SupportedHdfsAclProvider implements HdfsAclProvider {
       alluxio.security.authorization.AclEntry.Builder builder =
           new alluxio.security.authorization.AclEntry.Builder();
       builder.setType(getAclEntryType(entry));
-      builder.setSubject(entry.getName());
+      builder.setSubject(entry.getName() == null ? "" : entry.getName());
       FsAction permission = entry.getPermission();
       if (permission.implies(FsAction.READ)) {
         builder.addAction(AclAction.READ);
@@ -152,10 +152,12 @@ public class SupportedHdfsAclProvider implements HdfsAclProvider {
       throws IOException {
     switch (entry.getType()) {
       case USER:
-        return entry.getName().isEmpty() ? alluxio.security.authorization.AclEntryType.OWNING_USER
+        return entry.getName() == null || entry.getName().isEmpty()
+            ? alluxio.security.authorization.AclEntryType.OWNING_USER
             : alluxio.security.authorization.AclEntryType.NAMED_USER;
       case GROUP:
-        return entry.getName().isEmpty() ? alluxio.security.authorization.AclEntryType.OWNING_GROUP
+        return entry.getName() == null || entry.getName().isEmpty()
+            ? alluxio.security.authorization.AclEntryType.OWNING_GROUP
             : alluxio.security.authorization.AclEntryType.NAMED_GROUP;
       case MASK:
         return alluxio.security.authorization.AclEntryType.MASK;


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3305

This PR fixes issues uncovered during testing. 
1. ls failed to load files when acl profile is turned on (due to a masked exception) 
2. ACL inheritance should also respect the umask. Basically the inherited acl should not violate any umask and be an AND result with the umask. 