### PR TITLE
[DOCFIX] - accidentally escaped angled brackets and fixing compile from source instructions

### DIFF
--- a/docs/en/Building-Alluxio-From-Source.md
+++ b/docs/en/Building-Alluxio-From-Source.md
@@ -55,7 +55,7 @@ $ export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
 The Maven build system fetches its dependencies, compiles source code, runs unit tests, and packages the system. If this is the first time you are building the project, it can take a while to download all the dependencies. Subsequent builds, however, will be much faster.
 
-### Test 
+### Test
 
 Once Alluxio is built, you can validate and start it with:
 

--- a/docs/en/Building-Alluxio-From-Source.md
+++ b/docs/en/Building-Alluxio-From-Source.md
@@ -13,7 +13,7 @@ priority: 1
 
 This guide describes how to compile Alluxio from the beginning.
 
-The prerequisite for this guide is that you have [Java 8 or later](Java-Setup.html), [Maven 3.3.9 or later](Maven.html) installed.
+The prerequisite for this guide is that you must have [Java 8](Java-Setup.html) and [Maven 3.3.9 or later](Maven.html) installed.
 
 ### Checkout Source Code
 
@@ -55,14 +55,16 @@ $ export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
 The Maven build system fetches its dependencies, compiles source code, runs unit tests, and packages the system. If this is the first time you are building the project, it can take a while to download all the dependencies. Subsequent builds, however, will be much faster.
 
-### Test
+### Test 
 
-Once Alluxio is built, you can start it with:
+Once Alluxio is built, you can validate and start it with:
 
 ```bash
-$ echo "alluxio.master.hostname=localhost" > conf/alluxio-site.properties
+$ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
+$ echo "alluxio.master.hostname=localhost" >> conf/alluxio-site.properties
+$ ./bin/alluxio validateEnv local
 $ ./bin/alluxio format
-$ ./bin/alluxio-start.sh local
+$ ./bin/alluxio-start.sh local SudoMount
 ```
 
 To verify that Alluxio is running, you can visit [http://localhost:19999](http://localhost:19999) or check the log in the `alluxio/logs` directory. You can also run a simple program:

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -93,8 +93,8 @@ $ echo "aws.accessKeyId=<AWS_ACCESS_KEY_ID>" >> conf/alluxio-site.properties
 $ echo "aws.secretKey=<AWS_SECRET_ACCESS_KEY>" >> conf/alluxio-site.properties
 ```
 
-You will have to replace **<AWS_ACCESS_KEY_ID>** with your AWS access key id, and
-**<AWS_SECRET_ACCESS_KEY>** with your AWS secret access key. Now, Alluxio is fully configured for
+You will have to replace **`<AWS_ACCESS_KEY_ID>`** with your AWS access key id, and
+**`<AWS_SECRET_ACCESS_KEY>`** with your AWS secret access key. Now, Alluxio is fully configured for
 the rest of this guide.
 
 ## Validating Alluxio environment
@@ -107,7 +107,7 @@ Alluxio configuration:
 $ ./bin/alluxio validateEnv local
 ```
 
-This will report potential problems that might prevent you from starting Alluxio services locally. If
+This will report potential problems that might prevent you from starting Alluxio services locally. If you're running it for the first time, you might see an error about underFSStorage. You can ignore that for now. If
 you configured Alluxio to run in a cluster and you want to validate environment on all nodes, you
 can run the following command instead:
 

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -107,8 +107,7 @@ Alluxio configuration:
 $ ./bin/alluxio validateEnv local
 ```
 
-This will report potential problems that might prevent you from starting Alluxio services locally. If you're running it for the first time, you might see an error about underFSStorage. You can ignore that for now. If
-you configured Alluxio to run in a cluster and you want to validate environment on all nodes, you
+This will report potential problems that might prevent you from starting Alluxio services locally. If you configured Alluxio to run in a cluster and you want to validate environment on all nodes, you
 can run the following command instead:
 
 ```bash


### PR DESCRIPTION
- There were a set of variables which were escaped because I believe jekyll thought they were HTML tags. I fixed that by adding preformatting outside of the angled brackets.

- The build from source instructions indicated java 8 or higher. I found that I could only build with java 8. Not 9 or 10.
- I also updated the steps to run the local version to match the same setup as what is in the quick start guide. The original steps did not work for me. However, the quick start instructions did.