### PR TITLE
[ALLUXIO-3293] Fix retry policy being invalid when reading local block from a crashed local worker (#7828)

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +144,8 @@ public final class AlluxioBlockStore {
    * Gets a stream to read the data of a block. This method is primarily responsible for
    * determining the data source and type of data source. The latest BlockInfo will be fetched
    * from the master to ensure the locations are up to date. It takes a map of failed workers and
-   * their most recently failed time and attempts to avoid reading from a recently failed worker.
+   * their most recently failed time and tries to update it when BlockInStream created failed,
+   * attempting to avoid reading from a recently failed worker.
    *
    * @param blockId the id of the block to read
    * @param options the options associated with the read request
@@ -212,7 +214,15 @@ public final class AlluxioBlockStore {
     if (dataSource == null) {
       throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
     }
-    return BlockInStream.create(mContext, info, dataSource, dataSourceType, options);
+
+    try {
+      return BlockInStream.create(mContext, info, dataSource, dataSourceType, options);
+    } catch (ConnectException e) {
+      //When BlockInStream created failed, it will update the passed-in failedWorkers
+      //to attempt to avoid reading from this failed worker in next try.
+      failedWorkers.put(dataSource, System.currentTimeMillis());
+      throw e;
+    }
   }
 
   private Set<WorkerNetAddress> handleFailedWorkers(Set<WorkerNetAddress> workers,

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -113,8 +113,8 @@ public class FileInStream extends InputStream implements BoundedStream, Position
     CountingRetry retry = new CountingRetry(MAX_WORKERS_TO_RETRY);
     IOException lastException = null;
     while (retry.attempt()) {
-      updateStream();
       try {
+        updateStream();
         int result = mBlockInStream.read();
         if (result != -1) {
           mPosition++;
@@ -122,8 +122,10 @@ public class FileInStream extends InputStream implements BoundedStream, Position
         return result;
       } catch (UnavailableException | DeadlineExceededException | ConnectException e) {
         lastException = e;
-        handleRetryableException(mBlockInStream, e);
-        mBlockInStream = null;
+        if (mBlockInStream != null) {
+          handleRetryableException(mBlockInStream, e);
+          mBlockInStream = null;
+        }
       }
     }
     throw lastException;
@@ -151,8 +153,8 @@ public class FileInStream extends InputStream implements BoundedStream, Position
     CountingRetry retry = new CountingRetry(MAX_WORKERS_TO_RETRY);
     IOException lastException = null;
     while (bytesLeft > 0 && mPosition != mLength && retry.attempt()) {
-      updateStream();
       try {
+        updateStream();
         int bytesRead = mBlockInStream.read(b, currentOffset, bytesLeft);
         if (bytesRead > 0) {
           bytesLeft -= bytesRead;
@@ -163,8 +165,10 @@ public class FileInStream extends InputStream implements BoundedStream, Position
         lastException = null;
       } catch (UnavailableException | ConnectException | DeadlineExceededException e) {
         lastException = e;
-        handleRetryableException(mBlockInStream, e);
-        mBlockInStream = null;
+        if (mBlockInStream != null) {
+          handleRetryableException(mBlockInStream, e);
+          mBlockInStream = null;
+        }
       }
     }
     if (lastException != null) {
@@ -214,8 +218,9 @@ public class FileInStream extends InputStream implements BoundedStream, Position
         break;
       }
       long blockId = mStatus.getBlockIds().get(Math.toIntExact(pos / mBlockSize));
-      BlockInStream stream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
+      BlockInStream stream = null;
       try {
+        stream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
         long offset = pos % mBlockSize;
         int bytesRead =
             stream.positionedRead(offset, b, off, (int) Math.min(mBlockSize - offset, len));
@@ -227,8 +232,10 @@ public class FileInStream extends InputStream implements BoundedStream, Position
         lastException = null;
       } catch (UnavailableException | DeadlineExceededException | ConnectException e) {
         lastException = e;
-        handleRetryableException(stream, e);
-        stream = null;
+        if (stream != null) {
+          handleRetryableException(stream, e);
+          stream = null;
+        }
       } finally {
         closeBlockInStream(stream);
       }

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -62,6 +62,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -336,6 +337,58 @@ public final class AlluxioBlockStoreTest {
         4, 1L);
     int expectedWorker = 2;
     testGetInStreamFallback(workerCount, persisted, blockLocations, failedWorkers, expectedWorker);
+  }
+
+  @Test
+  public void getInStreamInAlluxioWhenCreateStreamIsFailed() throws Exception {
+    int workerCount = 5;
+    boolean persisted = false;
+    int[] blockLocations = new int[]{2, 3, 4};
+    Map<Integer, Long> failedWorkers = ImmutableMap.of(
+            0, 3L,
+            1, 1L,
+            3, 2L);
+    int expectedWorker = 2;
+    WorkerNetAddress[] workers = new WorkerNetAddress[workerCount];
+    for (int i = 0; i < workers.length - 1; i++) {
+      workers[i] = new WorkerNetAddress().setHost(String.format("worker-%d", i));
+    }
+    workers[workers.length - 1] = new WorkerNetAddress().setHost(WORKER_HOSTNAME_LOCAL);
+    when(mContext.acquireNettyChannel(WORKER_NET_ADDRESS_LOCAL))
+        .thenThrow(new ConnectException("failed to connect to "
+            + WORKER_NET_ADDRESS_LOCAL.getHost()));
+    BlockInfo info = new BlockInfo().setBlockId(BLOCK_ID)
+        .setLocations(Arrays.stream(blockLocations).mapToObj(x ->
+            new BlockLocation().setWorkerAddress(workers[x])).collect(Collectors.toList()));
+    URIStatus dummyStatus =
+        new URIStatus(new FileInfo().setPersisted(persisted)
+            .setBlockIds(Collections.singletonList(BLOCK_ID))
+            .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
+    BlockLocationPolicy mockPolicy = mock(BlockLocationPolicy.class);
+    when(mockPolicy.getWorker(any())).thenAnswer(arg -> arg
+        .getArgumentAt(0, GetWorkerOptions.class).getBlockWorkerInfos().iterator().next()
+        .getNetAddress());
+    OpenFileOptions readOptions =
+        OpenFileOptions.defaults().setUfsReadLocationPolicy(mockPolicy);
+    InStreamOptions options = new InStreamOptions(dummyStatus, readOptions);
+    when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
+    when(mMasterClient.getWorkerInfoList()).thenReturn(Arrays.stream(workers)
+        .map(x -> new WorkerInfo().setAddress(x)).collect((Collectors.toList())));
+    Map<WorkerNetAddress, Long> failedWorkerAddresses = failedWorkers.entrySet().stream()
+        .map(x -> new AbstractMap.SimpleImmutableEntry<>(workers[x.getKey()], x.getValue()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    BlockInStream inStream = null;
+    int i = 2;
+    while (i-- > 0) {
+      try {
+        inStream = mBlockStore.getInStream(BLOCK_ID, options,
+                failedWorkerAddresses);
+      } catch (Exception e) {
+        //do nothing
+      }
+    }
+    assertEquals(workers[expectedWorker], inStream.getAddress());
   }
 
   private void testGetInStreamFallback(int workerCount, boolean isPersisted, int[] blockLocations,


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3293

Cherry-pick from master branch 

* Fix retry policy being invalid when reading local block from a crashed local worker

* move updatestream to try