### PR TITLE
[SMALLFIX] - Quote formatted paths in path exceptions (#7833)

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -25,12 +25,12 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public enum ExceptionMessage {
   // general
-  INVALID_PREFIX("Parent path {0} is not a prefix of child {1}"),
-  NOT_SUPPORTED("This method is not supported"),
-  PATH_DOES_NOT_EXIST("Path {0} does not exist"),
-  PATH_MUST_BE_FILE("Path {0} must be a file"),
-  PATH_MUST_BE_DIRECTORY("Path {0} must be a directory"),
-  PATH_INVALID("Path {0} is invalid"),
+  INVALID_PREFIX("Parent path \"{0}\" is not a prefix of child {1}."),
+  NOT_SUPPORTED("This method is not supported."),
+  PATH_DOES_NOT_EXIST("Path \"{0}\" does not exist."),
+  PATH_MUST_BE_FILE("Path \"{0}\" must be a file."),
+  PATH_MUST_BE_DIRECTORY("Path \"{0}\" must be a directory."),
+  PATH_INVALID("Path \"{0}\" is invalid."),
 
   // general block
   BLOCK_UNAVAILABLE("Block {0} is unavailable in both Alluxio and UFS."),

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -397,7 +397,7 @@ public final class InodeTreeTest {
   @Test
   public void getInodeByNonexistingPath() throws Exception {
     mThrown.expect(FileDoesNotExistException.class);
-    mThrown.expectMessage("Path /test does not exist");
+    mThrown.expectMessage("Path \"/test\" does not exist");
 
     assertFalse(mTree.inodePathExists(TEST_URI));
     getInodeByPath(mTree, TEST_URI);
@@ -409,7 +409,7 @@ public final class InodeTreeTest {
   @Test
   public void getInodeByNonexistingNestedPath() throws Exception {
     mThrown.expect(FileDoesNotExistException.class);
-    mThrown.expectMessage("Path /nested/test/file does not exist");
+    mThrown.expectMessage("Path \"/nested/test/file\" does not exist");
 
     createPath(mTree, NESTED_URI, sNestedDirectoryOptions);
     assertFalse(mTree.inodePathExists(NESTED_FILE_URI));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CatCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CatCommandIntegrationTest.java
@@ -31,7 +31,7 @@ public final class CatCommandIntegrationTest extends AbstractFileSystemShellTest
     int ret = mFsShell.run("cat", "/testDir");
     Assert.assertEquals(-1, ret);
     String expected = getCommandOutput(command);
-    expected += "Path /testDir must be a file\n";
+    expected += "Path \"/testDir\" must be a file.\n";
     Assert.assertEquals(expected, mOutput.toString());
   }
 


### PR DESCRIPTION
* quote formatted paths in path exceptions

* Fix unit and integration test