### PR TITLE
[SMALLFIX] Allow + as a uri authority address delimiter

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -63,7 +63,8 @@ public final class AbstractFileSystemApiTest {
 
   @Test
   public void parseZkUriWithPlusDelimiters() throws Exception {
-    FileSystem.get(URI.create("alluxio://zk@a:0+b:1+c:2/"), new org.apache.hadoop.conf.Configuration());
+    FileSystem.get(URI.create("alluxio://zk@a:0+b:1+c:2/"),
+        new org.apache.hadoop.conf.Configuration());
     assertTrue(Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
     assertEquals("a:0,b:1,c:2", Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
   }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -11,9 +11,12 @@
 
 package alluxio.hadoop;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.TestLoggerRule;
 
 import org.junit.After;
@@ -56,5 +59,12 @@ public final class AbstractFileSystemApiTest {
     URI unknown = URI.create("alluxio://localhost:12345/");
     FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration());
     assertFalse(mTestLogger.wasLogged("Authority \"localhost:12345\" is unknown"));
+  }
+
+  @Test
+  public void parseZkUriWithPlusDelimiters() throws Exception {
+    FileSystem.get(URI.create("alluxio://zk@a:0+b:1+c:2/"), new org.apache.hadoop.conf.Configuration());
+    assertTrue(Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
+    assertEquals("a:0,b:1,c:2", Configuration.get(PropertyKey.ZOOKEEPER_ADDRESS));
   }
 }

--- a/core/common/src/main/java/alluxio/uri/Authority.java
+++ b/core/common/src/main/java/alluxio/uri/Authority.java
@@ -24,7 +24,8 @@ import java.util.regex.Pattern;
 public interface Authority extends Comparable<Authority>, Serializable {
   Logger LOG = LoggerFactory.getLogger(Authority.class);
   Pattern SINGLE_MASTER_AUTH = Pattern.compile("^([^:,;]+):(\\d+)$");
-  Pattern ZOOKEEPER_AUTH = Pattern.compile("^zk@([^:,;]+:\\d+([,;][^:,;]+:\\d+)*)$");
+  // We allow zookeeper authorities to be delimited by ',' ';' or '+'.
+  Pattern ZOOKEEPER_AUTH = Pattern.compile("^zk@([^:,;+]+:\\d+([,;+][^:,;+]+:\\d+)*)$");
 
   /**
    * Gets the Authority object from the input string.
@@ -38,8 +39,7 @@ public interface Authority extends Comparable<Authority>, Serializable {
     }
     Matcher matcher = ZOOKEEPER_AUTH.matcher(authority);
     if (matcher.matches()) {
-      return new ZookeeperAuthority(authority,
-          matcher.group(1).replaceAll(";", ","));
+      return new ZookeeperAuthority(authority, matcher.group(1).replaceAll("[;+]", ","));
     } else {
       matcher = SINGLE_MASTER_AUTH.matcher(authority);
       if (matcher.matches()) {

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -76,5 +76,9 @@ public class AuthorityTest {
     authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181;host2:2181;host3:2181");
     assertEquals("zk@host1:2181;host2:2181;host3:2181", authority.toString());
     assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
+
+    authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181+host2:2181+host3:2181");
+    assertEquals("zk@host1:2181+host2:2181+host3:2181", authority.toString());
+    assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
   }
 }

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Unit tests for {@link Authority}.
  */
@@ -80,5 +82,18 @@ public class AuthorityTest {
     authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181+host2:2181+host3:2181");
     assertEquals("zk@host1:2181+host2:2181+host3:2181", authority.toString());
     assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
+  }
+
+  @Test
+  public void mixedDelimiters() {
+    String normalized = "a:0,b:0,c:0";
+    for (String test : Arrays.asList(
+        "zk@a:0;b:0+c:0",
+        "zk@a:0,b:0;c:0",
+        "zk@a:0+b:0,c:0"
+    )) {
+      assertEquals(normalized,
+          ((ZookeeperAuthority) Authority.fromString(test)).getZookeeperAddress());
+    }
   }
 }


### PR DESCRIPTION
I tried running hibench-spark with both `alluxio://zkHost1:2181,zkHost2:2181` and `alluxio://zkHost1:2181;zkHost2`. Neither worked because the prepare phases uses hadoop, while the run phase uses spark. Using a comma breaks Spark because it tries to split on the comma. Using a semicolon breaks hadoop because it splits on semicolon. They both seem happy with `+` though, so it's nice if we could support it as a third option.

If everyone is on board with supporting `+`, I'll update the docs in a followup PR