### PR TITLE
[SMALLFIX] Check for null in ListStatus

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2264,8 +2264,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             listOptions.setRecursive(false);
           }
           UfsStatus[] children = ufs.listStatus(ufsUri.toString(), listOptions);
+          // children can be null if the pathname does not denote a directory
+          // or if the we do not have permission to listStatus on the directory in the ufs.
           if (children == null) {
-            return;
+            throw new IOException("Failed to loadMetadata because ufs can not listStatus at path "
+                + ufsUri.toString());
           }
           Arrays.sort(children, Comparator.comparing(UfsStatus::getName));
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2264,6 +2264,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             listOptions.setRecursive(false);
           }
           UfsStatus[] children = ufs.listStatus(ufsUri.toString(), listOptions);
+          if (children == null) {
+            return;
+          }
           Arrays.sort(children, Comparator.comparing(UfsStatus::getName));
 
           for (UfsStatus childStatus : children) {


### PR DESCRIPTION
This fixes a potential NPE in listStatus when the returned children array is null. 