### PR TITLE
[SMALLFIX] Handle Zookeeper authorities in uri check

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -277,7 +277,8 @@ public final class FileSystemContext implements Closeable {
 
     synchronized (this) {
       if (mMetricsMasterClient != null) {
-        ThreadUtils.shutdownAndAwaitTermination(mExecutorService);
+        ThreadUtils.shutdownAndAwaitTermination(mExecutorService,
+            Configuration.getMs(PropertyKey.METRICS_CONTEXT_SHUTDOWN_TIMEOUT));
         mMetricsMasterClient.close();
         mMetricsMasterClient = null;
         mClientMasterSync = null;

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -14,16 +14,15 @@ package alluxio.client.file;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doNothing;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
@@ -509,17 +508,11 @@ public final class BaseFileSystemTest {
     Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     Configuration.set(PropertyKey.MASTER_RPC_PORT, "19998");
 
-    AlluxioURI uri = new AlluxioURI("alluxio://localhost:1234/root");
-    try {
-      mFileSystem.createDirectory(uri);
-      fail("Should have failed on bad host and port");
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), containsString("does not match the configured value of"));
-    }
+    assertBadAuthority("localhost:1234", "Should fail on bad host and port");
+    assertBadAuthority("zk@localhost:19998", "Should fail on zk authority");
 
-    assertTrue(mTestLogger.wasLogged("The URI scheme"));
-    assertTrue(mTestLogger.wasLogged("The URI authority"));
-
+    assertTrue(loggedAuthorityWarning());
+    assertTrue(loggedSchemeWarning());
   }
 
   /**
@@ -529,6 +522,7 @@ public final class BaseFileSystemTest {
   public void uriCheckBadScheme() throws Exception {
     Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     Configuration.set(PropertyKey.MASTER_RPC_PORT, "19998");
+
     AlluxioURI uri = new AlluxioURI("hdfs://localhost:19998/root");
     try {
       mFileSystem.createDirectory(uri);
@@ -536,7 +530,6 @@ public final class BaseFileSystemTest {
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage(), containsString("Scheme hdfs:// in AlluxioURI is invalid"));
     }
-
   }
 
   /**
@@ -547,12 +540,10 @@ public final class BaseFileSystemTest {
     Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     Configuration.set(PropertyKey.MASTER_RPC_PORT, "19998");
 
-    AlluxioURI uri = new AlluxioURI("alluxio://localhost:19998/root");
-    mFileSystem.createDirectory(uri);
+    useUriWithAuthority("localhost:19998");
 
-    assertTrue(mTestLogger.wasLogged("The URI scheme"));
-    assertTrue(mTestLogger.wasLogged("The URI authority"));
-
+    assertTrue(loggedAuthorityWarning());
+    assertTrue(loggedSchemeWarning());
   }
 
   /**
@@ -567,8 +558,49 @@ public final class BaseFileSystemTest {
     AlluxioURI uri = new AlluxioURI("/root");
     mFileSystem.createDirectory(uri);
 
-    assertFalse(mTestLogger.wasLogged("The URI authority"));
-    assertFalse(mTestLogger.wasLogged("The URI scheme"));
+    assertFalse(loggedAuthorityWarning());
+    assertFalse(loggedSchemeWarning());
   }
 
+  @Test
+  public void uriCheckZkAuthorityMatch() throws Exception {
+    configureZk("a:0,b:0,c:0");
+    useUriWithAuthority("zk@a:0,b:0,c:0"); // Same authority
+    useUriWithAuthority("zk@a:0;b:0+c:0"); // Same authority, but different delimiters
+  }
+
+  @Test
+  public void uriCheckZkAuthorityMismatch() throws Exception {
+    configureZk("a:0,b:0,c:0");
+
+    assertBadAuthority("a:0,b:0,c:0", "Should fail on non-zk authority");
+    assertBadAuthority("zk@a:0", "Should fail on zk authority with different addresses");
+    assertBadAuthority("zk@a:0,b:0,c:1", "Should fail on zk authority with different addresses");
+  }
+
+  private void assertBadAuthority(String authority, String failureMessage) throws Exception {
+    try {
+      useUriWithAuthority("zk@a:0,b:0,c:1");
+      fail(failureMessage);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("does not match"));
+    }
+  }
+
+  private void useUriWithAuthority(String authority) throws Exception {
+    mFileSystem.createDirectory(new AlluxioURI(String.format("alluxio://%s/dir", authority)));
+  }
+
+  private boolean loggedAuthorityWarning() {
+    return mTestLogger.wasLogged("The URI authority .* is ignored");
+  }
+
+  private boolean loggedSchemeWarning() {
+    return mTestLogger.wasLogged("The URI scheme .* is ignored");
+  }
+
+  private void configureZk(String addrs) {
+    Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
+    Configuration.set(PropertyKey.ZOOKEEPER_ADDRESS, addrs);
+  }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -580,7 +580,7 @@ public final class BaseFileSystemTest {
 
   private void assertBadAuthority(String authority, String failureMessage) throws Exception {
     try {
-      useUriWithAuthority("zk@a:0,b:0,c:1");
+      useUriWithAuthority(authority);
       fail(failureMessage);
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage(), containsString("does not match"));

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -350,6 +350,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey METRICS_CONTEXT_SHUTDOWN_TIMEOUT =
+      new Builder(Name.METRICS_CONTEXT_SHUTDOWN_TIMEOUT)
+          .setDefaultValue("1sec")
+          .setDescription("Time to wait for the metrics context to shut down. The main purpose for "
+              + "this property is to allow tests to shut down faster.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setIsHidden(true)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
       new Builder(Name.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)
           .setAlias(new String[]{"alluxio.network.host.resolution.timeout.ms"})
@@ -3148,6 +3157,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String LOGGER_TYPE = "alluxio.logger.type";
     public static final String LOGS_DIR = "alluxio.logs.dir";
     public static final String METRICS_CONF_FILE = "alluxio.metrics.conf.file";
+    public static final String METRICS_CONTEXT_SHUTDOWN_TIMEOUT =
+        "alluxio.metrics.context.shutdown.timeout";
     public static final String NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
         "alluxio.network.host.resolution.timeout";
     public static final String NETWORK_NETTY_HEARTBEAT_TIMEOUT_MS =

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -17,6 +17,7 @@ import alluxio.PropertyKey;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.SingleMasterInquireClient.SingleMasterConnectDetails;
 import alluxio.master.ZkMasterInquireClient.ZkMasterConnectDetails;
+import alluxio.uri.Authority;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
@@ -56,7 +57,12 @@ public interface MasterInquireClient {
    * Connect info should be unique so that if two inquire clients have the same connect info, they
    * connect to the same cluster.
    */
-  interface ConnectDetails {}
+  interface ConnectDetails {
+    /**
+     * @return an authority string representing the connect details
+     */
+    Authority toAuthority();
+  }
 
   /**
    * Factory for getting a master inquire client.

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -19,6 +19,8 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.network.thrift.ThriftUtils;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authentication.TransportProvider;
+import alluxio.uri.Authority;
+import alluxio.uri.UnknownAuthority;
 
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
@@ -127,6 +129,13 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     }
 
     @Override
+    public Authority toAuthority() {
+      // TODO(andrew): add authority type for multiple masters
+      return new UnknownAuthority(mAddresses.stream()
+          .map(addr -> addr.getHostString() + ":" + addr.getPort()).collect(joining(",")));
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -145,8 +154,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
 
     @Override
     public String toString() {
-      return mAddresses.stream().map(addr -> addr.getHostString() + ":" + addr.getPort())
-          .collect(joining(","));
+      return toAuthority().toString();
     }
   }
 }

--- a/core/common/src/main/java/alluxio/master/SingleMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/SingleMasterInquireClient.java
@@ -11,6 +11,9 @@
 
 package alluxio.master;
 
+import alluxio.uri.Authority;
+import alluxio.uri.SingleMasterAuthority;
+
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +68,11 @@ public class SingleMasterInquireClient implements MasterInquireClient {
     }
 
     @Override
+    public Authority toAuthority() {
+      return new SingleMasterAuthority(mAddress.getHostString(), mAddress.getPort());
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -83,7 +91,7 @@ public class SingleMasterInquireClient implements MasterInquireClient {
 
     @Override
     public String toString() {
-      return mAddress.getHostString() + ":" + mAddress.getPort();
+      return toAuthority().toString();
     }
   }
 }

--- a/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
@@ -15,6 +15,8 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.exception.status.UnavailableException;
+import alluxio.uri.Authority;
+import alluxio.uri.ZookeeperAuthority;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -231,6 +233,11 @@ public final class ZkMasterInquireClient implements MasterInquireClient, Closeab
     }
 
     @Override
+    public Authority toAuthority() {
+      return new ZookeeperAuthority(mZkAddress);
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -250,7 +257,7 @@ public final class ZkMasterInquireClient implements MasterInquireClient, Closeab
 
     @Override
     public String toString() {
-      return "zk://" + mZkAddress + mLeaderPath;
+      return toAuthority() + "/" + mLeaderPath;
     }
   }
 }

--- a/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
@@ -257,7 +257,7 @@ public final class ZkMasterInquireClient implements MasterInquireClient, Closeab
 
     @Override
     public String toString() {
-      return toAuthority() + "/" + mLeaderPath;
+      return toAuthority() + mLeaderPath;
     }
   }
 }

--- a/core/common/src/main/java/alluxio/uri/Authority.java
+++ b/core/common/src/main/java/alluxio/uri/Authority.java
@@ -39,7 +39,7 @@ public interface Authority extends Comparable<Authority>, Serializable {
     }
     Matcher matcher = ZOOKEEPER_AUTH.matcher(authority);
     if (matcher.matches()) {
-      return new ZookeeperAuthority(authority, matcher.group(1).replaceAll("[;+]", ","));
+      return new ZookeeperAuthority(matcher.group(1).replaceAll("[;+]", ","));
     } else {
       matcher = SINGLE_MASTER_AUTH.matcher(authority);
       if (matcher.matches()) {

--- a/core/common/src/main/java/alluxio/uri/ZookeeperAuthority.java
+++ b/core/common/src/main/java/alluxio/uri/ZookeeperAuthority.java
@@ -19,23 +19,20 @@ import com.google.common.base.Objects;
 public final class ZookeeperAuthority implements Authority {
   private static final long serialVersionUID = -3549197285125519688L;
 
-  private final String mAuthority;
-  private final String mZookeeperAddress;
+  private final String mZkAddress;
 
   /**
-   * @param authority the authority string of the uri
-   * @param zookeeperAddress the zookeeper address inside the uri
+   * @param zkAddress the zookeeper address inside the uri
    */
-  public ZookeeperAuthority(String authority, String zookeeperAddress) {
-    mAuthority = authority;
-    mZookeeperAddress = zookeeperAddress;
+  public ZookeeperAuthority(String zkAddress) {
+    mZkAddress = zkAddress;
   }
 
   /**
    * @return the Zookeeper address in this authority
    */
   public String getZookeeperAddress() {
-    return mZookeeperAddress;
+    return mZkAddress;
   }
 
   @Override
@@ -52,11 +49,11 @@ public final class ZookeeperAuthority implements Authority {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mAuthority);
+    return Objects.hashCode(mZkAddress);
   }
 
   @Override
   public String toString() {
-    return mAuthority;
+    return "zk@" + mZkAddress;
   }
 }

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -57,15 +57,16 @@ public final class ThreadUtils {
    * tasks.
    *
    * @param pool the executor service to shutdown
+   * @param timeoutMs how long to wait for the service to shut down
    */
-  public static void shutdownAndAwaitTermination(ExecutorService pool) {
+  public static void shutdownAndAwaitTermination(ExecutorService pool, long timeoutMs) {
     pool.shutdown(); // Disable new tasks from being submitted
     try {
       // Wait a while for existing tasks to terminate
-      if (!pool.awaitTermination(1, TimeUnit.SECONDS)) {
+      if (!pool.awaitTermination(timeoutMs / 2, TimeUnit.MILLISECONDS)) {
         pool.shutdownNow(); // Cancel currently executing tasks
         // Wait a while for tasks to respond to being cancelled
-        if (!pool.awaitTermination(1, TimeUnit.SECONDS)) {
+        if (!pool.awaitTermination(timeoutMs / 2, TimeUnit.MILLISECONDS)) {
           LOG.warn("Pool did not terminate");
         }
       }

--- a/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -159,7 +159,7 @@ public class AlluxioURITest {
     AlluxioURI uri =
         new AlluxioURI("alluxio://zk@host1:2181;host2:2181;host3:2181/xy z/a b c");
     assertTrue(uri.hasAuthority());
-    assertEquals("zk@host1:2181;host2:2181;host3:2181", uri.getAuthority().toString());
+    assertEquals("zk@host1:2181,host2:2181,host3:2181", uri.getAuthority().toString());
     assertTrue(uri.getAuthority() instanceof ZookeeperAuthority);
     ZookeeperAuthority zkAuthority = (ZookeeperAuthority) uri.getAuthority();
     assertEquals("host1:2181,host2:2181,host3:2181", zkAuthority.getZookeeperAddress());

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -19,6 +19,9 @@ import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.annotation.concurrent.GuardedBy;
 
 public class TestLoggerRule extends AbstractResourceRule {
 
@@ -36,39 +39,40 @@ public class TestLoggerRule extends AbstractResourceRule {
   }
 
   /**
-   * Determine if a specific piece of text appears in log output.
+   * Determine if a specific pattern appears in log output.
    *
-   * @param eventString The piece of text to search for in log events
-   * @return True if an event containing the string exists, false otherwise
+   * @param pattern a pattern text to search for in log events
+   * @return true if a log message containing the pattern exists, false otherwise
    */
-  public boolean wasLogged(String eventString) {
-    return mAppender.wasLogged(eventString);
+  public boolean wasLogged(String pattern) {
+    return mAppender.wasLogged(Pattern.compile(".*" + pattern + ".*"));
   }
 
   public class TestAppender extends AppenderSkeleton {
-
-    public List<LoggingEvent> mEvents = new ArrayList<LoggingEvent>();
+    @GuardedBy("this")
+    private List<LoggingEvent> mEvents = new ArrayList<>();
 
     public void close() { }
 
     /**
-     * Determines whether string was logged.
+     * Determines whether a message with the given pattern was logged.
      */
-    public boolean wasLogged(String eventString) {
+    public synchronized boolean wasLogged(Pattern pattern) {
       for (LoggingEvent e : mEvents) {
-        if (e.getRenderedMessage().contains(eventString)) {
+        if (pattern.matcher(e.getRenderedMessage()).matches()) {
           return true;
         }
       }
       return false;
     }
 
+    @Override
     public boolean requiresLayout() {
       return false;
     }
 
     @Override
-    protected void append(LoggingEvent event) {
+    protected synchronized void append(LoggingEvent event) {
       mEvents.add(event);
     }
   }

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -74,7 +74,7 @@ public final class MasterInquireClientTest {
           new ConfigurationRule(PropertyKey.ZOOKEEPER_ENABLED, "true").toResource()) {
         ConnectDetails zkConnect = new ZkMasterConnectDetails(zkAddr, leaderPath);
         assertCurrentConnectString(zkConnect);
-        assertEquals("zk://zkAddr:1234/my/leader/path", zkConnect.toString());
+        assertEquals("zk@zkAddr:1234/my/leader/path", zkConnect.toString());
       }
     }
   }

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -76,11 +76,11 @@ public class AuthorityTest {
     assertEquals("127.0.0.1:2181,127.0.0.2:2181,127.0.0.3:2181", authority.getZookeeperAddress());
 
     authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181;host2:2181;host3:2181");
-    assertEquals("zk@host1:2181;host2:2181;host3:2181", authority.toString());
+    assertEquals("zk@host1:2181,host2:2181,host3:2181", authority.toString());
     assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
 
     authority = (ZookeeperAuthority) Authority.fromString("zk@host1:2181+host2:2181+host3:2181");
-    assertEquals("zk@host1:2181+host2:2181+host3:2181", authority.toString());
+    assertEquals("zk@host1:2181,host2:2181,host3:2181", authority.toString());
     assertEquals("host1:2181,host2:2181,host3:2181", authority.getZookeeperAddress());
   }
 


### PR DESCRIPTION
This adds support for Zookeeper authorities, e.g. `zk@host1:2181,host2:2181,host3:2181`. If the user has Zookeeper configured, and they use the configured connect details in the authority string, we shouldn't throw an exception.

To get the currently configured `Authority` this PR leverages the existing code to create a `ConnectDetails` object based on configuration. Each type of `ConnectDetails` now implements a `toAuthority` method which gives the authority represented by the connect details.

@ZacBlanco 