### PR TITLE
[SMALLFIX] Add checkstyle rule for whitespace at end of block

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -64,6 +64,10 @@
     <property name="fileExtensions" value=".java"/>
     <property name="message" value="Extra newline"/>
   </module>
+  <module name="RegexpMultiline">
+    <property name="format" value="\n\s*\n\s*}"/>
+    <property name="message" value="Extra newline at end of block"/>
+  </module>
 
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">

--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -66,6 +66,7 @@
   </module>
   <module name="RegexpMultiline">
     <property name="format" value="\n\s*\n\s*}"/>
+    <property name="fileExtensions" value=".java"/>
     <property name="message" value="Extra newline at end of block"/>
   </module>
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -585,5 +585,4 @@ public final class FileSystemContext implements Closeable {
           .toString();
     }
   }
-
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
@@ -69,7 +69,6 @@ public final class LocalFirstAvoidEvictionPolicy
   @Override
   public WorkerNetAddress getWorker(GetWorkerOptions options) {
     return getWorkerForNextBlock(options.getBlockWorkerInfos(), options.getBlockSize());
-
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -458,6 +458,5 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     public UnresolvablePropertyException(String msg) {
       super(msg);
     }
-
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/PlainSaslServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/PlainSaslServer.java
@@ -194,5 +194,4 @@ public final class PlainSaslServer implements SaslServer {
       return new String[] {PlainSaslServerProvider.MECHANISM};
     }
   }
-
 }

--- a/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerProvider.java
+++ b/core/common/src/main/java/alluxio/security/authentication/PlainSaslServerProvider.java
@@ -44,5 +44,4 @@ public final class PlainSaslServerProvider extends Provider {
     super(NAME, VERSION, "Plain SASL server provider");
     put("SaslServerFactory." + MECHANISM, PlainSaslServer.Factory.class.getName());
   }
-
 }

--- a/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
+++ b/core/common/src/main/java/alluxio/security/group/GroupMappingService.java
@@ -64,7 +64,6 @@ public interface GroupMappingService {
       }
       return sCachedGroupMapping;
     }
-
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -103,7 +103,6 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
       } else {
         return Fingerprint.create(getUnderFSType(), status, aclPair.getFirst()).serialize();
       }
-
     } catch (Exception e) {
       // In certain scenarios, it is expected that the UFS path does not exist.
       LOG.debug("Failed fingerprint. path: {} error: {}", path, e.toString());

--- a/core/common/src/main/java/alluxio/uri/URI.java
+++ b/core/common/src/main/java/alluxio/uri/URI.java
@@ -203,7 +203,6 @@ public interface URI extends Comparable<URI>, Serializable {
       }
       return new Pair<>(scheme.substring(0, colon), scheme.substring(colon + 1));
     }
-
   }
 
   /**

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -76,6 +76,4 @@ public class TestLoggerRule extends AbstractResourceRule {
       mEvents.add(event);
     }
   }
-
 }
-

--- a/core/common/src/test/java/alluxio/TestLoggerRuleTest.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRuleTest.java
@@ -34,5 +34,4 @@ public final class TestLoggerRuleTest {
     LOG.info(logEvent);
     assertTrue(mLogger.wasLogged(logEvent));
   }
-
 }

--- a/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
@@ -298,5 +298,4 @@ public final class DynamicResourcePoolTest {
     Assert.assertFalse(future.isDone());
     future.cancel(true);
   }
-
 }

--- a/core/common/src/test/java/alluxio/resource/ResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/ResourcePoolTest.java
@@ -134,5 +134,4 @@ public final class ResourcePoolTest {
     assertFalse(future.isDone());
     future.cancel(true);
   }
-
 }

--- a/core/common/src/test/java/alluxio/security/authentication/TransportProviderTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/TransportProviderTest.java
@@ -395,5 +395,4 @@ public final class TransportProviderTest {
       }
     }
   }
-
 }

--- a/core/common/src/test/java/alluxio/security/authorization/AclEntryTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/AclEntryTest.java
@@ -101,7 +101,6 @@ public class AclEntryTest {
     checkCliStringInvalid("other:other:---");
 
     checkCliStringInvalid("default:user:test");
-
   }
 
   private void checkCliString(String stringEntry) {

--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -785,5 +785,4 @@ public abstract class AbstractUnderFileSystemContractTest {
       return mSubDirectoryNames;
     }
   }
-
 }

--- a/core/common/src/test/java/alluxio/util/WaitForOptionsTest.java
+++ b/core/common/src/test/java/alluxio/util/WaitForOptionsTest.java
@@ -47,5 +47,4 @@ public final class WaitForOptionsTest {
   public void equalsTest() throws Exception {
     CommonUtils.testEquals(WaitForOptions.class);
   }
-
 }

--- a/core/common/src/test/java/alluxio/wire/BlockLocationTest.java
+++ b/core/common/src/test/java/alluxio/wire/BlockLocationTest.java
@@ -42,7 +42,6 @@ public final class BlockLocationTest {
     Assert.assertEquals(a.getWorkerAddress(), b.getWorkerAddress());
     Assert.assertEquals(a.getTierAlias(), b.getTierAlias());
     Assert.assertEquals(a, b);
-
   }
 
   public static BlockLocation createRandom() {

--- a/core/server/common/src/main/java/alluxio/cli/validation/UfsSuperUserValidationTask.java
+++ b/core/server/common/src/main/java/alluxio/cli/validation/UfsSuperUserValidationTask.java
@@ -69,6 +69,5 @@ public final class UfsSuperUserValidationTask extends AbstractValidationTask {
           + "Please check if Alluxio is super user on the file system.%n", mPath, e.getMessage());
       return TaskResult.WARNING;
     }
-
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2353,7 +2353,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             LOG.warn("File {} has default ACL in the UFS", inodePath.getUri());
           }
         }
-
       }
     }
 
@@ -3021,7 +3020,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
               LOG.debug("Failed to load metadata for mount point: {}", mountPointUri, e);
             }
             mUfsSyncPathCache.notifySyncedPath(mountPoint);
-
           }
         }
       } catch (InvalidPathException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeFile.java
@@ -309,7 +309,6 @@ public final class InodeFile extends Inode<InodeFile> implements InodeFileView {
         .setAcl(options.getAcl())
         .setPersistenceState(options.isPersisted() ? PersistenceState.PERSISTED
             : PersistenceState.NOT_PERSISTED);
-
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -232,5 +232,4 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
       // nothing to clean up
     }
   }
-
 }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1097,7 +1097,6 @@ public final class FileSystemMasterTest {
     infos = mFileSystemMaster.listStatus(ROOT_URI, ListStatusOptions.defaults()
         .setLoadMetadataType(LoadMetadataType.Always).setRecursive(true));
     assertEquals(files + files +  2 + 2 + 2 , infos.size());
-
   }
 
   @Test
@@ -2475,7 +2474,6 @@ public final class FileSystemMasterTest {
         LoadMetadataOptions.defaults().setCreateAncestors(true));
     FileInfo info = mFileSystemMaster.getFileInfo(uri, GetStatusOptions.defaults());
     Assert.assertTrue(info.convertAclToStringEntries().contains("user::r-x"));
-
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -298,7 +298,6 @@ public final class InodeTreeTest {
       assertEquals(childAcl.toStringEntries().stream().map(AclEntry::toDefault)
           .collect(Collectors.toList()), dAcl.toStringEntries());
     }
-
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -129,7 +129,6 @@ public class TtlBucketTest {
     Assert.assertTrue(mBucket.getInodes().contains(mDirectoryTtl2));
     mBucket.removeInode(mDirectoryTtl2);
     Assert.assertEquals(0, mBucket.getInodes().size());
-
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerGeneralServlet.java
+++ b/core/server/worker/src/main/java/alluxio/web/WebInterfaceWorkerGeneralServlet.java
@@ -128,7 +128,6 @@ public final class WebInterfaceWorkerGeneralServlet extends HttpServlet {
     public String getWorkerAddress() {
       return mWorkerAddress;
     }
-
   }
 
   /**
@@ -174,7 +173,6 @@ public final class WebInterfaceWorkerGeneralServlet extends HttpServlet {
     public long getUsedBytes() {
       return mUsedBytes;
     }
-
   }
 
   private static final long serialVersionUID = 3735143768058466487L;

--- a/core/server/worker/src/main/java/alluxio/worker/block/AbstractBlockStoreEventListener.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AbstractBlockStoreEventListener.java
@@ -42,5 +42,4 @@ public abstract class AbstractBlockStoreEventListener implements BlockStoreEvent
 
   @Override
   public void onRemoveBlockByWorker(long sessionId, long blockId) {}
-
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStoreEventListener.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStoreEventListener.java
@@ -82,5 +82,4 @@ public interface BlockStoreEventListener {
    * @param blockId the id of the block to be removed
    */
   void onRemoveBlockByWorker(long sessionId, long blockId);
-
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -297,7 +297,6 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
         mode |= FileStat.S_IFREG;
       }
       stat.st_mode.set(mode);
-
     } catch (InvalidPathException e) {
       LOG.debug("Invalid path {}", path, e);
       return -ErrorCodes.ENOENT();
@@ -404,7 +403,6 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
         // Assuming I will never wrap around (2^64 open files are quite a lot anyway)
         mNextOpenFileId += 1;
       }
-
     } catch (FileDoesNotExistException e) {
       LOG.debug("File does not exist {}", path, e);
       return -ErrorCodes.ENOENT();
@@ -520,7 +518,6 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       for (final URIStatus file : ls) {
         filter.apply(buff, file.getName(), null, 0);
       }
-
     } catch (FileDoesNotExistException e) {
       LOG.debug("File does not exist {}", path, e);
       return -ErrorCodes.ENOENT();
@@ -822,5 +819,4 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       return new AlluxioURI(tpath.toString());
     }
   }
-
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/BasePayloadReader.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/BasePayloadReader.java
@@ -53,5 +53,4 @@ final class BasePayloadReader implements PayloadReader {
     final int valueFrom = pos + KEY_DATA_OFFSET + keyLength;
     return BufferUtils.sliceByteBuffer(mBuf, valueFrom, valueLength);
   }
-
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/Index.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/Index.java
@@ -77,5 +77,4 @@ public interface Index {
    * @return an iterator of keys, the iterator does not support remove
    */
   Iterator<ByteBuffer> keyIterator(PayloadReader reader);
-
 }

--- a/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreWriter.java
+++ b/keyvalue/client/src/main/java/alluxio/client/keyvalue/KeyValueStoreWriter.java
@@ -39,5 +39,4 @@ public interface KeyValueStoreWriter extends Closeable, Cancelable {
    * @param value value to put, cannot be null
    */
   void put(ByteBuffer key, ByteBuffer value) throws IOException, AlluxioException;
-
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
@@ -78,6 +78,5 @@ public abstract class AbstractFileSystemCommand implements Command {
     if (errorMessages.size() != 0) {
       throw new IOException(Joiner.on('\n').join(errorMessages));
     }
-
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
@@ -101,7 +101,6 @@ public class SummaryCommand {
       }
       mIndentationLevel--;
     }
-
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
@@ -110,5 +110,4 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
             + "with the under storage system.\n";
     Assert.assertEquals(expected, mOutput.toString());
   }
-
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/ChecksumCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/ChecksumCommandIntegrationTest.java
@@ -80,5 +80,4 @@ public final class ChecksumCommandIntegrationTest extends AbstractFileSystemShel
     int ret = mFsShell.run("checksum", "/testFolder");
     Assert.assertEquals(-1, ret);
   }
-
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
@@ -562,5 +562,4 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
 
     Assert.assertEquals(expected, mOutput.toString());
   }
-
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/MkdirCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/MkdirCommandIntegrationTest.java
@@ -91,7 +91,6 @@ public final class MkdirCommandIntegrationTest extends AbstractFileSystemShellTe
     status = mFileSystem.getStatus(new AlluxioURI(path3));
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isFolder());
-
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
@@ -159,5 +159,4 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     files[3] = mFileSystem.getStatus(new AlluxioURI("/testRoot/testFileC"));
     return files;
   }
-
 }

--- a/tests/src/test/java/alluxio/client/fs/ConcurrentFileSystemMasterUtils.java
+++ b/tests/src/test/java/alluxio/client/fs/ConcurrentFileSystemMasterUtils.java
@@ -133,7 +133,6 @@ public class ConcurrentFileSystemMasterUtils {
                 break;
               default: throw new IllegalArgumentException("'operation' is not a valid operation.");
             }
-
           } catch (Exception e) {
             Throwables.propagate(e);
           }

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemBlockLocationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemBlockLocationIntegrationTest.java
@@ -104,5 +104,4 @@ public class FileSystemBlockLocationIntegrationTest extends BaseIntegrationTest 
     len = 1;
     Assert.assertEquals(0, sTFS.getFileBlockLocations(fStatus, start, len).length);
   }
-
 }

--- a/tests/src/test/java/alluxio/client/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCase.java
@@ -144,7 +144,6 @@ public final class TestCase {
 
     while ((len = br.read(buffer)) > 0) {
       sb.append(buffer, 0, len);
-
     }
     br.close();
 

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -319,7 +319,6 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
           blockMaster2.getWorkerId(new alluxio.wire.WorkerNetAddress().setHost("host1"));
       blockMaster2.workerRegister(workerId1b, Collections.EMPTY_LIST, Collections.EMPTY_MAP,
           Collections.EMPTY_MAP, Collections.EMPTY_MAP, new RegisterWorkerTOptions());
-
     } finally {
       cluster.stop();
     }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/NoopHdfsAclProvider.java
@@ -36,5 +36,4 @@ public class NoopHdfsAclProvider implements HdfsAclProvider {
       throws IOException {
     // Noop for setAclEntries
   }
-
 }

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -109,5 +109,4 @@ public class OSSInputStreamTest {
     mOssInputStream.skip(1);
     assertEquals(3, mOssInputStream.read());
   }
-
 }


### PR DESCRIPTION
Similar to our existing extra newline rule. There's very little value to ending a block with a newline, and 99% of the time we don't. Now it will be 100% and enforced automatically