### PR TITLE
[SMALLFIX] Improvements to invokeAll

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -25,7 +25,6 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.io.Closer;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
@@ -49,7 +48,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -454,56 +452,48 @@ public final class CommonUtils {
    * an exception, that exception will be re-thrown from this method.
    *
    * @param callables the callables to execute
-   * @param timeout the maximum time to wait
-   * @param unit the time unit of the timeout argument
+   * @param timeoutMs time to wait for the callables to complete, in milliseconds
    * @param <T> the return type of the callables
-   * @throws Exception if any of the callables throws an exception
+   * @throws TimeoutException if the callables don't complete before the timeout
+   * @throws ExecutionException if any of the callables throws an exception
    */
-  public static <T> void invokeAll(List<Callable<T>> callables, long timeout, TimeUnit unit)
-      throws TimeoutException, Exception {
+  public static <T> void invokeAll(List<Callable<T>> callables, long timeoutMs)
+      throws TimeoutException, ExecutionException {
+    long endMs = System.currentTimeMillis() + timeoutMs;
     ExecutorService service = Executors.newCachedThreadPool();
     try {
-      List<Future<T>> results = service.invokeAll(callables, timeout, unit);
+      List<Future<T>> pending = new ArrayList<>();
+      for (Callable<T> c : callables) {
+        pending.add(service.submit(c));
+      }
+      // Poll the tasks to exit early in case of failure.
+      while (!pending.isEmpty()) {
+        Iterator<Future<T>> it = pending.iterator();
+        while (it.hasNext()) {
+          Future<T> future = it.next();
+          if (future.isDone()) {
+            // Check whether the callable threw an exception.
+            try {
+              future.get();
+            } catch (InterruptedException e) {
+              // This should never happen since we already checked isDone().
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(e);
+            }
+            it.remove();
+          }
+        }
+        if (pending.isEmpty()) {
+          break;
+        }
+        long remainingMs = endMs - System.currentTimeMillis();
+        if (remainingMs <= 0) {
+          throw new TimeoutException(String.format("Timed out after %dms", timeoutMs));
+        }
+        CommonUtils.sleepMs(Math.min(remainingMs, 50));
+      }
+    } finally {
       service.shutdownNow();
-      propagateExceptions(results);
-      for (Future<T> result : results) {
-        if (result.isCancelled()) {
-          throw new TimeoutException("Timed out invoking task");
-        }
-      }
-      // All tasks are guaranteed to have finished at this point. If they were still running, their
-      // futures would have been canceled by invokeAll.
-      if (!service.awaitTermination(1, TimeUnit.SECONDS)) {
-        throw new IllegalStateException("Failed to shutdown service");
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      service.shutdownNow();
-      throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Checks whether any of the futures have completed with an exception, propagating the exception
-   * if any is found.
-   *
-   * @param futures the futures to check
-   * @throws Exception if one of the futures completed with an exception
-   */
-  private static <T> void propagateExceptions(List<Future<T>> futures) throws Exception {
-    for (Future<?> future : futures) {
-      try {
-        if (future.isDone() && !future.isCancelled()) {
-          future.get();
-        }
-      } catch (ExecutionException e) {
-        Throwable cause = e.getCause();
-        Throwables.propagateIfPossible(cause);
-        if (cause instanceof Exception) {
-          throw (Exception) cause;
-        }
-        throw new RuntimeException(cause);
-      }
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -11,13 +11,13 @@
 
 package alluxio.master;
 
+import alluxio.Constants;
 import alluxio.ServiceUtils;
 import alluxio.util.CommonUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This class encapsulates the different master services that are configured to run.
@@ -45,7 +45,7 @@ final class MasterUtils {
       });
     }
     try {
-      CommonUtils.invokeAll(callables, 10, TimeUnit.SECONDS);
+      CommonUtils.invokeAll(callables, 10 * Constants.SECOND_MS);
     } catch (Exception e) {
       throw new RuntimeException("Failed to start masters", e);
     }

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -58,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -137,8 +136,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       // registered at worker registry, so the maximum timeout here is set to the multiply of
       // the number of factories by the default timeout of getting a worker from the registry.
       CommonUtils.invokeAll(callables,
-          (long) callables.size() * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS,
-          TimeUnit.MILLISECONDS);
+          (long) callables.size() * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
Main improvement is to exit early if one of the tasks fails. This also improves the exception types - ExecutionException is needed to differentiate `TimeoutExceptions` thrown by callables vs `TimeoutExceptions` thrown by `invokeAll`

I noticed this issue when my worker failed to start due to an incorrect ramdisk size, but it took over 10 seconds for the error to appear because the process was stuck in `invokeAll`.