### PR TITLE
[ALLUXIO-3311] Use symlink instead of rename for docker build (#7817)

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -19,9 +19,10 @@ RUN apk add --update bash && \
 ADD ${ALLUXIO_TARBALL} /opt/
 
 # if the tarball was remote, it needs to be untarred
+# use ln -s instead of mv to avoid issues with Centos (see https://github.com/moby/moby/issues/27358)
 RUN cd /opt && \
     (if ls | grep -q ".tar.gz"; then tar -xzf *.tar.gz && rm *.tar.gz; fi) && \
-    mv alluxio-* alluxio
+    ln -s alluxio-* alluxio
 
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3311

Cherry-pick from https://github.com/Alluxio/alluxio/pull/7817