### PR TITLE
[SMALLFIX] Use cached threadpools for masters

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -82,7 +82,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     super(uri, ufsConf);
 
     int numThreads = Configuration.getInt(PropertyKey.UNDERFS_OBJECT_STORE_SERVICE_THREADS);
-    mExecutorService = ExecutorServiceFactories.fixedThreadPoolExecutorServiceFactory(
+    mExecutorService = ExecutorServiceFactories.fixedThreadPool(
         "alluxio-underfs-object-service-worker", numThreads).create();
   }
 

--- a/core/common/src/main/java/alluxio/util/executor/ExecutorServiceFactories.java
+++ b/core/common/src/main/java/alluxio/util/executor/ExecutorServiceFactories.java
@@ -22,20 +22,26 @@ import java.util.concurrent.Executors;
 public final class ExecutorServiceFactories {
   /**
    * Returns a {@link ExecutorServiceFactory} which creates threadpool executors with the given base
+   * name. Created threads will be daemonic.
+   *
+   * @param name the base name for executor thread names
+   * @return the {@link ExecutorServiceFactory}
+   */
+  public static ExecutorServiceFactory cachedThreadPool(String name) {
+    return () -> Executors.newCachedThreadPool(ThreadFactoryUtils.build(name + "-%d", true));
+  }
+
+  /**
+   * Returns a {@link ExecutorServiceFactory} which creates threadpool executors with the given base
    * name and number of threads. Created threads will be daemonic.
    *
    * @param name the base name for executor thread names
    * @param nThreads the number of threads to create executors with
    * @return the {@link ExecutorServiceFactory}
    */
-  public static ExecutorServiceFactory fixedThreadPoolExecutorServiceFactory(final String name,
-      final int nThreads) {
-    return new ExecutorServiceFactory() {
-      @Override
-      public ExecutorService create() {
-        return Executors.newFixedThreadPool(nThreads, ThreadFactoryUtils.build(name + "-%d", true));
-      }
-    };
+  public static ExecutorServiceFactory fixedThreadPool(String name, int nThreads) {
+    return () -> Executors.newFixedThreadPool(nThreads,
+        ThreadFactoryUtils.build(name + "-%d", true));
   }
 
   /**
@@ -44,13 +50,8 @@ public final class ExecutorServiceFactories {
    *         {@link ExecutorService}
    */
   public static ExecutorServiceFactory constantExecutorServiceFactory(
-      final ExecutorService executorService) {
-    return new ExecutorServiceFactory() {
-      @Override
-      public ExecutorService create() {
-        return executorService;
-      }
-    };
+      ExecutorService executorService) {
+    return () -> executorService;
   }
 
   private ExecutorServiceFactories() {} // Not intended for instantiation.

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -210,8 +210,8 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
    * @param masterContext the context for Alluxio master
    */
   DefaultBlockMaster(MetricsMaster metricsMaster, MasterContext masterContext) {
-    this(metricsMaster, masterContext, new SystemClock(), ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.BLOCK_MASTER_NAME, 2));
+    this(metricsMaster, masterContext, new SystemClock(),
+        ExecutorServiceFactories.cachedThreadPool(Constants.BLOCK_MASTER_NAME));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -331,8 +331,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @param masterContext the context for Alluxio master
    */
   DefaultFileSystemMaster(BlockMaster blockMaster, MasterContext masterContext) {
-    this(blockMaster, masterContext, ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.FILE_SYSTEM_MASTER_NAME, 4));
+    this(blockMaster, masterContext,
+        ExecutorServiceFactories.cachedThreadPool(Constants.FILE_SYSTEM_MASTER_NAME));
   }
 
   /**
@@ -495,7 +495,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       if (Configuration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
         mStartupConsistencyCheck = getExecutorService().submit(() -> startupCheckConsistency(
             ExecutorServiceFactories
-               .fixedThreadPoolExecutorServiceFactory("startup-consistency-check", 32).create()));
+               .fixedThreadPool("startup-consistency-check", 32).create()));
       }
       if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
         mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter();

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -139,8 +139,8 @@ public final class DefaultMetaMaster extends AbstractMaster implements MetaMaste
    * @param masterContext the context for Alluxio master
    */
   DefaultMetaMaster(BlockMaster blockMaster, MasterContext masterContext) {
-    this(blockMaster, masterContext, ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.META_MASTER_NAME, 2));
+    this(blockMaster, masterContext,
+        ExecutorServiceFactories.cachedThreadPool(Constants.META_MASTER_NAME));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -66,8 +66,8 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
    * @param masterContext the context for metrics master
    */
   DefaultMetricsMaster(MasterContext masterContext) {
-    this(masterContext, new SystemClock(), ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.METRICS_MASTER_NAME, 2));
+    this(masterContext, new SystemClock(),
+        ExecutorServiceFactories.cachedThreadPool(Constants.METRICS_MASTER_NAME));
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
@@ -78,7 +78,7 @@ public class UfsInputStreamManager {
   public UfsInputStreamManager() {
     mFileIdToInputStreamIds = new HashMap<>();
     mRemovalThreadPool = ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.UFS_INPUT_STREAM_CACHE_EXPIRATION, 2)
+        .fixedThreadPool(Constants.UFS_INPUT_STREAM_CACHE_EXPIRATION, 2)
         .create();
 
     // A listener to the input stream removal.

--- a/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
+++ b/keyvalue/server/src/main/java/alluxio/master/keyvalue/DefaultKeyValueMaster.java
@@ -79,8 +79,8 @@ public class DefaultKeyValueMaster extends AbstractMaster implements KeyValueMas
    * @param masterContext the context for Alluxio master
    */
   DefaultKeyValueMaster(FileSystemMaster fileSystemMaster, MasterContext masterContext) {
-    super(masterContext, new SystemClock(), ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.KEY_VALUE_MASTER_NAME, 2));
+    super(masterContext, new SystemClock(),
+        ExecutorServiceFactories.cachedThreadPool(Constants.KEY_VALUE_MASTER_NAME));
     mFileSystemMaster = fileSystemMaster;
     mCompleteStoreToPartitions = new HashMap<>();
     mIncompleteStoreToPartitions = new HashMap<>();

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -231,7 +231,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     }
 
     ExecutorService service = ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory("alluxio-s3-transfer-manager-worker",
+        .fixedThreadPool("alluxio-s3-transfer-manager-worker",
             numTransferThreads).create();
 
     TransferManager transferManager = TransferManagerBuilder.standard()


### PR DESCRIPTION
Our master threads live forever, so there isn't
any functional difference between fixed vs cached
when things are working properly. But it's easy
to add a new thread without remembering to update
the fixed threadpool size, which results in a
difficult to debug situation where the thread
never gets run.