### PR TITLE
[SMALLFIX] Add extra tests for job service

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -328,6 +328,26 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     return ret;
   }
 
+  @Override
+  public short getDefaultReplication() {
+    return (short) Math.max(1, CreateFileOptions.defaults().getReplicationMin());
+  }
+
+  @Override
+  public boolean setReplication(Path path, short replication) throws IOException {
+    AlluxioURI uri = new AlluxioURI(HadoopUtils.getPathWithoutScheme(path));
+
+    try {
+      if (!mFileSystem.exists(uri) || mFileSystem.getStatus(uri).isFolder()) {
+        return false;
+      }
+      mFileSystem.setAttribute(uri, SetAttributeOptions.defaults().setReplicationMin(replication));
+      return true;
+    } catch (AlluxioException e) {
+      throw new IOException(e);
+    }
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -358,7 +378,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   }
 
   private int getReplica(URIStatus status) {
-    return BLOCK_REPLICATION_CONSTANT;
+    return status.getReplicationMin();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/cli/job/JobShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/JobShellTest.java
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.job;
+
+import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.options.CreateFileOptions;
+import alluxio.job.persist.PersistConfig;
+import alluxio.job.util.JobTestUtils;
+import alluxio.job.wire.JobInfo;
+import alluxio.job.wire.Status;
+
+import java.util.concurrent.TimeoutException;
+
+public abstract class JobShellTest extends AbstractFileSystemShellTest {
+  protected long runPersistJob() throws Exception {
+    // write a file in alluxio only
+    AlluxioURI filePath = new AlluxioURI("/test");
+    FileOutStream os = mFileSystem.createFile(filePath,
+        CreateFileOptions.defaults().setWriteType(WriteType.MUST_CACHE));
+    os.write((byte) 0);
+    os.write((byte) 1);
+    os.close();
+
+    // persist the file
+    URIStatus status = mFileSystem.getStatus(filePath);
+    return mJobMaster.run(new PersistConfig("/test", 1, true, status.getUfsPath()));
+  }
+
+  protected JobInfo waitForJobToFinish(final long jobId)
+      throws InterruptedException, TimeoutException {
+    return JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.COMPLETED);
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/job/LeaderCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/LeaderCommandTest.java
@@ -1,0 +1,28 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.job;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the job leader shell command.
+ */
+public final class LeaderCommandTest extends JobShellTest {
+  @Test
+  public void jobLeader() {
+    mJobShell.run("leader");
+    String expected =
+        mLocalAlluxioCluster.getLocalAlluxioMaster().getAddress().getHostName() + "\n";
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/job/ListCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/ListCommandTest.java
@@ -1,0 +1,28 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.job;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for job list command.
+ */
+public final class ListCommandTest extends JobShellTest {
+  @Test
+  public void listTest() throws Exception {
+    long jobId = runPersistJob();
+
+    mJobShell.run("ls");
+    Assert.assertEquals(jobId + "\n", mOutput.toString());
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/job/StatCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/StatCommandTest.java
@@ -1,0 +1,29 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.job;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for getting job status command.
+ */
+public final class StatCommandTest extends JobShellTest {
+  @Test
+  public void statTest() throws Exception {
+    long jobId = runPersistJob();
+    waitForJobToFinish(jobId);
+    mJobShell.run("stat", "-v", Long.toString(jobId));
+    String expected = "ID: " + jobId + "\nStatus: COMPLETED\nTask 0\n\tStatus: COMPLETED\n";
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+}

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -1,0 +1,143 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.rest;
+
+import alluxio.ConfigurationTestUtils;
+import alluxio.Constants;
+import alluxio.client.rest.RestApiTest;
+import alluxio.client.rest.TestCase;
+import alluxio.client.rest.TestCaseOptions;
+import alluxio.job.JobConfig;
+import alluxio.job.ServiceConstants;
+import alluxio.job.SleepJobConfig;
+import alluxio.job.wire.JobInfo;
+import alluxio.job.wire.Status;
+import alluxio.master.LocalAlluxioJobCluster;
+import alluxio.master.job.JobMaster;
+import alluxio.master.job.JobMasterClientRestServiceHandler;
+import alluxio.security.LoginUserTestUtils;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.HttpMethod;
+
+/**
+ * Tests {@link JobMasterClientRestServiceHandler}.
+ */
+public final class JobMasterClientRestApiTest extends RestApiTest {
+  private static final Map<String, String> NO_PARAMS = Maps.newHashMap();
+  private LocalAlluxioJobCluster mJobCluster;
+  private JobMaster mJobMaster;
+
+  @Before
+  public void before() throws Exception {
+    mJobCluster = new LocalAlluxioJobCluster();
+    mJobCluster.start();
+    mJobMaster = mJobCluster.getMaster().getJobMaster();
+    mHostname = mJobCluster.getHostname();
+    mPort = mJobCluster.getMaster().getWebAddress().getPort();
+    mServicePrefix = ServiceConstants.MASTER_SERVICE_PREFIX;
+  }
+
+  @After
+  public void after() throws Exception {
+    mJobCluster.stop();
+    LoginUserTestUtils.resetLoginUser();
+    ConfigurationTestUtils.resetConfiguration();
+  }
+
+  @Test
+  public void serviceName() throws Exception {
+    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.SERVICE_NAME),
+        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_NAME).run();
+  }
+
+  @Test
+  public void serviceVersion() throws Exception {
+    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.SERVICE_VERSION),
+        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_VERSION).run();
+  }
+
+  @Test
+  public void run() throws Exception {
+    final long jobId = startJob(new SleepJobConfig(Constants.SECOND_MS));
+    Assert.assertEquals(1, mJobMaster.list().size());
+    waitForStatus(jobId, Status.COMPLETED);
+  }
+
+  @Test
+  public void cancel() throws Exception {
+    long jobId = startJob(new SleepJobConfig(10 * Constants.SECOND_MS));
+    // Sleep to make sure the run request and the cancel request are separated by a job worker
+    // heartbeat. If not, job service will not handle that case correctly.
+    CommonUtils.sleepMs(Constants.SECOND_MS);
+    Map<String, String> params = Maps.newHashMap();
+    params.put("jobId", Long.toString(jobId));
+    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.CANCEL),
+        params, HttpMethod.POST, null).run();
+    waitForStatus(jobId, Status.CANCELED);
+  }
+
+  @Test
+  public void list() throws Exception {
+    List<Long> empty = Lists.newArrayList();
+    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.LIST), NO_PARAMS,
+        HttpMethod.GET, empty).run();
+  }
+
+  @Test
+  public void getStatus() throws Exception {
+    JobConfig config = new SleepJobConfig(Constants.SECOND_MS);
+    final long jobId = startJob(config);
+    Map<String, String> params = Maps.newHashMap();
+    params.put("jobId", Long.toString(jobId));
+
+    TestCaseOptions options = TestCaseOptions.defaults().setPrettyPrint(true);
+    String result = new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.GET_STATUS),
+        params, HttpMethod.GET, null, options).call();
+    JobInfo jobInfo = new ObjectMapper().readValue(result, JobInfo.class);
+    Assert.assertEquals(jobId, jobInfo.getJobId());
+    Assert.assertEquals(1, jobInfo.getTaskInfoList().size());
+  }
+
+  private long startJob(JobConfig config) throws Exception {
+    TestCaseOptions options = TestCaseOptions.defaults().setBody(config);
+    String result = new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.RUN),
+        NO_PARAMS, HttpMethod.POST, null, options).call();
+    return new ObjectMapper().readValue(result, Long.TYPE);
+  }
+
+  private void waitForStatus(final long jobId, final Status status)
+      throws InterruptedException, TimeoutException {
+    CommonUtils.waitFor("Waiting for job status", () -> {
+      try {
+        return mJobMaster.getStatus(jobId).getStatus() == status;
+      } catch (Exception e) {
+        Throwables.propagate(e);
+      }
+      return null;
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
+  }
+}

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -1,0 +1,56 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.rest;
+
+import alluxio.ConfigurationTestUtils;
+import alluxio.master.AlluxioJobMasterRestServiceHandler;
+import alluxio.master.LocalAlluxioJobCluster;
+import alluxio.security.LoginUserTestUtils;
+
+import com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+
+/**
+ * Tests for {@link AlluxioJobMasterRestServiceHandler}.
+ */
+public final class JobMasterRestApiTest extends RestApiTest {
+  private static final Map<String, String> NO_PARAMS = Maps.newHashMap();
+  private LocalAlluxioJobCluster mJobCluster;
+
+  @Before
+  public void before() throws Exception {
+    mJobCluster = new LocalAlluxioJobCluster();
+    mJobCluster.start();
+    mHostname = mJobCluster.getHostname();
+    mPort = mJobCluster.getMaster().getWebAddress().getPort();
+    mServicePrefix = AlluxioJobMasterRestServiceHandler.SERVICE_PREFIX;
+  }
+
+  @After
+  public void after() throws Exception {
+    mJobCluster.stop();
+    LoginUserTestUtils.resetLoginUser();
+    ConfigurationTestUtils.resetConfiguration();
+  }
+
+  @Test
+  public void getInfo() throws Exception {
+    new TestCase(mHostname, mPort, getEndpoint(AlluxioJobMasterRestServiceHandler.GET_INFO),
+        NO_PARAMS, HttpMethod.GET, null).call();
+  }
+}


### PR DESCRIPTION
There are a few integration tests for the job shell and rest API along with a minor modification for determining the default replication.

@aaudiber 