### PR TITLE
[SMALLFIX] Java 8 migration: replace anonymous type with method reference in alluxio.proto.dataserver.alluxio.proto.dataserver#internalValueMap #316

### DIFF
--- a/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
+++ b/core/protobuf/src/main/java/alluxio/proto/dataserver/Protocol.java
@@ -53,12 +53,7 @@ public final class Protocol {
       return internalValueMap;
     }
     private static com.google.protobuf.Internal.EnumLiteMap<RequestType>
-        internalValueMap =
-          new com.google.protobuf.Internal.EnumLiteMap<RequestType>() {
-            public RequestType findValueByNumber(int number) {
-              return RequestType.valueOf(number);
-            }
-          };
+        internalValueMap = RequestType::valueOf;
 
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
@@ -6499,12 +6494,7 @@ public final class Protocol {
         return internalValueMap;
       }
       private static com.google.protobuf.Internal.EnumLiteMap<Type>
-          internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<Type>() {
-              public Type findValueByNumber(int number) {
-                return Type.valueOf(number);
-              }
-            };
+          internalValueMap = RequestType::valueOf;
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {


### PR DESCRIPTION
replace anonymous type with method reference in alluxio.proto.dataserver.alluxio.proto.dataserver#internalValueMap #316