### PR TITLE
[SMALLFIX] Java 8 migrartion: replace for with foreach in alluxio.cli.fs.command.CheckConsistencyCommand#checkConsistency

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
@@ -106,8 +106,7 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
       Collections.sort(inconsistentUris);
       System.out.println(path + " has: " + inconsistentUris.size() + " inconsistent files.");
       List<AlluxioURI> inconsistentDirs = new ArrayList<AlluxioURI>();
-      for (int i = 0; i < inconsistentUris.size(); i++) {
-        AlluxioURI inconsistentUri = inconsistentUris.get(i);
+      for (AlluxioURI inconsistentUri : inconsistentUris) {
         URIStatus status = mFileSystem.getStatus(inconsistentUri);
         if (status.isFolder()) {
           inconsistentDirs.add(inconsistentUri);


### PR DESCRIPTION
[SMALLFIX] Java 5 migrartion: replace for with foreach in alluxio.cli.fs.command.CheckConsistencyCommand#checkConsistency