### PR TITLE
[SMALLFIX] Java 8 Improvement: replace lambda with method reference #376

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/netty/AbstractWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/netty/AbstractWriteHandlerTest.java
@@ -202,7 +202,7 @@ public abstract class AbstractWriteHandlerTest {
    */
   protected Object waitForResponse(final EmbeddedChannel channel)
       throws TimeoutException, InterruptedException {
-    return CommonUtils.waitForResult("response from the channel.", () -> channel.readOutbound(),
+    return CommonUtils.waitForResult("response from the channel.", channel::readOutbound,
         WaitForOptions.defaults().setTimeoutMs(Constants.MINUTE_MS));
   }
 


### PR DESCRIPTION
Java 8 Improvement: replace lambda with method reference in alluxio.worker.netty.AbstractWriteHandlerTest#waitForResponse #376