### PR TITLE
[SMALLFIX] Java 8 Improvement: replace lambda with method reference

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -130,7 +130,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
       mCluster.notifySuccess();
     } finally {
-      opThreads.forEach(Thread::interrupt);
+      opThreads.forEach();
     }
   }
 

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -130,7 +130,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
       mCluster.notifySuccess();
     } finally {
-      opThreads.forEach();
+      opThreads.forEach(Thread::interrupt);
     }
   }
 

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -130,7 +130,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
       mCluster.notifySuccess();
     } finally {
-      opThreads.forEach(thread -> thread.interrupt());
+      opThreads.forEach(Thread::interrupt);
     }
   }
 


### PR DESCRIPTION
Java 8 Improvement: replace lambda with method reference in alluxio.server.ft.journal.JournalBackupIntegrationTest#backupRestoreTest