### PR TITLE
[SMALLFIX] Improve comment style in GlusterFSUnderFileSystem

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -296,7 +296,7 @@ public class HdfsUnderFileSystem extends BaseUnderFileSystem
   public List<String> getFileLocations(String path, FileLocationOptions options)
       throws IOException {
     // If the user has hinted the underlying storage nodes are not co-located with Alluxio
-    // workers, short circuit without querying the locations
+    // workers, short circuit without querying the locations.
     if (Boolean.valueOf(mUfsConf.get(PropertyKey.UNDERFS_HDFS_REMOTE))) {
       return null;
     }


### PR DESCRIPTION
Please check it.

There is no file named "GlusterFSUnderFileSystem" or "GlusterFSUnderFileSystem.java" in alluxio

and the comment

    // workers, short circuit without querying the locations

can only be found in "underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java" by "grep -r '// workers, short circuit without querying the locations'"
