### PR TITLE
Replay journals in parallel (#8095)

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -11,10 +11,12 @@
 
 package alluxio.master.journal.ufs;
 
+import alluxio.Constants;
 import alluxio.master.journal.AbstractJournalSystem;
 import alluxio.master.journal.JournalEntryStateMachine;
 import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
+import alluxio.util.CommonUtils;
 import alluxio.util.URIUtils;
 
 import com.google.common.io.Closer;
@@ -24,7 +26,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -63,12 +70,17 @@ public class UfsJournalSystem extends AbstractJournalSystem {
 
   @Override
   public void gainPrimacy() {
-    try {
-      for (UfsJournal journal : mJournals.values()) {
+    List<Callable<Void>> callables = new ArrayList<>();
+    for (UfsJournal journal : mJournals.values()) {
+      callables.add(() -> {
         journal.gainPrimacy();
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to upgrade journal to primary", e);
+        return null;
+      });
+    }
+    try {
+      CommonUtils.invokeAll(callables, 1 * Constants.HOUR_MS);
+    } catch (TimeoutException | ExecutionException e) {
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Journals can be replayed independently, so we
can greatly improve master startup time by replaying
the journals in parallel instead of one after another.
Running locally with a new journal and default
configuration, this change reduces master startup time
from 26 seconds to 11 seconds.