### PR TITLE
[ALLUXIO-3355] Improvements for behavior for when job master is at full capacity

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -278,6 +278,7 @@ public enum ExceptionMessage {
   // job manager
   JOB_DEFINITION_DOES_NOT_EXIST("The job definition for config {0} does not exist"),
   JOB_DOES_NOT_EXIST("The job of id {0} does not exist"),
+  JOB_MASTER_FULL_CAPACITY("Job master is at full capacity"),
 
   // block worker
   FAILED_COMMIT_BLOCK_TO_MASTER("Failed to commit block with blockId {0,number,#} to master"),

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -278,7 +278,7 @@ public enum ExceptionMessage {
   // job manager
   JOB_DEFINITION_DOES_NOT_EXIST("The job definition for config {0} does not exist"),
   JOB_DOES_NOT_EXIST("The job of id {0} does not exist"),
-  JOB_MASTER_FULL_CAPACITY("Job master is at full capacity"),
+  JOB_MASTER_FULL_CAPACITY("Job master is at full capacity of {0} jobs"),
 
   // block worker
   FAILED_COMMIT_BLOCK_TO_MASTER("Failed to commit block with blockId {0,number,#} to master"),

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -48,6 +48,15 @@ public class TestLoggerRule extends AbstractResourceRule {
     return mAppender.wasLogged(Pattern.compile(".*" + pattern + ".*"));
   }
 
+  /**
+   * Count the number of times a specific pattern appears in log messages.
+   * @param pattern Pattern to search for in log events
+   * @return The number of log messages which match the pattern
+   */
+  public int logCount(String pattern) {
+    return mAppender.logCount(Pattern.compile(".*" + pattern + ".*"));
+  }
+
   public class TestAppender extends AppenderSkeleton {
     @GuardedBy("this")
     private List<LoggingEvent> mEvents = new ArrayList<>();
@@ -64,6 +73,19 @@ public class TestLoggerRule extends AbstractResourceRule {
         }
       }
       return false;
+    }
+
+    /**
+     * Counts the number of log message with a given pattern.
+     */
+    public synchronized int logCount(Pattern pattern) {
+      int logCount = 0;
+      for (LoggingEvent e: mEvents) {
+        if (pattern.matcher(e.getRenderedMessage()).matches()) {
+          logCount++;
+        }
+      }
+      return logCount;
     }
 
     @Override

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -50,6 +50,7 @@ public class TestLoggerRule extends AbstractResourceRule {
 
   /**
    * Count the number of times a specific pattern appears in log messages.
+   *
    * @param pattern Pattern to search for in log events
    * @return The number of log messages which match the pattern
    */

--- a/core/common/src/test/java/alluxio/TestLoggerRuleTest.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRuleTest.java
@@ -34,4 +34,14 @@ public final class TestLoggerRuleTest {
     LOG.info(logEvent);
     assertTrue(mLogger.wasLogged(logEvent));
   }
+
+  @Test
+  public void logCountTest() {
+    String logEvent = "I'm a test";
+    assertTrue(mLogger.logCount(logEvent) == 0);
+    LOG.info(logEvent);
+    assertTrue(mLogger.logCount(logEvent) == 1);
+    LOG.info(logEvent);
+    assertTrue(mLogger.logCount(logEvent) == 2);
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3688,6 +3688,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
           mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
               Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
           remove = false;
+          // End the method here until the next heartbeat. No more jobs should be scheduled during
+          // the current heartbeat if the job master is at full capacity.
+          return;
         } catch (Exception e) {
           LOG.warn("Unexpected exception encountered when scheduling the persist job for file {} "
               + "(id={}) : {}", uri, fileId, e.getMessage());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -35,6 +35,7 @@ import alluxio.exception.status.FailedPreconditionException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.PermissionDeniedException;
+import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatThread;
@@ -3681,7 +3682,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         } catch (UnavailableException e) {
           LOG.warn("Failed to persist file {}, will retry later: {}", uri, e.toString());
           remove = false;
-        } catch (alluxio.exception.status.ResourceExhaustedException e) {
+        } catch (ResourceExhaustedException e) {
           LOG.warn("The job service is busy, will retry later: {}", e.getMessage());
           LOG.debug("Exception: ", e);
           mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3683,7 +3683,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
           LOG.warn("Failed to persist file {}, will retry later: {}", uri, e.toString());
           remove = false;
         } catch (ResourceExhaustedException e) {
-          LOG.warn("The job service is busy, will retry later: {}", e.getMessage());
+          LOG.warn("The job service is busy, will retry later: {}", e.toString());
           LOG.debug("Exception: ", e);
           mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
               Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -221,11 +221,11 @@ public final class ReplicationChecker implements HeartbeatExecutor {
             e.getMessage());
         return;
       } catch (ResourceExhaustedException e) {
-          LOG.warn("The job service is busy, will retry later: {}", e.getMessage());
-          LOG.debug("Exception: ", e);
-          mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
-              Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
-          return;
+        LOG.warn("The job service is busy, will retry later: {}", e.getMessage());
+        LOG.debug("Exception: ", e);
+        mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
+            Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
+        return;
       } catch (Exception e) {
         LOG.warn(
             "Unexpected exception encountered when starting a replication / eviction job (uri={},"

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -212,7 +212,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
             LOG.warn("Unexpected replication mode {}.", mode);
         }
       } catch (JobDoesNotExistException | ResourceExhaustedException e) {
-        LOG.warn("The job service is busy, will retry later. {}", e.getMessage());
+        LOG.warn("The job service is busy, will retry later. {}", e.toString());
         mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
             Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
         return;

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -211,20 +211,14 @@ public final class ReplicationChecker implements HeartbeatExecutor {
           default:
             LOG.warn("Unexpected replication mode {}.", mode);
         }
-      } catch (JobDoesNotExistException e) {
-        LOG.warn("The job service is busy, will retry later.");
+      } catch (JobDoesNotExistException | ResourceExhaustedException e) {
+        LOG.warn("The job service is busy, will retry later. {}", e.getMessage());
         mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
             Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
         return;
       } catch (UnavailableException e) {
         LOG.warn("Unable to complete the replication check: {}, will retry later.",
             e.getMessage());
-        return;
-      } catch (ResourceExhaustedException e) {
-        LOG.warn("The job service is busy, will retry later: {}", e.getMessage());
-        LOG.debug("Exception: ", e);
-        mQuietPeriodSeconds = (mQuietPeriodSeconds == 0) ? 1 :
-            Math.min(MAX_QUIET_PERIOD_SECONDS, mQuietPeriodSeconds * 2);
         return;
       } catch (Exception e) {
         LOG.warn(

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -194,7 +194,8 @@ public final class JobMaster extends AbstractNonJournaledMaster {
     if (mIdToJobCoordinator.size() == CAPACITY) {
       if (mFinishedJobs.isEmpty()) {
         // The job master is at full capacity and no job has finished.
-        throw new ResourceExhaustedException("Job master is at full capacity");
+        throw new ResourceExhaustedException(
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage());
       }
       // Discard old jobs that have completion time beyond retention policy
       Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
@@ -213,7 +214,8 @@ public final class JobMaster extends AbstractNonJournaledMaster {
         isfull = false;
       }
       if (isfull) {
-        throw new ResourceExhaustedException("Job master is at full capacity");
+        throw new ResourceExhaustedException(
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage());
       }
     }
     long jobId = mJobIdGenerator.getNewJobId();

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -195,7 +195,8 @@ public final class JobMaster extends AbstractNonJournaledMaster {
       if (mFinishedJobs.isEmpty()) {
         // The job master is at full capacity and no job has finished.
         throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage());
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY
+                .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY)));
       }
       // Discard old jobs that have completion time beyond retention policy
       Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
@@ -215,7 +216,8 @@ public final class JobMaster extends AbstractNonJournaledMaster {
       }
       if (isfull) {
         throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage());
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY
+                .getMessage(CAPACITY));
       }
     }
     long jobId = mJobIdGenerator.getNewJobId();

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -70,7 +70,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class JobMaster extends AbstractNonJournaledMaster {
   private static final Logger LOG = LoggerFactory.getLogger(JobMaster.class);
-  private static final long CAPACITY = Configuration.getLong(PropertyKey.JOB_MASTER_JOB_CAPACITY);
   private static final long RETENTION_MS =
       Configuration.getLong(PropertyKey.JOB_MASTER_FINISHED_JOB_RETENTION_MS);
 
@@ -90,6 +89,11 @@ public final class JobMaster extends AbstractNonJournaledMaster {
           return o.getWorkerAddress();
         }
       };
+
+  /**
+   * The total number of jobs that the JobMaster may run at any moment.
+   */
+  private final long mCapacity = Configuration.getLong(PropertyKey.JOB_MASTER_JOB_CAPACITY);
 
   /**
    * All worker information. Access must be controlled on mWorkers using the RW lock(mWorkerRWLock).
@@ -191,12 +195,11 @@ public final class JobMaster extends AbstractNonJournaledMaster {
    */
   public synchronized long run(JobConfig jobConfig)
       throws JobDoesNotExistException, ResourceExhaustedException {
-    if (mIdToJobCoordinator.size() == CAPACITY) {
+    if (mIdToJobCoordinator.size() == mCapacity) {
       if (mFinishedJobs.isEmpty()) {
         // The job master is at full capacity and no job has finished.
         throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY
-                .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY)));
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
       }
       // Discard old jobs that have completion time beyond retention policy
       Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
@@ -216,8 +219,7 @@ public final class JobMaster extends AbstractNonJournaledMaster {
       }
       if (isfull) {
         throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY
-                .getMessage(CAPACITY));
+            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
       }
     }
     long jobId = mJobIdGenerator.getNewJobId();

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -109,7 +109,7 @@ public final class JobMasterTest {
       mJobMaster.run(jobConfig);
       Assert.fail("should not be able to run more jobs than job master capacity");
     } catch (ResourceExhaustedException e) {
-      Assert.assertEquals("Job master is at full capacity", e.getMessage());
+      Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY, e.getMessage());
     }
   }
 

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -109,7 +109,8 @@ public final class JobMasterTest {
       mJobMaster.run(jobConfig);
       Assert.fail("should not be able to run more jobs than job master capacity");
     } catch (ResourceExhaustedException e) {
-      Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(), e.getMessage());
+      Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY
+          .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY)), e.getMessage());
     }
   }
 

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -109,7 +109,7 @@ public final class JobMasterTest {
       mJobMaster.run(jobConfig);
       Assert.fail("should not be able to run more jobs than job master capacity");
     } catch (ResourceExhaustedException e) {
-      Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY, e.getMessage());
+      Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(), e.getMessage());
     }
   }
 

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -57,7 +57,6 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
   public void before() throws Exception {
     super.before();
 
-
     AlluxioURI filePath = new AlluxioURI(TEST_URI);
     // write a file outside of Alluxio
     createFileOutsideOfAlluxio(filePath);

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -112,8 +112,9 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     }
     String exceptionMsg = ExceptionMessage.JOB_MASTER_FULL_CAPACITY
         .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY));
-    String replicationCheckerMsg = "The job service is busy, will retry later. " + exceptionMsg;
-    String rpcUtilsMsg = "alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
+    String replicationCheckerMsg = "The job service is busy, will retry later." +
+        " alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
+    String rpcUtilsMsg = "Error=alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
     SetAttributeOptions opts = SetAttributeOptions.defaults();
     opts.setReplicationMin(2);
     mFileSystem.setAttribute(new AlluxioURI(rootDir), opts);

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -112,9 +112,10 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     }
     String exceptionMsg = ExceptionMessage.JOB_MASTER_FULL_CAPACITY
         .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY));
-    String replicationCheckerMsg = "The job service is busy, will retry later." +
-        " alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
-    String rpcUtilsMsg = "Error=alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
+    String replicationCheckerMsg = "The job service is busy, will retry later."
+        + " alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
+    String rpcUtilsMsg = "Error=alluxio.exception.status.ResourceExhaustedException: "
+        + exceptionMsg;
     SetAttributeOptions opts = SetAttributeOptions.defaults();
     opts.setReplicationMin(2);
     mFileSystem.setAttribute(new AlluxioURI(rootDir), opts);

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -118,8 +118,8 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     opts.setReplicationMin(2);
     mFileSystem.setAttribute(new AlluxioURI(rootDir), opts);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_REPLICATION_CHECK);
-    // After logging we should expect only one log message to be logged as the job master
-    // has a zero job capacity even though there are two jobs.
+    // After logging we expect only one log message to be logged as the job master has a zero job
+    // capacity even though there should be 10 replication jobs.
     Assert.assertEquals(1, mLogger.logCount(replicationCheckerMsg));
     Assert.assertEquals(1, mLogger.logCount(rpcUtilsMsg));
   }

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -113,7 +113,7 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     }
     String exceptionMsg = ExceptionMessage.JOB_MASTER_FULL_CAPACITY
         .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY));
-    String replicationCehckerMsg = "The job service is busy, will retry later. " + exceptionMsg;
+    String replicationCheckerMsg = "The job service is busy, will retry later. " + exceptionMsg;
     String rpcUtilsMsg = "alluxio.exception.status.ResourceExhaustedException: " + exceptionMsg;
     SetAttributeOptions opts = SetAttributeOptions.defaults();
     opts.setReplicationMin(2);
@@ -121,7 +121,7 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_REPLICATION_CHECK);
     // After logging we should expect only one log message to be logged as the job master
     // has a zero job capacity even though there are two jobs.
-    Assert.assertEquals(1, mLogger.logCount(replicationCehckerMsg));
+    Assert.assertEquals(1, mLogger.logCount(replicationCheckerMsg));
     Assert.assertEquals(1, mLogger.logCount(rpcUtilsMsg));
   }
 }

--- a/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/replicate/ReplicateIntegrationTest.java
@@ -65,7 +65,7 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     mBlockId2 = status.getBlockIds().get(1);
   }
 
-  public void createFileOutsideOfAlluxio(AlluxioURI uri) throws Exception {
+  private void createFileOutsideOfAlluxio(AlluxioURI uri) throws Exception {
     try (FileOutStream os = mFileSystem.createFile(uri,
         CreateFileOptions.defaults()
             .setWriteType(WriteType.THROUGH)
@@ -118,6 +118,7 @@ public final class ReplicateIntegrationTest extends JobIntegrationTest {
     opts.setReplicationMin(2);
     mFileSystem.setAttribute(new AlluxioURI(rootDir), opts);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_REPLICATION_CHECK);
+
     // After logging we expect only one log message to be logged as the job master has a zero job
     // capacity even though there should be 10 replication jobs.
     Assert.assertEquals(1, mLogger.logCount(replicationCheckerMsg));


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3355

- Previously when the job master needed to schedule hundreds or thousands of jobs at once, we would send all of the RPCs for each job. Depending on the system this caused a ton of logging messages and would clog the logs when a large number operations ran and could not all be completed at once.

These changes use the same backoff strategy used when we get a `JobDoesNotExist` exception in the replication checker. The `PersistenceChecker` already uses this strategy for `ResourceExhaustedException` as well.