### PR TITLE
[ALLUXIO-3365] Fix setAcl permission

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2789,11 +2789,11 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
          LockedInodePathList children = options.getRecursive()
              ? mInodeTree.lockDescendants(inodePath, InodeTree.LockMode.WRITE) : null) {
       try {
-        mPermissionChecker.checkPermission(Mode.Bits.WRITE, inodePath);
+        mPermissionChecker.checkSetAttributePermission(inodePath, false, true);
 
         if (children != null) {
           for (LockedInodePath child : children.getInodePathList()) {
-            mPermissionChecker.checkPermission(Mode.Bits.WRITE, child);
+            mPermissionChecker.checkSetAttributePermission(child, false, true);
           }
         }
       } catch (AccessControlException e) {

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1407,6 +1407,47 @@ public final class FileSystemMasterTest {
   }
 
   @Test
+  public void setAclWithoutOwner() throws Exception {
+    SetAclOptions options = SetAclOptions.defaults();
+    createFileWithSingleBlock(NESTED_FILE_URI);
+    mFileSystemMaster.setAttribute(NESTED_URI,
+        SetAttributeOptions.defaults().setMode((short) 0777));
+    Set<String> entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
+    assertEquals(3, entries.size());
+    mThrown.expect(AccessControlException.class);
+    try (AuthenticatedClientUserResource userA = new AuthenticatedClientUserResource("userA")) {
+      Set<String> newEntries = Sets.newHashSet("user::rwx", "group::rwx", "other::rwx");
+      mFileSystemMaster.setAcl(NESTED_FILE_URI, SetAclAction.REPLACE,
+          newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
+      entries = Sets.newHashSet(mFileSystemMaster
+          .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
+      assertEquals(newEntries, entries);
+    }
+  }
+
+  @Test
+  public void setAclNestedWithoutOwner() throws Exception {
+    SetAclOptions options = SetAclOptions.defaults().setRecursive(true);
+    createFileWithSingleBlock(NESTED_FILE_URI);
+    mFileSystemMaster.setAttribute(NESTED_URI,
+        SetAttributeOptions.defaults().setMode((short) 0777).setOwner("userA"));
+    Set<String> entries = Sets.newHashSet(mFileSystemMaster
+        .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
+    assertEquals(3, entries.size());
+    // recursive setAcl should fail if one of the child is not owned by the user
+    mThrown.expect(AccessControlException.class);
+    try (AuthenticatedClientUserResource userA = new AuthenticatedClientUserResource("userA")) {
+      Set<String> newEntries = Sets.newHashSet("user::rwx", "group::rwx", "other::rwx");
+      mFileSystemMaster.setAcl(NESTED_URI, SetAclAction.REPLACE,
+          newEntries.stream().map(AclEntry::fromCliString).collect(Collectors.toList()), options);
+      entries = Sets.newHashSet(mFileSystemMaster
+          .getFileInfo(NESTED_FILE_URI, GET_STATUS_OPTIONS).convertAclToStringEntries());
+      assertEquals(newEntries, entries);
+    }
+  }
+
+  @Test
   public void removeExtendedAclMask() throws Exception {
     mFileSystemMaster.createDirectory(NESTED_URI,
         CreateDirectoryOptions.defaults().setRecursive(true));


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3365
`setAcl()` should only be performed by owner of the target.