### PR TITLE
[SMALLFIX] Improve builds by using rerunFailingTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     <surefire.forkCount>2</surefire.forkCount>
     <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>
     <surefire.excludesFile>slow-tests</surefire.excludesFile>
+    <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
     <test.output.redirect>true</test.output.redirect>
   </properties>
 
@@ -961,6 +962,7 @@
             <argLine>-Djava.net.preferIPv4Stack=true</argLine>
             <excludesFile>${build.path}/surefire/${surefire.excludesFile}</excludesFile>
             <forkCount>${surefire.forkCount}</forkCount>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <runOrder>alphabetical</runOrder>


### PR DESCRIPTION
Surefire's `rerunFailingTests` option allows us to rerun tests which fail at build time for a specified number of retries.

Failures may be due to a variety of errors. Some deterministic, and others not. By adding in this flag we will be allowing some non-deterministically failing tests to fly under the radar for a short period of time until we have proper tracking on jenkins.

For the time being, this should improve the build pass rate due to tests like the `journalFencingFailoverTest` (and a few others) which have been failing at seemingly random times which causes  some inefficiency in getting code merged.

I've set the rerun count to 1, which allows a single test rerun upon one failure (single test may be run a maximum of 2 times). If we see a build fail due to a flake, the test should be fixed ASAP.

@aaudiber PTAL, thanks!