### PR TITLE
[SMALLFIX] Locking cleanups

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -56,6 +56,7 @@ import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeFileView;
 import alluxio.master.file.meta.InodePathPair;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.LockedInodePathList;
@@ -207,7 +208,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * {@link LockedInodePath} is always unlocked, the following paradigm is recommended:
    *
    * <p><blockquote><pre>
-   *    try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, InodeTree.LockMode.READ)) {
+   *    try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.READ)) {
    *      ...
    *    }
    * </pre></blockquote>
@@ -509,7 +510,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // Rebuild the list of persist jobs (mPersistJobs) and map of pending persist requests
       // (mPersistRequests)
       try (LockedInodePath inodePath = mInodeTree.lockInodePath(new AlluxioURI("/"),
-          alluxio.master.file.meta.InodeTree.LockMode.WRITE)) {
+          LockPattern.WRITE_LAST)) {
         // Walk the inode tree looking for files in the TO_BE_PERSISTED state.
         java.util.Queue<InodeDirectoryView> dirsToProcess = new java.util.LinkedList<>();
         dirsToProcess.add((InodeDirectoryView) inodePath.getInode());
@@ -657,7 +658,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       @Override
       public List<AlluxioURI> call() throws IOException {
         List<AlluxioURI> inconsistentUris = new ArrayList<>();
-        try (LockedInodePath dir = mInodeTree.lockFullInodePath(mFileId, InodeTree.LockMode.READ)) {
+        try (LockedInodePath dir = mInodeTree.lockFullInodePath(mFileId, LockPattern.READ)) {
           InodeView parentInode = dir.getInode();
           AlluxioURI parentUri = dir.getUri();
           if (!checkConsistencyInternal(parentInode, parentUri)) {
@@ -769,12 +770,12 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public long getFileId(AlluxioURI path) throws AccessControlException, UnavailableException {
     try (RpcContext rpcContext = createRpcContext();
-         LockedInodePath inodePath = mInodeTree.lockInodePath(path, InodeTree.LockMode.WRITE)) {
+         LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.WRITE_LAST)) {
       // This is WRITE locked, since loading metadata is possible.
       mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
       loadMetadataIfNotExist(rpcContext, inodePath,
           LoadMetadataOptions.defaults().setCreateAncestors(true));
-      mInodeTree.ensureFullInodePath(inodePath, InodeTree.LockMode.READ);
+      mInodeTree.ensureFullInodePath(inodePath, LockPattern.READ);
       return inodePath.getInode().getId();
     } catch (InvalidPathException | FileDoesNotExistException e) {
       return IdUtils.INVALID_FILE_ID;
@@ -786,7 +787,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws FileDoesNotExistException, AccessControlException, UnavailableException {
     Metrics.GET_FILE_INFO_OPS.inc();
     try (
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, InodeTree.LockMode.READ)) {
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, LockPattern.READ)) {
       return getFileInfoInternal(inodePath);
     }
   }
@@ -796,7 +797,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
     Metrics.GET_FILE_INFO_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.READ);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.READ);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -864,7 +865,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public PersistenceState getPersistenceState(long fileId) throws FileDoesNotExistException {
     try (
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, InodeTree.LockMode.READ)) {
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, LockPattern.READ)) {
       return inodePath.getInode().getPersistenceState();
     }
   }
@@ -875,7 +876,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       UnavailableException {
     Metrics.GET_FILE_INFO_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, listStatusOptions.getCommonOptions(), InodeTree.LockMode.READ);
+        createLockingScheme(path, listStatusOptions.getCommonOptions(), LockPattern.READ);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -994,7 +995,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         childComponents[childComponents.length - 1] = child.getName();
 
         try (LockedInodePath childInodePath  = mInodeTree.lockChildPath(currInodePath,
-            InodeTree.LockMode.READ, child, childComponents)) {
+            LockPattern.READ, child, childComponents)) {
           listStatusInternal(childInodePath, auditContext,
               nextDescendantType, statusList);
         } catch (InvalidPathException e) {
@@ -1032,7 +1033,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws InvalidPathException, FileDoesNotExistException {
     boolean exists = false;
     try {
-      mInodeTree.ensureFullInodePath(inodePath, InodeTree.LockMode.READ);
+      mInodeTree.ensureFullInodePath(inodePath, LockPattern.READ);
       exists = true;
     } finally {
       if (!exists) {
@@ -1050,7 +1051,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   public List<AlluxioURI> checkConsistency(AlluxioURI path, CheckConsistencyOptions options)
       throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException {
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.READ);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.READ);
     List<AlluxioURI> inconsistentUris = new ArrayList<>();
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath parent =
@@ -1071,7 +1072,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       }
 
       try (LockedInodePathList children =
-               mInodeTree.lockDescendants(parent, InodeTree.LockMode.READ)) {
+               mInodeTree.lockDescendants(parent, LockPattern.READ)) {
         for (LockedInodePath child : children.getInodePathList()) {
           AlluxioURI currentPath = child.getUri();
           if (!checkConsistencyInternal(child.getInode(), currentPath)) {
@@ -1132,7 +1133,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     Metrics.COMPLETE_FILE_OPS.inc();
     // No need to syncMetadata before complete.
     try (RpcContext rpcContext = createRpcContext();
-         LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE);
+         LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.WRITE_LAST);
          FileSystemMasterAuditContext auditContext =
              createAuditContext("completeFile", path, null, inodePath.getInodeOrNull())) {
       try {
@@ -1277,7 +1278,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       BlockInfoException, IOException, FileDoesNotExistException {
     Metrics.CREATE_FILES_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -1340,7 +1341,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       InvalidPathException, AccessControlException, UnavailableException {
     Metrics.GET_NEW_BLOCK_OPS.inc();
     try (RpcContext rpcContext = createRpcContext();
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE);
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.WRITE_LAST);
         FileSystemMasterAuditContext auditContext =
             createAuditContext("getNewBlockIdForFile", path, null, inodePath.getInodeOrNull())) {
       try {
@@ -1424,14 +1425,14 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       AccessControlException {
     Metrics.DELETE_PATHS_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
         LockedInodePath inodePath =
             mInodeTree.lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
         FileSystemMasterAuditContext auditContext =
             createAuditContext("delete", path, null, inodePath.getInodeOrNull());
         LockedInodePathList children =
-            options.isRecursive() ? mInodeTree.lockDescendants(inodePath, InodeTree.LockMode.WRITE)
+            options.isRecursive() ? mInodeTree.lockDescendants(inodePath, LockPattern.WRITE_LAST)
                 : null) {
       try {
         mPermissionChecker.checkParentPermission(Mode.Bits.WRITE, inodePath);
@@ -1513,7 +1514,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     inodesToDelete.add(new Pair<>(inodePath.getUri(), inodePath));
 
     try (LockedInodePathList children =
-        mInodeTree.lockDescendants(inodePath, InodeTree.LockMode.WRITE)) {
+        mInodeTree.lockDescendants(inodePath, LockPattern.WRITE_LAST)) {
       // Traverse inodes top-down
       for (LockedInodePath child : children.getInodePathList()) {
         inodesToDelete
@@ -1611,7 +1612,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws FileDoesNotExistException, InvalidPathException, AccessControlException,
       UnavailableException {
     Metrics.GET_FILE_BLOCK_INFO_OPS.inc();
-    try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.READ);
+    try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.READ);
         FileSystemMasterAuditContext auditContext =
             createAuditContext("getFileBlockInfoList", path, null, inodePath.getInodeOrNull())) {
       try {
@@ -1864,7 +1865,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     LOG.debug("createDirectory {} ", path);
     Metrics.CREATE_DIRECTORIES_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -1950,9 +1951,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       IOException, AccessControlException {
     Metrics.RENAME_PATH_OPS.inc();
     LockingScheme srcLockingScheme =
-        createLockingScheme(srcPath, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(srcPath, options.getCommonOptions(), LockPattern.WRITE_LAST);
     LockingScheme dstLockingScheme =
-        createLockingScheme(dstPath, options.getCommonOptions(), InodeTree.LockMode.READ);
+        createLockingScheme(dstPath, options.getCommonOptions(), LockPattern.READ);
     // Require a WRITE lock on the source but only a READ lock on the destination. Since the
     // destination should not exist, we will only obtain a READ lock on the destination parent. The
     // modify operations on the parent inodes are thread safe so WRITE locks are not required.
@@ -2201,7 +2202,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     Metrics.FREE_FILE_OPS.inc();
     // No need to syncMetadata before free.
     try (RpcContext rpcContext = createRpcContext();
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE);
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.WRITE_LAST);
         FileSystemMasterAuditContext auditContext =
              createAuditContext("free", path, null, inodePath.getInodeOrNull())) {
       try {
@@ -2236,7 +2237,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     List<InodeView> freeInodes = new ArrayList<>();
     freeInodes.add(inode);
     List<LockedInodePath> descendants = mInodeTree.lockDescendants(inodePath,
-        InodeTree.LockMode.WRITE).getInodePathList();
+        LockPattern.WRITE_LAST).getInodePathList();
     Closer closer = Closer.create();
     // Using a closer here because we add the inodePath to the descendants list which does not
     // need to be closed
@@ -2277,7 +2278,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public AlluxioURI getPath(long fileId) throws FileDoesNotExistException {
     try (
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, InodeTree.LockMode.READ)) {
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, LockPattern.READ)) {
       // the path is already locked.
       return mInodeTree.getPath(inodePath.getInode());
     }
@@ -2327,7 +2328,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
       InvalidFileSizeException, FileAlreadyCompletedException, IOException, AccessControlException {
     try (RpcContext rpcContext = createRpcContext();
-        LockedInodePath inodePath = mInodeTree.lockInodePath(path, InodeTree.LockMode.WRITE);
+        LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.WRITE_LAST);
         FileSystemMasterAuditContext auditContext =
              createAuditContext("loadMetadata", path, null, inodePath.getParentInodeOrNull())) {
       if (options.isCreateAncestors()) {
@@ -2513,7 +2514,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         completeOptions.setOperationTimeMs(ufsLastModified);
       }
       completeFileInternal(rpcContext, inodePath, completeOptions);
-      if (inodePath.getLockMode() == InodeTree.LockMode.READ) {
+      if (inodePath.getLockPattern() == LockPattern.READ) {
         // After completing the inode, the lock on the last inode which stands for the created file
         // should be downgraded to a read lock, so that it won't block the reads operations from
         // other thread. More importantly, it's possible the subsequent read operations within the
@@ -2526,7 +2527,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     } catch (FileAlreadyExistsException e) {
       // This may occur if there are concurrent load metadata requests. To allow loading metadata
       // to be idempotent, ensure the full path exists when this happens.
-      mInodeTree.ensureFullInodePath(inodePath, inodePath.getLockMode());
+      mInodeTree.ensureFullInodePath(inodePath, inodePath.getLockPattern());
     }
   }
 
@@ -2593,7 +2594,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
     try {
       createDirectoryInternal(rpcContext, inodePath, createDirectoryOptions);
-      if (inodePath.getLockMode() == InodeTree.LockMode.READ) {
+      if (inodePath.getLockPattern() == LockPattern.READ) {
         // If the directory is successfully created, createDirectoryInternal will add a write lock
         // to the inodePath's lock list. We are done modifying the directory, so we downgrade it to
         // a read lock.
@@ -2602,7 +2603,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     } catch (FileAlreadyExistsException e) {
       // This may occur if there are concurrent load metadata requests. To allow loading metadata
       // to be idempotent, ensure the full path exists when this happens.
-      mInodeTree.ensureFullInodePath(inodePath, inodePath.getLockMode());
+      mInodeTree.ensureFullInodePath(inodePath, inodePath.getLockPattern());
     }
   }
 
@@ -2645,7 +2646,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       IOException, AccessControlException {
     Metrics.MOUNT_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(alluxioPath, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(alluxioPath, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -2756,7 +2757,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     // Unmount should lock the parent to remove the child inode.
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
-            .lockFullInodePath(alluxioPath, InodeTree.LockMode.WRITE_PARENT);
+            .lockFullInodePath(alluxioPath, LockPattern.WRITE_LAST);
          FileSystemMasterAuditContext auditContext =
              createAuditContext("unmount", alluxioPath, null, inodePath.getInodeOrNull())) {
       try {
@@ -2810,14 +2811,14 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws FileDoesNotExistException, AccessControlException, InvalidPathException, IOException {
     Metrics.SET_ACL_OPS.inc();
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme.getPath(),
              lockingScheme.getMode());
          FileSystemMasterAuditContext auditContext = createAuditContext("setAcl", path, null,
              inodePath.getInodeOrNull());
          LockedInodePathList children = options.getRecursive()
-             ? mInodeTree.lockDescendants(inodePath, InodeTree.LockMode.WRITE) : null) {
+             ? mInodeTree.lockDescendants(inodePath, LockPattern.WRITE_LAST) : null) {
       try {
         mPermissionChecker.checkSetAttributePermission(inodePath, false, true);
 
@@ -2946,7 +2947,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       SetAclOptions options) throws IOException, FileDoesNotExistException {
     setAclSingleInode(rpcContext, action, inodePath, entries, replay, opTimeMs);
     try (LockedInodePathList children = options.getRecursive()
-        ? mInodeTree.lockDescendants(inodePath, InodeTree.LockMode.WRITE) : null) {
+        ? mInodeTree.lockDescendants(inodePath, LockPattern.WRITE_LAST) : null) {
       if (children != null) {
         for (LockedInodePath child : children.getInodePathList()) {
           setAclSingleInode(rpcContext, action, child, entries, replay, opTimeMs);
@@ -2984,7 +2985,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       commandName = "setAttribute";
     }
     LockingScheme lockingScheme =
-        createLockingScheme(path, options.getCommonOptions(), InodeTree.LockMode.WRITE);
+        createLockingScheme(path, options.getCommonOptions(), LockPattern.WRITE_LAST);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -3041,7 +3042,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     long opTimeMs = System.currentTimeMillis();
     if (options.isRecursive() && targetInode.isDirectory()) {
       try (LockedInodePathList descendants = mInodeTree.lockDescendants(inodePath,
-          InodeTree.LockMode.WRITE)) {
+          LockPattern.WRITE_LAST)) {
         for (LockedInodePath childPath : descendants.getInodePathList()) {
           mPermissionChecker.checkSetAttributePermission(childPath, rootRequired, ownerRequired);
         }
@@ -3058,7 +3059,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws AlluxioException, UnavailableException {
     // We retry an async persist request until ufs permits the operation
     try (RpcContext rpcContext = createRpcContext();
-        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, InodeTree.LockMode.WRITE)) {
+        LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.WRITE_LAST)) {
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(inodePath.getInode().getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())
@@ -3094,7 +3095,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
     LockingScheme lockingScheme =
         createLockingScheme(path, CommonOptions.defaults().setSyncIntervalMs(0),
-            InodeTree.LockMode.WRITE);
+            LockPattern.WRITE_LAST);
     Map<AlluxioURI, UfsStatus> statusCache;
     try (RpcContext rpcContext = createRpcContext()) {
       if (changedFiles == null) {
@@ -3109,7 +3110,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         }
       } else {
         try (LockedInodePath inodePath =
-                 mInodeTree.lockInodePath(lockingScheme.getPath(), InodeTree.LockMode.READ)) {
+                 mInodeTree.lockInodePath(lockingScheme.getPath(), LockPattern.READ)) {
           statusCache = populateStatusCache(inodePath, DescendantType.ALL);
         }
         Set<Callable<Void>> callables = new HashSet<>();
@@ -3117,7 +3118,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
           callables.add(() -> {
             LockingScheme fileLockingScheme =
                 createLockingScheme(alluxioUri, CommonOptions.defaults().setSyncIntervalMs(0),
-                    InodeTree.LockMode.WRITE);
+                    LockPattern.WRITE_LAST);
             try (LockedInodePath inodePathChangedFile =
                      mInodeTree.lockInodePath(alluxioUri, fileLockingScheme.getMode())) {
               syncMetadataInternal(rpcContext, inodePathChangedFile, fileLockingScheme,
@@ -3455,7 +3456,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
             continue;
           }
           try (LockedInodePath tempInodePath = mInodeTree.lockDescendantPath(inodePath,
-              InodeTree.LockMode.READ, inodePath.getUri().join(inodeEntry.getKey()))) {
+              LockPattern.READ, inodePath.getUri().join(inodeEntry.getKey()))) {
             // Recursively sync children
             if (syncDescendantType != DescendantType.ALL) {
               syncDescendantType = DescendantType.NONE;
@@ -3635,7 +3636,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws InvalidPathException, IOException {
     try (LockedInodePath inodePath = mInodeTree
         .lockInodePath(new AlluxioURI(addSyncPointEntry.getSyncpointPath()),
-            InodeTree.LockMode.WRITE)) {
+            LockPattern.WRITE_LAST)) {
       mSyncManager.addSyncPointFromJournal(inodePath.getUri());
     }
   }
@@ -3644,7 +3645,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       throws InvalidPathException, IOException {
     try (LockedInodePath inodePath = mInodeTree
         .lockInodePath(new AlluxioURI(removeSyncPointEntry.getSyncpointPath()),
-            InodeTree.LockMode.WRITE)) {
+            LockPattern.WRITE_LAST)) {
       mSyncManager.stopSync(inodePath.getUri());
     }
   }
@@ -3653,7 +3654,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   public void startSync(AlluxioURI syncPoint)
       throws IOException, InvalidPathException,
       AccessControlException, ConnectionFailedException {
-    LockingScheme lockingScheme = new LockingScheme(syncPoint, InodeTree.LockMode.WRITE, true);
+    LockingScheme lockingScheme = new LockingScheme(syncPoint, LockPattern.WRITE_LAST, true);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -3686,7 +3687,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   @Override
   public void stopSync(AlluxioURI syncPoint) throws IOException, InvalidPathException,
       AccessControlException {
-    LockingScheme lockingScheme = new LockingScheme(syncPoint, InodeTree.LockMode.READ, false);
+    LockingScheme lockingScheme = new LockingScheme(syncPoint, LockPattern.READ, false);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getMode());
@@ -3758,7 +3759,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     private void handleExpired(long fileId) throws AlluxioException, UnavailableException {
       try (JournalContext journalContext = createJournalContext();
            LockedInodePath inodePath = mInodeTree
-               .lockFullInodePath(fileId, InodeTree.LockMode.WRITE)) {
+               .lockFullInodePath(fileId, LockPattern.WRITE_LAST)) {
         InodeFileView inode = inodePath.getInodeFile();
         switch (inode.getPersistenceState()) {
           case LOST:
@@ -3798,7 +3799,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       AlluxioURI uri;
       String tempUfsPath;
       try (LockedInodePath inodePath = mInodeTree
-          .lockFullInodePath(fileId, InodeTree.LockMode.READ)) {
+          .lockFullInodePath(fileId, LockPattern.READ)) {
         InodeFileView inode = inodePath.getInodeFile();
         uri = inodePath.getUri();
         switch (inode.getPersistenceState()) {
@@ -3846,7 +3847,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       // Update the inode and journal the change.
       try (JournalContext journalContext = createJournalContext();
            LockedInodePath inodePath = mInodeTree
-               .lockFullInodePath(fileId, InodeTree.LockMode.WRITE)) {
+               .lockFullInodePath(fileId, LockPattern.WRITE_LAST)) {
         InodeFileView inode = inodePath.getInodeFile();
         mInodeTree.updateInodeFile(journalContext, UpdateInodeFileEntry.newBuilder()
             .setId(inode.getId())
@@ -3884,7 +3885,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         AlluxioURI uri = null;
         try {
           try (LockedInodePath inodePath = mInodeTree
-              .lockFullInodePath(fileId, InodeTree.LockMode.READ)) {
+              .lockFullInodePath(fileId, LockPattern.READ)) {
             uri = inodePath.getUri();
           }
           try {
@@ -3962,7 +3963,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       UfsManager.UfsClient ufsClient = null;
       try (JournalContext journalContext = createJournalContext();
           LockedInodePath inodePath = mInodeTree
-              .lockFullInodePath(fileId, InodeTree.LockMode.WRITE)) {
+              .lockFullInodePath(fileId, LockPattern.WRITE_LAST)) {
         InodeFileView inode = inodePath.getInodeFile();
         MountTable.Resolution resolution = mMountTable.resolve(inodePath.getUri());
         ufsClient = mUfsManager.get(resolution.getMountId());
@@ -4382,7 +4383,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
   }
 
   private LockingScheme createLockingScheme(AlluxioURI path, CommonOptions options,
-      InodeTree.LockMode desiredLockMode) {
+      LockPattern desiredLockMode) {
     boolean shouldSync =
         mUfsSyncPathCache.shouldSyncPath(path.getPath(), options.getSyncIntervalMs());
     return new LockingScheme(path, desiredLockMode, shouldSync);

--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -17,6 +17,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.master.ProtobufUtils;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.TtlBucket;
@@ -60,8 +61,8 @@ final class InodeTtlChecker implements HeartbeatExecutor {
     for (TtlBucket bucket : expiredBuckets) {
       for (InodeView inode : bucket.getInodes()) {
         AlluxioURI path = null;
-        try (LockedInodePath inodePath = mInodeTree
-            .lockFullInodePath(inode.getId(), InodeTree.LockMode.READ)) {
+        try (LockedInodePath inodePath =
+            mInodeTree.lockFullInodePath(inode.getId(), LockPattern.READ)) {
           path = inodePath.getUri();
         } catch (FileDoesNotExistException e) {
           // The inode has already been deleted, nothing needs to be done.

--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -15,6 +15,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.PersistenceState;
@@ -48,8 +49,8 @@ final class LostFileDetector implements HeartbeatExecutor {
     for (long fileId : mFileSystemMaster.getLostFiles()) {
       // update the state
       try (JournalContext journalContext = mFileSystemMaster.createJournalContext();
-           LockedInodePath inodePath = mInodeTree
-               .lockFullInodePath(fileId, InodeTree.LockMode.WRITE)) {
+          LockedInodePath inodePath =
+              mInodeTree.lockFullInodePath(fileId, LockPattern.WRITE_LAST)) {
         InodeView inode = inodePath.getInode();
         if (inode.getPersistenceState() != PersistenceState.PERSISTED) {
           mInodeTree.updateInode(journalContext, UpdateInodeEntry.newBuilder()

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -12,6 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.exception.InvalidPathException;
+import alluxio.master.file.meta.InodeTree.LockMode;
 
 import com.google.common.collect.Lists;
 
@@ -27,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public class InodeLockList implements AutoCloseable {
   private static final int INITIAL_CAPACITY = 4;
   protected List<InodeView> mInodes;
-  protected List<InodeTree.LockMode> mLockModes;
+  protected List<LockMode> mLockModes;
 
   /**
    * Creates a new instance of {@link InodeLockList}.
@@ -46,7 +47,7 @@ public class InodeLockList implements AutoCloseable {
   public synchronized void lockRead(InodeView inode) {
     inode.lockRead();
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.READ);
+    mLockModes.add(LockMode.READ);
   }
 
   /**
@@ -63,7 +64,7 @@ public class InodeLockList implements AutoCloseable {
       throws InvalidPathException {
     inode.lockReadAndCheckParent(parent);
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.READ);
+    mLockModes.add(LockMode.READ);
   }
 
   /**
@@ -81,7 +82,7 @@ public class InodeLockList implements AutoCloseable {
       String name) throws InvalidPathException {
     inode.lockReadAndCheckNameAndParent(parent, name);
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.READ);
+    mLockModes.add(LockMode.READ);
   }
 
   /**
@@ -93,7 +94,7 @@ public class InodeLockList implements AutoCloseable {
     }
     InodeView inode = mInodes.remove(mInodes.size() - 1);
     InodeTree.LockMode lockMode = mLockModes.remove(mLockModes.size() - 1);
-    if (lockMode == InodeTree.LockMode.READ) {
+    if (lockMode == LockMode.READ) {
       inode.unlockRead();
     } else {
       inode.unlockWrite();
@@ -108,14 +109,14 @@ public class InodeLockList implements AutoCloseable {
     if (mInodes.isEmpty()) {
       return;
     }
-    if (mLockModes.get(mLockModes.size() - 1) != InodeTree.LockMode.READ) {
+    if (mLockModes.get(mLockModes.size() - 1) != LockMode.READ) {
       // The last inode was previously WRITE locked, so downgrade the lock.
       InodeView inode = mInodes.get(mInodes.size() - 1);
       inode.lockRead();
       inode.unlockWrite();
       // Update the last lock mode to READ
       mLockModes.remove(mLockModes.size() - 1);
-      mLockModes.add(InodeTree.LockMode.READ);
+      mLockModes.add(LockMode.READ);
     }
   }
 
@@ -128,7 +129,7 @@ public class InodeLockList implements AutoCloseable {
   public synchronized void lockWrite(InodeView inode) {
     inode.lockWrite();
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.WRITE);
+    mLockModes.add(LockMode.WRITE);
   }
 
   /**
@@ -145,7 +146,7 @@ public class InodeLockList implements AutoCloseable {
       throws InvalidPathException {
     inode.lockWriteAndCheckParent(parent);
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.WRITE);
+    mLockModes.add(LockMode.WRITE);
   }
 
   /**
@@ -163,7 +164,7 @@ public class InodeLockList implements AutoCloseable {
       String name) throws InvalidPathException {
     inode.lockWriteAndCheckNameAndParent(parent, name);
     mInodes.add(inode);
-    mLockModes.add(InodeTree.LockMode.WRITE);
+    mLockModes.add(LockMode.WRITE);
   }
 
   /**
@@ -202,7 +203,7 @@ public class InodeLockList implements AutoCloseable {
     for (int i = mInodes.size() - 1; i >= 0; i--) {
       InodeView inode = mInodes.get(i);
       InodeTree.LockMode lockMode = mLockModes.get(i);
-      if (lockMode == InodeTree.LockMode.READ) {
+      if (lockMode == LockMode.READ) {
         inode.unlockRead();
       } else {
         inode.unlockWrite();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
@@ -12,6 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -21,38 +22,38 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class LockingScheme {
   private final AlluxioURI mPath;
-  private final InodeTree.LockMode mDesiredLockMode;
+  private final LockPattern mDesiredLockPattern;
   private final boolean mShouldSync;
 
   /**
    * Constructs a {@link LockingScheme}.
    *
    * @param path the path to lock
-   * @param desiredLockMode the desired lock mode
+   * @param desiredLockPattern the desired lock mode
    * @param shouldSync true if the path should be synced
    */
-  public LockingScheme(AlluxioURI path, InodeTree.LockMode desiredLockMode, boolean shouldSync) {
+  public LockingScheme(AlluxioURI path, LockPattern desiredLockPattern, boolean shouldSync) {
     mPath = path;
-    mDesiredLockMode = desiredLockMode;
+    mDesiredLockPattern = desiredLockPattern;
     mShouldSync = shouldSync;
   }
 
   /**
    * @return the desired mode for the locking
    */
-  InodeTree.LockMode getDesiredMode() {
-    return mDesiredLockMode;
+  LockPattern getDesiredMode() {
+    return mDesiredLockPattern;
   }
 
   /**
    * @return the mode that should be used to lock the path, considering if ufs sync should occur
    */
-  public InodeTree.LockMode getMode() {
+  public LockPattern getMode() {
     if (mShouldSync) {
       // Syncing requires write.
-      return InodeTree.LockMode.WRITE;
+      return LockPattern.WRITE_LAST;
     }
-    return mDesiredLockMode;
+    return mDesiredLockPattern;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableLockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableLockedInodePath.java
@@ -13,6 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.exception.InvalidPathException;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -27,14 +28,13 @@ public class MutableLockedInodePath extends LockedInodePath {
    *
    * @param uri the URI
    * @param lockList the lock list of the inodes
-   * @param lockMode the lock mode for the path
+   * @param lockPattern the lock mode for the path
    * @throws InvalidPathException if the path passed is invalid
    */
   // TODO(gpang): restructure class hierarchy, rename class
-  public MutableLockedInodePath(AlluxioURI uri, InodeLockList lockList,
-      InodeTree.LockMode lockMode)
+  public MutableLockedInodePath(AlluxioURI uri, InodeLockList lockList, LockPattern lockPattern)
       throws InvalidPathException {
-    super(uri, lockList, lockMode);
+    super(uri, lockList, lockPattern);
   }
 
   /**
@@ -43,11 +43,11 @@ public class MutableLockedInodePath extends LockedInodePath {
    * @param uri the URI
    * @param lockList the lock list of the inodes
    * @param pathComponents the array of path components
-   * @param lockMode the lock mode for the path
+   * @param lockPattern the lock mode for the path
    */
   public MutableLockedInodePath(AlluxioURI uri, InodeLockList lockList, String[] pathComponents,
-      InodeTree.LockMode lockMode) {
-    super(uri, lockList, pathComponents, lockMode);
+      LockPattern lockPattern) {
+    super(uri, lockList, pathComponents, lockPattern);
   }
 
   /**
@@ -59,7 +59,7 @@ public class MutableLockedInodePath extends LockedInodePath {
    * @throws InvalidPathException if the path passed is invalid
    */
   public MutableLockedInodePath(AlluxioURI descendantUri, LockedInodePath lockedInodePath,
-                                InodeLockList descendants) throws InvalidPathException {
+      InodeLockList descendants) throws InvalidPathException {
     super(descendantUri, lockedInodePath, descendants);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -25,6 +25,7 @@ import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.meta.InodeFileView;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.wire.BlockInfo;
@@ -145,7 +146,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       // file and may increase lock contention in this tree. Investigate if we could avoid
       // locking the entire path but just the inode file since this access is read-only.
       try (LockedInodePath inodePath =
-          mInodeTree.lockFullInodePath(inodeId, InodeTree.LockMode.READ)) {
+          mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
         InodeFileView file = inodePath.getInodeFile();
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -36,12 +36,12 @@ import alluxio.master.MasterTestUtils;
 import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
-
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeDirectory;
 import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeLockList;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.MutableLockedInodePath;
 import alluxio.master.file.options.CompleteFileOptions;
@@ -967,7 +967,7 @@ public final class PermissionCheckTest {
     InodeLockList lockList = new InodeLockList();
     lockList.lockRead(getRootInode());
     if (permissions.size() == 0) {
-      return new MutableLockedInodePath(new AlluxioURI("/"), lockList, InodeTree.LockMode.READ);
+      return new MutableLockedInodePath(new AlluxioURI("/"), lockList, LockPattern.READ);
     }
     String uri = "";
     for (int i = 0; i < permissions.size(); i++) {
@@ -987,6 +987,6 @@ public final class PermissionCheckTest {
         lockList.lockRead(inode);
       }
     }
-    return new MutableLockedInodePath(new AlluxioURI(uri), lockList, InodeTree.LockMode.READ);
+    return new MutableLockedInodePath(new AlluxioURI(uri), lockList, LockPattern.READ);
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -29,6 +29,7 @@ import alluxio.master.block.BlockMasterFactory;
 import alluxio.master.file.meta.InodeDirectoryIdGenerator;
 import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.MountTable;
@@ -225,7 +226,7 @@ public final class PermissionCheckerTest {
       throws Exception {
     try (
         LockedInodePath inodePath = sTree
-            .lockInodePath(new AlluxioURI(path), InodeTree.LockMode.WRITE)) {
+            .lockInodePath(new AlluxioURI(path), LockPattern.WRITE_LAST)) {
       InodeTree.CreatePathResult result = sTree.createPath(RpcContext.NOOP, inodePath, option);
       ((InodeFile) result.getCreated().get(result.getCreated().size() - 1))
           .setOwner(option.getOwner()).setGroup(option.getGroup())
@@ -250,19 +251,19 @@ public final class PermissionCheckerTest {
   @Test
   public void createFileAndDirs() throws Exception {
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_DIR_FILE_URI),
-        InodeTree.LockMode.READ)) {
+        LockPattern.READ)) {
       verifyInodesList(TEST_DIR_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_FILE_URI),
-        InodeTree.LockMode.READ)) {
+        LockPattern.READ)) {
       verifyInodesList(TEST_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI),
-        InodeTree.LockMode.READ)) {
+        LockPattern.READ)) {
       verifyInodesList(TEST_WEIRD_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_NOT_EXIST_URI),
-        InodeTree.LockMode.READ)) {
+        LockPattern.READ)) {
       verifyInodesList(new String[]{"", "testDir"}, inodePath.getInodeList());
     }
   }
@@ -383,7 +384,7 @@ public final class PermissionCheckerTest {
   public void invalidPath() throws Exception {
     mThrown.expect(InvalidPathException.class);
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(""), InodeTree.LockMode.READ)) {
+        .lockInodePath(new AlluxioURI(""), LockPattern.READ)) {
       mPermissionChecker.checkPermission(Mode.Bits.WRITE, inodePath);
     }
   }
@@ -391,7 +392,7 @@ public final class PermissionCheckerTest {
   @Test
   public void getPermission() throws Exception {
     try (LockedInodePath path =
-             sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI), InodeTree.LockMode.READ)) {
+             sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI), LockPattern.READ)) {
       // user is admin
       AuthenticatedClientUser.set(TEST_USER_ADMIN.getUser());
       Mode.Bits perm = mPermissionChecker.getPermission(path);
@@ -421,7 +422,7 @@ public final class PermissionCheckerTest {
       throws Exception {
     AuthenticatedClientUser.set(user.getUser());
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(path), InodeTree.LockMode.READ)) {
+        .lockInodePath(new AlluxioURI(path), LockPattern.READ)) {
       mPermissionChecker.checkPermission(action, inodePath);
     }
   }
@@ -438,7 +439,7 @@ public final class PermissionCheckerTest {
       throws Exception {
     AuthenticatedClientUser.set(user.getUser());
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(path), InodeTree.LockMode.READ)) {
+        .lockInodePath(new AlluxioURI(path), LockPattern.READ)) {
       mPermissionChecker.checkParentPermission(action, inodePath);
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -32,6 +32,8 @@ import alluxio.master.MasterTestUtils;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
 import alluxio.master.file.RpcContext;
+import alluxio.master.file.meta.InodeTree.LockMode;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.file.options.CreateDirectoryOptions;
 import alluxio.master.file.options.CreateFileOptions;
@@ -213,7 +215,7 @@ public final class InodeTreeTest {
 
     // pin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, InodeTree.LockMode.WRITE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_LAST)) {
       mTree.setPinned(RpcContext.NOOP, inodePath, true);
     }
 
@@ -545,7 +547,7 @@ public final class InodeTreeTest {
     mThrown.expectMessage(ExceptionMessage.INODE_DOES_NOT_EXIST.getMessage(1));
 
     assertFalse(mTree.inodeIdExists(1));
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(1, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(1, LockPattern.READ)) {
       // inode exists
     }
   }
@@ -564,7 +566,7 @@ public final class InodeTreeTest {
    */
   @Test
   public void getPath() throws Exception {
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.READ)) {
       InodeView root = inodePath.getInode();
       // test root path
       assertEquals(new AlluxioURI("/"), mTree.getPath(root));
@@ -572,20 +574,17 @@ public final class InodeTreeTest {
 
     // test one level
     createPath(mTree, TEST_URI, sDirectoryOptions);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(TEST_URI, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(TEST_URI, LockPattern.READ)) {
       assertEquals(new AlluxioURI("/test"), mTree.getPath(inodePath.getInode()));
     }
 
     // test nesting
     createPath(mTree, NESTED_URI, sNestedDirectoryOptions);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.READ)) {
       assertEquals(new AlluxioURI("/nested/test"), mTree.getPath(inodePath.getInode()));
     }
   }
 
-  /**
-   * Tests the {@link InodeTree#lockDescendants(LockedInodePath, InodeTree.LockMode)} method.
-   */
   @Test
   public void getInodeChildrenRecursive() throws Exception {
     createPath(mTree, TEST_URI, sDirectoryOptions);
@@ -594,9 +593,9 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_FILE_URI, sNestedFileOptions);
 
     // all inodes under root
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, InodeTree.LockMode.READ);
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.READ);
       LockedInodePathList lockedInodePathList = mTree.lockDescendants(inodePath,
-          InodeTree.LockMode.READ)) {
+          LockPattern.READ)) {
       // /test, /nested, /nested/test, /nested/test/file
       assertEquals(4, lockedInodePathList.getInodePathList().size());
     }
@@ -610,9 +609,9 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_URI, sNestedDirectoryOptions);
 
     // all inodes under root
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, InodeTree.LockMode.WRITE);
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.WRITE_LAST);
       LockedInodePathList lockedInodePathList = mTree.lockDescendants(inodePath,
-          InodeTree.LockMode.READ)) {
+          LockPattern.READ)) {
       // /nested, /nested/test
       assertEquals(2, lockedInodePathList.getInodePathList().size());
 
@@ -620,7 +619,7 @@ public final class InodeTreeTest {
       deleteInodeByPath(mTree, NESTED_URI);
 
       try (LockedInodePathList lockedInodePathList2 = mTree.lockDescendants(inodePath,
-          InodeTree.LockMode.WRITE)) {
+          LockPattern.WRITE_LAST)) {
         // only /nested left
         assertEquals(1, lockedInodePathList2.getInodePathList().size());
       }
@@ -640,7 +639,7 @@ public final class InodeTreeTest {
 
     // pin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, InodeTree.LockMode.WRITE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_LAST)) {
       mTree.setPinned(RpcContext.NOOP, inodePath, true);
     }
     // nested file pinned
@@ -648,7 +647,7 @@ public final class InodeTreeTest {
 
     // unpin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, InodeTree.LockMode.WRITE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_LAST)) {
       mTree.setPinned(RpcContext.NOOP, inodePath, false);
     }
     assertEquals(0, mTree.getPinIdSet().size());
@@ -693,9 +692,9 @@ public final class InodeTreeTest {
     // re-init the root since the tree was reset above
     mTree.getRoot();
     try (LockedInodePath inodePath =
-             mTree.lockFullInodePath(new AlluxioURI("/"), InodeTree.LockMode.READ);
+             mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.READ);
          LockedInodePathList lockedInodePathList = mTree.lockDescendants(inodePath,
-             InodeTree.LockMode.READ)) {
+             LockPattern.READ)) {
       assertEquals(0, lockedInodePathList.getInodePathList().size());
       mTree.replayJournalEntryFromJournal(nested.toJournalEntry());
       verifyChildrenNames(mTree, inodePath, Sets.newHashSet("nested"));
@@ -729,15 +728,15 @@ public final class InodeTreeTest {
     // re-init the root since the tree was reset above
     mTree.getRoot();
     try (LockedInodePath inodePath =
-             mTree.lockFullInodePath(new AlluxioURI("/"), InodeTree.LockMode.READ);
+             mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.READ);
          LockedInodePathList lockedInodePathList = mTree.lockDescendants(inodePath,
-             InodeTree.LockMode.READ)) {
+             LockPattern.READ)) {
       assertEquals(0, lockedInodePathList.getInodePathList().size());
       mTree.replayJournalEntryFromJournal(nested.toJournalEntry());
       mTree.replayJournalEntryFromJournal(test.toJournalEntry());
       mTree.replayJournalEntryFromJournal(file.toJournalEntry());
       try (LockedInodePathList descendants = mTree.lockDescendants(inodePath,
-          InodeTree.LockMode.READ)) {
+          LockPattern.READ)) {
         assertEquals(inodeChildren.length, descendants.getInodePathList().size());
         for (LockedInodePath childPath : descendants.getInodePathList()) {
           InodeView child = childPath.getInodeOrNull();
@@ -752,7 +751,7 @@ public final class InodeTreeTest {
 
   @Test
   public void getInodePathById() throws Exception {
-    try (LockedInodePath rootPath = mTree.lockFullInodePath(0, InodeTree.LockMode.READ)) {
+    try (LockedInodePath rootPath = mTree.lockFullInodePath(0, LockPattern.READ)) {
       assertEquals(0, rootPath.getInode().getId());
     }
 
@@ -761,7 +760,7 @@ public final class InodeTreeTest {
 
     for (InodeView inode : createResult.getCreated()) {
       long id = inode.getId();
-      try (LockedInodePath inodePath = mTree.lockFullInodePath(id, InodeTree.LockMode.READ)) {
+      try (LockedInodePath inodePath = mTree.lockFullInodePath(id, LockPattern.READ)) {
         assertEquals(id, inodePath.getInode().getId());
       }
     }
@@ -770,7 +769,7 @@ public final class InodeTreeTest {
   @Test
   public void getInodePathByPath() throws Exception {
     try (LockedInodePath rootPath =
-        mTree.lockFullInodePath(new AlluxioURI("/"), InodeTree.LockMode.READ)) {
+        mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.READ)) {
       assertTrue(mTree.isRootId(rootPath.getInode().getId()));
     }
 
@@ -778,17 +777,17 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_FILE_URI, sNestedFileOptions);
 
     AlluxioURI uri = new AlluxioURI("/nested");
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
 
     uri = NESTED_URI;
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
 
     uri = NESTED_FILE_URI;
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
   }
@@ -800,17 +799,17 @@ public final class InodeTreeTest {
     InodeView dirInode = createResult.getCreated().get(0);
     assertTrue(dirInode.isDirectory());
     try (LockedInodePath lockedDirPath = mTree.lockFullInodePath(dirInode.getId(),
-         InodeTree.LockMode.READ);
+         LockPattern.READ);
          LockedInodePath path = mTree.lockDescendantPath(lockedDirPath,
-             InodeTree.LockMode.READ, NESTED_FILE_URI);
+             LockPattern.READ, NESTED_FILE_URI);
         ) {
       assertEquals(4, path.getInodeList().size());
     }
     // Testing descendant is the same as the LockedInodePath.
     try (LockedInodePath lockedDirPath = mTree.lockFullInodePath(dirInode.getId(),
-        InodeTree.LockMode.READ);
+        LockPattern.READ);
          LockedInodePath path = mTree.lockDescendantPath(lockedDirPath,
-             InodeTree.LockMode.READ, lockedDirPath.getUri())
+             LockPattern.READ, lockedDirPath.getUri())
     ) {
       Assert.fail();
     } catch (InvalidPathException e) {
@@ -821,9 +820,9 @@ public final class InodeTreeTest {
     InodeView subDirInode = createResult.getCreated().get(1);
     assertTrue(dirInode.isDirectory());
     try (LockedInodePath lockedDirPath = mTree.lockFullInodePath(subDirInode.getId(),
-        InodeTree.LockMode.READ);
+        LockPattern.READ);
          LockedInodePath path = mTree.lockDescendantPath(lockedDirPath,
-             InodeTree.LockMode.READ, new AlluxioURI(""));
+             LockPattern.READ, new AlluxioURI(""));
     ) {
       Assert.fail();
     } catch (InvalidPathException e) {
@@ -831,25 +830,38 @@ public final class InodeTreeTest {
     }
   }
 
+  @Test
+  public void getModeForLockPattern() {
+    assertEquals(LockMode.READ, LockPattern.READ.getLockMode(0, 5));
+    assertEquals(LockMode.READ, LockPattern.READ.getLockMode(2, 5));
+    assertEquals(LockMode.READ, LockPattern.READ.getLockMode(4, 5));
+    assertEquals(LockMode.READ, LockPattern.READ.getLockMode(0, 1));
+
+    assertEquals(LockMode.READ, LockPattern.WRITE_LAST.getLockMode(0, 5));
+    assertEquals(LockMode.READ, LockPattern.WRITE_LAST.getLockMode(2, 5));
+    assertEquals(LockMode.WRITE, LockPattern.WRITE_LAST.getLockMode(4, 5));
+    assertEquals(LockMode.WRITE, LockPattern.WRITE_LAST.getLockMode(0, 1));
+  }
+
   // Helper to create a path.
   private InodeTree.CreatePathResult createPath(InodeTree root, AlluxioURI path,
       CreatePathOptions<?> options) throws FileAlreadyExistsException, BlockInfoException,
       InvalidPathException, IOException, FileDoesNotExistException {
-    try (LockedInodePath inodePath = root.lockInodePath(path, InodeTree.LockMode.WRITE)) {
+    try (LockedInodePath inodePath = root.lockInodePath(path, LockPattern.WRITE_LAST)) {
       return root.createPath(RpcContext.NOOP, inodePath, options);
     }
   }
 
   // Helper to get an inode by path. The inode is unlocked before returning.
   private static InodeView getInodeByPath(InodeTree root, AlluxioURI path) throws Exception {
-    try (LockedInodePath inodePath = root.lockFullInodePath(path, InodeTree.LockMode.READ)) {
+    try (LockedInodePath inodePath = root.lockFullInodePath(path, LockPattern.READ)) {
       return inodePath.getInode();
     }
   }
 
   // Helper to delete an inode by path.
   private static void deleteInodeByPath(InodeTree root, AlluxioURI path) throws Exception {
-    try (LockedInodePath inodePath = root.lockFullInodePath(path, InodeTree.LockMode.WRITE)) {
+    try (LockedInodePath inodePath = root.lockFullInodePath(path, LockPattern.WRITE_LAST)) {
       root.deleteInode(RpcContext.NOOP, inodePath, System.currentTimeMillis());
     }
   }
@@ -868,7 +880,7 @@ public final class InodeTreeTest {
   private static void verifyChildrenNames(InodeTree tree, LockedInodePath inodePath,
       Set<String> childNames) throws Exception {
     try (LockedInodePathList childrenPath = tree.lockDescendants(inodePath,
-        InodeTree.LockMode.READ)) {
+        LockPattern.READ)) {
       assertEquals(childNames.size(), childrenPath.getInodePathList().size());
       for (LockedInodePath childPath : childrenPath.getInodePathList()) {
         assertTrue(childNames.contains(childPath.getInode().getName()));

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -28,6 +28,7 @@ import alluxio.master.file.RpcContext;
 import alluxio.master.file.meta.InodeDirectoryIdGenerator;
 import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.options.MountInfo;
@@ -155,7 +156,7 @@ public final class ReplicationCheckerTest {
    * @return the block ID
    */
   private long createBlockHelper(AlluxioURI path, CreatePathOptions<?> options) throws Exception {
-    try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, InodeTree.LockMode.WRITE)) {
+    try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.WRITE_LAST)) {
       InodeTree.CreatePathResult result =
           mInodeTree.createPath(RpcContext.NOOP, inodePath, options);
       InodeFile inodeFile = (InodeFile) result.getCreated().get(0);

--- a/tests/src/test/java/alluxio/server/health/BlockMasterIntegrityIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/BlockMasterIntegrityIntegrationTest.java
@@ -21,6 +21,7 @@ import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.RpcContext;
 import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.options.DeleteOptions;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -106,7 +107,7 @@ public class BlockMasterIntegrityIntegrationTest {
     FileSystemMaster fsm =
         mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(FileSystemMaster.class);
     InodeTree tree = Whitebox.getInternalState(fsm, "mInodeTree");
-    LockedInodePath path = tree.lockInodePath(uri, InodeTree.LockMode.WRITE);
+    LockedInodePath path = tree.lockInodePath(uri, LockPattern.WRITE_LAST);
     DeleteOptions options = DeleteOptions.defaults();
     RpcContext rpcContext = ((DefaultFileSystemMaster) fsm).createRpcContext();
     ((DefaultFileSystemMaster) fsm).deleteInternal(rpcContext, path, options);


### PR DESCRIPTION
- Split `LockMode` into `LockPattern` and `LockMode`
- Remove the `WRITE_PARENT` lock pattern. We can get the same effect using `WRITE_LAST` on the parent.
- Remove concept of lock hints. They are no longer needed for anything.
- Shorten `InodeTree.LockPattern` references to just `LockPattern`