### PR TITLE
[SMALLFIX] install fuse in docker

### DIFF
--- a/dev/jenkins/Dockerfile
+++ b/dev/jenkins/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --quiet jenkins
 RUN usermod -u 1000 jenkins && groupmod -g 1000 jenkins
 
 RUN apt-get update -y && \
-    apt-get install -y golang-go ruby ruby-dev make build-essential && \
+    apt-get install -y golang-go ruby ruby-dev make build-essential fuse && \
     gem install jekyll bundler
 
 # Give jenkins user access to /root/.m2. We can still run the image as root for local debugging


### PR DESCRIPTION
Fuse needs to be installed in docker to support #8130 `FuseFileSystemIntegrationTest` to be run.

Instead of running 
```
docker run -it --rm -v "$HOME/.m2":/root/.m2 -v "$(pwd)":/usr/src/alluxio -w /usr/src/alluxio alluxio/alluxio-maven:0.0.1 mvn -T 2C clean install -PcompileJsp -Pdeveloper -PgenerateDocs -Dsurefire.forkCount=4
```
in https://hub.docker.com/r/alluxio/alluxio-maven/

We need to add `--cap-add SYS_ADMIN --device /dev/fuse` to use fuse functionalities in docker. 
`SYS_ADMIN` is needed for mount/umount functionality, and `/dev/fuse` exposes the FUSE device to the container. For details, please refer to https://github.com/s3fs-fuse/s3fs-fuse/issues/647