### PR TITLE
[SMALLFIX]Fix compiling error when using maven 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -985,7 +985,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.0.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Maven 3.6.0 compile alluxio reported the following error
```
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.2:findbugs (findbugs) on project alluxio-parent: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.2:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginConfigurationException
exit status 1
```