### PR TITLE
[ALLUXIO-3370] Client metrics fixes

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -97,7 +97,6 @@ public final class FileSystemContext implements Closeable {
   private MetricsMasterClient mMetricsMasterClient;
   private ClientMasterSync mClientMasterSync;
 
-  private final String mAppId;
   @GuardedBy("CONTEXT_CACHE_LOCK")
   private int mRefCount;
 
@@ -192,11 +191,6 @@ public final class FileSystemContext implements Closeable {
     mParentSubject = subject;
     mExecutorService = Executors.newFixedThreadPool(1,
         ThreadFactoryUtils.build("metrics-master-heartbeat-%d", true));
-    mAppId = Configuration.containsKey(PropertyKey.USER_APP_ID)
-        ? Configuration.get(PropertyKey.USER_APP_ID) : IdUtils.createFileSystemContextId();
-    LOG.info("Created filesystem context with id {}. This ID will be used for identifying info "
-        + "from the client, such as metrics. It can be set manually through the {} property",
-        mAppId, PropertyKey.Name.USER_APP_ID);
     mClosed = new AtomicBoolean(false);
     mRefCount = 0;
   }
@@ -299,13 +293,6 @@ public final class FileSystemContext implements Closeable {
   public synchronized void reset(InstancedConfiguration configuration) throws IOException {
     closeInternal();
     init(MasterInquireClient.Factory.create(), configuration);
-  }
-
-  /**
-   * @return the unique id of the context
-   */
-  public String getId() {
-    return mAppId;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -30,7 +30,6 @@ import alluxio.network.netty.NettyClient;
 import alluxio.resource.CloseableResource;
 import alluxio.security.authentication.TransportProviderUtils;
 import alluxio.util.CommonUtils;
-import alluxio.util.IdUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.ThreadUtils;
 import alluxio.util.network.NetworkAddressUtils;

--- a/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
@@ -56,7 +56,7 @@ public final class ClientMasterSync implements HeartbeatExecutor {
   public synchronized void heartbeat() throws InterruptedException {
     List<alluxio.thrift.Metric> metrics = new ArrayList<>();
     for (Metric metric : MetricsSystem.allClientMetrics()) {
-      metric.setInstanceId(mContext.getId());
+      metric.setInstanceId(MetricsSystem.getAppId());
       metrics.add(metric.toThrift());
     }
     try {

--- a/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/MetricsMasterClient.java
@@ -13,10 +13,10 @@ package alluxio.client.metrics;
 
 import alluxio.AbstractMasterClient;
 import alluxio.Constants;
-import alluxio.client.file.FileSystemContext;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterClientConfig;
+import alluxio.metrics.MetricsSystem;
 import alluxio.retry.RetryUtils;
 import alluxio.thrift.AlluxioService.Client;
 import alluxio.thrift.AlluxioTException;
@@ -73,11 +73,11 @@ public class MetricsMasterClient extends AbstractMasterClient {
    *
    * @param metrics a list of client metrics
    */
-  public synchronized void heartbeat(final List<Metric> metrics) throws IOException {
+  public synchronized void heartbeat(List<Metric> metrics) throws IOException {
     connect();
     try {
-      mClient.metricsHeartbeat(FileSystemContext.get().getId(),
-          NetworkAddressUtils.getClientHostName(), new MetricsHeartbeatTOptions(metrics));
+      mClient.metricsHeartbeat(MetricsSystem.getAppId(), NetworkAddressUtils.getClientHostName(),
+          new MetricsHeartbeatTOptions(metrics));
     } catch (AlluxioTException e) {
       throw AlluxioStatusException.fromThrift(e);
     } catch (TException e) {

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -16,6 +16,7 @@ import alluxio.Configuration;
 import alluxio.PropertyKey;
 import alluxio.metrics.sink.Sink;
 import alluxio.util.CommonUtils;
+import alluxio.util.IdUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
 import com.codahale.metrics.Counter;
@@ -53,6 +54,7 @@ public final class MetricsSystem {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsSystem.class);
 
   private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
+  private static String mAppId;
 
   /**
    * An enum of supported instance type.
@@ -423,6 +425,20 @@ public final class MetricsSystem {
    */
   public static List<Metric> allClientMetrics() {
     return allMetrics(InstanceType.CLIENT);
+  }
+
+  /**
+   * @return the app ID for this MetricsSystem
+   */
+  public static synchronized String getAppId() {
+    if (mAppId == null) {
+      mAppId = Configuration.containsKey(PropertyKey.USER_APP_ID)
+          ? Configuration.get(PropertyKey.USER_APP_ID) : IdUtils.createFileSystemContextId();
+      LOG.info("Created metrics system with id {}. This ID will be used for identifying metrics "
+              + "data from the client. It can be set manually through the {} property",
+          mAppId, PropertyKey.Name.USER_APP_ID);
+    }
+    return mAppId;
   }
 
   private static List<Metric> allMetrics(MetricsSystem.InstanceType instanceType) {

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -54,7 +54,7 @@ public final class MetricsSystem {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsSystem.class);
 
   private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
-  private static String mAppId;
+  private static String sAppId;
 
   /**
    * An enum of supported instance type.
@@ -431,14 +431,14 @@ public final class MetricsSystem {
    * @return the app ID for this MetricsSystem
    */
   public static synchronized String getAppId() {
-    if (mAppId == null) {
-      mAppId = Configuration.containsKey(PropertyKey.USER_APP_ID)
+    if (sAppId == null) {
+      sAppId = Configuration.containsKey(PropertyKey.USER_APP_ID)
           ? Configuration.get(PropertyKey.USER_APP_ID) : IdUtils.createFileSystemContextId();
       LOG.info("Created metrics system with id {}. This ID will be used for identifying metrics "
               + "data from the client. It can be set manually through the {} property",
-          mAppId, PropertyKey.Name.USER_APP_ID);
+          sAppId, PropertyKey.Name.USER_APP_ID);
     }
-    return mAppId;
+    return sAppId;
   }
 
   private static List<Metric> allMetrics(MetricsSystem.InstanceType instanceType) {

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -142,7 +142,7 @@ public class MetricsStore {
     }
   }
 
-  private synchronized Set<Metric> getMasterMetrics(String name) {
+  private Set<Metric> getMasterMetrics(String name) {
     Set<Metric> metrics = new HashSet<>();
     for (Metric metric : MetricsSystem.allMasterMetrics()) {
       if (metric.getName().equals(name)) {

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -126,26 +126,22 @@ public class MetricsStore {
    * @param name the metric name
    * @return the set of matched metrics
    */
-  public Set<Metric> getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType instanceType,
+  public synchronized Set<Metric> getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType instanceType,
       String name) {
     if (instanceType == InstanceType.MASTER) {
       return getMasterMetrics(name);
     }
 
     if (instanceType == InstanceType.WORKER) {
-      synchronized (mWorkerMetrics) {
-        return mWorkerMetrics.getByField(NAME_INDEX, name);
-      }
+      return mWorkerMetrics.getByField(NAME_INDEX, name);
     } else if (instanceType == InstanceType.CLIENT) {
-      synchronized (mWorkerMetrics) {
-        return mClientMetrics.getByField(NAME_INDEX, name);
-      }
+      return mClientMetrics.getByField(NAME_INDEX, name);
     } else {
       throw new IllegalArgumentException("Unsupported instance type " + instanceType);
     }
   }
 
-  private Set<Metric> getMasterMetrics(String name) {
+  private synchronized Set<Metric> getMasterMetrics(String name) {
     Set<Metric> metrics = new HashSet<>();
     for (Metric metric : MetricsSystem.allMasterMetrics()) {
       if (metric.getName().equals(name)) {

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -109,6 +109,7 @@ public class MetricsStore {
     if (metrics.isEmpty()) {
       return;
     }
+    LOG.debug("Removing metrics for id {} to replace with {}", clientId, metrics);
     mClientMetrics.removeByField(ID_INDEX, getFullInstanceId(hostname, clientId));
     for (Metric metric : metrics) {
       if (metric.getHostname() == null) {

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -127,8 +127,8 @@ public class MetricsStore {
    * @param name the metric name
    * @return the set of matched metrics
    */
-  public synchronized Set<Metric> getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType instanceType,
-      String name) {
+  public synchronized Set<Metric> getMetricsByInstanceTypeAndName(
+      MetricsSystem.InstanceType instanceType, String name) {
     if (instanceType == InstanceType.MASTER) {
       return getMasterMetrics(name);
     }


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3370

This fixes 2 issues

**Master synchronization**

We update client metrics by removing the old client metrics and adding the new ones. This needs to be synchronized against the code which aggregates client metrics. Otherwise, metrics that should only go up could be seen to go down. (1) clear metrics for client A, (2) aggregate the metrics and report to web UI (doesn't include client A), (3) add metrics for client A.

Previously we synchronized the remove/add on the `mWorkerMetrics` field, but synchronized the lookup (`getMetricsByInstanceTypeAndName`) on the `MetricsStore` instance. This PR changes the synchronization so that all public methods of `MetricsStore` are synchronized on the `MetricsStore` instance. Nothing should synchronize on individual fields.

**Duplicated client metrics**

Clients report metrics to master using a periodic heartbeat in `FileSystemContext`. This is a problem because `FileSystemContext` is not singleton (different clients may have different contexts), but `MetricsSystem` *is* a singleton. When clients in the same classloader/JVM update metrics, they are all adding together in a single `MetricsSystem`. But clients send metrics using their own IDs in `FileSystemContext`, so we will count the same metrics once for every client.

To fix this I'm associating the client ID with `MetricsSystem` instead of `FileSystemContext`. It's still wasteful to have multiple clients sending heartbeats, but at least the metrics will be correct.

I've created https://alluxio.atlassian.net/browse/ALLUXIO-3377 for followup work on improving the client metrics heartbeat