### PR TITLE
[SMALLFIX] wait for file completed in fuse

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -303,7 +303,13 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
         return -ErrorCodes.ENOENT();
       }
       final URIStatus status = mFileSystem.getStatus(turi);
-
+      if (!status.isCompleted() && !waitForFileCompleted(turi)) {
+        if (status.getLength() == 0) {
+          LOG.error("file {} has length 0, we thought it may be fine...", path);
+        } else {
+          LOG.error("File {} has not completed", turi);
+        }
+      }
       long size = status.getLength();
       long blockSize = status.getBlockSizeBytes();
       stat.st_size.set(size);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -304,11 +304,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
       }
       final URIStatus status = mFileSystem.getStatus(turi);
       if (!status.isCompleted() && !waitForFileCompleted(turi)) {
-        if (status.getLength() == 0) {
-          LOG.error("file {} has length 0, we thought it may be fine...", path);
-        } else {
-          LOG.error("File {} has not completed", turi);
-        }
+        LOG.error("File {} is not completed", path);
       }
       long size = status.getLength();
       long blockSize = status.getBlockSizeBytes();


### PR DESCRIPTION
In tensorflow with Alluxio-Fuse integration, scripts call `getAttr()` right after written a file. The file may be not completed and `getAttr()` will show that the file has a size of 0 which script will think as an error.