### PR TITLE
[ALLUXIO-3387] Fix some link errors in alluxio documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Alluxio (formerly Tachyon)
 
 The master branch is in version 2.0.0-SNAPSHOT:
 
-- [Alluxio Open Source Website](http://www.alluxio.org/) | [Alluxio Latest Release Document](http://www.alluxio.org/documentation/) | [Master Branch Document](http://alluxio.org/documentation/master/) | [Alluxio Inc.](http://www.alluxio.com/)
+- [Alluxio Open Source Website](http://www.alluxio.org/) | [Alluxio Latest Release Document](https://www.alluxio.org/download/releases/) | [Master Branch Document](https://www.alluxio.org/docs/master/en/) | [Alluxio Inc.](http://www.alluxio.com/)
 - [Contribute to Alluxio](http://alluxio.org/documentation/master/en/Contributing-to-Alluxio.html) and
 [New Contributor Tasks](https://alluxio.atlassian.net/issues/?jql=project%20%3D%20ALLUXIO%20AND%20labels%20%3D%20NewContributor%20AND%20status%20%3D%20Open%20AND%20Assignee%20%3D%20null)
   - Please limit 2 tasks per new contributor. Afterwards, try some [beginner tasks](https://alluxio.atlassian.net/issues/?jql=project%20%3D%20ALLUXIO%20AND%20labels%20%3D%20Beginner%20AND%20status%20%3D%20Open) or [intermediate tasks](https://alluxio.atlassian.net/issues/?jql=project%20%3D%20ALLUXIO%20AND%20labels%20%3D%20Intermediate%20AND%20status%20%3D%20Open),


### PR DESCRIPTION
Fix some link errors in alluxio documentation:
 - Alluxio Latest Release Document: 
http://www.alluxio.org/documentation/.  =>  https://www.alluxio.org/download/releases/
 - Master Branch Document:
 http://alluxio.org/documentation/master/ => https://www.alluxio.org/docs/master/en/
