### PR TITLE
[SMALLFIX] Add job tests

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -919,7 +919,7 @@ public class InodeTree implements JournalEntryIterable, JournalEntryReplayable {
         PreconditionMessage.INVALID_REPLICATION_MAX_MIN_VALUE_NULL);
     Preconditions.checkArgument(replicationMin == null || replicationMin >= 0,
         PreconditionMessage.INVALID_REPLICATION_MIN_VALUE);
-    Preconditions.checkState(inodePath.getLockPattern() == LockPattern.WRITE_INODE);
+    Preconditions.checkState(inodePath.getLockPattern().isWrite());
 
     InodeView inode = inodePath.getInode();
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -1,0 +1,62 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import alluxio.AlluxioURI;
+import alluxio.cli.fs.command.DistributedLoadCommand;
+import alluxio.client.WriteType;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.AlluxioException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Test for {@link DistributedLoadCommand}.
+ */
+public final class DistributedLoadCommandTest extends AbstractFileSystemShellTest {
+  @Test
+  public void loadDir() throws IOException, AlluxioException {
+    FileSystemTestUtils.createByteFile(mFileSystem, "/testRoot/testFileA", WriteType.THROUGH, 10);
+    FileSystemTestUtils
+        .createByteFile(mFileSystem, "/testRoot/testFileB", WriteType.MUST_CACHE, 10);
+    AlluxioURI uriA = new AlluxioURI("/testRoot/testFileA");
+    AlluxioURI uriB = new AlluxioURI("/testRoot/testFileB");
+
+    URIStatus statusA = mFileSystem.getStatus(uriA);
+    URIStatus statusB = mFileSystem.getStatus(uriB);
+    Assert.assertFalse(statusA.getInMemoryPercentage() == 100);
+    Assert.assertTrue(statusB.getInMemoryPercentage() == 100);
+    // Testing loading of a directory
+    mFsShell.run("distributedLoad", "/testRoot");
+    statusA = mFileSystem.getStatus(uriA);
+    statusB = mFileSystem.getStatus(uriB);
+    Assert.assertTrue(statusA.getInMemoryPercentage() == 100);
+    Assert.assertTrue(statusB.getInMemoryPercentage() == 100);
+  }
+
+  @Test
+  public void loadFile() throws IOException, AlluxioException {
+    FileSystemTestUtils.createByteFile(mFileSystem, "/testFile", WriteType.THROUGH, 10);
+    AlluxioURI uri = new AlluxioURI("/testFile");
+    URIStatus status = mFileSystem.getStatus(uri);
+    Assert.assertFalse(status.getInMemoryPercentage() == 100);
+    // Testing loading of a single file
+    mFsShell.run("distributedLoad", "/testFile");
+    status = mFileSystem.getStatus(uri);
+    Assert.assertTrue(status.getInMemoryPercentage() == 100);
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedMvCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedMvCommandTest.java
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.cli.fs.command.MvCommand;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.util.io.PathUtils;
+
+import com.google.common.base.Joiner;
+import com.google.common.io.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+/**
+ * Tests for cross-mount {@link MvCommand}.
+ */
+public final class DistributedMvCommandTest extends AbstractFileSystemShellTest {
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Test
+  public void crossMountMove() throws Exception {
+    File file = mFolder.newFile();
+    Files.write("hello".getBytes(), file);
+    run("mount", "/cross", mFolder.getRoot().getAbsolutePath());
+    run("ls", "-f", "/cross");
+    run("distributedMv", PathUtils.concatPath("/cross", file.getName()), "/moved");
+    mOutput.reset();
+    run("cat", "/moved");
+    assertEquals("hello", mOutput.toString());
+  }
+
+  private void run(String ...args) {
+    if (mFsShell.run(args) != 0) {
+      throw new RuntimeException(
+          "Failed command <" + Joiner.on(" ").join(args) + "> " + mOutput.toString());
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetReplicationCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetReplicationCommandTest.java
@@ -1,0 +1,155 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.URIStatus;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests for setReplication command.
+ */
+public final class SetReplicationCommandTest extends AbstractFileSystemShellTest {
+  private static final String TEST_FILE = "/testFile";
+
+  @Rule
+  public final ExpectedException mThrown = ExpectedException.none();
+
+  @Test
+  public void setReplicationMin() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "1", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(1, status.getReplicationMin());
+  }
+
+  @Test
+  public void setReplicationMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-max", "2", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(2, status.getReplicationMax());
+  }
+
+  @Test
+  public void setReplicationMinMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "1", "-max", "2", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(1, status.getReplicationMin());
+    Assert.assertEquals(2, status.getReplicationMax());
+  }
+
+  @Test
+  public void setReplicationNoMinMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationBadMinMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "2", "-max", "1", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationBadMinMaxSeparately() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "2", TEST_FILE);
+    Assert.assertEquals(0, ret);
+    ret = mFsShell.run("setReplication", "-max", "1", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationZeroMin() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "0", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(0, status.getReplicationMin());
+  }
+
+  @Test
+  public void setReplicationNegativeMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-max", "-2", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationInfinityMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-max", "-1", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(-1, status.getReplicationMax());
+  }
+
+  @Test
+  public void setReplicationZeroMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-max", "0", TEST_FILE);
+    Assert.assertEquals(0, ret);
+
+    URIStatus status = mFileSystem.getStatus(new AlluxioURI(TEST_FILE));
+    Assert.assertEquals(0, status.getReplicationMin());
+  }
+
+  @Test
+  public void setReplicationNegativeMin() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "-2", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationNegativeMinMax() throws Exception {
+    FileSystemTestUtils.createByteFile(mFileSystem, TEST_FILE, WriteType.MUST_CACHE, 10);
+    int ret = mFsShell.run("setReplication", "-min", "-2", "-max", "-1", TEST_FILE);
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
+  public void setReplicationRecursively() throws Exception {
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    int ret =
+        mFsShell.run("setReplication", "-R", "-min", "2", PathUtils.concatPath(testDir, "foo"));
+    Assert.assertEquals(0, ret);
+
+    URIStatus status1 =
+        mFileSystem.getStatus(new AlluxioURI(PathUtils.concatPath(testDir, "foo", "foobar1")));
+    URIStatus status2 =
+        mFileSystem.getStatus(new AlluxioURI(PathUtils.concatPath(testDir, "foo", "foobar2")));
+    Assert.assertEquals(2, status1.getReplicationMin());
+    Assert.assertEquals(2, status2.getReplicationMin());
+  }
+}


### PR DESCRIPTION
This also fixes an issue with recursive `setReplication`, where we create a `WRITE_EDGE` locked inode path instead of a `WRITE_INODE` locked inode path