### PR TITLE
[Branch-1.8] Fix compiling error when using maven 3.6.0 (#8174)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -982,7 +982,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.0.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Cherrypick #8174 to branch-1.8 to fix compilation with maven 3.6.0