### PR TITLE
Build script improvements

### DIFF
--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -20,5 +20,10 @@ myuid=$(id -u)
 mygid=$(id -g)
 echo "$myuid:x:$myuid:$mygid:anonymous uid:/home/jenkins:/bin/false" >> /etc/passwd
 
+if [ -z ${ALLUXIO_BUILD_FORKCOUNT} ]
+then
+  ALLUXIO_BUILD_FORKCOUNT=4
+fi
+
 git clean -fdx
-mvn -Duser.home=/home/jenkins -T 4C clean install -PcompileJsp -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=8 $@
+mvn -Duser.home=/home/jenkins -T 4C clean install -PcompileJsp -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} $@

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -21,4 +21,4 @@ mygid=$(id -g)
 echo "$myuid:x:$myuid:$mygid:anonymous uid:/home/jenkins:/bin/false" >> /etc/passwd
 
 git clean -fdx
-mvn -Duser.home=/home/jenkins -T 4C clean install -PcompileJsp -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=8
+mvn -Duser.home=/home/jenkins -T 4C clean install -PcompileJsp -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=8 $@

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -12,49 +12,53 @@
 
 set -e
 
-if [ -z "${ALLUXIO_DOCKER_ID}" ]
-then
-  ALLUXIO_DOCKER_ID="$(id -u)"
-fi
-if [ -z "${ALLUXIO_DOCKER_M2}" ]
-then
-  ALLUXIO_DOCKER_M2="${HOME}/.m2"
-fi
-if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
-then
-  ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.3"
-fi
+function main {
+  if [ -z "${ALLUXIO_DOCKER_ID}" ]
+  then
+    ALLUXIO_DOCKER_ID="$(id -u)"
+  fi
+  if [ -z "${ALLUXIO_DOCKER_M2}" ]
+  then
+    ALLUXIO_DOCKER_M2="${HOME}/.m2"
+  fi
+  if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
+  then
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.3"
+  fi
 
-docker run \
-       --rm \
-       --cap-add SYS_ADMIN \
-       --device /dev/fuse \
-       --security-opt apparmor:unconfined \
-       --user ${ALLUXIO_DOCKER_ID}:0 \
-       -v $(pwd):/usr/src/alluxio \
-       -w /usr/src/alluxio \
-       -v ${ALLUXIO_DOCKER_M2}:/home/jenkins/.m2 \
-       -e npm_config_cache=/home/jenkins/.npm \
-       -e MAVEN_CONFIG=/home/jenkins/.m2 \
-       -e ALLUXIO_USE_FIXED_TEST_PORTS=true \
-       ${ALLUXIO_DOCKER_IMAGE} \
-       dev/jenkins/build.sh
+  local run_args="--rm"
 
-# Needed to run fuse tests:
-# --cap-add SYS_ADMIN
-# --device /dev/fuse
-# --security-opt apparmor:unconfined
+  if [ -z ${ALLUXIO_DOCKER_NO_TTY} ]
+  then
+    run_args+=" -it"
+  fi
 
-# Run as the host jenkins user so that files written to .m2 are written as jenkins.
-# Use group 0 to get certain elevated permissions.
-# --user $(id -u jenkins):0
+  # Needed to run fuse tests:
+  run_args+=" --cap-add SYS_ADMIN"
+  run_args+=" --device /dev/fuse"
+  run_args+=" --security-opt apparmor:unconfined"
 
-# Mount the local directory inside the docker container, and set it as the working directory
-# -v $(pwd):/usr/src/alluxio
-# -w /usr/src/alluxio
+  # Run as the host jenkins user so that files written to .m2 are written as jenkins.
+  # Use group 0 to get certain elevated permissions.
+  run_args+=" --user ${ALLUXIO_DOCKER_ID}:0"
 
-# Since we're running as a user unknown to the Docker container, we need to explicitly
-# configure anything that's relative to ${HOME}.
-# -v ${ALLUXIO_DOCKER_M2}:/home/jenkins/.m2
-# -e npm_config_cache=/home/jenkins/.npm
-# -e MAVEN_CONFIG=/home/jenkins/.m2
+  # Mount the local directory inside the docker container, and set it as the working directory
+  run_args+=" -v $(pwd):/usr/src/alluxio"
+  run_args+=" -w /usr/src/alluxio"
+
+  # Since we're running as a user unknown to the Docker container, we need to explicitly
+  # configure anything that's relative to ${HOME}.
+  run_args+=" -v ${ALLUXIO_DOCKER_M2}:/home/jenkins/.m2"
+  run_args+=" -e npm_config_cache=/home/jenkins/.npm"
+  run_args+=" -e HOME=/home/jenkins"
+  run_args+=" -e MAVEN_CONFIG=/home/jenkins/.m2"
+
+  run_args+=" -e ALLUXIO_USE_FIXED_TEST_PORTS=true"
+
+  # Use this as an entrypoint instead of image argument so that it can be interrupted by Ctrl-C
+  run_args+=" --entrypoint=dev/jenkins/build.sh"
+
+  docker run ${run_args} ${ALLUXIO_DOCKER_IMAGE} $@
+}
+
+main "$@"

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -33,6 +33,7 @@ function main {
     run_args+=" -it"
   fi
 
+  local home="/home/jenkins"
   # Needed to run fuse tests:
   run_args+=" --cap-add SYS_ADMIN"
   run_args+=" --device /dev/fuse"
@@ -48,10 +49,10 @@ function main {
 
   # Since we're running as a user unknown to the Docker container, we need to explicitly
   # configure anything that's relative to ${HOME}.
-  run_args+=" -v ${ALLUXIO_DOCKER_M2}:/home/jenkins/.m2"
-  run_args+=" -e npm_config_cache=/home/jenkins/.npm"
-  run_args+=" -e HOME=/home/jenkins"
-  run_args+=" -e MAVEN_CONFIG=/home/jenkins/.m2"
+  run_args+=" -e HOME=${home}"
+  run_args+=" -v ${ALLUXIO_DOCKER_M2}:${home}/.m2"
+  run_args+=" -e npm_config_cache=${home}/.npm"
+  run_args+=" -e MAVEN_CONFIG=${home}/.m2"
 
   run_args+=" -e ALLUXIO_USE_FIXED_TEST_PORTS=true"
 


### PR DESCRIPTION
- Make script interruptible with Ctrl-C
- Construct args list incrementally to improve comment style
- Run inside a main function
- Set HOME=/home/jenkins
- Support mvn arguments passed to run_docker.sh
- Make fork count configurable