### PR TITLE
[SMALLFIX] various performance tuning changes

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -745,7 +745,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       }
       // If the destination is an existing folder, try to move the src into the folder
       if (dstStatus != null && dstStatus.isFolder()) {
-        dstPath = dstPath.join(srcPath.getName());
+        dstPath = dstPath.joinUnsafe(srcPath.getName());
       } else {
         LOG.warn("rename failed: {}", e.getMessage());
         return false;

--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -468,30 +468,6 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
    */
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    if (mUri.getScheme() != null) {
-      sb.append(mUri.getScheme());
-      sb.append("://");
-    }
-    if (hasAuthority()) {
-      if (mUri.getScheme() == null) {
-        sb.append("//");
-      }
-      sb.append(mUri.getAuthority().toString());
-    }
-    if (mUri.getPath() != null) {
-      String path = mUri.getPath();
-      if (path.indexOf('/') == 0 && hasWindowsDrive(path, true) && // has windows drive
-          mUri.getScheme() == null && // but no scheme
-          mUri.getAuthority() == null) { // or authority
-        path = path.substring(1); // remove slash before drive
-      }
-      sb.append(path);
-    }
-    if (mUri.getQuery() != null) {
-      sb.append("?");
-      sb.append(mUri.getQuery());
-    }
-    return sb.toString();
+    return "";
   }
 }

--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -66,6 +66,8 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
   /** A {@link URI} is used to hold the URI components. */
   private final URI mUri;
 
+  private String mUriString = "";
+
   /**
    * Constructs an {@link AlluxioURI} from a String. Path strings are URIs, but with unescaped
    * elements and some additional normalization.
@@ -468,6 +470,34 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
    */
   @Override
   public String toString() {
-    return "";
+    if (!mUriString.isEmpty()) {
+      return mUriString;
+    }
+    StringBuilder sb = new StringBuilder();
+    if (mUri.getScheme() != null) {
+      sb.append(mUri.getScheme());
+      sb.append("://");
+    }
+    if (hasAuthority()) {
+      if (mUri.getScheme() == null) {
+        sb.append("//");
+      }
+      sb.append(mUri.getAuthority().toString());
+    }
+    if (mUri.getPath() != null) {
+      String path = mUri.getPath();
+      if (path.indexOf('/') == 0 && hasWindowsDrive(path, true) && // has windows drive
+          mUri.getScheme() == null && // but no scheme
+          mUri.getAuthority() == null) { // or authority
+        path = path.substring(1); // remove slash before drive
+      }
+      sb.append(path);
+    }
+    if (mUri.getQuery() != null) {
+      sb.append("?");
+      sb.append(mUri.getQuery());
+    }
+    mUriString = sb.toString();
+    return mUriString;
   }
 }

--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -76,6 +76,7 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
    */
   public AlluxioURI(String pathStr) {
     mUri = URI.Factory.create(pathStr);
+    mUriString = pathStr;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/uri/SingleMasterAuthority.java
+++ b/core/common/src/main/java/alluxio/uri/SingleMasterAuthority.java
@@ -64,6 +64,6 @@ public class SingleMasterAuthority implements Authority {
 
   @Override
   public String toString() {
-    return String.format("%s:%d", mHost, mPort);
+    return mHost + ":" + mPort;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2408,7 +2408,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
             }
 
             try (LockedInodePath descendant = inodePath
-                .lockDescendant(inodePath.getUri().join(childStatus.getName()), LockPattern.READ)) {
+                .lockDescendant(inodePath.getUri().joinUnsafe(childStatus.getName()), LockPattern.READ)) {
               LoadMetadataOptions loadMetadataOptions =
                   LoadMetadataOptions.defaults().setLoadDescendantType(DescendantType.NONE)
                       .setCreateAncestors(false).setUfsStatus(childStatus);
@@ -3176,7 +3176,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           UfsStatus[] children = ufs.listStatus(ufsUri.toString(), listOptions);
           if (children != null) {
             for (UfsStatus childStatus : children) {
-              statusCache.put(path.join(childStatus.getName()),
+              statusCache.put(path.joinUnsafe(childStatus.getName()),
                   childStatus);
             }
           }
@@ -3446,7 +3446,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           // Technically we don't need to lock here since inodePath is already write-locked. We can
           // improve this by implementing a way to traverse an inode path without locking.
           try (LockedInodePath descendant = inodePath.lockDescendant(
-              inodePath.getUri().join(inodeEntry.getKey()), LockPattern.WRITE_EDGE)) {
+              inodePath.getUri().joinUnsafe(inodeEntry.getKey()), LockPattern.WRITE_EDGE)) {
             // Recursively sync children
             if (syncDescendantType != DescendantType.ALL) {
               syncDescendantType = DescendantType.NONE;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -236,7 +236,7 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
           PathUtils.concatPath(AlluxioURI.SEPARATOR, baseComponents));
       List<AlluxioURI> components = new ArrayList<>(fullComponents.length - startComponentIndex);
       for (int i = startComponentIndex; i < fullComponents.length; i++) {
-        uri = uri.join(fullComponents[i]);
+        uri = uri.joinUnsafe(fullComponents[i]);
         components.add(uri);
       }
       return components;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -46,7 +46,7 @@ public class InodeLockManager {
    */
   public final LoadingCache<Long, WeakSafeReentrantReadWriteLock> mInodeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(1000000)
+          .maximumSize(100000)
           .initialCapacity(1_000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Long, WeakSafeReentrantReadWriteLock>() {
@@ -61,7 +61,7 @@ public class InodeLockManager {
    */
   public final LoadingCache<Edge, WeakSafeReentrantReadWriteLock> mEdgeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(1000000)
+          .maximumSize(100000)
           .initialCapacity(1_000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -46,9 +46,9 @@ public class InodeLockManager {
    */
   public final LoadingCache<Long, WeakSafeReentrantReadWriteLock> mInodeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .weakValues()
+          .maximumSize(10000)
           .initialCapacity(1_000)
-          .concurrencyLevel(1000)
+          .concurrencyLevel(100)
           .build(new CacheLoader<Long, WeakSafeReentrantReadWriteLock>() {
             @Override
             public WeakSafeReentrantReadWriteLock load(Long key) {
@@ -61,9 +61,9 @@ public class InodeLockManager {
    */
   public final LoadingCache<Edge, WeakSafeReentrantReadWriteLock> mEdgeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .weakValues()
+          .maximumSize(10000)
           .initialCapacity(1_000)
-          .concurrencyLevel(1000)
+          .concurrencyLevel(100)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {
             @Override
             public WeakSafeReentrantReadWriteLock load(Edge key) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -63,7 +63,7 @@ public class InodeLockManager {
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
           .weakValues()
           .initialCapacity(1_000)
-          .concurrencyLevel(100)
+          .concurrencyLevel(10000)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {
             @Override
             public WeakSafeReentrantReadWriteLock load(Edge key) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -48,7 +48,7 @@ public class InodeLockManager {
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
           .weakValues()
           .initialCapacity(1_000)
-          .concurrencyLevel(100)
+          .concurrencyLevel(1000)
           .build(new CacheLoader<Long, WeakSafeReentrantReadWriteLock>() {
             @Override
             public WeakSafeReentrantReadWriteLock load(Long key) {
@@ -63,7 +63,7 @@ public class InodeLockManager {
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
           .weakValues()
           .initialCapacity(1_000)
-          .concurrencyLevel(10000)
+          .concurrencyLevel(1000)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {
             @Override
             public WeakSafeReentrantReadWriteLock load(Edge key) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -46,7 +46,7 @@ public class InodeLockManager {
    */
   public final LoadingCache<Long, WeakSafeReentrantReadWriteLock> mInodeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(10000)
+          .maximumSize(1000000)
           .initialCapacity(1_000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Long, WeakSafeReentrantReadWriteLock>() {
@@ -61,7 +61,7 @@ public class InodeLockManager {
    */
   public final LoadingCache<Edge, WeakSafeReentrantReadWriteLock> mEdgeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(10000)
+          .maximumSize(1000000)
           .initialCapacity(1_000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -46,8 +46,8 @@ public class InodeLockManager {
    */
   public final LoadingCache<Long, WeakSafeReentrantReadWriteLock> mInodeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(100000)
-          .initialCapacity(1_000)
+          .maximumSize(1000000)
+          .initialCapacity(10000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Long, WeakSafeReentrantReadWriteLock>() {
             @Override
@@ -61,8 +61,8 @@ public class InodeLockManager {
    */
   public final LoadingCache<Edge, WeakSafeReentrantReadWriteLock> mEdgeLocks =
       CacheBuilder.<Long, WeakSafeReentrantReadWriteLock>newBuilder()
-          .maximumSize(100000)
-          .initialCapacity(1_000)
+          .maximumSize(1000000)
+          .initialCapacity(10000)
           .concurrencyLevel(100)
           .build(new CacheLoader<Edge, WeakSafeReentrantReadWriteLock>() {
             @Override

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -377,7 +377,7 @@ public class LockedInodePath implements Closeable {
    */
   public LockedInodePath lockChild(InodeView child, LockPattern lockPattern,
       String[] childComponentsHint) throws InvalidPathException {
-    LockedInodePath path = new LockedInodePath(mUri.join(child.getName()), mExistingInodes,
+    LockedInodePath path = new LockedInodePath(mUri.joinUnsafe(child.getName()), mExistingInodes,
         mLockList, childComponentsHint, lockPattern);
     path.traverseOrClose();
     return path;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -323,7 +323,7 @@ public final class MountTable implements JournalEntryIterable, JournalEntryRepla
     if (relativePath.isEmpty()) {
       return mountPoint;
     } else {
-      return mountPoint.join(relativePath);
+      return mountPoint.joinUnsafe(relativePath);
     }
   }
 


### PR DESCRIPTION
1. change to use `joinUnsafe` where we can
2. optimize `AlluxioURI.toString`, to cache results and to produce string more efficiently
3. change the lock cache to use more suitable parameters to avoid eviction. 
