### PR TITLE
Refactor gRPC worker ports

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1663,6 +1663,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_BIND_HOST =
       new Builder(Name.WORKER_BIND_HOST)
+          .setAlias(new String[]{Name.WORKER_DATA_BIND_HOST})
           .setDefaultValue("0.0.0.0")
           .setDescription("The hostname Alluxio's worker node binds to.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
@@ -1706,13 +1707,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey WORKER_DATA_BIND_HOST =
-      new Builder(Name.WORKER_DATA_BIND_HOST)
-          .setDefaultValue("0.0.0.0")
-          .setDescription("The hostname that the Alluxio worker's data server runs on.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_DATA_FOLDER =
       new Builder(Name.WORKER_DATA_FOLDER)
           .setDefaultValue("/alluxioworker/")
@@ -1726,19 +1720,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("rwxrwxrwx")
           .setDescription("The permission set for the worker data folder. If short circuit is used "
               + "this folder should be accessible by all users (rwxrwxrwx).")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  public static final PropertyKey WORKER_DATA_HOSTNAME =
-      new Builder(Name.WORKER_DATA_HOSTNAME)
-          .setDescription("The hostname of Alluxio worker data service.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  public static final PropertyKey WORKER_DATA_PORT =
-      new Builder(Name.WORKER_DATA_PORT)
-          .setDefaultValue(29999)
-          .setDescription("The port Alluxio's worker's data server runs on.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
@@ -2014,7 +1995,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .build();
   public static final PropertyKey WORKER_RPC_PORT =
       new Builder(Name.WORKER_RPC_PORT)
-          .setDefaultValue(29998)
+          .setAlias(new String[]{Name.WORKER_DATA_PORT})
+          .setDefaultValue(29999)
           .setDescription("The port Alluxio's worker node runs on.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -356,8 +356,6 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     if (maxWorkersPerHost > 1) {
       String message = "%s cannot be specified when allowing multiple workers per host with "
           + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
-      Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_DATA_PORT) == null,
-          String.format(message, PropertyKey.WORKER_DATA_PORT));
       Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
           String.format(message, PropertyKey.WORKER_RPC_PORT));
       Preconditions.checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -125,12 +125,6 @@ public final class NetworkAddressUtils {
         PropertyKey.WORKER_BIND_HOST, PropertyKey.WORKER_RPC_PORT),
 
     /**
-     * Worker data service (gRPC).
-     */
-    WORKER_DATA("Alluxio Worker data service", PropertyKey.WORKER_DATA_HOSTNAME,
-        PropertyKey.WORKER_DATA_BIND_HOST, PropertyKey.WORKER_DATA_PORT),
-
-    /**
      * Worker web service (Jetty).
      */
     WORKER_WEB("Alluxio Worker Web service", PropertyKey.WORKER_WEB_HOSTNAME,

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -50,7 +50,6 @@ public final class ConfigurationTestUtils {
     Map<PropertyKey, String> conf = new HashMap<>();
     conf.put(PropertyKey.MASTER_HOSTNAME, hostname);
     conf.put(PropertyKey.WORKER_BIND_HOST, hostname);
-    conf.put(PropertyKey.WORKER_DATA_BIND_HOST, hostname);
     conf.put(PropertyKey.WORKER_WEB_BIND_HOST, hostname);
     conf.put(PropertyKey.MASTER_BIND_HOST, hostname);
     conf.put(PropertyKey.MASTER_WEB_BIND_HOST, hostname);

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -203,9 +203,6 @@ public class NetworkAddressUtilsTest {
       case WORKER_RPC:
         Configuration.set(PropertyKey.WORKER_RPC_PORT, "20000");
         break;
-      case WORKER_DATA:
-        Configuration.set(PropertyKey.WORKER_DATA_PORT, "20000");
-        break;
       case WORKER_WEB:
         Configuration.set(PropertyKey.WORKER_WEB_PORT, "20000");
         break;

--- a/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/core/server/common/src/main/java/alluxio/cli/ValidateEnv.java
@@ -100,10 +100,6 @@ public final class ValidateEnv {
         "validate master web port is available",
         new PortAvailabilityValidationTask(ServiceType.MASTER_WEB, ALLUXIO_MASTER_CLASS),
         MASTER_TASKS);
-    registerTask("worker.data.port.available",
-        "validate worker data port is available",
-        new PortAvailabilityValidationTask(ServiceType.WORKER_DATA, ALLUXIO_WORKER_CLASS),
-        WORKER_TASKS);
     registerTask("worker.rpc.port.available",
         "validate worker RPC port is available",
         new PortAvailabilityValidationTask(ServiceType.WORKER_RPC, ALLUXIO_WORKER_CLASS),

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -135,7 +135,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
 
       // Setup Data server
       mDataServer = DataServer.Factory
-          .create(NetworkAddressUtils.getBindAddress(ServiceType.WORKER_RPC), this);
+          .create(mRpcAddress, this);
 
       // Setup domain socket data server
       if (isDomainSocketEnabled()) {

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -15,7 +15,6 @@ import alluxio.Configuration;
 import alluxio.Constants;
 import alluxio.PropertyKey;
 import alluxio.RuntimeConstants;
-import alluxio.grpc.GrpcServer;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.sink.MetricsServlet;
 import alluxio.metrics.sink.PrometheusMetricsServlet;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -132,10 +132,13 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
         bindPort = configuredBindAddress.getPort();
       }
       mRpcAddress = new InetSocketAddress(configuredBindAddress.getHostName(), bindPort);
-
+      if (mBindSocket != null) {
+        // Socket opened for auto bind.
+        // Close it.
+        mBindSocket.close();
+      }
       // Setup Data server
-      mDataServer = DataServer.Factory
-          .create(mRpcAddress, this);
+      mDataServer = DataServer.Factory.create(mRpcAddress, this);
 
       // Setup domain socket data server
       if (isDomainSocketEnabled()) {

--- a/core/server/worker/src/main/java/alluxio/worker/DataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/DataServer.java
@@ -63,4 +63,9 @@ public interface DataServer extends Closeable {
    * @return true if the {@link DataServer} is closed, false otherwise
    */
   boolean isClosed();
+
+  /**
+   * Waits for server to terminate.
+   */
+  void awaitTermination();
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -149,4 +149,9 @@ public final class GrpcDataServer implements DataServer {
   public boolean isClosed() {
     return !mServer.isServing();
   }
+
+  @Override
+  public void awaitTermination() {
+    mServer.awaitTermination();
+  }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -84,7 +84,7 @@ public class BlockWorkerTest {
           .put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH,
               AlluxioTestDirectory.createTemporaryDirectory("WORKER_TIERED_STORE_LEVEL0_DIRS_PATH")
                   .getAbsolutePath())
-          .put(PropertyKey.WORKER_DATA_PORT, Integer.toString(0))
+          .put(PropertyKey.WORKER_RPC_PORT, Integer.toString(0))
           .put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_ALIAS, "HDD")
           .put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_DIRS_PATH, AlluxioTestDirectory
               .createTemporaryDirectory("WORKER_TIERED_STORE_LEVEL1_DIRS_PATH").getAbsolutePath())

--- a/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/AlluxioScheduler.java
@@ -361,9 +361,6 @@ public class AlluxioScheduler implements Scheduler {
             .addRange(Protos.Value.Range.newBuilder()
                 .setBegin(Configuration.getLong(PropertyKey.WORKER_RPC_PORT))
                 .setEnd(Configuration.getLong(PropertyKey.WORKER_RPC_PORT)))
-            .addRange(Protos.Value.Range.newBuilder()
-                .setBegin(Configuration.getLong(PropertyKey.WORKER_DATA_PORT))
-                .setEnd(Configuration.getLong(PropertyKey.WORKER_DATA_PORT)))
             .addRange((Protos.Value.Range.newBuilder()
                 .setBegin(Configuration.getLong(PropertyKey.WORKER_WEB_PORT))
                 .setEnd(Configuration.getLong(PropertyKey.WORKER_WEB_PORT))))).build());

--- a/integration/mesos/src/main/java/alluxio/mesos/OfferUtils.java
+++ b/integration/mesos/src/main/java/alluxio/mesos/OfferUtils.java
@@ -48,8 +48,7 @@ public final class OfferUtils {
 
     return ranges != null
         && hasAvailablePorts(Configuration.getInt(PropertyKey.WORKER_WEB_PORT), ranges)
-        && hasAvailablePorts(Configuration.getInt(PropertyKey.WORKER_RPC_PORT), ranges)
-        && hasAvailablePorts(Configuration.getInt(PropertyKey.WORKER_DATA_PORT), ranges);
+        && hasAvailablePorts(Configuration.getInt(PropertyKey.WORKER_RPC_PORT), ranges);
   }
 
   private static boolean hasAvailablePorts(int port, Protos.Value.Ranges ranges) {

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -272,7 +272,6 @@ public abstract class AbstractLocalAlluxioCluster {
     Configuration.set(PropertyKey.MASTER_WEB_PORT, 0);
     Configuration.set(PropertyKey.PROXY_WEB_PORT, 0);
     Configuration.set(PropertyKey.WORKER_RPC_PORT, 0);
-    Configuration.set(PropertyKey.WORKER_DATA_PORT, 0);
     Configuration.set(PropertyKey.WORKER_WEB_PORT, 0);
   }
 

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -556,7 +556,6 @@ public final class MultiProcessCluster {
         ramdisk.getAbsolutePath());
     conf.put(PropertyKey.LOGS_DIR, logsDir.getAbsolutePath());
     conf.put(PropertyKey.WORKER_RPC_PORT, Integer.toString(rpcPort));
-    conf.put(PropertyKey.WORKER_DATA_PORT, Integer.toString(dataPort));
     conf.put(PropertyKey.WORKER_WEB_PORT, Integer.toString(webPort));
 
     Worker worker = mCloser.register(new Worker(logsDir, conf));

--- a/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
@@ -57,7 +57,6 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
     map.put(PropertyKey.MASTER_RPC_PORT, "0");
     map.put(PropertyKey.MASTER_WEB_PORT, "0");
     map.put(PropertyKey.WORKER_RPC_PORT, "0");
-    map.put(PropertyKey.WORKER_DATA_PORT, "0");
     map.put(PropertyKey.WORKER_WEB_PORT, "0");
 
     return map;

--- a/tests/src/test/java/alluxio/client/keyvalue/KeyValuePartitionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/keyvalue/KeyValuePartitionIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,6 +37,7 @@ import java.util.List;
 /**
  * Integration tests for {@link KeyValuePartitionReader} and {@link KeyValuePartitionWriter}.
  */
+@Ignore("deprecated")
 public final class KeyValuePartitionIntegrationTest extends BaseIntegrationTest {
   private static final int BLOCK_SIZE = 512 * Constants.MB;
   private static final String BASE_KEY = "base_key";


### PR DESCRIPTION
Removed unused worker RPC server from worker process.
Removed property definition for `WORKER_DATA_PORT`. `GrpcDataServer` now uses `WORKER_RPC_PORT`. For backward compatibility, the default value for `WORKER_RPC_PORT` is now `29999` and `alluxio.worker.data.port` becomes an alias for `WORKER_RPC_PORT`.