### PR TITLE
Provide JSON-to-Protobuf mapping in Proxy server

### DIFF
--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -87,6 +87,11 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.hubspot.jackson</groupId>
+      <artifactId>jackson-datatype-protobuf</artifactId>
+      <version>0.9.10-jackson2.9-proto3</version>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/core/server/proxy/src/main/java/alluxio/web/JacksonProtobufObjectMapperProvider.java
+++ b/core/server/proxy/src/main/java/alluxio/web/JacksonProtobufObjectMapperProvider.java
@@ -1,0 +1,44 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Custom context resolver for Jersey to handle JSON-to-Protobuf conversion.
+ */
+@Provider
+public class JacksonProtobufObjectMapperProvider implements ContextResolver<ObjectMapper> {
+  final ObjectMapper mDefaultObjectMapper;
+
+  /**
+   * Create {@link ObjectMapper} provider that handles protobuf.
+   */
+  public JacksonProtobufObjectMapperProvider() {
+    mDefaultObjectMapper = createDefaultMapper();
+  }
+
+  private static ObjectMapper createDefaultMapper() {
+    final ObjectMapper jackson = new ObjectMapper();
+    jackson.registerModule(new ProtobufModule());
+    return jackson;
+  }
+
+  @Override
+  public ObjectMapper getContext(Class<?> type) {
+    return mDefaultObjectMapper;
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -50,7 +50,8 @@ public final class ProxyWebServer extends WebServer {
     super(serviceName, address);
 
     // REST configuration
-    ResourceConfig config = new ResourceConfig().packages("alluxio.proxy", "alluxio.proxy.s3");
+    ResourceConfig config = new ResourceConfig().packages("alluxio.proxy", "alluxio.proxy.s3")
+        .register(JacksonProtobufObjectMapperProvider.class);
     ServletContainer servlet = new ServletContainer(config) {
       private static final long serialVersionUID = 7756010860672831556L;
 


### PR DESCRIPTION
Earlier options wrapper classes were JSON compatible thus JSON-to-JSON conversion was working fine. Now that FileSystem methods requires proto options classes, this change provides custom mapper for deserializing JSON data to Protobuf classes.