### PR TITLE
MultiHdfs Support

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -3302,6 +3302,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.NONE)
           .build();
+  //Assumes that HDFS is the UFS and version is 2.2
+  //TODO(ns) Change default value to be "default". This should identify the default version from UFSVersion.java
+  public static final PropertyKey UNDERFS_VERSION =
+      new Builder(Name.UNDERFS_VERSION)
+          .setDefaultValue("2.2")
+          .setIsHidden(true)
+          .build();
 
   //
   // Job service
@@ -3496,6 +3503,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_HDFS_IMPL = "alluxio.underfs.hdfs.impl";
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
+    public static final String UNDERFS_VERSION = "alluxio.underfs.version";
     public static final String UNDERFS_OBJECT_STORE_SERVICE_THREADS =
         "alluxio.underfs.object.store.service.threads";
     public static final String UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY =

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactory.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactory.java
@@ -54,4 +54,13 @@ public interface UnderFileSystemFactory
   default boolean supportsPath(String path, @Nullable UnderFileSystemConfiguration conf) {
     return supportsPath(path);
   }
+
+  /**
+   * Get the version supported by this factory.
+   *
+   * @return the version string
+   */
+  default String getVersion() {
+    return "";
+  }
 }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -16,6 +16,8 @@ import alluxio.extensions.ExtensionFactoryRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.List;
 import java.util.ServiceLoader;
 
@@ -101,7 +103,24 @@ public final class UnderFileSystemFactoryRegistry {
    */
   public static List<UnderFileSystemFactory> findAll(String path,
       UnderFileSystemConfiguration ufsConf) {
-    return sRegistryInstance.findAll(path, ufsConf);
+    List<UnderFileSystemFactory> eligibleFactories = sRegistryInstance.findAll(path, ufsConf);
+    if (eligibleFactories.isEmpty() && ufsConf != null) {
+      // Check if any versioned factory supports the default configuration
+      List<UnderFileSystemFactory> factories = sRegistryInstance.findAll(path, null);
+      List<String> supportedVersions = new java.util.ArrayList<>();
+      for (UnderFileSystemFactory factory : factories) {
+        if (!factory.getVersion().isEmpty()) {
+          supportedVersions.add(factory.getVersion());
+        }
+      }
+      if (!supportedVersions.isEmpty()) {
+        String configuredVersion = ufsConf.get(alluxio.PropertyKey.UNDERFS_VERSION);
+        LOG.warn("Versions [{}] are supported for path {} but you have configured version: {}",
+            org.apache.commons.lang.StringUtils.join(supportedVersions, ","), path,
+            configuredVersion);
+      }
+    }
+    return eligibleFactories;
   }
 
   private static synchronized void init() {

--- a/core/common/src/main/java/alluxio/uri/Authority.java
+++ b/core/common/src/main/java/alluxio/uri/Authority.java
@@ -48,7 +48,7 @@ public interface Authority extends Comparable<Authority>, Serializable {
       } else {
         matcher = MULTI_MASTERS_AUTH.matcher(authority);
         if (matcher.matches()) {
-          return new MultiMasterAuthority(authority);
+          return new MultiMasterAuthority(authority.replaceAll("[;+]", ","));
         }
         return new UnknownAuthority(authority);
       }

--- a/core/common/src/main/java/alluxio/uri/MultiMasterAuthority.java
+++ b/core/common/src/main/java/alluxio/uri/MultiMasterAuthority.java
@@ -12,7 +12,6 @@
 package alluxio.uri;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 
 /**
  * A multi-master authority implementation.
@@ -20,23 +19,18 @@ import com.google.common.base.Preconditions;
 public class MultiMasterAuthority implements Authority {
   private static final long serialVersionUID = 2580736424809131651L;
 
-  /** The original authority string. */
-  private final String mAuthority;
   /**
    * The master addresses transform from the original authority string.
-   * Semicolons in authority are replaced by commas to match our
+   * Semicolons and plus signs in authority are replaced by commas to match our
    * internal property format.
    */
   private final String mMasterAddresses;
 
   /**
-   * @param authority the authority string of the URI
+   * @param masterAddresses the multi master addresses
    */
-  public MultiMasterAuthority(String authority) {
-    Preconditions.checkArgument(authority != null && authority.length() != 0,
-        "authority should not be null or empty string");
-    mAuthority = authority;
-    mMasterAddresses = authority.replaceAll("[;+]", ",");
+  public MultiMasterAuthority(String masterAddresses) {
+    mMasterAddresses = masterAddresses;
   }
 
   /**
@@ -65,11 +59,11 @@ public class MultiMasterAuthority implements Authority {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mAuthority);
+    return Objects.hashCode(mMasterAddresses);
   }
 
   @Override
   public String toString() {
-    return mAuthority;
+    return mMasterAddresses;
   }
 }

--- a/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -152,7 +152,7 @@ public class AlluxioURITest {
     AlluxioURI uri =
         new AlluxioURI("alluxio://host1:1323;host2:54325;host3:64354/xy z/a b c");
     assertTrue(uri.hasAuthority());
-    assertEquals("host1:1323;host2:54325;host3:64354", uri.getAuthority().toString());
+    assertEquals("host1:1323,host2:54325,host3:64354", uri.getAuthority().toString());
     assertTrue(uri.getAuthority() instanceof MultiMasterAuthority);
     MultiMasterAuthority authority = (MultiMasterAuthority) uri.getAuthority();
     assertEquals("host1:1323,host2:54325,host3:64354", authority.getMasterAddresses());
@@ -163,7 +163,6 @@ public class AlluxioURITest {
     AlluxioURI uri =
         new AlluxioURI("alluxio://host1:526+host2:54325+host3:624/xy z/a b c");
     assertTrue(uri.hasAuthority());
-    assertEquals("host1:526+host2:54325+host3:624", uri.getAuthority().toString());
     assertTrue(uri.getAuthority() instanceof MultiMasterAuthority);
     MultiMasterAuthority authority = (MultiMasterAuthority) uri.getAuthority();
     assertEquals("host1:526,host2:54325,host3:624", authority.getMasterAddresses());

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -78,11 +78,9 @@ public class AuthorityTest {
     assertEquals("127.0.0.1:213,127.0.0.2:532423,127.0.0.3:3213", authority.getMasterAddresses());
 
     authority = (MultiMasterAuthority) Authority.fromString("host1:19998;host2:19998;host3:19998");
-    assertEquals("host1:19998;host2:19998;host3:19998", authority.toString());
     assertEquals("host1:19998,host2:19998,host3:19998", authority.getMasterAddresses());
 
     authority = (MultiMasterAuthority) Authority.fromString("host1:19998+host2:19998+host3:19998");
-    assertEquals("host1:19998+host2:19998+host3:19998", authority.toString());
     assertEquals("host1:19998,host2:19998,host3:19998", authority.getMasterAddresses());
 
     assertFalse(Authority.fromString("localhost:19998")

--- a/dev/jenkins/Dockerfile
+++ b/dev/jenkins/Dockerfile
@@ -13,14 +13,12 @@
 
 FROM maven:3.5.4-jdk-8
 
-# Add jenkins user to make it easier to use this image from jenkins contexts
-RUN adduser --quiet jenkins
-RUN usermod -u 1000 jenkins && groupmod -g 1000 jenkins
-
-RUN apt-get update -y && \
+# need to create /.config to avoid npm errors
+RUN mkdir -p /home/jenkins && \
+    chmod -R 777 /home/jenkins && \
+    chmod g+w /etc/passwd && \
+    mkdir -p /.config && \
+    chmod -R 777 /.config && \
+    apt-get update -y && \
     apt-get install -y golang-go ruby ruby-dev make build-essential fuse && \
     gem install jekyll bundler
-
-# Give jenkins user access to /root/.m2. We can still run the image as root for local debugging
-RUN mkdir -p /root/.m2 && \
-    chown -R jenkins:jenkins /root/.m2

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+#
+# This script is run from inside the Docker container
+#
+set -e
+
+# Set things up so that the current user has a real name and can authenticate.
+myuid=$(id -u)
+mygid=$(id -g)
+echo "$myuid:x:$myuid:$mygid:anonymous uid:/home/jenkins:/bin/false" >> /etc/passwd
+
+if [ -z ${ALLUXIO_BUILD_FORKCOUNT} ]
+then
+  ALLUXIO_BUILD_FORKCOUNT=4
+fi
+
+git clean -fdx
+mvn -Duser.home=/home/jenkins -T 4C clean install -PcompileJsp -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} $@

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+set -e
+
+function main {
+  if [ -z "${ALLUXIO_DOCKER_ID}" ]
+  then
+    ALLUXIO_DOCKER_ID="$(id -u)"
+  fi
+  if [ -z "${ALLUXIO_DOCKER_M2}" ]
+  then
+    ALLUXIO_DOCKER_M2="${HOME}/.m2"
+  fi
+  if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
+  then
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.3"
+  fi
+
+  local run_args="--rm"
+
+  if [ -z ${ALLUXIO_DOCKER_NO_TTY} ]
+  then
+    run_args+=" -it"
+  fi
+
+  local home="/home/jenkins"
+  # Needed to run fuse tests:
+  run_args+=" --cap-add SYS_ADMIN"
+  run_args+=" --device /dev/fuse"
+  run_args+=" --security-opt apparmor:unconfined"
+
+  # Run as the host jenkins user so that files written to .m2 are written as jenkins.
+  # Use group 0 to get certain elevated permissions.
+  run_args+=" --user ${ALLUXIO_DOCKER_ID}:0"
+
+  # Mount the local directory inside the docker container, and set it as the working directory
+  run_args+=" -v $(pwd):/usr/src/alluxio"
+  run_args+=" -w /usr/src/alluxio"
+
+  # Since we're running as a user unknown to the Docker container, we need to explicitly
+  # configure anything that's relative to ${HOME}.
+  run_args+=" -e HOME=${home}"
+  run_args+=" -v ${ALLUXIO_DOCKER_M2}:${home}/.m2"
+  run_args+=" -e npm_config_cache=${home}/.npm"
+  run_args+=" -e MAVEN_CONFIG=${home}/.m2"
+
+  run_args+=" -e ALLUXIO_USE_FIXED_TEST_PORTS=true"
+
+  # Use this as an entrypoint instead of image argument so that it can be interrupted by Ctrl-C
+  run_args+=" --entrypoint=dev/jenkins/build.sh"
+
+  docker run ${run_args} ${ALLUXIO_DOCKER_IMAGE} $@
+}
+
+main "$@"

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
@@ -41,6 +41,45 @@ var hadoopDistributions = map[string]version{
 	"default": parseVersion("2.2.0"),
 }
 
+type module struct {
+	name      string // the name used in the generated tarball
+	isDefault bool   // whether to build the module by default
+	mavenArgs string // maven args for building the module
+}
+
+// ufsModules is a map from ufs module to information for building the module.
+var ufsModules = map[string]module{
+	"ufs-hadoop-1.0": {"hadoop-1.0", false, "-pl underfs/hdfs -Pufs-hadoop-1 -Dufs.hadoop.version=1.0.4"},
+	"ufs-hadoop-1.2": {"hadoop-1.2", true, "-pl underfs/hdfs -Pufs-hadoop-1 -Dufs.hadoop.version=1.2.1"},
+	"ufs-hadoop-2.2": {"hadoop-2.2", true, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.2.0"},
+	"ufs-hadoop-2.3": {"hadoop-2.3", false, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.3.0"},
+	"ufs-hadoop-2.4": {"hadoop-2.4", false, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.4.1"},
+	"ufs-hadoop-2.5": {"hadoop-2.5", false, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.5.2"},
+	"ufs-hadoop-2.6": {"hadoop-2.6", false, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.6.5 -PhdfsActiveSync"},
+	"ufs-hadoop-2.7": {"hadoop-2.7", true, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.7.3 -PhdfsActiveSync"},
+	"ufs-hadoop-2.8": {"hadoop-2.8", false, "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.8.0 -PhdfsActiveSync"},
+}
+
+func validModules(modules map[string]module) []string {
+	result := []string{}
+	for moduleName := range modules {
+		result = append(result, moduleName)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func defaultModules(modules map[string]module) []string {
+	result := []string{}
+	for moduleName := range modules {
+		if modules[moduleName].isDefault {
+			result = append(result, moduleName)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
 func validHadoopDistributions() []string {
 	var result []string
 	for distribution := range hadoopDistributions {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
@@ -34,6 +34,9 @@ func init() {
 }
 
 func checkReleaseFlags() error {
+	if err := checkRootFlags(); err != nil {
+		return err
+	}
 	for _, distribution := range strings.Split(hadoopDistributionsFlag, ",") {
 		_, ok := hadoopDistributions[distribution]
 		if !ok {
@@ -44,6 +47,9 @@ func checkReleaseFlags() error {
 }
 
 func release(_ *cmdline.Env, _ []string) error {
+	if err := updateRootFlags(); err != nil {
+		return err
+	}
 	if err := checkReleaseFlags(); err != nil {
 		return err
 	}

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -12,7 +12,9 @@
 package cmd
 
 import (
+	"fmt"
 	"v.io/x/lib/cmdline"
+	"strings"
 )
 
 var (
@@ -30,8 +32,27 @@ or generating a suite of release tarballs.
 	}
 
 	debugFlag bool
+	ufsModulesFlag string
 )
+
+func updateRootFlags() error {
+	if strings.ToLower(ufsModulesFlag) == "all" {
+		ufsModulesFlag = strings.Join(validModules(ufsModules), ",")
+	}
+	return nil
+}
+
+func checkRootFlags() error {
+	for _, module := range strings.Split(ufsModulesFlag, ",") {
+		if _, ok := ufsModules[module]; !ok {
+			return fmt.Errorf("ufs module %v not recognized", module)
+		}
+	}
+	return nil
+}
 
 func init() {
 	Root.Flags.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")
+	Root.Flags.StringVar(&ufsModulesFlag, "ufs-modules", strings.Join(defaultModules(ufsModules), ","),
+		fmt.Sprintf("a comma-separated list of ufs modules to compile into the distribution tarball(s). Specify 'all' to build all ufs modules. Supported ufs modules: [%v]", strings.Join(validModules(ufsModules), ",")))
 }

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -15,7 +15,29 @@ a recovering master will read the edit logs to restore itself back to its previo
 We use the term "journal" to refer to the system of edit logs used to support fault-tolerance.
 The purpose of this documentation is to help Alluxio administrators understand and manage the Alluxio journal.
 
-## Configuration
+## UFS Journal vs Embedded Journal
+
+The UFS journal simplifies certain aspects of Alluxio operation, but it relies on 
+an external Zookeeper cluster for coordination, and relies on a UFS for persistent storage. 
+To get reasonable performance, the UFS journal requires a UFS that supports fast streaming writes, 
+such as HDFS or NFS.
+
+The embedded journal does its own coordination and persistent storage, but has a few limitations.
+
+First, `n` masters using the embedded journal can tolerate only `floor(n/2)` master failures, 
+compared to `n-1` for UFS journal. For example, With `3` masters, UFS journal can tolerate `2` failures, 
+while embedded journal can only tolerate `1`. However, UFS journal depends on Zookeeper, 
+which similarly only supports `floor(#zookeeper_nodes / 2)` failures.
+
+The other limitation is that embedded journal does not support dynamically changing master membership. 
+With UFS journal, replacing a master on `host1` with a new master on `host2` is as simple as starting a new master on `host2`, 
+then killing the master on `host1`. Changing the masters in an embedded journal cluster requires backing up the cluster, 
+shutting it down, and then starting up again with the new masters using the backup.
+
+If a fast UFS and Zookeeper cluster are readily available and stable, it is recommended to use the UFS journal. 
+Otherwise, we recommend using the embedded journal.
+
+## UFS Journal Configuration
 
 The most important configuration value to set for the journal is
 `alluxio.master.journal.folder`. This must be set to a filesystem folder that is
@@ -39,6 +61,45 @@ Use the local file system to store the journal:
 ```
 alluxio.master.journal.folder=/opt/alluxio/journal
 ```
+
+## Embedded Journal Configuration
+
+### Required configuration
+
+The configuration specified below should be applied to both Alluxio servers and Alluxio clients.
+
+Set the journal type to "EMBEDDED":
+```
+alluxio.master.journal.type=EMBEDDED
+```
+
+Set the addresses of all masters in the cluster. The default embedded journal port is `19200`.
+```
+alluxio.master.embedded.journal.addresses=master_hostname_1:19200,master_hostname_2:19200,master_hostname_3:19200
+```
+
+### Optional configuration
+
+* `alluxio.master.embedded.journal.port`: The port masters use for embedded journal communication. Default: `19200`.
+* `alluxio.master.port`: The port masters use for RPCs. Default: `19998`.
+* `alluxio.master.rpc.addresses`: A list of comma-separated `host:port` RPC addresses where the client 
+should look for masters when using multiple masters without Zookeeper. This property is not used when Zookeeper is enabled, 
+since Zookeeper already stores the master addresses. If this is not set, clients will look for masters using the hostnames 
+from `alluxio.master.embedded.journal.addresses` and the master rpc port.
+
+### Job service configuration
+
+It is usually best not to set any of these - by default the job master will use the same hostnames as the Alluxio master, 
+so it is enough to set only `alluxio.master.embedded.journal.addresses`. These properties only need to be set 
+when the job service is being run independent from the rest of the system or using a non-standard port.
+
+* `alluxio.job.master.embedded.journal.port`: the port job masters use for embedded journal communications. Default: `20003`.
+* `alluxio.job.master.embedded.journal.addresses`: a comma-separated list of journal addresses for all job masters in the cluster. 
+The format is `hostname1:port1,hostname2:port2,...`.
+* `alluxio.job.master.rpc.addresses`: A list of comma-separated host:port RPC addresses where the client should look for job masters 
+when using multiple job masters without Zookeeper. This property is not used when Zookeeper is enabled, 
+since Zookeeper already stores the job master addresses. If this is not set, clients will look for job masters using the hostnames 
+from `alluxio.master.embedded.journal.addresses` and the job master rpc port.
 
 ## Formatting the journal
 

--- a/job/server/src/main/java/alluxio/master/JobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/JobMasterProcess.java
@@ -18,7 +18,10 @@ import alluxio.PropertyKey;
 import alluxio.master.job.JobMaster;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
+import alluxio.master.journal.raft.RaftJournalSystem;
 import alluxio.util.URIUtils;
+
+import com.google.common.base.Preconditions;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -44,7 +47,12 @@ public interface JobMasterProcess extends Process {
           .setLocation(URIUtils.appendPathOrDie(journalLocation, Constants.JOB_JOURNAL_NAME))
           .build();
       if (Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
+        Preconditions.checkState(!(journalSystem instanceof RaftJournalSystem),
+            "Raft journal cannot be used with Zookeeper enabled");
         PrimarySelector primarySelector = PrimarySelector.Factory.createZkJobPrimarySelector();
+        return new FaultTolerantAlluxioJobMasterProcess(journalSystem, primarySelector);
+      } else if (journalSystem instanceof RaftJournalSystem) {
+        PrimarySelector primarySelector = ((RaftJournalSystem) journalSystem).getPrimarySelector();
         return new FaultTolerantAlluxioJobMasterProcess(journalSystem, primarySelector);
       }
 

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -25,7 +25,8 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
-    <ufs.hadoop.version>${hadoop.version}</ufs.hadoop.version>
+    <!-- Decouple hadoop versions between north and south bound -->
+    <ufs.hadoop.version>2.2.0</ufs.hadoop.version>
   </properties>
 
   <dependencies>
@@ -57,7 +58,8 @@
   <profiles>
     <!-- Profile to build this UFS module connecting to hdfs 1 -->
     <profile>
-      <id>hadoop-1</id>
+      <!-- Decouple hadoop profiles: hadoop-1 to indicate north bound and ufs-hadoop-1 to indicate the south bound -->
+      <id>ufs-hadoop-1</id>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
@@ -84,7 +86,8 @@
 
     <!-- Profile to build this UFS module connecting to hdfs 2, this is the default profile -->
     <profile>
-      <id>hadoop-2</id>
+      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
+      <id>ufs-hadoop-2</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -198,6 +201,22 @@
         <artifactId>copy-rename-maven-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${basedir}/src/main/java-templates</sourceDirectory>
+              <outputDirectory>${basedir}/src/main/java</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.igormaznitsa</groupId>
         <artifactId>jcp</artifactId>

--- a/underfs/hdfs/src/main/java-templates/alluxio/UfsConstants.java
+++ b/underfs/hdfs/src/main/java-templates/alluxio/UfsConstants.java
@@ -1,0 +1,22 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+/**
+ * Ufs constants from compilation time by maven.
+ */
+public final class UfsConstants {
+  /* Hadoop version, specified in maven property. **/
+  public static final String UFS_HADOOP_VERSION = "${ufs.hadoop.version}";
+
+  private UfsConstants() {} // prevent instantiation
+}

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -55,4 +55,29 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
     }
     return false;
   }
+
+  @Override
+  public boolean supportsPath(String path, UnderFileSystemConfiguration conf) {
+    if (path != null) {
+      // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
+      // FileSystem.getFileSystemClass() without any need for having users explicitly declare the
+      // file system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop
+      // are supported this is not an option and we have to continue to use this method.
+      for (final String prefix : Configuration.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
+        if (path.startsWith(prefix)) {
+          if (conf != null && HdfsVersion
+              .find(conf.get(PropertyKey.UNDERFS_VERSION)) != HdfsVersion.find(getVersion())) {
+            continue;
+          }
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String getVersion() {
+    return alluxio.UfsConstants.UFS_HADOOP_VERSION;
+  }
 }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsVersion.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsVersion.java
@@ -1,0 +1,68 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+/** The set of supported Hdfs versions. */
+public enum HdfsVersion {
+  HADOOP_1_0("hadoop-1.0", "(hadoop-?1\\.0(\\.(\\d+))?|1\\.0(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_1_2("hadoop-1.2", "(hadoop-?1\\.2(\\.(\\d+))?|1\\.2(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_2("hadoop-2.2", "(hadoop-?2\\.2(\\.(\\d+))?|2\\.2(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_3("hadoop-2.3", "(hadoop-?2\\.3(\\.(\\d+))?|2\\.3(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_4("hadoop-2.4", "(hadoop-?2\\.4(\\.(\\d+))?|2\\.4(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_5("hadoop-2.5", "(hadoop-?2\\.5(\\.(\\d+))?|2\\.5(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_6("hadoop-2.6", "(hadoop-?2\\.6(\\.(\\d+))?|2\\.6(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_7("hadoop-2.7", "(hadoop-?2\\.7(\\.(\\d+))?|2\\.7(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_8("hadoop-2.8", "(hadoop-?2\\.8(\\.(\\d+))?|2\\.8(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_2_9("hadoop-2.9", "(hadoop-?2\\.9(\\.(\\d+))?|2\\.9(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_3_0("hadoop-3.0", "(hadoop-?3\\.0(\\.(\\d+))?|3\\.0(\\.(\\d+)(-.*)?)?)"),
+  HADOOP_3_1("hadoop-3.1", "(hadoop-?3\\.1(\\.(\\d+))?|3\\.1(\\.(\\d+)(-.*)?)?)"),
+  ;
+
+  private final String mCanonicalVersion;
+  private final Pattern mVersionPattern;
+
+  /**
+   * Constructs an instance of {@link HdfsVersion}.
+   *
+   * @param canonicalVersion the canonical version of an HDFS
+   * @param versionPattern the regex pattern of version for an HDFS
+   */
+  HdfsVersion(String canonicalVersion, String versionPattern) {
+    mCanonicalVersion = canonicalVersion;
+    mVersionPattern = Pattern.compile(versionPattern);
+  }
+
+  /**
+   * @param versionString given version string
+   * @return the corresponding {@link HdfsVersion} instance
+   */
+  @Nullable
+  public static HdfsVersion find(String versionString) {
+    for (HdfsVersion version : HdfsVersion.values()) {
+      if (version.mVersionPattern.matcher(versionString).matches()) {
+        return version;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return the canonical version string
+   */
+  public String getCanonicalVersion() {
+    return mCanonicalVersion;
+  }
+}

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsVersionTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsVersionTest.java
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link HdfsVersion}.
+ */
+public class HdfsVersionTest {
+
+  @Test
+  public void find() throws Exception {
+    Assert.assertNull(HdfsVersion.find("NotValid"));
+    for (HdfsVersion version : HdfsVersion.values()) {
+      Assert.assertEquals(version, HdfsVersion.find(version.getCanonicalVersion()));
+    }
+  }
+
+  @Test
+  public void findByHadoopLabel() throws Exception {
+    Assert.assertEquals(HdfsVersion.HADOOP_1_0, HdfsVersion.find("1.0.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_0, HdfsVersion.find("1.0.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_0, HdfsVersion.find("hadoop-1.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_0, HdfsVersion.find("hadoop-1.0.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_0, HdfsVersion.find("hadoop1.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_2, HdfsVersion.find("1.2.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_2, HdfsVersion.find("1.2.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_2, HdfsVersion.find("hadoop-1.2"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_2, HdfsVersion.find("hadoop-1.2.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_1_2, HdfsVersion.find("hadoop1.2"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_2, HdfsVersion.find("2.2.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_2, HdfsVersion.find("2.2.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_2, HdfsVersion.find("hadoop-2.2"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_2, HdfsVersion.find("hadoop-2.2.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_2, HdfsVersion.find("hadoop2.2"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_3, HdfsVersion.find("2.3.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_3, HdfsVersion.find("2.3.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_3, HdfsVersion.find("hadoop-2.3"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_3, HdfsVersion.find("hadoop-2.3.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_3, HdfsVersion.find("hadoop2.3"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_4, HdfsVersion.find("2.4.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_4, HdfsVersion.find("2.4.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_4, HdfsVersion.find("hadoop-2.4"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_4, HdfsVersion.find("hadoop-2.4.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_4, HdfsVersion.find("hadoop2.4"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_5, HdfsVersion.find("2.5.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_5, HdfsVersion.find("2.5.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_5, HdfsVersion.find("hadoop-2.5"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_5, HdfsVersion.find("hadoop-2.5.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_5, HdfsVersion.find("hadoop2.5"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_6, HdfsVersion.find("2.6.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_6, HdfsVersion.find("2.6.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_6, HdfsVersion.find("hadoop-2.6"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_6, HdfsVersion.find("hadoop-2.6.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_6, HdfsVersion.find("hadoop2.6"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_7, HdfsVersion.find("2.7.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_7, HdfsVersion.find("2.7.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_7, HdfsVersion.find("hadoop-2.7"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_7, HdfsVersion.find("hadoop-2.7.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_7, HdfsVersion.find("hadoop2.7"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_8, HdfsVersion.find("2.8.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_8, HdfsVersion.find("2.8.0-SNAPSHOT"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_8, HdfsVersion.find("hadoop-2.8"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_8, HdfsVersion.find("hadoop-2.8.0"));
+    Assert.assertEquals(HdfsVersion.HADOOP_2_8, HdfsVersion.find("hadoop2.8"));
+  }
+}


### PR DESCRIPTION
This feature is to allow multiple different HDFS versions to be mounted as a UFS to Alluxio. The core points are below.

- **alluxio.underfs.hdfs.version** is now removed in favor of **alluxio.underfs.version**
- Go build scripts now have the option --ufs-modules to allow building of an Alluxio release with a list of supported UFS versions

@aaudiber @apc999 @bf8086 