### PR TITLE
Improve FileSystemMasterTest performance

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -68,6 +68,7 @@ import alluxio.master.journal.JournalTestUtils;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.metrics.Metric;
+import alluxio.metrics.MetricsSystem;
 import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.security.authorization.AclEntry;
 import alluxio.thrift.Command;
@@ -195,6 +196,7 @@ public final class FileSystemMasterTest {
   @Before
   public void before() throws Exception {
     GroupMappingServiceTestUtils.resetCache();
+    MetricsSystem.clearAllMetrics();
     // This makes sure that the mount point of the UFS corresponding to the Alluxio root ("/")
     // doesn't exist by default (helps loadRootTest).
     mUnderFS = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);

--- a/tests/src/test/java/alluxio/testutils/BaseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/testutils/BaseIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.testutils;
 
 import alluxio.Constants;
-import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.PathUtils;
 
 import org.apache.log4j.Appender;
@@ -20,7 +19,6 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PatternLayout;
 import org.junit.AssumptionViolatedException;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestWatcher;
@@ -43,11 +41,6 @@ public abstract class BaseIntegrationTest {
   @Rule
   public RuleChain mRules = RuleChain.outerRule(logHandler())
       .around(Timeout.millis(Constants.MAX_TEST_DURATION_MS));
-
-  @Before
-  public void baseBefore() {
-    MetricsSystem.clearAllMetrics();
-  }
 
   private TestWatcher logHandler() {
     return new TestWatcher() {

--- a/tests/src/test/java/alluxio/testutils/BaseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/testutils/BaseIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.testutils;
 
 import alluxio.Constants;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.PathUtils;
 
 import org.apache.log4j.Appender;
@@ -19,6 +20,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PatternLayout;
 import org.junit.AssumptionViolatedException;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestWatcher;
@@ -41,6 +43,11 @@ public abstract class BaseIntegrationTest {
   @Rule
   public RuleChain mRules = RuleChain.outerRule(logHandler())
       .around(Timeout.millis(Constants.MAX_TEST_DURATION_MS));
+
+  @Before
+  public void baseBefore() {
+    MetricsSystem.clearAllMetrics();
+  }
 
   private TestWatcher logHandler() {
     return new TestWatcher() {


### PR DESCRIPTION
Most of the tests in FileSystemMasterTest take 100-200ms when run individually. But when running all 100 tests in a suite, they take longer and longer, with the last tests taking ~600ms. The slowdown happens because it takes longer and longer for the MetricsMaster to stop. It takes longer and longer to stop because it is stuck in `ClusterMetricsUpdater#heartbeat`: https://github.com/Alluxio/alluxio/blob/master/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java#L227. This method keeps taking longer and longer because we don't reset metrics across test runs, so the number of metrics to aggregate keeps increasing.

With this change, the test duration drops from 24 seconds to 10 seconds when running in my local intellij.

@ggezer This might fix the test slowdown issue you pointed out to me a while back