### PR TITLE
properly release buffer for gRPC data path

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -232,7 +232,8 @@ public class GrpcBlockingStream<ReqT, ResT> {
   }
 
   private String formatErrorMessage(String format, Object... args) {
-    StringBuilder errorMessage = new StringBuilder(String.format(format, args));
+    StringBuilder errorMessage = new StringBuilder(
+        format == null ? "Unknown error" : String.format(format, args));
     return new StringBuilder(errorMessage).append(String.format(" (%s)", mDescription)).toString();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -157,6 +157,7 @@ public final class GrpcDataWriter implements DataWriter {
   public void writeChunk(final ByteBuf buf) throws IOException {
     mPosToQueue += buf.readableBytes();
     try {
+      // TODO(bf8086): find a way to do zero-copy data streaming
       mStream.send(WriteRequest.newBuilder().setCommand(mPartialRequest).setChunk(
           Chunk.newBuilder()
               .setData(ByteString.copyFrom(buf.nioBuffer()))

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -26,7 +26,7 @@ import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.UnsafeByteOperations;
+import com.google.protobuf.ByteString;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,7 +159,7 @@ public final class GrpcDataWriter implements DataWriter {
     try {
       mStream.send(WriteRequest.newBuilder().setCommand(mPartialRequest).setChunk(
           Chunk.newBuilder()
-              .setData(UnsafeByteOperations.unsafeWrap(buf.nioBuffer()))
+              .setData(ByteString.copyFrom(buf.nioBuffer()))
               .build()).build(),
           WRITE_TIMEOUT_MS);
     } finally {


### PR DESCRIPTION
When we were using netty the data buffer is release by netty when it sends the data. With gRPC however, it is assumed to be immutable so the lifecycle management is on us. For now, switching to pass on heap buffer to gRPC so it can be garbage collected.