### PR TITLE
remove extra copy of data buffer for gRPC streaming

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -26,7 +26,7 @@ import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,10 +157,9 @@ public final class GrpcDataWriter implements DataWriter {
   public void writeChunk(final ByteBuf buf) throws IOException {
     mPosToQueue += buf.readableBytes();
     try {
-      // TODO(bf8086): find a way to do zero-copy data streaming
       mStream.send(WriteRequest.newBuilder().setCommand(mPartialRequest).setChunk(
           Chunk.newBuilder()
-              .setData(ByteString.copyFrom(buf.nioBuffer()))
+              .setData(UnsafeByteOperations.unsafeWrap(buf.nioBuffer()))
               .build()).build(),
           WRITE_TIMEOUT_MS);
     } finally {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
@@ -24,7 +24,7 @@ import alluxio.resource.LockResource;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -303,7 +303,7 @@ abstract class AbstractReadHandler<T extends ReadRequestContext<?>>
 
           if (chunk != null) {
             ReadResponse response = ReadResponse.newBuilder().setChunk(Chunk.newBuilder()
-                .setData(ByteString.copyFrom(chunk.getReadOnlyByteBuffer())).build())
+                .setData(UnsafeByteOperations.unsafeWrap(chunk.getReadOnlyByteBuffer())).build())
                 .build();
             mResponse.onNext(response);
             incrementMetrics(chunk.getLength());

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.when;
 
 import alluxio.grpc.ReadRequest;
+import alluxio.grpc.ReadResponse;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.LocalFileBlockReader;
@@ -50,6 +51,12 @@ public final class BlockReadHandlerTest extends ReadHandlerTest {
       mError = args.getArgumentAt(0, Throwable.class);
       return null;
     }).when(mResponseObserver).onError(any(Throwable.class));
+    doAnswer((args) -> {
+      // make a copy of response data before it is released
+      mResponses.add(ReadResponse.parseFrom(
+          args.getArgumentAt(0, ReadResponse.class).toByteString()));
+      return null;
+    }).when(mResponseObserver).onNext(any(ReadResponse.class));
     mReadHandler = new BlockReadHandler(GrpcExecutors.BLOCK_READER_EXECUTOR, mBlockWorker,
         mResponseObserver);
     mReadHandlerNoException = new BlockReadHandler(


### PR DESCRIPTION
Pass in direct buffer for gRPC streams instead of on-heap copy. This should be safe given gRPC serializes the message on the same thread as the caller. No errors so far in the initial concurrent IO tests.