### PR TITLE
Fix gRPC channel pooling

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -51,7 +51,9 @@ public final class GrpcChannel extends Channel {
    * Shuts down the channel.
    */
   public void shutdown() {
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey);
+    if(!mChannelReleased) {
+      GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey);
+    }
     mChannelReleased = true;
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -102,11 +102,11 @@ public class GrpcManagedChannelPool {
     long channelTerminationIntervalMs =
         Configuration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT);
     mScheduler.scheduleAtFixedRate(() -> {
-      destroyChannels();
+      destroyInactiveChannels();
     }, channelTerminationIntervalMs, channelTerminationIntervalMs, TimeUnit.MILLISECONDS);
   }
 
-  private synchronized void destroyChannels() {
+  private void destroyInactiveChannels() {
     int channelCount = 0;
     int destroyedCount = 0;
     List<Pair<ChannelKey, ManagedChannelReference>> channelsToDestroy = new ArrayList<>();

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -122,6 +122,7 @@ public class GrpcManagedChannelPool {
       }
     }
 
+    // TODO(ggezer) Consider shutting down in parallel.
     for (Pair<ChannelKey, ManagedChannelReference> channelPair : channelsToDestroy) {
       ManagedChannel channel = channelPair.getSecond().get();
       channel.shutdown();

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
- * "License"). You may not use this work except in compliance with the License, which is available
- * at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -1,0 +1,143 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.grpc;
+
+import static org.junit.Assert.assertTrue;
+
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.util.SleepUtils;
+
+import io.grpc.ManagedChannel;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link GrpcManagedChannelPool}.
+ */
+public final class GrpcManagedChannelPoolTest {
+
+  @Before
+  public void before() throws Exception {
+    GrpcManagedChannelPool.INSTANCE().restart();
+  }
+
+  @Test
+  public void testEqualKeys() {
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+
+    SocketAddress address = new InetSocketAddress("localhost", 1);
+
+    key1.setAddress(address);
+    key2.setAddress(address);
+
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+
+    assertTrue(channel1 == channel2);
+
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+  }
+
+  @Test
+  public void testEqualKeysComplex() {
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+
+    SocketAddress address1 = new InetSocketAddress("localhost", 1);
+
+    key1.setAddress(address1);
+    key2.setAddress(address1);
+
+    key1.setFlowControlWindow(100);
+    key2.setFlowControlWindow(100);
+
+    key1.setMaxInboundMessageSize(100);
+    key2.setMaxInboundMessageSize(100);
+
+    key1.setKeepAliveTime(100, TimeUnit.MINUTES);
+    key2.setKeepAliveTime(100, TimeUnit.MINUTES);
+
+    key1.setKeepAliveTimeout(100, TimeUnit.MINUTES);
+    key2.setKeepAliveTimeout(100, TimeUnit.MINUTES);
+
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+
+    assertTrue(channel1 == channel2);
+
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+  }
+
+  @Test
+  public void testNotEqualKeys() {
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+
+    SocketAddress address1 = new InetSocketAddress("localhost", 1);
+    SocketAddress address2 = new InetSocketAddress("localhost", 2);
+
+    key1.setAddress(address1);
+    key2.setAddress(address2);
+
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+
+    assertTrue(channel1 != channel2);
+
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+  }
+
+  @Test
+  public void testTermination() throws Exception {
+    // This will cause channel terminator to run every second.
+    Configuration.set(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT, "1sec");
+    GrpcManagedChannelPool.INSTANCE().restart();
+
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
+    key1.setAddress(new InetSocketAddress("localhost", 1));
+
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+    // Give enough time for channel terminator to run through channels.
+    SleepUtils.sleepMs(TimeUnit.SECONDS.toMillis(5));
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    assertTrue(channel1 != channel2);
+
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+  }
+
+  @Test
+  public void testReacquiringBeforeTermination() throws Exception {
+    // This will cause channel terminator to run every minute.
+    Configuration.set(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT, "1min");
+    GrpcManagedChannelPool.INSTANCE().restart();
+
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
+    key1.setAddress(new InetSocketAddress("localhost", 1));
+
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
+    assertTrue(channel1 == channel2);
+
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
+  }
+}

--- a/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
@@ -105,7 +105,7 @@ final class FaultTolerantAlluxioJobMasterProcess extends AlluxioJobMasterProcess
   @Override
   public boolean waitForReady(int timeoutMs) {
     try {
-      CommonUtils.waitFor(this + " to start", () -> mServingThread == null || isServing(),
+      CommonUtils.waitFor(this + " to start", () -> mServingThread != null && isServing(),
           WaitForOptions.defaults().setTimeoutMs(timeoutMs));
       return true;
     } catch (InterruptedException e) {


### PR DESCRIPTION
ChannelKey's equals() method was wrong and was missing hashcode() implementation. This caused gRPC channel pooling to always create new managed channel upon every request. This PR fixes it and adds further optimization to delay actual channel destruction.