### PR TITLE
Use client pool for gRPC streaming

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -38,7 +38,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
   private static final int WORKER_CLIENT_POOL_GC_THREADPOOL_SIZE = 10;
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(WORKER_CLIENT_POOL_GC_THREADPOOL_SIZE,
-          ThreadFactoryUtils.build("WorkerClientPoolGcThreads-%d", true));
+          ThreadFactoryUtils.build("BlockWorkerClientPoolGcThreads-%d", true));
   private final long mGcThresholdMs;
 
   /**
@@ -60,7 +60,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
 
   @Override
   protected void closeResource(BlockWorkerClient client) throws IOException {
-    LOG.info("Worker client for {} closed.", mAddress);
+    LOG.info("Block worker client for {} closed.", mAddress);
     client.close();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -1,0 +1,72 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.stream;
+
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.resource.ResourcePool;
+
+import com.google.common.io.Closer;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.security.auth.Subject;
+
+/**
+ * Class for managing block worker clients. After obtaining a client with
+ * {@link ResourcePool#acquire()}, {@link ResourcePool#release(Object)} must be called when the
+ * thread is done using the client.
+ */
+@ThreadSafe
+public final class BlockWorkerClientPool extends ResourcePool<BlockWorkerClient> {
+  private final Queue<BlockWorkerClient> mClientList;
+  private final Subject mSubject;
+  private final SocketAddress mAddress;
+
+  /**
+   * Creates a new block master client pool.
+   *
+   * @param subject the parent subject
+   * @param address address of the worker
+   */
+  public BlockWorkerClientPool(Subject subject, SocketAddress address) {
+    super(Configuration.getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_SIZE));
+    mSubject = subject;
+    mAddress = address;
+    mClientList = new ConcurrentLinkedQueue<>();
+  }
+
+  @Override
+  public void close() throws IOException {
+    BlockWorkerClient client;
+    Closer closer = Closer.create();
+    while ((client = mClientList.poll()) != null) {
+      closer.register(client);
+    }
+    closer.close();
+  }
+
+  @Override
+  protected BlockWorkerClient createNewResource() {
+    try {
+      BlockWorkerClient client = BlockWorkerClient.Factory.create(mSubject, mAddress);
+      mClientList.add(client);
+      return client;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -99,12 +99,13 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
 
   @Override
   public boolean isShutdown() {
-    return mStreamingChannel.isShutdown();
+    return mStreamingChannel.isShutdown() || mRpcChannel.isShutdown();
   }
 
   @Override
   public void close() throws IOException {
     mStreamingChannel.shutdown();
+    mRpcChannel.shutdown();
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -101,11 +101,15 @@ public final class GrpcDataReader implements DataReader {
 
   @Override
   public void close() throws IOException {
-    if (mClient.isShutdown()) {
-      return;
+    try {
+      if (mClient.isShutdown()) {
+        return;
+      }
+      mStream.close();
+      mStream.waitForComplete(READ_TIMEOUT_MS);
+    } finally {
+      mContext.releaseBlockWorkerClient(mAddress, mClient);
     }
-    mStream.close();
-    mStream.waitForComplete(READ_TIMEOUT_MS);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -78,7 +78,7 @@ public final class LocalFileDataWriter implements DataWriter {
       closer.register(new Closeable() {
         @Override
         public void close() throws IOException {
-          blockWorker.close();
+          context.releaseBlockWorkerClient(address, blockWorker);
         }
       });
       CreateLocalBlockRequest.Builder builder =

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -352,9 +352,12 @@ public class FileInStream extends InputStream implements BoundedStream, Position
                 .setOpenUfsBlockOptions(mOptions.getOpenUfsBlockOptions(blockId))
                 .setSourceHost(dataSource.getHost()).setSourcePort(dataSource.getDataPort())
                 .build();
-        try (BlockWorkerClient blockWorker = mContext.acquireBlockWorkerClient(worker)) {
+        BlockWorkerClient blockWorker = mContext.acquireBlockWorkerClient(worker);
+        try {
           blockWorker.asyncCache(request);
           mLastBlockIdCached = blockId;
+        } finally {
+          mContext.releaseBlockWorkerClient(worker, blockWorker);
         }
       } catch (Exception e) {
         LOG.warn("Failed to complete async cache request for block {} at worker {}: {}", blockId,

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -97,7 +97,7 @@ public final class FileSystemContext implements Closeable {
   @GuardedBy("CONTEXT_CACHE_LOCK")
   private int mRefCount;
 
-  // The netty data server channel pools.
+  // The data server channel pools. This pool will only grow and keys are not removed.
   private final ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool>
       mBlockWorkerClientPool = new ConcurrentHashMap<>();
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -16,6 +16,7 @@ import alluxio.PropertyKey;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.block.BlockMasterClientPool;
 import alluxio.client.block.stream.BlockWorkerClient;
+import alluxio.client.block.stream.BlockWorkerClientPool;
 import alluxio.client.metrics.ClientMasterSync;
 import alluxio.client.metrics.MetricsMasterClient;
 import alluxio.conf.InstancedConfiguration;
@@ -27,6 +28,7 @@ import alluxio.master.MasterClientConfig;
 import alluxio.master.MasterInquireClient;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
+import alluxio.security.authentication.SaslParticipantProviderUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.ThreadUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -35,6 +37,8 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Gauge;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -91,6 +96,10 @@ public final class FileSystemContext implements Closeable {
 
   @GuardedBy("CONTEXT_CACHE_LOCK")
   private int mRefCount;
+
+  // The netty data server channel pools.
+  private final ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool>
+      mBlockWorkerClientPool = new ConcurrentHashMap<>();
 
   /** The shared master inquire client associated with the {@link FileSystemContext}. */
   @GuardedBy("this")
@@ -349,15 +358,26 @@ public final class FileSystemContext implements Closeable {
   }
 
   /**
-   * Acquires a block worker client. It may reuse the same connection if possible.
+   * Acquires a block worker client from the client pools. If there is no available client instance
+   * available in the pool, it tries to create a new one. And an exception is thrown if it fails to
+   * create a new one.
    *
    * @param workerNetAddress the network address of the channel
-   * @return the acquired block worker
+   * @return the acquired netty channel
    */
   public BlockWorkerClient acquireBlockWorkerClient(final WorkerNetAddress workerNetAddress)
       throws IOException {
     SocketAddress address = NetworkAddressUtils.getDataPortSocketAddress(workerNetAddress);
-    return BlockWorkerClient.Factory.create(mParentSubject, address);
+    ClientPoolKey key = new ClientPoolKey(address,
+        SaslParticipantProviderUtils.getImpersonationUser(mParentSubject));
+    if (!mBlockWorkerClientPool.containsKey(key)) {
+      BlockWorkerClientPool pool = new BlockWorkerClientPool(mParentSubject, address);
+      if (mBlockWorkerClientPool.putIfAbsent(key, pool) != null) {
+        // This can happen if this function is called concurrently.
+        pool.close();
+      }
+    }
+    return mBlockWorkerClientPool.get(key).acquire();
   }
 
   /**
@@ -369,10 +389,18 @@ public final class FileSystemContext implements Closeable {
   public void releaseBlockWorkerClient(WorkerNetAddress workerNetAddress,
       BlockWorkerClient client) {
     SocketAddress address = NetworkAddressUtils.getDataPortSocketAddress(workerNetAddress);
-    try {
-      client.close();
-    } catch (IOException e) {
-      LOG.warn("Error closing block worker client for address {}", address, e);
+    ClientPoolKey key = new ClientPoolKey(address,
+        SaslParticipantProviderUtils.getImpersonationUser(mParentSubject));
+    if (mBlockWorkerClientPool.containsKey(key)) {
+      mBlockWorkerClientPool.get(key).release(client);
+    } else {
+      LOG.warn("No client pool for key {}, closing client instead. Context is closed: {}",
+          key, mClosed.get());
+      try {
+        client.close();
+      } catch (IOException e) {
+        LOG.warn("Error closing block worker client for key {}", key, e);
+      }
     }
   }
 
@@ -495,5 +523,45 @@ public final class FileSystemContext implements Closeable {
     }
 
     private Metrics() {} // prevent instantiation
+  }
+
+  /**
+   * Key for worker client pools. This requires both the worker address and the username, so that
+   * netty channels are created for different users.
+   */
+  private static final class ClientPoolKey {
+    private final SocketAddress mSocketAddress;
+    private final String mUsername;
+
+    public ClientPoolKey(SocketAddress socketAddress, String username) {
+      mSocketAddress = socketAddress;
+      mUsername = username;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mSocketAddress, mUsername);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ClientPoolKey)) {
+        return false;
+      }
+      ClientPoolKey that = (ClientPoolKey) o;
+      return Objects.equal(mSocketAddress, that.mSocketAddress)
+          && Objects.equal(mUsername, that.mUsername);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("socketAddress", mSocketAddress)
+          .add("username", mUsername)
+          .toString();
+    }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -371,7 +371,9 @@ public final class FileSystemContext implements Closeable {
     ClientPoolKey key = new ClientPoolKey(address,
         SaslParticipantProviderUtils.getImpersonationUser(mParentSubject));
     if (!mBlockWorkerClientPool.containsKey(key)) {
-      BlockWorkerClientPool pool = new BlockWorkerClientPool(mParentSubject, address);
+      BlockWorkerClientPool pool = new BlockWorkerClientPool(mParentSubject, address,
+          Configuration.getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_SIZE),
+          Configuration.getMs(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS));
       if (mBlockWorkerClientPool.putIfAbsent(key, pool) != null) {
         // This can happen if this function is called concurrently.
         pool.close();

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -363,7 +363,7 @@ public final class FileSystemContext implements Closeable {
    * create a new one.
    *
    * @param workerNetAddress the network address of the channel
-   * @return the acquired netty channel
+   * @return the acquired block worker
    */
   public BlockWorkerClient acquireBlockWorkerClient(final WorkerNetAddress workerNetAddress)
       throws IOException {
@@ -523,8 +523,8 @@ public final class FileSystemContext implements Closeable {
   }
 
   /**
-   * Key for worker client pools. This requires both the worker address and the username, so that
-   * netty channels are created for different users.
+   * Key for block worker client pools. This requires both the worker address and the username, so
+   * that block workers are created for different users.
    */
   private static final class ClientPoolKey {
     private final SocketAddress mSocketAddress;

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1987,7 +1987,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-
   public static final PropertyKey WORKER_PRINCIPAL = new Builder(Name.WORKER_PRINCIPAL)
       .setDescription("Kerberos principal for Alluxio worker.")
       .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
@@ -2403,6 +2402,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(10)
           .setDescription("The number of threads used by a block master client pool to talk "
               + "to the block master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_SIZE =
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_SIZE)
+          .setDefaultValue(1024)
+          .setDescription("The maximum number of block worker clients cached in the block "
+              + "worker client pool.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
@@ -3737,6 +3744,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     public static final String USER_BLOCK_MASTER_CLIENT_THREADS =
         "alluxio.user.block.master.client.threads";
+    public static final String USER_BLOCK_WORKER_CLIENT_POOL_SIZE =
+        "alluxio.user.block.worker.client.pool.size";
     public static final String USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.block.remote.read.buffer.size.bytes";
     public static final String USER_BLOCK_SIZE_BYTES_DEFAULT =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -2413,6 +2413,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS)
+          .setAlias(new String[]{"alluxio.user.block.worker.client.pool.gc.threshold.ms"})
+          .setDefaultValue("300sec")
+          .setDescription("A block worker client is closed if it has been idle for more than this "
+              + "threshold.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES =
       new Builder(Name.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES)
           .setDefaultValue("8MB")
@@ -3746,6 +3755,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.block.master.client.threads";
     public static final String USER_BLOCK_WORKER_CLIENT_POOL_SIZE =
         "alluxio.user.block.worker.client.pool.size";
+    public static final String USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
+        "alluxio.user.block.worker.client.pool.gc.threshold";
     public static final String USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.block.remote.read.buffer.size.bytes";
     public static final String USER_BLOCK_SIZE_BYTES_DEFAULT =

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -2415,7 +2415,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
       new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS)
-          .setAlias(new String[]{"alluxio.user.block.worker.client.pool.gc.threshold.ms"})
           .setDefaultValue("300sec")
           .setDescription("A block worker client is closed if it has been idle for more than this "
               + "threshold.")

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -174,6 +174,17 @@ public final class GrpcChannelBuilder {
   }
 
   /**
+   * Sets the pooling strategy.
+   *
+   * @param strategy the pooling strategy
+   * @return a new instance of {@link GrpcChannelBuilder}
+   */
+  public GrpcChannelBuilder setPoolingStrategy(GrpcManagedChannelPool.PoolingStrategy strategy) {
+    mChannelKey.setPoolingStrategy(strategy);
+    return this;
+  }
+
+  /**
    * Creates an authenticated channel of type {@link GrpcChannel}.
    * 
    * @return the built {@link GrpcChannel}

--- a/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
@@ -109,11 +109,6 @@ public final class DynamicResourcePoolTest {
     }
 
     @Override
-    protected void closeResourceSync(Resource resource) {
-      closeResource(resource);
-    }
-
-    @Override
     protected Resource createNewResource() {
       return new Resource(mCounter++);
     }

--- a/job/server/src/main/java/alluxio/job/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/replicate/EvictDefinition.java
@@ -130,13 +130,18 @@ public final class EvictDefinition
     }
 
     RemoveBlockRequest request = RemoveBlockRequest.newBuilder().setBlockId(blockId).build();
-    try (BlockWorkerClient blockWorker =
-             FileSystemContext.get().acquireBlockWorkerClient(localNetAddress)) {
+    BlockWorkerClient blockWorker = null;
+    try {
+      blockWorker = FileSystemContext.get().acquireBlockWorkerClient(localNetAddress);
       blockWorker.removeBlock(request);
     } catch (NotFoundException e) {
       // Instead of throwing this exception, we continue here because the block to evict does not
       // exist on this worker anyway.
       LOG.warn("Failed to delete block {} on {}: block does not exist", blockId, localNetAddress);
+    } finally {
+      if (blockWorker != null) {
+        FileSystemContext.get().releaseBlockWorkerClient(localNetAddress, blockWorker);
+      }
     }
     return null;
   }


### PR DESCRIPTION
- Added an option to not reuse same gRPC channel for streaming data.
- Create a worker client pool to reuse the worker client if possible.