### PR TITLE
Remove blockworker upon failure + Autheticate bi-di calls before creating stream

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -61,6 +61,11 @@ public interface BlockWorkerClient extends Closeable {
   boolean isShutdown();
 
   /**
+   * @return whether the client is healthy
+   */
+  boolean isHealthy();
+
+  /**
    * Writes a block to the worker asynchronously. The caller should pass in a response observer
    * for receiving server responses and handling errors.
    *

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -77,7 +77,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
    */
   @Override
   protected boolean isHealthy(BlockWorkerClient client) {
-    return !client.isShutdown();
+    return client.isHealthy();
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -107,6 +107,11 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   }
 
   @Override
+  public boolean isHealthy() {
+    return !isShutdown() && mStreamingChannel.isHealthy() && mRpcChannel.isHealthy();
+  }
+
+  @Override
   public void close() throws IOException {
     try (Closer closer = Closer.create()) {
       closer.register(() -> mStreamingChannel.shutdown());

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -96,8 +96,6 @@ public final class GrpcDataWriter implements DataWriter {
       return new GrpcDataWriter(context, address, id, length, chunkSize, type, options,
           grpcClient);
     } catch (Exception e) {
-      // Close the client before releasing in order to get it removed from the pool.
-      grpcClient.close();
       context.releaseBlockWorkerClient(address, grpcClient);
       throw e;
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -96,6 +96,8 @@ public final class GrpcDataWriter implements DataWriter {
       return new GrpcDataWriter(context, address, id, length, chunkSize, type, options,
           grpcClient);
     } catch (Exception e) {
+      // Close the client before releasing in order to get it removed from the pool.
+      grpcClient.close();
       context.releaseBlockWorkerClient(address, grpcClient);
       throw e;
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -100,8 +100,6 @@ public final class LocalFileDataWriter implements DataWriter {
       return new LocalFileDataWriter(chunkSize, blockWorker,
           writer, createRequest, stream, closer);
     } catch (Exception e) {
-      // Close the client before releasing in order to get it removed from the pool.
-      blockWorker.close();
       throw CommonUtils.closeAndRethrow(closer, e);
     }
   }

--- a/core/common/src/main/java/alluxio/grpc/ChannelHealthChecker.java
+++ b/core/common/src/main/java/alluxio/grpc/ChannelHealthChecker.java
@@ -1,0 +1,55 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.grpc;
+
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+
+import java.util.concurrent.TimeoutException;
+
+public class ChannelHealthChecker {
+  private final ManagedChannel mManagedChannel;
+  private final int mHealthCheckTimeoutMs;
+
+  public ChannelHealthChecker(ManagedChannel managedChannel, int healthCheckTimeoutMs) {
+    mManagedChannel = managedChannel;
+    mHealthCheckTimeoutMs = healthCheckTimeoutMs;
+  }
+
+  public boolean waitForChannelReady() {
+    try {
+      Boolean res = CommonUtils.waitForResult("channel to be ready", () -> {
+        ConnectivityState currentState = mManagedChannel.getState(true);
+        switch (currentState) {
+          case READY:
+            return true;
+          case TRANSIENT_FAILURE:
+          case SHUTDOWN:
+            return false;
+          case IDLE:
+          case CONNECTING:
+            return null;
+          default:
+            return null;
+        }
+      }, WaitForOptions.defaults().setTimeoutMs((int) mHealthCheckTimeoutMs));
+      return res;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (TimeoutException e) {
+      return false;
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -103,9 +103,7 @@ public final class GrpcChannel extends Channel {
               responseListener) {
             @Override
             public void onClose(io.grpc.Status status, Metadata trailers) {
-              if (status == Status.UNAUTHENTICATED) {
-                mGrpcChannel.mChannelHealthy = false;
-              } else if (status == Status.UNAVAILABLE) {
+              if (status == Status.UNAUTHENTICATED || status == Status.UNAVAILABLE) {
                 mGrpcChannel.mChannelHealthy = false;
               }
               super.onClose(status, trailers);

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -14,7 +14,13 @@ package alluxio.grpc;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 
 /**
  * An authenticated gRPC channel. This channel can communicate with servers of type
@@ -24,6 +30,7 @@ public final class GrpcChannel extends Channel {
   private final GrpcManagedChannelPool.ChannelKey mChannelKey;
   private final Channel mChannel;
   private boolean mChannelReleased;
+  private boolean mChannelHealthy = true;
 
   /**
    * Create a new instance of {@link GrpcChannel}.
@@ -32,7 +39,7 @@ public final class GrpcChannel extends Channel {
    */
   public GrpcChannel(GrpcManagedChannelPool.ChannelKey channelKey, Channel channel) {
     mChannelKey = channelKey;
-    mChannel = channel;
+    mChannel = ClientInterceptors.intercept(channel, new ChannelResponseTracker((this)));
     mChannelReleased = false;
   }
 
@@ -62,5 +69,50 @@ public final class GrpcChannel extends Channel {
    */
   public boolean isShutdown(){
     return mChannelReleased;
+  }
+
+  /**
+   * @return {@code true} if channel is healthy
+   */
+  public boolean isHealthy() {
+    return mChannelHealthy;
+  }
+
+  /**
+   * An interceptor that is used to track server calls and invalidate the channel status. Upon
+   * receiving Unauthenticated or Unavailable code from the server it invalidates the channel by
+   * marking it unhealthy for channel owner to be able to detect and re-authenticate or re-create
+   * the channel.
+   */
+  private class ChannelResponseTracker implements ClientInterceptor {
+    private GrpcChannel mGrpcChannel;
+
+    public ChannelResponseTracker(GrpcChannel grpcChannel) {
+      mGrpcChannel = grpcChannel;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions, Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+          next.newCall(method, callOptions)) {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          // Put channel Id to headers.
+          super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+              responseListener) {
+            @Override
+            public void onClose(io.grpc.Status status, Metadata trailers) {
+              if (status == Status.UNAUTHENTICATED) {
+                mGrpcChannel.mChannelHealthy = false;
+              } else if (status == Status.UNAVAILABLE) {
+                mGrpcChannel.mChannelHealthy = false;
+              }
+              super.onClose(status, trailers);
+            }
+          }, headers);
+        }
+      };
+    }
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
- * "License"). You may not use this work except in compliance with the License, which is available
- * at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
- * (the "License"). You may not use this work except in compliance with the License, which is
- * available at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.
@@ -19,22 +19,26 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.UUID;
 
 /**
- * Server side interceptor for setting authenticated user in {@link AuthenticatedClientUser}.
- * This interceptor requires {@link ChannelIdInjector} to have injected the channel id from which
- * the particular RPC is being made.
+ * Server side interceptor for setting authenticated user in {@link AuthenticatedClientUser}. This
+ * interceptor requires {@link ChannelIdInjector} to have injected the channel id from which the
+ * particular RPC is being made.
  */
 @ThreadSafe
 public final class AuthenticatedUserInjector implements ServerInterceptor {
 
+  private static final Logger LOG = LoggerFactory.getLogger(AuthenticatedUserInjector.class);
   private final AuthenticationServer mAuthenticationServer;
 
   /**
    * Creates {@link AuthenticationServer} with given authentication server.
+   * 
    * @param authenticationServer the authentication server
    */
   public AuthenticatedUserInjector(AuthenticationServer authenticationServer) {
@@ -44,39 +48,54 @@ public final class AuthenticatedUserInjector implements ServerInterceptor {
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
       Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    /**
+     * For streaming calls, below will make sure authenticated user is injected prior to creating
+     * the stream.
+     */
+    if (!authenticateCall(call, headers)) {
+      return next.startCall(call, headers);
+    }
+
+    /**
+     * For non-streaming calls to server, below listener will be invoked in the same thread that is
+     * serving the call.
+     */
     return new ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
         next.startCall(call, headers)) {
-      /**
-       * onHalfClose is called on the same thread that calls the service handler.
-       */
       @Override
       public void onHalfClose() {
-        // Try to fetch channel Id from the metadata.
-        UUID channelId = headers.get(ChannelIdInjector.S_CLIENT_ID_KEY);
-        boolean callClosed = false;
-        if (channelId != null) {
-          try {
-            // Fetch authenticated username for this channel and set it.
-            String userName = mAuthenticationServer.getUserNameForChannel(channelId);
-            if (userName != null) {
-              AuthenticatedClientUser.set(userName);
-            } else {
-              AuthenticatedClientUser.remove();
-            }
-          } catch (UnauthenticatedException e) {
-            call.close(Status.UNAUTHENTICATED, headers);
-            callClosed = true;
-          }
-        } else {
-          call.close(Status.UNAUTHENTICATED, headers);
-          callClosed = true;
-        }
-        // Move the call up to the handler chain,
-        // if we have not closed the call already due to authentication error.
-        if (!callClosed) {
+        if (authenticateCall(call, headers)) {
           super.onHalfClose();
         }
       }
     };
+  }
+
+  private <ReqT, RespT> boolean authenticateCall(ServerCall<ReqT, RespT> call, Metadata headers) {
+    // Try to fetch channel Id from the metadata.
+    UUID channelId = headers.get(ChannelIdInjector.S_CLIENT_ID_KEY);
+    boolean callClosed = false;
+    if (channelId != null) {
+      try {
+        // Fetch authenticated username for this channel and set it.
+        String userName = mAuthenticationServer.getUserNameForChannel(channelId);
+        if (userName != null) {
+          AuthenticatedClientUser.set(userName);
+        } else {
+          AuthenticatedClientUser.remove();
+        }
+      } catch (UnauthenticatedException e) {
+        LOG.debug("Channel:{} is not authenticated for call:{}", channelId.toString(),
+            call.getMethodDescriptor().getFullMethodName());
+        call.close(Status.UNAUTHENTICATED, headers);
+        callClosed = true;
+      }
+    } else {
+      LOG.debug("Channel Id is missing for call:{}.",
+          call.getMethodDescriptor().getFullMethodName());
+      call.close(Status.UNAUTHENTICATED, headers);
+      callClosed = true;
+    }
+    return !callClosed;
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
@@ -38,7 +38,7 @@ public final class AuthenticatedUserInjector implements ServerInterceptor {
 
   /**
    * Creates {@link AuthenticationServer} with given authentication server.
-   * 
+   *
    * @param authenticationServer the authentication server
    */
   public AuthenticatedUserInjector(AuthenticationServer authenticationServer) {


### PR DESCRIPTION
Fixing some issues that are discovered by issues in worker fault tolerance:
- Close BlockWorker clients before releasing when they are faulted.
- Authenticate bi-di calls before creating the stream