### PR TITLE
Use netty ByteBuf for better performance

### DIFF
--- a/core/common/src/main/java/alluxio/network/protocol/databuffer/DataNettyBuffer.java
+++ b/core/common/src/main/java/alluxio/network/protocol/databuffer/DataNettyBuffer.java
@@ -1,0 +1,72 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.network.protocol.databuffer;
+
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A DataBuffer with the underlying data being a {@link ByteBuf}.
+ */
+public final class DataNettyBuffer implements DataBuffer {
+  private final ByteBuf mNettyBuf;
+
+  /**
+   * Constructor for creating a DataNettyBuffer, by passing a Netty ByteBuf.
+   *
+   * @param bytebuf The ByteBuf having the data
+   */
+  public DataNettyBuffer(ByteBuf bytebuf) {
+    Preconditions.checkNotNull(bytebuf, "bytebuf");
+    mNettyBuf = bytebuf;
+  }
+
+  /**
+   * @return the netty buffer
+   */
+  @Override
+  public Object getNettyOutput() {
+    return mNettyBuf;
+  }
+
+  @Override
+  public long getLength() {
+    return mNettyBuf.readableBytes();
+  }
+
+  @Override
+  public ByteBuffer getReadOnlyByteBuffer() {
+    ByteBuffer buffer = mNettyBuf.nioBuffer().asReadOnlyBuffer();
+    buffer.position(0);
+    return buffer;
+  }
+
+  @Override
+  public void readBytes(byte[] dst, int dstIndex, int length) {
+    mNettyBuf.readBytes(dst, dstIndex, length);
+  }
+
+  @Override
+  public int readableBytes() {
+    return mNettyBuf.readableBytes();
+  }
+
+  /**
+   * Release the Netty ByteBuf.
+   */
+  @Override
+  public void release() {
+    mNettyBuf.release();
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -25,7 +25,7 @@ import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
 import alluxio.network.protocol.databuffer.DataBuffer;
-import alluxio.network.protocol.databuffer.DataByteBuffer;
+import alluxio.network.protocol.databuffer.DataNettyBuffer;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.TimeoutRetry;
@@ -36,10 +36,11 @@ import alluxio.worker.block.io.BlockReader;
 
 import com.google.common.base.Preconditions;
 import io.grpc.stub.StreamObserver;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.ExecutorService;
 
@@ -101,8 +102,15 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
       openBlock(context, response);
       BlockReader blockReader = context.getBlockReader();
       Preconditions.checkState(blockReader != null);
-      ByteBuffer buf = blockReader.read(offset, len);
-      return new DataByteBuffer(buf, len);
+      ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(len, len);
+      try {
+        while (buf.writableBytes() > 0 && blockReader.transferTo(buf) != -1) {
+        }
+        return new DataNettyBuffer(buf);
+      } catch (Throwable e) {
+        buf.release();
+        throw e;
+      }
     }
 
     /**


### PR DESCRIPTION
Move back to use netty `ByteBuf` for better performance on local caching.