### PR TITLE
[CHERRY-PICK] Fuse 2: fuse user group mapping

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -2911,6 +2911,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.NONE)
           .build();
+  public static final PropertyKey FUSE_USER_GROUP_TRANSLATION_ENABLED =
+      new Builder(Name.FUSE_USER_GROUP_TRANSLATION_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to translate Alluxio users and groups "
+              + "into Unix users and groups when exposing Alluxio files through the FUSE API. "
+              + "When this property is set to false, the user and group for all FUSE files "
+              + "will match the user who started the alluxio-fuse process.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.NONE)
+          .build();
 
   //
   // Security related properties
@@ -3692,6 +3702,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String FUSE_DEBUG_ENABLED = "alluxio.fuse.debug.enabled";
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
+    public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
+        "alluxio.fuse.user.group.translation.enabled";
 
     //
     // Security related properties

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -12,6 +12,8 @@ alluxio.fuse.fs.name:
   'The FUSE file system name.'
 alluxio.fuse.maxwrite.bytes:
   'Maximum granularity of write operations, capped by the kernel to 128KB max (as of Linux 3.16.0).'
+alluxio.fuse.user.group.translation.enabled:
+  'Whether to translate Alluxio users and groups into Unix users and groups when exposing Alluxio files through the FUSE API. When this property is set to false, the user and group for all FUSE files will match the user who started the alluxio-fuse process.'
 alluxio.home:
   'Alluxio installation directory.'
 alluxio.jvm.monitor.info.threshold:

--- a/docs/en/api/FUSE-API.md
+++ b/docs/en/api/FUSE-API.md
@@ -116,18 +116,10 @@ characteristics, please be aware that:
 * Alluxio does not have hard-link and soft-link concepts, so the commands like `ln` are not supported,
   neither the hardlinks number is displayed in `ll` output.
 * The user and group are mapped to the Unix user and group only when Alluxio Fuse is configured to use
-<<<<<<< HEAD:docs/en/api/FUSE-API.md
-  shell user group translation service, by setting `alluxio.fuse.user.group.translation.enabled` to `true`
-  in `conf/alluxio-site.properties`. Otherwise `chown` and `chgrp` are no-ops, and `ll` will return the
-  user and group of the user who started the alluxio-fuse process. The translation service
-  does not change the actual file permission when running `ll`.
-=======
   shell user group translation service, by setting `alluxio.fuse.user.group.translation.enabled` to `true` 
   in `conf/alluxio-site.properties`. Otherwise `chown` and `chgrp` are no-ops, and `ll` will return the
   user and group of the user who started the alluxio-fuse process. The translation service
   does not change the actual file permission when running `ll`. 
->>>>>>> e9d242659d... [ALLUXIO-3344] Fuse user group translation (#7986):docs/en/Mounting-Alluxio-FS-with-FUSE.md
-
 ## Performance considerations
 
 Due to the conjunct use of FUSE and JNR, the performance of the mounted file system is expected to

--- a/docs/en/api/FUSE-API.md
+++ b/docs/en/api/FUSE-API.md
@@ -120,6 +120,7 @@ characteristics, please be aware that:
   in `conf/alluxio-site.properties`. Otherwise `chown` and `chgrp` are no-ops, and `ll` will return the
   user and group of the user who started the alluxio-fuse process. The translation service
   does not change the actual file permission when running `ll`. 
+
 ## Performance considerations
 
 Due to the conjunct use of FUSE and JNR, the performance of the mounted file system is expected to

--- a/docs/en/api/FUSE-API.md
+++ b/docs/en/api/FUSE-API.md
@@ -116,10 +116,17 @@ characteristics, please be aware that:
 * Alluxio does not have hard-link and soft-link concepts, so the commands like `ln` are not supported,
   neither the hardlinks number is displayed in `ll` output.
 * The user and group are mapped to the Unix user and group only when Alluxio Fuse is configured to use
+<<<<<<< HEAD:docs/en/api/FUSE-API.md
   shell user group translation service, by setting `alluxio.fuse.user.group.translation.enabled` to `true`
   in `conf/alluxio-site.properties`. Otherwise `chown` and `chgrp` are no-ops, and `ll` will return the
   user and group of the user who started the alluxio-fuse process. The translation service
   does not change the actual file permission when running `ll`.
+=======
+  shell user group translation service, by setting `alluxio.fuse.user.group.translation.enabled` to `true` 
+  in `conf/alluxio-site.properties`. Otherwise `chown` and `chgrp` are no-ops, and `ll` will return the
+  user and group of the user who started the alluxio-fuse process. The translation service
+  does not change the actual file permission when running `ll`. 
+>>>>>>> e9d242659d... [ALLUXIO-3344] Fuse user group translation (#7986):docs/en/Mounting-Alluxio-FS-with-FUSE.md
 
 ## Performance considerations
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -23,7 +23,6 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.security.authorization.Mode;
-import alluxio.security.group.provider.ShellBasedUnixGroupsMapping;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
@@ -66,9 +65,10 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
 
   private static final int MAX_OPEN_FILES = Integer.MAX_VALUE;
   private static final int MAX_OPEN_WAITTIME_MS = 5000;
+
   private static final long UID = AlluxioFuseUtils.getUid(System.getProperty("user.name"));
   private static final long GID = AlluxioFuseUtils.getGid(System.getProperty("user.name"));
-  private final boolean mIsShellGroupMapping;
+  private final boolean mIsUserGroupTranslation;
 
   private final FileSystem mFileSystem;
   // base path within Alluxio namespace that is used for FUSE operations
@@ -97,8 +97,8 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
     mOpenFiles = new HashMap<>();
 
     final int maxCachedPaths = Configuration.getInt(PropertyKey.FUSE_CACHED_PATHS_MAX);
-    mIsShellGroupMapping = ShellBasedUnixGroupsMapping.class.getName()
-        .equals(Configuration.get(PropertyKey.SECURITY_GROUP_MAPPING_CLASS));
+    mIsUserGroupTranslation
+        = Configuration.getBoolean(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED);
     mPathResolverCache = CacheBuilder.newBuilder()
         .maximumSize(maxCachedPaths)
         .build(new PathCacheLoader());
@@ -130,29 +130,32 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
   }
 
   /**
-   * Changes the owner of an Alluxio file.
+   * Changes the user and group ownership of an Alluxio file.
+   * This operation only works when the user group translation is enabled in Alluxio-Fuse.
    *
-   * This operation only works when the group mapping service is shelled based and the user is
-   * registered in unix. Otherwise it errors as not implemented. This is because the input uid and
-   * gid must match the user and group in Unix.
+   * @param path the path of the file
+   * @param uid the uid to change to
+   * @param gid the gid to change to
+   * @return 0 on success, a negative value on error
    */
   @Override
   public int chown(String path, @uid_t long uid, @gid_t long gid) {
-    if (!mIsShellGroupMapping) {
-      LOG.info("Cannot change the owner of path {} because the group mapping is not shell based",
-          path);
-      // not supported if the group mapping is not shell based
+    if (!mIsUserGroupTranslation) {
+      LOG.info("Cannot change the owner of path {}. Please set {} to be true to enable "
+          + "user group translation in Alluxio-Fuse.",
+          path, PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED.getName());
       return -ErrorCodes.ENOSYS();
     }
     try {
       String userName = AlluxioFuseUtils.getUserName(uid);
-      String groupName = AlluxioFuseUtils.getGroupName(uid);
+      String groupName = AlluxioFuseUtils.getGroupName(gid);
+      // Uid and gid should exist in the unix to get valid user name and group name
       if (userName.isEmpty()) {
         LOG.error("Failed to get user name from uid {}", uid);
         return -ErrorCodes.EFAULT();
       }
       if (groupName.isEmpty()) {
-        LOG.error("Failed to get group name from uid {}", uid);
+        LOG.error("Failed to get group name from gid {}.", gid);
         return -ErrorCodes.EFAULT();
       }
       SetAttributeOptions options =
@@ -278,12 +281,12 @@ final class AlluxioFuseFileSystem extends FuseStubFS {
       stat.st_mtim.tv_sec.set(ctime_sec);
       stat.st_mtim.tv_nsec.set(ctime_nsec);
 
-      // for shell-based group mapping, use the uid and gid of the corresponding user registered in
-      // unix; otherwise use uid and gid of the user running alluxio-fuse
-      if (mIsShellGroupMapping) {
-        String owner = status.getOwner();
-        stat.st_uid.set(AlluxioFuseUtils.getUid(owner));
-        stat.st_gid.set(AlluxioFuseUtils.getGid(owner));
+      if (mIsUserGroupTranslation) {
+        // Translate the file owner/group to unix uid/gid
+        // Show as uid==-1 (nobody) if owner does not exist in unix
+        // Show as gid==-1 (nogroup) if group does not exist in unix
+        stat.st_uid.set(AlluxioFuseUtils.getUid(status.getOwner()));
+        stat.st_gid.set(AlluxioFuseUtils.getGidFromGroupName(status.getGroup()));
       } else {
         stat.st_uid.set(UID);
         stat.st_gid.set(GID);

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -66,7 +66,8 @@ public class AlluxioFuseFileSystemTest {
 
   @Rule
   public ConfigurationRule mConfiguration =
-      new ConfigurationRule(ImmutableMap.of(PropertyKey.FUSE_CACHED_PATHS_MAX, "0"));
+      new ConfigurationRule(ImmutableMap.of(PropertyKey.FUSE_CACHED_PATHS_MAX, "0",
+          PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, "true"));
 
   @Before
   public void before() throws Exception {
@@ -99,7 +100,7 @@ public class AlluxioFuseFileSystemTest {
     long gid = AlluxioFuseUtils.getGid(System.getProperty("user.name"));
     mFuseFs.chown("/foo/bar", uid, gid);
     String userName = System.getProperty("user.name");
-    String groupName = AlluxioFuseUtils.getGroupName(uid);
+    String groupName = AlluxioFuseUtils.getGroupName(gid);
     AlluxioURI expectedPath = BASE_EXPECTED_URI.join("/foo/bar");
     SetAttributeOptions options =
         SetAttributeOptions.defaults().setGroup(groupName).setOwner(userName);
@@ -135,7 +136,9 @@ public class AlluxioFuseFileSystemTest {
     FileInfo info = new FileInfo();
     info.setLength(10);
     info.setLastModificationTimeMs(1000);
-    info.setOwner(System.getProperty("user.name"));
+    String userName = System.getProperty("user.name");
+    info.setOwner(userName);
+    info.setGroup(AlluxioFuseUtils.getGroupName(userName));
     info.setFolder(true);
     info.setMode(123);
     URIStatus status = new URIStatus(info);


### PR DESCRIPTION
The previous user group mapping does not work, so I also think it's a bug. In addition, the user group translation is mistakenly included in the 1.8 doc (and a user asked about it in mailing list before) so we should cherry pick it to 1.8.