### PR TITLE
[SMALLFIX] Use a separate PropertyKey for MultiRangeObjectInputStream reads

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2799,7 +2799,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
           .setDescription("Default chunk size for ranged reads from Alluxio files.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
+          .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey USER_APP_ID =
       new Builder(Name.USER_APP_ID)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -589,8 +589,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES =
-      new Builder(Name.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES)
+  public static final PropertyKey UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE =
+      new Builder(Name.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE)
           .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
           .setDescription("Default chunk size for ranged reads from multi-range object input "
               + "streams.")
@@ -3495,8 +3495,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.object.store.service.threads";
     public static final String UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY =
         "alluxio.underfs.object.store.mount.shared.publicly";
-    public static final String UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES =
-        "alluxio.underfs.object.store.multi.range.chunk.size.bytes";
+    public static final String UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE =
+        "alluxio.underfs.object.store.multi.range.chunk.size";
     public static final String UNDERFS_OBJECT_STORE_READ_RETRY_BASE_SLEEP_MS =
         "alluxio.underfs.object.store.read.retry.base.sleep";
     public static final String UNDERFS_OBJECT_STORE_READ_RETRY_MAX_NUM =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -589,6 +589,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES =
+      new Builder(Name.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES)
+          .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
+          .setDescription("Default chunk size for ranged reads from multi-range object input "
+              + "streams.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_SERVICE_THREADS =
       new Builder(Name.UNDERFS_OBJECT_STORE_SERVICE_THREADS)
           .setDefaultValue(20)
@@ -2794,13 +2802,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_MULTI_RANGE_CHUNK_SIZE_BYTES =
-      new Builder(Name.USER_MULTI_RANGE_CHUNK_SIZE_BYTES)
-          .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
-          .setDescription("Default chunk size for ranged reads from Alluxio files.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
   public static final PropertyKey USER_APP_ID =
       new Builder(Name.USER_APP_ID)
           .setScope(Scope.CLIENT)
@@ -3494,6 +3495,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.object.store.service.threads";
     public static final String UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY =
         "alluxio.underfs.object.store.mount.shared.publicly";
+    public static final String UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES =
+        "alluxio.underfs.object.store.multi.range.chunk.size.bytes";
     public static final String UNDERFS_OBJECT_STORE_READ_RETRY_BASE_SLEEP_MS =
         "alluxio.underfs.object.store.read.retry.base.sleep";
     public static final String UNDERFS_OBJECT_STORE_READ_RETRY_MAX_NUM =
@@ -3941,8 +3944,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metrics.collection.enabled";
     public static final String USER_METRICS_HEARTBEAT_INTERVAL_MS =
         "alluxio.user.metrics.heartbeat.interval";
-    public static final String USER_MULTI_RANGE_CHUNK_SIZE_BYTES =
-        "alluxio.user.multi.range.chunk.size.bytes";
     public static final String USER_APP_ID = "alluxio.user.app.id";
     public static final String USER_NETWORK_DATA_TIMEOUT_MS =
         "alluxio.user.network.data.timeout";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2794,6 +2794,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_MULTI_RANGE_CHUNK_SIZE_BYTES =
+      new Builder(Name.USER_MULTI_RANGE_CHUNK_SIZE_BYTES)
+          .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
+          .setDescription("Default chunk size for ranged reads from Alluxio files.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_APP_ID =
       new Builder(Name.USER_APP_ID)
           .setScope(Scope.CLIENT)
@@ -3934,6 +3941,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metrics.collection.enabled";
     public static final String USER_METRICS_HEARTBEAT_INTERVAL_MS =
         "alluxio.user.metrics.heartbeat.interval";
+    public static final String USER_MULTI_RANGE_CHUNK_SIZE_BYTES =
+        "alluxio.user.multi.range.chunk.size.bytes";
     public static final String USER_APP_ID = "alluxio.user.app.id";
     public static final String USER_NETWORK_DATA_TIMEOUT_MS =
         "alluxio.user.network.data.timeout";

--- a/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
@@ -129,15 +129,6 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
       throws IOException;
 
   /**
-   * Block size for reading an object in chunks.
-   *
-   * @return chunk size in bytes
-   */
-  private long getChunkSize() {
-    return mMultiRangeChunkSize;
-  }
-
-  /**
    * Opens a new stream at mPos if the wrapped stream mStream is null.
    */
   private void openStream() throws IOException {

--- a/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
@@ -33,8 +33,19 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
   /** Position the current stream was open till (exclusive). */
   protected long mEndPos;
 
-  /** The block size to read with. */
-  protected long mBlockSize = -1L;
+  /** The chunk size to perform reads with. */
+  private final long mMultiRangeChunkSize;
+
+  /**
+   * creates the input stream that will perform reads with a specified chunk size. Reading in
+   * chunks allows us to read in smaller portions so that we don't need to read all the way to
+   * the end of a block.
+   *
+   * @param multiRangeChunkSize the chunk size in bytes to read with
+   */
+  protected MultiRangeObjectInputStream(long multiRangeChunkSize) {
+    mMultiRangeChunkSize = multiRangeChunkSize;
+  }
 
   @Override
   public void close() throws IOException {
@@ -120,10 +131,10 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
   /**
    * Block size for reading an object in chunks.
    *
-   * @return block size in bytes
+   * @return chunk size in bytes
    */
-  private long getBlockSize() {
-    return mBlockSize;
+  private long getChunkSize() {
+    return mMultiRangeChunkSize;
   }
 
   /**
@@ -133,14 +144,14 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
     if (mClosed) {
       throw new IOException("Stream closed");
     }
-    if (mBlockSize <= 0) {
-      throw new IOException(ExceptionMessage.BLOCK_SIZE_INVALID.getMessage(mBlockSize));
+    if (mMultiRangeChunkSize <= 0) {
+      throw new IOException(ExceptionMessage.BLOCK_SIZE_INVALID.getMessage(mMultiRangeChunkSize));
     }
 
     if (mStream != null) { // stream is already open
       return;
     }
-    final long endPos = mPos + mBlockSize - (mPos % mBlockSize);
+    final long endPos = mPos + mMultiRangeChunkSize - (mPos % mMultiRangeChunkSize);
     mEndPos = endPos;
     mStream = createStream(mPos, endPos);
   }

--- a/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
@@ -37,7 +37,7 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
   private final long mMultiRangeChunkSize;
 
   /**
-   * creates the input stream that will perform reads with a specified chunk size. Reading in
+   * Creates the input stream that will perform reads with a specified chunk size. Reading in
    * chunks allows us to read in smaller portions so that we don't need to read all the way to
    * the end of a block.
    *

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -49,9 +49,9 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for COS
    */
-  COSInputStream(String bucketName, String key, COSClient client, long blockSize)
+  COSInputStream(String bucketName, String key, COSClient client, long multiRangeChunkSize)
       throws IOException {
-    this(bucketName, key, client, 0L, blockSize);
+    this(bucketName, key, client, 0L, multiRangeChunkSize);
   }
 
   /**
@@ -62,9 +62,9 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param client the client for COS
    * @param position the position to begin reading from
    */
-  COSInputStream(String bucketName, String key, COSClient client, long position, long blockSize)
-      throws IOException {
-    mBlockSize = blockSize;
+  COSInputStream(String bucketName, String key, COSClient client, long position,
+      long multiRangeChunkSize) throws IOException {
+    super(multiRangeChunkSize);
     mBucketName = bucketName;
     mKey = key;
     mCosClient = client;

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -48,6 +48,7 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the client for COS
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
   COSInputStream(String bucketName, String key, COSClient client, long multiRangeChunkSize)
       throws IOException {
@@ -61,6 +62,7 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for COS
    * @param position the position to begin reading from
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
   COSInputStream(String bucketName, String key, COSClient client, long position,
       long multiRangeChunkSize) throws IOException {

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -303,7 +303,7 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new COSInputStream(mBucketNameInternal, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
+          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (CosClientException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -303,7 +303,7 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new COSInputStream(mBucketNameInternal, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (CosClientException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -303,7 +303,7 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new COSInputStream(mBucketNameInternal, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (CosClientException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
@@ -39,7 +39,9 @@ public class KodoInputStream extends MultiRangeObjectInputStream {
    */
   private final long mContentLength;
 
-  KodoInputStream(String key, KodoClient kodoClient, long position) throws QiniuException {
+  KodoInputStream(String key, KodoClient kodoClient, long position,
+      long multiRangeChunkSize) throws QiniuException {
+    super(multiRangeChunkSize);
     mKey = key;
     mKodoclent = kodoClient;
     mPos = position;

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -207,7 +207,7 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) {
     try {
       return new KodoInputStream(key, mKodoClinet, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (QiniuException e) {
       LOG.error("Failed to open Object {}, Msg: {}", key, e);
     }

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -207,7 +207,7 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) {
     try {
       return new KodoInputStream(key, mKodoClinet, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (QiniuException e) {
       LOG.error("Failed to open Object {}, Msg: {}", key, e);
     }

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -206,7 +206,8 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options) {
     try {
-      return new KodoInputStream(key, mKodoClinet, options.getOffset());
+      return new KodoInputStream(key, mKodoClinet, options.getOffset(),
+          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (QiniuException e) {
       LOG.error("Failed to open Object {}, Msg: {}", key, e);
     }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -49,6 +49,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the client for OSS
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
   OSSInputStream(String bucketName, String key, OSSClient client, long multiRangeChunkSize)
       throws IOException {
@@ -62,6 +63,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for OSS
    * @param position the position to begin reading from
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
   OSSInputStream(String bucketName, String key, OSSClient client, long position,
       long multiRangeChunkSize) throws IOException {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -50,9 +50,9 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for OSS
    */
-  OSSInputStream(String bucketName, String key, OSSClient client, long blockSize)
+  OSSInputStream(String bucketName, String key, OSSClient client, long multiRangeChunkSize)
       throws IOException {
-    this(bucketName, key, client, 0L, blockSize);
+    this(bucketName, key, client, 0L, multiRangeChunkSize);
   }
 
   /**
@@ -63,9 +63,9 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param client the client for OSS
    * @param position the position to begin reading from
    */
-  OSSInputStream(String bucketName, String key, OSSClient client, long position, long blockSize)
-      throws IOException {
-    mBlockSize = blockSize;
+  OSSInputStream(String bucketName, String key, OSSClient client, long position,
+      long multiRangeChunkSize) throws IOException {
+    super(multiRangeChunkSize);
     mBucketName = bucketName;
     mKey = key;
     mOssClient = client;

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -281,7 +281,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new OSSInputStream(mBucketName, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
+          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (ServiceException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -281,7 +281,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new OSSInputStream(mBucketName, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
     } catch (ServiceException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -281,7 +281,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     try {
       return new OSSInputStream(mBucketName, key, mClient, options.getOffset(),
-          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
+          mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (ServiceException e) {
       throw new IOException(e.getMessage());
     }

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -84,7 +84,7 @@ public class OSSInputStreamTest {
       when(mOssObject[i].getObjectContent()).thenReturn(mInputStreamSpy[i]);
     }
     mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient,
-        sConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
+        sConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
   }
 
   @Test

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -84,7 +84,7 @@ public class OSSInputStreamTest {
       when(mOssObject[i].getObjectContent()).thenReturn(mInputStreamSpy[i]);
     }
     mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient,
-        sConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
+        sConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
   }
 
   @Test

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -84,7 +84,7 @@ public class OSSInputStreamTest {
       when(mOssObject[i].getObjectContent()).thenReturn(mInputStreamSpy[i]);
     }
     mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient,
-        sConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
+        sConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
   }
 
   @Test

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -43,10 +43,11 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param account JOSS account with authentication credentials
    * @param container the name of container where the object resides
    * @param object path of the object in the container
-   * @param blockSize the block size to use on this stream
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
-  public SwiftInputStream(Account account, String container, String object, long blockSize) {
-    this(account, container, object, 0L, blockSize);
+  public SwiftInputStream(Account account, String container, String object,
+      long multiRangeChunkSize) {
+    this(account, container, object, 0L, multiRangeChunkSize);
   }
 
   /**
@@ -56,11 +57,11 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param container the name of container where the object resides
    * @param object path of the object in the container
    * @param position the position to begin reading from
-   * @param blockSize the block size to use on this stream
+   * @param multiRangeChunkSize the block size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object, long position,
-      long blockSize) {
-    mBlockSize = blockSize;
+      long multiRangeChunkSize) {
+    super(multiRangeChunkSize);
     mAccount = account;
     mContainerName = container;
     mObjectPath = object;

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -57,7 +57,7 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param container the name of container where the object resides
    * @param object path of the object in the container
    * @param position the position to begin reading from
-   * @param multiRangeChunkSize the block size to use on this stream
+   * @param multiRangeChunkSize the chunk size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object, long position,
       long multiRangeChunkSize) {

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -370,6 +370,6 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset(),
-        mAlluxioConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
+        mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
   }
 }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -370,6 +370,6 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset(),
-        mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
+        mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
   }
 }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -370,6 +370,6 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options) throws IOException {
     return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset(),
-        mAlluxioConf.getBytes(PropertyKey.USER_MULTI_RANGE_CHUNK_SIZE_BYTES));
+        mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE_BYTES));
   }
 }


### PR DESCRIPTION
This fix adds the USER_MULTI_RANGE_CHUNK_SIZE_BYTES property key.
It should now be used in place of the block size parameter wen creating
MultiRangeObjectInputStreams. The default for the property key is the
same as USER_BLOCK_SIZE_BYTES_DEFAULT.