### PR TITLE
Fix weight tracking bug in caching inode store

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -627,7 +627,6 @@ public final class CachingInodeStore implements InodeStore, Closeable {
     public void addEdge(Edge edge, Long childId) {
       evictIfNecessary();
       mMap.computeIfPresent(edge.getId(), (key, entry) -> {
-        mWeight.incrementAndGet();
         entry.mModified = true;
         entry.addChild(edge.getName(), childId);
         return entry;
@@ -641,7 +640,6 @@ public final class CachingInodeStore implements InodeStore, Closeable {
      */
     public void removeEdge(Edge edge) {
       mMap.computeIfPresent(edge.getId(), (key, entry) -> {
-        mWeight.incrementAndGet();
         entry.mModified = true;
         entry.removeChild(edge.getName());
         return entry;
@@ -689,9 +687,6 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       if (entry == null || !createdNewEntry.get()) {
         // Skip caching if the cache is full or someone else is already caching.
         return mEdgeCache.getChildIds(inodeId).values();
-      }
-      if (entry.mChildren != null) {
-        return entry.mChildren.values();
       }
       return loadChildren(inodeId, entry).values();
     }


### PR DESCRIPTION
`entry.addChild()/entry.removeChild()` already increment/decrement the weight, so we don't need to do it at the call site. Also, calling `incrementAndGet()` in `removeEdge` makes no sense in the first place.

The added tests fail with either bug individually

The behavior with this bug is that the cache thinks it is full, but it's actually empty. As a result, all reads from the cache become cache misses