### PR TITLE
[SMALLFIX] Update docs to use `--from-env-file`

### DIFF
--- a/docs/cn/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/cn/deploy/Running-Alluxio-On-Kubernetes.md
@@ -73,7 +73,7 @@ $ cp conf/alluxio.properties.template conf/alluxio.properties
 
 创建一个ConfigMap。
 ```bash
-$ kubectl create configmap alluxio-config --from-file=ALLUXIO_CONFIG=conf/alluxio.properties
+$ kubectl create configmap alluxio-config --from-env-file=ALLUXIO_CONFIG=conf/alluxio.properties
 ```
 
 ## 部署

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -100,7 +100,7 @@ $ cp conf/alluxio.properties.template conf/alluxio.properties
 
 Create a ConfigMap.
 ```bash
-$ kubectl create configmap alluxio-config --from-file=ALLUXIO_CONFIG=conf/alluxio.properties
+$ kubectl create configmap alluxio-config --from-env-file=ALLUXIO_CONFIG=conf/alluxio.properties
 ```
 
 ### Deploy


### PR DESCRIPTION
I had to use `--from-env-file` or else k8s dumps the whole config file into a single env var named after the file (lol).