### PR TITLE
[SMALLFIX] Create clients less often in REST handlers

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -187,7 +187,8 @@ public final class AlluxioMasterRestServiceHandler {
     mBlockMaster = mMasterProcess.getMaster(BlockMaster.class);
     mFileSystemMaster = mMasterProcess.getMaster(FileSystemMaster.class);
     mMetaMaster = mMasterProcess.getMaster(MetaMaster.class);
-    mFsClient = FileSystem.Factory.get(ServerConfiguration.global());
+    mFsClient = (FileSystem) context
+        .getAttribute(MasterWebServer.ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -188,7 +188,7 @@ public final class AlluxioMasterRestServiceHandler {
     mFileSystemMaster = mMasterProcess.getMaster(FileSystemMaster.class);
     mMetaMaster = mMasterProcess.getMaster(MetaMaster.class);
     mFsClient = (FileSystem) context
-        .getAttribute(MasterWebServer.ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY);
+        .getAttribute(MasterWebServer.ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -43,7 +43,8 @@ public final class MasterWebServer extends WebServer {
   private static final Logger LOG = LoggerFactory.getLogger(MasterWebServer.class);
 
   public static final String ALLUXIO_MASTER_SERVLET_RESOURCE_KEY = "Alluxio Master";
-  public static final String ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY = "Alluxio Master client";
+  public static final String ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY =
+      "Alluxio Master FileSystem client";
 
   /**
    * Creates a new instance of {@link MasterWebServer}.
@@ -69,7 +70,7 @@ public final class MasterWebServer extends WebServer {
       public void init() throws ServletException {
         super.init();
         getServletContext().setAttribute(ALLUXIO_MASTER_SERVLET_RESOURCE_KEY, masterProcess);
-        getServletContext().setAttribute(ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY,
+        getServletContext().setAttribute(ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY,
             FileSystem.Factory.get(ServerConfiguration.global()));
       }
     };

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -12,6 +12,7 @@
 package alluxio.web;
 
 import alluxio.Constants;
+import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.AlluxioMasterProcess;
@@ -42,6 +43,7 @@ public final class MasterWebServer extends WebServer {
   private static final Logger LOG = LoggerFactory.getLogger(MasterWebServer.class);
 
   public static final String ALLUXIO_MASTER_SERVLET_RESOURCE_KEY = "Alluxio Master";
+  public static final String ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY = "Alluxio Master client";
 
   /**
    * Creates a new instance of {@link MasterWebServer}.
@@ -67,6 +69,8 @@ public final class MasterWebServer extends WebServer {
       public void init() throws ServletException {
         super.init();
         getServletContext().setAttribute(ALLUXIO_MASTER_SERVLET_RESOURCE_KEY, masterProcess);
+        getServletContext().setAttribute(ALLUXIO_MASTER_CLIENT_SERVLET_RESOURCE_KEY,
+            FileSystem.Factory.get(ServerConfiguration.global()));
       }
     };
 

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -11,7 +11,6 @@
 
 package alluxio.web;
 
-import alluxio.ClientContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
@@ -62,7 +61,7 @@ public final class ProxyWebServer extends WebServer {
         getServletContext().setAttribute(ALLUXIO_PROXY_SERVLET_RESOURCE_KEY, proxyProcess);
         getServletContext()
             .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY,
-                FileSystem.Factory.get(ClientContext.create(ServerConfiguration.global())));
+                FileSystem.Factory.get(ServerConfiguration.global()));
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
             new StreamCache(ServerConfiguration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
       }

--- a/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
+++ b/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
@@ -44,7 +44,7 @@ public final class WorkerWebServer extends WebServer {
   private static final Logger LOG = LoggerFactory.getLogger(WorkerWebServer.class);
 
   public static final String ALLUXIO_WORKER_SERVLET_RESOURCE_KEY = "Alluxio Worker";
-  public static final String ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY =
+  public static final String ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY =
       "Alluxio Worker FileSystem Client";
 
   /**
@@ -72,7 +72,7 @@ public final class WorkerWebServer extends WebServer {
       public void init() throws ServletException {
         super.init();
         getServletContext().setAttribute(ALLUXIO_WORKER_SERVLET_RESOURCE_KEY, workerProcess);
-        getServletContext().setAttribute(ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY,
+        getServletContext().setAttribute(ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY,
             FileSystem.Factory.get(ServerConfiguration.global()));
       }
     };

--- a/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
+++ b/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
@@ -11,6 +11,7 @@
 
 package alluxio.web;
 
+import alluxio.client.file.FileSystem;
 import alluxio.conf.ServerConfiguration;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
@@ -43,6 +44,8 @@ public final class WorkerWebServer extends WebServer {
   private static final Logger LOG = LoggerFactory.getLogger(WorkerWebServer.class);
 
   public static final String ALLUXIO_WORKER_SERVLET_RESOURCE_KEY = "Alluxio Worker";
+  public static final String ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY =
+      "Alluxio Worker FileSystem Client";
 
   /**
    * Creates a new instance of {@link WorkerWebServer}.
@@ -69,6 +72,8 @@ public final class WorkerWebServer extends WebServer {
       public void init() throws ServletException {
         super.init();
         getServletContext().setAttribute(ALLUXIO_WORKER_SERVLET_RESOURCE_KEY, workerProcess);
+        getServletContext().setAttribute(ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY,
+            FileSystem.Factory.get(ServerConfiguration.global()));
       }
     };
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -143,7 +143,8 @@ public final class AlluxioWorkerRestServiceHandler {
         (WorkerProcess) context.getAttribute(WorkerWebServer.ALLUXIO_WORKER_SERVLET_RESOURCE_KEY);
     mBlockWorker = mWorkerProcess.getWorker(BlockWorker.class);
     mStoreMeta = mWorkerProcess.getWorker(BlockWorker.class).getStoreMeta();
-    mFsClient = FileSystem.Factory.get(ServerConfiguration.global());
+    mFsClient = (FileSystem) context
+            .getAttribute(WorkerWebServer.ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -144,7 +144,7 @@ public final class AlluxioWorkerRestServiceHandler {
     mBlockWorker = mWorkerProcess.getWorker(BlockWorker.class);
     mStoreMeta = mWorkerProcess.getWorker(BlockWorker.class).getStoreMeta();
     mFsClient = (FileSystem) context
-            .getAttribute(WorkerWebServer.ALLUXIO_WORKER_FILESYSTEM_CLIENT_RESOURCE_KEY);
+            .getAttribute(WorkerWebServer.ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY);
   }
 
   /**


### PR DESCRIPTION
The web server rest handler instances are created every time a request
is propagated. We shouldn't be creating new client objects within the
service handlers.

Instead we initialize a client in the servlet's `init` method which will
only be called once. Then subsequent calls to the REST service handler
will only utilize the single client.

@aaudiber 