### PR TITLE
Make GRPC use a separate forkjoin pool

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1699,7 +1699,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM =
       new Builder(Name.MASTER_RPC_FORKJOIN_POOL_PARALLELISM)
-          .setDefaultValue(25)
+          .setDefaultValue(50)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1697,6 +1697,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM=
+          new Builder("alluxio.master.fork.parallelism")
+                  .setDefaultValue(25)
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.MASTER)
+                  .build();
   public static final PropertyKey MASTER_WHITELIST =
       new Builder(Name.MASTER_WHITELIST)
           .setDefaultValue("/")
@@ -1714,9 +1720,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "This property determines the wait time.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
-          .build();
+              .build();
   public static final PropertyKey MASTER_WORKER_THREADS_MAX =
-      new Builder(Name.MASTER_WORKER_THREADS_MAX)
+          new Builder(Name.MASTER_WORKER_THREADS_MAX)
           .setDefaultSupplier(() -> {
             try {
               java.lang.management.OperatingSystemMXBean os =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1698,7 +1698,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM =
-      new Builder(Name.MASTER_RPC_FORK_PARALLELISM)
+      new Builder(Name.MASTER_RPC_FORKJOIN_POOL_PARALLELISM)
           .setDefaultValue(25)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -3762,7 +3762,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS =
         "alluxio.master.journal.temporary.file.gc.threshold";
 
-    public static final String MASTER_RPC_FORK_PARALLELISM =
+    public static final String MASTER_RPC_FORKJOIN_POOL_PARALLELISM =
         "alluxio.master.rpc.fork.parallelism";
     //
     // Worker related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1698,11 +1698,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM =
-          new Builder("alluxio.master.fork.parallelism")
-                  .setDefaultValue(25)
-                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-                  .setScope(Scope.MASTER)
-                  .build();
+      new Builder(Name.MASTER_RPC_FORK_PARALLELISM)
+          .setDefaultValue(25)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_WHITELIST =
       new Builder(Name.MASTER_WHITELIST)
           .setDefaultValue("/")
@@ -3762,6 +3762,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS =
         "alluxio.master.journal.temporary.file.gc.threshold";
 
+    public static final String MASTER_RPC_FORK_PARALLELISM =
+        "alluxio.master.rpc.fork.parallelism";
     //
     // Worker related properties
     //

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1697,7 +1697,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM=
+  public static final PropertyKey MASTER_RPC_FORKJOIN_POOL_PARALLELISM =
           new Builder("alluxio.master.fork.parallelism")
                   .setDefaultValue(25)
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -231,6 +232,7 @@ public class GrpcManagedChannelPool {
     if (channelKey.mPlain) {
       channelBuilder.usePlaintext();
     }
+    channelBuilder.executor(ForkJoinPool.commonPool());
     return channelBuilder.build();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -286,7 +286,8 @@ public class AlluxioMasterProcess extends MasterProcess {
           ServerConfiguration.global());
 
       ExecutorService executorService =
-          new ForkJoinPool(ServerConfiguration.getInt(PropertyKey.MASTER_RPC_FORKJOIN_POOL_PARALLELISM));
+          new ForkJoinPool(ServerConfiguration.getInt(
+              PropertyKey.MASTER_RPC_FORKJOIN_POOL_PARALLELISM));
       serverBuilder.executor(executorService);
       for (Master master : mRegistry.getServers()) {
         registerServices(serverBuilder, master.getServices());

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -82,7 +82,7 @@ public class AlluxioMasterProcess extends MasterProcess {
   /** The manager for creating and restoring backups. */
   private final BackupManager mBackupManager;
 
-  private final ExecutorService mRPCExecutor = null;
+  private ExecutorService mRPCExecutor = null;
 
   /**
    * Creates a new {@link AlluxioMasterProcess}.
@@ -288,7 +288,7 @@ public class AlluxioMasterProcess extends MasterProcess {
       GrpcServerBuilder serverBuilder = GrpcServerBuilder.forAddress(bindAddress,
           ServerConfiguration.global());
 
-      ExecutorService mRPCExecutor =
+      mRPCExecutor =
           new ForkJoinPool(ServerConfiguration.getInt(
               PropertyKey.MASTER_RPC_FORKJOIN_POOL_PARALLELISM));
       serverBuilder.executor(mRPCExecutor);

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -321,7 +321,8 @@ public class AlluxioMasterProcess extends MasterProcess {
       mRPCExecutor.shutdown();
       try {
         mRPCExecutor.awaitTermination(
-            ServerConfiguration.getMs(PropertyKey.MASTER_GRPC_SERVER_SHUTDOWN_TIMEOUT), TimeUnit.MILLISECONDS);
+            ServerConfiguration.getMs(PropertyKey.MASTER_GRPC_SERVER_SHUTDOWN_TIMEOUT),
+            TimeUnit.MILLISECONDS);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
       } finally {

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -41,7 +41,6 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.Lock;
@@ -370,22 +369,5 @@ public class AlluxioMasterProcess extends MasterProcess {
     }
 
     private Factory() {} // prevent instantiation
-  }
-
-  class QueueTaker<E> implements ForkJoinPool.ManagedBlocker {
-    final BlockingQueue<E> queue;
-    volatile E item = null;
-    QueueTaker(BlockingQueue<E> q) { this.queue = q; }
-    public boolean block() throws InterruptedException {
-      if (item == null)
-        item = queue.take();
-      return true;
-    }
-    public boolean isReleasable() {
-      return item != null || (item = queue.poll()) != null;
-    }
-    public E getItem() { // call after pool.managedBlock completes
-      return item;
-    }
   }
 }


### PR DESCRIPTION
GRPC performance improves if we use a dedicated thread pool for it and experimentation have shown that forkjoin pool performs the best for in mem operations. 
Hence, we are moving to use a forkjoin pool for gRPC threads. 