### PR TITLE
Fix checkpoint replay state reset bug

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -140,7 +140,7 @@ public final class UfsJournalCheckpointThread extends Thread {
       try {
         entry = mJournalReader.read();
         if (entry != null) {
-          if (mJournalReader.getNextSequenceNumber() == 0) {
+          if (entry.getSequenceNumber() == 0) {
             mMaster.resetState();
           }
           mMaster.processJournalEntry(entry);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -139,10 +139,10 @@ public final class UfsJournalCheckpointThread extends Thread {
     while (true) {
       try {
         entry = mJournalReader.read();
-        if (mJournalReader.getNextSequenceNumber() == 0) {
-          mMaster.resetState();
-        }
         if (entry != null) {
+          if (mJournalReader.getNextSequenceNumber() == 0) {
+            mMaster.resetState();
+          }
           mMaster.processJournalEntry(entry);
           if (quietPeriodWaited) {
             LOG.info("Quiet period interrupted by new journal entry");

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
@@ -52,14 +52,14 @@ public final class UfsJournalSnapshot {
   /**
    * @return the checkpoints sorted by end sequence number increasingly
    */
-  List<UfsJournalFile> getCheckpoints() {
+  public List<UfsJournalFile> getCheckpoints() {
     return mCheckpoints;
   }
 
   /**
    * @return the latest checkpoint, null if no checkpoint exists
    */
-  UfsJournalFile getLatestCheckpoint() {
+  public UfsJournalFile getLatestCheckpoint() {
     if (!mCheckpoints.isEmpty()) {
       return mCheckpoints.get(mCheckpoints.size() - 1);
     }
@@ -69,14 +69,14 @@ public final class UfsJournalSnapshot {
   /**
    * @return the logs sorted by the end sequence number increasingly
    */
-  List<UfsJournalFile> getLogs() {
+  public List<UfsJournalFile> getLogs() {
     return mLogs;
   }
 
   /**
    * @return the temporary checkpoints
    */
-  List<UfsJournalFile> getTemporaryCheckpoints() {
+  public List<UfsJournalFile> getTemporaryCheckpoints() {
     return mTemporaryCheckpoints;
   }
 
@@ -85,7 +85,7 @@ public final class UfsJournalSnapshot {
    *
    * @return the journal snapshot
    */
-  static UfsJournalSnapshot getSnapshot(UfsJournal journal) throws IOException {
+  public static UfsJournalSnapshot getSnapshot(UfsJournal journal) throws IOException {
     // Checkpoints.
     List<UfsJournalFile> checkpoints = new ArrayList<>();
     UfsStatus[] statuses = journal.getUfs().listStatus(journal.getCheckpointDir().toString());

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSnapshot.java
@@ -83,6 +83,7 @@ public final class UfsJournalSnapshot {
   /**
    * Creates a snapshot of the journal.
    *
+   * @param journal the journal
    * @return the journal snapshot
    */
   public static UfsJournalSnapshot getSnapshot(UfsJournal journal) throws IOException {

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
@@ -1,0 +1,66 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.server.ft.journal;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.master.MultiMasterLocalAlluxioCluster;
+import alluxio.master.NoopMaster;
+import alluxio.master.journal.JournalUtils;
+import alluxio.master.journal.ufs.UfsJournal;
+import alluxio.master.journal.ufs.UfsJournalSnapshot;
+import alluxio.util.CommonUtils;
+import alluxio.util.URIUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class MultiMasterJournalTest {
+  private MultiMasterLocalAlluxioCluster mCluster;
+
+  @Before
+  public void before() throws Exception {
+    mCluster = new MultiMasterLocalAlluxioCluster(2, 0);
+    mCluster.initConfiguration();
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
+    mCluster.start();
+  }
+
+  @Test
+  public void testCheckpointReplay() throws Exception {
+    // Trigger a checkpoint.
+    for (int i = 0; i < 10; i++) {
+      mCluster.getClient().createFile(new AlluxioURI("/" + i)).close();
+    }
+    UfsJournal journal = new UfsJournal(URIUtils.appendPathOrDie(JournalUtils.getJournalLocation(),
+        Constants.FILE_SYSTEM_MASTER_NAME), new NoopMaster(""), 0);
+    CommonUtils.waitFor("checkpoint to be written", () -> {
+      UfsJournalSnapshot snapshot;
+      try {
+        snapshot = UfsJournalSnapshot.getSnapshot(journal);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return !snapshot.getCheckpoints().isEmpty();
+    });
+    mCluster.restartMasters();
+    assertEquals("The cluster should remember the 10 files", 10,
+        mCluster.getClient().listStatus(new AlluxioURI("/")).size());
+  }
+}


### PR DESCRIPTION
Without this fix, replaying a checkpoint is almost guaranteed to crash the master. 

The code-level issue is that `mJournalReader.getNextSequenceNumber()` always returns `0` while replaying a checkpoint, so the recently-added
```java
if (mJournalReader.getNextSequenceNumber() == 0) {	
  mMaster.resetState();	
}
```
will reset state before applying every single entry of the checkpoint.