### PR TITLE
Fix race condition in persist tests

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -261,9 +261,10 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
    */
   protected void checkFilePersisted(AlluxioURI uri, int size) throws Exception {
     assertTrue(mFileSystem.getStatus(uri).isPersisted());
-    mFileSystem.free(uri);
     CommonUtils.waitFor("file to be completely freed", () -> {
       try {
+        // Call free inside the loop in case a worker reports blocks after the call to free.
+        mFileSystem.free(uri);
         return mFileSystem.getStatus(uri).getInAlluxioPercentage() == 0;
       } catch (Exception e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
This fixes a flaky failure observed in https://amplab.cs.berkeley.edu/jenkins/job/Alluxio-Pull-Request-Builder/1869/console, specifically 

> java.util.concurrent.TimeoutException: Timed out waiting for file to be completely freed options: WaitForOptions{interval=20, timeout=10000}
> 	at alluxio.client.cli.fs.command.PersistCommandTest.persistPartial(PersistCommandTest.java:242)

The problem occurs when a test (such as persistPartial) calls `checkFilePersisted` twice on the same file. The first call frees the data and then reads it from a worker. This read causes the worker to re-cache the data. However, the worker reports blocks to the master asynchronously, so the second call to `checkFilePersisted` could happen before the worker's block report. If the blocks are reported after the second call to `free` but before the call to `getStatus(uri).getInAlluxioPercentage()`, the `waitFor` command will hang.
