### PR TITLE
Move GrpcManagedChannelPool timeout parameters to GrpcChannel and GrpcChannelBuilder

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -31,16 +31,19 @@ public final class GrpcChannel extends Channel {
   private final Channel mChannel;
   private boolean mChannelReleased;
   private boolean mChannelHealthy = true;
+  private final long mShutdownTimeoutMs;
 
   /**
    * Create a new instance of {@link GrpcChannel}.
    *
    * @param channel the grpc channel to wrap
    */
-  public GrpcChannel(GrpcManagedChannelPool.ChannelKey channelKey, Channel channel) {
+  public GrpcChannel(GrpcManagedChannelPool.ChannelKey channelKey, Channel channel,
+      long shutdownTimeoutMs) {
     mChannelKey = channelKey;
     mChannel = ClientInterceptors.intercept(channel, new ChannelResponseTracker((this)));
     mChannelReleased = false;
+    mShutdownTimeoutMs = shutdownTimeoutMs;
   }
 
   @Override
@@ -59,7 +62,7 @@ public final class GrpcChannel extends Channel {
    */
   public void shutdown() {
     if(!mChannelReleased) {
-      GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey);
+      GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey, mShutdownTimeoutMs);
     }
     mChannelReleased = true;
   }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -192,7 +192,9 @@ public final class GrpcChannelBuilder {
    */
   public GrpcChannel build() throws UnauthenticatedException, UnavailableException {
     ManagedChannel underlyingChannel =
-        GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(mChannelKey);
+        GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(mChannelKey,
+            mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS),
+            mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     try {
       Channel clientChannel = underlyingChannel;
 
@@ -211,10 +213,12 @@ public final class GrpcChannelBuilder {
         clientChannel = channelAuthenticator.authenticate(underlyingChannel, mConfiguration);
       }
       // Create the channel after authentication with the target.
-      return new GrpcChannel(mChannelKey, clientChannel);
+      return new GrpcChannel(mChannelKey, clientChannel,
+          mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     } catch (Exception exc) {
       // Release the managed channel to the pool before throwing.
-      GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey);
+      GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey,
+          mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
       throw exc;
     }
   }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -50,7 +50,9 @@ public final class GrpcChannelBuilder {
 
   private GrpcChannelBuilder(SocketAddress address, AlluxioConfiguration conf) {
     mChannelKey = GrpcManagedChannelPool.ChannelKey.create();
-    mChannelKey.setAddress(address).usePlaintext();
+    mChannelKey.setAddress(address).usePlaintext()
+        .setHealthCheckTimeout(conf.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS))
+        .setShutdownTimeout(conf.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     mUseSubject = true;
     mAuthenticateChannel = true;
     mConfiguration = conf;

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -49,10 +49,8 @@ public final class GrpcChannelBuilder {
   protected AlluxioConfiguration mConfiguration;
 
   private GrpcChannelBuilder(SocketAddress address, AlluxioConfiguration conf) {
-    mChannelKey = GrpcManagedChannelPool.ChannelKey.create();
-    mChannelKey.setAddress(address).usePlaintext()
-        .setHealthCheckTimeout(conf.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS))
-        .setShutdownTimeout(conf.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
+    mChannelKey = GrpcManagedChannelPool.ChannelKey.create(conf);
+    mChannelKey.setAddress(address).usePlaintext();
     mUseSubject = true;
     mAuthenticateChannel = true;
     mConfiguration = conf;

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -415,8 +415,6 @@ public class GrpcManagedChannelPool {
           .append(mMaxInboundMessageSize)
           .append(mFlowControlWindow)
           .append(mPoolKey)
-          .append(mHealthCheckTimeoutMs)
-          .append(mShutdownTimeoutMs)
           .append(
               mChannelType.isPresent() ? System.identityHashCode(mChannelType.get()) : null)
           .append(
@@ -436,8 +434,6 @@ public class GrpcManagedChannelPool {
             && mMaxInboundMessageSize.equals(otherKey.mMaxInboundMessageSize)
             && mChannelType.equals(otherKey.mChannelType)
             && mPoolKey == otherKey.mPoolKey
-            && mHealthCheckTimeoutMs == otherKey.mHealthCheckTimeoutMs
-            && mShutdownTimeoutMs== otherKey.mShutdownTimeoutMs
             && mEventLoopGroup.equals(otherKey.mEventLoopGroup);
       }
       return false;

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -1,6 +1,8 @@
 package alluxio.grpc;
 
 import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
@@ -272,14 +274,20 @@ public class GrpcManagedChannelPool {
     private Optional<Integer> mFlowControlWindow = Optional.empty();
     private Optional<Class<? extends io.netty.channel.Channel>> mChannelType = Optional.empty();
     private Optional<EventLoopGroup> mEventLoopGroup = Optional.empty();
-    private long mShutdownTimeoutMs = 0;
-    private long mHealthCheckTimeoutMs = 0;
     private long mPoolKey = 0;
-    private ChannelKey() {}
+    // Set some sane default if not set by the programmer
+    private long mShutdownTimeoutMs;
+    private long mHealthCheckTimeoutMs;
 
-    public static ChannelKey create() {
-      return new ChannelKey();
+    public static ChannelKey create(AlluxioConfiguration conf) {
+      return new ChannelKey(conf);
     }
+
+    private ChannelKey(AlluxioConfiguration conf) {
+      mShutdownTimeoutMs = conf.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT);
+      mHealthCheckTimeoutMs = conf.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS);
+    }
+
 
     /**
      * @param address destination address of the channel

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -67,7 +67,6 @@ public class GrpcManagedChannelPool {
 
   /** Scheduler for destruction of idle channels. */
   protected ScheduledExecutorService mScheduler;
-  /** Timeout for health check on managed channels. */
 
   /**
    * Creates a new {@link GrpcManagedChannelPool}.
@@ -80,7 +79,6 @@ public class GrpcManagedChannelPool {
   private void shutdownManagedChannel(ManagedChannel managedChannel, long shutdownTimeoutMs) {
     managedChannel.shutdown();
     try {
-
       managedChannel.awaitTermination(shutdownTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -208,7 +206,6 @@ public class GrpcManagedChannelPool {
     if (channelKey.mEventLoopGroup.isPresent()) {
       channelBuilder.eventLoopGroup(channelKey.mEventLoopGroup.get());
     }
-
     if (channelKey.mPlain) {
       channelBuilder.usePlaintext();
     }
@@ -287,7 +284,6 @@ public class GrpcManagedChannelPool {
       mShutdownTimeoutMs = conf.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT);
       mHealthCheckTimeoutMs = conf.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS);
     }
-
 
     /**
      * @param address destination address of the channel

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -32,6 +32,10 @@ import java.util.concurrent.TimeUnit;
 public final class GrpcManagedChannelPoolTest {
 
   private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static final long SHUTDOWN_TIMEOUT =
+      sConf.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT);
+  private static final long HEALTH_CHECK_TIMEOUT =
+      sConf.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS);
 
   @BeforeClass
   public static void classSetup() {
@@ -56,13 +60,15 @@ public final class GrpcManagedChannelPoolTest {
     key1.setAddress(address);
     key2.setAddress(address);
 
-    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
-    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
 
     assertTrue(channel1 == channel2);
 
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1, SHUTDOWN_TIMEOUT);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2, SHUTDOWN_TIMEOUT);
     server1.shutdown();
   }
 
@@ -79,13 +85,15 @@ public final class GrpcManagedChannelPoolTest {
     key1.setAddress(address);
     key2.setAddress(address);
 
-    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
-    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
 
     assertTrue(channel1 != channel2);
 
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1, SHUTDOWN_TIMEOUT);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2, SHUTDOWN_TIMEOUT);
   }
 
   @Test
@@ -113,13 +121,15 @@ public final class GrpcManagedChannelPoolTest {
     key1.setKeepAliveTimeout(100, TimeUnit.MINUTES);
     key2.setKeepAliveTimeout(100, TimeUnit.MINUTES);
 
-    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
-    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
 
     assertTrue(channel1 == channel2);
 
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1, SHUTDOWN_TIMEOUT);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2, SHUTDOWN_TIMEOUT);
     server1.shutdown();
   }
 
@@ -139,13 +149,15 @@ public final class GrpcManagedChannelPoolTest {
     key1.setAddress(address1);
     key2.setAddress(address2);
 
-    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
-    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
 
     assertTrue(channel1 != channel2);
 
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1, SHUTDOWN_TIMEOUT);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2, SHUTDOWN_TIMEOUT);
     server2.shutdown();
     server2.shutdown();
   }
@@ -165,13 +177,16 @@ public final class GrpcManagedChannelPoolTest {
     key1.setAddress(address);
     key2.setAddress(address);
 
-    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1);
-    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2);
+    ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
+    ManagedChannel channel2 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key2,
+        HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
 
     assertTrue(channel1 != channel2);
 
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1);
-    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key1, SHUTDOWN_TIMEOUT);
+    GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(key2, SHUTDOWN_TIMEOUT);
+
     server1.shutdown();
   }
 }

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -48,8 +48,8 @@ public final class GrpcManagedChannelPoolTest {
   @Test
   public void testEqualKeys() throws Exception {
 
-    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
-    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create(sConf);
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create(sConf);
 
     GrpcServer server1 =
         GrpcServerBuilder.forAddress(new InetSocketAddress("0.0.0.0", 0), sConf).build().start();
@@ -71,8 +71,8 @@ public final class GrpcManagedChannelPoolTest {
   @Test
   public void testUnhealthyChannelRecreation() throws Exception {
 
-    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
-    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create(sConf);
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create(sConf);
 
     // Not creating the coresponding server will ensure, the channels will never
     // be ready.
@@ -92,8 +92,8 @@ public final class GrpcManagedChannelPoolTest {
 
   @Test
   public void testEqualKeysComplex() throws Exception {
-    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
-    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create(sConf);
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create(sConf);
 
     GrpcServer server1 =
             GrpcServerBuilder.forAddress(new InetSocketAddress("0.0.0.0", 0), sConf).build().start();
@@ -127,8 +127,8 @@ public final class GrpcManagedChannelPoolTest {
 
   @Test
   public void testNotEqualKeys() throws Exception {
-    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create();
-    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create();
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create(sConf);
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create(sConf);
 
     GrpcServer server1 =
             GrpcServerBuilder.forAddress(new InetSocketAddress("0.0.0.0", 0), sConf).build().start();
@@ -154,9 +154,9 @@ public final class GrpcManagedChannelPoolTest {
 
   @Test
   public void testEqualKeysNoPooling() throws Exception {
-    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create()
+    GrpcManagedChannelPool.ChannelKey key1 = GrpcManagedChannelPool.ChannelKey.create(sConf)
         .setPoolingStrategy(GrpcManagedChannelPool.PoolingStrategy.DISABLED);
-    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create()
+    GrpcManagedChannelPool.ChannelKey key2 = GrpcManagedChannelPool.ChannelKey.create(sConf)
         .setPoolingStrategy(GrpcManagedChannelPool.PoolingStrategy.DISABLED);
 
     GrpcServer server1 =

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -16,11 +16,9 @@ import static org.junit.Assert.assertTrue;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.SleepUtils;
 
 import io.grpc.ManagedChannel;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -25,7 +25,6 @@ import alluxio.client.RetryHandlingMetaMasterClient;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateDirectoryPOptions;
-import alluxio.grpc.GrpcManagedChannelPool;
 import alluxio.grpc.WritePType;
 import alluxio.master.MasterClientContext;
 import alluxio.multi.process.MultiProcessCluster;
@@ -35,7 +34,6 @@ import alluxio.testutils.AlluxioOperationThread;
 import alluxio.testutils.BaseIntegrationTest;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,11 +55,6 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
       put(PropertyKey.USER_METRICS_COLLECTION_ENABLED, "false");
     }
   }, ServerConfiguration.global());
-
-  @Before
-  public void before() throws Exception {
-    GrpcManagedChannelPool.renewChannelPool(2000, 2000);
-  }
 
   @After
   public void after() throws Exception {

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -21,7 +21,6 @@ import alluxio.client.file.FileSystem;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
-import alluxio.grpc.GrpcManagedChannelPool;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.MultiProcessCluster.DeployMode;
 import alluxio.multi.process.PortCoordination;
@@ -30,7 +29,6 @@ import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -52,11 +50,6 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
           ServerConfiguration.global());
 
   public MultiProcessCluster mCluster;
-
-  @Before
-  public void before() throws Exception {
-    GrpcManagedChannelPool.renewChannelPool(1000, 1000);
-  }
 
   @After
   public void after() throws Exception {


### PR DESCRIPTION
By moving the parameters ~into the channel key~ we can acquire and shutdown channels with timeouts based on per-client configurations rather than using a load-once-per-jvm strategy.

The advantage of doing this is that users who choose to modify timeouts within the same JVM across different client objects will have those timeouts respected by the channel pool when acquiring and releasing channels.