### PR TITLE
Remove some serialization logic for exception handling

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcExceptionUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcExceptionUtils.java
@@ -11,14 +11,12 @@
 
 package alluxio.grpc;
 
-import alluxio.collections.Pair;
 import alluxio.exception.status.AlluxioStatusException;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
-import org.apache.commons.lang.SerializationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Remove some unnecessary exception serialization to improve file system metadata performance when it throws a lot of exceptions. 
