### PR TITLE
Remove static reference to EventLoopGroup in DefaultBlockWorkerClient

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -26,6 +26,7 @@ import alluxio.grpc.WriteResponse;
 
 import io.grpc.stub.StreamObserver;
 import io.grpc.StatusRuntimeException;
+import io.netty.channel.EventLoopGroup;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -51,9 +52,9 @@ public interface BlockWorkerClient extends Closeable {
      * @return a new {@link BlockWorkerClient}
      */
     public static BlockWorkerClient create(@Nullable Subject subject, SocketAddress address,
-        AlluxioConfiguration alluxioConf)
+        AlluxioConfiguration alluxioConf, EventLoopGroup workerGroup)
         throws IOException {
-      return new DefaultBlockWorkerClient(subject, address, alluxioConf);
+      return new DefaultBlockWorkerClient(subject, address, alluxioConf, workerGroup);
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -52,6 +52,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
    * @param address address of the worker
    * @param maxCapacity the maximum capacity of the pool
    * @param alluxioConf Alluxio configuration
+   * @param workerGroup netty event loop group to create clients with
    *        is above the minimum capacity(1), it is closed and removed from the pool.
    */
   public BlockWorkerClientPool(Subject subject, SocketAddress address, int maxCapacity,

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -16,6 +16,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.util.ThreadFactoryUtils;
 
+import io.netty.channel.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
       new ScheduledThreadPoolExecutor(WORKER_CLIENT_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("BlockWorkerClientPoolGcThreads-%d", true));
   private final AlluxioConfiguration mConf;
+  private final EventLoopGroup mWorkerGroup;
 
   /**
    * Creates a new block master client pool.
@@ -53,11 +55,12 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
    *        is above the minimum capacity(1), it is closed and removed from the pool.
    */
   public BlockWorkerClientPool(Subject subject, SocketAddress address, int maxCapacity,
-      AlluxioConfiguration alluxioConf) {
+      AlluxioConfiguration alluxioConf, EventLoopGroup workerGroup) {
     super(Options.defaultOptions().setMaxCapacity(maxCapacity).setGcExecutor(GC_EXECUTOR));
     mSubject = subject;
     mAddress = address;
     mConf = alluxioConf;
+    mWorkerGroup = workerGroup;
   }
 
   @Override
@@ -68,7 +71,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
 
   @Override
   protected BlockWorkerClient createNewResource() throws IOException {
-    return BlockWorkerClient.Factory.create(mSubject, mAddress, mConf);
+    return BlockWorkerClient.Factory.create(mSubject, mAddress, mConf, mWorkerGroup);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -16,7 +16,6 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.BlockWorkerGrpc;
 import alluxio.grpc.CreateLocalBlockRequest;
@@ -33,7 +32,6 @@ import alluxio.grpc.RemoveBlockRequest;
 import alluxio.grpc.RemoveBlockResponse;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NettyUtils;
 
 import com.google.common.io.Closer;
@@ -72,7 +70,7 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
    * @param subject the user subject, can be null if the user is not available
    * @param address the address of the worker
    * @param alluxioConf Alluxio configuration
-   * @param workerGroup The netty {@link EventLoopGroup} the channels are will utilize.
+   * @param workerGroup The netty {@link EventLoopGroup} the channels are will utilize
    */
   public DefaultBlockWorkerClient(Subject subject, SocketAddress address,
       AlluxioConfiguration alluxioConf, EventLoopGroup workerGroup) throws IOException {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -13,7 +13,6 @@ package alluxio.client.file;
 
 import alluxio.ClientContext;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.block.BlockMasterClientPool;
@@ -29,7 +28,6 @@ import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.IdUtils;
 import alluxio.security.authentication.SaslParticipantProviderUtils;
 import alluxio.util.ThreadFactoryUtils;


### PR DESCRIPTION
In order to properly respect a client's configuration this static object should not be created here, but rather in the FileSystemContext. The worker group can then be passed down to the DefaultBlockWorkerClient when one is created.

@calvinjia 