### PR TITLE
Clean auto-generated java files prior to proto/grpc code generation

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -81,7 +81,14 @@
             <configuration>
               <filesets>
                 <fileset>
-                  <directory>src/main/java</directory>
+                  <directory>src/main/java/alluxio/proto</directory>
+                  <followSymlinks>false</followSymlinks>
+                  <includes>
+                    <include>**/*.java</include>
+                  </includes>
+                </fileset>
+                <fileset>
+                  <directory>src/main/java/alluxio/grpc</directory>
                   <followSymlinks>false</followSymlinks>
                   <includes>
                     <include>**/*.java</include>

--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -111,7 +111,6 @@
       </extension>
     </extensions>
     <plugins>
-
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>

--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -72,6 +72,26 @@
       <properties>
         <skip.protoc>false</skip.protoc>
       </properties>
+      <build>
+        <plugins>
+          <!-- Cleans the generated java files, prior to regenerating them from the proto/grpc definitions.  -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>src/main/java</directory>
+                  <followSymlinks>false</followSymlinks>
+                  <includes>
+                    <include>**/*.java</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
@@ -84,6 +104,7 @@
       </extension>
     </extensions>
     <plugins>
+
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
@@ -105,6 +126,15 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      
+      <!-- Disable findbugs since there are only generated files in this module. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Clean auto-generated java files prior to proto/grpc code generation.
- Disable findbugs for core-transport module.