### PR TITLE
Improve journal batching under heavy load

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -287,7 +287,6 @@ public final class AsyncJournalWriter {
    *
    * @param targetCounter the counter to flush
    */
-  @SuppressWarnings("Duplicates")
   public void flush(final long targetCounter) throws IOException, JournalClosedException {
     // Return if flushed.
     if (targetCounter <= mFlushCounter.get()) {

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -88,7 +89,7 @@ public final class AsyncJournalWriter {
    * List of flush tickets submitted by ::flush() method.
    */
   @GuardedBy("mTicketLock")
-  private final List<FlushTicket> mTicketList = new ArrayList<>(200);
+  private final List<FlushTicket> mTicketList = new LinkedList<>();
 
   /**
    * Dedicated thread for writing and flushing entries in journal queue.

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -11,19 +11,26 @@
 
 package alluxio.master.journal;
 
-import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.JournalClosedException;
+import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.Status;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.resource.LockResource;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.SettableFuture;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -31,6 +38,35 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class AsyncJournalWriter {
+  /**
+   * Used to manage and keep track of pending callers of ::flush.
+   */
+  private class FlushTicket {
+    private long mTargetCounter;
+    private SettableFuture<Void> mIsCompleted;
+
+    public FlushTicket(long targetCounter) {
+      mTargetCounter = targetCounter;
+      mIsCompleted = SettableFuture.create();
+    }
+
+    public long getTargetCounter() {
+      return mTargetCounter;
+    }
+
+    public void setCompleted() {
+      mIsCompleted.set(null);
+    }
+
+    public void setError(Throwable exc) {
+      mIsCompleted.setException(exc);
+    }
+
+    public void waitCompleted() throws InterruptedException, ExecutionException {
+      mIsCompleted.get();
+    }
+  }
+
   private final JournalWriter mJournalWriter;
   private final ConcurrentLinkedQueue<JournalEntry> mQueue;
   /** Represents the count of entries added to the journal queue. */
@@ -46,10 +82,21 @@ public final class AsyncJournalWriter {
   private final long mFlushBatchTimeNs;
 
   /**
-   * Use a {@link ReentrantLock} to guard the journal writing. Using the fairness policy seems to
-   * result in better throughput.
+   * List of flush tickets submitted by ::flush() method.
    */
-  private final ReentrantLock mFlushLock = new ReentrantLock(true);
+  @GuardedBy("mTicketLock")
+  private final List<FlushTicket> mTicketList = new ArrayList<>(200);
+
+  /**
+   * Used to guard access to ticket cache.
+   */
+  private final ReentrantLock mTicketLock = new ReentrantLock(true);
+
+  /**
+   * Dedicated thread for writing and flushing entries in journal queue.
+   * It goes over the {@code mTicketList} after every flush session and releases waiters.
+   */
+  private final Thread mFlushThread = new Thread(this::flushProc);
 
   /**
    * Creates a {@link AsyncJournalWriter}.
@@ -62,9 +109,9 @@ public final class AsyncJournalWriter {
     mCounter = new AtomicLong(0);
     mFlushCounter = new AtomicLong(0);
     mWriteCounter = new AtomicLong(0);
-    // convert milliseconds to nanoseconds.
     mFlushBatchTimeNs =
-        1000000L * ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS);
+            1000000L * ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS);
+    mFlushThread.start();
   }
 
   /**
@@ -99,49 +146,161 @@ public final class AsyncJournalWriter {
   }
 
   /**
-   * Flushes and waits until the specified counter is flushed to the journal. If the specified
-   * counter is already flushed, this is essentially a no-op.
+   * Closes the async writer.
+   * PS: It initiates but does not wait for outstanding entries to be flushed.
+   */
+  public void close() {
+    if (mFlushThread != null) {
+      mFlushThread.interrupt();
+    }
+  }
+
+  /**
+   * A dedicated thread that goes over outstanding queue items and writes/flushes them. Other
+   * threads can track progress by submitting tickets via ::flush() call.
+   */
+  private void flushProc() {
+    /**
+     * Runs the loop until thread is interrupted.
+     */
+    boolean exit = false;
+    while (!exit) {
+
+      /**
+       * Wait to be woken up by flush requests as long as the queue is empty. Bail and drain the
+       * queue, if interrupted.
+       */
+      synchronized (mFlushThread) {
+        while (mQueue.isEmpty()) {
+          try {
+            mFlushThread.wait();
+          } catch (InterruptedException ie) {
+            // Time to exit.
+            exit = true;
+            break;
+          }
+        }
+      }
+
+      try {
+        long writeCounter = mWriteCounter.get();
+        long startTime = System.nanoTime();
+        boolean needFlush = false;
+
+        /**
+         * Write pending entries to journal.
+         */
+        while (!mQueue.isEmpty()) {
+          // Get, but do not remove, the head entry.
+          JournalEntry entry = mQueue.peek();
+          if (entry == null) {
+            // No more entries in the queue. Break write session.
+            break;
+          }
+          mJournalWriter.write(entry);
+          needFlush = true;
+          // Remove the head entry, after the entry was successfully written.
+          mQueue.poll();
+          writeCounter = mWriteCounter.incrementAndGet();
+
+          if ((System.nanoTime() - startTime) >= mFlushBatchTimeNs) {
+            // This thread has been writing to the journal for enough time. Break out of the
+            // infinite while-loop.
+            break;
+          }
+        }
+
+        if (needFlush) {
+          mJournalWriter.flush();
+          mFlushCounter.set(writeCounter);
+
+          /**
+           * Notify tickets that have been served to wake up.
+           */
+          List<FlushTicket> closedTickets = new ArrayList<>();
+          try (LockResource lr = new LockResource(mTicketLock)) {
+            for (FlushTicket ticket : mTicketList) {
+              if (ticket.getTargetCounter() <= writeCounter) {
+                ticket.setCompleted();
+                closedTickets.add(ticket);
+              }
+            }
+            mTicketList.removeAll(closedTickets);
+          }
+        }
+      } catch (IOException | JournalClosedException exc) {
+        /**
+         * Release only tickets that have been flushed. Fail the rest.
+         */
+        List<FlushTicket> closedTickets = new ArrayList<>();
+        try (LockResource lr = new LockResource(mTicketLock)) {
+          for (FlushTicket ticket : mTicketList) {
+            closedTickets.add(ticket);
+            if (ticket.getTargetCounter() <= mFlushCounter.get()) {
+              ticket.setCompleted();
+            } else {
+              ticket.setError(exc);
+            }
+          }
+          mTicketList.removeAll(closedTickets);
+        }
+      }
+    }
+  }
+
+  /**
+   * Submits a ticket to flush thread and waits until ticket is served.
+   *
+   * If the specified counter is already flushed, this is essentially a no-op.
    *
    * @param targetCounter the counter to flush
    */
   @SuppressWarnings("Duplicates")
   public void flush(final long targetCounter) throws IOException, JournalClosedException {
+    // Return if flushed.
     if (targetCounter <= mFlushCounter.get()) {
       return;
     }
-    // Using reentrant lock, since it seems to result in higher throughput than using 'synchronized'
-    try (LockResource lr = new LockResource(mFlushLock)) {
-      long startTime = System.nanoTime();
-      long flushCounter = mFlushCounter.get();
-      if (targetCounter <= flushCounter) {
-        // The specified counter is already flushed, so just return.
-        return;
-      }
-      long writeCounter = mWriteCounter.get();
-      while (targetCounter > writeCounter) {
-        for (;;) {
-          // Get, but do not remove, the head entry.
-          JournalEntry entry = mQueue.peek();
-          if (entry == null) {
-            // No more entries in the queue. Break out of the infinite for-loop.
-            break;
-          }
-          mJournalWriter.write(entry);
-          // Remove the head entry, after the entry was successfully written.
-          mQueue.poll();
-          writeCounter = mWriteCounter.incrementAndGet();
 
-          if (writeCounter >= targetCounter) {
-            if ((System.nanoTime() - startTime) >= mFlushBatchTimeNs) {
-              // This thread has been writing to the journal for enough time. Break out of the
-              // infinite for-loop.
-              break;
-            }
-          }
-        }
+    /**
+     * Submit the ticket for flush thread to process.
+     */
+    FlushTicket ticket = new FlushTicket(targetCounter);
+    try (LockResource lr = new LockResource(mTicketLock)) {
+      mTicketList.add(ticket);
+    }
+
+    try {
+      /**
+       * Notify the flush thread. It will have no effect if there is no ticket left to process,
+       * which means this ticket has been served as well.
+       */
+      synchronized (mFlushThread) {
+        mFlushThread.notify();
       }
-      mJournalWriter.flush();
-      mFlushCounter.set(writeCounter);
+
+      /**
+       * Wait on the ticket until completed.
+       */
+      ticket.waitCompleted();
+    } catch (InterruptedException ie) {
+      /**
+       * Interpret interruption as cancellation.
+       */
+      throw new AlluxioStatusException(Status.CANCELED, ie);
+    } catch (ExecutionException ee) {
+      /**
+       * Filter, journal specific exception codes.
+       */
+      Throwable cause = ee.getCause();
+      if (cause != null && cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      if (cause != null && cause instanceof JournalClosedException) {
+        throw (JournalClosedException) cause;
+      }
+      // Not expected. throw internal error.
+      throw new AlluxioStatusException(Status.INTERNAL, ee);
     }
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.SettableFuture;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -405,6 +405,8 @@ public class UfsJournal implements Journal {
     if (mWriter != null) {
       mWriter.close();
       mWriter = null;
+    }
+    if (mAsyncWriter != null) {
       mAsyncWriter.close();
       mAsyncWriter = null;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -405,6 +405,7 @@ public class UfsJournal implements Journal {
     if (mWriter != null) {
       mWriter.close();
       mWriter = null;
+      mAsyncWriter.close();
       mAsyncWriter = null;
     }
     if (mTailerThread != null) {


### PR DESCRIPTION
With gRPC timing of incoming RPCs changed in a way that they are contending heavily on the async-journal-writer. This fix aims to improve async-journal-writer's batching by:
 * Keeping a dedicated thread for flushing the journal.
 * Making RPC threads wait on flush progress.