### PR TITLE
Disallow persist to read incomplete file

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -166,7 +166,8 @@ public class FileOutStream extends AbstractOutStream {
         }
       }
 
-      if (mUnderStorageType.isAsyncPersist()) {
+      if (!mCanceled && mUnderStorageType.isAsyncPersist()) {
+        // only schedule the persist for completed files.
         scheduleAsyncPersist();
       }
     } catch (Throwable e) { // must catch Throwable

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3107,6 +3107,10 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     // We retry an async persist request until ufs permits the operation
     try (RpcContext rpcContext = createRpcContext();
         LockedInodePath inodePath = mInodeTree.lockFullInodePath(path, LockPattern.WRITE_INODE)) {
+      if (!inodePath.getInodeFile().isCompleted()) {
+        throw new InvalidPathException(
+            "Cannot persist an incomplete Alluxio file: " + inodePath.getUri());
+      }
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(inodePath.getInode().getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())

--- a/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
@@ -14,10 +14,10 @@ package alluxio.master.file;
 import static org.mockito.Matchers.any;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 import alluxio.client.job.JobMasterClient;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
@@ -35,13 +35,13 @@ import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
 import alluxio.master.SafeModeManager;
 import alluxio.master.block.BlockMasterFactory;
-import alluxio.master.file.meta.PersistenceState;
 import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.contexts.CreateFileContext;
 import alluxio.master.file.contexts.DeleteContext;
 import alluxio.master.file.contexts.GetStatusContext;
 import alluxio.master.file.contexts.RenameContext;
+import alluxio.master.file.meta.PersistenceState;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalTestUtils;
 import alluxio.master.metrics.MetricsMasterFactory;
@@ -144,13 +144,9 @@ public final class PersistenceTest {
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(testFile, GET_STATUS_CONTEXT);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), fileInfo.getPersistenceState());
 
-    // Repeatedly schedule the async persistence, checking the internal state.
-    {
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-    }
+    // schedule the async persistence, checking the internal state.
+    mFileSystemMaster.scheduleAsyncPersistence(testFile);
+    checkPersistenceRequested(testFile);
 
     // Mock the job service interaction.
     Random random = new Random();
@@ -223,13 +219,9 @@ public final class PersistenceTest {
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(testFile, GET_STATUS_CONTEXT);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), fileInfo.getPersistenceState());
 
-    // Repeatedly schedule the async persistence, checking the internal state.
-    {
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-    }
+    // schedule the async persistence, checking the internal state.
+    mFileSystemMaster.scheduleAsyncPersistence(testFile);
+    checkPersistenceRequested(testFile);
 
     // Mock the job service interaction.
     Random random = new Random();
@@ -266,13 +258,9 @@ public final class PersistenceTest {
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(testFile, GET_STATUS_CONTEXT);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), fileInfo.getPersistenceState());
 
-    // Repeatedly schedule the async persistence, checking the internal state.
-    {
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-    }
+    // schedule the async persistence, checking the internal state.
+    mFileSystemMaster.scheduleAsyncPersistence(testFile);
+    checkPersistenceRequested(testFile);
 
     // Mock the job service interaction.
     Random random = new Random();
@@ -327,6 +315,7 @@ public final class PersistenceTest {
         CreateFileContext.defaults().setPersisted(false));
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(),
         mFileSystemMaster.getFileInfo(fileId).getPersistenceState());
+    mFileSystemMaster.completeFile(alluxioFileSrc, CompleteFileContext.defaults());
 
     // Schedule the async persistence, checking the internal state.
     mFileSystemMaster.scheduleAsyncPersistence(alluxioFileSrc);
@@ -401,13 +390,9 @@ public final class PersistenceTest {
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(testFile, GET_STATUS_CONTEXT);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), fileInfo.getPersistenceState());
 
-    // Repeatedly schedule the async persistence, checking the internal state.
-    {
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-    }
+    // schedule the async persistence, checking the internal state.
+    mFileSystemMaster.scheduleAsyncPersistence(testFile);
+    checkPersistenceRequested(testFile);
 
     // Simulate restart.
     stopServices();
@@ -426,13 +411,9 @@ public final class PersistenceTest {
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(testFile, GET_STATUS_CONTEXT);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), fileInfo.getPersistenceState());
 
-    // Repeatedly schedule the async persistence, checking the internal state.
-    {
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-      mFileSystemMaster.scheduleAsyncPersistence(testFile);
-      checkPersistenceRequested(testFile);
-    }
+    // schedule the async persistence, checking the internal state.
+    mFileSystemMaster.scheduleAsyncPersistence(testFile);
+    checkPersistenceRequested(testFile);
 
     // Mock the job service interaction.
     Random random = new Random();

--- a/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
@@ -137,6 +137,10 @@ public final class PersistDefinition
         }
       }
 
+      URIStatus uriStatus = mFileSystem.getStatus(uri);
+      if (!uriStatus.isCompleted()) {
+        throw new IOException("Cannot persist an incomplete Alluxio file: " + uri);
+      }
       long bytesWritten;
       try (Closer closer = Closer.create()) {
         OpenFilePOptions options =
@@ -171,7 +175,6 @@ public final class PersistDefinition
                     .getSecond().toString());
           }
         }
-        URIStatus uriStatus = mFileSystem.getStatus(uri);
         OutputStream out = closer.register(
             ufs.create(dstPath.toString(),
                 CreateOptions.defaults(ServerConfiguration.global()).setOwner(uriStatus.getOwner())

--- a/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
@@ -11,20 +11,28 @@
 
 package alluxio.job.persist;
 
+import static alluxio.job.wire.Status.COMPLETED;
+import static alluxio.job.wire.Status.FAILED;
+
 import alluxio.AlluxioURI;
-import alluxio.conf.PropertyKey;
+import alluxio.Constants;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.job.JobIntegrationTest;
+import alluxio.job.wire.JobInfo;
 import alluxio.master.file.meta.PersistenceState;
+import alluxio.master.job.JobMaster;
+import alluxio.security.authorization.Mode;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
+import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,6 +42,7 @@ import org.junit.Test;
  */
 public final class PersistIntegrationTest extends JobIntegrationTest {
   private static final String TEST_URI = "/test";
+  private static final Mode TEST_MODE = new Mode((short) 0777);
 
   /**
    * Tests persisting a file.
@@ -114,5 +123,85 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     String ufsPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
     Assert.assertFalse(ufs.exists(ufsPath));
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS, "10s"})
+  public void disallowIncompletePersist() throws Exception {
+    AlluxioURI path = new AlluxioURI("/" + CommonUtils.randomAlphaNumString(10));
+
+    // Create file, but do not complete
+    FileOutStream os = mFileSystem.createFile(path,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE)
+            .setMode(TEST_MODE.toProto()).build());
+
+    // schedule an async persist
+    FileSystemMasterClient client = mFsContext.acquireMasterClient();
+    try {
+      client.scheduleAsyncPersist(path);
+      Assert.fail("Should not be able to schedule persistence for incomplete file");
+    } catch (Exception e) {
+      // expected
+      Assert.assertTrue("Failure expected to be about incomplete files",
+          e.getMessage().toLowerCase().contains("incomplete"));
+    } finally {
+      mFsContext.releaseMasterClient(client);
+    }
+  }
+
+  @Test(timeout = 30000)
+  public void persistOnlyCompleteFiles() throws Exception {
+    AlluxioURI path = new AlluxioURI("/" + CommonUtils.randomAlphaNumString(10));
+
+    // Create file, but do not complete
+    FileOutStream os = mFileSystem.createFile(path,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE)
+            .setMode(TEST_MODE.toProto()).build());
+    URIStatus status = mFileSystem.getStatus(path);
+
+    // Generate a temporary path to be used by the persist job.
+    String tempUfsPath =
+        PathUtils.temporaryFileName(System.currentTimeMillis(), status.getUfsPath());
+    JobMaster jobMaster = mLocalAlluxioJobCluster.getMaster().getJobMaster();
+    // Run persist job on incomplete file (expected to fail)
+    long failId =
+        jobMaster.run(new PersistConfig(path.toString(), status.getMountId(), false, tempUfsPath));
+
+    CommonUtils.waitFor("Wait for persist job to complete", () -> {
+      try {
+        JobInfo jobInfo = jobMaster.getStatus(failId);
+        Assert.assertNotEquals("Persist should not succeed for incomplete file", COMPLETED,
+            jobInfo.getStatus());
+        if (jobInfo.getStatus() == FAILED) {
+          // failed job is expected
+          Assert.assertTrue("Failure expected to be about incomplete files",
+              jobInfo.getErrorMessage().toLowerCase().contains("incomplete"));
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS)
+        .setInterval(100));
+
+    // close the file to allow persist to happen
+    os.close();
+
+    // Run persist job on complete file (expected to succeed)
+    long successId =
+        jobMaster.run(new PersistConfig(path.toString(), status.getMountId(), false, tempUfsPath));
+
+    CommonUtils.waitFor("Wait for persist job to complete", () -> {
+      try {
+        JobInfo jobInfo = jobMaster.getStatus(successId);
+        Assert.assertNotEquals("Persist should not fail", FAILED, jobInfo.getStatus());
+        return jobInfo.getStatus() == COMPLETED;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS)
+        .setInterval(100));
   }
 }


### PR DESCRIPTION
Persisting a file only makes sense once the file is complete. When persist reads an incomplete file, it will treat the persist as successful even if the file wasn't completely written yet. Therefore, persist should not be able to read an incomplete file. 