### PR TITLE
Increase timeout for creating masters

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -55,7 +55,7 @@ final class MasterUtils {
       });
     }
     try {
-      CommonUtils.invokeAll(callables, 10 * Constants.SECOND_MS);
+      CommonUtils.invokeAll(callables, 10 * Constants.MINUTE_MS);
     } catch (Exception e) {
       throw new RuntimeException("Failed to start masters", e);
     }


### PR DESCRIPTION
10 minutes is long enough that exceeding the time limit
indicates that something is hanging. I hit the 10 seconds
limit due to cleaning up the rocks metastore from the
previous run. The metastore directory was over 100GB, so it
took around 10 seconds to remove.