### PR TITLE
Increase timeout for replaying journal

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -78,7 +78,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
       });
     }
     try {
-      CommonUtils.invokeAll(callables, 1 * Constants.HOUR_MS);
+      CommonUtils.invokeAll(callables, 365 * Constants.DAY_MS);
     } catch (TimeoutException | ExecutionException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Now that the rocks metastore can support billions of files,
we may take more than an hour to replay the journal on
fresh startup. With no checkpoints, I see replay taking about
1 hour per 150 million files.