### PR TITLE
 Fix various minor issues in alluxio-fuse script

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -71,11 +71,11 @@ mount_fuse() {
   # sleep: workaround to let the bg java process exit on errors, if any
   sleep 2s
   if kill -0 $! > /dev/null 2>&1 ; then
-    echo "alluxio-fuse successfully mounted Alluxio path "${alluxio_root}" to ${mount_point}."
+    echo "Successfully mounted Alluxio path \"${alluxio_root}\" to ${mount_point}."
     echo "See ${ALLUXIO_LOGS_DIR}/fuse.log for logging messages"
     return 0
   else
-    echo "alluxio-fuse failed to start. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2
+    echo "Failed to mount. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2
     return 1
   fi
 }
@@ -84,7 +84,7 @@ umount_fuse() {
   local mount_point=$1
   local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')
   if [[ -z ${fuse_pid} ]]; then
-    echo "No fuse mounted at ${mount_point}" >&2
+    echo "${mount_point} not mounted" >&2
     return 1
   else
     echo "Unmount fuse at ${mount_point} (PID: ${fuse_pid})."

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -75,7 +75,8 @@ mount_fuse() {
     echo "See ${ALLUXIO_LOGS_DIR}/fuse.log for logging messages"
     return 0
   else
-    echo "Failed to mount. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2
+    echo "Failed to mount Alluxio path \"${alluxio_root}\" to ${mount_point}."
+    echo "See ${ALLUXIO_LOGS_DIR}/fuse.out for more details"
     return 1
   fi
 }

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -71,17 +71,18 @@ mount_fuse() {
   # sleep: workaround to let the bg java process exit on errors, if any
   sleep 2s
   if kill -0 $! > /dev/null 2>&1 ; then
-    echo "Alluxio-fuse mounted at ${mount_point}. See ${ALLUXIO_LOGS_DIR}/fuse.log for logs"
+    echo "alluxio-fuse successfully mounted Alluxio path "${alluxio_root}" to ${mount_point}."
+    echo "See ${ALLUXIO_LOGS_DIR}/fuse.log for logging messages"
     return 0
   else
-    echo "alluxio-fuse not started. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2
+    echo "alluxio-fuse failed to start. See ${ALLUXIO_LOGS_DIR}/fuse.out for details" >&2
     return 1
   fi
 }
 
 umount_fuse() {
-  local mount_point=$1  
-  local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')  
+  local mount_point=$1
+  local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')
   if [[ -z ${fuse_pid} ]]; then
     echo "No fuse mounted at ${mount_point}" >&2
     return 1
@@ -94,17 +95,17 @@ umount_fuse() {
 
 fuse_stat() {
   local fuse_info=$("${JAVA_HOME}/bin/jps" | grep AlluxioFuse)
-  if [[ -z ${fuse_info} ]]; then    
+  if [[ -z ${fuse_info} ]]; then
     echo "AlluxioFuse: not running"
     return 1
   else
     echo -e "pid\tmount_point\talluxio_path"
     echo -e "$(ps aux | grep [A]lluxioFuse | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $NF}')"
-    return 0    
+    return 0
   fi
 }
 
-USAGE_MSG="Usage:\n\t$0 [mount|umount|stat]"
+USAGE_MSG="Usage:\n\talluxio-fuse [mount|umount|stat]"
 
 if [[ $# -lt 1 ]]; then
   echo -e "${USAGE_MSG}" >&2
@@ -127,12 +128,16 @@ case $1 in
           mount_option=${OPTARG}
           ;;
         *)
-          echo -e "${USAGE}" >&2
+          echo -e "${USAGE_MSG}" >&2
           exit 1
           ;;
       esac
     done
     shift $((${OPTIND} - 1))
+    if [[ $# -eq 0 ]]; then
+      fuse_stat
+      exit $?
+    fi
     if [[ $# -eq 1 ]]; then
       mount_fuse $1 /
       exit $?
@@ -141,22 +146,22 @@ case $1 in
       mount_fuse $1 $2
       exit $?
     fi
-    echo -e "Usage\n\t$0 mount mount_point [alluxio_path]\n\t alluxio_path is default to root" >&2
+    echo -e "Usage\n\talluxio-fuse mount mount_point [alluxio_path]\n\t alluxio_path is default to root" >&2
     exit 1
     ;;
-  umount)
+  umount|unmount)
     if [[ $# -eq 2 ]]; then
       umount_fuse $2
       exit $?
     fi
-    echo -e "Usage\n\t$0 umount mount_point\n\tuse mount stat to show mount points" >&2
+    echo -e "Usage\n\talluxio-fuse umount mount_point\n\tuse mount stat to show mount points" >&2
     exit 1
     ;;
   stat)
     fuse_stat
     ;;
   *)
-    echo "${USAGE_MSG}" >&2
+    echo -e "${USAGE_MSG}" >&2
     exit 1
     ;;
 esac

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -39,6 +39,7 @@ public final class FileSystemShell extends AbstractShell {
   private static final Map<String, String[]> CMD_ALIAS = ImmutableMap.<String, String[]>builder()
       .put("lsr", new String[] {"ls", "-R"})
       .put("rmr", new String[] {"rm", "-R"})
+      .put("umount", new String[] {"unmount"})
       .build();
 
   /**


### PR DESCRIPTION
- Fix  https://github.com/Alluxio/alluxio/issues/8362: use `echo -e` rather than `echo` to respect the escaped characters in error messages
- Fix various typos and trailing whitespaces in this script
- Make `umount` the alias of `unmount` and make this convention consistent in Alluxio mount and fuse mount too. Previously we only support `unmount` in `alluxio fs` and only `umount` in `alluxio-fuse`
- Support `alluxio-fuse mount` without argument to list all fuse mount points, to be consistent with Alluxio mount command