### PR TITLE
Diligently release resources - web servers, clients, and ports

### DIFF
--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -45,5 +45,6 @@ public class PollingMasterInquireClientTest {
     } catch (UnavailableException e) {
       // Expected
     }
+    PortRegistry.INSTANCE.release(port);
   }
 }

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -73,8 +73,7 @@ public final class MasterWebServer extends WebServer {
       public void init() throws ServletException {
         super.init();
         getServletContext().setAttribute(ALLUXIO_MASTER_SERVLET_RESOURCE_KEY, masterProcess);
-        getServletContext().setAttribute(ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY,
-            mFileSystem);
+        getServletContext().setAttribute(ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY, mFileSystem);
       }
     };
 

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -46,6 +46,8 @@ public final class MasterWebServer extends WebServer {
   public static final String ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY =
       "Alluxio Master FileSystem client";
 
+  private final FileSystem mFileSystem;
+
   /**
    * Creates a new instance of {@link MasterWebServer}.
    *
@@ -61,6 +63,7 @@ public final class MasterWebServer extends WebServer {
     ResourceConfig config = new ResourceConfig()
         .packages("alluxio.master", "alluxio.master.block", "alluxio.master.file")
         .register(JacksonProtobufObjectMapperProvider.class);
+    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
     // Override the init method to inject a reference to AlluxioMaster into the servlet context.
     // ServletContext may not be modified until after super.init() is called.
     ServletContainer servlet = new ServletContainer(config) {
@@ -71,7 +74,7 @@ public final class MasterWebServer extends WebServer {
         super.init();
         getServletContext().setAttribute(ALLUXIO_MASTER_SERVLET_RESOURCE_KEY, masterProcess);
         getServletContext().setAttribute(ALLUXIO_FILESYSTEM_CLIENT_RESOURCE_KEY,
-            FileSystem.Factory.create(ServerConfiguration.global()));
+            mFileSystem);
       }
     };
 
@@ -95,5 +98,11 @@ public final class MasterWebServer extends WebServer {
     } catch (MalformedURLException e) {
       LOG.error("ERROR: resource path is malformed", e);
     }
+  }
+
+  @Override
+  public void stop() throws Exception {
+    mFileSystem.close();
+    super.stop();
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.NotThreadSafe;

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -38,6 +39,8 @@ public final class ProxyWebServer extends WebServer {
   public static final String FILE_SYSTEM_SERVLET_RESOURCE_KEY = "File System";
   public static final String STREAM_CACHE_SERVLET_RESOURCE_KEY = "Stream Cache";
 
+  private FileSystem mFileSystem;
+
   /**
    * Creates a new instance of {@link ProxyWebServer}.
    *
@@ -52,6 +55,7 @@ public final class ProxyWebServer extends WebServer {
     // REST configuration
     ResourceConfig config = new ResourceConfig().packages("alluxio.proxy", "alluxio.proxy.s3")
         .register(JacksonProtobufObjectMapperProvider.class);
+    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
     ServletContainer servlet = new ServletContainer(config) {
       private static final long serialVersionUID = 7756010860672831556L;
 
@@ -60,8 +64,7 @@ public final class ProxyWebServer extends WebServer {
         super.init();
         getServletContext().setAttribute(ALLUXIO_PROXY_SERVLET_RESOURCE_KEY, proxyProcess);
         getServletContext()
-            .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY,
-                FileSystem.Factory.create(ServerConfiguration.global()));
+            .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, mFileSystem);
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
             new StreamCache(ServerConfiguration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
       }
@@ -69,5 +72,11 @@ public final class ProxyWebServer extends WebServer {
     ServletHolder servletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);
     mServletContextHandler
         .addServlet(servletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
+  }
+
+  @Override
+  public void stop() throws Exception {
+    mFileSystem.close();
+    super.stop();
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -61,7 +61,8 @@ public class AsyncCacheRequestManager {
    * @param service thread pool to run the background caching work
    * @param blockWorker handler to the block worker
    */
-  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker) {
+  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker,
+      FileSystemContext fsContext) {
     mAsyncCacheExecutor = service;
     mBlockWorker = blockWorker;
     mPendingRequests = new ConcurrentHashMap<>();
@@ -70,7 +71,7 @@ public class AsyncCacheRequestManager {
             (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
     // TODO(zac): Make this object accept FileSystemContext parameter. Shouldn't be creating one
     //  here
-    mFsContext = FileSystemContext.create(ServerConfiguration.global());
+    mFsContext = fsContext;
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -60,6 +60,7 @@ public class AsyncCacheRequestManager {
   /**
    * @param service thread pool to run the background caching work
    * @param blockWorker handler to the block worker
+   * @param fsContext context used to instantiate {@link RemoteBlockReader}
    */
   public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker,
       FileSystemContext fsContext) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -62,6 +62,7 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
    * Creates a new implementation of gRPC BlockWorker interface.
    *
    * @param workerProcess the worker process
+   * @param fsContext context used to read blocks
    */
   public BlockWorkerImpl(WorkerProcess workerProcess, FileSystemContext fsContext) {
     mWorkerProcess = workerProcess;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -14,6 +14,7 @@ package alluxio.worker.grpc;
 import alluxio.RpcUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.client.file.FileSystemContext;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.grpc.BlockWorkerGrpc;
@@ -62,10 +63,11 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
    *
    * @param workerProcess the worker process
    */
-  public BlockWorkerImpl(WorkerProcess workerProcess) {
+  public BlockWorkerImpl(WorkerProcess workerProcess, FileSystemContext fsContext) {
     mWorkerProcess = workerProcess;
     mRequestManager = new AsyncCacheRequestManager(
-        GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class));
+        GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class),
+        fsContext);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.grpc;
 
-import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -11,6 +11,8 @@
 
 package alluxio.worker.grpc;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.GrpcServer;
@@ -63,6 +65,8 @@ public final class GrpcDataServer implements DataServer {
   private EventLoopGroup mBossGroup;
   private EventLoopGroup mWorkerGroup;
   private GrpcServer mServer;
+  private final FileSystemContext mFsContext =
+      FileSystemContext.create(ServerConfiguration.global());
   /** non-null when the server is used with domain socket address.  */
   private DomainSocketAddress mDomainSocketAddress = null;
 
@@ -75,7 +79,7 @@ public final class GrpcDataServer implements DataServer {
   public GrpcDataServer(final SocketAddress address, final WorkerProcess workerProcess) {
     mSocketAddress = address;
     try {
-      BlockWorkerImpl blockWorkerService = new BlockWorkerImpl(workerProcess);
+      BlockWorkerImpl blockWorkerService = new BlockWorkerImpl(workerProcess, mFsContext);
       mServer = createServerBuilder(address, NettyUtils.getWorkerChannel(
           ServerConfiguration.global()))
           .addService(new GrpcService(
@@ -133,7 +137,8 @@ public final class GrpcDataServer implements DataServer {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
+    mFsContext.close();
     if (mServer != null) {
       boolean completed = mServer.shutdown();
       if (!completed) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -64,10 +64,11 @@ public final class GrpcDataServer implements DataServer {
   private EventLoopGroup mBossGroup;
   private EventLoopGroup mWorkerGroup;
   private GrpcServer mServer;
-  private final FileSystemContext mFsContext =
-      FileSystemContext.create(ServerConfiguration.global());
   /** non-null when the server is used with domain socket address.  */
   private DomainSocketAddress mDomainSocketAddress = null;
+
+  private final FileSystemContext mFsContext =
+      FileSystemContext.create(ServerConfiguration.global());
 
   /**
    * Creates a new instance of {@link GrpcDataServer}.

--- a/minicluster/src/main/java/alluxio/master/ClientPool.java
+++ b/minicluster/src/main/java/alluxio/master/ClientPool.java
@@ -63,6 +63,13 @@ public final class ClientPool implements Closeable {
   @Override
   public void close() throws IOException {
     synchronized (mClients) {
+      mClients.forEach((client) -> {
+        try {
+          client.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
       mClients.clear();
     }
   }

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
@@ -79,7 +79,6 @@ public final class FileSystemMasterClientIntegrationTest extends BaseIntegration
   @LocalAlluxioClusterResource.Config(
       confParams = {PropertyKey.Name.USER_RPC_RETRY_MAX_DURATION, "10s"})
   public void masterUnavailable() throws Exception {
-    FileSystem fileSystem = mLocalAlluxioClusterResource.get().getClient();
     mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().stop();
 
     Thread thread = new Thread(new Runnable() {
@@ -94,7 +93,7 @@ public final class FileSystemMasterClientIntegrationTest extends BaseIntegration
       }
     });
     thread.start();
-
+    FileSystem fileSystem = mLocalAlluxioClusterResource.get().getClient();
     fileSystem.listStatus(new AlluxioURI("/"));
     thread.join();
   }

--- a/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
@@ -117,6 +117,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), status.getPersistenceState());
     // restart master
     mLocalAlluxioClusterResource.get().restartMasters();
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient(); // need new client after restart
     // verify not persisted
     status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), status.getPersistenceState());

--- a/tests/src/test/java/alluxio/server/ft/MasterFailoverIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFailoverIntegrationTest.java
@@ -107,6 +107,7 @@ public final class MasterFailoverIntegrationTest extends BaseIntegrationTest {
     assertFalse(mFileSystem.exists(dir));
     // Restart to make sure the journal is consistent (we didn't write two delete entries for /dir).
     mMultiMasterLocalAlluxioCluster.restartMasters();
+    mFileSystem = mMultiMasterLocalAlluxioCluster.getClient(); // need new client after restart
     assertEquals(0, mFileSystem.listStatus(new AlluxioURI("/")).size());
   }
 

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalReplayIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalReplayIntegrationTest.java
@@ -61,6 +61,7 @@ public final class JournalReplayIntegrationTest extends BaseIntegrationTest {
     mFs.delete(alluxioPath, DeletePOptions.newBuilder().setRecursive(true).build());
     mFs.mount(alluxioPath, ufsPath);
     mCluster.restartMasters();
+    mFs = mCluster.getClient(); // need new client after restart
     List<URIStatus> status = mFs.listStatus(new AlluxioURI("/"));
     assertEquals(1, status.size());
     assertTrue(status.get(0).isMountPoint());

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -169,6 +169,8 @@ public final class LocalAlluxioClusterResource implements TestRule {
           }
         } catch (Exception e) {
           throw new RuntimeException(e);
+        } finally {
+          IntegrationTestUtils.releaseMasterPorts();
         }
         try {
           statement.evaluate();


### PR DESCRIPTION
Previously, none of the web servers closed their FIleSystem client. This
has been fixed. The AsyncCacheRequestManager created it's own
FileSystemContext upon instantiation. This has been changed such that
the GrpcDataServer is now reponsible for creating and closing the
FileSystemContext that the AsyncCacheRequestManager uses. Lastly,
the ClientPool, LocalAlluxioClusterResource, and PollingMasterInquireClientTest
all had cases where resources may not be released, so I made sure to close
them properly.