### PR TITLE
Revise gRPC exception flow for channel building and authentication

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -11,8 +11,7 @@
 
 package alluxio.client.block.stream;
 
-import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnavailableException;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.conf.AlluxioConfiguration;
@@ -177,7 +176,7 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   private GrpcChannel buildChannel(Subject subject, SocketAddress address,
       GrpcManagedChannelPool.PoolingStrategy poolingStrategy, AlluxioConfiguration alluxioConf,
       EventLoopGroup workerGroup)
-      throws UnauthenticatedException, UnavailableException {
+      throws AlluxioStatusException {
     return GrpcChannelBuilder.newBuilder(address, alluxioConf).setSubject(subject)
         .setChannelType(NettyUtils
             .getClientChannelClass(!(address instanceof InetSocketAddress), alluxioConf))

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -13,8 +13,7 @@ package alluxio.grpc;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnavailableException;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.ChannelAuthenticator;
 import io.grpc.Channel;
@@ -190,7 +189,7 @@ public final class GrpcChannelBuilder {
    *
    * @return the built {@link GrpcChannel}
    */
-  public GrpcChannel build() throws UnauthenticatedException, UnavailableException {
+  public GrpcChannel build() throws AlluxioStatusException {
     ManagedChannel underlyingChannel =
         GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(mChannelKey,
             mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS),

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import static java.util.stream.Collectors.joining;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.exception.status.UnauthenticatedException;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.GetServiceVersionPRequest;
 import alluxio.grpc.GrpcChannel;
@@ -97,7 +97,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
       } catch (UnavailableException e) {
         LOG.debug("Failed to connect to {}", address);
         continue;
-      } catch (UnauthenticatedException e) {
+      } catch (AlluxioStatusException e) {
         throw new RuntimeException(e);
       }
     }
@@ -105,7 +105,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   }
 
   private void pingMetaService(InetSocketAddress address)
-      throws UnauthenticatedException, UnavailableException {
+      throws AlluxioStatusException {
     GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, mConfiguration).build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -13,8 +13,8 @@ package alluxio.security.authentication;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.SaslAuthenticationServiceGrpc;
 import alluxio.grpc.SaslMessage;
 import alluxio.util.SecurityUtils;
@@ -105,7 +105,7 @@ public class ChannelAuthenticator {
    * @throws UnauthenticatedException
    */
   public Channel authenticate(ManagedChannel managedChannel, AlluxioConfiguration conf)
-      throws UnauthenticatedException, UnavailableException {
+      throws AlluxioStatusException {
     if (mAuthType == AuthType.NOSASL) {
       return managedChannel;
     }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -108,6 +108,11 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
     } catch (ExecutionException e) {
       Throwable cause = (e.getCause() != null) ? e.getCause() : e;
       if (cause != null && cause instanceof StatusRuntimeException) {
+        StatusRuntimeException sre = (StatusRuntimeException) cause;
+        // If caught unimplemented, that means server does not support authentication.
+        if (sre.getStatus().getCode() == Status.Code.UNIMPLEMENTED) {
+          throw new UnauthenticatedException("Authentication is disabled on target host.");
+        }
         throw GrpcExceptionUtils.fromGrpcStatusException((StatusRuntimeException) cause);
       }
       throw new UnknownException(cause.getMessage(), cause);

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -107,7 +107,7 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
       Thread.currentThread().interrupt();
       throw new CanceledException(ie.getMessage(), ie);
     } catch (ExecutionException e) {
-      Throwable cause = e.getCause();
+      Throwable cause = (e.getCause() != null) ? e.getCause() : e;
       if (cause != null && cause instanceof StatusRuntimeException) {
         throw GrpcExceptionUtils.fromGrpcStatusException((StatusRuntimeException) cause);
       }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -12,7 +12,6 @@
 package alluxio.security.authentication;
 
 import alluxio.exception.status.AlluxioStatusException;
-import alluxio.exception.status.CanceledException;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.exception.status.UnknownException;
@@ -105,7 +104,7 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
       throw new UnauthenticatedException(se.getMessage(), se);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
-      throw new CanceledException(ie.getMessage(), ie);
+      throw new UnavailableException(ie.getMessage(), ie);
     } catch (ExecutionException e) {
       Throwable cause = (e.getCause() != null) ? e.getCause() : e;
       if (cause != null && cause instanceof StatusRuntimeException) {

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -13,8 +13,8 @@ package alluxio.util.network;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.GetServiceVersionPRequest;
 import alluxio.grpc.GrpcChannel;
 import alluxio.grpc.GrpcChannelBuilder;
@@ -643,7 +643,7 @@ public final class NetworkAddressUtils {
    */
   public static void pingService(InetSocketAddress address, alluxio.grpc.ServiceType serviceType,
       AlluxioConfiguration conf)
-      throws UnauthenticatedException, UnavailableException {
+      throws AlluxioStatusException {
     Preconditions.checkNotNull(address, "address");
     Preconditions.checkNotNull(serviceType, "serviceType");
     GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, conf).build();

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -14,7 +14,6 @@ package alluxio.security.authentication;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnimplementedException;
 import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerBuilder;
@@ -121,7 +120,7 @@ public class GrpcSecurityTest {
     mConfiguration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE);
     GrpcChannelBuilder channelBuilder =
         GrpcChannelBuilder.newBuilder(getServerConnectAddress(server), mConfiguration);
-    mThrown.expect(UnimplementedException.class);
+    mThrown.expect(UnauthenticatedException.class);
     channelBuilder.build();
     server.shutdown();
   }

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -14,6 +14,7 @@ package alluxio.security.authentication;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnauthenticatedException;
+import alluxio.exception.status.UnimplementedException;
 import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerBuilder;
@@ -120,7 +121,7 @@ public class GrpcSecurityTest {
     mConfiguration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE);
     GrpcChannelBuilder channelBuilder =
         GrpcChannelBuilder.newBuilder(getServerConnectAddress(server), mConfiguration);
-    mThrown.expect(UnauthenticatedException.class);
+    mThrown.expect(UnimplementedException.class);
     channelBuilder.build();
     server.shutdown();
   }

--- a/shell/src/main/java/alluxio/common/RpcPortHealthCheckClient.java
+++ b/shell/src/main/java/alluxio/common/RpcPortHealthCheckClient.java
@@ -13,7 +13,7 @@ package alluxio.common;
 
 import alluxio.HealthCheckClient;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.exception.status.UnauthenticatedException;
+import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.RetryPolicy;
@@ -65,7 +65,7 @@ public class RpcPortHealthCheckClient implements HealthCheckClient {
         return true;
       } catch (UnavailableException e) {
         LOG.debug("Failed to connect to {}", mNodeAddress);
-      } catch (UnauthenticatedException e) {
+      } catch (AlluxioStatusException e) {
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
Throwing unavailable and unauthenticated exceptions from channel building logic is too simplistic for gRPC flow as we handle most of the channel/authentication logic internally. Rather than blanketing various issues into 2 categories, this PR makes them throw proper AlluxioStatusException types.