### PR TITLE
[SMALLFIX] Remove TODOs

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -43,7 +43,6 @@ public class GrpcManagedChannelPool {
   private static GrpcManagedChannelPool sInstance;
 
   static {
-    // TODO(zac): Find a better way to handle handle this instance
     sInstance = new GrpcManagedChannelPool();
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -70,8 +70,6 @@ public class AsyncCacheRequestManager {
     mLocalWorkerHostname =
         NetworkAddressUtils.getLocalHostName(
             (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
-    // TODO(zac): Make this object accept FileSystemContext parameter. Shouldn't be creating one
-    //  here
     mFsContext = fsContext;
   }
 


### PR DESCRIPTION
These todos are out of date. The original issue from the managed
channel pool was taken care of by moving the configuration parameters
out of the managed channel pool.

The AsyncCacheRequestManager now has its FileSystemContext passed
in rather than creating one, rendering the TODO finished.