### PR TITLE
Add infra for in-memory time series metrics on the master

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1274,6 +1274,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METRICS_TIME_SERIES_INTERVAL =
+      new Builder(Name.MASTER_METRICS_TIME_SERIES_INTERVAL)
+          .setDefaultValue("5min")
+          .setDescription("Interval for which the master records metrics information. This affects "
+              + "the granularity of the metrics graphed in the UI.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_WORKER_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_WORKER_HEARTBEAT_INTERVAL)
           .setAlias(new String[]{"alluxio.master.heartbeat.interval.ms",
@@ -3708,6 +3716,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.inode.cache.max.size";
     public static final String MASTER_PERSISTENCE_CHECKER_INTERVAL_MS =
         "alluxio.master.persistence.checker.interval.ms";
+    public static final String MASTER_METRICS_TIME_SERIES_INTERVAL =
+        "alluxio.master.metrics.time.series.interval";
     public static final String MASTER_PERSISTENCE_INITIAL_INTERVAL_MS =
         "alluxio.master.persistence.initial.interval.ms";
     public static final String MASTER_PERSISTENCE_INITIAL_WAIT_TIME_MS =

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -46,6 +46,7 @@ public final class HeartbeatContext {
   public static final String MASTER_LOST_MASTER_DETECTION = "Master Lost Master Detection";
   public static final String MASTER_LOST_WORKER_DETECTION = "Master Lost Worker Detection";
   public static final String MASTER_METRICS_SYNC = "Master Metrics Sync";
+  public static final String MASTER_METRICS_TIME_SERIES = "Master Metrics Time Series";
   public static final String MASTER_UFS_CLEANUP = "Master Ufs Cleanup";
   public static final String MASTER_TTL_CHECK = "Master TTL Check";
   public static final String MASTER_ACTIVE_UFS_SYNC = "Master Active UFS Sync";
@@ -84,6 +85,7 @@ public final class HeartbeatContext {
     sTimerClasses.put(WORKER_SPACE_RESERVER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_STORAGE_HEALTH, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_METRICS_SYNC, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_METRICS_TIME_SERIES, SLEEPING_TIMER_CLASS);
   }
 
   private HeartbeatContext() {} // to prevent initialization

--- a/core/common/src/main/java/alluxio/metrics/TimeSeries.java
+++ b/core/common/src/main/java/alluxio/metrics/TimeSeries.java
@@ -1,0 +1,85 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Represents a time series which can be graphed in the UI.
+ */
+public class TimeSeries {
+  private final String mName;
+  private final List<DataPoint> mDataPoints;
+
+  /**
+   * Create a new time series with the given name and no data.
+   * @param name name of the time series
+   */
+  public TimeSeries(String name) {
+    mName = name;
+    mDataPoints = new LinkedList<>();
+  }
+
+  /**
+   * Record a value at the current time.
+   * @param value value to record
+   */
+  public void record(double value) {
+    mDataPoints.add(new DataPoint(value));
+  }
+
+  /**
+   * @return the name of the time series
+   */
+  public String getName() {
+    return mName;
+  }
+
+  /**
+   * @return the data of the time series
+   */
+  public List<DataPoint> getDataPoints() {
+    return mDataPoints;
+  }
+
+  /**
+   * Represents a datapoint in a time series. Millisecond epoch time is used for the timestamp.
+   */
+  public final class DataPoint {
+    private final long mTimestamp;
+    private final double mValue;
+
+    /**
+     * Construct a new data point with the current time as the timestamp.
+     * @param value the value of the data point
+     */
+    public DataPoint(double value) {
+      mTimestamp = System.currentTimeMillis();
+      mValue = value;
+    }
+
+    /**
+     * @return the timestamp of the data point in milliseconds epoch time
+     */
+    public long getTimeStamp() {
+      return mTimestamp;
+    }
+
+    /**
+     * @return the value of the data point
+     */
+    public double getValue() {
+      return mValue;
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -17,6 +17,7 @@ import com.google.common.base.MoreObjects;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -36,6 +37,7 @@ public final class MasterWebUIMetrics implements Serializable {
   private Map<String, Metric> mOperationMetrics;
   private Map<String, String> mUfsReadSize;
   private Map<String, String> mUfsWriteSize;
+  private Map<String, TreeMap<Long, Long>> mTimeSeriesMetrics;
   private String mCacheHitLocal;
   private String mCacheHitRemote;
   private String mCacheMiss;
@@ -252,6 +254,13 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public Map<String, Counter> getRpcInvocationMetrics() {
     return mRpcInvocationMetrics;
+  }
+
+  /**
+   * @return the time series metrics
+   */
+  public Map<String, TreeMap<Long, Long>> getTimeSeriesMetrics() {
+    return mTimeSeriesMetrics;
   }
 
   /**
@@ -491,6 +500,15 @@ public final class MasterWebUIMetrics implements Serializable {
   }
 
   /**
+   * @param timeSeries the time series metrics to set
+   * @return the updated masterWebUIMetrics object
+   */
+  public MasterWebUIMetrics setTimeSeriesMetrics(Map<String, TreeMap<Long, Long>> timeSeries) {
+    mTimeSeriesMetrics = timeSeries;
+    return this;
+  }
+
+  /**
    * Sets rpc invocation metrics.
    *
    * @param rpcInvocationMetrics the rpc invocation metrics
@@ -520,6 +538,7 @@ public final class MasterWebUIMetrics implements Serializable {
         .add("totalBytesWrittenUfs", mTotalBytesWrittenUfs)
         .add("totalBytesWrittenUfsThroughput", mTotalBytesWrittenUfsThroughput)
         .add("ufsOps", mUfsOps).add("ufsReadSize", mUfsReadSize).add("ufsWriteSize", mUfsWriteSize)
+        .add("timeSeriesMetrics", mTimeSeriesMetrics)
         .toString();
   }
 }

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -11,13 +11,15 @@
 
 package alluxio.wire;
 
+import alluxio.metrics.TimeSeries;
+
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Metric;
 import com.google.common.base.MoreObjects;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -37,7 +39,7 @@ public final class MasterWebUIMetrics implements Serializable {
   private Map<String, Metric> mOperationMetrics;
   private Map<String, String> mUfsReadSize;
   private Map<String, String> mUfsWriteSize;
-  private Map<String, TreeMap<Long, Long>> mTimeSeriesMetrics;
+  private List<TimeSeries> mTimeSeriesMetrics;
   private String mCacheHitLocal;
   private String mCacheHitRemote;
   private String mCacheMiss;
@@ -259,7 +261,7 @@ public final class MasterWebUIMetrics implements Serializable {
   /**
    * @return the time series metrics
    */
-  public Map<String, TreeMap<Long, Long>> getTimeSeriesMetrics() {
+  public List<TimeSeries> getTimeSeriesMetrics() {
     return mTimeSeriesMetrics;
   }
 
@@ -503,7 +505,7 @@ public final class MasterWebUIMetrics implements Serializable {
    * @param timeSeries the time series metrics to set
    * @return the updated masterWebUIMetrics object
    */
-  public MasterWebUIMetrics setTimeSeriesMetrics(Map<String, TreeMap<Long, Long>> timeSeries) {
+  public MasterWebUIMetrics setTimeSeriesMetrics(List<TimeSeries> timeSeries) {
     mTimeSeriesMetrics = timeSeries;
     return this;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -107,6 +107,7 @@ import alluxio.master.metastore.ReadOnlyInodeStore;
 import alluxio.master.metrics.TimeSeriesStore;
 import alluxio.metrics.MasterMetrics;
 import alluxio.metrics.MetricsSystem;
+import alluxio.metrics.TimeSeries;
 import alluxio.proto.journal.File;
 import alluxio.proto.journal.File.AddSyncPointEntry;
 import alluxio.proto.journal.File.NewBlockEntry;
@@ -4520,7 +4521,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   @Override
-  public Map<String, TreeMap<Long, Long>> getTimeSeries() {
+  public List<TimeSeries> getTimeSeries() {
     return mTimeSeriesStore.getTimeSeries();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -64,6 +64,7 @@ import alluxio.master.audit.AsyncUserAccessAuditLogWriter;
 import alluxio.master.audit.AuditContext;
 import alluxio.master.block.BlockId;
 import alluxio.master.block.BlockMaster;
+import alluxio.master.block.DefaultBlockMaster;
 import alluxio.master.file.activesync.ActiveSyncManager;
 import alluxio.master.file.contexts.CheckConsistencyContext;
 import alluxio.master.file.contexts.CompleteFileContext;
@@ -103,6 +104,7 @@ import alluxio.master.metastore.DelegatingReadOnlyInodeStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.InodeStore.InodeStoreArgs;
 import alluxio.master.metastore.ReadOnlyInodeStore;
+import alluxio.master.metrics.TimeSeriesStore;
 import alluxio.metrics.MasterMetrics;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.journal.File;
@@ -164,6 +166,7 @@ import alluxio.worker.job.JobMasterClientContext;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -366,10 +369,12 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   private Future<List<AlluxioURI>> mStartupConsistencyCheck;
 
   private ActiveSyncManager mSyncManager;
-  /**
-   * Log writer for user access audit log.
-   */
+
+  /** Log writer for user access audit log. */
   private AsyncUserAccessAuditLogWriter mAsyncAuditLogWriter;
+
+  /** Stores the time series for various metrics which are exposed in the UI. */
+  private TimeSeriesStore mTimeSeriesStore;
 
   /**
    * Creates a new instance of {@link DefaultFileSystemMaster}.
@@ -417,6 +422,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     mUfsBlockLocationCache = UfsBlockLocationCache.Factory.create(mMountTable);
     mUfsSyncPathCache = new UfsSyncPathCache();
     mSyncManager = new ActiveSyncManager(mMountTable, this);
+    mTimeSeriesStore = new TimeSeriesStore();
 
     resetState();
     Metrics.registerGauges(this, mUfsManager);
@@ -618,6 +624,11 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           new HeartbeatThread(HeartbeatContext.MASTER_PERSISTENCE_CHECKER,
               new PersistenceChecker(),
               (int) ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS),
+              ServerConfiguration.global()));
+      getExecutorService().submit(
+          new HeartbeatThread(HeartbeatContext.MASTER_METRICS_TIME_SERIES,
+              new TimeSeriesRecorder(),
+              (int) ServerConfiguration.getMs(PropertyKey.MASTER_METRICS_TIME_SERIES_INTERVAL),
               ServerConfiguration.global()));
       if (ServerConfiguration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
         mStartupConsistencyCheck = getExecutorService().submit(() -> startupCheckConsistency(
@@ -4210,6 +4221,39 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     }
   }
 
+  @NotThreadSafe
+  private final class TimeSeriesRecorder implements alluxio.heartbeat.HeartbeatExecutor {
+    @Override
+    public void heartbeat() throws InterruptedException {
+      // TODO(calvin): Provide a better way to keep track of metrics collected as time series
+      MetricRegistry registry = MetricsSystem.METRIC_REGISTRY;
+
+      // % Alluxio space used
+      Long masterCapacityTotal = (Long) registry.getGauges()
+          .get(MetricsSystem.getMetricName(DefaultBlockMaster.Metrics.CAPACITY_TOTAL)).getValue();
+      Long masterCapacityUsed = (Long) registry.getGauges()
+          .get(MetricsSystem.getMetricName(DefaultBlockMaster.Metrics.CAPACITY_USED)).getValue();
+      int percentAlluxioSpaceUsed =
+          (masterCapacityTotal > 0) ? (int) (100L * masterCapacityUsed / masterCapacityTotal) : 0;
+      mTimeSeriesStore.record("% Alluxio Space Used", percentAlluxioSpaceUsed);
+
+      // % UFS space used
+      Long masterUnderfsCapacityTotal =
+          (Long) registry.getGauges()
+              .get(MetricsSystem.getMetricName(MasterMetrics.UFS_CAPACITY_TOTAL)).getValue();
+      Long masterUnderfsCapacityUsed =
+          (Long) registry.getGauges()
+              .get(MetricsSystem.getMetricName(MasterMetrics.UFS_CAPACITY_USED)).getValue();
+      int percentUfsSpaceUsed =
+          (masterUnderfsCapacityTotal > 0) ? (int) (100L * masterUnderfsCapacityUsed
+              / masterUnderfsCapacityTotal) : 0;
+      mTimeSeriesStore.record("% UFS Space Used", percentUfsSpaceUsed);
+    }
+
+    @Override
+    public void close() {} // Nothing to clean up.
+  }
+
   private static void cleanup(UnderFileSystem ufs, String ufsPath) {
     final String errMessage = "Failed to delete UFS file {}.";
     if (!ufsPath.isEmpty()) {
@@ -4473,5 +4517,10 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
   private boolean isAclEnabled() {
     return ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
+  }
+
+  @Override
+  public Map<String, TreeMap<Long, Long>> getTimeSeries() {
+    return mTimeSeriesStore.getTimeSeries();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -43,6 +43,7 @@ import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.master.file.contexts.WorkerHeartbeatContext;
 import alluxio.master.file.meta.FileSystemMasterView;
 import alluxio.master.file.meta.PersistenceState;
+import alluxio.metrics.TimeSeries;
 import alluxio.security.authorization.AclEntry;
 import alluxio.underfs.UfsMode;
 import alluxio.wire.FileBlockInfo;
@@ -58,7 +59,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -558,5 +558,5 @@ public interface FileSystemMaster extends Master {
   /**
    * @return the time series data stored by the master
    */
-  Map<String, TreeMap<Long, Long>> getTimeSeries();
+  List<TimeSeries> getTimeSeries();
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -58,6 +58,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -553,4 +554,9 @@ public interface FileSystemMaster extends Master {
    * @return true if successfully recorded in the journal
    */
   boolean recordActiveSyncTxid(long txId, long mountId);
+
+  /**
+   * @return the time series data stored by the master
+   */
+  Map<String, TreeMap<Long, Long>> getTimeSeries();
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -994,6 +994,8 @@ public final class AlluxioMasterRestServiceHandler {
 
       response.setOperationMetrics(operations).setRpcInvocationMetrics(rpcInvocationsUpdated);
 
+      response.setTimeSeriesMetrics(mFileSystemMaster.getTimeSeries());
+
       return response;
     }, ServerConfiguration.global());
   }

--- a/core/server/master/src/main/java/alluxio/master/metrics/TimeSeriesStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/TimeSeriesStore.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metrics;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An in-memory time series store for Alluxio metrics.
+ */
+@ThreadSafe
+public class TimeSeriesStore {
+  /** <MetricName, Map<Epoch Time, Value>>. **/
+  private final Map<String, TreeMap<Long, Long>> mTimeSeries;
+
+  /**
+   * Constructs a new time series store.
+   */
+  public TimeSeriesStore() {
+    mTimeSeries = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Records a value for the given metric at the current time.
+   *
+   * @param metric the name of the metric
+   * @param value the value of the metric
+   */
+  public void record(String metric, long value) {
+    mTimeSeries.compute(metric, (metricName, timeseries) -> {
+      if (timeseries == null) {
+        timeseries = new TreeMap<>();
+      }
+      timeseries.put(System.currentTimeMillis(), value);
+      return timeseries;
+    });
+  }
+
+  /**
+   * @return a copy of the time series data collected so far
+   */
+  public Map<String, TreeMap<Long, Long>> getTimeSeries() {
+    return ImmutableMap.copyOf(mTimeSeries);
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/metrics/TimeSeriesStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/TimeSeriesStore.java
@@ -11,11 +11,13 @@
 
 package alluxio.master.metrics;
 
-import com.google.common.collect.ImmutableMap;
+import alluxio.metrics.TimeSeries;
+
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -23,8 +25,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @ThreadSafe
 public class TimeSeriesStore {
-  /** <MetricName, Map<Epoch Time, Value>>. **/
-  private final Map<String, TreeMap<Long, Long>> mTimeSeries;
+  /** <MetricName, TimeSeries>. **/
+  private final Map<String, TimeSeries> mTimeSeries;
 
   /**
    * Constructs a new time series store.
@@ -39,20 +41,20 @@ public class TimeSeriesStore {
    * @param metric the name of the metric
    * @param value the value of the metric
    */
-  public void record(String metric, long value) {
-    mTimeSeries.compute(metric, (metricName, timeseries) -> {
-      if (timeseries == null) {
-        timeseries = new TreeMap<>();
+  public void record(String metric, double value) {
+    mTimeSeries.compute(metric, (metricName, timeSeries) -> {
+      if (timeSeries == null) {
+        timeSeries = new TimeSeries(metricName);
       }
-      timeseries.put(System.currentTimeMillis(), value);
-      return timeseries;
+      timeSeries.record(value);
+      return timeSeries;
     });
   }
 
   /**
-   * @return a copy of the time series data collected so far
+   * @return a copy of all the time series data collected so far
    */
-  public Map<String, TreeMap<Long, Long>> getTimeSeries() {
-    return ImmutableMap.copyOf(mTimeSeries);
+  public List<TimeSeries> getTimeSeries() {
+    return ImmutableList.copyOf(mTimeSeries.values());
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
@@ -1,0 +1,66 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.util.CommonUtils;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link TimeSeriesStore}.
+ */
+public class TimeSeriesStoreTest {
+  @Test
+  public void recordTimeSeries() {
+    TimeSeriesStore store = new TimeSeriesStore();
+    String metric1 = "test_metric";
+    long value1 = 10;
+    long value2 = 20;
+    store.record(metric1, value1);
+    assertTrue(store.getTimeSeries().containsKey(metric1));
+    assertEquals(1, store.getTimeSeries().get(metric1).size());
+    CommonUtils.sleepMs(10); // To prevent the two records from being placed in the same ms.
+    store.record(metric1, value2);
+    assertEquals(2, store.getTimeSeries().get(metric1).size());
+  }
+
+  @Test
+  public void recordMultipleTimeSeries() {
+    TimeSeriesStore store = new TimeSeriesStore();
+    String metric1 = "test_metric_1";
+    String metric2 = "test_metric_2";
+    long value1 = 10;
+    long value2 = 20;
+    store.record(metric1, value1);
+    store.record(metric2, value2);
+    assertTrue(store.getTimeSeries().containsKey(metric1));
+    assertTrue(store.getTimeSeries().containsKey(metric2));
+    assertTrue(store.getTimeSeries().get(metric1).containsValue(value1));
+    assertTrue(store.getTimeSeries().get(metric2).containsValue(value2));
+  }
+
+  @Test
+  public void orderedTimeSeries() {
+    TimeSeriesStore store = new TimeSeriesStore();
+    String metric1 = "test_metric";
+    Long value1 = 10L;
+    Long value2 = 20L;
+    store.record(metric1, value1);
+    CommonUtils.sleepMs(10); // To prevent the two records from being placed in the same ms.
+    store.record(metric1, value2);
+    assertEquals(value1, store.getTimeSeries().get(metric1).firstEntry().getValue());
+    assertEquals(value2, store.getTimeSeries().get(metric1).lastEntry().getValue());
+  }
+}


### PR DESCRIPTION
@WilliamZapata 

This adds a field to the WebUIMetrics endpoint:

```
timeSeriesMetrics: [
  MetricName: [
    timestamp : value,
    ...
  ],
  ...
]
```

These metrics last for the lifetime of a single master and will be lost when the master restarts/fails over.