### PR TITLE
Stop job and secondary_master processes before starting them

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -498,7 +498,7 @@ main() {
 
   if [[ "${killonstart}" != "no" ]]; then
     case "${ACTION}" in
-      all | local | master | masters | proxy | proxies | worker | workers | logserver)
+      all | local | master | masters | secondary_master | job_master | job_masters | proxy | proxies | worker | workers | job_worker | job_workers | logserver)
         stop ${ACTION}
         sleep 1
         ;;


### PR DESCRIPTION
Previously we would stop most processes, but not secondary_master or job.
This makes the behavior consistent across all processes