### PR TITLE
Fix secondary master to create checkpoints

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -77,13 +77,13 @@ public final class AlluxioSecondaryMaster implements Process {
 
   @Override
   public void start() throws Exception {
-    mRegistry.start(false);
+    mJournalSystem.start();
     mLatch.await();
   }
 
   @Override
   public void stop() throws Exception {
-    mRegistry.stop();
+    mJournalSystem.stop();
     mLatch.countDown();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -11,13 +11,15 @@
 
 package alluxio.master;
 
-import alluxio.conf.ServerConfiguration;
 import alluxio.Process;
 import alluxio.ProcessUtils;
-import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -41,6 +44,8 @@ public final class AlluxioSecondaryMaster implements Process {
   private final BackupManager mBackupManager;
   private final long mStartTimeMs;
   private final int mPort;
+
+  private volatile boolean mRunning = false;
 
   /**
    * Creates a {@link AlluxioSecondaryMaster}.
@@ -78,18 +83,29 @@ public final class AlluxioSecondaryMaster implements Process {
   @Override
   public void start() throws Exception {
     mJournalSystem.start();
+    mRunning = true;
     mLatch.await();
+    mJournalSystem.stop();
+    mRunning = false;
   }
 
   @Override
   public void stop() throws Exception {
-    mJournalSystem.stop();
     mLatch.countDown();
   }
 
   @Override
   public boolean waitForReady(int timeoutMs) {
-    return true;
+    try {
+      CommonUtils.waitFor("Secondary master to start", () -> mRunning,
+          WaitForOptions.defaults().setTimeoutMs(timeoutMs));
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (TimeoutException e) {
+      return false;
+    }
   }
 
   @Override

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -155,7 +155,6 @@ public final class LocalAlluxioMaster {
       mSecondaryMaster.stop();
       while (mSecondaryMasterThread.isAlive()) {
         LOG.info("Stopping thread {}.", mSecondaryMasterThread.getName());
-        mSecondaryMasterThread.interrupt();
         mSecondaryMasterThread.join(1000);
       }
       mSecondaryMasterThread = null;

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/SecondaryMasterTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/SecondaryMasterTest.java
@@ -1,0 +1,42 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.server.ft.journal.ufs;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.file.FileSystem;
+import alluxio.conf.PropertyKey;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.IntegrationTestUtils;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SecondaryMasterTest extends BaseIntegrationTest {
+  @Rule
+  public LocalAlluxioClusterResource mClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 10)
+          .setProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 1)
+          .build();
+
+  @Test
+  public void secondaryShouldCreateCheckpoints() throws Exception {
+    FileSystem fs = mClusterResource.get().getClient();
+    // Create a bunch of directories to trigger a checkpoint.
+    for (int i = 0; i < 10; i++) {
+      fs.createDirectory(new AlluxioURI("/dir" + i));
+    }
+    IntegrationTestUtils.waitForCheckpoint(Constants.FILE_SYSTEM_MASTER_NAME);
+  }
+}

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -24,8 +24,13 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.master.MasterClientContext;
+import alluxio.master.NoopMaster;
 import alluxio.master.PortRegistry;
+import alluxio.master.journal.JournalUtils;
+import alluxio.master.journal.ufs.UfsJournal;
+import alluxio.master.journal.ufs.UfsJournalSnapshot;
 import alluxio.util.CommonUtils;
+import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.BlockHeartbeatReporter;
 import alluxio.worker.block.BlockWorker;
@@ -125,6 +130,26 @@ public final class IntegrationTestUtils {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Waits for a checkpoint to be written in the specified master's journal.
+   *
+   * @param masterName the name of the master
+   */
+  public static void waitForCheckpoint(String masterName)
+      throws TimeoutException, InterruptedException {
+    UfsJournal journal = new UfsJournal(URIUtils.appendPathOrDie(JournalUtils.getJournalLocation(),
+        masterName), new NoopMaster(""), 0);
+    CommonUtils.waitFor("checkpoint to be written", () -> {
+      UfsJournalSnapshot snapshot;
+      try {
+        snapshot = UfsJournalSnapshot.getSnapshot(journal);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return !snapshot.getCheckpoints().isEmpty();
+    });
   }
 
   /**


### PR DESCRIPTION
Previously, it wouldn't do anything. Now it creates
checkpoints like it's supposed to.

fixes #8390