### PR TITLE
Centralize exception conversion

### DIFF
--- a/core/base/src/main/java/alluxio/exception/status/AlluxioStatusException.java
+++ b/core/base/src/main/java/alluxio/exception/status/AlluxioStatusException.java
@@ -266,7 +266,8 @@ public class AlluxioStatusException extends IOException {
    * @return the converted {@link AlluxioStatusException}
    */
   public static AlluxioStatusException fromStatusRuntimeException(StatusRuntimeException e) {
-    return AlluxioStatusException.from(Status.from(e.getStatus().getCode()), e.getMessage(), e);
+    return AlluxioStatusException.from(Status.from(e.getStatus().getCode()),
+        e.getStatus().getDescription(), e);
   }
 
   /**

--- a/core/base/src/main/java/alluxio/exception/status/AlluxioStatusException.java
+++ b/core/base/src/main/java/alluxio/exception/status/AlluxioStatusException.java
@@ -30,6 +30,8 @@ import alluxio.exception.UfsBlockAccessTokenUnavailableException;
 import alluxio.exception.WorkerOutOfSpaceException;
 
 import com.google.common.base.Preconditions;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -108,6 +110,14 @@ public class AlluxioStatusException extends IOException {
       default:
         return new AlluxioException(getMessage(), this);
     }
+  }
+
+  /**
+   * @return a gRPC status exception representation of this exception
+   */
+  public StatusException toGrpcStatusException() {
+    return io.grpc.Status.fromCode(mStatus.toGrpcCode()).withDescription(getMessage())
+        .asException();
   }
 
   /**
@@ -240,10 +250,23 @@ public class AlluxioStatusException extends IOException {
    * @return the converted {@link AlluxioStatusException}
    */
   public static AlluxioStatusException fromThrowable(Throwable t) {
+    if (t instanceof StatusRuntimeException) {
+      return fromStatusRuntimeException((StatusRuntimeException) t);
+    }
     if (t instanceof Error || t instanceof RuntimeException) {
       return new InternalException(t);
     }
     return fromCheckedException(t);
+  }
+
+  /**
+   * Converts a gRPC StatusRuntimeException to an Alluxio status exception.
+   *
+   * @param e a gRPC StatusRuntimeException
+   * @return the converted {@link AlluxioStatusException}
+   */
+  public static AlluxioStatusException fromStatusRuntimeException(StatusRuntimeException e) {
+    return AlluxioStatusException.from(Status.from(e.getStatus().getCode()), e.getMessage(), e);
   }
 
   /**

--- a/core/base/src/main/java/alluxio/exception/status/Status.java
+++ b/core/base/src/main/java/alluxio/exception/status/Status.java
@@ -11,10 +11,13 @@
 
 package alluxio.exception.status;
 
+import io.grpc.Status.Code;
+
 /**
  * A class representing gRPC status codes. The definitions are from
  * https://github.com/grpc/grpc-go/blob/v1.2.0/codes/codes.go.
  */
+// TODO(andrew): replace alluxio.exception.status.Status with io.grpc.Status
 public enum Status {
   // OK is returned on success.
   OK,
@@ -131,4 +134,89 @@ public enum Status {
 
   // DataLoss indicates unrecoverable data loss or corruption.
   DATA_LOSS;
+
+  /**
+   * @return the corresponding gRPC status code
+   */
+  public Code toGrpcCode() {
+    switch (this) {
+      case OK:
+        return Code.OK;
+      case ABORTED:
+        return Code.ABORTED;
+      case ALREADY_EXISTS:
+        return Code.ALREADY_EXISTS;
+      case CANCELED:
+        return Code.CANCELLED;
+      case DATA_LOSS:
+        return Code.DATA_LOSS;
+      case DEADLINE_EXCEEDED:
+        return Code.DEADLINE_EXCEEDED;
+      case FAILED_PRECONDITION:
+        return Code.FAILED_PRECONDITION;
+      case INTERNAL:
+        return Code.INTERNAL;
+      case INVALID_ARGUMENT:
+        return Code.INVALID_ARGUMENT;
+      case NOT_FOUND:
+        return Code.NOT_FOUND;
+      case OUT_OF_RANGE:
+        return Code.OUT_OF_RANGE;
+      case PERMISSION_DENIED:
+        return Code.PERMISSION_DENIED;
+      case RESOURCE_EXHAUSTED:
+        return Code.RESOURCE_EXHAUSTED;
+      case UNAUTHENTICATED:
+        return Code.UNAUTHENTICATED;
+      case UNAVAILABLE:
+        return Code.UNAVAILABLE;
+      case UNIMPLEMENTED:
+        return Code.UNIMPLEMENTED;
+      default:
+        return Code.UNKNOWN;
+    }
+  }
+
+  /**
+   * @param code a grpc status code
+   * @return the corresponding status
+   */
+  public static Status from(Code code) {
+    switch (code) {
+      case OK:
+        return OK;
+      case ABORTED:
+        return ABORTED;
+      case ALREADY_EXISTS:
+        return ALREADY_EXISTS;
+      case CANCELLED:
+        return CANCELED;
+      case DATA_LOSS:
+        return DATA_LOSS;
+      case DEADLINE_EXCEEDED:
+        return DEADLINE_EXCEEDED;
+      case FAILED_PRECONDITION:
+        return FAILED_PRECONDITION;
+      case INTERNAL:
+        return INTERNAL;
+      case INVALID_ARGUMENT:
+        return INVALID_ARGUMENT;
+      case NOT_FOUND:
+        return NOT_FOUND;
+      case OUT_OF_RANGE:
+        return OUT_OF_RANGE;
+      case PERMISSION_DENIED:
+        return PERMISSION_DENIED;
+      case RESOURCE_EXHAUSTED:
+        return RESOURCE_EXHAUSTED;
+      case UNAUTHENTICATED:
+        return UNAUTHENTICATED;
+      case UNAVAILABLE:
+        return UNAVAILABLE;
+      case UNIMPLEMENTED:
+        return UNIMPLEMENTED;
+      default:
+        return UNKNOWN;
+    }
+  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -23,7 +23,6 @@ import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.DataMessageMarshallerProvider;
 import alluxio.grpc.GrpcChannel;
 import alluxio.grpc.GrpcChannelBuilder;
-import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.GrpcManagedChannelPool;
 import alluxio.grpc.DataMessageMarshaller;
 import alluxio.grpc.OpenLocalBlockRequest;
@@ -87,7 +86,7 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
       mRpcChannel = buildChannel(subject, address,
           GrpcManagedChannelPool.PoolingStrategy.DEFAULT, alluxioConf, workerGroup);
     } catch (StatusRuntimeException e) {
-      throw GrpcExceptionUtils.fromGrpcStatusException(e);
+      throw AlluxioStatusException.fromStatusRuntimeException(e);
     }
     mStreamingAsyncStub = BlockWorkerGrpc.newStub(mStreamingChannel);
     mRpcBlockingStub = BlockWorkerGrpc.newBlockingStub(mRpcChannel);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -16,7 +16,6 @@ import alluxio.exception.status.CanceledException;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.Status;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.resource.LockResource;
 
 import io.grpc.StatusRuntimeException;
@@ -216,7 +215,7 @@ public class GrpcBlockingStream<ReqT, ResT> {
   private AlluxioStatusException toAlluxioStatusException(Throwable t) {
     AlluxioStatusException ex;
     if (t instanceof StatusRuntimeException) {
-      ex = GrpcExceptionUtils.fromGrpcStatusException((StatusRuntimeException) t);
+      ex = AlluxioStatusException.fromStatusRuntimeException((StatusRuntimeException) t);
       if (ex.getStatus() == Status.CANCELED) {
         // Streams are canceled when server is shutdown. Convert it to UnavailableException for
         // client to retry.

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -30,7 +30,6 @@ import alluxio.retry.RetryUtils;
 import alluxio.security.LoginUser;
 import alluxio.grpc.GrpcChannel;
 import alluxio.util.SecurityUtils;
-import alluxio.grpc.GrpcExceptionUtils;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
@@ -348,7 +347,7 @@ public abstract class AbstractClient implements Client {
       try {
         return rpc.call();
       } catch (StatusRuntimeException e) {
-        AlluxioStatusException se = GrpcExceptionUtils.fromGrpcStatusException(e);
+        AlluxioStatusException se = AlluxioStatusException.fromStatusRuntimeException(e);
         if (se.getStatus() == Status.UNAVAILABLE
             || se.getStatus() == Status.CANCELED
             || se.getStatus() == Status.UNAUTHENTICATED) {

--- a/core/common/src/main/java/alluxio/grpc/GrpcExceptionUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcExceptionUtils.java
@@ -13,12 +13,7 @@ package alluxio.grpc;
 
 import alluxio.exception.status.AlluxioStatusException;
 
-import io.grpc.Metadata;
-import io.grpc.Status;
 import io.grpc.StatusException;
-import io.grpc.StatusRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -27,149 +22,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class GrpcExceptionUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(GrpcExceptionUtils.class);
-
-  private static final String sInnerCauseKeyName = "grpc-exception-cause-bin";
-  private static final Metadata.Key<byte[]> sInnerCauseKey =
-      Metadata.Key.of(sInnerCauseKeyName, Metadata.BINARY_BYTE_MARSHALLER);
-
-  private GrpcExceptionUtils() {} // prevent instantiation
-
-  /**
-   * Convert from grpc exception to alluxio status exception.
-   *
-   * @param e the grpc exception
-   * @return the alluxio status exception
-   */
-  public static AlluxioStatusException fromGrpcStatusException(StatusRuntimeException e) {
-    alluxio.exception.status.Status alluxioStatus;
-    switch (Status.fromThrowable(e).getCode()) {
-      case ABORTED:
-        alluxioStatus = alluxio.exception.status.Status.ABORTED;
-        break;
-      case ALREADY_EXISTS:
-        alluxioStatus = alluxio.exception.status.Status.ALREADY_EXISTS;
-        break;
-      case CANCELLED:
-        alluxioStatus = alluxio.exception.status.Status.CANCELED;
-        break;
-      case DATA_LOSS:
-        alluxioStatus = alluxio.exception.status.Status.DATA_LOSS;
-        break;
-      case DEADLINE_EXCEEDED:
-        alluxioStatus = alluxio.exception.status.Status.DEADLINE_EXCEEDED;
-        break;
-      case FAILED_PRECONDITION:
-        alluxioStatus = alluxio.exception.status.Status.FAILED_PRECONDITION;
-        break;
-      case INTERNAL:
-        alluxioStatus = alluxio.exception.status.Status.INTERNAL;
-        break;
-      case INVALID_ARGUMENT:
-        alluxioStatus = alluxio.exception.status.Status.INVALID_ARGUMENT;
-        break;
-      case NOT_FOUND:
-        alluxioStatus = alluxio.exception.status.Status.NOT_FOUND;
-        break;
-      case OK:
-        alluxioStatus = alluxio.exception.status.Status.OK;
-        break;
-      case OUT_OF_RANGE:
-        alluxioStatus = alluxio.exception.status.Status.OUT_OF_RANGE;
-        break;
-      case PERMISSION_DENIED:
-        alluxioStatus = alluxio.exception.status.Status.PERMISSION_DENIED;
-        break;
-      case RESOURCE_EXHAUSTED:
-        alluxioStatus = alluxio.exception.status.Status.RESOURCE_EXHAUSTED;
-        break;
-      case UNAUTHENTICATED:
-        alluxioStatus = alluxio.exception.status.Status.UNAUTHENTICATED;
-        break;
-      case UNAVAILABLE:
-        alluxioStatus = alluxio.exception.status.Status.UNAVAILABLE;
-        break;
-      case UNIMPLEMENTED:
-        alluxioStatus = alluxio.exception.status.Status.UNIMPLEMENTED;
-        break;
-      case UNKNOWN:
-        alluxioStatus = alluxio.exception.status.Status.UNKNOWN;
-        break;
-      default:
-        alluxioStatus = alluxio.exception.status.Status.UNKNOWN;
-    }
-
-    return AlluxioStatusException.from(alluxioStatus, e.getStatus().getDescription());
-  }
-
-  /**
-   * Convert from alluxio status exception to grpc exception.
-   *
-   * @param e the alluxio status exception
-   * @return the grpc status exception
-   */
-  public static StatusException toGrpcStatusException(AlluxioStatusException e) {
-    Status.Code code;
-    switch (e.getStatus()) {
-      case ABORTED:
-        code = Status.Code.ABORTED;
-        break;
-      case ALREADY_EXISTS:
-        code = Status.Code.ALREADY_EXISTS;
-        break;
-      case CANCELED:
-        code = Status.Code.CANCELLED;
-        break;
-      case DATA_LOSS:
-        code = Status.Code.DATA_LOSS;
-        break;
-      case DEADLINE_EXCEEDED:
-        code = Status.Code.DEADLINE_EXCEEDED;
-        break;
-      case FAILED_PRECONDITION:
-        code = Status.Code.FAILED_PRECONDITION;
-        break;
-      case INTERNAL:
-        code = Status.Code.INTERNAL;
-        break;
-      case INVALID_ARGUMENT:
-        code = Status.Code.INVALID_ARGUMENT;
-        break;
-      case NOT_FOUND:
-        code = Status.Code.NOT_FOUND;
-        break;
-      case OK:
-        code = Status.Code.OK;
-        break;
-      case OUT_OF_RANGE:
-        code = Status.Code.OUT_OF_RANGE;
-        break;
-      case PERMISSION_DENIED:
-        code = Status.Code.PERMISSION_DENIED;
-        break;
-      case RESOURCE_EXHAUSTED:
-        code = Status.Code.RESOURCE_EXHAUSTED;
-        break;
-      case UNAUTHENTICATED:
-        code = Status.Code.UNAUTHENTICATED;
-        break;
-      case UNAVAILABLE:
-        code = Status.Code.UNAVAILABLE;
-        break;
-      case UNIMPLEMENTED:
-        code = Status.Code.UNIMPLEMENTED;
-        break;
-      case UNKNOWN:
-        code = Status.Code.UNKNOWN;
-        break;
-      default:
-        code = Status.Code.UNKNOWN;
-    }
-    Throwable cause = (e.getCause() != null) ? e.getCause() : e;
-
-    return Status.fromCode(code).withDescription(cause.getMessage()).asException();
-  }
-
   /**
    * Converts a throwable to a gRPC exception.
    *
@@ -177,6 +29,6 @@ public final class GrpcExceptionUtils {
    * @return gRPC exception
    */
   public static StatusException fromThrowable(Throwable e) {
-    return toGrpcStatusException(AlluxioStatusException.fromThrowable(e));
+    return AlluxioStatusException.fromThrowable(e).toGrpcStatusException();
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -15,7 +15,6 @@ import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.exception.status.UnknownException;
-import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.SaslMessage;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -25,10 +24,11 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.sasl.SaslException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import javax.security.sasl.SaslException;
 
 /**
  * Responsible for driving sasl traffic from client-side. Acts as a client's Sasl stream.
@@ -119,7 +119,7 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
         if (sre.getStatus().getCode() == Status.Code.UNIMPLEMENTED) {
           throw new UnauthenticatedException("Authentication is disabled on target host.");
         }
-        throw GrpcExceptionUtils.fromGrpcStatusException((StatusRuntimeException) cause);
+        throw AlluxioStatusException.fromStatusRuntimeException((StatusRuntimeException) cause);
       }
       throw new UnknownException(cause.getMessage(), cause);
     } catch (TimeoutException e) {

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
@@ -13,16 +13,16 @@ package alluxio.security.authentication;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.UnauthenticatedException;
-import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.SaslMessage;
 
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-import java.util.UUID;
 
 /**
  * Responsible for driving sasl traffic from server-side. Acts as a server's Sasl stream.
@@ -88,11 +88,9 @@ public class SaslStreamServerDriver implements StreamObserver<SaslMessage> {
       // Respond to client.
       mRequestObserver.onNext(mSaslHandshakeServerHandler.handleSaslMessage(saslMessage));
     } catch (SaslException se) {
-      mRequestObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(new UnauthenticatedException(se)));
+      mRequestObserver.onError(new UnauthenticatedException(se).toGrpcStatusException());
     } catch (UnauthenticatedException ue) {
-      mRequestObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(ue));
+      mRequestObserver.onError(ue.toGrpcStatusException());
     }
   }
 

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -28,10 +28,9 @@ import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.grpc.GrpcChannel;
 import alluxio.grpc.GrpcChannelBuilder;
-import alluxio.grpc.GrpcExceptionUtils;
+import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.MetaMasterConfigurationServiceGrpc;
 import alluxio.grpc.Scope;
-import alluxio.grpc.GrpcUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
@@ -408,7 +407,7 @@ public final class ConfigurationUtils {
           client.getConfiguration(GetConfigurationPOptions.newBuilder().setRawValue(true).build())
               .getConfigsList();
     } catch (io.grpc.StatusRuntimeException e) {
-      AlluxioStatusException ase = GrpcExceptionUtils.fromGrpcStatusException(e);
+      AlluxioStatusException ase = AlluxioStatusException.fromStatusRuntimeException(e);
       LOG.warn("Failed to handshake with master {} : {}", address, ase.getMessage());
       throw new UnavailableException(String.format(
           "Failed to handshake with master %s to load cluster default configuration values",

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -17,6 +17,7 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -56,6 +57,17 @@ public class TestLoggerRule extends AbstractResourceRule {
    */
   public int logCount(String pattern) {
     return mAppender.logCount(Pattern.compile(".*" + pattern + ".*"));
+  }
+
+  /**
+   * Writes all log messages to the given stream, useful for debugging.
+   *
+   * @param stream the stream to write to
+   */
+  public void dumpLogs(PrintStream stream) {
+    for (LoggingEvent event : mAppender.mEvents) {
+      stream.println(event.getRenderedMessage());
+    }
   }
 
   public class TestAppender extends AppenderSkeleton {

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -18,7 +18,6 @@ import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.grpc.GrpcExceptionUtils;
 
 import com.codahale.metrics.Timer;
 import io.grpc.stub.StreamObserver;
@@ -55,10 +54,10 @@ public final class RpcUtils {
       responseObserver.onNext(ret);
       responseObserver.onCompleted();
     } catch (AlluxioException e) {
-      responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromAlluxioException(e)));
+      responseObserver
+          .onError(AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException());
     } catch (RuntimeException e) {
-      responseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(new InternalException(e)));
+      responseObserver.onError(new InternalException(e).toGrpcStatusException());
     }
   }
 
@@ -116,11 +115,11 @@ public final class RpcUtils {
         }
       }
       responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromAlluxioException(e)));
+          AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException());
     } catch (RuntimeException e) {
       logger.error("Exit (Error): {}: {}", methodName, String.format(description, args), e);
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
-      responseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(new InternalException(e)));
+      responseObserver.onError(new InternalException(e).toGrpcStatusException());
     }
   }
 
@@ -139,13 +138,12 @@ public final class RpcUtils {
       responseObserver.onNext(ret);
       responseObserver.onCompleted();
     } catch (AlluxioException e) {
-      responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromAlluxioException(e)));
+      responseObserver
+          .onError(AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException());
     } catch (IOException e) {
-      responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromIOException(e)));
+      responseObserver.onError(AlluxioStatusException.fromIOException(e).toGrpcStatusException());
     } catch (RuntimeException e) {
-      responseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(new InternalException(e)));
+      responseObserver.onError((new InternalException(e).toGrpcStatusException()));
     }
   }
 
@@ -203,8 +201,8 @@ public final class RpcUtils {
               String.format(description, args), e);
         }
       }
-      responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromAlluxioException(e)));
+      responseObserver
+          .onError(AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException());
     } catch (IOException e) {
       logger.debug("Exit (Error): {}: {}", methodName, debugDesc, e);
       if (!failureOk) {
@@ -214,12 +212,11 @@ public final class RpcUtils {
               String.format(description, args), e);
         }
       }
-      responseObserver.onError(
-          GrpcExceptionUtils.toGrpcStatusException(AlluxioStatusException.fromIOException(e)));
+      responseObserver.onError(AlluxioStatusException.fromIOException(e).toGrpcStatusException());
     } catch (RuntimeException e) {
       logger.error("Exit (Error): {}: {}", methodName, String.format(description, args), e);
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
-      responseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(new InternalException(e)));
+      responseObserver.onError(new InternalException(e).toGrpcStatusException());
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
@@ -11,13 +11,12 @@
 
 package alluxio.worker.grpc;
 
-import alluxio.grpc.DataMessage;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.Chunk;
-import alluxio.grpc.GrpcExceptionUtils;
+import alluxio.grpc.DataMessage;
 import alluxio.grpc.ReadResponse;
 import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.resource.LockResource;
@@ -111,8 +110,8 @@ abstract class AbstractReadHandler<T extends ReadRequestContext<?>>
       mDataReaderExecutor.submit(createDataReader(mContext, mResponseObserver));
       mContext.setDataReaderActive(true);
     } catch (Exception e) {
-      mSerializingExecutor.execute(() ->
-          mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(e)));
+      mSerializingExecutor.execute(() -> mResponseObserver
+          .onError(AlluxioStatusException.fromCheckedException(e).toGrpcStatusException()));
     }
   }
 
@@ -389,7 +388,7 @@ abstract class AbstractReadHandler<T extends ReadRequestContext<?>>
     private void replyError(Error error) {
       mSerializingExecutor.execute(() -> {
         try {
-          mResponse.onError(GrpcExceptionUtils.toGrpcStatusException(error.getCause()));
+          mResponse.onError(error.getCause().toGrpcStatusException());
         } catch (StatusRuntimeException e) {
           // Ignores the error when client already closed the stream.
           if (e.getStatus().getCode() != Status.Code.CANCELLED) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
@@ -14,17 +14,15 @@ package alluxio.worker.grpc;
 import alluxio.client.block.stream.GrpcDataWriter;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InvalidArgumentException;
-import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteRequestCommand;
 import alluxio.grpc.WriteResponse;
 
-import com.google.protobuf.ByteString;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-
+import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -288,7 +286,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>> {
   private void replyError() {
     Error error = Preconditions.checkNotNull(mContext.getError());
     if (error.isNotifyClient()) {
-      mResponseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(error.getCause()));
+      mResponseObserver.onError(error.getCause().toGrpcStatusException());
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
@@ -63,8 +63,8 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
   }
 
   /**
-   * Handles request to create local block. No exceptions should be
-   * thrown.
+   * Handles request to create local block. No exceptions should be thrown.
+   *
    * @param request a create request
    */
   @Override
@@ -74,8 +74,7 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
       @Override
       public CreateLocalBlockResponse call() throws Exception {
         if (request.getOnlyReserveSpace()) {
-          mBlockWorker
-              .requestSpace(mSessionId, request.getBlockId(), request.getSpaceToReserve());
+          mBlockWorker.requestSpace(mSessionId, request.getBlockId(), request.getSpaceToReserve());
           return CreateLocalBlockResponse.newBuilder().build();
         } else {
           Preconditions.checkState(mRequest == null);
@@ -110,8 +109,7 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
         }
         mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(throwable));
       }
-    }, methodName, true, false, "Session=%d, Request=%s",
-        mResponseObserver, mSessionId, request);
+    }, methodName, true, false, "Session=%d, Request=%s", mResponseObserver, mSessionId, request);
   }
 
   @Override
@@ -150,32 +148,32 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
   public void handleBlockCompleteRequest(boolean isCanceled) {
     final String methodName = isCanceled ? "AbortBlock" : "CommitBlock";
     RpcUtils.streamingRPCAndLog(LOG, new RpcUtils.StreamingRpcCallable<CreateLocalBlockResponse>() {
-        @Override
-        public CreateLocalBlockResponse call() throws Exception {
-          if (mRequest == null) {
-            return null;
-          }
-          Context newContext = Context.current().fork();
-          Context previousContext = newContext.attach();
-          try {
-            if (isCanceled) {
-              mBlockWorker.abortBlock(mSessionId, mRequest.getBlockId());
-            } else {
-              mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId());
-            }
-          } finally {
-            newContext.detach(previousContext);
-          }
-          mSessionId = INVALID_SESSION_ID;
+      @Override
+      public CreateLocalBlockResponse call() throws Exception {
+        if (mRequest == null) {
           return null;
         }
+        Context newContext = Context.current().fork();
+        Context previousContext = newContext.attach();
+        try {
+          if (isCanceled) {
+            mBlockWorker.abortBlock(mSessionId, mRequest.getBlockId());
+          } else {
+            mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId());
+          }
+        } finally {
+          newContext.detach(previousContext);
+        }
+        mSessionId = INVALID_SESSION_ID;
+        return null;
+      }
 
-        @Override
+      @Override
       public void exceptionCaught(Throwable throwable) {
         mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(throwable));
-          mSessionId = INVALID_SESSION_ID;
-        }
-      }, methodName, false, !isCanceled, "Session=%d, Request=%s",
-        mResponseObserver, mSessionId, mRequest);
+        mSessionId = INVALID_SESSION_ID;
+      }
+    }, methodName, false, !isCanceled, "Session=%d, Request=%s", mResponseObserver, mSessionId,
+        mRequest);
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
@@ -16,7 +16,6 @@ import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
-import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.GrpcExceptionUtils;
@@ -103,8 +102,7 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
           // In case the client is a UfsFallbackDataWriter, DO NOT clean the temp blocks.
           if (throwable instanceof alluxio.exception.WorkerOutOfSpaceException
               && request.hasCleanupOnFailure() && !request.getCleanupOnFailure()) {
-            mResponseObserver.onError(GrpcExceptionUtils.toGrpcStatusException(
-                AlluxioStatusException.fromThrowable(throwable)));
+            mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(throwable));
             return;
           }
           mBlockWorker.cleanupSession(mSessionId);
@@ -173,8 +171,8 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
         }
 
         @Override
-        public void exceptionCaught(Throwable throwable) {
-          mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(throwable));
+      public void exceptionCaught(Throwable throwable) {
+        mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(throwable));
           mSessionId = INVALID_SESSION_ID;
         }
       }, methodName, false, !isCanceled, "Session=%d, Request=%s",

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -11,17 +11,19 @@
 
 package alluxio.client.cli.fs.command;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
-import alluxio.conf.PropertyKey;
 import alluxio.SystemPropertyRule;
 import alluxio.client.WriteType;
-import alluxio.client.file.FileInStream;
-import alluxio.client.file.URIStatus;
-import alluxio.conf.ServerConfiguration;
-import alluxio.exception.AlluxioException;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -29,7 +31,6 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.io.BufferUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -194,7 +195,8 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
     // Write the second file to the same location, which should cause an exception
     String[] cmd2 = {"copyFromLocal", testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, mFsShell.run(cmd2));
-    Assert.assertEquals(alluxioFilePath.getPath() + " already exists\n", mOutput.toString());
+    Assert.assertThat(mOutput.toString(),
+        containsString(alluxioFilePath.getPath() + " already exists\n"));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));
@@ -212,7 +214,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
         BufferUtils.getIncreasingByteArray(10, 20));
 
     mFsShell.run("copyFromLocal", testFile.getParent(), "/testDir");
-    Assert.assertThat(mOutput.toString(), CoreMatchers.containsString(
+    Assert.assertThat(mOutput.toString(), containsString(
         getCommandOutput(new String[]{"copyFromLocal", testFile.getParent(), "/testDir"})));
     AlluxioURI uri1 = new AlluxioURI("/testDir/testFile");
     AlluxioURI uri2 = new AlluxioURI("/testDir/testDirInner/testFile2");
@@ -240,7 +242,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
       mOutput.reset();
       mFsShell.run("copyFromLocal", file.getAbsolutePath(), "/");
     }
-    Assert.assertThat(mOutput.toString(), CoreMatchers.containsString("already exists"));
+    Assert.assertThat(mOutput.toString(), containsString("already exists"));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -11,12 +11,14 @@
 
 package alluxio.client.cli.fs.command;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 import alluxio.AlluxioURI;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
-import alluxio.client.cli.fs.AbstractFileSystemShellTest;
-import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.WritePType;
@@ -24,7 +26,6 @@ import alluxio.util.io.BufferUtils;
 
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -316,7 +317,8 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     // Write the second file to the same location, which should cause an exception
     String[] cmd2 = {"cp", "file://" +  testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, mFsShell.run(cmd2));
-    Assert.assertEquals(alluxioFilePath.getPath() + " already exists\n", mOutput.toString());
+    Assert.assertThat(mOutput.toString(),
+        containsString(alluxioFilePath.getPath() + " already exists"));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));
@@ -334,7 +336,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
         BufferUtils.getIncreasingByteArray(10, 20));
     String[] cmd = new String[]{"cp", "file://" + testFile.getParent(), "/testDir"};
     mFsShell.run(cmd);
-    Assert.assertThat(mOutput.toString(), CoreMatchers.containsString(getCommandOutput(cmd)));
+    Assert.assertThat(mOutput.toString(), containsString(getCommandOutput(cmd)));
     AlluxioURI uri1 = new AlluxioURI("/testDir/testFile");
     AlluxioURI uri2 = new AlluxioURI("/testDir/testDirInner/testFile2");
     URIStatus status1 = mFileSystem.getStatus(uri1);

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.cli.fsadmin.command;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 import alluxio.AlluxioURI;
 import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
 import alluxio.client.file.FileSystem;
@@ -20,7 +22,6 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.WritePType;
 import alluxio.master.block.BlockId;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ public final class GetBlockInfoCommandIntegrationTest extends AbstractFsAdminShe
     String invalidId = "invalidId";
     int ret = mFsAdminShell.run("getBlockInfo", invalidId);
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(invalidId + " is not a valid block id.\n", mOutput.toString());
+    Assert.assertThat(mOutput.toString(), containsString(invalidId + " is not a valid block id."));
   }
 
   @Test
@@ -43,8 +44,8 @@ public final class GetBlockInfoCommandIntegrationTest extends AbstractFsAdminShe
     long invalidId = 1421312312L;
     int ret = mFsAdminShell.run("getBlockInfo", String.valueOf(invalidId));
     Assert.assertEquals(-1, ret);
-    Assert.assertEquals(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(invalidId) + "\n",
-        mOutput.toString());
+    Assert.assertThat(mOutput.toString(),
+        containsString(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(invalidId)));
   }
 
   @Test
@@ -58,9 +59,9 @@ public final class GetBlockInfoCommandIntegrationTest extends AbstractFsAdminShe
     Assert.assertEquals(0, ret);
     String output = mOutput.toString();
 
-    Assert.assertThat(output, CoreMatchers.containsString(
+    Assert.assertThat(output, containsString(
         "BlockInfo{id=" + blockId + ", length=10, locations=[BlockLocation{workerId="));
-    Assert.assertThat(output, CoreMatchers.containsString(
+    Assert.assertThat(output, containsString(
         "This block belongs to file {id=" + BlockId.getFileId(blockId) + ", path=/foo/foobar1}"));
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
@@ -11,11 +11,13 @@
 
 package alluxio.client.fs;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
@@ -94,8 +96,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.createFile(uri, writeBoth).close();
       Assert.fail("createFile should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH)));
     }
 
     uri = new AlluxioURI(SUB_FILE_PATH + "_create");
@@ -103,8 +105,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.createFile(uri, writeBoth).close();
       Assert.fail("createFile should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH)));
     }
   }
 
@@ -115,8 +117,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.createDirectory(uri);
       Assert.fail("createDirectory should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH)));
     }
 
     uri = new AlluxioURI(PathUtils.concatPath(SUB_DIR_PATH, "create"));
@@ -124,8 +126,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.createDirectory(uri);
       Assert.fail("createDirectory should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH)));
     }
   }
 
@@ -137,8 +139,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.delete(fileUri);
       Assert.fail("deleteFile should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(fileUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(fileUri, MOUNT_PATH)));
     }
     Assert.assertTrue(mFileSystem.exists(fileUri));
     Assert.assertNotNull(mFileSystem.getStatus(fileUri));
@@ -149,8 +151,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.delete(fileUri);
       Assert.fail("deleteFile should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(fileUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(fileUri, MOUNT_PATH)));
     }
     Assert.assertTrue(mFileSystem.exists(fileUri));
     Assert.assertNotNull(mFileSystem.getStatus(fileUri));
@@ -175,8 +177,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH)));
     }
 
     srcUri = new AlluxioURI(SUB_FILE_PATH);
@@ -185,8 +187,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH)));
     }
   }
 
@@ -198,8 +200,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(dstUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(dstUri, MOUNT_PATH)));
     }
 
     dstUri = new AlluxioURI(SUB_FILE_PATH + "_renamed");
@@ -207,8 +209,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(dstUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(dstUri, MOUNT_PATH)));
     }
   }
 
@@ -220,8 +222,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH)));
     }
 
     srcUri = new AlluxioURI(SUB_FILE_PATH);
@@ -229,8 +231,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("rename should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH)));
     }
   }
 
@@ -242,8 +244,8 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
       mFileSystem.rename(srcUri, dstUri);
       Assert.fail("renameDirectory should not succeed under a readonly mount.");
     } catch (AccessControlException e) {
-      Assert.assertEquals(e.getMessage(),
-          ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH));
+      Assert.assertThat(e.getMessage(),
+          containsString(ExceptionMessage.MOUNT_READONLY.getMessage(srcUri, MOUNT_PATH)));
     }
   }
 


### PR DESCRIPTION
This PR moves conversion to/from grpc statuses and status exceptions into `AlluxioStatusException` and `alluxio.exception.status.Status`. This improves discoverability, and centralizes our exception conversion logic in one place.