### PR TITLE
Fix reauthentication without the overhead of extra health check

### DIFF
--- a/alluxio-ui/pom.xml
+++ b/alluxio-ui/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-ui</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0-preview-RC1</version>
   <packaging>pom</packaging>
   <name>Alluxio UI</name>
   <description>Alluxio web UI pom</description>

--- a/assembly/client/pom.xml
+++ b/assembly/client/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-assembly</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-assembly-client</artifactId>
   <packaging>jar</packaging>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-assembly</artifactId>
   <packaging>pom</packaging>

--- a/assembly/server/pom.xml
+++ b/assembly/server/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-assembly</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-assembly-server</artifactId>
   <packaging>jar</packaging>

--- a/core/base/pom.xml
+++ b/core/base/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-base</artifactId>
   <packaging>jar</packaging>

--- a/core/client/fs/pom.xml
+++ b/core/client/fs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core-client</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-client-fs</artifactId>
   <packaging>jar</packaging>

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -17,7 +17,6 @@ import alluxio.grpc.AsyncCacheResponse;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.BlockWorkerGrpc;
-import alluxio.grpc.CheckRequest;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.DataMessageMarshallerProvider;
@@ -103,13 +102,6 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
 
   @Override
   public boolean isHealthy() {
-    try {
-      mRpcBlockingStub.withDeadlineAfter(mDataTimeoutMs, TimeUnit.MILLISECONDS)
-          .check(CheckRequest.getDefaultInstance());
-    } catch (Exception e) {
-      LOG.warn("Block worker check failed for {}", mAddress, e);
-      return false;
-    }
     return !isShutdown() && mStreamingChannel.isHealthy() && mRpcChannel.isHealthy();
   }
 

--- a/core/client/hdfs/pom.xml
+++ b/core/client/hdfs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core-client</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-client-hdfs</artifactId>
   <packaging>jar</packaging>

--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-client</artifactId>
   <packaging>pom</packaging>

--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core-client</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-client-runtime</artifactId>
   <packaging>jar</packaging>

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-common</artifactId>
   <packaging>jar</packaging>

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -11,6 +11,8 @@
 
 package alluxio.grpc;
 
+import alluxio.security.authentication.AuthenticatedChannel;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -73,7 +75,7 @@ public final class GrpcChannel extends Channel {
   /**
    * @return {@code true} if the channel has been shut down
    */
-  public boolean isShutdown(){
+  public boolean isShutdown() {
     return mChannelReleased;
   }
 
@@ -81,6 +83,10 @@ public final class GrpcChannel extends Channel {
    * @return {@code true} if channel is healthy
    */
   public boolean isHealthy() {
+    if (mChannel instanceof AuthenticatedChannel
+        && !((AuthenticatedChannel) mChannel).isAuthenticated()) {
+      return false;
+    }
     return mChannelHealthy;
   }
 

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
@@ -1,0 +1,22 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authentication;
+
+/**
+ * A gRPC channel with authentication state.
+ */
+public interface AuthenticatedChannel {
+  /**
+   * @return whether the channel is authenticated
+   */
+  boolean isAuthenticated();
+}

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -21,10 +21,14 @@ import alluxio.grpc.SaslMessage;
 import alluxio.util.SecurityUtils;
 import alluxio.grpc.GrpcChannelBuilder;
 
+import io.grpc.CallOptions;
 import io.grpc.Channel;
+import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -116,46 +120,10 @@ public class ChannelAuthenticator {
       return managedChannel;
     }
 
-    try {
-      // Create a channel for talking with target host's authentication service.
-      // Create SaslClient for authentication based on provided credentials.
-      SaslClient saslClient;
-      if (mUseSubject) {
-        saslClient = SaslParticipantProvider.Factory.create(mAuthType)
-            .createSaslClient(mParentSubject, conf);
-      } else {
-        saslClient = SaslParticipantProvider.Factory.create(mAuthType).createSaslClient(mUserName,
-            mPassword, mImpersonationUser);
-      }
-
-      // Create authentication scheme specific handshake handler.
-      SaslHandshakeClientHandler handshakeClient =
-          SaslHandshakeClientHandler.Factory.create(mAuthType, saslClient);
-      // Create driver for driving sasl traffic from client side.
-      SaslStreamClientDriver clientDriver =
-          new SaslStreamClientDriver(handshakeClient, mGrpcAuthTimeoutMs);
-      // Start authentication call with the service and update the client driver.
-      StreamObserver<SaslMessage> requestObserver =
-          SaslAuthenticationServiceGrpc.newStub(managedChannel).authenticate(clientDriver);
-      clientDriver.setServerObserver(requestObserver);
-      // Start authentication traffic with the target.
-      clientDriver.start(mChannelId.toString());
-      // Authentication succeeded!
-      // Attach scheme specific interceptors to the channel.
-
-      Channel authenticatedChannel =
-          ClientInterceptors.intercept(managedChannel, getInterceptors(saslClient));
-      return authenticatedChannel;
-    } catch (Exception exc) {
-      String message = String.format(
-          "Channel authentication failed. ChannelId: %s, AuthType: %s, Target: %s, Error: %s",
-          mChannelId, mAuthType, managedChannel.authority(), exc.toString());
-      if (exc instanceof AlluxioStatusException) {
-        throw AlluxioStatusException.from(((AlluxioStatusException) exc).getStatus(), message, exc);
-      } else {
-        throw new UnknownException(message, exc);
-      }
-    }
+    AuthenticatedManagedChannel authenticatedChannel =
+        new AuthenticatedManagedChannel(managedChannel, conf);
+    authenticatedChannel.authenticate();
+    return authenticatedChannel;
   }
 
   /**
@@ -180,5 +148,78 @@ public class ChannelAuthenticator {
             String.format("Authentication type:%s not supported", mAuthType.name()));
     }
     return interceptorsList;
+  }
+
+  private class AuthenticatedManagedChannel extends Channel implements AuthenticatedChannel {
+    private final ManagedChannel mManagedChannel;
+    private final AlluxioConfiguration mConf;
+    private Channel mChannel;
+    private boolean mAuthenticated;
+
+    AuthenticatedManagedChannel(ManagedChannel managedChannel, AlluxioConfiguration conf) {
+      mManagedChannel = managedChannel;
+      mConf = conf;
+    }
+
+    void authenticate() throws AlluxioStatusException {
+      try {
+        // Create a channel for talking with target host's authentication service.
+        // Create SaslClient for authentication based on provided credentials.
+        SaslClient saslClient;
+        if (mUseSubject) {
+          saslClient = SaslParticipantProvider.Factory.create(mAuthType)
+              .createSaslClient(mParentSubject, mConf);
+        } else {
+          saslClient = SaslParticipantProvider.Factory.create(mAuthType).createSaslClient(mUserName,
+              mPassword, mImpersonationUser);
+        }
+
+        // Create authentication scheme specific handshake handler.
+        SaslHandshakeClientHandler handshakeClient =
+            SaslHandshakeClientHandler.Factory.create(mAuthType, saslClient);
+        // Create driver for driving sasl traffic from client side.
+        SaslStreamClientDriver clientDriver =
+            new SaslStreamClientDriver(handshakeClient, mGrpcAuthTimeoutMs);
+        // Start authentication call with the service and update the client driver.
+        StreamObserver<SaslMessage> requestObserver =
+            SaslAuthenticationServiceGrpc.newStub(mManagedChannel).authenticate(clientDriver);
+        clientDriver.setServerObserver(requestObserver);
+        // Start authentication traffic with the target.
+        clientDriver.start(mChannelId.toString());
+        // Authentication succeeded!
+        mAuthenticated = true;
+        mManagedChannel.notifyWhenStateChanged(ConnectivityState.READY, () -> {
+          mAuthenticated = false;
+        });
+        // Attach scheme specific interceptors to the channel.
+        mChannel = ClientInterceptors.intercept(mManagedChannel, getInterceptors(saslClient));
+      } catch (Exception exc) {
+        String message = String.format(
+            "Channel authentication failed. ChannelId: %s, AuthType: %s, Target: %s, Error: %s",
+            mChannelId, mAuthType, mManagedChannel.authority(), exc.toString());
+        if (exc instanceof AlluxioStatusException) {
+          throw AlluxioStatusException.from(((AlluxioStatusException) exc).getStatus(), message,
+              exc);
+        } else {
+          throw new UnknownException(message, exc);
+        }
+      }
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+        MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+      return mChannel.newCall(methodDescriptor, callOptions);
+    }
+
+    @Override
+    public String authority() {
+      return mChannel.authority();
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+      return mAuthenticated;
+    }
   }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core</artifactId>
   <packaging>pom</packaging>

--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-server-common</artifactId>
   <packaging>jar</packaging>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-server-master</artifactId>
   <packaging>jar</packaging>

--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-server</artifactId>
   <packaging>pom</packaging>

--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-server-proxy</artifactId>
   <packaging>jar</packaging>

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-server-worker</artifactId>
   <packaging>jar</packaging>

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -18,8 +18,6 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.grpc.BlockWorkerGrpc;
-import alluxio.grpc.CheckRequest;
-import alluxio.grpc.CheckResponse;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.OpenLocalBlockRequest;
@@ -144,11 +142,5 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
       mWorkerProcess.getWorker(BlockWorker.class).removeBlock(sessionId, request.getBlockId());
       return RemoveBlockResponse.getDefaultInstance();
     }, "removeBlock", "request=%s", responseObserver, request);
-  }
-
-  @Override
-  public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
-    responseObserver.onNext(CheckResponse.getDefaultInstance());
-    responseObserver.onCompleted();
   }
 }

--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-core</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-core-transport</artifactId>
   <packaging>jar</packaging>

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -21,8 +21,6 @@ service BlockWorker {
 
   rpc AsyncCache (AsyncCacheRequest) returns (AsyncCacheResponse);
   rpc RemoveBlock (RemoveBlockRequest) returns (RemoveBlockResponse);
-
-  rpc Check(CheckRequest) returns (CheckResponse);
 }
 
 // The check request

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerGrpc.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerGrpc.java
@@ -222,38 +222,6 @@ public final class BlockWorkerGrpc {
      return getRemoveBlockMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest,
-      alluxio.grpc.CheckResponse> getCheckMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "Check",
-      requestType = alluxio.grpc.CheckRequest.class,
-      responseType = alluxio.grpc.CheckResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest,
-      alluxio.grpc.CheckResponse> getCheckMethod() {
-    io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest, alluxio.grpc.CheckResponse> getCheckMethod;
-    if ((getCheckMethod = BlockWorkerGrpc.getCheckMethod) == null) {
-      synchronized (BlockWorkerGrpc.class) {
-        if ((getCheckMethod = BlockWorkerGrpc.getCheckMethod) == null) {
-          BlockWorkerGrpc.getCheckMethod = getCheckMethod = 
-              io.grpc.MethodDescriptor.<alluxio.grpc.CheckRequest, alluxio.grpc.CheckResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(
-                  "alluxio.grpc.block.BlockWorker", "Check"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  alluxio.grpc.CheckRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  alluxio.grpc.CheckResponse.getDefaultInstance()))
-                  .setSchemaDescriptor(new BlockWorkerMethodDescriptorSupplier("Check"))
-                  .build();
-          }
-        }
-     }
-     return getCheckMethod;
-  }
-
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -332,13 +300,6 @@ public final class BlockWorkerGrpc {
       asyncUnimplementedUnaryCall(getRemoveBlockMethod(), responseObserver);
     }
 
-    /**
-     */
-    public void check(alluxio.grpc.CheckRequest request,
-        io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getCheckMethod(), responseObserver);
-    }
-
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -383,13 +344,6 @@ public final class BlockWorkerGrpc {
                 alluxio.grpc.RemoveBlockRequest,
                 alluxio.grpc.RemoveBlockResponse>(
                   this, METHODID_REMOVE_BLOCK)))
-          .addMethod(
-            getCheckMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                alluxio.grpc.CheckRequest,
-                alluxio.grpc.CheckResponse>(
-                  this, METHODID_CHECK)))
           .build();
     }
   }
@@ -468,14 +422,6 @@ public final class BlockWorkerGrpc {
       asyncUnaryCall(
           getChannel().newCall(getRemoveBlockMethod(), getCallOptions()), request, responseObserver);
     }
-
-    /**
-     */
-    public void check(alluxio.grpc.CheckRequest request,
-        io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse> responseObserver) {
-      asyncUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request, responseObserver);
-    }
   }
 
   /**
@@ -511,13 +457,6 @@ public final class BlockWorkerGrpc {
     public alluxio.grpc.RemoveBlockResponse removeBlock(alluxio.grpc.RemoveBlockRequest request) {
       return blockingUnaryCall(
           getChannel(), getRemoveBlockMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public alluxio.grpc.CheckResponse check(alluxio.grpc.CheckRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCheckMethod(), getCallOptions(), request);
     }
   }
 
@@ -557,23 +496,14 @@ public final class BlockWorkerGrpc {
       return futureUnaryCall(
           getChannel().newCall(getRemoveBlockMethod(), getCallOptions()), request);
     }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<alluxio.grpc.CheckResponse> check(
-        alluxio.grpc.CheckRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request);
-    }
   }
 
   private static final int METHODID_ASYNC_CACHE = 0;
   private static final int METHODID_REMOVE_BLOCK = 1;
-  private static final int METHODID_CHECK = 2;
-  private static final int METHODID_READ_BLOCK = 3;
-  private static final int METHODID_WRITE_BLOCK = 4;
-  private static final int METHODID_OPEN_LOCAL_BLOCK = 5;
-  private static final int METHODID_CREATE_LOCAL_BLOCK = 6;
+  private static final int METHODID_READ_BLOCK = 2;
+  private static final int METHODID_WRITE_BLOCK = 3;
+  private static final int METHODID_OPEN_LOCAL_BLOCK = 4;
+  private static final int METHODID_CREATE_LOCAL_BLOCK = 5;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -599,10 +529,6 @@ public final class BlockWorkerGrpc {
         case METHODID_REMOVE_BLOCK:
           serviceImpl.removeBlock((alluxio.grpc.RemoveBlockRequest) request,
               (io.grpc.stub.StreamObserver<alluxio.grpc.RemoveBlockResponse>) responseObserver);
-          break;
-        case METHODID_CHECK:
-          serviceImpl.check((alluxio.grpc.CheckRequest) request,
-              (io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -683,7 +609,6 @@ public final class BlockWorkerGrpc {
               .addMethod(getCreateLocalBlockMethod())
               .addMethod(getAsyncCacheMethod())
               .addMethod(getRemoveBlockMethod())
-              .addMethod(getCheckMethod())
               .build();
         }
       }

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -139,7 +139,7 @@ public final class BlockWorkerProto {
       "eBlockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023Remov" +
       "eBlockResponse*F\n\013RequestType\022\021\n\rALLUXIO" +
       "_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_B" +
-      "LOCK\020\0022\243\005\n\013BlockWorker\022R\n\tReadBlock\022\037.al" +
+      "LOCK\020\0022\325\004\n\013BlockWorker\022R\n\tReadBlock\022\037.al" +
       "luxio.grpc.block.ReadRequest\032 .alluxio.g" +
       "rpc.block.ReadResponse(\0010\001\022U\n\nWriteBlock" +
       "\022 .alluxio.grpc.block.WriteRequest\032!.all" +
@@ -154,9 +154,8 @@ public final class BlockWorkerProto {
       ".grpc.block.AsyncCacheResponse\022^\n\013Remove" +
       "Block\022&.alluxio.grpc.block.RemoveBlockRe" +
       "quest\032\'.alluxio.grpc.block.RemoveBlockRe" +
-      "sponse\022L\n\005Check\022 .alluxio.grpc.block.Che" +
-      "ckRequest\032!.alluxio.grpc.block.CheckResp" +
-      "onseB\"\n\014alluxio.grpcB\020BlockWorkerProtoP\001"
+      "sponseB\"\n\014alluxio.grpcB\020BlockWorkerProto" +
+      "P\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,15 +6,15 @@ kramdown:
 
 # For release candidates and release branches, this should match the pom.xml Alluxio version, e.g. "1.5.0" or "1.5.0-RC1"
 # For master branch, this should be the latest released version, e.g. "1.5.0"
-ALLUXIO_RELEASED_VERSION: 1.8.1
+ALLUXIO_RELEASED_VERSION: 2.0.0-preview-RC1
 # This should be the same as ALLUXIO_RELEASED_VERSION, except on master branch, where it should be "master"
-ALLUXIO_MASTER_VERSION_SHORT: master
+ALLUXIO_MASTER_VERSION_SHORT: 2.0.0-preview-RC1
 # For release candidates and release branches, this should be the major Alluxio version, e.g. both 1.5.0 and 1.5.0-RC1 should use "1.5"
 # For master branch, this should be "master"
-ALLUXIO_MAJOR_VERSION: master
+ALLUXIO_MAJOR_VERSION: 2.0
 # We must inline the version string (e.g., "1.4.0-SNAPSHOT") rather than using the macro of Alluxio version.
 # Otherwise the macro name remains in the output.
-ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/client/alluxio-2.0.0-SNAPSHOT-client.jar
+ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/client/alluxio-2.0.0-preview-RC1-client.jar
 
 # These attach the pages of different languages with different 'lang' attributes
 defaults:

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-examples</artifactId>
   <packaging>jar</packaging>

--- a/integration/checker/pom.xml
+++ b/integration/checker/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-integration</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-checker</artifactId>
   <name>Alluxio Integration - Checker</name>

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM openjdk:8-jdk-alpine
 
-ARG ALLUXIO_TARBALL=http://downloads.alluxio.org/downloads/files/1.8.1/alluxio-1.8.1-bin.tar.gz
+ARG ALLUXIO_TARBALL=http://downloads.alluxio.org/downloads/files/2.0.0-preview-RC1/alluxio-2.0.0-preview-RC1-bin.tar.gz
 
 RUN apk add --update bash && \
     rm -rf /var/cache/apk/*

--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-integration</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-integration-fuse</artifactId>
   <name>Alluxio Integration - FUSE</name>

--- a/integration/mesos/pom.xml
+++ b/integration/mesos/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>alluxio-integration</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <name>Alluxio Integration - Mesos</name>
   <artifactId>alluxio-integration-mesos</artifactId>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-integration</artifactId>
   <packaging>pom</packaging>

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>alluxio-integration</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <name>Alluxio Integration - YARN</name>
   <artifactId>alluxio-integration-yarn</artifactId>

--- a/job/client/pom.xml
+++ b/job/client/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>alluxio-job</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job-client</artifactId>

--- a/job/common/pom.xml
+++ b/job/common/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>alluxio-job</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job-common</artifactId>

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job</artifactId>

--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-job</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-job-server</artifactId>
   <packaging>jar</packaging>

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -27,7 +27,7 @@ this="${config_bin}/${script}"
 
 # This will set the default installation for a tarball installation while os distributors can
 # set system installation locations.
-VERSION=2.0.0-SNAPSHOT
+VERSION=2.0.0-preview-RC1
 ALLUXIO_HOME=$(dirname $(dirname "${this}"))
 ALLUXIO_ASSEMBLY_CLIENT_JAR="${ALLUXIO_HOME}/assembly/client/target/alluxio-assembly-client-${VERSION}-jar-with-dependencies.jar"
 ALLUXIO_ASSEMBLY_SERVER_JAR="${ALLUXIO_HOME}/assembly/server/target/alluxio-assembly-server-${VERSION}-jar-with-dependencies.jar"

--- a/logserver/pom.xml
+++ b/logserver/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>alluxio-parent</artifactId>
         <groupId>org.alluxio</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0-preview-RC1</version>
     </parent>
     <artifactId>alluxio-logserver</artifactId>
     <packaging>jar</packaging>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>alluxio-parent</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-parent</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0-preview-RC1</version>
   <packaging>pom</packaging>
   <name>Alluxio Parent</name>
   <description>Parent POM of Alluxio project: a Memory-Speed Virtual Distributed Storage System</description>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-shell</artifactId>
   <packaging>jar</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-tests</artifactId>
   <packaging>jar</packaging>

--- a/underfs/cos/pom.xml
+++ b/underfs/cos/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-cos</artifactId>
   <name>Alluxio Under File System - Tencent Cloud COS</name>

--- a/underfs/gcs/pom.xml
+++ b/underfs/gcs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-gcs</artifactId>
   <name>Alluxio Under File System - GCS</name>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-hdfs</artifactId>
   <name>Alluxio Under File System - HDFS</name>

--- a/underfs/kodo/pom.xml
+++ b/underfs/kodo/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>alluxio-underfs</artifactId>
         <groupId>org.alluxio</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0-preview-RC1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/underfs/local/pom.xml
+++ b/underfs/local/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-local</artifactId>
   <name>Alluxio Under File System - Local FS</name>

--- a/underfs/oss/pom.xml
+++ b/underfs/oss/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-oss</artifactId>
   <name>Alluxio Under File System - Aliyun OSS</name>

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs</artifactId>
   <packaging>pom</packaging>

--- a/underfs/s3a/pom.xml
+++ b/underfs/s3a/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-s3a</artifactId>
   <name>Alluxio Under File System - S3A</name>

--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-swift</artifactId>
   <name>Alluxio Under File System - Swift</name>

--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-underfs</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-preview-RC1</version>
   </parent>
   <artifactId>alluxio-underfs-wasb</artifactId>
   <name>Alluxio Under File System - Microsoft Azure Blob Storage</name>


### PR DESCRIPTION
In 2.0 RC1 we employed an extra health check for block worker client to make sure authentication kicks in if gRPC channel reconnects to a new worker. It introduced some overhead especially for small random reads. This change revert the previous fix and force reauthentication by informing the block worker client pool to drop the cached client when the client is disconnected.