### PR TITLE
Fix reauthentication without the overhead of extra health check

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -17,7 +17,6 @@ import alluxio.grpc.AsyncCacheResponse;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.BlockWorkerGrpc;
-import alluxio.grpc.CheckRequest;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.DataMessageMarshallerProvider;
@@ -103,13 +102,6 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
 
   @Override
   public boolean isHealthy() {
-    try {
-      mRpcBlockingStub.withDeadlineAfter(mDataTimeoutMs, TimeUnit.MILLISECONDS)
-          .check(CheckRequest.getDefaultInstance());
-    } catch (Exception e) {
-      LOG.warn("Block worker check failed for {}", mAddress, e);
-      return false;
-    }
     return !isShutdown() && mStreamingChannel.isHealthy() && mRpcChannel.isHealthy();
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -11,6 +11,8 @@
 
 package alluxio.grpc;
 
+import alluxio.security.authentication.AuthenticatedChannel;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -73,7 +75,7 @@ public final class GrpcChannel extends Channel {
   /**
    * @return {@code true} if the channel has been shut down
    */
-  public boolean isShutdown(){
+  public boolean isShutdown() {
     return mChannelReleased;
   }
 
@@ -81,6 +83,10 @@ public final class GrpcChannel extends Channel {
    * @return {@code true} if channel is healthy
    */
   public boolean isHealthy() {
+    if (mChannel instanceof AuthenticatedChannel
+        && !((AuthenticatedChannel) mChannel).isAuthenticated()) {
+      return false;
+    }
     return mChannelHealthy;
   }
 

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
@@ -1,0 +1,22 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.security.authentication;
+
+/**
+ * A gRPC channel with authentication state.
+ */
+public interface AuthenticatedChannel {
+  /**
+   * @return whether the channel is authenticated
+   */
+  boolean isAuthenticated();
+}

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -122,7 +122,6 @@ public class ChannelAuthenticator {
 
     AuthenticatedManagedChannel authenticatedChannel =
         new AuthenticatedManagedChannel(managedChannel, conf);
-    authenticatedChannel.authenticate();
     return authenticatedChannel;
   }
 
@@ -156,12 +155,14 @@ public class ChannelAuthenticator {
     private Channel mChannel;
     private boolean mAuthenticated;
 
-    AuthenticatedManagedChannel(ManagedChannel managedChannel, AlluxioConfiguration conf) {
+    AuthenticatedManagedChannel(ManagedChannel managedChannel, AlluxioConfiguration conf)
+        throws AlluxioStatusException {
       mManagedChannel = managedChannel;
       mConf = conf;
+      authenticate();
     }
 
-    void authenticate() throws AlluxioStatusException {
+    public void authenticate() throws AlluxioStatusException {
       try {
         // Create a channel for talking with target host's authentication service.
         // Create SaslClient for authentication based on provided credentials.

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -21,10 +21,14 @@ import alluxio.grpc.SaslMessage;
 import alluxio.util.SecurityUtils;
 import alluxio.grpc.GrpcChannelBuilder;
 
+import io.grpc.CallOptions;
 import io.grpc.Channel;
+import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -116,46 +120,10 @@ public class ChannelAuthenticator {
       return managedChannel;
     }
 
-    try {
-      // Create a channel for talking with target host's authentication service.
-      // Create SaslClient for authentication based on provided credentials.
-      SaslClient saslClient;
-      if (mUseSubject) {
-        saslClient = SaslParticipantProvider.Factory.create(mAuthType)
-            .createSaslClient(mParentSubject, conf);
-      } else {
-        saslClient = SaslParticipantProvider.Factory.create(mAuthType).createSaslClient(mUserName,
-            mPassword, mImpersonationUser);
-      }
-
-      // Create authentication scheme specific handshake handler.
-      SaslHandshakeClientHandler handshakeClient =
-          SaslHandshakeClientHandler.Factory.create(mAuthType, saslClient);
-      // Create driver for driving sasl traffic from client side.
-      SaslStreamClientDriver clientDriver =
-          new SaslStreamClientDriver(handshakeClient, mGrpcAuthTimeoutMs);
-      // Start authentication call with the service and update the client driver.
-      StreamObserver<SaslMessage> requestObserver =
-          SaslAuthenticationServiceGrpc.newStub(managedChannel).authenticate(clientDriver);
-      clientDriver.setServerObserver(requestObserver);
-      // Start authentication traffic with the target.
-      clientDriver.start(mChannelId.toString());
-      // Authentication succeeded!
-      // Attach scheme specific interceptors to the channel.
-
-      Channel authenticatedChannel =
-          ClientInterceptors.intercept(managedChannel, getInterceptors(saslClient));
-      return authenticatedChannel;
-    } catch (Exception exc) {
-      String message = String.format(
-          "Channel authentication failed. ChannelId: %s, AuthType: %s, Target: %s, Error: %s",
-          mChannelId, mAuthType, managedChannel.authority(), exc.toString());
-      if (exc instanceof AlluxioStatusException) {
-        throw AlluxioStatusException.from(((AlluxioStatusException) exc).getStatus(), message, exc);
-      } else {
-        throw new UnknownException(message, exc);
-      }
-    }
+    AuthenticatedManagedChannel authenticatedChannel =
+        new AuthenticatedManagedChannel(managedChannel, conf);
+    authenticatedChannel.authenticate();
+    return authenticatedChannel;
   }
 
   /**
@@ -180,5 +148,78 @@ public class ChannelAuthenticator {
             String.format("Authentication type:%s not supported", mAuthType.name()));
     }
     return interceptorsList;
+  }
+
+  private class AuthenticatedManagedChannel extends Channel implements AuthenticatedChannel {
+    private final ManagedChannel mManagedChannel;
+    private final AlluxioConfiguration mConf;
+    private Channel mChannel;
+    private boolean mAuthenticated;
+
+    AuthenticatedManagedChannel(ManagedChannel managedChannel, AlluxioConfiguration conf) {
+      mManagedChannel = managedChannel;
+      mConf = conf;
+    }
+
+    void authenticate() throws AlluxioStatusException {
+      try {
+        // Create a channel for talking with target host's authentication service.
+        // Create SaslClient for authentication based on provided credentials.
+        SaslClient saslClient;
+        if (mUseSubject) {
+          saslClient = SaslParticipantProvider.Factory.create(mAuthType)
+              .createSaslClient(mParentSubject, mConf);
+        } else {
+          saslClient = SaslParticipantProvider.Factory.create(mAuthType).createSaslClient(mUserName,
+              mPassword, mImpersonationUser);
+        }
+
+        // Create authentication scheme specific handshake handler.
+        SaslHandshakeClientHandler handshakeClient =
+            SaslHandshakeClientHandler.Factory.create(mAuthType, saslClient);
+        // Create driver for driving sasl traffic from client side.
+        SaslStreamClientDriver clientDriver =
+            new SaslStreamClientDriver(handshakeClient, mGrpcAuthTimeoutMs);
+        // Start authentication call with the service and update the client driver.
+        StreamObserver<SaslMessage> requestObserver =
+            SaslAuthenticationServiceGrpc.newStub(mManagedChannel).authenticate(clientDriver);
+        clientDriver.setServerObserver(requestObserver);
+        // Start authentication traffic with the target.
+        clientDriver.start(mChannelId.toString());
+        // Authentication succeeded!
+        mAuthenticated = true;
+        mManagedChannel.notifyWhenStateChanged(ConnectivityState.READY, () -> {
+          mAuthenticated = false;
+        });
+        // Attach scheme specific interceptors to the channel.
+        mChannel = ClientInterceptors.intercept(mManagedChannel, getInterceptors(saslClient));
+      } catch (Exception exc) {
+        String message = String.format(
+            "Channel authentication failed. ChannelId: %s, AuthType: %s, Target: %s, Error: %s",
+            mChannelId, mAuthType, mManagedChannel.authority(), exc.toString());
+        if (exc instanceof AlluxioStatusException) {
+          throw AlluxioStatusException.from(((AlluxioStatusException) exc).getStatus(), message,
+              exc);
+        } else {
+          throw new UnknownException(message, exc);
+        }
+      }
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+        MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+      return mChannel.newCall(methodDescriptor, callOptions);
+    }
+
+    @Override
+    public String authority() {
+      return mChannel.authority();
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+      return mAuthenticated;
+    }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -18,8 +18,6 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.grpc.BlockWorkerGrpc;
-import alluxio.grpc.CheckRequest;
-import alluxio.grpc.CheckResponse;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.OpenLocalBlockRequest;
@@ -144,11 +142,5 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
       mWorkerProcess.getWorker(BlockWorker.class).removeBlock(sessionId, request.getBlockId());
       return RemoveBlockResponse.getDefaultInstance();
     }, "removeBlock", "request=%s", responseObserver, request);
-  }
-
-  @Override
-  public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
-    responseObserver.onNext(CheckResponse.getDefaultInstance());
-    responseObserver.onCompleted();
   }
 }

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -21,8 +21,6 @@ service BlockWorker {
 
   rpc AsyncCache (AsyncCacheRequest) returns (AsyncCacheResponse);
   rpc RemoveBlock (RemoveBlockRequest) returns (RemoveBlockResponse);
-
-  rpc Check(CheckRequest) returns (CheckResponse);
 }
 
 // The check request

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerGrpc.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerGrpc.java
@@ -222,38 +222,6 @@ public final class BlockWorkerGrpc {
      return getRemoveBlockMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest,
-      alluxio.grpc.CheckResponse> getCheckMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "Check",
-      requestType = alluxio.grpc.CheckRequest.class,
-      responseType = alluxio.grpc.CheckResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest,
-      alluxio.grpc.CheckResponse> getCheckMethod() {
-    io.grpc.MethodDescriptor<alluxio.grpc.CheckRequest, alluxio.grpc.CheckResponse> getCheckMethod;
-    if ((getCheckMethod = BlockWorkerGrpc.getCheckMethod) == null) {
-      synchronized (BlockWorkerGrpc.class) {
-        if ((getCheckMethod = BlockWorkerGrpc.getCheckMethod) == null) {
-          BlockWorkerGrpc.getCheckMethod = getCheckMethod = 
-              io.grpc.MethodDescriptor.<alluxio.grpc.CheckRequest, alluxio.grpc.CheckResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(
-                  "alluxio.grpc.block.BlockWorker", "Check"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  alluxio.grpc.CheckRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  alluxio.grpc.CheckResponse.getDefaultInstance()))
-                  .setSchemaDescriptor(new BlockWorkerMethodDescriptorSupplier("Check"))
-                  .build();
-          }
-        }
-     }
-     return getCheckMethod;
-  }
-
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -332,13 +300,6 @@ public final class BlockWorkerGrpc {
       asyncUnimplementedUnaryCall(getRemoveBlockMethod(), responseObserver);
     }
 
-    /**
-     */
-    public void check(alluxio.grpc.CheckRequest request,
-        io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getCheckMethod(), responseObserver);
-    }
-
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -383,13 +344,6 @@ public final class BlockWorkerGrpc {
                 alluxio.grpc.RemoveBlockRequest,
                 alluxio.grpc.RemoveBlockResponse>(
                   this, METHODID_REMOVE_BLOCK)))
-          .addMethod(
-            getCheckMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                alluxio.grpc.CheckRequest,
-                alluxio.grpc.CheckResponse>(
-                  this, METHODID_CHECK)))
           .build();
     }
   }
@@ -468,14 +422,6 @@ public final class BlockWorkerGrpc {
       asyncUnaryCall(
           getChannel().newCall(getRemoveBlockMethod(), getCallOptions()), request, responseObserver);
     }
-
-    /**
-     */
-    public void check(alluxio.grpc.CheckRequest request,
-        io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse> responseObserver) {
-      asyncUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request, responseObserver);
-    }
   }
 
   /**
@@ -511,13 +457,6 @@ public final class BlockWorkerGrpc {
     public alluxio.grpc.RemoveBlockResponse removeBlock(alluxio.grpc.RemoveBlockRequest request) {
       return blockingUnaryCall(
           getChannel(), getRemoveBlockMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public alluxio.grpc.CheckResponse check(alluxio.grpc.CheckRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCheckMethod(), getCallOptions(), request);
     }
   }
 
@@ -557,23 +496,14 @@ public final class BlockWorkerGrpc {
       return futureUnaryCall(
           getChannel().newCall(getRemoveBlockMethod(), getCallOptions()), request);
     }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<alluxio.grpc.CheckResponse> check(
-        alluxio.grpc.CheckRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request);
-    }
   }
 
   private static final int METHODID_ASYNC_CACHE = 0;
   private static final int METHODID_REMOVE_BLOCK = 1;
-  private static final int METHODID_CHECK = 2;
-  private static final int METHODID_READ_BLOCK = 3;
-  private static final int METHODID_WRITE_BLOCK = 4;
-  private static final int METHODID_OPEN_LOCAL_BLOCK = 5;
-  private static final int METHODID_CREATE_LOCAL_BLOCK = 6;
+  private static final int METHODID_READ_BLOCK = 2;
+  private static final int METHODID_WRITE_BLOCK = 3;
+  private static final int METHODID_OPEN_LOCAL_BLOCK = 4;
+  private static final int METHODID_CREATE_LOCAL_BLOCK = 5;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -599,10 +529,6 @@ public final class BlockWorkerGrpc {
         case METHODID_REMOVE_BLOCK:
           serviceImpl.removeBlock((alluxio.grpc.RemoveBlockRequest) request,
               (io.grpc.stub.StreamObserver<alluxio.grpc.RemoveBlockResponse>) responseObserver);
-          break;
-        case METHODID_CHECK:
-          serviceImpl.check((alluxio.grpc.CheckRequest) request,
-              (io.grpc.stub.StreamObserver<alluxio.grpc.CheckResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -683,7 +609,6 @@ public final class BlockWorkerGrpc {
               .addMethod(getCreateLocalBlockMethod())
               .addMethod(getAsyncCacheMethod())
               .addMethod(getRemoveBlockMethod())
-              .addMethod(getCheckMethod())
               .build();
         }
       }

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -139,7 +139,7 @@ public final class BlockWorkerProto {
       "eBlockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023Remov" +
       "eBlockResponse*F\n\013RequestType\022\021\n\rALLUXIO" +
       "_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_B" +
-      "LOCK\020\0022\243\005\n\013BlockWorker\022R\n\tReadBlock\022\037.al" +
+      "LOCK\020\0022\325\004\n\013BlockWorker\022R\n\tReadBlock\022\037.al" +
       "luxio.grpc.block.ReadRequest\032 .alluxio.g" +
       "rpc.block.ReadResponse(\0010\001\022U\n\nWriteBlock" +
       "\022 .alluxio.grpc.block.WriteRequest\032!.all" +
@@ -154,9 +154,8 @@ public final class BlockWorkerProto {
       ".grpc.block.AsyncCacheResponse\022^\n\013Remove" +
       "Block\022&.alluxio.grpc.block.RemoveBlockRe" +
       "quest\032\'.alluxio.grpc.block.RemoveBlockRe" +
-      "sponse\022L\n\005Check\022 .alluxio.grpc.block.Che" +
-      "ckRequest\032!.alluxio.grpc.block.CheckResp" +
-      "onseB\"\n\014alluxio.grpcB\020BlockWorkerProtoP\001"
+      "sponseB\"\n\014alluxio.grpcB\020BlockWorkerProto" +
+      "P\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {


### PR DESCRIPTION
In 2.0 RC1 we employed an extra health check for block worker client to make sure authentication kicks in if gRPC channel reconnects to a new worker. It introduced some overhead especially for small random reads. This change revert the previous fix and force reauthentication by informing the block worker client pool to drop the cached client when the client is disconnected.