### PR TITLE
[CHERRY-PICK] [#8366] Move FileSystemUtils into FileSystem (#8369)

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -24,6 +24,7 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CompleteFilePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
 import alluxio.resource.CloseableResource;
@@ -297,7 +298,8 @@ public class FileOutStream extends AbstractOutStream {
   protected void scheduleAsyncPersist() throws IOException {
     try (CloseableResource<FileSystemMasterClient> masterClient = mContext
         .acquireMasterClientResource()) {
-      masterClient.get().scheduleAsyncPersist(mUri);
+      masterClient.get().scheduleAsyncPersist(mUri,
+          ScheduleAsyncPersistencePOptions.getDefaultInstance());
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -34,6 +34,7 @@ import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAclPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -498,6 +499,27 @@ public interface FileSystem extends Closeable {
    * @throws FileDoesNotExistException if the given file does not exist
    */
   FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
+  /**
+   * Convenience method for {@link #persist(AlluxioURI, ScheduleAsyncPersistencePOptions)} which
+   * uses the default {@link ScheduleAsyncPersistencePOptions}.
+   *
+   * @param path the uri of the file to persist
+   */
+  void persist(AlluxioURI path)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
+  /**
+   * Schedules the given path to be asynchronously persisted to the under file system.
+   *
+   * To persist synchronously please see
+   * {@link FileSystemUtils#persistAndWait(FileSystem, AlluxioURI)}.
+   *
+   * @param path the uri of the file to persist
+   * @param options the options to use when submitting persist the path
+   */
+  void persist(AlluxioURI path, ScheduleAsyncPersistencePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -26,6 +26,7 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAclPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -229,8 +230,10 @@ public interface FileSystemMasterClient extends Client {
    * Schedules the async persistence of the given file.
    *
    * @param path the file path
+   * @param options options to use when scheduling the persist
    */
-  void scheduleAsyncPersist(AlluxioURI path) throws AlluxioStatusException;
+  void scheduleAsyncPersist(AlluxioURI path, ScheduleAsyncPersistencePOptions options)
+      throws AlluxioStatusException;
 
   /**
    * Unmounts the given Alluxio path.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
-import alluxio.grpc.CheckConsistencyPOptions;
+import alluxio.exception.FileDoesNotExistException;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -40,7 +39,6 @@ public final class FileSystemUtils {
   // prevent instantiation
   private FileSystemUtils() {}
 
-  // TODO(calvin): make this PublicApi as it meant to be user facing.
   /**
    * Shortcut for {@code waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS)}, i.e., wait for an
    * indefinite amount of time. Note that if a file is never completed, the thread will block
@@ -48,16 +46,15 @@ public final class FileSystemUtils {
    *
    * @param fs a {@link FileSystem} instance
    * @param uri the URI of the file on which the thread should wait
-   * @param waitCompletedPollMs milliseconds to wait between polling the filesystem
    * @return true if the file is complete when this method returns and false if the method timed out
    *         before the file was complete.
    * @throws InterruptedException if the thread receives an interrupt while waiting for file
    *         completion
-   * @see #waitCompleted(FileSystem, AlluxioURI, long, TimeUnit, long)
+   * @see #waitCompleted(FileSystem, AlluxioURI, long, TimeUnit)
    */
-  public static boolean waitCompleted(FileSystem fs, AlluxioURI uri, long waitCompletedPollMs)
+  public static boolean waitCompleted(FileSystem fs, AlluxioURI uri)
       throws IOException, AlluxioException, InterruptedException {
-    return FileSystemUtils.waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS, waitCompletedPollMs);
+    return FileSystemUtils.waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -84,17 +81,18 @@ public final class FileSystemUtils {
    * @param uri the URI of the file whose completion status is to be watied for
    * @param timeout maximum time the calling thread should be blocked on this call
    * @param tunit the @{link TimeUnit} instance describing the {@code timeout} parameter
-   * @param fileWaitCompletedPollMs the milliseconds to wait between polling
    * @return true if the file is complete when this method returns and false if the method timed out
    *         before the file was complete.
    * @throws InterruptedException if the thread receives an interrupt while waiting for file
    *         completion
    */
   public static boolean waitCompleted(final FileSystem fs, final AlluxioURI uri,
-      final long timeout, final TimeUnit tunit, long fileWaitCompletedPollMs)
-          throws IOException, AlluxioException, InterruptedException {
+      final long timeout, final TimeUnit tunit)
+      throws IOException, AlluxioException, InterruptedException {
 
     final long deadline = System.currentTimeMillis() + tunit.toMillis(timeout);
+    final long fileWaitCompletedPollMs =
+        fs.getConf().getMs(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS);
     boolean completed = false;
     long timeleft = deadline - System.currentTimeMillis();
 
@@ -122,53 +120,45 @@ public final class FileSystemUtils {
         timeleft = deadline - System.currentTimeMillis();
       }
     }
-
     return completed;
   }
 
   /**
-   * Persists the given file to the under file system.
+   * Convenience method for {@code #persistAndWait(fs, uri, -1)}. i.e. wait for an indefinite period
+   * of time to persist. This will block for an indefinite period of time if the path is never
+   * persisted. Use with care.
    *
    * @param fs {@link FileSystem} to carry out Alluxio operations
-   * @param fsContext the {@link FileSystemContext} linked to the {@link FileSystem} client
    * @param uri the uri of the file to persist
    */
-  public static void persistFile(final FileSystem fs, final FileSystemContext fsContext,
-      final AlluxioURI uri)
-      throws IOException, TimeoutException, InterruptedException {
-    FileSystemMasterClient client = fsContext.acquireMasterClient();
-    try {
-      client.scheduleAsyncPersist(uri);
-    } finally {
-      fsContext.releaseMasterClient(client);
-    }
+  public static void persistAndWait(final FileSystem fs, final AlluxioURI uri)
+      throws FileDoesNotExistException, IOException, AlluxioException, TimeoutException,
+      InterruptedException {
+    persistAndWait(fs, uri, -1);
+  }
+
+  /**
+   * Persists the given path to the under file system and returns once the persist is complete.
+   * Note that if this method times out, the persist may still occur after the timeout period.
+   *
+   * @param fs {@link FileSystem} to carry out Alluxio operations
+   * @param uri the uri of the file to persist
+   * @param timeoutMs max amount of time to wait for persist in milliseconds. -1 to wait
+   *                  indefinitely
+   * @throws TimeoutException if the persist takes longer than the timeout
+   */
+  public static void persistAndWait(final FileSystem fs, final AlluxioURI uri, int timeoutMs)
+      throws FileDoesNotExistException, IOException, AlluxioException, TimeoutException,
+      InterruptedException {
+    fs.persist(uri);
     CommonUtils.waitFor(String.format("%s to be persisted", uri) , () -> {
       try {
         return fs.getStatus(uri).isPersisted();
       } catch (Exception e) {
-        Throwables.propagateIfPossible(e);
+        Throwables.throwIfUnchecked(e);
         throw new RuntimeException(e);
       }
-    }, WaitForOptions.defaults().setTimeoutMs(20 * Constants.MINUTE_MS)
+    }, WaitForOptions.defaults().setTimeoutMs(timeoutMs)
         .setInterval(Constants.SECOND_MS));
-  }
-
-  /**
-   * Checks the consistency of Alluxio metadata against the under storage for all files and
-   * directories in a given subtree.
-   *
-   * @param fsContext the {@link FileSystemContext} linked to the {@link FileSystem} client
-   * @param path the root of the subtree to check
-   * @param options method options
-   * @return a list of inconsistent files and directories
-   */
-  public static List<AlluxioURI> checkConsistency(FileSystemContext fsContext, AlluxioURI path,
-      CheckConsistencyPOptions options) throws IOException {
-    FileSystemMasterClient client = fsContext.acquireMasterClient();
-    try {
-      return client.checkConsistency(path, options);
-    } finally {
-      fsContext.releaseMasterClient(client);
-    }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -42,6 +42,7 @@ import alluxio.grpc.MountPOptions;
 import alluxio.grpc.MountPRequest;
 import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.RenamePRequest;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.ScheduleAsyncPersistencePRequest;
 import alluxio.grpc.ServiceType;
 import alluxio.grpc.SetAclAction;
@@ -259,12 +260,11 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   }
 
   @Override
-  public void scheduleAsyncPersist(final AlluxioURI path)
+  public void scheduleAsyncPersist(final AlluxioURI path, ScheduleAsyncPersistencePOptions options)
       throws AlluxioStatusException {
     retryRPC(
-        () -> mClient.scheduleAsyncPersistence(
-            ScheduleAsyncPersistencePRequest.newBuilder().setPath(path.getPath()).build()),
-        "ScheduleAsyncPersist");
+        () -> mClient.scheduleAsyncPersistence(ScheduleAsyncPersistencePRequest.newBuilder()
+            .setPath(path.getPath()).setOptions(options).build()), "ScheduleAsyncPersist");
   }
 
   @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -43,6 +43,7 @@ import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CompleteFilePOptions;
 import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.DummyCloseableResource;
 import alluxio.security.GroupMappingServiceTestUtils;
@@ -382,7 +383,8 @@ public class FileOutStreamTest {
     mTestStream.write(BufferUtils.getIncreasingByteArray((int) (BLOCK_LENGTH * 1.5)));
     mTestStream.close();
     verify(mFileSystemMasterClient).completeFile(eq(FILE_NAME), any(CompleteFilePOptions.class));
-    verify(mFileSystemMasterClient).scheduleAsyncPersist(eq(FILE_NAME));
+    verify(mFileSystemMasterClient).scheduleAsyncPersist(eq(FILE_NAME),
+        any(ScheduleAsyncPersistencePOptions.class));
   }
 
   /**

--- a/examples/src/main/java/alluxio/cli/RunOperation.java
+++ b/examples/src/main/java/alluxio/cli/RunOperation.java
@@ -17,6 +17,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
+import alluxio.grpc.CreateFilePOptions;
 import alluxio.util.ConfigurationUtils;
 
 import com.beust.jcommander.JCommander;
@@ -147,7 +148,9 @@ public class RunOperation {
           mFileSystem.delete(uri);
           break;
         case CreateFile:
-          try (FileOutStream file = mFileSystem.createFile(uri)) {
+          try (FileOutStream file =
+              mFileSystem.createFile(uri,
+                  CreateFilePOptions.newBuilder().setRecursive(true).build())) {
             file.write(mFiledata);
           }
           break;

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
@@ -28,6 +28,8 @@ import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 
 import java.io.File;
 import java.io.IOException;
@@ -216,6 +218,23 @@ public final class FileSystemShellUtils {
       }
     }
     return res;
+  }
+
+  /**
+   * Gets the value of an option from the command line.
+   *
+   * @param cl command line object
+   * @param option the option to check for in the command line
+   * @param defaultValue default value for the option
+   * @return argument from command line or default if not present
+   */
+  public static int getIntArg(CommandLine cl, Option option, int defaultValue) {
+    int arg = defaultValue;
+    if (cl.hasOption(option.getLongOpt())) {
+      String argOption = cl.getOptionValue(option.getLongOpt());
+      arg = Integer.parseInt(argOption);
+    }
+    return arg;
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
@@ -14,7 +14,7 @@ package alluxio.cli.fs.command;
 import alluxio.AlluxioURI;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.file.FileSystemUtils;
+import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
@@ -52,7 +52,7 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
       throws AlluxioException, IOException {
-    checkConsistency(plainPath, cl.hasOption("r"));
+    runConsistencyCheck(plainPath, cl.hasOption("r"));
   }
 
   @Override
@@ -80,6 +80,24 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
   }
 
   /**
+   * Checks the consistency of Alluxio metadata against the under storage for all files and
+   * directories in a given subtree.
+   *
+   * @param path the root of the subtree to check
+   * @param options method options
+   * @return a list of inconsistent files and directories
+   */
+  List<AlluxioURI> checkConsistency(AlluxioURI path, CheckConsistencyPOptions options)
+      throws IOException {
+    FileSystemMasterClient client = mFsContext.acquireMasterClient();
+    try {
+      return client.checkConsistency(path, options);
+    } finally {
+      mFsContext.releaseMasterClient(client);
+    }
+  }
+
+  /**
    * Checks the inconsistent files and directories which exist in Alluxio but don't exist in the
    * under storage, repairs the inconsistent paths by deleting them if repairConsistency is true.
    *
@@ -88,11 +106,10 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
    * @throws AlluxioException
    * @throws IOException
    */
-  private void checkConsistency(AlluxioURI path, boolean repairConsistency) throws
+  private void runConsistencyCheck(AlluxioURI path, boolean repairConsistency) throws
       AlluxioException, IOException {
     List<AlluxioURI> inconsistentUris =
-        FileSystemUtils.checkConsistency(mFsContext, path,
-            CheckConsistencyPOptions.getDefaultInstance());
+        checkConsistency(path, CheckConsistencyPOptions.getDefaultInstance());
     if (inconsistentUris.isEmpty()) {
       System.out.println(path + " is consistent with the under storage system.");
       return;

--- a/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
@@ -12,6 +12,7 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.cli.CommandUtils;
 import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.client.file.FileSystemContext;
@@ -37,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -56,6 +58,16 @@ public final class PersistCommand extends AbstractFileSystemCommand {
           .desc("Number of concurrent persist operations, default: " + DEFAULT_PARALLELISM)
           .required(false)
           .build();
+  private static final int DEFAULT_TIMEOUT = 20 * Constants.MINUTE_MS;
+  private static final Option TIMEOUT_OPTION =
+      Option.builder("t")
+          .longOpt("timeout")
+          .argName("timeout in milliseconds")
+          .numberOfArgs(1)
+          .desc("Time in milliseconds for a single file persist to time out; default:"
+              + DEFAULT_TIMEOUT)
+          .required(false)
+          .build();
 
   /**
    * @param fsContext the filesystem of Alluxio
@@ -71,7 +83,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(PARALLELISM_OPTION);
+    return new Options().addOption(PARALLELISM_OPTION).addOption(TIMEOUT_OPTION);
   }
 
   @Override
@@ -81,7 +93,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "persist [-p|--parallelism <#>] <path> [<path> ...]";
+    return "persist [-p|--parallelism <#>] [-t|--timeout <milliseconds>] <path> [<path> ...]";
   }
 
   @Override
@@ -92,11 +104,8 @@ public final class PersistCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     // Parse arguments.
-    int parallelism = DEFAULT_PARALLELISM;
-    if (cl.hasOption(PARALLELISM_OPTION.getLongOpt())) {
-      String parellismOption = cl.getOptionValue(PARALLELISM_OPTION.getLongOpt());
-      parallelism = Integer.parseInt(parellismOption);
-    }
+    int parallelism = FileSystemShellUtils.getIntArg(cl, PARALLELISM_OPTION, DEFAULT_PARALLELISM);
+    int timeoutMs = FileSystemShellUtils.getIntArg(cl, TIMEOUT_OPTION, DEFAULT_TIMEOUT);
     String[] args = cl.getArgs();
 
     // Gather files to persist and enqueue them.
@@ -123,7 +132,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
     List<Future<Void>> futures = new ArrayList<>(parallelism);
     for (int i = 0; i < parallelism; i++) {
       futures.add(service.submit(new PersistCallable(toPersist, totalFiles, completedFiles,
-          progressLock)));
+          progressLock, timeoutMs)));
     }
 
     // Await result.
@@ -164,13 +173,15 @@ public final class PersistCommand extends AbstractFileSystemCommand {
     private final int mTotalFiles;
     private final Object mProgressLock;
     private final AtomicInteger mCompletedFiles;
+    private final int mTimeoutMs;
 
     PersistCallable(Queue<AlluxioURI> toPersist, int totalFiles, AtomicInteger completedFiles,
-        Object progressLock) {
+        Object progressLock, int timeoutMs) {
       mFilesToPersist = toPersist;
       mTotalFiles = totalFiles;
       mProgressLock = progressLock;
       mCompletedFiles = completedFiles;
+      mTimeoutMs = timeoutMs;
     }
 
     @Override
@@ -178,7 +189,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
       AlluxioURI toPersist = mFilesToPersist.poll();
       while (toPersist != null) {
         try {
-          FileSystemUtils.persistFile(mFileSystem, mFsContext, toPersist);
+          FileSystemUtils.persistAndWait(mFileSystem, toPersist, mTimeoutMs);
           synchronized (mProgressLock) { // Prevents out of order progress tracking.
             String progress = "(" + mCompletedFiles.incrementAndGet() + "/" + mTotalFiles + ")";
             System.out.println(progress + " Successfully persisted file: " + toPersist);
@@ -186,6 +197,11 @@ public final class PersistCommand extends AbstractFileSystemCommand {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw e;
+        } catch (TimeoutException e) {
+          String timeoutMsg =
+              String.format("Timed out waiting for file to be persisted: %s", toPersist);
+          System.out.println(timeoutMsg);
+          LOG.error(timeoutMsg, e);
         } catch (Exception e) {
           System.out.println("Failed to persist file " + toPersist);
           LOG.error("Failed to persist file {}", toPersist, e);

--- a/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
+++ b/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.master.backcompat.TestOp;
 import alluxio.master.backcompat.Utils;
 import alluxio.multi.process.Clients;
@@ -35,9 +36,11 @@ public final class PersistFile implements TestOp {
   public void apply(Clients clients) throws Exception {
     FileSystem fs = clients.getFileSystemClient();
     Utils.createFile(fs, PATH);
-    clients.getFileSystemMasterClient().scheduleAsyncPersist(PATH);
+    clients.getFileSystemMasterClient().scheduleAsyncPersist(PATH,
+        ScheduleAsyncPersistencePOptions.getDefaultInstance());
     Utils.createFile(fs, NESTED_PATH);
-    clients.getFileSystemMasterClient().scheduleAsyncPersist(NESTED_PATH);
+    clients.getFileSystemMasterClient().scheduleAsyncPersist(NESTED_PATH,
+        ScheduleAsyncPersistencePOptions.getDefaultInstance());
     CommonUtils.waitFor("file to be async persisted", () -> {
       try {
         return fs.getStatus(PATH).isPersisted() && fs.getStatus(NESTED_PATH).isPersisted();

--- a/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.cli.fs;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
@@ -27,8 +29,12 @@ import alluxio.grpc.WritePType;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,7 +78,7 @@ public final class FileSystemShellUtilsTest {
     String expected = "/dir";
     for (String path : paths) {
       String result = FileSystemShellUtils.getFilePath(path, ConfigurationTestUtils.defaults());
-      Assert.assertEquals(expected, result);
+      assertEquals(expected, result);
     }
   }
 
@@ -219,53 +225,76 @@ public final class FileSystemShellUtilsTest {
       String rootDir = resetFsHierarchy(fsType);
 
       List<String> tl1 = getPaths(rootDir + "/foo", fsType);
-      Assert.assertEquals(tl1.size(), 1);
-      Assert.assertEquals(tl1.get(0), rootDir + "/foo");
+      assertEquals(tl1.size(), 1);
+      assertEquals(tl1.get(0), rootDir + "/foo");
 
       // Trailing slash
       List<String> tl2 = getPaths(rootDir + "/foo/", fsType);
-      Assert.assertEquals(tl2.size(), 1);
-      Assert.assertEquals(tl2.get(0), rootDir + "/foo");
+      assertEquals(tl2.size(), 1);
+      assertEquals(tl2.get(0), rootDir + "/foo");
 
       // Wildcard
       List<String> tl3 = getPaths(rootDir + "/foo/*", fsType);
-      Assert.assertEquals(tl3.size(), 2);
-      Assert.assertEquals(tl3.get(0), rootDir + "/foo/foobar1");
-      Assert.assertEquals(tl3.get(1), rootDir + "/foo/foobar2");
+      assertEquals(tl3.size(), 2);
+      assertEquals(tl3.get(0), rootDir + "/foo/foobar1");
+      assertEquals(tl3.get(1), rootDir + "/foo/foobar2");
 
       // Trailing slash + wildcard
       List<String> tl4 = getPaths(rootDir + "/foo/*/", fsType);
-      Assert.assertEquals(tl4.size(), 2);
-      Assert.assertEquals(tl4.get(0), rootDir + "/foo/foobar1");
-      Assert.assertEquals(tl4.get(1), rootDir + "/foo/foobar2");
+      assertEquals(tl4.size(), 2);
+      assertEquals(tl4.get(0), rootDir + "/foo/foobar1");
+      assertEquals(tl4.get(1), rootDir + "/foo/foobar2");
 
       // Multiple wildcards
       List<String> tl5 = getPaths(rootDir + "/*/foo*", fsType);
-      Assert.assertEquals(tl5.size(), 3);
-      Assert.assertEquals(tl5.get(0), rootDir + "/bar/foobar3");
-      Assert.assertEquals(tl5.get(1), rootDir + "/foo/foobar1");
-      Assert.assertEquals(tl5.get(2), rootDir + "/foo/foobar2");
+      assertEquals(tl5.size(), 3);
+      assertEquals(tl5.get(0), rootDir + "/bar/foobar3");
+      assertEquals(tl5.get(1), rootDir + "/foo/foobar1");
+      assertEquals(tl5.get(2), rootDir + "/foo/foobar2");
     }
   }
 
   @Test
   public void match() {
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/c"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/*"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/*/"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c/", "/a/*/*/"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c/", "/a/*/*"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/c"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/*"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "/a/*/*/"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c/", "/a/*/*/"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c/", "/a/*/*"), true);
 
-    Assert.assertEquals(FileSystemShellUtils.match("/foo/bar/foobar/", "/foo*/*"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/foo/bar/foobar/", "/*/*/foobar"), true);
+    assertEquals(FileSystemShellUtils.match("/foo/bar/foobar/", "/foo*/*"), true);
+    assertEquals(FileSystemShellUtils.match("/foo/bar/foobar/", "/*/*/foobar"), true);
 
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c/", "/b/*"), false);
-    Assert.assertEquals(FileSystemShellUtils.match("/", "/*/*"), false);
+    assertEquals(FileSystemShellUtils.match("/a/b/c/", "/b/*"), false);
+    assertEquals(FileSystemShellUtils.match("/", "/*/*"), false);
 
-    Assert.assertEquals(FileSystemShellUtils.match("/a/b/c", "*"), true);
-    Assert.assertEquals(FileSystemShellUtils.match("/", "/*"), true);
+    assertEquals(FileSystemShellUtils.match("/a/b/c", "*"), true);
+    assertEquals(FileSystemShellUtils.match("/", "/*"), true);
+  }
+
+  @Test
+  public void getIntArgTest() throws Exception {
+    Option opt = Option.builder("t")
+        .longOpt("test")
+        .numberOfArgs(1)
+        .required(false)
+        .build();
+
+    CommandLine cmdLine = getCmdLine(opt, "--test", "1");
+    assertEquals("Should get long form", 1, FileSystemShellUtils.getIntArg(cmdLine, opt, 0));
+
+    cmdLine = getCmdLine(opt, "-t", "5");
+    assertEquals("Should get short form", 5, FileSystemShellUtils.getIntArg(cmdLine, opt, 0));
+
+    cmdLine = getCmdLine(opt);
+    assertEquals("Should not get arg", 0, FileSystemShellUtils.getIntArg(cmdLine, opt, 0));
+  }
+
+  CommandLine getCmdLine(Option opt, String... args) throws Exception {
+    CommandLineParser parser = new DefaultParser();
+    return parser.parse(new Options().addOption(opt), args);
   }
 
   @Test
@@ -277,8 +306,8 @@ public final class FileSystemShellUtilsTest {
     Reflections reflections = new Reflections(pkgName);
     Set<Class<? extends Command>> cmdSet = reflections.getSubTypesOf(Command.class);
     for (Map.Entry<String, Command> entry : map.entrySet()) {
-      Assert.assertEquals(entry.getValue().getCommandName(), entry.getKey());
-      Assert.assertEquals(cmdSet.contains(entry.getValue().getClass()), true);
+      assertEquals(entry.getValue().getCommandName(), entry.getKey());
+      assertEquals(cmdSet.contains(entry.getValue().getClass()), true);
     }
 
     int expectSize = 0;
@@ -289,7 +318,7 @@ public final class FileSystemShellUtilsTest {
         expectSize++;
       }
     }
-    Assert.assertEquals(expectSize, map.size());
+    assertEquals(expectSize, map.size());
   }
 }
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
@@ -11,7 +11,12 @@
 
 package alluxio.client.cli.fs.command;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.AlluxioURI;
+import alluxio.TestLoggerRule;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileSystemTestUtils;
@@ -28,6 +33,7 @@ import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -37,12 +43,15 @@ import java.util.List;
  * Tests for persist command.
  */
 public final class PersistCommandTest extends AbstractFileSystemShellTest {
+
+  @Rule
+  public TestLoggerRule mLogRule = new TestLoggerRule();
+
   @Test
   public void persist() throws Exception {
     String testFilePath = "/testPersist/testFile";
     FileSystemTestUtils.createByteFile(mFileSystem, testFilePath, WritePType.MUST_CACHE, 10);
-    Assert
-        .assertFalse(mFileSystem.getStatus(new AlluxioURI("/testPersist/testFile")).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI("/testPersist/testFile")).isPersisted());
 
     int ret = mFsShell.run("persist", testFilePath);
     Assert.assertEquals(0, ret);
@@ -54,18 +63,14 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     // Set the default write type to MUST_CACHE, so that directories are not persisted by default
     ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
-    Assert
-        .assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
-    Assert
-        .assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
     int ret = mFsShell.run("persist", testDir);
     Assert.assertEquals(0, ret);
-    Assert.assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
-    Assert
-        .assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
-    Assert
-        .assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
     checkFilePersisted(new AlluxioURI(testDir + "/foo/foobar1"), 10);
     checkFilePersisted(new AlluxioURI(testDir + "/foo/foobar2"), 20);
     checkFilePersisted(new AlluxioURI(testDir + "/bar/foobar3"), 30);
@@ -82,9 +87,9 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, filePath2, WritePType.MUST_CACHE, 20);
     FileSystemTestUtils.createByteFile(mFileSystem, filePath3, WritePType.MUST_CACHE, 30);
 
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
 
     int ret = mFsShell.run("persist", filePath1, filePath2, filePath3);
     Assert.assertEquals(0, ret);
@@ -100,20 +105,20 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
   public void persistMultiFilesAndDirs() throws Exception {
     ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
-    Assert.assertFalse(
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
+    assertFalse(
         mFileSystem.getStatus(new AlluxioURI(testDir + "/foo/foobar2")).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
 
     int ret = mFsShell.run("persist", testDir + "/foo/foobar1", testDir + "/foobar4",
         testDir + "/bar", testDir + "/bar/foobar3");
     Assert.assertEquals(0, ret);
-    Assert.assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
-    Assert.assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
-    Assert.assertFalse(
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
+    assertFalse(
         mFileSystem.getStatus(new AlluxioURI(testDir + "/foo/foobar2")).isPersisted());
-    Assert.assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
+    assertTrue(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
     checkFilePersisted(new AlluxioURI(testDir + "/foo/foobar1"), 10);
     checkFilePersisted(new AlluxioURI(testDir + "/bar/foobar3"), 30);
     checkFilePersisted(new AlluxioURI(testDir + "/foobar4"), 40);
@@ -135,8 +140,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     // Persisting an already-persisted file is okay
     String testFilePath = "/testPersist/testFile";
     FileSystemTestUtils.createByteFile(mFileSystem, testFilePath, WritePType.MUST_CACHE, 10);
-    Assert
-        .assertFalse(mFileSystem.getStatus(new AlluxioURI("/testPersist/testFile")).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI("/testPersist/testFile")).isPersisted());
     int ret = mFsShell.run("persist", testFilePath);
     Assert.assertEquals(0, ret);
     ret = mFsShell.run("persist", testFilePath);
@@ -157,7 +161,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     Mode grandParentMode = new Mode((short) 0777);
     FileSystemTestUtils.createByteFile(mFileSystem, testFile, WritePType.MUST_CACHE, 10);
     URIStatus status = mFileSystem.getStatus(testFile);
-    Assert.assertFalse(status.isPersisted());
+    assertFalse(status.isPersisted());
     mFileSystem.setAttribute(grandParent,
         SetAttributePOptions.newBuilder().setMode(grandParentMode.toProto()).build());
     int ret = mFsShell.run("persist", testFile.toString());
@@ -185,9 +189,9 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, filePath2, WritePType.MUST_CACHE, 20);
     FileSystemTestUtils.createByteFile(mFileSystem, filePath3, WritePType.MUST_CACHE, 30);
 
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
 
     int ret = mFsShell.run("persist", "/*/testFile*");
     Assert.assertEquals(0, ret);
@@ -205,9 +209,9 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, filePath2, WritePType.MUST_CACHE, 20);
     FileSystemTestUtils.createByteFile(mFileSystem, filePath3, WritePType.MUST_CACHE, 30);
 
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
 
     int ret = mFsShell.run("persist", "/testPersistRecursive");
     Assert.assertEquals(0, ret);
@@ -225,16 +229,16 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     FileSystemTestUtils.createByteFile(mFileSystem, filePath2, WritePType.MUST_CACHE, 20);
     FileSystemTestUtils.createByteFile(mFileSystem, filePath3, WritePType.MUST_CACHE, 30);
 
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath1)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
 
     // Persist testFile1 first.
     int ret = mFsShell.run("persist", "/testPersistPartial/testFile1");
     Assert.assertEquals(0, ret);
     checkFilePersisted(new AlluxioURI(filePath1), 10);
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
-    Assert.assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath2)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(filePath3)).isPersisted());
 
     // Persist entire directory.
     ret = mFsShell.run("persist", "/testPersistPartial");
@@ -259,16 +263,56 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     persistParallel(2, 1);
   }
 
-  public void persistParallel(int totalFiles, int parallelism) throws Exception {
-    int fileSize = 30;
+  @Test
+  public void persistShortTimeout() throws Exception {
+    shortTimeoutTest("--timeout");
+  }
+
+  @Test
+  public void persistShortTimeoutShortOption() throws Exception {
+    shortTimeoutTest("-t");
+  }
+
+  /**
+   * Ensure a short timeout results in a proper log message.
+   *
+   * @param option the short or long-form command line option
+   */
+  void shortTimeoutTest(String option) throws Exception {
+    createUnpersistedFiles("/testPersistTimeout", 100, 50);
+    mFsShell.run("persist", option, String.valueOf(1), "/*"); // 1ms persist timeout
+    assertTrue("Should log at least one timeout",
+        mLogRule.wasLogged("Timed out waiting for file to be persisted:"));
+  }
+
+  @Test
+  public void persistLongTimeout() throws Exception {
+    int fileSize = 100;
+    List<AlluxioURI> files = createUnpersistedFiles("/testPersistTimeout", fileSize, 25);
+    int ret = mFsShell.run("persist", "--timeout", String.valueOf(60 * 1000), "/*");
+    assertEquals("shell should not report error", 0, ret);
+    assertFalse("Should not have logged timeout",
+        mLogRule.wasLogged("Timed out waiting for file to be persisted:"));
+    for (AlluxioURI file : files) {
+      checkFilePersisted(file, fileSize);
+    }
+  }
+
+  private List<AlluxioURI> createUnpersistedFiles(String dirPath, int fileSize, int totalFiles)
+      throws Exception {
     List<AlluxioURI> files = new ArrayList<>(totalFiles);
     for (int i = 0; i < totalFiles; i++) {
-      String path = "/testPersistParallel/" + i;
+      String path = String.format("%s/%d", dirPath, i);
       files.add(new AlluxioURI(path));
       FileSystemTestUtils.createByteFile(mFileSystem, path, WritePType.MUST_CACHE, fileSize);
-      Assert.assertFalse(mFileSystem.getStatus(files.get(i)).isPersisted());
+      assertFalse(mFileSystem.getStatus(files.get(i)).isPersisted());
     }
+    return files;
+  }
 
+  public void persistParallel(int totalFiles, int parallelism) throws Exception {
+    int fileSize = 30;
+    List<AlluxioURI> files = createUnpersistedFiles("/testPersistParallel", fileSize, totalFiles);
     int ret = mFsShell.run("persist", "--parallelism", String.valueOf(parallelism), "/*");
     Assert.assertEquals(0, ret);
     for (AlluxioURI file : files) {

--- a/tests/src/test/java/alluxio/client/fs/FileSystemUtilsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemUtilsIntegrationTest.java
@@ -11,7 +11,11 @@
 
 package alluxio.client.fs;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileOutStream;
@@ -20,6 +24,7 @@ import alluxio.client.file.FileSystemUtils;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
+import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
@@ -34,6 +39,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Tests for {@link alluxio.client.file.FileSystemUtils}.
@@ -45,6 +51,8 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
           .build();
+
+  public static LocalAlluxioJobCluster sJobCluster;
   private static CreateFilePOptions sWriteBoth;
   private static FileSystem sFileSystem = null;
 
@@ -53,6 +61,8 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    sJobCluster = new LocalAlluxioJobCluster();
+    sJobCluster.start();
     sFileSystem = sLocalAlluxioClusterResource.get().getClient();
     sWriteBoth = CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH)
         .setRecursive(true).build();
@@ -70,14 +80,14 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
         try {
           FileOutStream os = sFileSystem.createFile(uri, sWriteBoth);
           boolean completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertFalse(completed);
+          assertFalse(completed);
           for (int i = 0; i < numWrites; i++) {
             os.write(42);
             CommonUtils.sleepMs(200);
           }
           os.close();
           completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertTrue(completed);
+          assertTrue(completed);
         } catch (Exception e) {
           Assert.fail(e.getMessage());
         }
@@ -88,11 +98,10 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
       @Override
       public void run() {
         try {
-          boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri,
-              ServerConfiguration.getMs(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS));
-          Assert.assertTrue(completed);
+          boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri);
+          assertTrue(completed);
           completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertTrue(completed);
+          assertTrue(completed);
         } catch (Exception e) {
           e.printStackTrace();
           Assert.fail(e.getMessage());
@@ -122,7 +131,7 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
         try {
           FileOutStream os = sFileSystem.createFile(uri, sWriteBoth);
           boolean completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertFalse(completed);
+          assertFalse(completed);
           // four writes that will take > 600ms due to the sleeps
           for (int i = 0; i < numWrites; i++) {
             os.write(42);
@@ -130,7 +139,7 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
           }
           os.close();
           completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertTrue(completed);
+          assertTrue(completed);
         } catch (Exception e) {
           Assert.fail(e.getMessage());
         }
@@ -148,11 +157,10 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
           try {
             // The write will take at most 600ms I am waiting for at most 400ms - epsilon.
             boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri, 300,
-                TimeUnit.MILLISECONDS, ServerConfiguration
-                    .getMs(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS));
-            Assert.assertFalse(completed);
+                TimeUnit.MILLISECONDS);
+            assertFalse(completed);
             completed = sFileSystem.getStatus(uri).isCompleted();
-            Assert.assertFalse(completed);
+            assertFalse(completed);
           } finally {
             ServerConfiguration.set(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS, original);
           }
@@ -171,5 +179,25 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
 
     waitingThread.join();
     writingThread.join();
+  }
+
+  @Test
+  public void waitPersistTimeoutTest() throws Exception {
+    String path = PathUtils.uniqPath();
+    AlluxioURI alluxioPath = new AlluxioURI(path);
+    FileSystemTestUtils.createByteFile(sFileSystem, path, WritePType.MUST_CACHE, 4096);
+    assertFalse("File cannot yet be persisted", sFileSystem.getStatus(alluxioPath).isPersisted());
+    mThrown.expect(TimeoutException.class);
+    FileSystemUtils.persistAndWait(sFileSystem, alluxioPath, 1); // 1ms timeout
+  }
+
+  @Test
+  public void waitPersistIndefiniteTimeoutTest() throws Exception {
+    String path = PathUtils.uniqPath();
+    AlluxioURI alluxioPath = new AlluxioURI(path);
+    FileSystemTestUtils.createByteFile(sFileSystem, path, WritePType.MUST_CACHE, 4096);
+    assertFalse("File cannot yet be persisted", sFileSystem.getStatus(alluxioPath).isPersisted());
+    FileSystemUtils.persistAndWait(sFileSystem, alluxioPath, -1);
+    assertTrue("File must be persisted", sFileSystem.getStatus(alluxioPath).isPersisted());
   }
 }

--- a/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.job.JobIntegrationTest;
 import alluxio.job.wire.JobInfo;
@@ -100,7 +101,8 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     // persist the file
     FileSystemMasterClient client = mFsContext.acquireMasterClient();
     try {
-      client.scheduleAsyncPersist(new AlluxioURI(TEST_URI));
+      client.scheduleAsyncPersist(new AlluxioURI(TEST_URI),
+          ScheduleAsyncPersistencePOptions.getDefaultInstance());
     } finally {
       mFsContext.releaseMasterClient(client);
     }
@@ -140,7 +142,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     // schedule an async persist
     FileSystemMasterClient client = mFsContext.acquireMasterClient();
     try {
-      client.scheduleAsyncPersist(path);
+      client.scheduleAsyncPersist(path, ScheduleAsyncPersistencePOptions.getDefaultInstance());
       Assert.fail("Should not be able to schedule persistence for incomplete file");
     } catch (Exception e) {
       // expected


### PR DESCRIPTION
* Move FileSystemUtils into FileSystem

Tests were integrated into FileSystemIntegrationTest.

* Leave primitive methods in FileSystem client

Compound operations have been moved or left inside of FileSystemUtils

* Update perist command to add timeout

During testing RunOperation can't seem to create files any more unless
we default the CreatePOptions recursive value to true. So this has been
set for CreateFile.

Related shell utilities and tests have been updated

* Add persistence options to client API

ScheduleAsyncPersistencePOptions already existed. It needs to be
exposed on the client so that users can pass options to it in the future
if desired

* Remove unused options sWriteBoth

* Fix confusing argument in createUnpersistedFiles

* Address minor typos in PersistCommand output

* move checkConsistency to respective command class

checkConsistency isn't used anywhere except inside the command. It doesn't make sense to leave it inside FileSystemUtils because of it's requirement for a FileSystemContext. It doesn't belong in the client either.

* Rename waitPersisted to persistAndWait

* Test both option forms

Added test for getIntArg as well as PersistCommand

* style issues

* fix javadoc nits

* Improvements to persist exception handling and logging

These changes make the persist mirror more closely how the other client functions handle errors. Some variables were also renamed in order to make the function more similar to others. A debug logging statement was added as well.

* rename variables

- `client` moved to `masterClient` in BaseFileSystem
- `uri` changed to `path` in FileSystem