### PR TITLE
[CHERRYPICK] ActiveSync fixes (#8400)

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -487,6 +487,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   public void resetState() {
     mInodeTree.reset();
     mMountTable.reset();
+    mSyncManager.reset();
   }
 
   @Override


### PR DESCRIPTION
* Cherry-pick with conflicts
Various active sync related fixes (#1573)

Start initial active sync & safely remove from map

* fix cherry-pick conflict

* Stop master fail over from clearing state for Active Sync (#1580)

* Fix the fail over cleaning out state for active sync.

* add more comment

* address comments

* resolve conflicts

* fix checkstyle