### PR TITLE
Fix symbol not found error.

### DIFF
--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -11,10 +11,16 @@
 
 package alluxio.master;
 
+import static java.util.stream.Collectors.joining;
+
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.*;
+import alluxio.grpc.GetServiceVersionPRequest;
+import alluxio.grpc.GrpcChannel;
+import alluxio.grpc.GrpcChannelBuilder;
+import alluxio.grpc.ServiceType;
+import alluxio.grpc.ServiceVersionClientServiceGrpc;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.uri.Authority;
@@ -30,8 +36,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
-
-import static java.util.stream.Collectors.joining;
 
 /**
  * PollingMasterInquireClient finds the address of the primary master by polling a list of master

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -11,17 +11,10 @@
 
 package alluxio.master;
 
-import static java.util.stream.Collectors.joining;
-
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.GetServiceVersionPRequest;
-import alluxio.grpc.GrpcChannel;
-import alluxio.grpc.GrpcChannelBuilder;
-import alluxio.grpc.GrpcExceptionUtils;
-import alluxio.grpc.ServiceType;
-import alluxio.grpc.ServiceVersionClientServiceGrpc;
+import alluxio.grpc.*;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.uri.Authority;
@@ -37,6 +30,8 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * PollingMasterInquireClient finds the address of the primary master by polling a list of master
@@ -114,7 +109,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
       versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()
           .setServiceType(ServiceType.META_MASTER_CLIENT_SERVICE).build());
     } catch (StatusRuntimeException e) {
-      throw GrpcExceptionUtils.fromGrpcStatusException(e);
+      throw AlluxioStatusException.fromThrowable(e);
     }
     channel.shutdown();
   }


### PR DESCRIPTION
Master branch cannot compile due to a symbol not found error.