### PR TITLE
Use configuration instead of boolean for tieredIdentity nearest

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -202,9 +202,7 @@ public final class AlluxioBlockStore {
               .collect(toList());
       Collections.shuffle(tieredLocations);
       Optional<TieredIdentity> nearest =
-          TieredIdentityUtils.nearest(mTieredIdentity, tieredLocations,
-              mContext.getConf()
-                  .getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP));
+          TieredIdentityUtils.nearest(mTieredIdentity, tieredLocations, mContext.getConf());
       if (nearest.isPresent()) {
         dataSource = locations.stream().map(BlockLocation::getWorkerAddress)
             .filter(addr -> addr.getTieredIdentity().equals(nearest.get())).findFirst().get();

--- a/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/policy/LocalFirstAvoidEvictionPolicy.java
@@ -56,8 +56,7 @@ public final class LocalFirstAvoidEvictionPolicy
   @VisibleForTesting
   LocalFirstAvoidEvictionPolicy(TieredIdentity localTieredIdentity,
       AlluxioConfiguration conf) {
-    mPolicy = LocalFirstPolicy.create(localTieredIdentity,
-        conf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP));
+    mPolicy = LocalFirstPolicy.create(localTieredIdentity, conf);
     mFileWriteCapacityReserved = conf
         .getBytes(PropertyKey.USER_FILE_WRITE_AVOID_EVICTION_POLICY_RESERVED_BYTES);
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/policy/LocalFirstPolicyTest.java
@@ -98,14 +98,14 @@ public final class LocalFirstPolicyTest {
     WorkerNetAddress chosen;
     // local rack
     policy = LocalFirstPolicy.create(TieredIdentityFactory.fromString("node=node1,rack=rack2",
-        sConf), sConf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP));
+        sConf), sConf);
     chosen = policy.getWorkerForNextBlock(workers, Constants.GB);
     assertEquals("rack2", chosen.getTieredIdentity().getTier(1).getValue());
 
     // local node
     policy = LocalFirstPolicy.create(TieredIdentityFactory.fromString("node=node4,rack=rack3",
         sConf),
-        sConf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP));
+        sConf);
     chosen = policy.getWorkerForNextBlock(workers, Constants.GB);
     assertEquals("node4", chosen.getTieredIdentity().getTier(0).getValue());
   }
@@ -120,7 +120,7 @@ public final class LocalFirstPolicyTest {
     workers.add(worker(Constants.GB, "node4", "rack3"));
     LocalFirstPolicy policy =
         LocalFirstPolicy.create(TieredIdentityFactory.fromString("node=node2,rack=rack3", sConf),
-            sConf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP));
+            sConf);
     WorkerNetAddress chosen = policy.getWorkerForNextBlock(workers, Constants.GB);
     assertEquals(workers.get(2).getNetAddress(), chosen);
   }
@@ -130,10 +130,10 @@ public final class LocalFirstPolicyTest {
     new EqualsTester()
         .addEqualityGroup(
             LocalFirstPolicy.create(TieredIdentityFactory.fromString("node=x,rack=y", sConf),
-                sConf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP)))
+                sConf))
         .addEqualityGroup(
             LocalFirstPolicy.create(TieredIdentityFactory.fromString("node=x,rack=z", sConf),
-                sConf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP)))
+                sConf))
         .testEquals();
   }
 

--- a/core/common/src/main/java/alluxio/util/TieredIdentityUtils.java
+++ b/core/common/src/main/java/alluxio/util/TieredIdentityUtils.java
@@ -12,6 +12,8 @@
 package alluxio.util;
 
 import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.TieredIdentity;
 
@@ -68,19 +70,20 @@ public final class TieredIdentityUtils {
   /**
    * @param tieredIdentity the tiered identity
    * @param identities the tiered identities to compare to
-   * @param resolveIpAddress whether or not to resolve IP addresses for node locality
+   * @param conf Alluxio configuration
    * @return the identity closest to this one. If none of the identities match, the first identity
    *         is returned
    */
   public static Optional<TieredIdentity> nearest(TieredIdentity tieredIdentity,
-      List<TieredIdentity> identities, boolean resolveIpAddress) {
+      List<TieredIdentity> identities, AlluxioConfiguration conf) {
     if (identities.isEmpty()) {
       return Optional.empty();
     }
     for (TieredIdentity.LocalityTier tier : tieredIdentity.getTiers()) {
       for (TieredIdentity identity : identities) {
         for (TieredIdentity.LocalityTier otherTier : identity.getTiers()) {
-          if (tier != null && matches(tier, otherTier, resolveIpAddress)) {
+          if (tier != null
+              && matches(tier, otherTier,conf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP))) {
             return Optional.of(identity);
           }
         }

--- a/core/common/src/main/java/alluxio/util/TieredIdentityUtils.java
+++ b/core/common/src/main/java/alluxio/util/TieredIdentityUtils.java
@@ -83,7 +83,7 @@ public final class TieredIdentityUtils {
       for (TieredIdentity identity : identities) {
         for (TieredIdentity.LocalityTier otherTier : identity.getTiers()) {
           if (tier != null
-              && matches(tier, otherTier,conf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP))) {
+              && matches(tier, otherTier, conf.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP))) {
             return Optional.of(identity);
           }
         }

--- a/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
+++ b/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
@@ -57,16 +57,16 @@ public class TieredIdentityTest {
     boolean resolveIp = mConfiguration.getBoolean(PropertyKey.LOCALITY_COMPARE_NODE_IP);
     assertSame(id1, TieredIdentityUtils
         .nearest(TieredIdentityFactory.fromString("node=D,rack=rack1", mConfiguration), identities,
-            resolveIp).get());
+            mConfiguration).get());
     assertSame(id2, TieredIdentityUtils
         .nearest(TieredIdentityFactory.fromString("node=B,rack=rack2", mConfiguration), identities,
-            resolveIp).get());
+            mConfiguration).get());
     assertSame(id3, TieredIdentityUtils
         .nearest(TieredIdentityFactory.fromString("node=C,rack=rack2", mConfiguration), identities,
-            resolveIp).get());
+            mConfiguration).get());
     assertSame(id1, TieredIdentityUtils
         .nearest(TieredIdentityFactory.fromString("node=D,rack=rack3", mConfiguration), identities,
-            resolveIp).get());
+            mConfiguration).get());
   }
 
   @Test


### PR DESCRIPTION
Changing the method signature makes passing arguments simpler.