### PR TITLE
Fix Alluxio Yarn integration

### DIFF
--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -55,12 +55,6 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.alluxio</groupId>
-          <artifactId>alluxio-core-transport</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Internal test dependencies -->

--- a/integration/yarn/src/main/java/alluxio/yarn/Client.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/Client.java
@@ -394,13 +394,13 @@ public final class Client {
 
   private void setupAppMasterEnv(Map<String, String> appMasterEnv) throws IOException {
     String classpath = ApplicationConstants.Environment.CLASSPATH.name();
+    Apps.addToEnvironment(appMasterEnv, classpath, PathUtils.concatPath(Environment.PWD.$(), "*"),
+        ApplicationConstants.CLASS_PATH_SEPARATOR);
     for (String path : mYarnConf.getStrings(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
         YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH)) {
       Apps.addToEnvironment(appMasterEnv, classpath, path.trim(),
           ApplicationConstants.CLASS_PATH_SEPARATOR);
     }
-    Apps.addToEnvironment(appMasterEnv, classpath, PathUtils.concatPath(Environment.PWD.$(), "*"),
-        ApplicationConstants.CLASS_PATH_SEPARATOR);
 
     appMasterEnv.put("ALLUXIO_HOME", ApplicationConstants.Environment.PWD.$());
 

--- a/integration/yarn/src/main/java/alluxio/yarn/Client.java
+++ b/integration/yarn/src/main/java/alluxio/yarn/Client.java
@@ -393,6 +393,11 @@ public final class Client {
   }
 
   private void setupAppMasterEnv(Map<String, String> appMasterEnv) throws IOException {
+    // NOTE(cc): class path order matters, for example:
+    // Alluxio uses a newer version of Guava, an old version of Guava might also exist in the
+    // YARN_APPLICATION_CLASSPATH, if YARN_APPLICATION_CLASSPATH has the highest priority in
+    // class paths, then the old version Guava will be loaded, which may lack some functionality
+    // required by Alluxio.
     String classpath = ApplicationConstants.Environment.CLASSPATH.name();
     Apps.addToEnvironment(appMasterEnv, classpath, PathUtils.concatPath(Environment.PWD.$(), "*"),
         ApplicationConstants.CLASS_PATH_SEPARATOR);


### PR DESCRIPTION
1. There are classes in alluxio-core-common that depend on grpc, grpc is only included in alluxio-core-transport, so it has to be included, otherwise, ClassNotFound issues will happen. Previously, we exclude alluxio-core-protobuf because of some shading hacks which no longer work for alluxio-core-transport.
2. Alluxio uses a newer version of Guava, an older version of Guava also exists in the YARN_APPLICATION_CLASSPATH, so without this change, the classloader will load the older version of Guava, so MethodNotFound exception might be thrown in some Alluxio  classes due to their needs for the newer version of Guava.