### PR TITLE
Fix gRPC unit test

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -113,6 +113,11 @@ public final class GrpcDataReader implements DataReader {
       if (message != null) {
         response = message.getMessage();
         buffer = message.getBuffer();
+        if (buffer == null && response.hasChunk() && response.getChunk().hasData()) {
+          // falls back to use chunk message for compatibility
+          ByteBuffer byteBuffer = response.getChunk().getData().asReadOnlyByteBuffer();
+          buffer = new NioDataBuffer(byteBuffer, byteBuffer.remaining());
+        }
         Preconditions.checkState(buffer != null, "response should always contain chunk");
       }
     } else {


### PR DESCRIPTION
Some gRPC unit tests are failing because the test does not work well with zero-copy streaming. This fix  some code to attempt falling back to message buffer if zero copy buffer is not provided.