### PR TITLE
Fix issue with phantom inodes

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -595,6 +595,7 @@ public class InodeTree implements JournalEntryIterable {
 
         if (!currentInodeDirectory.addChild(dir)) {
           // The child directory inode already exists. Get the existing child inode.
+          dir.setDeleted(true);
           extensibleInodePath.getLockList().unlockLast();
 
           dir =
@@ -612,7 +613,8 @@ public class InodeTree implements JournalEntryIterable {
               // Do not journal the persist entry, since a creation entry will be journaled instead.
               syncPersistDirectory(RpcContext.NOOP, dir);
             }
-          } catch (Exception e) {
+          } catch (Throwable e) {
+            dir.setDeleted(true);
             // Failed to persist the directory, so remove it from the parent.
             currentInodeDirectory.removeChild(dir);
             throw e;
@@ -718,6 +720,7 @@ public class InodeTree implements JournalEntryIterable {
         if (!currentInodeDirectory.addChild(lastInode)) {
           // Could not add the child inode to the parent. Continue and try again.
           // Cleanup is not necessary, since other state is updated later, after a successful add.
+          lastInode.setDeleted(true);
           mInodes.remove(lastInode);
           extensibleInodePath.getLockList().unlockLast();
           lastInode = null;

--- a/tests/src/test/java/alluxio/client/fs/ConcurrentRecursiveCreateTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ConcurrentRecursiveCreateTest.java
@@ -1,0 +1,126 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fs;
+
+import static junit.framework.TestCase.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.Constants;
+import alluxio.PropertyKey;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.options.CreateDirectoryOptions;
+import alluxio.client.file.options.DeleteOptions;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystem.Factory;
+import alluxio.util.CommonUtils;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the correctness of concurrent recursive creates.
+ */
+public class ConcurrentRecursiveCreateTest extends BaseIntegrationTest {
+  private static final int NUM_TOP_LEVEL_DIRS = 10;
+
+  @Rule
+  public LocalAlluxioClusterResource mClusterResource =
+      new LocalAlluxioClusterResource.Builder().build();
+
+  @Test
+  public void createDuringUfsRename() throws Exception {
+    FileSystem fs = mClusterResource.get().getClient();
+    ExecutorService executor = Executors.newCachedThreadPool();
+    UnderFileSystem ufs = Factory.createForRoot();
+    String ufsRoot = Configuration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    List<String> paths = new ArrayList<>();
+    for (int i = 0; i < NUM_TOP_LEVEL_DIRS / 2; i++) {
+      String alluxioPath = PathUtils.concatPath("/dir" + i, "a", "b", "c");
+      ufs.mkdirs(PathUtils.concatPath(ufsRoot, alluxioPath));
+      paths.add(alluxioPath);
+    }
+    executor.submit(new UfsRenamer(ufs, ufsRoot));
+    for (int i = 0; i < 10; i++) {
+      executor.submit(new AlluxioCreator(fs, paths));
+    }
+    CommonUtils.sleepMs(2 * Constants.SECOND_MS);
+    executor.shutdownNow();
+    assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    mClusterResource.get().restartMasters();
+    fs.listStatus(new AlluxioURI("/"));
+  }
+
+  private static class UfsRenamer implements Callable<Void> {
+    private final UnderFileSystem mUfs;
+    private final String mUfsRoot;
+
+    public UfsRenamer(UnderFileSystem ufs, String ufsRoot) {
+      mUfs = ufs;
+      mUfsRoot = ufsRoot;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      while (!Thread.interrupted()) {
+        String src = PathUtils.concatPath(mUfsRoot,
+            "dir" + ThreadLocalRandom.current().nextInt(NUM_TOP_LEVEL_DIRS));
+        String dst = PathUtils.concatPath(mUfsRoot,
+            "dir" + ThreadLocalRandom.current().nextInt(NUM_TOP_LEVEL_DIRS));
+        if (mUfs.exists(src) && !mUfs.exists(dst)) {
+          mUfs.renameDirectory(src, dst);
+        }
+      }
+      return null;
+    }
+  }
+
+  private static class AlluxioCreator implements Callable<Void> {
+    private final FileSystem mFs;
+    private final List<String> mPaths;
+
+    public AlluxioCreator(FileSystem fs, List<String> paths) {
+      mFs = fs;
+      mPaths = paths;
+    }
+
+    @Override
+    public Void call() {
+      while (!Thread.interrupted()) {
+        int ind = ThreadLocalRandom.current().nextInt(mPaths.size());
+        String path = mPaths.get(ind);
+        try {
+          mFs.createDirectory(new AlluxioURI(path),
+              CreateDirectoryOptions.defaults().setRecursive(true).setAllowExists(true));
+          while (!PathUtils.isRoot(PathUtils.getParent(path))) {
+            path = PathUtils.getParent(path);
+          }
+          mFs.delete(new AlluxioURI(path), DeleteOptions.defaults().setRecursive(true));
+        } catch (Exception e) {
+          continue;
+        }
+      }
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This fixes a bug where concurrent creation operations can lead to invalid inodes. The race condition looks like:

Initial state: Only inode in Alluxio is "/", ufs contains "/a/b/c"
Thread A: begins to create /a/b
Thread B: tries to create /a/b/c
Thread A: begins to create /a
Thread A: takes a write lock on /a
Thread A: creates a new inode for /a
Thread A: adds /a to the children list of "/"
Thread A: calls syncPersistDirectory to sync "/a" with the ufs
Out of band: /a/b/c gets removed in the UFS
Thread B: traverses to "/a/b/c" and finds "/a" as a child of "/"
Thread B: takes a read lock on "/a" and blocks since thread A still has the write lock
Thread A: throws InvalidPathException("Cannot create or load UFS directory")
Thread A: removes "/a" from the child list of "/"
Thread A: unlocks "/a"
Thread B: acquires read lock on "/a" and continues traversal
Thread B: assumes that "/a" is part of the inode tree and performs operations on it. But there is no journal creation entry for "/a", so any operations will cause journal replay to fail.

To address the race, we need to mark inodes as deleted if we add and then remove them from the inode tree. Then the "acquires read lock on "/a" and continues traversal" step will fail, because traversal checks whether inodes are deleted after acquiring their lock.

As a defensive measure, this PR marks all constructed inodes as deleted if they don't eventually get added to the inode tree.

The integration test fails consistently without the fix

fixes #8430