### PR TITLE
Use separate gRPC client executor for workers

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -215,6 +216,7 @@ public abstract class AbstractClient implements Client {
         mChannel = GrpcChannelBuilder
             .newBuilder(mAddress, mContext.getConf())
             .setSubject(mContext.getSubject())
+            .setExecutor(ForkJoinPool.commonPool())
             .build();
         // Create stub for version service on host
         mVersionService = ServiceVersionClientServiceGrpc.newBlockingStub(mChannel);

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2035,7 +2035,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS =
       new Builder(Name.WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS)
-          .setDefaultValue("10sec")
+          .setDefaultValue("30sec")
           .setDescription("The maximum time for a data server (for block reads and block writes) "
               + "to wait for a keepalive response before closing the connection.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -22,6 +22,7 @@ import io.netty.channel.EventLoopGroup;
 
 import javax.security.auth.Subject;
 import java.net.SocketAddress;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -181,6 +182,11 @@ public final class GrpcChannelBuilder {
    */
   public GrpcChannelBuilder setPoolingStrategy(GrpcManagedChannelPool.PoolingStrategy strategy) {
     mChannelKey.setPoolingStrategy(strategy);
+    return this;
+  }
+
+  public GrpcChannelBuilder setExecutor(Executor executor) {
+    mChannelKey.setExecutor(executor);
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -106,7 +107,9 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   }
 
   private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {
-    GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, mConfiguration).build();
+    GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, mConfiguration)
+        .setExecutor(ForkJoinPool.commonPool())
+        .build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);
     try {

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ForkJoinPool;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -400,7 +401,9 @@ public final class ConfigurationUtils {
     List<alluxio.grpc.ConfigProperty> clusterConfig;
 
     try {
-      channel = GrpcChannelBuilder.newBuilder(address, conf).disableAuthentication().build();
+      channel = GrpcChannelBuilder.newBuilder(address, conf).disableAuthentication()
+          .setExecutor(ForkJoinPool.commonPool())
+          .build();
       MetaMasterConfigurationServiceGrpc.MetaMasterConfigurationServiceBlockingStub client =
           MetaMasterConfigurationServiceGrpc.newBlockingStub(channel);
       clusterConfig =

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -40,6 +40,7 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.ForkJoinPool;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -646,7 +647,9 @@ public final class NetworkAddressUtils {
       throws AlluxioStatusException {
     Preconditions.checkNotNull(address, "address");
     Preconditions.checkNotNull(serviceType, "serviceType");
-    GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, conf).build();
+    GrpcChannel channel = GrpcChannelBuilder.newBuilder(address, conf)
+        .setExecutor(ForkJoinPool.commonPool())
+        .build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);
     versionClient.getServiceVersion(


### PR DESCRIPTION
Workers handles long running blocking streams which will exhaust the common `ForkJoinPool` (by default `cpu core - 1` parallelism) pretty quickly if user holds on to streams concurrently. This change makes the worker client use default gRPC executor which is not bounded by the number of CPU cores.