### PR TITLE
Define a default value for gRPC client-side message size (100MB)

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2889,7 +2889,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_NETWORK_MAX_INBOUND_MESSAGE_SIZE =
       new Builder(Name.USER_NETWORK_MAX_INBOUND_MESSAGE_SIZE)
-          .setDefaultValue("4MB")
+          .setDefaultValue("100MB")
           .setDescription("The max inbound message size used by user gRPC connections.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
@@ -2980,13 +2980,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("Alluxio client RPCs automatically retry for transient errors with "
               + "an exponential backoff. This property determines the maximum duration to retry for"
               + " before giving up. Note that, this value is set to 5s for fs and fsadmin CLIs.")
-          .build();
-  public static final PropertyKey USER_RPC_MAX_INBOUND_MESSAGE_SIZE =
-          new Builder(Name.USER_RPC_MAX_INBOUND_MESSAGE_SIZE)
-          .setDefaultValue("100MB")
-          .setDescription("The max inbound message size used by user calls.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_WORKER_LIST_REFRESH_INTERVAL =
       new Builder(Name.USER_WORKER_LIST_REFRESH_INTERVAL)
@@ -4050,8 +4043,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_RPC_RETRY_MAX_NUM_RETRY =
         "alluxio.user.rpc.retry.max.num.retry";
     public static final String USER_RPC_RETRY_MAX_SLEEP_MS = "alluxio.user.rpc.retry.max.sleep";
-    public static final String USER_RPC_MAX_INBOUND_MESSAGE_SIZE =
-        "alluxio.user.rpc.max.inbound.message.size";
     public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.ufs.delegation.read.buffer.size.bytes";
     public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2981,6 +2981,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "an exponential backoff. This property determines the maximum duration to retry for"
               + " before giving up. Note that, this value is set to 5s for fs and fsadmin CLIs.")
           .build();
+  public static final PropertyKey USER_RPC_MAX_INBOUND_MESSAGE_SIZE =
+          new Builder(Name.USER_RPC_MAX_INBOUND_MESSAGE_SIZE)
+          .setDefaultValue("100MB")
+          .setDescription("The max inbound message size used by user calls.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_WORKER_LIST_REFRESH_INTERVAL =
       new Builder(Name.USER_WORKER_LIST_REFRESH_INTERVAL)
           .setDefaultValue("2min")
@@ -4043,6 +4050,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_RPC_RETRY_MAX_NUM_RETRY =
         "alluxio.user.rpc.retry.max.num.retry";
     public static final String USER_RPC_RETRY_MAX_SLEEP_MS = "alluxio.user.rpc.retry.max.sleep";
+    public static final String USER_RPC_MAX_INBOUND_MESSAGE_SIZE =
+        "alluxio.user.rpc.max.inbound.message.size";
     public static final String USER_UFS_DELEGATION_READ_BUFFER_SIZE_BYTES =
         "alluxio.user.ufs.delegation.read.buffer.size.bytes";
     public static final String USER_UFS_DELEGATION_WRITE_BUFFER_SIZE_BYTES =

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -53,7 +53,7 @@ public final class GrpcChannelBuilder {
     // Set default overrides for the channel.
     mChannelKey.setAddress(address).usePlaintext();
     mChannelKey.setMaxInboundMessageSize(
-        (int) mConfiguration.getBytes(PropertyKey.USER_RPC_MAX_INBOUND_MESSAGE_SIZE));
+        (int) mConfiguration.getBytes(PropertyKey.USER_NETWORK_MAX_INBOUND_MESSAGE_SIZE));
     mUseSubject = true;
     mAuthenticateChannel = true;
   }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -48,11 +48,14 @@ public final class GrpcChannelBuilder {
   protected AlluxioConfiguration mConfiguration;
 
   private GrpcChannelBuilder(SocketAddress address, AlluxioConfiguration conf) {
+    mConfiguration = conf;
     mChannelKey = GrpcManagedChannelPool.ChannelKey.create(conf);
+    // Set default overrides for the channel.
     mChannelKey.setAddress(address).usePlaintext();
+    mChannelKey.setMaxInboundMessageSize(
+        (int) mConfiguration.getBytes(PropertyKey.USER_RPC_MAX_INBOUND_MESSAGE_SIZE));
     mUseSubject = true;
     mAuthenticateChannel = true;
-    mConfiguration = conf;
   }
 
   /**


### PR DESCRIPTION
ListStatus for ~20K files requires ~100MB of message buffer size...