### PR TITLE
Fix bug where listing caching inode store misses inodes

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreTest.java
@@ -121,6 +121,16 @@ public class CachingInodeStoreTest {
   }
 
   @Test
+  public void listChildrenOverCacheSize() {
+    for (long inodeId = 10; inodeId < 10 + CACHE_SIZE * 2; inodeId++) {
+      MutableInodeDirectory dir = createInodeDir(inodeId, 0);
+      mStore.addChild(0, dir);
+    }
+
+    assertEquals(CACHE_SIZE * 2, Iterables.size(mStore.getChildren(0L)));
+  }
+
+  @Test
   public void cacheGetChildrenInodeLookups() {
     List<Inode> children = new ArrayList<>();
     for (int id = 100; id < 110; id++) {


### PR DESCRIPTION
This could happen when listing /a if edge a->b=3 has
been evicted to the backing store, but inode 3 exists
only in the cache. Calling getChildren("/a") on the backing
store will not find inode 3 because the backing store
doesn't know anything about inode 3.

This bug rarely happens in practice because the edge
leading to an inode and the inode itself are usually
accessed around the same time, so they are usually either
both in the cache, or both in the backing store. 