### PR TITLE
Give more direct memory to FUSE

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -47,6 +47,7 @@ set_java_opt() {
     -server
     -Xms1G
     -Xmx1G
+    -XX:MaxDirectMemorySize=4g
   "
 
   ALLUXIO_FUSE_JAVA_OPTS=${ALLUXIO_JAVA_OPTS}


### PR DESCRIPTION
With zero-copy implemented for read path, Alluxio client now uses more direct memory for buffering data. This has lead to OOM in Alluxio FUSE process which currently only can use 1GB of direct memory.

This change bumps up the direct memory limit for Alluxio FUSE process thus reduces the chance of getting OOM.