### PR TITLE
Support flushing cached data to the backing store

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -88,7 +88,8 @@ public final class CachingInodeStore implements InodeStore, Closeable {
   private final InodeLockManager mLockManager;
 
   // Cache recently-accessed inodes.
-  private final InodeCache mInodeCache;
+  @VisibleForTesting
+  final InodeCache mInodeCache;
 
   // Cache recently-accessed inode tree edges.
   @VisibleForTesting
@@ -238,7 +239,8 @@ public final class CachingInodeStore implements InodeStore, Closeable {
    * least an mLockManager read lock on the modified inode. This allows the cache to flush inodes
    * asynchronously by acquiring a write lock before serializing the inode.
    */
-  private class InodeCache extends Cache<Long, MutableInode<?>> {
+  @VisibleForTesting
+  class InodeCache extends Cache<Long, MutableInode<?>> {
     public InodeCache(CacheConfiguration conf) {
       super(conf, "inode-cache");
     }


### PR DESCRIPTION
This prepares for supporting RocksDB-based snapshots. Before taking the RocksDB snapshot, we need to ensure that all data is flushed to RocksDB.