### PR TITLE
Do not show anything in the data page where there is no file.

### DIFF
--- a/alluxio-ui/master/src/store/data/reducer.tsx
+++ b/alluxio-ui/master/src/store/data/reducer.tsx
@@ -16,25 +16,7 @@ import {DataActionTypes, IDataState} from './types';
 export const initialDataState: IDataState = {
   data: {
     'fatalError': '',
-    'fileInfos': [{
-      'absolutePath': '',
-      'blockSizeBytes': '',
-      'blocksOnTier': {},
-      'creationTime': '',
-      'fileLocations': [],
-      'group': '',
-      'id': 0,
-      'inAlluxio': false,
-      'inAlluxioPercentage': 0,
-      'isDirectory': false,
-      'mode': '',
-      'modificationTime': '',
-      'name': 'LICENSE',
-      'owner': 'William',
-      'persistenceState': '',
-      'pinned': false,
-      'size': ''
-    }],
+    'fileInfos': [],
     'inAlluxioFileNum': 0,
     'masterNodeAddress': '',
     'permissionError': '',


### PR DESCRIPTION
The default fileInfo should be an empty list, the existing item should be only for debugging purpose during development.