### PR TITLE
Add back keep alive configuration

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -181,6 +181,8 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
             .getClientChannelClass(!(address instanceof InetSocketAddress), alluxioConf))
         .setPoolingStrategy(poolingStrategy)
         .setEventLoopGroup(workerGroup)
+        .setKeepAliveTime(alluxioConf.getMs(PropertyKey.USER_NETWORK_KEEPALIVE_TIME_MS),
+            TimeUnit.MILLISECONDS)
         .setKeepAliveTimeout(alluxioConf.getMs(PropertyKey.USER_NETWORK_KEEPALIVE_TIMEOUT_MS),
             TimeUnit.MILLISECONDS)
         .setMaxInboundMessageSize(


### PR DESCRIPTION
This line was missing as a result of a recent merge. I am adding it back to fix the keep alive configuration.