### PR TITLE
[SMALLFIX] Support pinging Job Master client service

### DIFF
--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -14,6 +14,7 @@ package alluxio.master;
 import static java.util.stream.Collectors.joining;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.GetServiceVersionPRequest;
@@ -112,9 +113,12 @@ public class PollingMasterInquireClient implements MasterInquireClient {
         .build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);
+    ServiceType serviceType
+        = address.getPort() == mConfiguration.getInt(PropertyKey.JOB_MASTER_RPC_PORT)
+        ? ServiceType.JOB_MASTER_CLIENT_SERVICE : ServiceType.META_MASTER_CLIENT_SERVICE;
     try {
       versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()
-          .setServiceType(ServiceType.META_MASTER_CLIENT_SERVICE).build());
+          .setServiceType(serviceType).build());
     } catch (StatusRuntimeException e) {
       throw AlluxioStatusException.fromThrowable(e);
     }


### PR DESCRIPTION
The `DefaultReplicationHandler.replicate` will connect to the job master client and run the replication work. 
In this process, it will First use `PollingMasterInquireCient.pingMetaService` to ping job master client service and get the error out because the job master does not have the `Meta_Master_Cient_Service`.

So `pingMetaService` actually pings meta master client service and job master client service.