### PR TITLE
Fix block location order

### DIFF
--- a/core/base/src/main/java/alluxio/wire/BlockLocationInfo.java
+++ b/core/base/src/main/java/alluxio/wire/BlockLocationInfo.java
@@ -1,0 +1,51 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.wire;
+
+import alluxio.annotation.PublicApi;
+
+import java.util.List;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * The file block with location information.
+ */
+@PublicApi
+@NotThreadSafe
+public final class BlockLocationInfo {
+  private final FileBlockInfo mBlockInfo;
+  private final List<WorkerNetAddress> mLocations;
+
+  /**
+   * @param blockInfo the block info
+   * @param locations the addresses of the workers containing the block
+   */
+  public BlockLocationInfo(FileBlockInfo blockInfo, List<WorkerNetAddress> locations) {
+    mBlockInfo = blockInfo;
+    mLocations = locations;
+  }
+
+  /**
+   * @return the block info
+   */
+  public FileBlockInfo getBlockInfo() {
+    return mBlockInfo;
+  }
+
+  /**
+   * @return the addresses of the workers containing the block
+   */
+  public List<WorkerNetAddress> getLocations() {
+    return mLocations;
+  }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -43,6 +43,7 @@ import alluxio.master.MasterInquireClient;
 import alluxio.security.authorization.AclEntry;
 import alluxio.uri.Authority;
 import alluxio.util.ConfigurationUtils;
+import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.SyncPointInfo;
@@ -351,10 +352,11 @@ public interface FileSystem extends Closeable {
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**
-   * Builds a mapping of {@link FileBlockInfo} to a list of {@link WorkerNetAddress} which allows a
-   * user to determine the physical location of a file stored within Alluxio. In the case where
-   * data is stored in a UFS, but not in Alluxio this function will only include a
-   * {@link WorkerNetAddress} if the block stored in the UFS is co-located with an Alluxio worker.
+   * Builds a list of {@link BlockLocationInfo} for the given file. Each list item contains a list
+   * of {@link WorkerNetAddress} which allows a user to determine the physical location of a block
+   * of the given file stored within Alluxio. In the case where data is stored in a UFS, but not in
+   * Alluxio this function will only include a {@link WorkerNetAddress} if the block stored in the
+   * UFS is co-located with an Alluxio worker.
    * However if there are no co-located Alluxio workers for the block, then the behavior is
    * controlled by the {@link PropertyKey#USER_UFS_BLOCK_LOCATION_ALL_FALLBACK_ENABLED} . If
    * this property is set to {@code true} then every Alluxio worker will be returned.
@@ -363,11 +365,12 @@ public interface FileSystem extends Closeable {
    * Alluxio workers which currently store the block.
    *
    * @param path the path to get block info for
-   * @return a map of blocks to the workers whose hosts have the blocks. The blocks may not
-   *         necessarily be stored in Alluxio
+   * @return a list of blocks with the workers whose hosts have the blocks. The blocks may not
+   *         necessarily be stored in Alluxio. The blocks are returned in the order of their
+   *         sequences in file.
    * @throws FileDoesNotExistException if the given path does not exist
    */
-  Map<FileBlockInfo, List<WorkerNetAddress>> getBlockLocations(AlluxioURI path)
+  List<BlockLocationInfo> getBlockLocations(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -44,7 +44,6 @@ import alluxio.security.authorization.AclEntry;
 import alluxio.uri.Authority;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockLocationInfo;
-import alluxio.wire.FileBlockInfo;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.SyncPointInfo;
 import alluxio.wire.WorkerNetAddress;

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -301,7 +301,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
               info.getBlockInfo().getLength()));
         }
       });
-      BlockLocation[] ret = blockLocations.toArray(new BlockLocation[0]);
+      BlockLocation[] ret = blockLocations.toArray(new BlockLocation[blockLocations.size()]);
       if (LOG.isDebugEnabled()) {
         LOG.debug("getFileBlockLocations({}, {}, {}) returned {}",
             file.getPath().getName(), start, len, Arrays.toString(ret));

--- a/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
@@ -41,8 +41,6 @@ import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockLocationInfo;
-import alluxio.wire.FileBlockInfo;
-import alluxio.wire.WorkerNetAddress;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,7 +50,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Integration tests for Alluxio Client (reuse the {@link LocalAlluxioCluster}).


### PR DESCRIPTION
There is a regression in `getFileBlockLocations()` API where the client does not return the block locations in their original order in file. This is causing Presto queries to fail because they are relying on the block orders.  This PR refactored the native API so it returns a list instead of an unordered map.