### PR TITLE
Fix list recursive for object store

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -869,7 +869,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
             if (!objectName.isEmpty()) {
               // include the separator with the prefix, to conform to what object stores return
               // as common prefixes.
-              prefixes.add(objectName + PATH_SEPARATOR);
+              prefixes.add(PathUtils.normalizePath(objectName, PATH_SEPARATOR));
             }
           }
         }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -867,7 +867,9 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           while (objectName.startsWith(keyPrefix)) {
             objectName = objectName.substring(0, objectName.lastIndexOf(PATH_SEPARATOR));
             if (!objectName.isEmpty()) {
-              prefixes.add(objectName);
+              // include the separator with the prefix, to conform to what object stores return
+              // as common prefixes.
+              prefixes.add(objectName + PATH_SEPARATOR);
             }
           }
         }

--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -573,6 +573,34 @@ public abstract class AbstractUnderFileSystemContractTest {
   }
 
   @Test
+  public void objectNestedDirsListStatusRecursive() throws IOException {
+    // Only run test for an object store
+    Assume.assumeTrue(mUfs.isObjectStorage());
+
+    ObjectUnderFileSystem ufs = (ObjectUnderFileSystem) mUfs;
+
+    String root = mUnderfsAddress;
+
+    String dir1 = PathUtils.concatPath(root, "dir1");
+    String dir2 = PathUtils.concatPath(dir1, "dir2");
+    String file1 = PathUtils.concatPath(dir2, "file.txt");
+
+    // Empty lsr should be empty
+    assertEquals(0, mUfs.listStatus(root, ListOptions.defaults().setRecursive(true)).length);
+
+    String fileKey = file1.substring(PathUtils.normalizePath(ufs.getRootKey(), "/").length());
+    assertTrue(ufs.createEmptyObject(fileKey));
+
+    String[] expectedStatus = { "dir1", "dir1/dir2", "dir1/dir2/file.txt" };
+    String[] actualStatus =
+        UfsStatus.convertToNames(mUfs.listStatus(root, ListOptions.defaults().setRecursive(true)));
+    assertEquals(expectedStatus.length, actualStatus.length);
+    Arrays.sort(expectedStatus);
+    Arrays.sort(actualStatus);
+    assertArrayEquals(expectedStatus, actualStatus);
+  }
+
+  @Test
   public void renameFile() throws IOException {
     String testFileSrc = PathUtils.concatPath(mUnderfsAddress, "renameFileSrc");
     String testFileDst = PathUtils.concatPath(mUnderfsAddress, "renameFileDst");


### PR DESCRIPTION
When recursively listing from an object store, Alluxio computes the prefixes from the object store results. However, the commonPrefixes returned by the object store include the path separators. Therefore, the Alluxio processing should follow the same convention and include the path separators. Further processing of the prefixes assume that the path separators are included.