### PR TITLE
Clean up the options for CLI commands to be consistent

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
@@ -18,9 +18,10 @@ import alluxio.exception.status.InvalidArgumentException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
 import java.io.IOException;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Copies the specified file specified by "source path" to the path specified by "remote path".
@@ -67,8 +68,8 @@ public final class CopyFromLocalCommand extends AbstractFileSystemCommand {
   @Override
   public String getUsage() {
     return "copyFromLocal "
-        + "[--thread <number of threads for copying>] "
-        + "[--buffersize <read buffer size in bytes>] "
+        + "[--thread <num>] "
+        + "[--buffersize <bytes>] "
         + "<src> <remoteDst>";
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/CopyToLocalCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CopyToLocalCommand.java
@@ -18,9 +18,10 @@ import alluxio.exception.status.InvalidArgumentException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
 import java.io.IOException;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Copies a file or a directory from the Alluxio filesystem to the local filesystem.
@@ -65,7 +66,7 @@ public final class CopyToLocalCommand extends AbstractFileSystemCommand {
   @Override
   public String getUsage() {
     return "copyToLocal "
-        + "[--buffersize <read buffer size in bytes>] "
+        + "[--buffersize <bytes>] "
         + " <src> <localDst>";
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -41,7 +41,6 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,6 +58,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Copies a file or a directory in the Alluxio filesystem.
@@ -758,7 +759,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   public String getUsage() {
     return "cp "
         + "[-R] "
-        + "[--buffersize <read buffer size in bytes>] "
+        + "[--buffersize <bytes>] "
         + "<src> <dst>";
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -24,9 +24,10 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.util.List;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Loads a file or directory in Alluxio space, makes it resident in memory.
@@ -51,7 +52,8 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(Option.builder(REPLICATION)
+    return new Options().addOption(Option.builder()
+        .longOpt(REPLICATION)
         .required(false)
         .hasArg(true)
         .desc("number of replicas to have for each block of the loaded file")
@@ -111,7 +113,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "distributedLoad [-replication N] <path>";
+    return "distributedLoad [--replication <num>] <path>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/SetReplicationCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/SetReplicationCommand.java
@@ -32,11 +32,13 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class SetReplicationCommand extends AbstractFileSystemCommand {
 
-  private static final Option REPLICATION_MAX_OPTION =
-      Option.builder("max").required(false).numberOfArgs(1).desc("the maximum number of replicas")
+  private static final Option MAX_OPTION =
+      Option.builder().longOpt("max").required(false).numberOfArgs(1)
+          .desc("the maximum number of replicas")
           .build();
-  private static final Option REPLICATION_MIN_OPTION =
-      Option.builder("min").required(false).numberOfArgs(1).desc("the minimum number of replicas")
+  private static final Option MIN_OPTION =
+      Option.builder().longOpt("min").required(false).numberOfArgs(1)
+          .desc("the minimum number of replicas")
           .build();
   private static final Option RECURSIVE_OPTION =
       Option.builder("R").required(false).hasArg(false).desc("set replication recursively")
@@ -56,8 +58,8 @@ public final class SetReplicationCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(RECURSIVE_OPTION).addOption(REPLICATION_MAX_OPTION)
-        .addOption(REPLICATION_MIN_OPTION);
+    return new Options().addOption(RECURSIVE_OPTION).addOption(MAX_OPTION)
+        .addOption(MIN_OPTION);
   }
 
   @Override
@@ -96,15 +98,17 @@ public final class SetReplicationCommand extends AbstractFileSystemCommand {
   public int run(CommandLine cl) throws AlluxioException, IOException {
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);
-    Integer replicationMax = cl.hasOption("max") ? Integer.valueOf(cl.getOptionValue("max")) : null;
-    Integer replicationMin = cl.hasOption("min") ? Integer.valueOf(cl.getOptionValue("min")) : null;
-    boolean recursive = cl.hasOption("R");
+    Integer replicationMax = cl.hasOption(MAX_OPTION.getLongOpt())
+        ? Integer.valueOf(cl.getOptionValue(MAX_OPTION.getLongOpt())) : null;
+    Integer replicationMin = cl.hasOption(MIN_OPTION.getLongOpt())
+        ? Integer.valueOf(cl.getOptionValue(MIN_OPTION.getLongOpt())) : null;
+    boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt());
     if (replicationMax == null && replicationMin == null) {
-      throw new IOException("At least one option of '-max' or '-min' must be specified");
+      throw new IOException("At least one option of '--max' or '--min' must be specified");
     }
     if (replicationMax != null && replicationMin != null && replicationMax >= 0
         && replicationMax < replicationMin) {
-      throw new IOException("Invalid values for '-max' and '-min' options");
+      throw new IOException("Invalid values for '--max' and '--min' options");
     }
     setReplication(path, replicationMax, replicationMin, recursive);
     return 0;
@@ -112,13 +116,13 @@ public final class SetReplicationCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "setReplication [-R] [-max <num> | -min <num>] <path>";
+    return "setReplication [-R] [--max <num> | --min <num>] <path>";
   }
 
   @Override
   public String getDescription() {
     return "Sets the minimum/maximum number of replicas for the file or directory at given path. "
-        + "Specify '-1' as the argument of '-max' option to indicate no limit of the maximum "
+        + "Specify '-1' as the argument of '--max' option to indicate no limit of the maximum "
         + "number of replicas. If 'path' is a directory and '-R' is specified, it will recursively "
         + "set all files in this directory.";
   }


### PR DESCRIPTION
- use opts like `--replication` rather than `-replication` in CLI consistently
- clean up CLI command description 