### PR TITLE
Reduce the number of RPCs used for create file

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -44,7 +44,6 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPOptions;
-import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -191,11 +190,7 @@ public class BaseFileSystem implements FileSystem {
     FileSystemMasterClient masterClient = mFsContext.acquireMasterClient();
     URIStatus status;
     try {
-      masterClient.createFile(path, options);
-      // Do not sync before this getStatus, since the UFS file is expected to not exist.
-      GetStatusPOptions gsOptions = FileSystemOptions.getStatusDefaults(mFsContext.getConf())
-          .toBuilder().setLoadMetadataType(LoadMetadataPType.NEVER).build();
-      status = masterClient.getStatus(path, gsOptions);
+      status = masterClient.createFile(path, options);
       LOG.debug("Created file {}, options: {}", path.getPath(), options);
     } catch (AlreadyExistsException e) {
       throw new FileAlreadyExistsException(e.getMessage());

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -89,8 +89,9 @@ public interface FileSystemMasterClient extends Client {
    * @param path the file path
    * @param options method options
    * @throws AlreadyExistsException if the file already exists
+   * @return the uri status of the newly created file
    */
-  void createFile(AlluxioURI path, CreateFilePOptions options) throws AlluxioStatusException;
+  URIStatus createFile(AlluxioURI path, CreateFilePOptions options) throws AlluxioStatusException;
 
   /**
    * Marks a file as completed.

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -133,10 +133,12 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   }
 
   @Override
-  public void createFile(final AlluxioURI path, final CreateFilePOptions options)
+  public URIStatus createFile(final AlluxioURI path, final CreateFilePOptions options)
       throws AlluxioStatusException {
-    retryRPC(() -> mClient.createFile(CreateFilePRequest.newBuilder().setPath(path.getPath())
-        .setOptions(options).build()), "CreateFile");
+    return retryRPC(
+        () -> new URIStatus(GrpcUtils.fromProto(mClient.createFile(
+            CreateFilePRequest.newBuilder().setPath(path.getPath()).setOptions(options).build())
+            .getFileInfo())), "CreateFile");
   }
 
   @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -36,7 +36,6 @@ import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
-import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -117,13 +116,10 @@ public final class BaseFileSystemTest {
    */
   @Test
   public void createFile() throws Exception {
-    doNothing().when(mFileSystemMasterClient)
-        .createFile(any(AlluxioURI.class), any(CreateFilePOptions.class));
     URIStatus status = new URIStatus(new FileInfo());
     AlluxioURI file = new AlluxioURI("/file");
-    GetStatusPOptions getStatusOptions = FileSystemOptions.getStatusDefaults(mConf)
-        .toBuilder().setLoadMetadataType(LoadMetadataPType.NEVER).build();
-    when(mFileSystemMasterClient.getStatus(file, getStatusOptions)).thenReturn(status);
+    when(mFileSystemMasterClient.createFile(any(AlluxioURI.class), any(CreateFilePOptions.class)))
+        .thenReturn(status);
     FileOutStream out = mFileSystem.createFile(file, CreateFilePOptions.getDefaultInstance());
     verify(mFileSystemMasterClient).createFile(file, FileSystemOptions.createFileDefaults(mConf)
             .toBuilder().mergeFrom(CreateFilePOptions.getDefaultInstance()).build());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1337,13 +1337,12 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   @Override
-  public long createFile(AlluxioURI path, CreateFileContext context)
+  public FileInfo createFile(AlluxioURI path, CreateFileContext context)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
       BlockInfoException, IOException, FileDoesNotExistException {
     Metrics.CREATE_FILES_OPS.inc();
     LockingScheme lockingScheme = createLockingScheme(path, context.getOptions().getCommonOptions(),
             LockPattern.WRITE_EDGE);
-    long id;
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern());
@@ -1368,7 +1367,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       }
       createFileInternal(rpcContext, inodePath, context);
       auditContext.setSrcInode(inodePath.getInode()).setSucceeded(true);
-      return inodePath.getInode().getId();
+      return getFileInfoInternal(inodePath);
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -189,7 +189,7 @@ public interface FileSystemMaster extends Master {
    *
    * @param path the file to create
    * @param context the method context
-   * @return the id of the created file
+   * @return the file info of the created file
    * @throws InvalidPathException if an invalid path is encountered
    * @throws FileAlreadyExistsException if the file already exists
    * @throws BlockInfoException if an invalid block information is encountered
@@ -197,7 +197,7 @@ public interface FileSystemMaster extends Master {
    * @throws FileDoesNotExistException if the parent of the path does not exist and the recursive
    *         option is false
    */
-  long createFile(AlluxioURI path, CreateFileContext context)
+  FileInfo createFile(AlluxioURI path, CreateFileContext context)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
       BlockInfoException, IOException, FileDoesNotExistException;
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -170,6 +170,7 @@ public final class FileSystemMasterClientServiceHandler
     String path = request.getPath();
     CreateFilePOptions options = request.getOptions();
     RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CreateFilePResponse>) () -> {
+      // TODO(calvin): Consider making createFile return the FileInfo directly
       long fileId = mFileSystemMaster.createFile(new AlluxioURI(path),
           CreateFileContext.create(options.toBuilder()));
       return CreateFilePResponse.newBuilder()

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -169,13 +169,11 @@ public final class FileSystemMasterClientServiceHandler
       StreamObserver<CreateFilePResponse> responseObserver) {
     String path = request.getPath();
     CreateFilePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CreateFilePResponse>) () -> {
-      // TODO(calvin): Consider making createFile return the FileInfo directly
-      long fileId = mFileSystemMaster.createFile(new AlluxioURI(path),
-          CreateFileContext.create(options.toBuilder()));
-      return CreateFilePResponse.newBuilder()
-          .setFileInfo(GrpcUtils.toProto(mFileSystemMaster.getFileInfo(fileId))).build();
-    }, "CreateFile", "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CreateFilePResponse>)
+        () -> CreateFilePResponse.newBuilder().setFileInfo(GrpcUtils.toProto(
+            mFileSystemMaster.createFile(new AlluxioURI(path),
+                CreateFileContext.create(options.toBuilder())))).build(),
+        "CreateFile", "path=%s, options=%s", responseObserver, path, options);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -170,9 +170,10 @@ public final class FileSystemMasterClientServiceHandler
     String path = request.getPath();
     CreateFilePOptions options = request.getOptions();
     RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CreateFilePResponse>) () -> {
-      mFileSystemMaster.createFile(new AlluxioURI(path),
+      long fileId = mFileSystemMaster.createFile(new AlluxioURI(path),
           CreateFileContext.create(options.toBuilder()));
-      return CreateFilePResponse.newBuilder().build();
+      return CreateFilePResponse.newBuilder()
+          .setFileInfo(GrpcUtils.toProto(mFileSystemMaster.getFileInfo(fileId))).build();
     }, "CreateFile", "path=%s, options=%s", responseObserver, path, options);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -245,8 +245,8 @@ public final class FileSystemMasterTest {
     };
     for (String path : paths) {
       AlluxioURI uri = new AlluxioURI(path);
-      long id = mFileSystemMaster.createFile(uri,
-          CreateFileContext.mergeFrom(CreateFilePOptions.newBuilder().setRecursive(true)));
+      long id = mFileSystemMaster.createFile(uri, CreateFileContext.mergeFrom(
+          CreateFilePOptions.newBuilder().setRecursive(true))).getFileId();
       Assert.assertEquals(id, mFileSystemMaster.getFileId(uri));
       mFileSystemMaster.delete(uri, DeleteContext.defaults());
       id = mFileSystemMaster.createDirectory(uri, CreateDirectoryContext
@@ -1624,7 +1624,7 @@ public final class FileSystemMasterTest {
     context.getOptions().setBlockSizeBytes(Constants.KB);
     context.getOptions().setRecursive(true);
     context.getOptions().setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(0));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
     assertEquals(fileInfo.getFileId(), fileId);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
@@ -1641,7 +1641,7 @@ public final class FileSystemMasterTest {
     context.getOptions().setBlockSizeBytes(Constants.KB);
     context.getOptions().setRecursive(true);
     context.getOptions().setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(0));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
 
     // Simulate restart.
     stopServices();
@@ -1797,7 +1797,7 @@ public final class FileSystemMasterTest {
   public void setTtlForFileWithNoTtl() throws Exception {
     CreateFileContext context = CreateFileContext.mergeFrom(
         CreateFilePOptions.newBuilder().setBlockSizeBytes(Constants.KB).setRecursive(true));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
     // Since no TTL is set, the file should not be deleted.
     assertEquals(fileId,
@@ -1824,7 +1824,7 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.createDirectory(NESTED_DIR_URI, directoryContext);
     CreateFileContext createFileContext = CreateFileContext.mergeFrom(
         CreateFilePOptions.newBuilder().setBlockSizeBytes(Constants.KB).setRecursive(true));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, createFileContext);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, createFileContext).getFileId();
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
     // Since no TTL is set, the file should not be deleted.
     assertEquals(fileId,
@@ -1850,7 +1850,7 @@ public final class FileSystemMasterTest {
     CreateFileContext context = CreateFileContext.mergeFrom(CreateFilePOptions.newBuilder()
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(Constants.HOUR_MS))
         .setBlockSizeBytes(Constants.KB).setRecursive(true));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
     // Since TTL is 1 hour, the file won't be deleted during last TTL check.
     assertEquals(fileId,
@@ -1898,7 +1898,7 @@ public final class FileSystemMasterTest {
     CreateFileContext context = CreateFileContext.mergeFrom(CreateFilePOptions.newBuilder()
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(0))
         .setBlockSizeBytes(Constants.KB).setRecursive(true));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
     assertEquals(fileId,
         mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_CONTEXT).getFileId());
 
@@ -1940,7 +1940,7 @@ public final class FileSystemMasterTest {
     CreateFileContext context = CreateFileContext.mergeFrom(CreateFilePOptions.newBuilder()
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(0))
         .setBlockSizeBytes(Constants.KB).setRecursive(true));
-    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context);
+    long fileId = mFileSystemMaster.createFile(NESTED_FILE_URI, context).getFileId();
     // After setting TTL to NO_TTL, the original TTL will be removed, and the file will not be
     // deleted during next TTL check.
     mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeContext

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -296,9 +296,7 @@ public final class PermissionCheckTest {
           .setGroup(SecurityUtils.getGroupFromGrpcClient(ServerConfiguration.global()))
           .setPersisted(true);
 
-      long fileId = mFileSystemMaster.createFile(new AlluxioURI(path), context);
-
-      FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
+      FileInfo fileInfo = mFileSystemMaster.createFile(new AlluxioURI(path), context);
       String[] pathComponents = path.split("/");
       assertEquals(pathComponents[pathComponents.length - 1], fileInfo.getName());
       assertEquals(user.getUser(), fileInfo.getOwner());

--- a/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
@@ -313,10 +313,9 @@ public final class PersistenceTest {
     mFileSystemMaster.createDirectory(alluxioDirSrc,
         CreateDirectoryContext.defaults().setPersisted(true));
     AlluxioURI alluxioFileSrc = new AlluxioURI("/src/in_alluxio");
-    long fileId = mFileSystemMaster.createFile(alluxioFileSrc,
+    FileInfo info = mFileSystemMaster.createFile(alluxioFileSrc,
         CreateFileContext.defaults().setPersisted(false));
-    Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(),
-        mFileSystemMaster.getFileInfo(fileId).getPersistenceState());
+    Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), info.getPersistenceState());
     mFileSystemMaster.completeFile(alluxioFileSrc, CompleteFileContext.defaults());
 
     // Schedule the async persistence, checking the internal state.
@@ -350,7 +349,7 @@ public final class PersistenceTest {
     // Create the temporary UFS file.
     {
       Map<Long, PersistJob> persistJobs = getPersistJobs();
-      PersistJob job = persistJobs.get(fileId);
+      PersistJob job = persistJobs.get(info.getFileId());
       UnderFileSystem ufs = UnderFileSystem.Factory.create(job.getTempUfsPath(),
           ServerConfiguration.global());
       UnderFileSystemUtils.touch(ufs, job.getTempUfsPath());

--- a/core/transport/src/grpc/file_system_master.proto
+++ b/core/transport/src/grpc/file_system_master.proto
@@ -81,7 +81,9 @@ message CreateDirectoryPRequest {
   optional CreateDirectoryPOptions options = 2;
 }
 
-message CreateFilePResponse {}
+message CreateFilePResponse {
+  optional FileInfo fileInfo = 1;
+}
 message CreateFilePOptions {
   optional int64 blockSizeBytes = 1;
   optional bool recursive = 2;

--- a/core/transport/src/main/java/alluxio/grpc/CreateFilePResponse.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateFilePResponse.java
@@ -31,6 +31,7 @@ private static final long serialVersionUID = 0L;
     if (extensionRegistry == null) {
       throw new java.lang.NullPointerException();
     }
+    int mutable_bitField0_ = 0;
     com.google.protobuf.UnknownFieldSet.Builder unknownFields =
         com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
@@ -46,6 +47,19 @@ private static final long serialVersionUID = 0L;
                 input, unknownFields, extensionRegistry, tag)) {
               done = true;
             }
+            break;
+          }
+          case 10: {
+            alluxio.grpc.FileInfo.Builder subBuilder = null;
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              subBuilder = fileInfo_.toBuilder();
+            }
+            fileInfo_ = input.readMessage(alluxio.grpc.FileInfo.PARSER, extensionRegistry);
+            if (subBuilder != null) {
+              subBuilder.mergeFrom(fileInfo_);
+              fileInfo_ = subBuilder.buildPartial();
+            }
+            bitField0_ |= 0x00000001;
             break;
           }
         }
@@ -72,6 +86,28 @@ private static final long serialVersionUID = 0L;
             alluxio.grpc.CreateFilePResponse.class, alluxio.grpc.CreateFilePResponse.Builder.class);
   }
 
+  private int bitField0_;
+  public static final int FILEINFO_FIELD_NUMBER = 1;
+  private alluxio.grpc.FileInfo fileInfo_;
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  public boolean hasFileInfo() {
+    return ((bitField0_ & 0x00000001) == 0x00000001);
+  }
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  public alluxio.grpc.FileInfo getFileInfo() {
+    return fileInfo_ == null ? alluxio.grpc.FileInfo.getDefaultInstance() : fileInfo_;
+  }
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  public alluxio.grpc.FileInfoOrBuilder getFileInfoOrBuilder() {
+    return fileInfo_ == null ? alluxio.grpc.FileInfo.getDefaultInstance() : fileInfo_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -84,6 +120,9 @@ private static final long serialVersionUID = 0L;
 
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
+    if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      output.writeMessage(1, getFileInfo());
+    }
     unknownFields.writeTo(output);
   }
 
@@ -92,6 +131,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
+    if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(1, getFileInfo());
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -108,6 +151,11 @@ private static final long serialVersionUID = 0L;
     alluxio.grpc.CreateFilePResponse other = (alluxio.grpc.CreateFilePResponse) obj;
 
     boolean result = true;
+    result = result && (hasFileInfo() == other.hasFileInfo());
+    if (hasFileInfo()) {
+      result = result && getFileInfo()
+          .equals(other.getFileInfo());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -119,6 +167,10 @@ private static final long serialVersionUID = 0L;
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
+    if (hasFileInfo()) {
+      hash = (37 * hash) + FILEINFO_FIELD_NUMBER;
+      hash = (53 * hash) + getFileInfo().hashCode();
+    }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -244,10 +296,17 @@ private static final long serialVersionUID = 0L;
     private void maybeForceBuilderInitialization() {
       if (com.google.protobuf.GeneratedMessageV3
               .alwaysUseFieldBuilders) {
+        getFileInfoFieldBuilder();
       }
     }
     public Builder clear() {
       super.clear();
+      if (fileInfoBuilder_ == null) {
+        fileInfo_ = null;
+      } else {
+        fileInfoBuilder_.clear();
+      }
+      bitField0_ = (bitField0_ & ~0x00000001);
       return this;
     }
 
@@ -270,6 +329,17 @@ private static final long serialVersionUID = 0L;
 
     public alluxio.grpc.CreateFilePResponse buildPartial() {
       alluxio.grpc.CreateFilePResponse result = new alluxio.grpc.CreateFilePResponse(this);
+      int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
+      if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        to_bitField0_ |= 0x00000001;
+      }
+      if (fileInfoBuilder_ == null) {
+        result.fileInfo_ = fileInfo_;
+      } else {
+        result.fileInfo_ = fileInfoBuilder_.build();
+      }
+      result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
     }
@@ -311,6 +381,9 @@ private static final long serialVersionUID = 0L;
 
     public Builder mergeFrom(alluxio.grpc.CreateFilePResponse other) {
       if (other == alluxio.grpc.CreateFilePResponse.getDefaultInstance()) return this;
+      if (other.hasFileInfo()) {
+        mergeFileInfo(other.getFileInfo());
+      }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -336,6 +409,125 @@ private static final long serialVersionUID = 0L;
         }
       }
       return this;
+    }
+    private int bitField0_;
+
+    private alluxio.grpc.FileInfo fileInfo_ = null;
+    private com.google.protobuf.SingleFieldBuilderV3<
+        alluxio.grpc.FileInfo, alluxio.grpc.FileInfo.Builder, alluxio.grpc.FileInfoOrBuilder> fileInfoBuilder_;
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public boolean hasFileInfo() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public alluxio.grpc.FileInfo getFileInfo() {
+      if (fileInfoBuilder_ == null) {
+        return fileInfo_ == null ? alluxio.grpc.FileInfo.getDefaultInstance() : fileInfo_;
+      } else {
+        return fileInfoBuilder_.getMessage();
+      }
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public Builder setFileInfo(alluxio.grpc.FileInfo value) {
+      if (fileInfoBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        fileInfo_ = value;
+        onChanged();
+      } else {
+        fileInfoBuilder_.setMessage(value);
+      }
+      bitField0_ |= 0x00000001;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public Builder setFileInfo(
+        alluxio.grpc.FileInfo.Builder builderForValue) {
+      if (fileInfoBuilder_ == null) {
+        fileInfo_ = builderForValue.build();
+        onChanged();
+      } else {
+        fileInfoBuilder_.setMessage(builderForValue.build());
+      }
+      bitField0_ |= 0x00000001;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public Builder mergeFileInfo(alluxio.grpc.FileInfo value) {
+      if (fileInfoBuilder_ == null) {
+        if (((bitField0_ & 0x00000001) == 0x00000001) &&
+            fileInfo_ != null &&
+            fileInfo_ != alluxio.grpc.FileInfo.getDefaultInstance()) {
+          fileInfo_ =
+            alluxio.grpc.FileInfo.newBuilder(fileInfo_).mergeFrom(value).buildPartial();
+        } else {
+          fileInfo_ = value;
+        }
+        onChanged();
+      } else {
+        fileInfoBuilder_.mergeFrom(value);
+      }
+      bitField0_ |= 0x00000001;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public Builder clearFileInfo() {
+      if (fileInfoBuilder_ == null) {
+        fileInfo_ = null;
+        onChanged();
+      } else {
+        fileInfoBuilder_.clear();
+      }
+      bitField0_ = (bitField0_ & ~0x00000001);
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public alluxio.grpc.FileInfo.Builder getFileInfoBuilder() {
+      bitField0_ |= 0x00000001;
+      onChanged();
+      return getFileInfoFieldBuilder().getBuilder();
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    public alluxio.grpc.FileInfoOrBuilder getFileInfoOrBuilder() {
+      if (fileInfoBuilder_ != null) {
+        return fileInfoBuilder_.getMessageOrBuilder();
+      } else {
+        return fileInfo_ == null ?
+            alluxio.grpc.FileInfo.getDefaultInstance() : fileInfo_;
+      }
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        alluxio.grpc.FileInfo, alluxio.grpc.FileInfo.Builder, alluxio.grpc.FileInfoOrBuilder> 
+        getFileInfoFieldBuilder() {
+      if (fileInfoBuilder_ == null) {
+        fileInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            alluxio.grpc.FileInfo, alluxio.grpc.FileInfo.Builder, alluxio.grpc.FileInfoOrBuilder>(
+                getFileInfo(),
+                getParentForChildren(),
+                isClean());
+        fileInfo_ = null;
+      }
+      return fileInfoBuilder_;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/CreateFilePResponseOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateFilePResponseOrBuilder.java
@@ -6,4 +6,17 @@ package alluxio.grpc;
 public interface CreateFilePResponseOrBuilder extends
     // @@protoc_insertion_point(interface_extends:alluxio.grpc.file.CreateFilePResponse)
     com.google.protobuf.MessageOrBuilder {
+
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  boolean hasFileInfo();
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  alluxio.grpc.FileInfo getFileInfo();
+  /**
+   * <code>optional .alluxio.grpc.file.FileInfo fileInfo = 1;</code>
+   */
+  alluxio.grpc.FileInfoOrBuilder getFileInfoOrBuilder();
 }

--- a/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
@@ -515,290 +515,291 @@ public final class FileSystemMasterProto {
       "c.file.FileSystemMasterCommonPOptions\"d\n" +
       "\027CreateDirectoryPRequest\022\014\n\004path\030\001 \001(\t\022;" +
       "\n\007options\030\002 \001(\0132*.alluxio.grpc.file.Crea" +
-      "teDirectoryPOptions\"\025\n\023CreateFilePRespon" +
-      "se\"\336\002\n\022CreateFilePOptions\022\026\n\016blockSizeBy" +
-      "tes\030\001 \001(\003\022\021\n\trecursive\030\002 \001(\010\022!\n\004mode\030\003 \001" +
-      "(\0132\023.alluxio.grpc.PMode\022\026\n\016replicationMa" +
-      "x\030\004 \001(\005\022\026\n\016replicationMin\030\005 \001(\005\022\032\n\022repli" +
-      "cationDurable\030\006 \001(\005\022\037\n\027fileWriteLocation" +
-      "Policy\030\007 \001(\t\022\021\n\twriteTier\030\010 \001(\005\0220\n\twrite" +
-      "Type\030\t \001(\0162\035.alluxio.grpc.file.WritePTyp" +
-      "e\022H\n\rcommonOptions\030\n \001(\01321.alluxio.grpc." +
-      "file.FileSystemMasterCommonPOptions\"Z\n\022C" +
-      "reateFilePRequest\022\014\n\004path\030\001 \001(\t\0226\n\007optio" +
-      "ns\030\002 \001(\0132%.alluxio.grpc.file.CreateFileP" +
-      "Options\"\021\n\017DeletePResponse\"\225\001\n\016DeletePOp" +
-      "tions\022\021\n\trecursive\030\001 \001(\010\022\023\n\013alluxioOnly\030" +
-      "\002 \001(\010\022\021\n\tunchecked\030\003 \001(\010\022H\n\rcommonOption" +
-      "s\030\004 \001(\01321.alluxio.grpc.file.FileSystemMa" +
-      "sterCommonPOptions\"R\n\016DeletePRequest\022\014\n\004" +
-      "path\030\001 \001(\t\0222\n\007options\030\002 \001(\0132!.alluxio.gr" +
-      "pc.file.DeletePOptions\"\017\n\rFreePResponse\"" +
-      "{\n\014FreePOptions\022\021\n\trecursive\030\001 \001(\010\022\016\n\006fo" +
-      "rced\030\002 \001(\010\022H\n\rcommonOptions\030\003 \001(\01321.allu" +
-      "xio.grpc.file.FileSystemMasterCommonPOpt" +
-      "ions\"N\n\014FreePRequest\022\014\n\004path\030\001 \001(\t\0220\n\007op" +
-      "tions\030\002 \001(\0132\037.alluxio.grpc.file.FreePOpt" +
-      "ions\"+\n\035GetNewBlockIdForFilePResponse\022\n\n" +
-      "\002id\030\001 \001(\003\"h\n\034GetNewBlockIdForFilePOption" +
-      "s\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.grpc." +
-      "file.FileSystemMasterCommonPOptions\"n\n\034G" +
-      "etNewBlockIdForFilePRequest\022\014\n\004path\030\001 \001(" +
-      "\t\022@\n\007options\030\002 \001(\0132/.alluxio.grpc.file.G" +
-      "etNewBlockIdForFilePOptions\"C\n\022GetStatus" +
-      "PResponse\022-\n\010fileInfo\030\001 \001(\0132\033.alluxio.gr" +
-      "pc.file.FileInfo\"\235\001\n\021GetStatusPOptions\022>" +
-      "\n\020loadMetadataType\030\001 \001(\0162$.alluxio.grpc." +
-      "file.LoadMetadataPType\022H\n\rcommonOptions\030" +
-      "\002 \001(\01321.alluxio.grpc.file.FileSystemMast" +
-      "erCommonPOptions\"X\n\021GetStatusPRequest\022\014\n" +
-      "\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\0132$.alluxio.g" +
-      "rpc.file.GetStatusPOptions\"\232\001\n\016ExistsPOp" +
+      "teDirectoryPOptions\"D\n\023CreateFilePRespon" +
+      "se\022-\n\010fileInfo\030\001 \001(\0132\033.alluxio.grpc.file" +
+      ".FileInfo\"\336\002\n\022CreateFilePOptions\022\026\n\016bloc" +
+      "kSizeBytes\030\001 \001(\003\022\021\n\trecursive\030\002 \001(\010\022!\n\004m" +
+      "ode\030\003 \001(\0132\023.alluxio.grpc.PMode\022\026\n\016replic" +
+      "ationMax\030\004 \001(\005\022\026\n\016replicationMin\030\005 \001(\005\022\032" +
+      "\n\022replicationDurable\030\006 \001(\005\022\037\n\027fileWriteL" +
+      "ocationPolicy\030\007 \001(\t\022\021\n\twriteTier\030\010 \001(\005\0220" +
+      "\n\twriteType\030\t \001(\0162\035.alluxio.grpc.file.Wr" +
+      "itePType\022H\n\rcommonOptions\030\n \001(\01321.alluxi" +
+      "o.grpc.file.FileSystemMasterCommonPOptio" +
+      "ns\"Z\n\022CreateFilePRequest\022\014\n\004path\030\001 \001(\t\0226" +
+      "\n\007options\030\002 \001(\0132%.alluxio.grpc.file.Crea" +
+      "teFilePOptions\"\021\n\017DeletePResponse\"\225\001\n\016De" +
+      "letePOptions\022\021\n\trecursive\030\001 \001(\010\022\023\n\013allux" +
+      "ioOnly\030\002 \001(\010\022\021\n\tunchecked\030\003 \001(\010\022H\n\rcommo" +
+      "nOptions\030\004 \001(\01321.alluxio.grpc.file.FileS" +
+      "ystemMasterCommonPOptions\"R\n\016DeletePRequ" +
+      "est\022\014\n\004path\030\001 \001(\t\0222\n\007options\030\002 \001(\0132!.all" +
+      "uxio.grpc.file.DeletePOptions\"\017\n\rFreePRe" +
+      "sponse\"{\n\014FreePOptions\022\021\n\trecursive\030\001 \001(" +
+      "\010\022\016\n\006forced\030\002 \001(\010\022H\n\rcommonOptions\030\003 \001(\013" +
+      "21.alluxio.grpc.file.FileSystemMasterCom" +
+      "monPOptions\"N\n\014FreePRequest\022\014\n\004path\030\001 \001(" +
+      "\t\0220\n\007options\030\002 \001(\0132\037.alluxio.grpc.file.F" +
+      "reePOptions\"+\n\035GetNewBlockIdForFilePResp" +
+      "onse\022\n\n\002id\030\001 \001(\003\"h\n\034GetNewBlockIdForFile" +
+      "POptions\022H\n\rcommonOptions\030\001 \001(\01321.alluxi" +
+      "o.grpc.file.FileSystemMasterCommonPOptio" +
+      "ns\"n\n\034GetNewBlockIdForFilePRequest\022\014\n\004pa" +
+      "th\030\001 \001(\t\022@\n\007options\030\002 \001(\0132/.alluxio.grpc" +
+      ".file.GetNewBlockIdForFilePOptions\"C\n\022Ge" +
+      "tStatusPResponse\022-\n\010fileInfo\030\001 \001(\0132\033.all" +
+      "uxio.grpc.file.FileInfo\"\235\001\n\021GetStatusPOp" +
       "tions\022>\n\020loadMetadataType\030\001 \001(\0162$.alluxi" +
       "o.grpc.file.LoadMetadataPType\022H\n\rcommonO" +
       "ptions\030\002 \001(\01321.alluxio.grpc.file.FileSys" +
-      "temMasterCommonPOptions\"]\n\rSyncPointInfo" +
-      "\022\024\n\014syncPointUri\030\001 \001(\t\0226\n\nsyncStatus\030\002 \001" +
-      "(\0162\".alluxio.grpc.file.SyncPointStatus\"O" +
-      "\n\030GetSyncPathListPResponse\0223\n\tsyncPaths\030" +
-      "\001 \003(\0132 .alluxio.grpc.file.SyncPointInfo\"" +
-      "\031\n\027GetSyncPathListPRequest\"E\n\023ListStatus" +
-      "PResponse\022.\n\tfileInfos\030\001 \003(\0132\033.alluxio.g" +
-      "rpc.file.FileInfo\"\315\001\n\022ListStatusPOptions" +
-      "\022\032\n\022loadDirectChildren\030\001 \001(\010\022>\n\020loadMeta" +
-      "dataType\030\002 \001(\0162$.alluxio.grpc.file.LoadM" +
-      "etadataPType\022H\n\rcommonOptions\030\003 \001(\01321.al" +
-      "luxio.grpc.file.FileSystemMasterCommonPO" +
-      "ptions\022\021\n\trecursive\030\004 \001(\010\"Z\n\022ListStatusP" +
-      "Request\022\014\n\004path\030\001 \001(\t\0226\n\007options\030\002 \001(\0132%" +
-      ".alluxio.grpc.file.ListStatusPOptions\"#\n" +
-      "\025LoadMetadataPResponse\022\n\n\002id\030\001 \001(\003\"\324\001\n\024L" +
-      "oadMetadataPOptions\022\021\n\trecursive\030\001 \001(\010\022\027" +
-      "\n\017createAncestors\030\002 \001(\010\022F\n\022loadDescendan" +
-      "tType\030\003 \001(\0162*.alluxio.grpc.fscommon.Load" +
-      "DescendantPType\022H\n\rcommonOptions\030\004 \001(\01321" +
-      ".alluxio.grpc.file.FileSystemMasterCommo" +
-      "nPOptions\"a\n\024LoadMetadataPRequest\022\017\n\007ufs" +
-      "Path\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.alluxio.gr" +
-      "pc.file.LoadMetadataPOptions\"\217\001\n\tPAclEnt" +
-      "ry\022.\n\004type\030\001 \001(\0162 .alluxio.grpc.file.PAc" +
-      "lEntryType\022\017\n\007subject\030\002 \001(\t\022.\n\007actions\030\003" +
-      " \003(\0162\035.alluxio.grpc.file.PAclAction\022\021\n\ti" +
-      "sDefault\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030\001 \001(\t\022\023" +
-      "\n\013owningGroup\030\002 \001(\t\022-\n\007entries\030\003 \003(\0132\034.a" +
-      "lluxio.grpc.file.PAclEntry\022\014\n\004mode\030\004 \001(\005" +
-      "\022\021\n\tisDefault\030\005 \001(\010\022\026\n\016isDefaultEmpty\030\006 " +
-      "\001(\010\"\235\001\n\rFileBlockInfo\022*\n\tblockInfo\030\001 \001(\013" +
-      "2\027.alluxio.grpc.BlockInfo\022\016\n\006offset\030\002 \001(" +
-      "\003\0224\n\014ufsLocations\030\003 \003(\0132\036.alluxio.grpc.W" +
-      "orkerNetAddress\022\032\n\022ufsStringLocations\030\004 " +
-      "\003(\t\"\304\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022\014\n\004name" +
-      "\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004 \001(\t\022\016\n" +
-      "\006length\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006 \001(\003\022\026\n" +
-      "\016creationTimeMs\030\007 \001(\003\022\021\n\tcompleted\030\010 \001(\010" +
-      "\022\016\n\006folder\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022\021\n\tcach" +
-      "eable\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n\010blockI" +
-      "ds\030\r \003(\003\022\036\n\026lastModificationTimeMs\030\016 \001(\003" +
-      "\022\013\n\003ttl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005group\030\021 " +
-      "\001(\t\022\014\n\004mode\030\022 \001(\005\022\030\n\020persistenceState\030\023 " +
-      "\001(\t\022\022\n\nmountPoint\030\024 \001(\010\0228\n\016fileBlockInfo" +
-      "s\030\025 \003(\0132 .alluxio.grpc.file.FileBlockInf" +
-      "o\022*\n\tttlAction\030\026 \001(\0162\027.alluxio.grpc.TtlA" +
-      "ction\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAlluxioPerce" +
-      "ntage\030\030 \001(\005\022\032\n\022inMemoryPercentage\030\031 \001(\005\022" +
-      "\026\n\016ufsFingerprint\030\032 \001(\t\022$\n\003acl\030\033 \001(\0132\027.a" +
-      "lluxio.grpc.file.PAcl\022+\n\ndefaultAcl\030\034 \001(" +
-      "\0132\027.alluxio.grpc.file.PAcl\022\026\n\016replicatio" +
-      "nMax\030\035 \001(\005\022\026\n\016replicationMin\030\036 \001(\005\"$\n\024Ge" +
-      "tFilePathPResponse\022\014\n\004path\030\001 \001(\t\"%\n\023GetF" +
-      "ilePathPRequest\022\016\n\006fileId\030\001 \001(\003\"\020\n\016Mount" +
-      "PResponse\"\364\001\n\rMountPOptions\022\020\n\010readOnly\030" +
-      "\001 \001(\010\022D\n\nproperties\030\002 \003(\01320.alluxio.grpc" +
-      ".file.MountPOptions.PropertiesEntry\022\016\n\006s" +
-      "hared\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(\01321.all" +
+      "temMasterCommonPOptions\"X\n\021GetStatusPReq" +
+      "uest\022\014\n\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\0132$.al" +
+      "luxio.grpc.file.GetStatusPOptions\"\232\001\n\016Ex" +
+      "istsPOptions\022>\n\020loadMetadataType\030\001 \001(\0162$" +
+      ".alluxio.grpc.file.LoadMetadataPType\022H\n\r" +
+      "commonOptions\030\002 \001(\01321.alluxio.grpc.file." +
+      "FileSystemMasterCommonPOptions\"]\n\rSyncPo" +
+      "intInfo\022\024\n\014syncPointUri\030\001 \001(\t\0226\n\nsyncSta" +
+      "tus\030\002 \001(\0162\".alluxio.grpc.file.SyncPointS" +
+      "tatus\"O\n\030GetSyncPathListPResponse\0223\n\tsyn" +
+      "cPaths\030\001 \003(\0132 .alluxio.grpc.file.SyncPoi" +
+      "ntInfo\"\031\n\027GetSyncPathListPRequest\"E\n\023Lis" +
+      "tStatusPResponse\022.\n\tfileInfos\030\001 \003(\0132\033.al" +
+      "luxio.grpc.file.FileInfo\"\315\001\n\022ListStatusP" +
+      "Options\022\032\n\022loadDirectChildren\030\001 \001(\010\022>\n\020l" +
+      "oadMetadataType\030\002 \001(\0162$.alluxio.grpc.fil" +
+      "e.LoadMetadataPType\022H\n\rcommonOptions\030\003 \001" +
+      "(\01321.alluxio.grpc.file.FileSystemMasterC" +
+      "ommonPOptions\022\021\n\trecursive\030\004 \001(\010\"Z\n\022List" +
+      "StatusPRequest\022\014\n\004path\030\001 \001(\t\0226\n\007options\030" +
+      "\002 \001(\0132%.alluxio.grpc.file.ListStatusPOpt" +
+      "ions\"#\n\025LoadMetadataPResponse\022\n\n\002id\030\001 \001(" +
+      "\003\"\324\001\n\024LoadMetadataPOptions\022\021\n\trecursive\030" +
+      "\001 \001(\010\022\027\n\017createAncestors\030\002 \001(\010\022F\n\022loadDe" +
+      "scendantType\030\003 \001(\0162*.alluxio.grpc.fscomm" +
+      "on.LoadDescendantPType\022H\n\rcommonOptions\030" +
+      "\004 \001(\01321.alluxio.grpc.file.FileSystemMast" +
+      "erCommonPOptions\"a\n\024LoadMetadataPRequest" +
+      "\022\017\n\007ufsPath\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.all" +
+      "uxio.grpc.file.LoadMetadataPOptions\"\217\001\n\t" +
+      "PAclEntry\022.\n\004type\030\001 \001(\0162 .alluxio.grpc.f" +
+      "ile.PAclEntryType\022\017\n\007subject\030\002 \001(\t\022.\n\007ac" +
+      "tions\030\003 \003(\0162\035.alluxio.grpc.file.PAclActi" +
+      "on\022\021\n\tisDefault\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030" +
+      "\001 \001(\t\022\023\n\013owningGroup\030\002 \001(\t\022-\n\007entries\030\003 " +
+      "\003(\0132\034.alluxio.grpc.file.PAclEntry\022\014\n\004mod" +
+      "e\030\004 \001(\005\022\021\n\tisDefault\030\005 \001(\010\022\026\n\016isDefaultE" +
+      "mpty\030\006 \001(\010\"\235\001\n\rFileBlockInfo\022*\n\tblockInf" +
+      "o\030\001 \001(\0132\027.alluxio.grpc.BlockInfo\022\016\n\006offs" +
+      "et\030\002 \001(\003\0224\n\014ufsLocations\030\003 \003(\0132\036.alluxio" +
+      ".grpc.WorkerNetAddress\022\032\n\022ufsStringLocat" +
+      "ions\030\004 \003(\t\"\304\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022" +
+      "\014\n\004name\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004" +
+      " \001(\t\022\016\n\006length\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006" +
+      " \001(\003\022\026\n\016creationTimeMs\030\007 \001(\003\022\021\n\tcomplete" +
+      "d\030\010 \001(\010\022\016\n\006folder\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022" +
+      "\021\n\tcacheable\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n" +
+      "\010blockIds\030\r \003(\003\022\036\n\026lastModificationTimeM" +
+      "s\030\016 \001(\003\022\013\n\003ttl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005g" +
+      "roup\030\021 \001(\t\022\014\n\004mode\030\022 \001(\005\022\030\n\020persistenceS" +
+      "tate\030\023 \001(\t\022\022\n\nmountPoint\030\024 \001(\010\0228\n\016fileBl" +
+      "ockInfos\030\025 \003(\0132 .alluxio.grpc.file.FileB" +
+      "lockInfo\022*\n\tttlAction\030\026 \001(\0162\027.alluxio.gr" +
+      "pc.TtlAction\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAllux" +
+      "ioPercentage\030\030 \001(\005\022\032\n\022inMemoryPercentage" +
+      "\030\031 \001(\005\022\026\n\016ufsFingerprint\030\032 \001(\t\022$\n\003acl\030\033 " +
+      "\001(\0132\027.alluxio.grpc.file.PAcl\022+\n\ndefaultA" +
+      "cl\030\034 \001(\0132\027.alluxio.grpc.file.PAcl\022\026\n\016rep" +
+      "licationMax\030\035 \001(\005\022\026\n\016replicationMin\030\036 \001(" +
+      "\005\"$\n\024GetFilePathPResponse\022\014\n\004path\030\001 \001(\t\"" +
+      "%\n\023GetFilePathPRequest\022\016\n\006fileId\030\001 \001(\003\"\020" +
+      "\n\016MountPResponse\"\364\001\n\rMountPOptions\022\020\n\010re" +
+      "adOnly\030\001 \001(\010\022D\n\nproperties\030\002 \003(\01320.allux" +
+      "io.grpc.file.MountPOptions.PropertiesEnt" +
+      "ry\022\016\n\006shared\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(" +
+      "\01321.alluxio.grpc.file.FileSystemMasterCo" +
+      "mmonPOptions\0321\n\017PropertiesEntry\022\013\n\003key\030\001" +
+      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"h\n\rMountPRequest" +
+      "\022\023\n\013alluxioPath\030\001 \001(\t\022\017\n\007ufsPath\030\002 \001(\t\0221" +
+      "\n\007options\030\003 \001(\0132 .alluxio.grpc.file.Moun" +
+      "tPOptions\"\300\001\n\026GetMountTablePResponse\022O\n\013" +
+      "mountPoints\030\001 \003(\0132:.alluxio.grpc.file.Ge" +
+      "tMountTablePResponse.MountPointsEntry\032U\n" +
+      "\020MountPointsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030" +
+      "\002 \001(\0132!.alluxio.grpc.file.MountPointInfo" +
+      ":\0028\001\"\027\n\025GetMountTablePRequest\"\205\002\n\016MountP" +
+      "ointInfo\022\016\n\006ufsUri\030\001 \001(\t\022\017\n\007ufsType\030\002 \001(" +
+      "\t\022\034\n\020ufsCapacityBytes\030\003 \001(\003:\002-1\022\030\n\014ufsUs" +
+      "edBytes\030\004 \001(\003:\002-1\022\020\n\010readOnly\030\005 \001(\010\022E\n\np" +
+      "roperties\030\006 \003(\01321.alluxio.grpc.file.Moun" +
+      "tPointInfo.PropertiesEntry\022\016\n\006shared\030\007 \001" +
+      "(\010\0321\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va" +
+      "lue\030\002 \001(\t:\0028\001\"\\\n\030FileSystemCommandOption" +
+      "s\022@\n\016persistOptions\030\001 \001(\0132(.alluxio.grpc" +
+      ".file.PersistCommandOptions\"M\n\025PersistCo" +
+      "mmandOptions\0224\n\014persistFiles\030\001 \003(\0132\036.all" +
+      "uxio.grpc.file.PersistFile\"/\n\013PersistFil" +
+      "e\022\016\n\006fileId\030\001 \001(\003\022\020\n\010blockIds\030\002 \003(\003\"\210\001\n\021" +
+      "FileSystemCommand\022.\n\013commandType\030\001 \001(\0162\031" +
+      ".alluxio.grpc.CommandType\022C\n\016commandOpti" +
+      "ons\030\002 \001(\0132+.alluxio.grpc.file.FileSystem" +
+      "CommandOptions\"\021\n\017RenamePResponse\"Z\n\016Ren" +
+      "amePOptions\022H\n\rcommonOptions\030\001 \001(\01321.all" +
       "uxio.grpc.file.FileSystemMasterCommonPOp" +
-      "tions\0321\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
-      "\005value\030\002 \001(\t:\0028\001\"h\n\rMountPRequest\022\023\n\013all" +
-      "uxioPath\030\001 \001(\t\022\017\n\007ufsPath\030\002 \001(\t\0221\n\007optio" +
-      "ns\030\003 \001(\0132 .alluxio.grpc.file.MountPOptio" +
-      "ns\"\300\001\n\026GetMountTablePResponse\022O\n\013mountPo" +
-      "ints\030\001 \003(\0132:.alluxio.grpc.file.GetMountT" +
-      "ablePResponse.MountPointsEntry\032U\n\020MountP" +
-      "ointsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001(\0132!" +
-      ".alluxio.grpc.file.MountPointInfo:\0028\001\"\027\n" +
-      "\025GetMountTablePRequest\"\205\002\n\016MountPointInf" +
-      "o\022\016\n\006ufsUri\030\001 \001(\t\022\017\n\007ufsType\030\002 \001(\t\022\034\n\020uf" +
-      "sCapacityBytes\030\003 \001(\003:\002-1\022\030\n\014ufsUsedBytes" +
-      "\030\004 \001(\003:\002-1\022\020\n\010readOnly\030\005 \001(\010\022E\n\nproperti" +
-      "es\030\006 \003(\01321.alluxio.grpc.file.MountPointI" +
-      "nfo.PropertiesEntry\022\016\n\006shared\030\007 \001(\010\0321\n\017P" +
-      "ropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001" +
-      "(\t:\0028\001\"\\\n\030FileSystemCommandOptions\022@\n\016pe" +
-      "rsistOptions\030\001 \001(\0132(.alluxio.grpc.file.P" +
-      "ersistCommandOptions\"M\n\025PersistCommandOp" +
-      "tions\0224\n\014persistFiles\030\001 \003(\0132\036.alluxio.gr" +
-      "pc.file.PersistFile\"/\n\013PersistFile\022\016\n\006fi" +
-      "leId\030\001 \001(\003\022\020\n\010blockIds\030\002 \003(\003\"\210\001\n\021FileSys" +
-      "temCommand\022.\n\013commandType\030\001 \001(\0162\031.alluxi" +
-      "o.grpc.CommandType\022C\n\016commandOptions\030\002 \001" +
-      "(\0132+.alluxio.grpc.file.FileSystemCommand" +
-      "Options\"\021\n\017RenamePResponse\"Z\n\016RenamePOpt" +
-      "ions\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.gr" +
-      "pc.file.FileSystemMasterCommonPOptions\"c" +
-      "\n\016RenamePRequest\022\014\n\004path\030\001 \001(\t\022\017\n\007dstPat" +
-      "h\030\002 \001(\t\0222\n\007options\030\003 \001(\0132!.alluxio.grpc." +
-      "file.RenamePOptions\"\027\n\025SetAttributePResp" +
-      "onse\"\207\002\n\024SetAttributePOptions\022\016\n\006pinned\030" +
-      "\001 \001(\010\022\021\n\tpersisted\030\002 \001(\010\022\r\n\005owner\030\003 \001(\t\022" +
-      "\r\n\005group\030\004 \001(\t\022!\n\004mode\030\005 \001(\0132\023.alluxio.g" +
-      "rpc.PMode\022\021\n\trecursive\030\006 \001(\010\022\026\n\016replicat" +
-      "ionMax\030\007 \001(\005\022\026\n\016replicationMin\030\010 \001(\005\022H\n\r" +
-      "commonOptions\030\t \001(\01321.alluxio.grpc.file." +
-      "FileSystemMasterCommonPOptions\"^\n\024SetAtt" +
-      "ributePRequest\022\014\n\004path\030\001 \001(\t\0228\n\007options\030" +
-      "\002 \001(\0132\'.alluxio.grpc.file.SetAttributePO" +
-      "ptions\"\021\n\017SetAclPResponse\"m\n\016SetAclPOpti" +
-      "ons\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.grp" +
-      "c.file.FileSystemMasterCommonPOptions\022\021\n" +
-      "\trecursive\030\002 \001(\010\"\262\001\n\016SetAclPRequest\022\014\n\004p" +
-      "ath\030\001 \001(\t\022/\n\006action\030\002 \001(\0162\037.alluxio.grpc" +
-      ".file.SetAclAction\022-\n\007entries\030\003 \003(\0132\034.al" +
-      "luxio.grpc.file.PAclEntry\0222\n\007options\030\004 \001" +
-      "(\0132!.alluxio.grpc.file.SetAclPOptions\"#\n" +
-      "!ScheduleAsyncPersistencePResponse\"l\n Sc" +
-      "heduleAsyncPersistencePOptions\022H\n\rcommon" +
-      "Options\030\001 \001(\01321.alluxio.grpc.file.FileSy" +
-      "stemMasterCommonPOptions\"v\n ScheduleAsyn" +
-      "cPersistencePRequest\022\014\n\004path\030\001 \001(\t\022D\n\007op" +
-      "tions\030\002 \001(\01323.alluxio.grpc.file.Schedule" +
-      "AsyncPersistencePOptions\"\024\n\022StartSyncPRe" +
-      "sponse\"]\n\021StartSyncPOptions\022H\n\rcommonOpt" +
-      "ions\030\001 \001(\01321.alluxio.grpc.file.FileSyste" +
-      "mMasterCommonPOptions\"X\n\021StartSyncPReque" +
-      "st\022\014\n\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\0132$.allu" +
-      "xio.grpc.file.StartSyncPOptions\"\023\n\021StopS" +
-      "yncPResponse\"\\\n\020StopSyncPOptions\022H\n\rcomm" +
-      "onOptions\030\001 \001(\01321.alluxio.grpc.file.File" +
-      "SystemMasterCommonPOptions\"V\n\020StopSyncPR" +
-      "equest\022\014\n\004path\030\001 \001(\t\0224\n\007options\030\002 \001(\0132#." +
-      "alluxio.grpc.file.StopSyncPOptions\"\022\n\020Un" +
-      "mountPResponse\"[\n\017UnmountPOptions\022H\n\rcom" +
-      "monOptions\030\001 \001(\01321.alluxio.grpc.file.Fil" +
-      "eSystemMasterCommonPOptions\"[\n\017UnmountPR" +
-      "equest\022\023\n\013alluxioPath\030\001 \001(\t\0223\n\007options\030\002" +
-      " \001(\0132\".alluxio.grpc.file.UnmountPOptions" +
-      "\"L\n\007UfsInfo\022\013\n\003uri\030\001 \001(\t\0224\n\nproperties\030\002" +
-      " \001(\0132 .alluxio.grpc.file.MountPOptions\"\030" +
-      "\n\026UpdateUfsModePResponse\"E\n\025UpdateUfsMod" +
-      "ePOptions\022,\n\007ufsMode\030\001 \001(\0162\033.alluxio.grp" +
-      "c.file.UfsPMode\"c\n\025UpdateUfsModePRequest" +
-      "\022\017\n\007ufsPath\030\001 \001(\t\0229\n\007options\030\002 \001(\0132(.all" +
-      "uxio.grpc.file.UpdateUfsModePOptions\"U\n\034" +
-      "FileSystemHeartbeatPResponse\0225\n\007command\030" +
-      "\001 \001(\0132$.alluxio.grpc.file.FileSystemComm" +
-      "and\"@\n\033FileSystemHeartbeatPOptions\022!\n\031pe" +
-      "rsistedFileFingerprints\030\001 \003(\t\"\210\001\n\033FileSy" +
-      "stemHeartbeatPRequest\022\020\n\010workerId\030\001 \001(\003\022" +
-      "\026\n\016persistedFiles\030\002 \003(\003\022?\n\007options\030\003 \001(\013" +
-      "2..alluxio.grpc.file.FileSystemHeartbeat" +
-      "POptions\"E\n\024GetFileInfoPResponse\022-\n\010file" +
-      "Info\030\001 \001(\0132\033.alluxio.grpc.file.FileInfo\"" +
-      "\025\n\023GetFileInfoPOptions\"^\n\023GetFileInfoPRe" +
-      "quest\022\016\n\006fileId\030\001 \001(\003\0227\n\007options\030\002 \001(\0132&" +
-      ".alluxio.grpc.file.GetFileInfoPOptions\"2" +
-      "\n\031GetPinnedFileIdsPResponse\022\025\n\rpinnedFil" +
-      "eIds\030\001 \003(\003\"\032\n\030GetPinnedFileIdsPOptions\"X" +
-      "\n\030GetPinnedFileIdsPRequest\022<\n\007options\030\001 " +
-      "\001(\0132+.alluxio.grpc.file.GetPinnedFileIds" +
-      "POptions\"B\n\023GetUfsInfoPResponse\022+\n\007ufsIn" +
-      "fo\030\001 \001(\0132\032.alluxio.grpc.file.UfsInfo\"\024\n\022" +
-      "GetUfsInfoPOptions\"]\n\022GetUfsInfoPRequest" +
-      "\022\017\n\007mountId\030\001 \001(\003\0226\n\007options\030\002 \001(\0132%.all" +
-      "uxio.grpc.file.GetUfsInfoPOptions*h\n\nWri" +
-      "tePType\022\016\n\nMUST_CACHE\020\001\022\r\n\tTRY_CACHE\020\002\022\021" +
-      "\n\rCACHE_THROUGH\020\003\022\013\n\007THROUGH\020\004\022\021\n\rASYNC_" +
-      "THROUGH\020\005\022\010\n\004NONE\020\006*7\n\tReadPType\022\014\n\010NO_C" +
-      "ACHE\020\001\022\t\n\005CACHE\020\002\022\021\n\rCACHE_PROMOTE\020\003*4\n\021" +
-      "LoadMetadataPType\022\t\n\005NEVER\020\000\022\010\n\004ONCE\020\001\022\n" +
-      "\n\006ALWAYS\020\002*N\n\017SyncPointStatus\022\030\n\024Not_Ini" +
-      "tially_Synced\020\000\022\013\n\007Syncing\020\001\022\024\n\020Initiall" +
-      "y_Synced\020\002*_\n\rPAclEntryType\022\t\n\005Owner\020\000\022\r" +
-      "\n\tNamedUser\020\001\022\017\n\013OwningGroup\020\002\022\016\n\nNamedG" +
-      "roup\020\003\022\010\n\004Mask\020\004\022\t\n\005Other\020\005*.\n\nPAclActio" +
-      "n\022\010\n\004Read\020\000\022\t\n\005Write\020\001\022\013\n\007Execute\020\002*W\n\014S" +
-      "etAclAction\022\013\n\007REPLACE\020\000\022\n\n\006MODIFY\020\001\022\n\n\006" +
-      "REMOVE\020\002\022\016\n\nREMOVE_ALL\020\003\022\022\n\016REMOVE_DEFAU" +
-      "LT\020\004*8\n\010UfsPMode\022\r\n\tNO_ACCESS\020\001\022\r\n\tREAD_" +
-      "ONLY\020\002\022\016\n\nREAD_WRITE\020\0032\200\020\n\035FileSystemMas" +
-      "terClientService\022m\n\020CheckConsistency\022+.a" +
-      "lluxio.grpc.file.CheckConsistencyPReques" +
-      "t\032,.alluxio.grpc.file.CheckConsistencyPR" +
-      "esponse\022a\n\014CompleteFile\022\'.alluxio.grpc.f" +
-      "ile.CompleteFilePRequest\032(.alluxio.grpc." +
-      "file.CompleteFilePResponse\022j\n\017CreateDire" +
-      "ctory\022*.alluxio.grpc.file.CreateDirector" +
-      "yPRequest\032+.alluxio.grpc.file.CreateDire" +
-      "ctoryPResponse\022[\n\nCreateFile\022%.alluxio.g" +
-      "rpc.file.CreateFilePRequest\032&.alluxio.gr" +
-      "pc.file.CreateFilePResponse\022I\n\004Free\022\037.al" +
-      "luxio.grpc.file.FreePRequest\032 .alluxio.g" +
-      "rpc.file.FreePResponse\022^\n\013GetFilePath\022&." +
-      "alluxio.grpc.file.GetFilePathPRequest\032\'." +
-      "alluxio.grpc.file.GetFilePathPResponse\022d" +
-      "\n\rGetMountTable\022(.alluxio.grpc.file.GetM" +
-      "ountTablePRequest\032).alluxio.grpc.file.Ge" +
-      "tMountTablePResponse\022j\n\017GetSyncPathList\022" +
-      "*.alluxio.grpc.file.GetSyncPathListPRequ" +
-      "est\032+.alluxio.grpc.file.GetSyncPathListP" +
-      "Response\022y\n\024GetNewBlockIdForFile\022/.allux" +
-      "io.grpc.file.GetNewBlockIdForFilePReques" +
-      "t\0320.alluxio.grpc.file.GetNewBlockIdForFi" +
-      "lePResponse\022X\n\tGetStatus\022$.alluxio.grpc." +
-      "file.GetStatusPRequest\032%.alluxio.grpc.fi" +
-      "le.GetStatusPResponse\022[\n\nListStatus\022%.al" +
-      "luxio.grpc.file.ListStatusPRequest\032&.all" +
-      "uxio.grpc.file.ListStatusPResponse\022L\n\005Mo" +
-      "unt\022 .alluxio.grpc.file.MountPRequest\032!." +
-      "alluxio.grpc.file.MountPResponse\022O\n\006Remo" +
-      "ve\022!.alluxio.grpc.file.DeletePRequest\032\"." +
-      "alluxio.grpc.file.DeletePResponse\022O\n\006Ren" +
-      "ame\022!.alluxio.grpc.file.RenamePRequest\032\"" +
-      ".alluxio.grpc.file.RenamePResponse\022\205\001\n\030S" +
-      "cheduleAsyncPersistence\0223.alluxio.grpc.f" +
-      "ile.ScheduleAsyncPersistencePRequest\0324.a" +
-      "lluxio.grpc.file.ScheduleAsyncPersistenc" +
-      "ePResponse\022O\n\006SetAcl\022!.alluxio.grpc.file" +
-      ".SetAclPRequest\032\".alluxio.grpc.file.SetA" +
-      "clPResponse\022a\n\014SetAttribute\022\'.alluxio.gr" +
-      "pc.file.SetAttributePRequest\032(.alluxio.g" +
-      "rpc.file.SetAttributePResponse\022X\n\tStartS" +
-      "ync\022$.alluxio.grpc.file.StartSyncPReques" +
-      "t\032%.alluxio.grpc.file.StartSyncPResponse" +
-      "\022U\n\010StopSync\022#.alluxio.grpc.file.StopSyn" +
-      "cPRequest\032$.alluxio.grpc.file.StopSyncPR" +
-      "esponse\022R\n\007Unmount\022\".alluxio.grpc.file.U" +
-      "nmountPRequest\032#.alluxio.grpc.file.Unmou" +
-      "ntPResponse\022d\n\rUpdateUfsMode\022(.alluxio.g" +
-      "rpc.file.UpdateUfsModePRequest\032).alluxio" +
-      ".grpc.file.UpdateUfsModePResponse2\303\003\n\035Fi" +
-      "leSystemMasterWorkerService\022v\n\023FileSyste" +
-      "mHeartbeat\022..alluxio.grpc.file.FileSyste" +
-      "mHeartbeatPRequest\032/.alluxio.grpc.file.F" +
-      "ileSystemHeartbeatPResponse\022^\n\013GetFileIn" +
-      "fo\022&.alluxio.grpc.file.GetFileInfoPReque" +
-      "st\032\'.alluxio.grpc.file.GetFileInfoPRespo" +
-      "nse\022m\n\020GetPinnedFileIds\022+.alluxio.grpc.f" +
-      "ile.GetPinnedFileIdsPRequest\032,.alluxio.g" +
-      "rpc.file.GetPinnedFileIdsPResponse\022[\n\nGe" +
-      "tUfsInfo\022%.alluxio.grpc.file.GetUfsInfoP" +
-      "Request\032&.alluxio.grpc.file.GetUfsInfoPR" +
-      "esponse2\331\001\n\032FileSystemMasterJobService\022^" +
-      "\n\013GetFileInfo\022&.alluxio.grpc.file.GetFil" +
-      "eInfoPRequest\032\'.alluxio.grpc.file.GetFil" +
-      "eInfoPResponse\022[\n\nGetUfsInfo\022%.alluxio.g" +
-      "rpc.file.GetUfsInfoPRequest\032&.alluxio.gr" +
-      "pc.file.GetUfsInfoPResponseB\'\n\014alluxio.g" +
-      "rpcB\025FileSystemMasterProtoP\001"
+      "tions\"c\n\016RenamePRequest\022\014\n\004path\030\001 \001(\t\022\017\n" +
+      "\007dstPath\030\002 \001(\t\0222\n\007options\030\003 \001(\0132!.alluxi" +
+      "o.grpc.file.RenamePOptions\"\027\n\025SetAttribu" +
+      "tePResponse\"\207\002\n\024SetAttributePOptions\022\016\n\006" +
+      "pinned\030\001 \001(\010\022\021\n\tpersisted\030\002 \001(\010\022\r\n\005owner" +
+      "\030\003 \001(\t\022\r\n\005group\030\004 \001(\t\022!\n\004mode\030\005 \001(\0132\023.al" +
+      "luxio.grpc.PMode\022\021\n\trecursive\030\006 \001(\010\022\026\n\016r" +
+      "eplicationMax\030\007 \001(\005\022\026\n\016replicationMin\030\010 " +
+      "\001(\005\022H\n\rcommonOptions\030\t \001(\01321.alluxio.grp" +
+      "c.file.FileSystemMasterCommonPOptions\"^\n" +
+      "\024SetAttributePRequest\022\014\n\004path\030\001 \001(\t\0228\n\007o" +
+      "ptions\030\002 \001(\0132\'.alluxio.grpc.file.SetAttr" +
+      "ibutePOptions\"\021\n\017SetAclPResponse\"m\n\016SetA" +
+      "clPOptions\022H\n\rcommonOptions\030\001 \001(\01321.allu" +
+      "xio.grpc.file.FileSystemMasterCommonPOpt" +
+      "ions\022\021\n\trecursive\030\002 \001(\010\"\262\001\n\016SetAclPReque" +
+      "st\022\014\n\004path\030\001 \001(\t\022/\n\006action\030\002 \001(\0162\037.allux" +
+      "io.grpc.file.SetAclAction\022-\n\007entries\030\003 \003" +
+      "(\0132\034.alluxio.grpc.file.PAclEntry\0222\n\007opti" +
+      "ons\030\004 \001(\0132!.alluxio.grpc.file.SetAclPOpt" +
+      "ions\"#\n!ScheduleAsyncPersistencePRespons" +
+      "e\"l\n ScheduleAsyncPersistencePOptions\022H\n" +
+      "\rcommonOptions\030\001 \001(\01321.alluxio.grpc.file" +
+      ".FileSystemMasterCommonPOptions\"v\n Sched" +
+      "uleAsyncPersistencePRequest\022\014\n\004path\030\001 \001(" +
+      "\t\022D\n\007options\030\002 \001(\01323.alluxio.grpc.file.S" +
+      "cheduleAsyncPersistencePOptions\"\024\n\022Start" +
+      "SyncPResponse\"]\n\021StartSyncPOptions\022H\n\rco" +
+      "mmonOptions\030\001 \001(\01321.alluxio.grpc.file.Fi" +
+      "leSystemMasterCommonPOptions\"X\n\021StartSyn" +
+      "cPRequest\022\014\n\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\013" +
+      "2$.alluxio.grpc.file.StartSyncPOptions\"\023" +
+      "\n\021StopSyncPResponse\"\\\n\020StopSyncPOptions\022" +
+      "H\n\rcommonOptions\030\001 \001(\01321.alluxio.grpc.fi" +
+      "le.FileSystemMasterCommonPOptions\"V\n\020Sto" +
+      "pSyncPRequest\022\014\n\004path\030\001 \001(\t\0224\n\007options\030\002" +
+      " \001(\0132#.alluxio.grpc.file.StopSyncPOption" +
+      "s\"\022\n\020UnmountPResponse\"[\n\017UnmountPOptions" +
+      "\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.grpc.f" +
+      "ile.FileSystemMasterCommonPOptions\"[\n\017Un" +
+      "mountPRequest\022\023\n\013alluxioPath\030\001 \001(\t\0223\n\007op" +
+      "tions\030\002 \001(\0132\".alluxio.grpc.file.UnmountP" +
+      "Options\"L\n\007UfsInfo\022\013\n\003uri\030\001 \001(\t\0224\n\nprope" +
+      "rties\030\002 \001(\0132 .alluxio.grpc.file.MountPOp" +
+      "tions\"\030\n\026UpdateUfsModePResponse\"E\n\025Updat" +
+      "eUfsModePOptions\022,\n\007ufsMode\030\001 \001(\0162\033.allu" +
+      "xio.grpc.file.UfsPMode\"c\n\025UpdateUfsModeP" +
+      "Request\022\017\n\007ufsPath\030\001 \001(\t\0229\n\007options\030\002 \001(" +
+      "\0132(.alluxio.grpc.file.UpdateUfsModePOpti" +
+      "ons\"U\n\034FileSystemHeartbeatPResponse\0225\n\007c" +
+      "ommand\030\001 \001(\0132$.alluxio.grpc.file.FileSys" +
+      "temCommand\"@\n\033FileSystemHeartbeatPOption" +
+      "s\022!\n\031persistedFileFingerprints\030\001 \003(\t\"\210\001\n" +
+      "\033FileSystemHeartbeatPRequest\022\020\n\010workerId" +
+      "\030\001 \001(\003\022\026\n\016persistedFiles\030\002 \003(\003\022?\n\007option" +
+      "s\030\003 \001(\0132..alluxio.grpc.file.FileSystemHe" +
+      "artbeatPOptions\"E\n\024GetFileInfoPResponse\022" +
+      "-\n\010fileInfo\030\001 \001(\0132\033.alluxio.grpc.file.Fi" +
+      "leInfo\"\025\n\023GetFileInfoPOptions\"^\n\023GetFile" +
+      "InfoPRequest\022\016\n\006fileId\030\001 \001(\003\0227\n\007options\030" +
+      "\002 \001(\0132&.alluxio.grpc.file.GetFileInfoPOp" +
+      "tions\"2\n\031GetPinnedFileIdsPResponse\022\025\n\rpi" +
+      "nnedFileIds\030\001 \003(\003\"\032\n\030GetPinnedFileIdsPOp" +
+      "tions\"X\n\030GetPinnedFileIdsPRequest\022<\n\007opt" +
+      "ions\030\001 \001(\0132+.alluxio.grpc.file.GetPinned" +
+      "FileIdsPOptions\"B\n\023GetUfsInfoPResponse\022+" +
+      "\n\007ufsInfo\030\001 \001(\0132\032.alluxio.grpc.file.UfsI" +
+      "nfo\"\024\n\022GetUfsInfoPOptions\"]\n\022GetUfsInfoP" +
+      "Request\022\017\n\007mountId\030\001 \001(\003\0226\n\007options\030\002 \001(" +
+      "\0132%.alluxio.grpc.file.GetUfsInfoPOptions" +
+      "*h\n\nWritePType\022\016\n\nMUST_CACHE\020\001\022\r\n\tTRY_CA" +
+      "CHE\020\002\022\021\n\rCACHE_THROUGH\020\003\022\013\n\007THROUGH\020\004\022\021\n" +
+      "\rASYNC_THROUGH\020\005\022\010\n\004NONE\020\006*7\n\tReadPType\022" +
+      "\014\n\010NO_CACHE\020\001\022\t\n\005CACHE\020\002\022\021\n\rCACHE_PROMOT" +
+      "E\020\003*4\n\021LoadMetadataPType\022\t\n\005NEVER\020\000\022\010\n\004O" +
+      "NCE\020\001\022\n\n\006ALWAYS\020\002*N\n\017SyncPointStatus\022\030\n\024" +
+      "Not_Initially_Synced\020\000\022\013\n\007Syncing\020\001\022\024\n\020I" +
+      "nitially_Synced\020\002*_\n\rPAclEntryType\022\t\n\005Ow" +
+      "ner\020\000\022\r\n\tNamedUser\020\001\022\017\n\013OwningGroup\020\002\022\016\n" +
+      "\nNamedGroup\020\003\022\010\n\004Mask\020\004\022\t\n\005Other\020\005*.\n\nPA" +
+      "clAction\022\010\n\004Read\020\000\022\t\n\005Write\020\001\022\013\n\007Execute" +
+      "\020\002*W\n\014SetAclAction\022\013\n\007REPLACE\020\000\022\n\n\006MODIF" +
+      "Y\020\001\022\n\n\006REMOVE\020\002\022\016\n\nREMOVE_ALL\020\003\022\022\n\016REMOV" +
+      "E_DEFAULT\020\004*8\n\010UfsPMode\022\r\n\tNO_ACCESS\020\001\022\r" +
+      "\n\tREAD_ONLY\020\002\022\016\n\nREAD_WRITE\020\0032\200\020\n\035FileSy" +
+      "stemMasterClientService\022m\n\020CheckConsiste" +
+      "ncy\022+.alluxio.grpc.file.CheckConsistency" +
+      "PRequest\032,.alluxio.grpc.file.CheckConsis" +
+      "tencyPResponse\022a\n\014CompleteFile\022\'.alluxio" +
+      ".grpc.file.CompleteFilePRequest\032(.alluxi" +
+      "o.grpc.file.CompleteFilePResponse\022j\n\017Cre" +
+      "ateDirectory\022*.alluxio.grpc.file.CreateD" +
+      "irectoryPRequest\032+.alluxio.grpc.file.Cre" +
+      "ateDirectoryPResponse\022[\n\nCreateFile\022%.al" +
+      "luxio.grpc.file.CreateFilePRequest\032&.all" +
+      "uxio.grpc.file.CreateFilePResponse\022I\n\004Fr" +
+      "ee\022\037.alluxio.grpc.file.FreePRequest\032 .al" +
+      "luxio.grpc.file.FreePResponse\022^\n\013GetFile" +
+      "Path\022&.alluxio.grpc.file.GetFilePathPReq" +
+      "uest\032\'.alluxio.grpc.file.GetFilePathPRes" +
+      "ponse\022d\n\rGetMountTable\022(.alluxio.grpc.fi" +
+      "le.GetMountTablePRequest\032).alluxio.grpc." +
+      "file.GetMountTablePResponse\022j\n\017GetSyncPa" +
+      "thList\022*.alluxio.grpc.file.GetSyncPathLi" +
+      "stPRequest\032+.alluxio.grpc.file.GetSyncPa" +
+      "thListPResponse\022y\n\024GetNewBlockIdForFile\022" +
+      "/.alluxio.grpc.file.GetNewBlockIdForFile" +
+      "PRequest\0320.alluxio.grpc.file.GetNewBlock" +
+      "IdForFilePResponse\022X\n\tGetStatus\022$.alluxi" +
+      "o.grpc.file.GetStatusPRequest\032%.alluxio." +
+      "grpc.file.GetStatusPResponse\022[\n\nListStat" +
+      "us\022%.alluxio.grpc.file.ListStatusPReques" +
+      "t\032&.alluxio.grpc.file.ListStatusPRespons" +
+      "e\022L\n\005Mount\022 .alluxio.grpc.file.MountPReq" +
+      "uest\032!.alluxio.grpc.file.MountPResponse\022" +
+      "O\n\006Remove\022!.alluxio.grpc.file.DeletePReq" +
+      "uest\032\".alluxio.grpc.file.DeletePResponse" +
+      "\022O\n\006Rename\022!.alluxio.grpc.file.RenamePRe" +
+      "quest\032\".alluxio.grpc.file.RenamePRespons" +
+      "e\022\205\001\n\030ScheduleAsyncPersistence\0223.alluxio" +
+      ".grpc.file.ScheduleAsyncPersistencePRequ" +
+      "est\0324.alluxio.grpc.file.ScheduleAsyncPer" +
+      "sistencePResponse\022O\n\006SetAcl\022!.alluxio.gr" +
+      "pc.file.SetAclPRequest\032\".alluxio.grpc.fi" +
+      "le.SetAclPResponse\022a\n\014SetAttribute\022\'.all" +
+      "uxio.grpc.file.SetAttributePRequest\032(.al" +
+      "luxio.grpc.file.SetAttributePResponse\022X\n" +
+      "\tStartSync\022$.alluxio.grpc.file.StartSync" +
+      "PRequest\032%.alluxio.grpc.file.StartSyncPR" +
+      "esponse\022U\n\010StopSync\022#.alluxio.grpc.file." +
+      "StopSyncPRequest\032$.alluxio.grpc.file.Sto" +
+      "pSyncPResponse\022R\n\007Unmount\022\".alluxio.grpc" +
+      ".file.UnmountPRequest\032#.alluxio.grpc.fil" +
+      "e.UnmountPResponse\022d\n\rUpdateUfsMode\022(.al" +
+      "luxio.grpc.file.UpdateUfsModePRequest\032)." +
+      "alluxio.grpc.file.UpdateUfsModePResponse" +
+      "2\303\003\n\035FileSystemMasterWorkerService\022v\n\023Fi" +
+      "leSystemHeartbeat\022..alluxio.grpc.file.Fi" +
+      "leSystemHeartbeatPRequest\032/.alluxio.grpc" +
+      ".file.FileSystemHeartbeatPResponse\022^\n\013Ge" +
+      "tFileInfo\022&.alluxio.grpc.file.GetFileInf" +
+      "oPRequest\032\'.alluxio.grpc.file.GetFileInf" +
+      "oPResponse\022m\n\020GetPinnedFileIds\022+.alluxio" +
+      ".grpc.file.GetPinnedFileIdsPRequest\032,.al" +
+      "luxio.grpc.file.GetPinnedFileIdsPRespons" +
+      "e\022[\n\nGetUfsInfo\022%.alluxio.grpc.file.GetU" +
+      "fsInfoPRequest\032&.alluxio.grpc.file.GetUf" +
+      "sInfoPResponse2\331\001\n\032FileSystemMasterJobSe" +
+      "rvice\022^\n\013GetFileInfo\022&.alluxio.grpc.file" +
+      ".GetFileInfoPRequest\032\'.alluxio.grpc.file" +
+      ".GetFileInfoPResponse\022[\n\nGetUfsInfo\022%.al" +
+      "luxio.grpc.file.GetUfsInfoPRequest\032&.all" +
+      "uxio.grpc.file.GetUfsInfoPResponseB\'\n\014al" +
+      "luxio.grpcB\025FileSystemMasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -885,7 +886,7 @@ public final class FileSystemMasterProto {
     internal_static_alluxio_grpc_file_CreateFilePResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_file_CreateFilePResponse_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "FileInfo", });
     internal_static_alluxio_grpc_file_CreateFilePOptions_descriptor =
       getDescriptor().getMessageTypes().get(12);
     internal_static_alluxio_grpc_file_CreateFilePOptions_fieldAccessorTable = new

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -191,10 +191,9 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void clientFileInfoEmptyFile() throws Exception {
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults());
-    FileInfo fileInfo = mFsMaster.getFileInfo(fileId);
+    FileInfo fileInfo =
+        mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults());
     Assert.assertEquals("testFile", fileInfo.getName());
-    Assert.assertEquals(fileId, fileInfo.getFileId());
     Assert.assertEquals(0, fileInfo.getLength());
     Assert.assertTrue(fileInfo.isCacheable());
     assertFalse(fileInfo.isCompleted());
@@ -382,10 +381,10 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryContext.defaults());
     mFsMaster.createDirectory(new AlluxioURI("/testFolder/testFolder2"),
         CreateDirectoryContext.defaults());
-    long fileId =
-        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"), CreateFileContext.defaults());
+    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"),
+        CreateFileContext.defaults()).getFileId();
     long fileId2 = mFsMaster.createFile(new AlluxioURI("/testFolder/testFolder2/testFile2"),
-        CreateFileContext.defaults());
+        CreateFileContext.defaults()).getFileId();
     Assert.assertEquals(1, mFsMaster.getFileId(new AlluxioURI("/testFolder")));
     Assert.assertEquals(2, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFolder2")));
     Assert.assertEquals(fileId, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile")));
@@ -402,10 +401,10 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryContext.defaults());
     mFsMaster.createDirectory(new AlluxioURI("/testFolder/testFolder2"),
         CreateDirectoryContext.defaults());
-    long fileId =
-        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"), CreateFileContext.defaults());
+    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"),
+        CreateFileContext.defaults()).getFileId();
     long fileId2 = mFsMaster.createFile(new AlluxioURI("/testFolder/testFolder2/testFile2"),
-        CreateFileContext.defaults());
+        CreateFileContext.defaults()).getFileId();
     Assert.assertEquals(1, mFsMaster.getFileId(new AlluxioURI("/testFolder")));
     Assert.assertEquals(2, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFolder2")));
     Assert.assertEquals(fileId, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile")));
@@ -430,8 +429,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void deleteDirectoryWithFiles() throws Exception {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryContext.defaults());
-    long fileId =
-        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"), CreateFileContext.defaults());
+    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"),
+        CreateFileContext.defaults()).getFileId();
     Assert.assertEquals(1, mFsMaster.getFileId(new AlluxioURI("/testFolder")));
     Assert.assertEquals(fileId, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile")));
     mFsMaster.delete(new AlluxioURI("/testFolder"),
@@ -443,8 +442,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void deleteDirectoryWithFilesTest2() throws Exception {
     mFsMaster.createDirectory(new AlluxioURI("/testFolder"), CreateDirectoryContext.defaults());
-    long fileId =
-        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"), CreateFileContext.defaults());
+    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile"),
+        CreateFileContext.defaults()).getFileId();
     Assert.assertEquals(1, mFsMaster.getFileId(new AlluxioURI("/testFolder")));
     Assert.assertEquals(fileId, mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile")));
     try {
@@ -513,7 +512,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void deleteFile() throws Exception {
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults());
+    long fileId =
+        mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults()).getFileId();
     Assert.assertEquals(fileId, mFsMaster.getFileId(new AlluxioURI("/testFile")));
     mFsMaster.delete(new AlluxioURI("/testFile"),
         DeleteContext.mergeFrom(DeletePOptions.newBuilder().setRecursive(true)));
@@ -538,7 +538,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void lastModificationTimeCompleteFile() throws Exception {
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults());
+    long fileId =
+        mFsMaster.createFile(new AlluxioURI("/testFile"), CreateFileContext.defaults()).getFileId();
     long opTimeMs = TEST_TIME_MS;
     mFsMaster.completeFile(new AlluxioURI("/testFile"), CompleteFileContext
         .mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(0)).setOperationTimeMs(opTimeMs));
@@ -595,7 +596,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
       mFsMaster.createDirectory(dir, CreateDirectoryContext.defaults());
       dirIds.add(mFsMaster.getFileId(dir));
       for (int j = 0; j < 10; j++) {
-        ids.add(mFsMaster.createFile(dir.join("j" + j), options));
+        ids.add(mFsMaster.createFile(dir.join("j" + j), options).getFileId());
       }
     }
     HashSet<Long> listedIds = new HashSet<>();
@@ -700,7 +701,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     long ttl = 1;
     CreateFileContext context = CreateFileContext.mergeFrom(CreateFilePOptions.newBuilder()
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(ttl)));
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), context);
+    long fileId =
+        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), context).getFileId();
     FileInfo folderInfo =
         mFsMaster.getFileInfo(mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile1")));
     Assert.assertEquals(fileId, folderInfo.getFileId());
@@ -720,7 +722,8 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         .mergeFrom(CreateFilePOptions.newBuilder().setCommonOptions(FileSystemMasterCommonPOptions
             .newBuilder().setTtl(ttl).setTtlAction(alluxio.grpc.TtlAction.FREE)))
         .setPersisted(true);
-    long fileId = mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), context);
+    long fileId =
+        mFsMaster.createFile(new AlluxioURI("/testFolder/testFile1"), context).getFileId();
     FileInfo folderInfo =
         mFsMaster.getFileInfo(mFsMaster.getFileId(new AlluxioURI("/testFolder/testFile1")));
     Assert.assertEquals(fileId, folderInfo.getFileId());
@@ -1388,7 +1391,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
       if (depth < 1) {
         return;
       } else if (depth == 1) {
-        long fileId = mFsMaster.createFile(path, mCreateFileContext);
+        long fileId = mFsMaster.createFile(path, mCreateFileContext).getFileId();
         Assert.assertEquals(fileId, mFsMaster.getFileId(path));
         // verify the user permission for file
         FileInfo fileInfo = mFsMaster.getFileInfo(fileId);


### PR DESCRIPTION
Instead of returning the file id, we return the file info. This can improve performance of create file by reducing the number of RPCs required.