### PR TITLE
SetAttribute options are merged when they shouldn't be

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -610,8 +610,6 @@ public class BaseFileSystem implements FileSystem {
   public void setAttribute(AlluxioURI path, SetAttributePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
-    options = FileSystemOptions.setAttributeDefaults(mFsContext.getConf())
-        .toBuilder().mergeFrom(options).build();
     FileSystemMasterClient masterClient = mFsContext.acquireMasterClient();
     try {
       masterClient.setAttribute(path, options);

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -480,8 +480,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions = SetAttributePOptions.getDefaultInstance();
     mFileSystem.setAttribute(file, setAttributeOptions);
-    verify(mFileSystemMasterClient).setAttribute(file, FileSystemOptions.setAttributeDefaults(mConf)
-        .toBuilder().mergeFrom(setAttributeOptions).build());
+    verify(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
   }
 
   /**
@@ -491,9 +490,7 @@ public final class BaseFileSystemTest {
   public void setStateException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions = SetAttributePOptions.getDefaultInstance();
-    doThrow(EXCEPTION).when(mFileSystemMasterClient).setAttribute(file,
-        FileSystemOptions.setAttributeDefaults(mConf)
-            .toBuilder().mergeFrom(setAttributeOptions).build());
+    doThrow(EXCEPTION).when(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
     try {
       mFileSystem.setAttribute(file, setAttributeOptions);
       fail(SHOULD_HAVE_PROPAGATED_MESSAGE);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -54,6 +54,7 @@ import alluxio.grpc.MountPOptions;
 import alluxio.grpc.ServiceType;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAttributePOptions;
+import alluxio.grpc.TtlAction;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.CoreMaster;
@@ -3584,16 +3585,21 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           protoOptions.hasReplicationMin() ? protoOptions.getReplicationMin() : null;
       mInodeTree.setReplication(rpcContext, inodePath, replicationMax, replicationMin, opTimeMs);
     }
-    if (protoOptions.hasCommonOptions() && protoOptions.getCommonOptions().hasTtl()
-        && protoOptions.getCommonOptions().hasTtlAction()) {
-      long ttl = protoOptions.getCommonOptions().getTtl();
-      if (inode.getTtl() != ttl
-          || inode.getTtlAction() != protoOptions.getCommonOptions().getTtlAction()) {
+    // protoOptions may not have both fields set
+    if (protoOptions.hasCommonOptions()) {
+      FileSystemMasterCommonPOptions commonOpts = protoOptions.getCommonOptions();
+      TtlAction action = commonOpts.hasTtlAction() ? commonOpts.getTtlAction() : null;
+      Long ttl = commonOpts.hasTtl() ? commonOpts.getTtl() : null;
 
+      if (ttl != null && inode.getTtl() != ttl) {
         entry.setTtl(ttl);
+      }
+      if (inode.getTtlAction() != action) {
+        entry.setTtlAction(ProtobufUtils.toProtobuf(action));
+      }
+      // We've set at least one if they are both non-null
+      if (ttl != null && action != null) {
         entry.setLastModificationTimeMs(opTimeMs);
-        entry.setTtlAction(ProtobufUtils.toProtobuf(
-            protoOptions.getCommonOptions().getTtlAction()));
       }
     }
     if (protoOptions.hasPersisted()) {

--- a/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
@@ -30,6 +30,8 @@ import alluxio.exception.InvalidPathException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
+import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.testutils.BaseIntegrationTest;
@@ -319,6 +321,25 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
     assertEquals("Should have 5 blocks", 5, locations.size());
     locations.forEach((FileBlockInfo info, List<WorkerNetAddress> workers) ->
         assertEquals("block " + info + " should have single worker", 1, workers.size()));
+  }
+
+  @Test
+  public void testMultiSetAttribute() throws Exception {
+    AlluxioURI testFile = new AlluxioURI("/test1");
+    FileSystemTestUtils.createByteFile(mFileSystem, testFile, WritePType.MUST_CACHE, 512);
+    long expectedTtl = ServerConfiguration.getMs(PropertyKey.USER_FILE_CREATE_TTL);
+    URIStatus stat = mFileSystem.getStatus(testFile);
+    assertEquals("TTL should be same", expectedTtl, stat.getTtl());
+    long newTtl = 14402478;
+    mFileSystem.setAttribute(testFile,
+        SetAttributePOptions.newBuilder().setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder().setTtl(newTtl).build()).build());
+    stat = mFileSystem.getStatus(testFile);
+    assertEquals("TTL should be same", newTtl, stat.getTtl());
+    mFileSystem.setAttribute(testFile,
+        SetAttributePOptions.newBuilder().setOwner("testOwner").build());
+    stat = mFileSystem.getStatus(testFile);
+    assertEquals("TTL should be same", newTtl, stat.getTtl());
   }
 
 // Test exception cases for all FileSystem RPCs


### PR DESCRIPTION
In SetAttribute on the filesystem client we previously merged the options
supplied to the client into the FileSystemOptions defaults based on
configuration. The issue is that SetAttribute is a unique operation in
that any value which is sent over the wire we assume was set explicitly by the
user. That's where the issue arose. We were merging default options
into the SetAttributePOptions when we shouldn't have been. The master was
taking the default options and setting the attributes which came from the
defaults.

This change now only explicitly sends a user's options if they are set.
No other options are merged in the setAttribute operation.

In this investigation I also found a bug in setting the TTL and
TtlAction on a file. Both TTL and TtlAction needed to be set in order
for the DefaultFileSystemMaster to actually update the inode. With these
changes this is no longer the case. A user can set Ttl or TtlAction
independently and the master will update the file accordingly.

Lastly, an integration test was added which exposed the original failure
case for both of these issues.