### PR TITLE
Fix concurrent initialization in hadoop compatible FileSystem

### DIFF
--- a/core/base/src/main/java/alluxio/exception/PreconditionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/PreconditionMessage.java
@@ -48,7 +48,6 @@ public enum PreconditionMessage {
   ERR_UNEXPECTED_EOF("Reached EOF unexpectedly."),
   ERR_WRITE_BUFFER_NULL("Cannot write a null input buffer"),
   ERR_ZK_ADDRESS_NOT_SET("Cannot get leader address from zookeeper; %s is not set"),
-  FILESYSTEM_UNINITIALIZED("FileSystem is not initialized"),
   FILE_TO_PERSIST_MUST_BE_COMPLETE("File being persisted must be complete"),
   FILE_WRITE_LOCATION_POLICY_UNSPECIFIED("The location policy is not specified"),
   UFS_READ_LOCATION_POLICY_UNSPECIFIED("The UFS read location policy is not specified"),

--- a/core/base/src/main/java/alluxio/exception/PreconditionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/PreconditionMessage.java
@@ -48,6 +48,7 @@ public enum PreconditionMessage {
   ERR_UNEXPECTED_EOF("Reached EOF unexpectedly."),
   ERR_WRITE_BUFFER_NULL("Cannot write a null input buffer"),
   ERR_ZK_ADDRESS_NOT_SET("Cannot get leader address from zookeeper; %s is not set"),
+  FILESYSTEM_UNINITIALIZED("FileSystem is not initialized"),
   FILE_TO_PERSIST_MUST_BE_COMPLETE("File being persisted must be complete"),
   FILE_WRITE_LOCATION_POLICY_UNSPECIFIED("The location policy is not specified"),
   UFS_READ_LOCATION_POLICY_UNSPECIFIED("The UFS read location policy is not specified"),

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -69,8 +69,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -91,10 +89,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   // Always tell Hadoop that we have 3x replication.
   private static final int BLOCK_REPLICATION_CONSTANT = 3;
 
-  /** Flag for if the client has been initialized. */
-  private final ReadWriteLock mInitializationLock = new ReentrantReadWriteLock();
-
-  protected volatile FileSystem mFileSystem = null;
+  protected FileSystem mFileSystem = null;
 
   private URI mUri = null;
   private Path mWorkingDir = new Path(AlluxioURI.SEPARATOR);

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -13,15 +13,15 @@ package alluxio.hadoop;
 
 import static java.util.stream.Collectors.toList;
 
-import alluxio.ClientContext;
-import alluxio.conf.AlluxioConfiguration;
 import alluxio.AlluxioURI;
-import alluxio.conf.AlluxioProperties;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.PropertyKey;
+import alluxio.ClientContext;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
@@ -455,8 +455,9 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   public void initialize(URI uri, org.apache.hadoop.conf.Configuration conf) throws IOException {
     Preconditions.checkArgument(uri.getScheme().equals(getScheme()),
         PreconditionMessage.URI_SCHEME_MISMATCH.toString(), uri.getScheme(), getScheme());
-    Preconditions.checkArgument(mInitialized.compareAndSet(false, true), "Cannot invoke "
-        + "initialize() more than once");
+    if (!mInitialized.compareAndSet(false, true)) {
+      return;
+    }
     super.initialize(uri, conf);
     LOG.debug("initialize({}, {}). Connecting to Alluxio", uri, conf);
     HadoopUtils.addSwiftCredentials(conf);


### PR DESCRIPTION
When HBase gets FileSystem through Hadoop, both Hadoop and HBase will call initialize.