### PR TITLE
Add libc6-compat to docker integration

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -13,7 +13,7 @@ FROM openjdk:8-jdk-alpine
 
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.org/downloads/files/1.8.1/alluxio-1.8.1-bin.tar.gz
 
-RUN apk add --update bash && \
+RUN apk add --update bash libc6-compat && \
     rm -rf /var/cache/apk/*
 
 ADD ${ALLUXIO_TARBALL} /opt/


### PR DESCRIPTION
This dependency is needed by rocksdbjni

Tested locally and adding the dependency prevents us from hitting `java.lang.UnsatisfiedLinkError: /tmp/librocksdbjni4519472487824987007.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/librocksdbjni4519472487824987007.so)`

@bf8086 