### PR TITLE
Improve embedded journal conf defaults

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -535,8 +535,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       alluxioConfProperties.put(PropertyKey.ZOOKEEPER_ADDRESS.getName(), null);
       // Unset the embedded journal related configuration
       // to support alluxio URI has the highest priority
-      alluxioConfProperties.put(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES.getName(),
-          PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES.getDefaultValue());
+      alluxioConfProperties.put(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES.getName(), null);
       alluxioConfProperties.put(PropertyKey.MASTER_RPC_ADDRESSES.getName(), null);
     } else if (alluxioUri.getAuthority() instanceof MultiMasterAuthority) {
       MultiMasterAuthority authority = (MultiMasterAuthority) alluxioUri.getAuthority();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -28,8 +28,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.sun.management.OperatingSystemMXBean;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
 import java.lang.annotation.Annotation;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
@@ -41,6 +39,9 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Configuration property keys. This class provides a set of pre-defined property keys.
@@ -1154,10 +1155,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_ADDRESSES =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_ADDRESSES)
-          .setDescription("A comma-separated list of journal addresses for all masters in the "
-              + "cluster. The format is 'hostname1:port1,hostname2:port2,...'. Required when using "
-              + "the embedded journal")
-          .setDefaultValue(String.format("localhost:${%s}", Name.MASTER_EMBEDDED_JOURNAL_PORT))
+          .setDescription(String.format("A comma-separated list of journal addresses for all "
+              + "masters in the cluster. The format is 'hostname1:port1,hostname2:port2,...'. When "
+              + "left unset, Alluxio uses ${%s}:${%s} by default", Name.MASTER_HOSTNAME,
+              Name.MASTER_EMBEDDED_JOURNAL_PORT))
+          // We intentionally don't set a default value here. That way, we can use isSet() to check
+          // whether the user explicitly set these addresses. If they did, we determine job master
+          // embedded journal addresses using the same hostnames the user set here. Otherwise, we
+          // use jobMasterHostname:jobMasterEmbeddedJournalPort by default.
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)
@@ -3365,10 +3370,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.JOB_MASTER_RPC_ADDRESSES).build();
   public static final PropertyKey JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES =
       new Builder(Name.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES)
-          .setDescription("A comma-separated list of journal addresses for all job masters in the "
-              + "cluster. The format is 'hostname1:port1,hostname2:port2,...'. Defaults to the "
-              + "journal addresses set for the Alluxio masters, but with the job master embedded "
-              + "journal port.")
+          .setDescription(String.format("A comma-separated list of journal addresses for all job "
+              + "masters in the cluster. The format is 'hostname1:port1,hostname2:port2,...'. "
+              + "Defaults to the journal addresses set for the Alluxio masters (%s), but with the "
+              + "job master embedded journal port.", Name.MASTER_EMBEDDED_JOURNAL_ADDRESSES))
           .build();
   public static final PropertyKey JOB_MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.JOB_MASTER_EMBEDDED_JOURNAL_PORT)

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -113,7 +113,7 @@ public final class ConfigurationUtils {
     // Fall back on using the master embedded journal addresses, with the job master port.
     PropertyKey masterProperty = PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES;
     int jobRaftPort = NetworkAddressUtils.getPort(ServiceType.JOB_MASTER_RAFT, conf);
-    if (conf.isSet(jobMasterProperty)) {
+    if (conf.isSet(masterProperty)) {
       return overridePort(getMasterEmbeddedJournalAddresses(conf), jobRaftPort);
     }
     // Fall back on job_master_hostname:job_master_raft_port.

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -120,19 +120,6 @@ public final class ConfigurationUtils {
     return Arrays.asList(NetworkAddressUtils.getConnectAddress(ServiceType.JOB_MASTER_RAFT, conf));
   }
 
-  private List<InetSocketAddress> parseAddresses(List<String> addresses) {
-    List<InetSocketAddress> inetAddresses = new ArrayList<>();
-    for (String address : addresses) {
-      try {
-        InetSocketAddress addr = NetworkAddressUtils.parseInetSocketAddress(address);
-        inetAddresses.add(addr);
-      } catch (IOException e) {
-        throw new IllegalArgumentException(String.format("Failed to parse address %s", address), e);
-      }
-    }
-    return inetAddresses;
-  }
-
   /**
    * Gets the RPC addresses of all masters based on the configuration.
    *
@@ -185,8 +172,7 @@ public final class ConfigurationUtils {
    * @return a list of InetSocketAddresses representing the given address strings
    */
   private static List<InetSocketAddress> parseInetSocketAddresses(List<String> addresses) {
-    List<InetSocketAddress> inetSocketAddresses =
-        new ArrayList<>(addresses.size());
+    List<InetSocketAddress> inetSocketAddresses = new ArrayList<>(addresses.size());
     for (String address : addresses) {
       try {
         inetSocketAddresses.add(NetworkAddressUtils.parseInetSocketAddress(address));

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -70,16 +70,18 @@ public final class NetworkAddressUtils {
    */
   public enum ServiceType {
     /**
-     * Job master Raft service (Netty).
+     * Job master Raft service (Netty). The bind and connect hosts are the same because the
+     * underlying Raft implementation doesn't differentiate between bind and connect hosts.
      */
     JOB_MASTER_RAFT("Alluxio Job Master Raft service", PropertyKey.JOB_MASTER_HOSTNAME,
-        PropertyKey.JOB_MASTER_BIND_HOST, PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT),
+        PropertyKey.JOB_MASTER_HOSTNAME, PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT),
 
     /**
-     * Master Raft service (Netty).
+     * Master Raft service (Netty). The bind and connect hosts are the same because the
+     * underlying Raft implementation doesn't differentiate between bind and connect hosts.
      */
     MASTER_RAFT("Alluxio Master Raft service", PropertyKey.MASTER_HOSTNAME,
-        PropertyKey.MASTER_BIND_HOST, PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT),
+        PropertyKey.MASTER_HOSTNAME, PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT),
 
     /**
      * Job master RPC service (gRPC).

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.network.NetworkAddressUtils;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ConfigurationUtils}.
+ */
+public final class ConfigurationUtilsTest {
+  @Test
+  public void getMasterRpcAddresses() {
+    AlluxioConfiguration conf =
+        createConf(ImmutableMap.of(PropertyKey.MASTER_RPC_ADDRESSES, "host1:99,host2:100"));
+    assertEquals(
+        Arrays.asList(new InetSocketAddress("host1", 99), new InetSocketAddress("host2", 100)),
+        ConfigurationUtils.getMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getMasterRpcAddressesFallback() {
+    AlluxioConfiguration conf =
+        createConf(ImmutableMap.of(
+            PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES, "host1:99,host2:100",
+            PropertyKey.MASTER_RPC_PORT, "50"));
+    assertEquals(
+        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        ConfigurationUtils.getMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getMasterRpcAddressesDefault() {
+    AlluxioConfiguration conf = createConf(Collections.emptyMap());
+    String host = NetworkAddressUtils.getLocalHostName(5 * Constants.SECOND_MS);
+    assertEquals(Arrays.asList(new InetSocketAddress(host, 19998)),
+        ConfigurationUtils.getMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getJobMasterRpcAddresses() {
+    AlluxioConfiguration conf =
+        createConf(ImmutableMap.of(PropertyKey.JOB_MASTER_RPC_ADDRESSES, "host1:99,host2:100"));
+    assertEquals(
+        Arrays.asList(new InetSocketAddress("host1", 99), new InetSocketAddress("host2", 100)),
+        ConfigurationUtils.getJobMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getJobMasterRpcAddressesMasterRpcFallback() {
+    AlluxioConfiguration conf =
+        createConf(ImmutableMap.of(
+            PropertyKey.MASTER_RPC_ADDRESSES, "host1:99,host2:100",
+            PropertyKey.JOB_MASTER_RPC_PORT, "50"));
+    assertEquals(
+        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        ConfigurationUtils.getJobMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getJobMasterRpcAddressesServerFallback() {
+    AlluxioConfiguration conf =
+        createConf(ImmutableMap.of(
+            PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES, "host1:99,host2:100",
+            PropertyKey.JOB_MASTER_RPC_PORT, "50"));
+    assertEquals(
+        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        ConfigurationUtils.getJobMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getJobMasterRpcAddressesDefault() {
+    AlluxioConfiguration conf = createConf(Collections.emptyMap());
+    String host = NetworkAddressUtils.getLocalHostName(5 * Constants.SECOND_MS);
+    assertEquals(Arrays.asList(new InetSocketAddress(host, 20001)),
+        ConfigurationUtils.getJobMasterRpcAddresses(conf));
+  }
+
+  private AlluxioConfiguration createConf(Map<PropertyKey, String> properties) {
+    AlluxioProperties props = ConfigurationUtils.defaults();
+    for (PropertyKey key : properties.keySet()) {
+      props.set(key, properties.get(key));
+    }
+    return new InstancedConfiguration(props);
+  }
+}

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -33,6 +33,15 @@ import java.util.Map;
  */
 public final class ConfigurationUtilsTest {
   @Test
+  public void getSingleMasterRpcAddress() {
+    AlluxioConfiguration conf = createConf(ImmutableMap.of(
+        PropertyKey.MASTER_HOSTNAME, "testhost",
+        PropertyKey.MASTER_RPC_PORT, "1000"));
+    assertEquals(Arrays.asList(new InetSocketAddress("testhost", 1000)),
+        ConfigurationUtils.getMasterRpcAddresses(conf));
+  }
+
+  @Test
   public void getMasterRpcAddresses() {
     AlluxioConfiguration conf =
         createConf(ImmutableMap.of(PropertyKey.MASTER_RPC_ADDRESSES, "host1:99,host2:100"));
@@ -58,6 +67,15 @@ public final class ConfigurationUtilsTest {
     String host = NetworkAddressUtils.getLocalHostName(5 * Constants.SECOND_MS);
     assertEquals(Arrays.asList(new InetSocketAddress(host, 19998)),
         ConfigurationUtils.getMasterRpcAddresses(conf));
+  }
+
+  @Test
+  public void getSingleJobMasterRpcAddress() {
+    AlluxioConfiguration conf = createConf(ImmutableMap.of(
+        PropertyKey.JOB_MASTER_HOSTNAME, "testhost",
+        PropertyKey.JOB_MASTER_RPC_PORT, "1000"));
+    assertEquals(Arrays.asList(new InetSocketAddress("testhost", 1000)),
+        ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -50,6 +50,10 @@ public class NetworkAddressUtilsTest {
   @Test
   public void testGetConnectAddress() throws Exception {
     for (ServiceType service : ServiceType.values()) {
+      if (service == ServiceType.JOB_MASTER_RAFT || service == ServiceType.MASTER_RAFT) {
+        // Skip the raft services, which don't support separate bind and connect ports.
+        continue;
+      }
       getConnectAddress(service);
     }
   }
@@ -131,6 +135,10 @@ public class NetworkAddressUtilsTest {
   @Test
   public void testGetBindAddress() throws Exception {
     for (ServiceType service : ServiceType.values()) {
+      if (service == ServiceType.JOB_MASTER_RAFT || service == ServiceType.MASTER_RAFT) {
+        // Skip the raft services, which don't support separate bind and connect ports.
+        continue;
+      }
       getBindAddress(service);
     }
   }
@@ -142,44 +150,42 @@ public class NetworkAddressUtilsTest {
    * @param service the service name used to connect
    */
   private void getBindAddress(ServiceType service) throws Exception {
-    int resolveTimeout = (int) mConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
-    String localHostName = NetworkAddressUtils.getLocalHostName(resolveTimeout);
-    InetSocketAddress workerAddress;
+    InetSocketAddress address;
 
     // all default
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
     assertEquals(
         new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, service.getDefaultPort()),
-        workerAddress);
+        address);
 
     // bind host only
     mConfiguration.set(service.getBindHostKey(), "bind.host");
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), address);
 
     // connect host and bind host
     mConfiguration.set(service.getHostNameKey(), "connect.host");
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), address);
 
     // wildcard connect host and bind host
     mConfiguration.set(service.getHostNameKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), address);
 
     // wildcard connect host and wildcard bind host
     mConfiguration.set(service.getBindHostKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
     assertEquals(
         new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, service.getDefaultPort()),
-        workerAddress);
+        address);
 
     // connect host and wildcard bind host
     mConfiguration.set(service.getHostNameKey(), "connect.host");
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
     assertEquals(
         new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, service.getDefaultPort()),
-        workerAddress);
+        address);
 
     // connect host and wildcard bind host with port
     switch (service) {
@@ -220,30 +226,30 @@ public class NetworkAddressUtilsTest {
         Assert.fail("Unrecognized service type: " + service.toString());
         break;
     }
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
     assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000),
-        workerAddress);
+        address);
 
     // connect host and bind host with port
     mConfiguration.set(service.getBindHostKey(), "bind.host");
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", 20000), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress("bind.host", 20000), address);
 
     // empty connect host and bind host with port
     mConfiguration.unset(service.getHostNameKey());
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", 20000), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress("bind.host", 20000), address);
 
     // empty connect host and wildcard bind host with port
     mConfiguration.set(service.getBindHostKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
     assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000),
-        workerAddress);
+        address);
 
     // unset connect host and bind host with port
     mConfiguration.unset(service.getBindHostKey());
-    workerAddress = NetworkAddressUtils.getBindAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000), workerAddress);
+    address = NetworkAddressUtils.getBindAddress(service, mConfiguration);
+    assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000), address);
   }
 
   @Test

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -14,15 +14,14 @@ package alluxio.master.journal.raft;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.journal.JournalUtils;
+import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import com.google.common.base.Preconditions;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,7 +50,8 @@ public class RaftJournalConfiguration {
    */
   public static RaftJournalConfiguration defaults(ServiceType serviceType) {
     return new RaftJournalConfiguration()
-        .setClusterAddresses(defaultClusterAddresses(serviceType))
+        .setClusterAddresses(ConfigurationUtils
+            .getEmbeddedJournalAddresses(ServerConfiguration.global(), serviceType))
         .setElectionTimeoutMs(
             ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT))
         .setHeartbeatIntervalMs(
@@ -62,6 +62,21 @@ public class RaftJournalConfiguration {
         .setPath(new File(JournalUtils.getJournalLocation().getPath()))
         .setStorageLevel(ServerConfiguration
             .getEnum(PropertyKey.MASTER_EMBEDDED_JOURNAL_STORAGE_LEVEL, StorageLevel.class));
+  }
+
+  /**
+   * Validates the configuration.
+   */
+  public void validate() {
+    Preconditions.checkState(getMaxLogSize() <= Integer.MAX_VALUE,
+        "{} has value {} but must not exceed {}", PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX,
+        getMaxLogSize(), Integer.MAX_VALUE);
+    Preconditions.checkState(getHeartbeatIntervalMs() < getElectionTimeoutMs() / 2,
+        "Heartbeat interval (%sms) should be less than half of the election timeout (%sms)",
+        getHeartbeatIntervalMs(), getElectionTimeoutMs());
+    Preconditions.checkState(getClusterAddresses().contains(getLocalAddress()),
+        "The cluster addresses (%s) must contain the local master address (%s)",
+        getClusterAddresses(), getLocalAddress());
   }
 
   /**
@@ -174,40 +189,5 @@ public class RaftJournalConfiguration {
   public RaftJournalConfiguration setStorageLevel(StorageLevel storageLevel) {
     mStorageLevel = storageLevel;
     return this;
-  }
-
-  private static List<InetSocketAddress> defaultClusterAddresses(ServiceType serviceType) {
-    PropertyKey addressKey;
-    if (serviceType.equals(ServiceType.MASTER_RAFT)) {
-      addressKey = PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES;
-    } else {
-      Preconditions.checkState(serviceType.equals(ServiceType.JOB_MASTER_RAFT));
-      // If the job master embedded journal addresses aren't explicitly configured, default to
-      // using the same hostnames as the alluxio master embedded journal addresses, but with the job
-      // master port.
-      if (!ServerConfiguration.isSet(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES)) {
-        List<InetSocketAddress> addrs = defaultClusterAddresses(ServiceType.MASTER_RAFT);
-        List<InetSocketAddress> jobAddrs = new ArrayList<>(addrs.size());
-        int port = NetworkAddressUtils.getPort(ServiceType.JOB_MASTER_RAFT,
-            ServerConfiguration.global()
-        );
-        for (InetSocketAddress addr : addrs) {
-          jobAddrs.add(new InetSocketAddress(addr.getHostName(), port));
-        }
-        return jobAddrs;
-      }
-      addressKey = PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES;
-    }
-    List<String> addresses = ServerConfiguration.getList(addressKey, ",");
-    List<InetSocketAddress> inetAddresses = new ArrayList<>();
-    for (String address : addresses) {
-      try {
-        inetAddresses.add(NetworkAddressUtils.parseInetSocketAddress(address));
-      } catch (IOException e) {
-        throw new IllegalArgumentException(
-            String.format("Failed to parse address %s for property %s", address, addressKey), e);
-      }
-    }
-    return inetAddresses;
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -12,7 +12,6 @@
 package alluxio.master.journal.raft;
 
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.master.Master;
 import alluxio.master.PrimarySelector;
@@ -167,12 +166,7 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
    * @param conf raft journal configuration
    */
   private RaftJournalSystem(RaftJournalConfiguration conf) {
-    Preconditions.checkState(conf.getMaxLogSize() <= Integer.MAX_VALUE,
-        "{} has value {} but must not exceed {}", PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX,
-        conf.getMaxLogSize(), Integer.MAX_VALUE);
-    Preconditions.checkState(conf.getHeartbeatIntervalMs() < conf.getElectionTimeoutMs() / 2,
-        "Heartbeat interval (%sms) should be less than half of the election timeout (%sms)",
-        conf.getHeartbeatIntervalMs(), conf.getElectionTimeoutMs());
+    conf.validate();
     mConf = conf;
     mJournals = new ConcurrentHashMap<>();
     mSnapshotAllowed = new AtomicBoolean(true);
@@ -398,17 +392,18 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
 
   @Override
   public synchronized void startInternal() throws InterruptedException, IOException {
-    LOG.info("Starting Raft journal system");
+    List<Address> clusterAddresses = getClusterAddresses(mConf);
+    LOG.info("Starting Raft journal system. Cluster addresses: {}. Local address: {}",
+        clusterAddresses, getLocalAddress(mConf));
     long startTime = System.currentTimeMillis();
     try {
-      mServer.bootstrap(getClusterAddresses(mConf)).get();
+      mServer.bootstrap(clusterAddresses).get();
     } catch (ExecutionException e) {
-      String errorMessage = ExceptionMessage.FAILED_RAFT_BOOTSTRAP.getMessage(
-          Arrays.toString(getClusterAddresses(mConf).toArray()), e.getCause().toString());
+      String errorMessage = ExceptionMessage.FAILED_RAFT_BOOTSTRAP
+          .getMessage(Arrays.toString(clusterAddresses.toArray()), e.getCause().toString());
       throw new IOException(errorMessage, e.getCause());
     }
-    LOG.info("Started Raft Journal System in {}ms. Cluster addresses: {}. Local address: {}",
-        System.currentTimeMillis() - startTime, getClusterAddresses(mConf), getLocalAddress(mConf));
+    LOG.info("Started Raft Journal System in {}ms", System.currentTimeMillis() - startTime);
   }
 
   @Override

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalConfigurationTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalConfigurationTest.java
@@ -1,0 +1,114 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.raft;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.util.network.NetworkAddressUtils.ServiceType;
+
+import com.google.common.collect.Sets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+
+/**
+ * Units tests for {@link RaftJournalConfiguration}.
+ */
+public final class RaftJournalConfigurationTest {
+  @Before
+  public void before() {
+    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "testhost");
+  }
+
+  @After
+  public void after() {
+    ServerConfiguration.reset();
+  }
+
+  @Test
+  public void defaultDefaults() {
+    RaftJournalConfiguration conf = getConf(ServiceType.MASTER_RAFT);
+    checkAddress("testhost", 19200, conf.getLocalAddress());
+  }
+
+  @Test
+  public void port() {
+    int testPort = 10000;
+    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, testPort);
+    RaftJournalConfiguration conf = getConf(ServiceType.MASTER_RAFT);
+    assertEquals(testPort, conf.getLocalAddress().getPort());
+    assertEquals(testPort, conf.getClusterAddresses().get(0).getPort());
+  }
+
+  @Test
+  public void derivedMasterHostname() {
+    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "test");
+    RaftJournalConfiguration conf = getConf(ServiceType.MASTER_RAFT);
+    checkAddress("test", 19200, conf.getLocalAddress());
+  }
+
+  @Test
+  public void derivedJobMasterHostname() {
+    ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, "test");
+    RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
+    checkAddress("test", 20003, conf.getLocalAddress());
+  }
+
+  @Test
+  public void derivedJobMasterHostnameFromMasterHostname() {
+    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "test");
+    RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
+    checkAddress("test", 20003, conf.getLocalAddress());
+  }
+
+  @Test
+  public void derivedJobMasterAddressesFromMasterAddresses() {
+    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES,
+        "host1:10,host2:20,host3:10");
+    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "host1");
+    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 5);
+    RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
+    assertEquals(Sets.newHashSet(new InetSocketAddress("host1", 5),
+        new InetSocketAddress("host2", 5),
+        new InetSocketAddress("host3", 5)),
+        new HashSet<>(conf.getClusterAddresses()));
+  }
+
+  @Test
+  public void derivedJobMasterAddressesFromJobMasterAddresses() {
+    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES,
+        "host1:10,host2:20,host3:10");
+    ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, "host1");
+    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 10);
+    RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
+    assertEquals(Sets.newHashSet(new InetSocketAddress("host1", 10),
+        new InetSocketAddress("host2", 20),
+        new InetSocketAddress("host3", 10)),
+        new HashSet<>(conf.getClusterAddresses()));
+  }
+
+  private RaftJournalConfiguration getConf(ServiceType serviceType) {
+    RaftJournalConfiguration conf = RaftJournalConfiguration.defaults(serviceType);
+    conf.validate();
+    return conf;
+  }
+
+  private void checkAddress(String hostname, int port, InetSocketAddress address) {
+    assertEquals(hostname, address.getHostString());
+    assertEquals(port, address.getPort());
+  }
+}


### PR DESCRIPTION
If the embedded journal local address isn't included in the cluster addresses, it will cause the journal to hang when it tries to bootstrap. Today, our default configuration will use `"localhost:19200"` for the cluster address and `"${alluxio.master.hostname}:19200"` for the local address. If the master hostname is unset or set to something other than "localhost", the master will hang at startup. This PR changes the defaults cluster addresses to `"${alluxio.master.hostname}:19200"` to match the local address. This PR also adds a validation check so that the master will crash with an exception if the local address isn't included in the list of cluster addresses.

This PR also adds unit tests for how we generate embedded journal configuration