### PR TITLE
Fix the way we shut down the checkpoint thread

### DIFF
--- a/core/common/src/main/java/alluxio/util/ExceptionUtils.java
+++ b/core/common/src/main/java/alluxio/util/ExceptionUtils.java
@@ -1,0 +1,42 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
+
+import java.io.InterruptedIOException;
+
+/**
+ * Utility methods for working with exceptions.
+ */
+public final class ExceptionUtils {
+  /**
+   * @param t a throwable to check
+   * @return whether the given throwable contains a type of interrupted exception in its causal
+   *         chain
+   */
+  public static boolean containsInterruptedException(Throwable t) {
+    return !Iterables
+        .isEmpty(Iterables.filter(Throwables.getCausalChain(t), x -> isInterrupted(x)));
+  }
+
+  /**
+   * @param t a throwable to check
+   * @return whether the throwable is a type of interrupted exception
+   */
+  public static boolean isInterrupted(Throwable t) {
+    return t instanceof InterruptedException || t instanceof InterruptedIOException;
+  }
+
+  private ExceptionUtils() {} // Utils class
+}

--- a/core/common/src/main/java/alluxio/util/ExceptionUtils.java
+++ b/core/common/src/main/java/alluxio/util/ExceptionUtils.java
@@ -23,7 +23,7 @@ public final class ExceptionUtils {
   /**
    * @param t a throwable to check
    * @return whether the given throwable contains a type of interrupted exception in its causal
-   *         chain
+   *         chain (the causal chain includes the throwable itself)
    */
   public static boolean containsInterruptedException(Throwable t) {
     return !Iterables

--- a/core/common/src/test/java/alluxio/util/ExceptionUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ExceptionUtilsTest.java
@@ -33,10 +33,12 @@ public final class ExceptionUtilsTest {
   @Test
   public void containsInterruptedException() {
     Throwable t1 = new IOException(new RuntimeException(new InterruptedException()));
-    Throwable t2 = new IOException(new RuntimeException(new InterruptedIOException()));
-    Throwable t3 = new IOException(new RuntimeException(new IOException()));
+    Throwable t2 = new IOException(new InterruptedIOException());
+    Throwable t3 = new InterruptedException();
+    Throwable t4 = new IOException(new RuntimeException(new IOException()));
     assertTrue(ExceptionUtils.containsInterruptedException(t1));
     assertTrue(ExceptionUtils.containsInterruptedException(t2));
-    assertFalse(ExceptionUtils.containsInterruptedException(t3));
+    assertTrue(ExceptionUtils.containsInterruptedException(t3));
+    assertFalse(ExceptionUtils.containsInterruptedException(t4));
   }
 }

--- a/core/common/src/test/java/alluxio/util/ExceptionUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ExceptionUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+
+/**
+ * Unit tests for {@link ExceptionUtils}.
+ */
+public final class ExceptionUtilsTest {
+  @Test
+  public void isInterrupted() {
+    assertTrue(ExceptionUtils.isInterrupted(new InterruptedException()));
+    assertTrue(ExceptionUtils.isInterrupted(new InterruptedIOException()));
+    assertFalse(ExceptionUtils.isInterrupted(new IOException()));
+  }
+
+  @Test
+  public void containsInterruptedException() {
+    Throwable t1 = new IOException(new RuntimeException(new InterruptedException()));
+    Throwable t2 = new IOException(new RuntimeException(new InterruptedIOException()));
+    Throwable t3 = new IOException(new RuntimeException(new IOException()));
+    assertTrue(ExceptionUtils.containsInterruptedException(t1));
+    assertTrue(ExceptionUtils.containsInterruptedException(t2));
+    assertFalse(ExceptionUtils.containsInterruptedException(t3));
+  }
+}


### PR DESCRIPTION
This PR makes two changes:
1. During checkpoint thread shutdown, only interrupt the journal checkpoint thread if it is in the process of creating a checkpoint. Interrupting is unnecessary outside of checkpointing, and may cause the thread to exit early instead of replaying all logs and waiting the quiet period.
2. When checkpointing throws an exception, inspect the causal chain to determine whether the root cause was interruption. If it wasn't, log an error. Either way, continue instead of crashing the checkpoint thread.

Previously we would catch `InterruptedException` thrown during `writeToCheckpoint()`, but this isn't enough because interrupted exceptions can get converted to `InterruptedIOException` or wrapped in a `RuntimeException` like `KyroException` (or both, like below).

> ERROR UfsJournalCheckpointThread - FileSystemMaster: Failed to run journal checkpoint thread, crashing.
> com.esotericsoftware.kryo.KryoException: java.io.InterruptedIOException: Interrupted while waiting for data to be acknowledged by pipeline
> Caused by: java.io.InterruptedIOException: Interrupted while waiting for data to be acknowledged by pipeline

Caveats:
- The checkpoint thread is not properly interruptible while shutting down and taking a checkpoint. Instead of exiting promptly, it will run until all logs are replayed and the quiet period elapses.
- If an implementation of `writeToCheckpoint` throws an exception because of interruption, but doesn't include an `InterruptedException` or `InterruptedIOException` in its causal chain, we will log an error