### PR TITLE
Keep track of number of inodes

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MasterMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/MasterMetrics.java
@@ -42,7 +42,7 @@ public final class MasterMetrics {
   public static final String SET_ATTRIBUTE_OPS = "SetAttributeOps";
   public static final String UNMOUNT_OPS = "UnmountOps";
   public static final String FILES_PINNED = "FilesPinned";
-  public static final String TOTAL_PATHS_ESTIMATE = "TotalPathsEstimate";
+  public static final String TOTAL_PATHS = "TotalPaths";
   public static final String UFS_CAPACITY_TOTAL = "UfsCapacityTotal";
   public static final String UFS_CAPACITY_USED = "UfsCapacityUsed";
   public static final String UFS_CAPACITY_FREE = "UfsCapacityFree";

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1486,8 +1486,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   @Override
-  public long estimateNumberOfPaths() {
-    return mInodeTree.estimateSize();
+  public long getInodeCount() {
+    return mInodeTree.getInodeCount();
   }
 
   @Override
@@ -4405,8 +4405,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           master::getNumberOfPinnedFiles);
 
       MetricsSystem.registerGaugeIfAbsent(MetricsSystem
-              .getMetricName(MasterMetrics.TOTAL_PATHS_ESTIMATE),
-          () -> master.estimateNumberOfPaths());
+              .getMetricName(MasterMetrics.TOTAL_PATHS),
+          () -> master.getInodeCount());
 
       final String ufsDataFolder = ServerConfiguration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -230,9 +230,9 @@ public interface FileSystemMaster extends Master {
   MountPointInfo getMountPointInfo(AlluxioURI path) throws InvalidPathException;
 
   /**
-   * @return an estimate of the number of files and directories
+   * @return the number of files and directories
    */
-  long estimateNumberOfPaths();
+  long getInodeCount();
 
   /**
    * @return the number of pinned files and directories

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -241,6 +241,13 @@ public class InodeTree implements DelegatingJournaled {
   }
 
   /**
+   * @return the number of inodes in the inode tree
+   */
+  public long getInodeCount() {
+    return mState.getInodeCount();
+  }
+
+  /**
    * Marks an inode directory as having its direct children loaded.
    *
    * @param context journal context supplier
@@ -303,13 +310,6 @@ public class InodeTree implements DelegatingJournaled {
       return null;
     }
     return mState.getRoot().getOwner();
-  }
-
-  /**
-   * @return an estimate for the total number of inodes
-   */
-  public long estimateSize() {
-    return mInodeStore.estimateSize();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/DelegatingReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/DelegatingReadOnlyInodeStore.java
@@ -40,11 +40,6 @@ public class DelegatingReadOnlyInodeStore implements ReadOnlyInodeStore {
   }
 
   @Override
-  public long estimateSize() {
-    return mDelegate.estimateSize();
-  }
-
-  @Override
   public Iterable<Long> getChildIds(Long inodeId) {
     return mDelegate.getChildIds(inodeId);
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
@@ -28,10 +28,6 @@ import java.util.Set;
  * Read-only access to the inode store.
  */
 public interface ReadOnlyInodeStore extends Closeable {
-  /**
-   * @return an estimate for the number of inodes in the inode store
-   */
-  long estimateSize();
 
   /**
    * @param id an inode id

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -178,11 +178,6 @@ public final class CachingInodeStore implements InodeStore, Closeable {
   }
 
   @Override
-  public long estimateSize() {
-    return mBackingStore.estimateSize();
-  }
-
-  @Override
   public Iterable<Long> getChildIds(Long inodeId) {
     return () -> mListingCache.getChildIds(inodeId).iterator();
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -65,11 +65,6 @@ public class HeapInodeStore implements InodeStore {
   }
 
   @Override
-  public long estimateSize() {
-    return mInodes.size();
-  }
-
-  @Override
   public Optional<MutableInode<?>> getMutable(long id) {
     return Optional.ofNullable(mInodes.get(id));
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -145,15 +145,6 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public long estimateSize() {
-    try {
-      return Long.parseLong(mDb.getProperty(mInodesColumn, "rocksdb.estimate-num-keys"));
-    } catch (RocksDBException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Override
   public Optional<MutableInode<?>> getMutable(long id) {
     byte[] inode;
     try {

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
@@ -50,8 +50,8 @@ public class FileSystemMasterMetricsTest {
 
   @Test
   public void testMetricsPathsTotal() {
-    when(mFileSystemMaster.estimateNumberOfPaths()).thenReturn(90L);
-    assertEquals(90L, getGauge(MasterMetrics.TOTAL_PATHS_ESTIMATE));
+    when(mFileSystemMaster.getInodeCount()).thenReturn(90L);
+    assertEquals(90L, getGauge(MasterMetrics.TOTAL_PATHS));
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -825,11 +825,8 @@ public final class FileSystemMasterTest {
     assertEquals(4, countPaths());
   }
 
-  private int countPaths() throws Exception {
-    return 1 + mFileSystemMaster
-            .listStatus(new AlluxioURI("/"),
-                ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder().setRecursive(true)))
-            .size();
+  private long countPaths() throws Exception {
+    return mFileSystemMaster.getInodeCount();
   }
 
   @Test


### PR DESCRIPTION
This change adds tracking for the exact number of inodes. Whenever we add or delete an inode, we increment or decrement the counter.

We track the number of inodes instead of requesting it from the inode store because some inode stores (e.g. RocksDB) don't have a fast way to count the number of inodes.

This change is motivated by a bug where calling estimateNumberOfPaths with a Rocks inode store would cause a segmentation fault if the inode store is in the process of being initialized.

This also addresses an issue where `CachingInodeStore#estimateNumberOfPaths()` was wildly inaccurate because it delegated to the backing store. With 5 million paths, the estimate would be `0` because the inodes still fit in the cache. It's very difficult for `CachingInodeStore` to determine how many inodes there are because it can't tell how many inodes are stored in the cache but not in the inode store.