### PR TITLE
Avoid infinite loop for OSSUnderFileSystem getNextChunk listing

### DIFF
--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -226,8 +226,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     @Override
     public ObjectListingChunk getNextChunk() throws IOException {
       if (mResult.isTruncated()) {
-        String nextMarker = mResult.getNextMarker();
-        mRequest.setMarker(nextMarker);
+        mRequest.setMarker(mResult.getNextMarker());
         ObjectListing nextResult = mClient.listObjects(mRequest);
         if (nextResult != null) {
           return new OSSObjectListingChunk(mRequest, nextResult);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -226,6 +226,8 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     @Override
     public ObjectListingChunk getNextChunk() throws IOException {
       if (mResult.isTruncated()) {
+        String nextMarker = mResult.getNextMarker();
+        mRequest.setMarker(nextMarker);
         ObjectListing nextResult = mClient.listObjects(mRequest);
         if (nextResult != null) {
           return new OSSObjectListingChunk(mRequest, nextResult);


### PR DESCRIPTION
when listing operation getNextChunk trap infinity loop without filling correct paging information for next round request