### PR TITLE
Hide short-circuit metrics

### DIFF
--- a/alluxio-ui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/alluxio-ui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -82,18 +82,18 @@ export class Metrics extends React.Component<AllProps> {
               <Table hover={true}>
                 <tbody>
                 <tr>
-                  <th>Short-circuit Read</th>
-                  <td>{data.totalBytesReadLocal}</td>
-                  <th>From Remote Instances</th>
+                  <th>Remote Alluxio Read</th>
                   <td>{data.totalBytesReadRemote}</td>
+                </tr>
+                <tr>
+                  <th>Remote Alluxio Write</th>
+                  <td>{data.totalBytesWrittenAlluxio}</td>
                 </tr>
                 <tr>
                   <th>Under Filesystem Read</th>
                   <td>{data.totalBytesReadUfs}</td>
                 </tr>
                 <tr>
-                  <th>Alluxio Write</th>
-                  <td>{data.totalBytesWrittenAlluxio}</td>
                   <th>Under Filesystem Write</th>
                   <td>{data.totalBytesWrittenUfs}</td>
                 </tr>
@@ -105,9 +105,7 @@ export class Metrics extends React.Component<AllProps> {
               <Table hover={true}>
                 <tbody>
                 <tr>
-                  <th>Short-circuit Read</th>
-                  <td>{data.totalBytesReadLocalThroughput}</td>
-                  <th>From Remote Instances</th>
+                  <th>Remote Alluxio Read</th>
                   <td>{data.totalBytesReadRemoteThroughput}</td>
                 </tr>
                 <tr>
@@ -115,27 +113,12 @@ export class Metrics extends React.Component<AllProps> {
                   <td>{data.totalBytesReadUfsThroughput}</td>
                 </tr>
                 <tr>
-                  <th>Alluxio Write</th>
+                  <th>Remote Alluxio Write</th>
                   <td>{data.totalBytesWrittenAlluxioThroughput}</td>
+                </tr>
+                <tr>
                   <th>Under Filesystem Write</th>
                   <td>{data.totalBytesWrittenUfsThroughput}</td>
-                </tr>
-                </tbody>
-              </Table>
-            </div>
-            <div className="col-12">
-              <h5>Cache Hit Rate (Percentage)</h5>
-              <Table hover={true}>
-                <tbody>
-                <tr>
-                  <th>Alluxio Local</th>
-                  <td>{data.cacheHitLocal}</td>
-                  <th>Alluxio Remote</th>
-                  <td>{data.cacheHitRemote}</td>
-                </tr>
-                <tr>
-                  <th>Miss</th>
-                  <td>{data.cacheMiss}</td>
                 </tr>
                 </tbody>
               </Table>

--- a/alluxio-ui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/alluxio-ui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -84,16 +84,12 @@ export class Metrics extends React.Component<AllProps> {
                 <tr>
                   <th>Remote Alluxio Read</th>
                   <td>{data.totalBytesReadRemote}</td>
-                </tr>
-                <tr>
                   <th>Remote Alluxio Write</th>
                   <td>{data.totalBytesWrittenAlluxio}</td>
                 </tr>
                 <tr>
                   <th>Under Filesystem Read</th>
                   <td>{data.totalBytesReadUfs}</td>
-                </tr>
-                <tr>
                   <th>Under Filesystem Write</th>
                   <td>{data.totalBytesWrittenUfs}</td>
                 </tr>
@@ -107,16 +103,12 @@ export class Metrics extends React.Component<AllProps> {
                 <tr>
                   <th>Remote Alluxio Read</th>
                   <td>{data.totalBytesReadRemoteThroughput}</td>
-                </tr>
-                <tr>
-                  <th>Under Filesystem Read</th>
-                  <td>{data.totalBytesReadUfsThroughput}</td>
-                </tr>
-                <tr>
                   <th>Remote Alluxio Write</th>
                   <td>{data.totalBytesWrittenAlluxioThroughput}</td>
                 </tr>
                 <tr>
+                  <th>Under Filesystem Read</th>
+                  <td>{data.totalBytesReadUfsThroughput}</td>
                   <th>Under Filesystem Write</th>
                   <td>{data.totalBytesWrittenUfsThroughput}</td>
                 </tr>

--- a/alluxio-ui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
+++ b/alluxio-ui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
@@ -1062,23 +1062,17 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
           <tbody>
             <tr>
               <th>
-                Short-circuit Read
+                Remote Alluxio Read
               </th>
               <td />
               <th>
-                From Remote Instances
+                Remote Alluxio Write
               </th>
               <td />
             </tr>
             <tr>
               <th>
                 Under Filesystem Read
-              </th>
-              <td />
-            </tr>
-            <tr>
-              <th>
-                Alluxio Write
               </th>
               <td />
               <th>
@@ -1103,11 +1097,11 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
           <tbody>
             <tr>
               <th>
-                Short-circuit Read
+                Remote Alluxio Read
               </th>
               <td />
               <th>
-                From Remote Instances
+                Remote Alluxio Write
               </th>
               <td />
             </tr>
@@ -1116,49 +1110,10 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
                 Under Filesystem Read
               </th>
               <td />
-            </tr>
-            <tr>
-              <th>
-                Alluxio Write
-              </th>
-              <td />
               <th>
                 Under Filesystem Write
               </th>
               <td />
-            </tr>
-          </tbody>
-        </Table>
-      </div>
-      <div
-        className="col-12"
-      >
-        <h5>
-          Cache Hit Rate (Percentage)
-        </h5>
-        <Table
-          hover={true}
-          responsiveTag="div"
-          tag="table"
-        >
-          <tbody>
-            <tr>
-              <th>
-                Alluxio Local
-              </th>
-              <td />
-              <th>
-                Alluxio Remote
-              </th>
-              <td />
-            </tr>
-            <tr>
-              <th>
-                Miss
-              </th>
-              <td>
-                0.00
-              </td>
             </tr>
           </tbody>
         </Table>


### PR DESCRIPTION
Client metrics collection is not guaranteed (in fact off by default), so the short circuit and cache rate metrics will be inaccurate most of the time. Therefore we remove them from the display. Users can still hit the rest endpoint to retrieve the values if the environment is setup to accurately measure them.