### PR TITLE
Add master hostname not configured exception message

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -207,7 +207,7 @@ public enum ExceptionMessage {
 
   // configuration
   UNABLE_TO_DETERMINE_MASTER_HOSTNAME("Cannot run {0}; Unable to determine {1} address. Please "
-      + "modify" + Constants.SITE_PROPERTIES + " to either set {2}, configure zookeeper with "
+      + "modify " + Constants.SITE_PROPERTIES + " to either set {2}, configure zookeeper with "
       + "{3}=true and {4}=[comma-separated zookeeper master addresses], or utilize internal HA by "
       + "setting {5}=[comma-separated alluxio {1} addresses]"),
   DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST("The default Alluxio properties file does not exist"),
@@ -305,9 +305,9 @@ public enum ExceptionMessage {
    * @return the formatted message
    */
   public String getMessage(Object... params) {
-    Preconditions.checkArgument(mMessage.getFormats().length == params.length,
-        "The message takes " + mMessage.getFormats().length + " arguments, but is given "
-            + params.length);
+    Preconditions.checkArgument(mMessage.getFormatsByArgumentIndex().length == params.length,
+        "The message takes " + mMessage.getFormatsByArgumentIndex().length + " arguments, but is "
+            + "given " + params.length);
     // MessageFormat is not thread-safe, so guard it
     synchronized (mMessage) {
       return mMessage.format(params);

--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -11,6 +11,8 @@
 
 package alluxio.exception;
 
+import alluxio.Constants;
+
 import com.google.common.base.Preconditions;
 
 import java.text.MessageFormat;
@@ -204,6 +206,10 @@ public enum ExceptionMessage {
   INCOMPATIBLE_VERSION("{0} client version {1} is not compatible with server version {2}"),
 
   // configuration
+  UNABLE_TO_DETERMINE_MASTER_HOSTNAME("Cannot run {0}; Unable to determine {1} address. Please "
+      + "modify" + Constants.SITE_PROPERTIES + " to either set {2}, configure zookeeper with "
+      + "{3}=true and {4}=[comma-separated zookeeper master addresses], or utilize internal HA by "
+      + "setting {5}=[comma-separated alluxio {1} addresses]"),
   DEFAULT_PROPERTIES_FILE_DOES_NOT_EXIST("The default Alluxio properties file does not exist"),
   INVALID_CONFIGURATION_KEY("Invalid property key {0}"),
   INVALID_CONFIGURATION_VALUE("Invalid value {0} for configuration key {1}"),

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -273,7 +273,7 @@ public final class ConfigurationUtils {
   /**
    * Returns a unified message for cases when the master hostname cannot be determined.
    *
-   * @param serviceName The name of the service that couldn't run. i.e. Alluxio worker, fsadmin
+   * @param serviceName the name of the service that couldn't run. i.e. Alluxio worker, fsadmin
    *                    shell, etc.
    * @return a string with the message
    */
@@ -285,7 +285,7 @@ public final class ConfigurationUtils {
   /**
    * Returns a unified message for cases when the job master hostname cannot be determined.
    *
-   * @param serviceName The name of the service that couldn't run. i.e. Alluxio worker, fsadmin
+   * @param serviceName the name of the service that couldn't run. i.e. Alluxio worker, fsadmin
    *                    shell, etc.
    * @return a string with the message
    */

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -21,6 +21,7 @@ import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
+import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.exception.status.UnavailableException;
@@ -267,6 +268,37 @@ public final class ConfigurationUtils {
         && conf.isSet(PropertyKey.ZOOKEEPER_ADDRESS);
     return conf.isSet(PropertyKey.JOB_MASTER_HOSTNAME) || usingZk
         || getJobMasterRpcAddresses(conf).size() > 1;
+  }
+
+  /**
+   * Returns a unified message for cases when the master hostname cannot be determined.
+   *
+   * @param serviceName The name of the service that couldn't run. i.e. Alluxio worker, fsadmin
+   *                    shell, etc.
+   * @return a string with the message
+   */
+  public static String getMasterHostNotConfiguredMessage(String serviceName) {
+    return getHostNotConfiguredMessage(serviceName, "master", PropertyKey.MASTER_HOSTNAME,
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES);
+  }
+
+  /**
+   * Returns a unified message for cases when the job master hostname cannot be determined.
+   *
+   * @param serviceName The name of the service that couldn't run. i.e. Alluxio worker, fsadmin
+   *                    shell, etc.
+   * @return a string with the message
+   */
+  public static String getJobMasterHostNotConfiguredMessage(String serviceName) {
+    return getHostNotConfiguredMessage(serviceName, "job master", PropertyKey.JOB_MASTER_HOSTNAME,
+        PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES);
+  }
+
+  private static String getHostNotConfiguredMessage(String serviceName, String masterName,
+      PropertyKey masterHostnameKey, PropertyKey embeddedJournalKey) {
+    return ExceptionMessage.UNABLE_TO_DETERMINE_MASTER_HOSTNAME.getMessage(serviceName, masterName,
+        masterHostnameKey.getName(), PropertyKey.ZOOKEEPER_ENABLED.getName(),
+        PropertyKey.ZOOKEEPER_ADDRESS.getName(), embeddedJournalKey.getName());
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -117,6 +117,26 @@ public final class ConfigurationUtilsTest {
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
+  @Test
+  public void testMasterNotConfiguredMessage() {
+    assertEquals("Messages should be the same",
+        "Cannot run test service; Unable to determine master address. Please modify "
+            + "alluxio-site.properties to either set alluxio.master.hostname, configure zookeeper "
+            + "with alluxio.zookeeper.enabled=true and alluxio.zookeeper.address=[comma-separated "
+            + "zookeeper master addresses], or utilize internal HA by setting alluxio.master"
+            + ".embedded.journal.addresses=[comma-separated alluxio master addresses]",
+        ConfigurationUtils.getMasterHostNotConfiguredMessage("test service"));
+
+    assertEquals("Messages should be the same",
+        "Cannot run test service 2; Unable to determine job master address. Please modify "
+            + "alluxio-site.properties to either set alluxio.job.master.hostname, configure "
+            + "zookeeper with alluxio.zookeeper.enabled=true and alluxio.zookeeper.address=[comma-"
+            + "separated zookeeper master addresses], or utilize internal HA by setting alluxio"
+            + ".job.master.embedded.journal.addresses=[comma-separated alluxio job master "
+            + "addresses]",
+        ConfigurationUtils.getJobMasterHostNotConfiguredMessage("test service 2"));
+  }
+
   private AlluxioConfiguration createConf(Map<PropertyKey, String> properties) {
     AlluxioProperties props = ConfigurationUtils.defaults();
     for (PropertyKey key : properties.keySet()) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
@@ -11,9 +11,7 @@
 
 package alluxio.proxy;
 
-import alluxio.Constants;
 import alluxio.ProcessUtils;
-import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.conf.ServerConfiguration;
 import alluxio.util.CommonUtils;
@@ -45,11 +43,7 @@ public final class AlluxioProxy {
 
     if (!ConfigurationUtils.masterHostConfigured(ServerConfiguration.global())) {
       ProcessUtils.fatalError(LOG,
-          "Cannot run alluxio proxy; master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString());
+          ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio proxy"));
     }
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.PROXY);

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -12,7 +12,6 @@
 package alluxio.worker;
 
 import alluxio.conf.ServerConfiguration;
-import alluxio.Constants;
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
@@ -50,11 +49,7 @@ public final class AlluxioWorker {
 
     if (!ConfigurationUtils.masterHostConfigured(ServerConfiguration.global())) {
       ProcessUtils.fatalError(LOG,
-          "Cannot run alluxio worker; master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString());
+          ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio worker"));
     }
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.WORKER);

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
@@ -12,7 +12,6 @@
 package alluxio.worker;
 
 import alluxio.conf.ServerConfiguration;
-import alluxio.Constants;
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
@@ -49,22 +48,14 @@ public final class AlluxioJobWorker {
     }
 
     if (!ConfigurationUtils.masterHostConfigured(ServerConfiguration.global())) {
-      System.out.println(String.format(
-          "Cannot run alluxio job worker; master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString()));
+      System.out.println(ConfigurationUtils
+          .getMasterHostNotConfiguredMessage("Alluxio job worker"));
       System.exit(1);
     }
 
     if (!ConfigurationUtils.jobMasterHostConfigured(ServerConfiguration.global())) {
-      System.out.println(String.format(
-          "Cannot run alluxio job worker; job master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.JOB_MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString()));
+      System.out.println(ConfigurationUtils
+          .getJobMasterHostNotConfiguredMessage("Alluxio job worker"));
       System.exit(1);
     }
 

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -17,7 +17,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.conf.Source;
-import alluxio.exception.ExceptionMessage;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -57,8 +56,7 @@ public final class FileSystemShell extends AbstractShell {
     InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
     if (!ConfigurationUtils.masterHostConfigured(conf)
         && argv.length > 0 && !argv[0].equals("help")) {
-      System.out.println(ExceptionMessage.UNABLE_TO_DETERMINE_MASTER_HOSTNAME
-              .getMessage("Alluxio fs shell"));
+      System.out.println(ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio fs shell"));
       System.exit(1);
     }
 

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -11,13 +11,13 @@
 
 package alluxio.cli.fs;
 
-import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.conf.Source;
+import alluxio.exception.ExceptionMessage;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -57,12 +57,8 @@ public final class FileSystemShell extends AbstractShell {
     InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
     if (!ConfigurationUtils.masterHostConfigured(conf)
         && argv.length > 0 && !argv[0].equals("help")) {
-      System.out.println(String.format(
-          "Cannot run alluxio fs shell; master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString()));
+      System.out.println(ExceptionMessage.UNABLE_TO_DETERMINE_MASTER_HOSTNAME
+              .getMessage("Alluxio fs shell"));
       System.exit(1);
     }
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
@@ -59,7 +59,8 @@ public final class FileSystemAdminShell extends AbstractShell {
   public static void main(String[] args) {
     InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
     if (!ConfigurationUtils.masterHostConfigured(conf) && args.length > 0) {
-      System.out.println("Cannot run alluxio fsadmin shell as master hostname is not configured.");
+      System.out.println(ConfigurationUtils
+          .getMasterHostNotConfiguredMessage("Alluxio fsadmin shell"));
       System.exit(1);
     }
     // Reduce the RPC retry max duration to fall earlier for CLIs

--- a/shell/src/main/java/alluxio/cli/job/JobShell.java
+++ b/shell/src/main/java/alluxio/cli/job/JobShell.java
@@ -11,10 +11,8 @@
 
 package alluxio.cli.job;
 
-import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
@@ -49,12 +47,8 @@ public final class JobShell extends AbstractShell {
     InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
 
     if (!ConfigurationUtils.masterHostConfigured(conf) && argv.length > 0) {
-      System.out.println(String.format(
-          "Cannot run alluxio job shell; master hostname is not "
-              + "configured. Please modify %s to either set %s or configure zookeeper with "
-              + "%s=true and %s=[comma-separated zookeeper master addresses]",
-          Constants.SITE_PROPERTIES, PropertyKey.MASTER_HOSTNAME.toString(),
-          PropertyKey.ZOOKEEPER_ENABLED.toString(), PropertyKey.ZOOKEEPER_ADDRESS.toString()));
+      System.out.println(ConfigurationUtils
+          .getMasterHostNotConfiguredMessage("Alluxio job shell"));
       System.exit(1);
     }
 


### PR DESCRIPTION
The same or similar message is used throughout the code base
when the proper hostname isn't configured and doesn't include
embedded journal configuration. This change adds a new
message to ExceptionMessage and some utility methods to
generate it due to the number of parameters.

ExceptionMessage exists in core/base which meant I couldn't
use PropertyKeys directly in the message itself. This is why
there are utility methods inside of ConfigurationUtils.

Fixes #8443