### PR TITLE
[SMALLFIX] Fix shell command ls sort by size

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -24,22 +24,14 @@ import alluxio.grpc.LoadMetadataPType;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.SecurityUtils;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.stream.Collectors;
-
 import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Displays information for the path specified in args. Depends on different options, this command
@@ -127,7 +119,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
     SORT_FIELD_COMPARATORS.put("name",
         Comparator.comparing(URIStatus::getName, String.CASE_INSENSITIVE_ORDER));
     SORT_FIELD_COMPARATORS.put("path", Comparator.comparing(URIStatus::getPath));
-    SORT_FIELD_COMPARATORS.put("size", Comparator.comparingLong(URIStatus::getBlockSizeBytes));
+    SORT_FIELD_COMPARATORS.put("size", Comparator.comparingLong(URIStatus::getLength));
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -24,6 +24,7 @@ import alluxio.grpc.LoadMetadataPType;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.SecurityUtils;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -28,10 +28,17 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Displays information for the path specified in args. Depends on different options, this command


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3029

This issue has actually been solved by others, but I found a minor bug regarding the implementation of the sort-by-size option.

Previously, sorting by file size checks "URIStatus::getBlockSizeBytes", which is not correct as it compares the default block size rather than the file size. Wrong sorting results can be observed as follows,
![image](https://user-images.githubusercontent.com/23428775/54083373-6199ce00-435d-11e9-94d9-ddef380c6b9d.png)

Replacing "getBlockSizeBytes" with "getLength" solves the problem. 
![image](https://user-images.githubusercontent.com/23428775/54083414-df5dd980-435d-11e9-87dd-879d34276a8c.png)





