### PR TITLE
Load metadata for the path that we are syncing

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3312,6 +3312,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           inodePath.removeLastInode();
         }
         pathsToLoad = result.getPathsToLoad();
+        pathsToLoad.add(mMountTable.getMountPoint(inodePath.getUri()));
       }
     } catch (InvalidPathException | FileDoesNotExistException | AccessControlException e) {
       LOG.warn("Exception encountered when syncing metadata for {}, exception is {}",

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3312,7 +3312,6 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           inodePath.removeLastInode();
         }
         pathsToLoad = result.getPathsToLoad();
-        pathsToLoad.add(mMountTable.getMountPoint(inodePath.getUri()));
       }
     } catch (InvalidPathException | FileDoesNotExistException | AccessControlException e) {
       LOG.warn("Exception encountered when syncing metadata for {}, exception is {}",


### PR DESCRIPTION
This fixes the issue #8531 . 

Previously, we do not add the path we are loading to the `UfsSyncPathCache`. So when only children need to be synced, we repeatedly request children information from the UFS but never call `loadMetadata` on the parent and therefore the parent is never in the `UfsSyncPathCache`, leaving the impression that we are syncing the parent repeatedly. 

Now with this change, we do sync the parent and add it to the `UfsSyncPathCache`, so we do not repeatedly make requests to the ufs. 
