### PR TITLE
Add baseurl support to docs - 1.7

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -82,3 +82,7 @@ categoryInfo:
     en: Resources
     cn: 开发者资源
     pt: Recursos
+
+# For no baseurl, leave blank
+# Anything other than blank: this should always START with a '/' and NEVER end with a '/' character
+baseurl:

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -13,15 +13,15 @@
     <title>{{ page.title }} - Alluxio {{site.ALLUXIO_MASTER_VERSION_SHORT}} Documentation</title>
     <meta name="description" content="">
 
-    <link rel="stylesheet" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="../css/bootstrap-responsive.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap-responsive.min.css">
     <link rel="stylesheet" href="../css/main.css">
 
-    <script src="../js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
+    <script src="{{site.baseurl}}/js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
 
-    <link rel="stylesheet" href="../css/pygments-default.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/pygments-default.css">
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -162,9 +162,9 @@
 </div>
 <!-- /container -->
 
-<script src="../js/vendor/jquery-1.8.0.min.js"></script>
-<script src="../js/vendor/bootstrap.min.js"></script>
-<script src="../js/main.js"></script>
+<script src="{{site.baseurl}}/js/vendor/jquery-1.8.0.min.js"></script>
+<script src="{{site.baseurl}}/js/vendor/bootstrap.min.js"></script>
+<script src="{{site.baseurl}}/js/main.js"></script>
 
 <!-- A script to fix internal hash links because we have an overlapping top bar.
      Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510 -->


### PR DESCRIPTION
Replace `..` with `{{site.baseurl}}`. The value for `site.baseurl` can be
set within `_config.yml`. This makes building docs for other locations
simpler.