### PR TITLE
Add baseurl support to docs - 1.4

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -64,3 +64,6 @@ categoryInfo:
     en: Resources
     cn: 开发者资源
     pt: Recursos
+# For no baseurl, leave blank
+# Anything other than blank: this should always START with a '/' and NEVER end with a '/' character
+baseurl:

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -13,15 +13,15 @@
     <title>{{ page.title }} - Alluxio {{site.ALLUXIO_MASTER_VERSION_SHORT}} Documentation</title>
     <meta name="description" content="">
 
-    <link rel="stylesheet" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="../css/bootstrap-responsive.min.css">
-    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap-responsive.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/main.css">
 
-    <script src="../js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
+    <script src="{{site.baseurl}}/js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
 
-    <link rel="stylesheet" href="../css/pygments-default.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/pygments-default.css">
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -44,10 +44,10 @@
 <div class="navbar navbar-fixed-top" id="topbar">
     <div class="navbar-inner">
         <div class="container">
-            <a href="/">
+            <a href="{{site.baseurl}}">
                 <div class="brand" style="display:table;">
                     <div style="position:relative;display:table-cell;vertical-align:middle;">
-                        <img src="../img/logo-white.png" alt="Alluxio Logo" style="height:34px;"/>
+                        <img src="{{site.baseurl}}/img/logo-white.png" alt="Alluxio Logo" style="height:34px;"/>
                         <div style="position:absolute;right:0;top:32px;text-shadow:none;">
                             <span class="version">{{site.ALLUXIO_MASTER_VERSION_SHORT}}</span>
                         </div>
@@ -59,10 +59,10 @@
                 {% for groupName in categories %}
                     <li class="dropdown">
                         {% if page.group == groupName %}
-                            <a href="#" class="dropdown-toggle active" data-toggle="dropdown">{{site.categoryInfo.[groupName].[page.lang]}}<b
+                            <a href="#" class="dropdown-toggle active" data-toggle="dropdown">{{site.categoryInfo[groupName][page.lang]}}<b
                                 class="caret"></b></a>
                         {% else %}
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{site.categoryInfo.[groupName].[page.lang]}}<b
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{site.categoryInfo[groupName][page.lang]}}<b
                                 class="caret"></b></a>
                         {% endif %}
 
@@ -81,8 +81,7 @@
                                         </a>
                                     </li>
                                 {% else %}
-                                    <!-- Use the prefix .. to change the absolute url to relative url -->
-                                    <li><a href="..{{ node.url }}">
+                                    <li><a href="{{site.baseurl}}{{ node.url }}">
                                         {% if node.nickname == null %}
                                             {{node.title}}
                                         {% else %}
@@ -112,8 +111,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{page.languageName}}<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         {% for singleLanguage in multiLanguagePages %}
-                            <!-- Use the prefix .. to change the absulote url to relative url -->
-                            <li><a href="..{{singleLanguage.url}}">{{singleLanguage.languageName}}</a></li>
+                            <li><a href="{{site.baseurl}}{{singleLanguage.url}}">{{singleLanguage.languageName}}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -162,9 +160,9 @@
 </div>
 <!-- /container -->
 
-<script src="../js/vendor/jquery-1.8.0.min.js"></script>
-<script src="../js/vendor/bootstrap.min.js"></script>
-<script src="../js/main.js"></script>
+<script src="{{site.baseurl}}/js/vendor/jquery-1.8.0.min.js"></script>
+<script src="{{site.baseurl}}/js/vendor/bootstrap.min.js"></script>
+<script src="{{site.baseurl}}/js/main.js"></script>
 
 <!-- A script to fix internal hash links because we have an overlapping top bar.
      Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510 -->
@@ -188,7 +186,7 @@
     })
 </script>
 
-<script src="../js/scrollspy.js"></script>
+<script src="{{site.baseurl}}/js/scrollspy.js"></script>
 
 </body>
 </html>

--- a/docs/cn/Command-Line-Interface.md
+++ b/docs/cn/Command-Line-Interface.md
@@ -43,7 +43,7 @@ fs命令中的所有“路径”都应该以以下开头：
     <tr>
       <td>{{ item.operation }}</td>
       <td>{{ item.syntax }}</td>
-      <td>{{ site.data.table.cn.operation-command.[item.operation] }}</td>
+      <td>{{ site.data.table.cn.operation-command[item][operation] }}</td>
     </tr>
   {% endfor %}
 </table>

--- a/docs/cn/Configuration-Settings.md
+++ b/docs/cn/Configuration-Settings.md
@@ -120,7 +120,7 @@ Hadoop MapReduce用户可以在`hadoop jar`命令中添加`-Dkey=property`将配
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.common-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.common-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -135,7 +135,7 @@ Master配置项指定master节点的信息，例如地址和端口号。
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.master-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.master-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -150,7 +150,7 @@ Worker配置项指定worker节点的信息，例如地址和端口号。
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.worker-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.worker-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -166,7 +166,7 @@ Worker配置项指定worker节点的信息，例如地址和端口号。
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.user-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.user-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -181,7 +181,7 @@ Worker配置项指定worker节点的信息，例如地址和端口号。
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.cluster-management.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.cluster-management[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -199,7 +199,7 @@ Worker配置项指定worker节点的信息，例如地址和端口号。
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.security-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.security-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Developer-Tips.md
+++ b/docs/cn/Developer-Tips.md
@@ -40,7 +40,7 @@ Alluxio使用协议缓冲区来读写日志消息。`.proto`文件被定义在`s
 <tr>
   <td>{{dscp.command}}</td>
   <td>{{dscp.args}}</td>
-  <td>{{site.data.table.cn.Developer-Tips.[dscp.command]}}</td>
+  <td>{{site.data.table.cn.Developer-Tips[dscp][command]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/cn/File-System-API.md
+++ b/docs/cn/File-System-API.md
@@ -45,7 +45,7 @@ Alluxio有两种存储类型：Alluxio管理的存储和底层存储。Alluxio�
 {% for readtype in site.data.table.ReadType %}
 <tr>
   <td>{{readtype.readtype}}</td>
-  <td>{{site.data.table.cn.ReadType.[readtype.readtype]}}</td>
+  <td>{{site.data.table.cn.ReadType[readtype][readtype]}}</td>
 </tr>
 {% endfor %}
 </table>
@@ -58,7 +58,7 @@ Alluxio有两种存储类型：Alluxio管理的存储和底层存储。Alluxio�
 {% for writetype in site.data.table.WriteType %}
 <tr>
   <td>{{writetype.writetype}}</td>
-  <td>{{site.data.table.cn.WriteType.[writetype.writetype]}}</td>
+  <td>{{site.data.table.cn.WriteType[writetype][writetype]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Key-Value-System-API.md
+++ b/docs/cn/Key-Value-System-API.md
@@ -33,7 +33,7 @@ Alluxio默认配置是禁用键值存储库的，可以通过配置`alluxio.keyv
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.key-value-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.cn.key-value-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Lineage-API.md
+++ b/docs/cn/Lineage-API.md
@@ -61,7 +61,7 @@ Alluxio提供了Java版本的API来操作和访问世系关系信息。
 <tr>
   <td>{{record.parameter}}</td>
   <td>{{record.defaultvalue}}</td>
-  <td>{{site.data.table.cn.LineageParameter.[record.parameter]}}</td>
+  <td>{{site.data.table.cn.LineageParameter[record][parameter]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Mounting-Alluxio-FS-with-FUSE.md
+++ b/docs/cn/Mounting-Alluxio-FS-with-FUSE.md
@@ -112,7 +112,7 @@ Seek操作只支持用于读的文件，即在指定`O_RDONLY` flags方式下被
   <tr>
     <td>{{ item.parameter }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.cn.Alluxio-FUSE-parameter.[item.parameter] }}</td>
+    <td>{{ site.data.table.cn.Alluxio-FUSE-parameter[item][parameter] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/cn/Running-Alluxio-Fault-Tolerant.md
@@ -65,7 +65,7 @@ Zookeeper和共享文件系统都正常运行时，需要在每个主机上配�
 <tr>
   <td>{{item.PropertyName}}</td>
   <td>{{item.Value}}</td>
-  <td>{{site.data.table.cn.java-options-for-fault-tolerance.[item.PropertyName]}}</td>
+  <td>{{site.data.table.cn.java-options-for-fault-tolerance[item][PropertyName]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/cn/Tiered-Storage-on-Alluxio.md
+++ b/docs/cn/Tiered-Storage-on-Alluxio.md
@@ -137,7 +137,7 @@ Alluxio使用回收策略决定当空间需要释放时，哪些数据块被移�
 <tr>
 <td>{{ item.parameter }}</td>
 <td>{{ item.defaultValue }}</td>
-<td>{{ site.data.table.cn.tiered-storage-configuration-parameters.[item.parameter] }}</td>
+<td>{{ site.data.table.cn.tiered-storage-configuration-parameters[item][parameter] }}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/en/Command-Line-Interface.md
+++ b/docs/en/Command-Line-Interface.md
@@ -48,7 +48,7 @@ should have the final escaped parameters (cat /\\*).
     <tr>
       <td>{{ item.operation }}</td>
       <td>{{ item.syntax }}</td>
-      <td>{{ site.data.table.en.operation-command.[item.operation] }}</td>
+      <td>{{ site.data.table.en.operation-command[item][operation] }}</td>
     </tr>
   {% endfor %}
 </table>

--- a/docs/en/Configuration-Settings.md
+++ b/docs/en/Configuration-Settings.md
@@ -166,7 +166,7 @@ The common configuration contains constants shared by different components.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.common-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.common-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -182,7 +182,7 @@ the port number.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.master-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.master-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -198,7 +198,7 @@ the port number.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.worker-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.worker-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -214,7 +214,7 @@ The user configuration specifies values regarding file system access.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.user-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.user-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -230,7 +230,7 @@ configuration options.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.cluster-management.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.cluster-management[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -248,7 +248,7 @@ See [Security](Security.html) for more information about security features.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.security-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.security-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/en/Developer-Tips.md
+++ b/docs/en/Developer-Tips.md
@@ -52,7 +52,7 @@ the syntax of each command.
 <tr>
   <td>{{dscp.command}}</td>
   <td>{{dscp.args}}</td>
-  <td>{{site.data.table.en.Developer-Tips.[dscp.command]}}</td>
+  <td>{{site.data.table.en.Developer-Tips[dscp][command]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/en/File-System-API.md
+++ b/docs/en/File-System-API.md
@@ -62,7 +62,7 @@ over the under storage system.
 {% for readtype in site.data.table.ReadType %}
 <tr>
   <td>{{readtype.readtype}}</td>
-  <td>{{site.data.table.en.ReadType.[readtype.readtype]}}</td>
+  <td>{{site.data.table.en.ReadType[readtype][readtype]}}</td>
 </tr>
 {% endfor %}
 </table>
@@ -75,7 +75,7 @@ Below is a table of the expected behaviors of `WriteType`
 {% for writetype in site.data.table.WriteType %}
 <tr>
   <td>{{writetype.writetype}}</td>
-  <td>{{site.data.table.en.WriteType.[writetype.writetype]}}</td>
+  <td>{{site.data.table.en.WriteType[writetype][writetype]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/en/Key-Value-System-API.md
+++ b/docs/en/Key-Value-System-API.md
@@ -35,7 +35,7 @@ Key-Value support in Alluxio is disabled by default, and it can be enabled in Al
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.key-value-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.key-value-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/en/Lineage-API.md
+++ b/docs/en/Lineage-API.md
@@ -80,7 +80,7 @@ These are the configuration parameters related to Alluxio's lineage feature.
 <tr>
   <td>{{record.parameter}}</td>
   <td>{{record.defaultvalue}}</td>
-  <td>{{site.data.table.en.LineageParameter.[record.parameter]}}</td>
+  <td>{{site.data.table.en.LineageParameter[record][parameter]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/en/Mounting-Alluxio-FS-with-FUSE.md
+++ b/docs/en/Mounting-Alluxio-FS-with-FUSE.md
@@ -149,7 +149,7 @@ These are the configuration parameters for Alluxio-FUSE.
   <tr>
     <td>{{ item.parameter }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.Alluxio-FUSE-parameter.[item.parameter] }}</td>
+    <td>{{ site.data.table.en.Alluxio-FUSE-parameter[item][parameter] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/en/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/en/Running-Alluxio-Fault-Tolerant.md
@@ -79,7 +79,7 @@ Alluxio masters, workers, and clients. In `conf/alluxio-site.properties`, these 
 <tr>
   <td>{{item.PropertyName}}</td>
   <td>{{item.Value}}</td>
-  <td>{{site.data.table.en.java-options-for-fault-tolerance.[item.PropertyName]}}</td>
+  <td>{{site.data.table.en.java-options-for-fault-tolerance[item][PropertyName]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/en/Tiered-Storage-on-Alluxio.md
+++ b/docs/en/Tiered-Storage-on-Alluxio.md
@@ -189,7 +189,7 @@ These are the configuration parameters for tiered storage.
 <tr>
 <td>{{ item.parameter }}</td>
 <td>{{ item.defaultValue }}</td>
-<td>{{ site.data.table.en.tiered-storage-configuration-parameters.[item.parameter] }}</td>
+<td>{{ site.data.table.en.tiered-storage-configuration-parameters[item][parameter] }}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Command-Line-Interface.md
+++ b/docs/pt/Command-Line-Interface.md
@@ -50,7 +50,7 @@ deve ter uma tratativa de parâmetros finais (`cat /\\*`).
     <tr>
       <td>{{ item.operation }}</td>
       <td>{{ item.syntax }}</td>
-      <td>{{ site.data.table.en.operation-command.[item.operation] }}</td>
+      <td>{{ site.data.table.en.operation-command[item][operation] }}</td>
     </tr>
   {% endfor %}
 </table>

--- a/docs/pt/Configuration-Settings.md
+++ b/docs/pt/Configuration-Settings.md
@@ -47,7 +47,7 @@ As configurações comum contém constantes compartilhadas por componentes difer
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.common-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.common-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -62,7 +62,7 @@ A configuração do `master` especifica informações referentes ao nó `master`
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.master-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.master-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -77,7 +77,7 @@ A configuração do `worker` especifica informações referentes ao nó `woeker`
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.worker-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.worker-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -93,7 +93,7 @@ A configuração do `worker` especifica informações referentes ao acesso do `f
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.user-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.user-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -109,7 +109,7 @@ opções de configuração adicionais.
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.cluster-management.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.cluster-management[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>
@@ -127,7 +127,7 @@ a página [Segurança](Security.html) para maiores informações sobre funcional
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.security-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.security-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Developer-Tips.md
+++ b/docs/pt/Developer-Tips.md
@@ -54,7 +54,7 @@ a sintaxe de cada comando.
 <tr>
   <td>{{dscp.command}}</td>
   <td>{{dscp.args}}</td>
-  <td>{{site.data.table.en.Developer-Tips.[dscp.command]}}</td>
+  <td>{{site.data.table.en.Developer-Tips[dscp][command]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/pt/File-System-API.md
+++ b/docs/pt/File-System-API.md
@@ -67,7 +67,7 @@ preferência no armazenamento do Alluxio do que no `under storage system`.
 {% for readtype in site.data.table.ReadType %}
 <tr>
   <td>{{readtype.readtype}}</td>
-  <td>{{site.data.table.en.ReadType.[readtype.readtype]}}</td>
+  <td>{{site.data.table.en.ReadType[readtype][readtype]}}</td>
 </tr>
 {% endfor %}
 </table>
@@ -80,7 +80,7 @@ Segue abaixo uma tabela com os comportamentos esperados do `WriteType`.
 {% for writetype in site.data.table.WriteType %}
 <tr>
   <td>{{writetype.writetype}}</td>
-  <td>{{site.data.table.en.WriteType.[writetype.writetype]}}</td>
+  <td>{{site.data.table.en.WriteType[writetype][writetype]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Key-Value-System-API.md
+++ b/docs/pt/Key-Value-System-API.md
@@ -90,7 +90,7 @@ Alluxio através da alteração do parametro `alluxio.keyvalue.enabled` para `tr
   <tr>
     <td>{{ item.propertyName }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.key-value-configuration.[item.propertyName] }}</td>
+    <td>{{ site.data.table.en.key-value-configuration[item][propertyName] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Lineage-API.md
+++ b/docs/pt/Lineage-API.md
@@ -82,7 +82,7 @@ Estes são os parâmetros de configuração relacionados as funcionalidades do `
 <tr>
   <td>{{record.parameter}}</td>
   <td>{{record.defaultvalue}}</td>
-  <td>{{site.data.table.en.LineageParameter.[record.parameter]}}</td>
+  <td>{{site.data.table.en.LineageParameter[record][parameter]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Running-Alluxio-Fault-Tolerant.md
+++ b/docs/pt/Running-Alluxio-Fault-Tolerant.md
@@ -82,7 +82,7 @@ Alluxio `masters`, `workers` e `clients`. Em `conf/alluxio-env.sh`, as opções 
 <tr>
   <td>{{item.PropertyName}}</td>
   <td>{{item.Value}}</td>
-  <td>{{site.data.table.en.java-options-for-fault-tolerance.[item.PropertyName]}}</td>
+  <td>{{site.data.table.en.java-options-for-fault-tolerance[item][PropertyName]}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/docs/pt/Tiered-Storage-on-Alluxio.md
+++ b/docs/pt/Tiered-Storage-on-Alluxio.md
@@ -202,7 +202,7 @@ Estes são os parâmetros de configuração para o armazenamento por nível.
 <tr>
 <td>{{ item.parameter }}</td>
 <td>{{ item.defaultValue }}</td>
-<td>{{ site.data.table.en.tiered-storage-configuration-parameters.[item.parameter] }}</td>
+<td>{{ site.data.table.en.tiered-storage-configuration-parameters[item][parameter] }}</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
Replace `..` with `{{site.baseurl}}`. The value for `site.baseurl` can be
set within `_config.yml`. This makes building docs for other locations
simpler.