### PR TITLE
Add baseurl support to docs - 1.5

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -69,3 +69,7 @@ categoryInfo:
     en: Resources
     cn: 开发者资源
     pt: Recursos
+
+# For no baseurl, leave blank
+# Anything other than blank: this should always START with a '/' and NEVER end with a '/' character
+baseurl:

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -13,15 +13,15 @@
     <title>{{ page.title }} - Alluxio {{site.ALLUXIO_MASTER_VERSION_SHORT}} Documentation</title>
     <meta name="description" content="">
 
-    <link rel="stylesheet" href="../css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="../css/bootstrap-responsive.min.css">
-    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap-responsive.min.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/main.css">
 
-    <script src="../js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
+    <script src="{{site.baseurl}}/js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
 
-    <link rel="stylesheet" href="../css/pygments-default.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/css/pygments-default.css">
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -47,7 +47,7 @@
             <a href="/">
                 <div class="brand" style="display:table;">
                     <div style="position:relative;display:table-cell;vertical-align:middle;">
-                        <img src="../img/logo-white.png" alt="Alluxio Logo" style="height:34px;"/>
+                        <img src="{{site.baseurl}}/img/logo-white.png" alt="Alluxio Logo" style="height:34px;"/>
                         <div style="position:absolute;right:0;top:32px;text-shadow:none;">
                             <span class="version">{{site.ALLUXIO_MASTER_VERSION_SHORT}}</span>
                         </div>
@@ -81,8 +81,7 @@
                                         </a>
                                     </li>
                                 {% else %}
-                                    <!-- Use the prefix .. to change the absolute url to relative url -->
-                                    <li><a href="..{{ node.url }}">
+                                    <li><a href="{{site.baseurl}}{{ node.url }}">
                                         {% if node.nickname == null %}
                                             {{node.title}}
                                         {% else %}
@@ -112,8 +111,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{page.languageName}}<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         {% for singleLanguage in multiLanguagePages %}
-                            <!-- Use the prefix .. to change the absulote url to relative url -->
-                            <li><a href="..{{singleLanguage.url}}">{{singleLanguage.languageName}}</a></li>
+                            <li><a href="{{site.baseurl}}{{singleLanguage.url}}">{{singleLanguage.languageName}}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -162,9 +160,9 @@
 </div>
 <!-- /container -->
 
-<script src="../js/vendor/jquery-1.8.0.min.js"></script>
-<script src="../js/vendor/bootstrap.min.js"></script>
-<script src="../js/main.js"></script>
+<script src="{{site.baseurl}}/js/vendor/jquery-1.8.0.min.js"></script>
+<script src="{{site.baseurl}}/js/vendor/bootstrap.min.js"></script>
+<script src="{{site.baseurl}}/js/main.js"></script>
 
 <!-- A script to fix internal hash links because we have an overlapping top bar.
      Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510 -->
@@ -188,7 +186,7 @@
     })
 </script>
 
-<script src="../js/scrollspy.js"></script>
+<script src="{{site.baseurl}}/js/scrollspy.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Replace `..` with `{{site.baseurl}}`. The value for `site.baseurl` can be
set within `_config.yml`. This makes building docs for other locations
simpler.