### PR TITLE
[SMALLFIX] Add datetime for contents in task.log

### DIFF
--- a/bin/alluxio-masters.sh
+++ b/bin/alluxio-masters.sh
@@ -41,10 +41,10 @@ for master in $(echo ${HOSTLIST}); do
   echo "[${master}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}
   if [[ ${ZOOKEEPER_ENABLED} == "true" || ${N} -eq 0 ]]; then
     nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${master} ${LAUNCHER} \
-      $"${@// /\\ }" 2>&1 | while read line; do echo "[${master}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
+      $"${@// /\\ }" 2>&1 | while read line; do echo "[$(date '+%F %T')][${master}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
   else
     nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${master} ${LAUNCHER} \
-      $"export ALLUXIO_MASTER_SECONDARY=true; ${@// /\\ }" 2>&1 | while read line; do echo "[${master}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
+      $"export ALLUXIO_MASTER_SECONDARY=true; ${@// /\\ }" 2>&1 | while read line; do echo "[$(date '+%F %T')][${master}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
   fi
   N=$((N+1))
 done

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -38,7 +38,7 @@ echo "Executing the following command on all worker nodes and logging to ${ALLUX
 for worker in $(echo ${HOSTLIST}); do
   echo "[${worker}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}
   nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
-    $"${@// /\\ }" 2>&1 | while read line; do echo "[${worker}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
+    $"${@// /\\ }" 2>&1 | while read line; do echo "[$(date '+%F %T')][${worker}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
 done
 
 echo "Waiting for tasks to finish..."


### PR DESCRIPTION
For a freshman or even an experienced guy, sometimes it's really confusing to read the task.log since there is no 'datetime' for each line. For example, it's hard to judge whether the following part 3 in the illustrated figured below is the newest log or the last time's log, so we cannot decide whether the latest 'retry' or 'test' for our 'code change' or 'environment update' takes effect or not. thus it is very import the add the "datetime" for the logs in task.log to make us much more efficient to find the issues or bugs.

<img width="510" alt="MacHi 2019-03-16 23-59-25" src="https://user-images.githubusercontent.com/10387174/54478123-f151e780-4849-11e9-9c72-9da918ea390c.png">
