### PR TITLE
Avoid loading configuration for invalid paths

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -67,12 +67,12 @@ public final class HdfsUnderFileSystemFactory implements UnderFileSystemFactory 
 
   @Override
   public boolean supportsPath(String path, UnderFileSystemConfiguration conf) {
-    // This loads the configuration from the JVM's system properties and the site properties file
-    // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programatically *not*
-    // work.
-    AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
-
     if (path != null) {
+      // This loads the configuration from the JVM's system properties and the site properties file
+      // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programatically *not*
+      // work.
+      AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+
       // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
       // FileSystem.getFileSystemClass() without any need for having users explicitly declare the
       // file system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop


### PR DESCRIPTION
Only new InstancedConfiguration when path is NOT null to avoid unnecessary waste of resources