### PR TITLE
Use an older version of guava for hdfs libs

### DIFF
--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -28,10 +28,19 @@
     <!-- Decouple hadoop versions between north and south bound -->
     <ufs.hadoop.version>2.2.0</ufs.hadoop.version>
     <lib.jar.name>${project.artifactId}-${ufs.hadoop.version}-${project.version}.jar</lib.jar.name>
+    <!-- The shading prefix should match the artifact ID, replacing '-' with '.' -->
+    <shading.prefix>alluxio.underfs.hdfs</shading.prefix>
   </properties>
 
   <dependencies>
     <!-- External dependencies -->
+    <dependency>
+      <!-- using older version to match dependency version from Hadoop -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+    </dependency>
+
     <!-- Hadoop dependencies are included in individual profiles -->
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -196,6 +205,39 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>uber-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${shading.prefix}.com.google.common</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>


### PR DESCRIPTION
HDFS does not like the new version of guava we use. Thus we need to shade an older version for our hdfs client. 