### PR TITLE
Improve read throughput with larger worker side buffer

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -285,7 +285,6 @@ public class GrpcBlockingStream<ReqT, ResT> {
         LOG.warn("Received error {} for stream ({})", t, mDescription);
         updateException(t);
         mReadyOrFailed.signal();
-        mClosedFromRemote = true;
       }
     }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -91,7 +91,7 @@ public class GrpcBlockingStream<ReqT, ResT> {
    * @throws IOException if any error occurs
    */
   public void send(ReqT request, long timeoutMs) throws IOException {
-    if (mClosed || mCanceled) {
+    if (mClosed || mCanceled || mClosedFromRemote) {
       throw new CanceledException(formatErrorMessage(
           "Failed to send request %s: stream is already closed or canceled.", request));
     }
@@ -123,7 +123,7 @@ public class GrpcBlockingStream<ReqT, ResT> {
    * @throws IOException if any error occurs
    */
   public void send(ReqT request) throws IOException {
-    if (mClosed || mCanceled) {
+    if (mClosed || mCanceled || mClosedFromRemote) {
       throw new CanceledException(formatErrorMessage(
           "Failed to send request %s: stream is already closed or canceled.", request));
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -141,13 +141,11 @@ public final class GrpcDataReader implements DataReader {
       return null;
     }
     mPosToRead += buffer.readableBytes();
-    if (!mStream.isClosedFromRemote()) {
-      try {
-        mStream.send(ReadRequest.newBuilder().setOffsetReceived(mPosToRead).build());
-      } catch (Exception e) {
-        // nothing is done as the receipt is sent at best effort
-        LOG.warn("Failed to send receipt of data: {}.", e.getMessage());
-      }
+    try {
+      mStream.send(ReadRequest.newBuilder().setOffsetReceived(mPosToRead).build());
+    } catch (Exception e) {
+      // nothing is done as the receipt is sent at best effort
+      LOG.warn("Failed to send receipt of data: {}.", e.getMessage());
     }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());
     return buffer;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -141,6 +141,14 @@ public final class GrpcDataReader implements DataReader {
       return null;
     }
     mPosToRead += buffer.readableBytes();
+    if (!mStream.isClosedFromRemote()) {
+      try {
+        mStream.send(ReadRequest.newBuilder().setOffsetReceived(mPosToRead).build());
+      } catch (Exception e) {
+        // nothing is done as the receipt is sent at best effort
+        LOG.warn("Failed to send receipt of data: {}.", e.getMessage());
+      }
+    }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());
     return buffer;
   }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -145,7 +145,8 @@ public final class GrpcDataReader implements DataReader {
       mStream.send(ReadRequest.newBuilder().setOffsetReceived(mPosToRead).build());
     } catch (Exception e) {
       // nothing is done as the receipt is sent at best effort
-      LOG.warn("Failed to send receipt of data: {}.", e.getMessage());
+      LOG.warn("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
+          mReadRequest, e.getMessage());
     }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());
     return buffer;

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -13,6 +13,7 @@ package alluxio.client.block;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +39,7 @@ import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.OpenLocalBlockRequest;
 import alluxio.grpc.OpenLocalBlockResponse;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.DummyCloseableResource;
@@ -102,6 +104,7 @@ public final class AlluxioBlockStoreTest {
       .setHost(WORKER_HOSTNAME_REMOTE);
   private ClientCallStreamObserver mStreamObserver;
   private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(4);
+  private StreamObserver<OpenLocalBlockResponse> mResponseObserver;
 
   /**
    * A mock class used to return controlled result when selecting workers.
@@ -343,16 +346,15 @@ public final class AlluxioBlockStoreTest {
 
     // Mock away gRPC usage.
     OpenLocalBlockResponse response = OpenLocalBlockResponse.newBuilder().setPath("/tmp").build();
-    when(mWorkerClient.openLocalBlock(any(StreamObserver.class)))
-            .thenAnswer(new Answer() {
-              public Object answer(InvocationOnMock invocation) {
-                StreamObserver<OpenLocalBlockResponse> observer =
-                        invocation.getArgumentAt(0, StreamObserver.class);
-                observer.onNext(response);
-                observer.onCompleted();
-                return mStreamObserver;
-              }
-            });
+    when(mWorkerClient.openLocalBlock(any(StreamObserver.class))).thenAnswer(invocation -> {
+      mResponseObserver = invocation.getArgumentAt(0, StreamObserver.class);
+      return mStreamObserver;
+    });
+    doAnswer(invocation -> {
+      mResponseObserver.onNext(response);
+      mResponseObserver.onCompleted();
+      return null;
+    }).when(mStreamObserver).onNext(any(OpenLocalBlockRequest.class));
 
     BlockInfo info = new BlockInfo().setBlockId(BLOCK_ID).setLocations(Arrays
         .asList(new BlockLocation().setWorkerAddress(remote),

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2097,8 +2097,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_NETWORK_READER_BUFFER_SIZE_BYTES =
       new Builder(Name.WORKER_NETWORK_READER_BUFFER_SIZE_BYTES)
           .setDefaultValue("4MB")
-          .setDescription("When a client read from a remote worker, the maximum amount of data"
-              + " not received by client allowed before the worker pauses sending more data.")
+          .setDescription("When a client reads from a remote worker, the maximum amount of data"
+              + " not received by client allowed before the worker pauses sending more data."
+              + " If this value is lower than read chunk size, read performance may be impacted"
+              + " as worker waits more often for buffer to free up. Higher value will increase"
+              + " the memory consumed by each read request.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2094,6 +2094,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_NETWORK_READER_BUFFER_SIZE_BYTES =
+      new Builder(Name.WORKER_NETWORK_READER_BUFFER_SIZE_BYTES)
+          .setDefaultValue("4MB")
+          .setDescription("When a client read from a remote worker, the maximum amount of data"
+              + " not received by client allowed before the worker pauses sending more data.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES =
       new Builder(Name.WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES)
           .setDefaultValue("2MB")
@@ -3869,6 +3877,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.network.netty.watermark.low";
     public static final String WORKER_NETWORK_NETTY_WORKER_THREADS =
         "alluxio.worker.network.netty.worker.threads";
+    public static final String WORKER_NETWORK_READER_BUFFER_SIZE_BYTES =
+        "alluxio.worker.network.reader.buffer.size";
     public static final String WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES =
         "alluxio.worker.network.reader.max.chunk.size.bytes";
     public static final String WORKER_NETWORK_SHUTDOWN_TIMEOUT =

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ReadRequestContext.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ReadRequestContext.java
@@ -42,6 +42,7 @@ public class ReadRequestContext<T extends ReadRequest> {
    */
   private long mPosToQueue;
 
+  private long mPosReceived;
   /**
    * mEof, mCancel and mError are the notifications processed by the data reader thread. They can
    * be set by either the gRPC I/O thread or the data reader thread. mError overrides mCancel
@@ -113,6 +114,14 @@ public class ReadRequestContext<T extends ReadRequest> {
   }
 
   /**
+   * @return the position before which data are received by the client
+   */
+  @GuardedBy("AbstractReadHandler#mLock")
+  public long getPosReceived() {
+    return mPosReceived;
+  }
+
+  /**
    * @return true when the data reader replies a SUCCESS response, false otherwise
    */
   @GuardedBy("AbstractReadHandler#mLock")
@@ -174,6 +183,14 @@ public class ReadRequestContext<T extends ReadRequest> {
   @GuardedBy("AbstractReadHandler#mLock")
   public void setPosToQueue(long posToQueue) {
     mPosToQueue = posToQueue;
+  }
+
+  /**
+   * @param posReceived the position before which data are received by the client
+   */
+  @GuardedBy("AbstractReadHandler#mLock")
+  public void setPosReceived(long posReceived) {
+    mPosReceived = posReceived;
   }
 
   /**

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -55,6 +55,9 @@ message ReadRequest {
 
   // This is only set for UFS block read.
   optional alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;
+
+  // Read receipt
+  optional int64 offset_received = 7;
 }
 
 // The read response.

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -106,56 +106,56 @@ public final class BlockWorkerProto {
       "\n\027grpc/block_worker.proto\022\022alluxio.grpc." +
       "block\032\037proto/dataserver/protocol.proto\"\016" +
       "\n\014CheckRequest\"\017\n\rCheckResponse\"\025\n\005Chunk" +
-      "\022\014\n\004data\030\001 \001(\014\"\263\001\n\013ReadRequest\022\020\n\010block_" +
+      "\022\014\n\004data\030\001 \001(\014\"\314\001\n\013ReadRequest\022\020\n\010block_" +
       "id\030\001 \001(\003\022\016\n\006offset\030\002 \001(\003\022\016\n\006length\030\003 \001(\003" +
       "\022\017\n\007promote\030\004 \001(\010\022\022\n\nchunk_size\030\005 \001(\003\022M\n" +
       "\026open_ufs_block_options\030\006 \001(\0132-.alluxio." +
-      "proto.dataserver.OpenUfsBlockOptions\"8\n\014" +
-      "ReadResponse\022(\n\005chunk\030\001 \001(\0132\031.alluxio.gr" +
-      "pc.block.Chunk\"\241\002\n\023WriteRequestCommand\022-" +
-      "\n\004type\030\001 \001(\0162\037.alluxio.grpc.block.Reques" +
-      "tType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tie" +
-      "r\030\004 \001(\005\022\r\n\005flush\030\005 \001(\010\022O\n\027create_ufs_fil" +
-      "e_options\030\006 \001(\0132..alluxio.proto.dataserv" +
-      "er.CreateUfsFileOptions\022Q\n\030create_ufs_bl" +
-      "ock_options\030\007 \001(\0132/.alluxio.proto.datase" +
-      "rver.CreateUfsBlockOptions\"\177\n\014WriteReque" +
-      "st\022:\n\007command\030\001 \001(\0132\'.alluxio.grpc.block" +
-      ".WriteRequestCommandH\000\022*\n\005chunk\030\002 \001(\0132\031." +
-      "alluxio.grpc.block.ChunkH\000B\007\n\005value\"\037\n\rW" +
-      "riteResponse\022\016\n\006offset\030\001 \001(\003\"\256\001\n\021AsyncCa" +
-      "cheRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013source_h" +
-      "ost\030\002 \001(\t\022\023\n\013source_port\030\003 \001(\005\022M\n\026open_u" +
-      "fs_block_options\030\004 \001(\0132-.alluxio.proto.d" +
-      "ataserver.OpenUfsBlockOptions\022\016\n\006length\030" +
-      "\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025OpenLocal" +
-      "BlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promot" +
-      "e\030\002 \001(\010\"&\n\026OpenLocalBlockResponse\022\014\n\004pat" +
-      "h\030\001 \001(\t\"\213\001\n\027CreateLocalBlockRequest\022\020\n\010b" +
-      "lock_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to_" +
-      "reserve\030\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001(" +
-      "\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\"(\n\030CreateL" +
-      "ocalBlockResponse\022\014\n\004path\030\001 \001(\t\"&\n\022Remov" +
-      "eBlockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023Remov" +
-      "eBlockResponse*F\n\013RequestType\022\021\n\rALLUXIO" +
-      "_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_B" +
-      "LOCK\020\0022\325\004\n\013BlockWorker\022R\n\tReadBlock\022\037.al" +
-      "luxio.grpc.block.ReadRequest\032 .alluxio.g" +
-      "rpc.block.ReadResponse(\0010\001\022U\n\nWriteBlock" +
-      "\022 .alluxio.grpc.block.WriteRequest\032!.all" +
-      "uxio.grpc.block.WriteResponse(\0010\001\022k\n\016Ope" +
-      "nLocalBlock\022).alluxio.grpc.block.OpenLoc" +
-      "alBlockRequest\032*.alluxio.grpc.block.Open" +
-      "LocalBlockResponse(\0010\001\022q\n\020CreateLocalBlo" +
-      "ck\022+.alluxio.grpc.block.CreateLocalBlock" +
-      "Request\032,.alluxio.grpc.block.CreateLocal" +
-      "BlockResponse(\0010\001\022[\n\nAsyncCache\022%.alluxi" +
-      "o.grpc.block.AsyncCacheRequest\032&.alluxio" +
-      ".grpc.block.AsyncCacheResponse\022^\n\013Remove" +
-      "Block\022&.alluxio.grpc.block.RemoveBlockRe" +
-      "quest\032\'.alluxio.grpc.block.RemoveBlockRe" +
-      "sponseB\"\n\014alluxio.grpcB\020BlockWorkerProto" +
-      "P\001"
+      "proto.dataserver.OpenUfsBlockOptions\022\027\n\017" +
+      "offset_received\030\007 \001(\003\"8\n\014ReadResponse\022(\n" +
+      "\005chunk\030\001 \001(\0132\031.alluxio.grpc.block.Chunk\"" +
+      "\241\002\n\023WriteRequestCommand\022-\n\004type\030\001 \001(\0162\037." +
+      "alluxio.grpc.block.RequestType\022\n\n\002id\030\002 \001" +
+      "(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\r\n\005flus" +
+      "h\030\005 \001(\010\022O\n\027create_ufs_file_options\030\006 \001(\013" +
+      "2..alluxio.proto.dataserver.CreateUfsFil" +
+      "eOptions\022Q\n\030create_ufs_block_options\030\007 \001" +
+      "(\0132/.alluxio.proto.dataserver.CreateUfsB" +
+      "lockOptions\"\177\n\014WriteRequest\022:\n\007command\030\001" +
+      " \001(\0132\'.alluxio.grpc.block.WriteRequestCo" +
+      "mmandH\000\022*\n\005chunk\030\002 \001(\0132\031.alluxio.grpc.bl" +
+      "ock.ChunkH\000B\007\n\005value\"\037\n\rWriteResponse\022\016\n" +
+      "\006offset\030\001 \001(\003\"\256\001\n\021AsyncCacheRequest\022\020\n\010b" +
+      "lock_id\030\001 \001(\003\022\023\n\013source_host\030\002 \001(\t\022\023\n\013so" +
+      "urce_port\030\003 \001(\005\022M\n\026open_ufs_block_option" +
+      "s\030\004 \001(\0132-.alluxio.proto.dataserver.OpenU" +
+      "fsBlockOptions\022\016\n\006length\030\005 \001(\003\"\024\n\022AsyncC" +
+      "acheResponse\":\n\025OpenLocalBlockRequest\022\020\n" +
+      "\010block_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"&\n\026Open" +
+      "LocalBlockResponse\022\014\n\004path\030\001 \001(\t\"\213\001\n\027Cre" +
+      "ateLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\014" +
+      "\n\004tier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032" +
+      "\n\022only_reserve_space\030\005 \001(\010\022\032\n\022cleanup_on" +
+      "_failure\030\006 \001(\010\"(\n\030CreateLocalBlockRespon" +
+      "se\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlockRequest\022\020" +
+      "\n\010block_id\030\001 \001(\003\"\025\n\023RemoveBlockResponse*" +
+      "F\n\013RequestType\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS" +
+      "_FILE\020\001\022\026\n\022UFS_FALLBACK_BLOCK\020\0022\325\004\n\013Bloc" +
+      "kWorker\022R\n\tReadBlock\022\037.alluxio.grpc.bloc" +
+      "k.ReadRequest\032 .alluxio.grpc.block.ReadR" +
+      "esponse(\0010\001\022U\n\nWriteBlock\022 .alluxio.grpc" +
+      ".block.WriteRequest\032!.alluxio.grpc.block" +
+      ".WriteResponse(\0010\001\022k\n\016OpenLocalBlock\022).a" +
+      "lluxio.grpc.block.OpenLocalBlockRequest\032" +
+      "*.alluxio.grpc.block.OpenLocalBlockRespo" +
+      "nse(\0010\001\022q\n\020CreateLocalBlock\022+.alluxio.gr" +
+      "pc.block.CreateLocalBlockRequest\032,.allux" +
+      "io.grpc.block.CreateLocalBlockResponse(\001" +
+      "0\001\022[\n\nAsyncCache\022%.alluxio.grpc.block.As" +
+      "yncCacheRequest\032&.alluxio.grpc.block.Asy" +
+      "ncCacheResponse\022^\n\013RemoveBlock\022&.alluxio" +
+      ".grpc.block.RemoveBlockRequest\032\'.alluxio" +
+      ".grpc.block.RemoveBlockResponseB\"\n\014allux" +
+      "io.grpcB\020BlockWorkerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -193,7 +193,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_ReadRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_ReadRequest_descriptor,
-        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "OpenUfsBlockOptions", });
+        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "OpenUfsBlockOptions", "OffsetReceived", });
     internal_static_alluxio_grpc_block_ReadResponse_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_grpc_block_ReadResponse_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
@@ -26,6 +26,7 @@ private static final long serialVersionUID = 0L;
     length_ = 0L;
     promote_ = false;
     chunkSize_ = 0L;
+    offsetReceived_ = 0L;
   }
 
   @java.lang.Override
@@ -95,6 +96,11 @@ private static final long serialVersionUID = 0L;
               openUfsBlockOptions_ = subBuilder.buildPartial();
             }
             bitField0_ |= 0x00000020;
+            break;
+          }
+          case 56: {
+            bitField0_ |= 0x00000040;
+            offsetReceived_ = input.readInt64();
             break;
           }
         }
@@ -238,6 +244,29 @@ private static final long serialVersionUID = 0L;
     return openUfsBlockOptions_ == null ? alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance() : openUfsBlockOptions_;
   }
 
+  public static final int OFFSET_RECEIVED_FIELD_NUMBER = 7;
+  private long offsetReceived_;
+  /**
+   * <pre>
+   * Read receipt
+   * </pre>
+   *
+   * <code>optional int64 offset_received = 7;</code>
+   */
+  public boolean hasOffsetReceived() {
+    return ((bitField0_ & 0x00000040) == 0x00000040);
+  }
+  /**
+   * <pre>
+   * Read receipt
+   * </pre>
+   *
+   * <code>optional int64 offset_received = 7;</code>
+   */
+  public long getOffsetReceived() {
+    return offsetReceived_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -267,6 +296,9 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000020) == 0x00000020)) {
       output.writeMessage(6, getOpenUfsBlockOptions());
+    }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      output.writeInt64(7, offsetReceived_);
     }
     unknownFields.writeTo(output);
   }
@@ -299,6 +331,10 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000020) == 0x00000020)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getOpenUfsBlockOptions());
+    }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(7, offsetReceived_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -346,6 +382,11 @@ private static final long serialVersionUID = 0L;
       result = result && getOpenUfsBlockOptions()
           .equals(other.getOpenUfsBlockOptions());
     }
+    result = result && (hasOffsetReceived() == other.hasOffsetReceived());
+    if (hasOffsetReceived()) {
+      result = result && (getOffsetReceived()
+          == other.getOffsetReceived());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -385,6 +426,11 @@ private static final long serialVersionUID = 0L;
     if (hasOpenUfsBlockOptions()) {
       hash = (37 * hash) + OPEN_UFS_BLOCK_OPTIONS_FIELD_NUMBER;
       hash = (53 * hash) + getOpenUfsBlockOptions().hashCode();
+    }
+    if (hasOffsetReceived()) {
+      hash = (37 * hash) + OFFSET_RECEIVED_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getOffsetReceived());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -537,6 +583,8 @@ private static final long serialVersionUID = 0L;
         openUfsBlockOptionsBuilder_.clear();
       }
       bitField0_ = (bitField0_ & ~0x00000020);
+      offsetReceived_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000040);
       return this;
     }
 
@@ -589,6 +637,10 @@ private static final long serialVersionUID = 0L;
       } else {
         result.openUfsBlockOptions_ = openUfsBlockOptionsBuilder_.build();
       }
+      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        to_bitField0_ |= 0x00000040;
+      }
+      result.offsetReceived_ = offsetReceived_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -648,6 +700,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasOpenUfsBlockOptions()) {
         mergeOpenUfsBlockOptions(other.getOpenUfsBlockOptions());
+      }
+      if (other.hasOffsetReceived()) {
+        setOffsetReceived(other.getOffsetReceived());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1005,6 +1060,54 @@ private static final long serialVersionUID = 0L;
         openUfsBlockOptions_ = null;
       }
       return openUfsBlockOptionsBuilder_;
+    }
+
+    private long offsetReceived_ ;
+    /**
+     * <pre>
+     * Read receipt
+     * </pre>
+     *
+     * <code>optional int64 offset_received = 7;</code>
+     */
+    public boolean hasOffsetReceived() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <pre>
+     * Read receipt
+     * </pre>
+     *
+     * <code>optional int64 offset_received = 7;</code>
+     */
+    public long getOffsetReceived() {
+      return offsetReceived_;
+    }
+    /**
+     * <pre>
+     * Read receipt
+     * </pre>
+     *
+     * <code>optional int64 offset_received = 7;</code>
+     */
+    public Builder setOffsetReceived(long value) {
+      bitField0_ |= 0x00000040;
+      offsetReceived_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Read receipt
+     * </pre>
+     *
+     * <code>optional int64 offset_received = 7;</code>
+     */
+    public Builder clearOffsetReceived() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      offsetReceived_ = 0L;
+      onChanged();
+      return this;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
@@ -84,4 +84,21 @@ public interface ReadRequestOrBuilder extends
    * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
    */
   alluxio.proto.dataserver.Protocol.OpenUfsBlockOptionsOrBuilder getOpenUfsBlockOptionsOrBuilder();
+
+  /**
+   * <pre>
+   * Read receipt
+   * </pre>
+   *
+   * <code>optional int64 offset_received = 7;</code>
+   */
+  boolean hasOffsetReceived();
+  /**
+   * <pre>
+   * Read receipt
+   * </pre>
+   *
+   * <code>optional int64 offset_received = 7;</code>
+   */
+  long getOffsetReceived();
 }


### PR DESCRIPTION
Current Alluxio worker uses gRPC stream isReady() signal for data path flow control. gRPC has a fixed buffer size of 32KB and is not configurable(See https://github.com/grpc/proposal/pull/135). This change work around this limitation by providing our own configurable flow control(client ack). In benchmark this shows 30% improvement on domain socket read with small number of concurrent streams.