### PR TITLE
Increase raft processing timeout from 2 to 30 seconds

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -35,7 +35,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class RaftJournalWriter implements JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalWriter.class);
-  private static final long FLUSH_TIMEOUT_S = 2;
+  private static final long FLUSH_TIMEOUT_S = 30;
 
   private final AtomicLong mNextSequenceNumberToWrite;
   private final AtomicLong mLastSubmittedSequenceNumber;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -35,7 +35,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class RaftJournalWriter implements JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalWriter.class);
-  private static final long FLUSH_TIMEOUT_S = 30;
+  // How long to wait for a response from the cluster before giving up and trying again.
+  private static final long PROCESS_TIMEOUT_S = 30;
 
   private final AtomicLong mNextSequenceNumberToWrite;
   private final AtomicLong mLastSubmittedSequenceNumber;
@@ -85,7 +86,7 @@ public class RaftJournalWriter implements JournalWriter {
         // number when applying them. This could happen if submit fails and we re-submit the same
         // entry on retry.
         mLastSubmittedSequenceNumber.set(flushSN);
-        mClient.submit(new JournalEntryCommand(mJournalEntryBuilder.build())).get(FLUSH_TIMEOUT_S,
+        mClient.submit(new JournalEntryCommand(mJournalEntryBuilder.build())).get(PROCESS_TIMEOUT_S,
             TimeUnit.SECONDS);
         mLastCommittedSequenceNumber.set(flushSN);
       } catch (InterruptedException e) {
@@ -95,8 +96,8 @@ public class RaftJournalWriter implements JournalWriter {
         throw new IOException(e.getCause());
       } catch (TimeoutException e) {
         throw new IOException(
-            String.format("Timed out after waiting %s seconds for journal flush", FLUSH_TIMEOUT_S),
-            e);
+            String.format("Timed out after waiting %s seconds for journal entries to be processed",
+                PROCESS_TIMEOUT_S), e);
       }
       mJournalEntryBuilder = null;
     }


### PR DESCRIPTION
At 2 seconds, it's easy for garbage collection to trigger
failures. The only downside of increasing to 30 seconds is
that it's harder to detect slow journal processing.