### PR TITLE
Improve efficiency of checkpoint writes

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
@@ -74,6 +74,11 @@ final class UfsJournalCheckpointWriter extends FilterOutputStream {
   }
 
   @Override
+  public void write(byte[] b, int offset, int length) throws IOException {
+    out.write(b, offset, length);
+  }
+
+  @Override
   public void close() throws IOException {
     if (mClosed) {
       return;


### PR DESCRIPTION
The default FilterInputStream write(byte[], int, int)
implementation is to write one byte at a time...