### PR TITLE
Fix journal folder deletion error

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -432,8 +432,12 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
 
   @Override
   public void format() throws IOException {
-    FileUtils.deletePathRecursively(mConf.getPath().getAbsolutePath());
-    mConf.getPath().mkdirs();
+    if (mConf.getPath().isDirectory()) {
+      org.apache.commons.io.FileUtils.cleanDirectory(mConf.getPath());
+    } else {
+      FileUtils.delete(mConf.getPath().getAbsolutePath());
+      mConf.getPath().mkdirs();
+    }
   }
 
   /**


### PR DESCRIPTION
When Alluxio is used in container environment, it is common that user mounts an external directory as the journal location in the container. This will result in error when Alluxio formats embedded journal because the directory cannot be deleted. This fix solves the issue by not removing the journal directory but instead removing all the files inside.