### PR TITLE
Make RR policy work with replication

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -338,13 +338,13 @@ public final class AlluxioBlockStore {
 
     // Select N workers on different hosts where N is the value of initialReplicas for this block
     List<WorkerNetAddress> workerAddressList = new ArrayList<>();
+    List<BlockWorkerInfo> updatedInfos = Lists.newArrayList(workerOptions.getBlockWorkerInfos());
     for (int i = 0; i < initialReplicas; i++) {
       address = locationPolicy.getWorker(workerOptions);
       if (address == null) {
         break;
       }
       workerAddressList.add(address);
-      List<BlockWorkerInfo> updatedInfos = Lists.newArrayList(workerOptions.getBlockWorkerInfos());
       updatedInfos.removeAll(blockWorkersByHost.get(address.getHost()));
       workerOptions.setBlockWorkerInfos(updatedInfos);
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -44,6 +44,7 @@ import alluxio.wire.WorkerNetAddress;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -343,7 +344,9 @@ public final class AlluxioBlockStore {
         break;
       }
       workerAddressList.add(address);
-      workerOptions.getBlockWorkerInfos().removeAll(blockWorkersByHost.get(address.getHost()));
+      List<BlockWorkerInfo> updatedInfos = Lists.newArrayList(workerOptions.getBlockWorkerInfos());
+      updatedInfos.removeAll(blockWorkersByHost.get(address.getHost()));
+      workerOptions.setBlockWorkerInfos(updatedInfos);
     }
     if (workerAddressList.size() < initialReplicas) {
       throw new alluxio.exception.status.ResourceExhaustedException(String.format(

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/RoundRobinPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/RoundRobinPolicy.java
@@ -22,9 +22,9 @@ import com.google.common.collect.Lists;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -60,9 +60,10 @@ public final class RoundRobinPolicy implements BlockLocationPolicy {
   @Override
   @Nullable
   public WorkerNetAddress getWorker(GetWorkerOptions options) {
-    Set<WorkerNetAddress> eligibleAddresses =
-        options.getBlockWorkerInfos().stream().map(BlockWorkerInfo::getNetAddress)
-            .collect(Collectors.toSet());
+    Set<WorkerNetAddress> eligibleAddresses = new HashSet<>();
+    for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
+      eligibleAddresses.add(info.getNetAddress());
+    }
 
     WorkerNetAddress address = mBlockLocationCache.get(options.getBlockInfo().getBlockId());
     if (address != null && eligibleAddresses.contains(address)) {

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/options/GetWorkerOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/options/GetWorkerOptions.java
@@ -53,7 +53,7 @@ public final class GetWorkerOptions {
   /**
    * @return the list of block worker infos
    */
-  public Iterable<BlockWorkerInfo> getBlockWorkerInfos() {
+  public List<BlockWorkerInfo> getBlockWorkerInfos() {
     return mBlockWorkerInfos;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/options/GetWorkerOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/options/GetWorkerOptions.java
@@ -53,7 +53,7 @@ public final class GetWorkerOptions {
   /**
    * @return the list of block worker infos
    */
-  public List<BlockWorkerInfo> getBlockWorkerInfos() {
+  public Iterable<BlockWorkerInfo> getBlockWorkerInfos() {
     return mBlockWorkerInfos;
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -57,6 +57,35 @@ public final class RoundRobinPolicyTest {
         policy.getWorker(options.setBlockInfo(options.getBlockInfo().setBlockId(555))).getHost());
   }
 
+  /**
+   * Tests that no workers are returned when there are no eligible workers.
+   */
+  @Test
+  public void getWorkerNoneEligible() {
+    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
+    GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(new ArrayList<>())
+        .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
+    Assert.assertNull(policy.getWorker(options));
+  }
+
+  /**
+   * Tests that no workers are returned when subsequent calls to the policy have no eligible
+   * workers.
+   */
+  @Test
+  public void getWorkerNoneEligibleAfterCache() {
+    List<BlockWorkerInfo> workerInfoList = new ArrayList<>();
+    workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
+        .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));
+
+    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
+    GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
+        .setBlockInfo(new BlockInfo().setLength((long) Constants.MB));
+    Assert.assertNotNull(policy.getWorker(options));
+    options.setBlockWorkerInfos(new ArrayList<>());
+    Assert.assertNull(policy.getWorker(options));
+  }
+
   @Test
   public void equalsTest() throws Exception {
     AlluxioConfiguration conf = ConfigurationTestUtils.defaults();


### PR DESCRIPTION
Previously the round robin policy would ignore the input worker list. This causes problems with replication because the same block would be sent to the same worker multiple times.