### PR TITLE
Add a hint to check task.log for errors

### DIFF
--- a/bin/alluxio-masters.sh
+++ b/bin/alluxio-masters.sh
@@ -67,4 +67,6 @@ done
 # only show the log when all tasks run OK!
 if [[ ${has_error} -eq 0 ]]; then
     echo "All tasks finished"
+else
+    echo "There are task failures, look at ${ALLUXIO_TASK_LOG} for details."
 fi

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -59,4 +59,6 @@ done
 # only show the log when all tasks run OK!
 if [[ ${has_error} -eq 0 ]]; then
     echo "All tasks finished"
+else
+    echo "There are task failures, look at ${ALLUXIO_TASK_LOG} for details."
 fi


### PR DESCRIPTION
When tasks fail, users might not know where to find errors.