### PR TITLE
Make read receipt more robust

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -142,10 +142,10 @@ public final class GrpcDataReader implements DataReader {
     }
     mPosToRead += buffer.readableBytes();
     try {
-      mStream.send(ReadRequest.newBuilder().setOffsetReceived(mPosToRead).build());
+      mStream.send(mReadRequest.toBuilder().setOffsetReceived(mPosToRead).build());
     } catch (Exception e) {
       // nothing is done as the receipt is sent at best effort
-      LOG.warn("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
+      LOG.debug("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
           mReadRequest, e.getMessage());
     }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());


### PR DESCRIPTION
Two minor fixes:
- Build read receipt from original request to work better with server validations.
- Lower the log level to avoid excessive warnings on closing a read request.
