### PR TITLE
Add support for filtering out metrics for mounted ufs

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -847,8 +847,15 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @VisibleForTesting
   static boolean isMounted(FileSystemMaster master, String ufs) {
+    if (ufs.endsWith("/")) {
+      ufs = ufs.substring(0, ufs.length() - 1);
+    }
     for (Map.Entry<String, MountPointInfo> entry : master.getMountTable().entrySet()) {
-      if (MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri())).equals(ufs)) {
+      String escaped = MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri()));
+      if (escaped.endsWith("/")) {
+        escaped = escaped.substring(0, escaped.length() - 1);
+      }
+      if (escaped.equals(ufs)) {
         return true;
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -841,16 +841,15 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   /**
-   * @param master the file system master
    * @param ufs the ufs uri encoded by {@link MetricsSystem#escape(AlluxioURI)}
    * @return whether the ufs uri is a mount point
    */
   @VisibleForTesting
-  static boolean isMounted(FileSystemMaster master, String ufs) {
+  boolean isMounted(String ufs) {
     if (ufs.endsWith("/")) {
       ufs = ufs.substring(0, ufs.length() - 1);
     }
-    for (Map.Entry<String, MountPointInfo> entry : master.getMountTable().entrySet()) {
+    for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
       String escaped = MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri()));
       if (escaped.endsWith("/")) {
         escaped = escaped.substring(0, escaped.length() - 1);
@@ -972,7 +971,7 @@ public final class AlluxioMasterRestServiceHandler {
         alluxio.metrics.Metric metric =
             alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue());
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(mFileSystemMaster, ufs)) {
+        if (isMounted(ufs)) {
           ufsReadSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
         }
       }
@@ -985,7 +984,7 @@ public final class AlluxioMasterRestServiceHandler {
         alluxio.metrics.Metric metric =
             alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue());
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(mFileSystemMaster, ufs)) {
+        if (isMounted(ufs)) {
           ufsWriteSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
         }
       }
@@ -1001,7 +1000,7 @@ public final class AlluxioMasterRestServiceHandler {
           continue;
         }
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(mFileSystemMaster, ufs)) {
+        if (isMounted(ufs)) {
           Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
           perUfsMap.put(ufs, (long) metric.getValue());
           ufsOpsMap.put(ufs, perUfsMap);

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -846,14 +846,10 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @VisibleForTesting
   boolean isMounted(String ufs) {
-    if (ufs.endsWith("/")) {
-      ufs = ufs.substring(0, ufs.length() - 1);
-    }
+    ufs = PathUtils.normalizePath(ufs, AlluxioURI.SEPARATOR);
     for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
       String escaped = MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri()));
-      if (escaped.endsWith("/")) {
-        escaped = escaped.substring(0, escaped.length() - 1);
-      }
+      escaped = PathUtils.normalizePath(escaped, AlluxioURI.SEPARATOR);
       if (escaped.equals(ufs)) {
         return true;
       }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -83,6 +83,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.qmino.miredot.annotations.ReturnType;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -843,7 +844,8 @@ public final class AlluxioMasterRestServiceHandler {
    * @param ufs the ufs uri encoded by {@link MetricsSystem#escape(AlluxioURI)}
    * @return whether the ufs uri is a mount point
    */
-  private boolean isMounted(String ufs) {
+  @VisibleForTesting
+  public boolean isMounted(String ufs) {
     for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
       if (MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri())).equals(ufs)) {
         return true;

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -841,12 +841,13 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   /**
+   * @param master the file system master
    * @param ufs the ufs uri encoded by {@link MetricsSystem#escape(AlluxioURI)}
    * @return whether the ufs uri is a mount point
    */
   @VisibleForTesting
-  public boolean isMounted(String ufs) {
-    for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
+  static boolean isMounted(FileSystemMaster master, String ufs) {
+    for (Map.Entry<String, MountPointInfo> entry : master.getMountTable().entrySet()) {
       if (MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri())).equals(ufs)) {
         return true;
       }
@@ -964,7 +965,7 @@ public final class AlluxioMasterRestServiceHandler {
         alluxio.metrics.Metric metric =
             alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue());
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(ufs)) {
+        if (isMounted(mFileSystemMaster, ufs)) {
           ufsReadSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
         }
       }
@@ -977,7 +978,7 @@ public final class AlluxioMasterRestServiceHandler {
         alluxio.metrics.Metric metric =
             alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue());
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(ufs)) {
+        if (isMounted(mFileSystemMaster, ufs)) {
           ufsWriteSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
         }
       }
@@ -993,7 +994,7 @@ public final class AlluxioMasterRestServiceHandler {
           continue;
         }
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
-        if (isMounted(ufs)) {
+        if (isMounted(mFileSystemMaster, ufs)) {
           Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
           perUfsMap.put(ufs, (long) metric.getValue());
           ufsOpsMap.put(ufs, perUfsMap);

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -839,6 +839,10 @@ public final class AlluxioMasterRestServiceHandler {
     }, ServerConfiguration.global());
   }
 
+  /**
+   * @param ufs the ufs uri encoded by {@link MetricsSystem#escape(AlluxioURI)}
+   * @return whether the ufs uri is a mount point
+   */
   private boolean isMounted(String ufs) {
     for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
       if (MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri())).equals(ufs)) {

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -444,13 +444,18 @@ public final class AlluxioMasterRestServiceHandlerTest {
     FileSystemMaster mockMaster = mock(FileSystemMaster.class);
     when(mockMaster.getMountTable()).thenReturn(mountTable);
 
-    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, s3Uri));
-    assertTrue(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
-        MetricsSystem.escape(new AlluxioURI(s3Uri))));
-    assertTrue(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
-        MetricsSystem.escape(new AlluxioURI(s3Uri + "/"))));
-    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, hdfsUri));
-    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
-        MetricsSystem.escape(new AlluxioURI(hdfsUri))));
+    AlluxioMasterProcess masterProcess = mock(AlluxioMasterProcess.class);
+    when(masterProcess.getMaster(FileSystemMaster.class)).thenReturn(mockMaster);
+
+    ServletContext context = mock(ServletContext.class);
+    when(context.getAttribute(MasterWebServer.ALLUXIO_MASTER_SERVLET_RESOURCE_KEY)).thenReturn(
+        masterProcess);
+    AlluxioMasterRestServiceHandler handler = new AlluxioMasterRestServiceHandler(context);
+
+    assertFalse(handler.isMounted(s3Uri));
+    assertTrue(handler.isMounted(MetricsSystem.escape(new AlluxioURI(s3Uri))));
+    assertTrue(handler.isMounted(MetricsSystem.escape(new AlluxioURI(s3Uri + "/"))));
+    assertFalse(handler.isMounted(hdfsUri));
+    assertFalse(handler.isMounted(MetricsSystem.escape(new AlluxioURI(hdfsUri))));
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -36,6 +36,7 @@ import alluxio.master.MasterTestUtils;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
 import alluxio.master.file.FileSystemMaster;
+import alluxio.master.file.FileSystemMasterFactory;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.metrics.MasterMetrics;
@@ -123,7 +124,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
     mRegistry.add(MetricsMaster.class, mMetricsMaster);
     registerMockUfs();
     mBlockMaster = new BlockMasterFactory().create(mRegistry, masterContext);
-    mFileSystemMaster = mock(FileSystemMaster.class);
+    mFileSystemMaster = new FileSystemMasterFactory().create(mRegistry, masterContext);
     mRegistry.start(true);
     when(mMasterProcess.getMaster(BlockMaster.class)).thenReturn(mBlockMaster);
     when(mMasterProcess.getMaster(FileSystemMaster.class)).thenReturn(mFileSystemMaster);
@@ -440,11 +441,14 @@ public final class AlluxioMasterRestServiceHandlerTest {
 
     Map<String, MountPointInfo> mountTable = new HashMap<>();
     mountTable.put("/s3", new MountPointInfo().setUfsUri(s3Uri));
-    when(mFileSystemMaster.getMountTable()).thenReturn(mountTable);
+    FileSystemMaster mockMaster = mock(FileSystemMaster.class);
+    when(mockMaster.getMountTable()).thenReturn(mountTable);
 
-    assertFalse(mHandler.isMounted(s3Uri));
-    assertTrue(mHandler.isMounted(MetricsSystem.escape(new AlluxioURI(s3Uri))));
-    assertFalse(mHandler.isMounted(hdfsUri));
-    assertFalse(mHandler.isMounted(MetricsSystem.escape(new AlluxioURI(hdfsUri))));
+    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, s3Uri));
+    assertTrue(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
+        MetricsSystem.escape(new AlluxioURI(s3Uri))));
+    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, hdfsUri));
+    assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
+        MetricsSystem.escape(new AlluxioURI(hdfsUri))));
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -435,7 +435,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
   }
 
   @Test
-  public void isMounted() throws Exception {
+  public void isMounted() {
     String s3Uri = "s3a://test/dir_1/dir-2";
     String hdfsUri = "hdfs://test";
 

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -447,6 +447,8 @@ public final class AlluxioMasterRestServiceHandlerTest {
     assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, s3Uri));
     assertTrue(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
         MetricsSystem.escape(new AlluxioURI(s3Uri))));
+    assertTrue(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
+        MetricsSystem.escape(new AlluxioURI(s3Uri + "/"))));
     assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster, hdfsUri));
     assertFalse(AlluxioMasterRestServiceHandler.isMounted(mockMaster,
         MetricsSystem.escape(new AlluxioURI(hdfsUri))));


### PR DESCRIPTION
When a ufs is unmounted, its metrics still exist in the metrics system, this PR filters out ufs metrics for the mounted ufs only.