### PR TITLE
Fix NPE in server address

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
@@ -27,7 +27,7 @@ public class GrpcServerAddress {
    * @param socketAddress physical address
    */
   public GrpcServerAddress(InetSocketAddress socketAddress) {
-    mHostName = socketAddress.getAddress().getHostName();
+    mHostName = socketAddress.getHostName();
     mSocketAddress = socketAddress;
   }
 


### PR DESCRIPTION
Fixed an NPE in `GrpcServerAddress` when the address is passed in unresolved.