### PR TITLE
Refactor filesystem, fsContext into JobMaster/Worker contexts

### DIFF
--- a/job/common/pom.xml
+++ b/job/common/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/job/server/src/main/java/alluxio/job/JobMasterContext.java
+++ b/job/server/src/main/java/alluxio/job/JobMasterContext.java
@@ -11,6 +11,8 @@
 
 package alluxio.job;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.underfs.UfsManager;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -20,16 +22,39 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class JobMasterContext {
+  private final FileSystem mFileSystem;
+  private final FileSystemContext mFsContext;
   private final long mJobId;
   private final UfsManager mUfsManager;
 
   /**
+   * Creates a new instance of {@link JobMasterContext}.
+   *
+   * @param filesystem the Alluxio client used to contact the master
+   * @param fsContext the filesystem client's underlying context
    * @param jobId the job id
    * @param ufsManager the UFS manager
    */
-  public JobMasterContext(long jobId, UfsManager ufsManager) {
+  public JobMasterContext(FileSystem filesystem, FileSystemContext fsContext, long jobId,
+      UfsManager ufsManager) {
+    mFsContext = fsContext;
+    mFileSystem = filesystem;
     mJobId = jobId;
     mUfsManager = ufsManager;
+  }
+
+  /**
+   * @return the {@link FileSystem} client
+   */
+  public FileSystem getFileSystem() {
+    return mFileSystem;
+  }
+
+  /**
+   * @return the FileSystemContext for the client
+   */
+  public FileSystemContext getFsContext() {
+    return mFsContext;
   }
 
   /**

--- a/job/server/src/main/java/alluxio/job/JobWorkerContext.java
+++ b/job/server/src/main/java/alluxio/job/JobWorkerContext.java
@@ -11,6 +11,8 @@
 
 package alluxio.job;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.underfs.UfsManager;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -20,6 +22,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class JobWorkerContext {
+  private final FileSystem mFileSystem;
+  private final FileSystemContext mFsContext;
   private final long mJobId;
   private final int mTaskId;
   private final UfsManager mUfsManager;
@@ -27,14 +31,33 @@ public final class JobWorkerContext {
   /**
    * Creates a new instance of {@link JobWorkerContext}.
    *
+   * @param filesystem the filesystem client that is used when running jobs
+   * @param fsContext the filesystem client's underlying context
    * @param jobId the job id
    * @param taskId the task id
    * @param ufsManager the UFS manager
    */
-  public JobWorkerContext(long jobId, int taskId, UfsManager ufsManager) {
+  public JobWorkerContext(FileSystem filesystem, FileSystemContext fsContext, long jobId,
+      int taskId, UfsManager ufsManager) {
+    mFsContext = fsContext;
+    mFileSystem = filesystem;
     mJobId = jobId;
     mTaskId = taskId;
     mUfsManager = ufsManager;
+  }
+
+  /**
+   * @return the {@link FileSystem} client
+   */
+  public FileSystem getFileSystem() {
+    return mFileSystem;
+  }
+
+  /**
+   * @return the FileSystemContext for the client
+   */
+  public FileSystemContext getFsContext() {
+    return mFsContext;
   }
 
   /**

--- a/job/server/src/main/java/alluxio/job/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/migrate/MigrateDefinition.java
@@ -15,11 +15,9 @@ import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
-import alluxio.client.file.BaseFileSystem;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
-import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
@@ -104,30 +102,15 @@ import java.util.concurrent.ConcurrentMap;
 public final class MigrateDefinition
     extends AbstractVoidJobDefinition<MigrateConfig, ArrayList<MigrateCommand>> {
   private static final Logger LOG = LoggerFactory.getLogger(MigrateDefinition.class);
-  private final FileSystem mFileSystem;
-  private final FileSystemContext mFsContext;
   private final Random mRandom = new Random();
 
   /**
    * Constructs a new {@link MigrateDefinition}.
    */
   public MigrateDefinition() {
-    mFsContext = FileSystemContext.create(ServerConfiguration.global());
-    mFileSystem = BaseFileSystem.create(mFsContext);
   }
 
-  /**
-   * Constructs a new {@link MigrateDefinition} with FileSystem context and instance.
-   *
-   * @param fsContext the {@link FileSystemContext} used by the {@link FileSystem}
-   * @param fileSystem the {@link FileSystem} client
-   */
-  public MigrateDefinition(FileSystemContext fsContext, FileSystem fileSystem) {
-    mFsContext = fsContext;
-    mFileSystem = fileSystem;
-  }
-
-  private void checkMigrateValid(MigrateConfig config) throws Exception {
+  private void checkMigrateValid(MigrateConfig config, FileSystem fs) throws Exception {
     AlluxioURI source = new AlluxioURI(config.getSource());
     AlluxioURI destination = new AlluxioURI(config.getDestination());
     // The source cannot be a prefix of the destination -
@@ -138,9 +121,9 @@ public final class MigrateDefinition
     }
 
     // This will throw an appropriate exception if the source does not exist.
-    boolean sourceIsDirectory = mFileSystem.getStatus(source).isFolder();
+    boolean sourceIsDirectory = fs.getStatus(source).isFolder();
     try {
-      URIStatus destinationStatus = mFileSystem.getStatus(destination);
+      URIStatus destinationStatus = fs.getStatus(destination);
       // Handle the case where the destination exists.
       boolean destinationIsDirectory = destinationStatus.isFolder();
       if (sourceIsDirectory && !destinationIsDirectory) {
@@ -157,7 +140,7 @@ public final class MigrateDefinition
     } catch (FileDoesNotExistException e) {
       // Handle the case where the destination does not exist.
       // This will throw an appropriate exception if the destination's parent does not exist.
-      URIStatus destinationParentStatus = mFileSystem.getStatus(destination.getParent());
+      URIStatus destinationParentStatus = fs.getStatus(destination.getParent());
       if (!destinationParentStatus.isFolder()) {
         throw new RuntimeException(ExceptionMessage.MIGRATE_TO_FILE_AS_DIRECTORY
             .getMessage(destination, destination.getParent()));
@@ -179,21 +162,22 @@ public final class MigrateDefinition
     if (source.equals(destination)) {
       return new HashMap<>();
     }
-    checkMigrateValid(config);
+    checkMigrateValid(config, jobMasterContext.getFileSystem());
     Preconditions.checkState(!jobWorkerInfoList.isEmpty(), "No workers are available");
 
-    List<URIStatus> allPathStatuses = getPathStatuses(source);
+    List<URIStatus> allPathStatuses = getPathStatuses(source, jobMasterContext.getFileSystem());
     ConcurrentMap<WorkerInfo, ArrayList<MigrateCommand>> assignments = Maps.newConcurrentMap();
     ConcurrentMap<String, WorkerInfo> hostnameToWorker = Maps.newConcurrentMap();
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       hostnameToWorker.put(workerInfo.getAddress().getHost(), workerInfo);
     }
     List<BlockWorkerInfo> alluxioWorkerInfoList =
-        AlluxioBlockStore.create(mFsContext).getAllWorkers();
+        AlluxioBlockStore.create(jobMasterContext.getFsContext()).getAllWorkers();
     // Assign each file to the worker with the most block locality.
     for (URIStatus status : allPathStatuses) {
       if (status.isFolder()) {
-        migrateDirectory(status.getPath(), source.getPath(), destination.getPath());
+        migrateDirectory(status.getPath(), source.getPath(), destination.getPath(),
+            jobMasterContext.getFileSystem());
       } else {
         WorkerInfo bestJobWorker = getBestJobWorker(status, alluxioWorkerInfoList,
             jobWorkerInfoList, hostnameToWorker);
@@ -242,9 +226,10 @@ public final class MigrateDefinition
    * @param source the base source path being migrated
    * @param destination the destination path
    */
-  private void migrateDirectory(String path, String source, String destination) throws Exception {
+  private void migrateDirectory(String path, String source, String destination, FileSystem fs)
+      throws Exception {
     String newDir = computeTargetPath(path, source, destination);
-    mFileSystem.createDirectory(new AlluxioURI(newDir));
+    fs.createDirectory(new AlluxioURI(newDir));
   }
 
   /**
@@ -256,17 +241,17 @@ public final class MigrateDefinition
    * @return a list of the {@link URIStatus} for all paths under the given path
    * @throws Exception if an exception occurs
    */
-  private List<URIStatus> getPathStatuses(AlluxioURI path) throws Exception {
+  private List<URIStatus> getPathStatuses(AlluxioURI path, FileSystem fs) throws Exception {
     // Depth-first search to to find all files under path.
     Stack<AlluxioURI> pathsToConsider = new Stack<>();
     pathsToConsider.add(path);
     List<URIStatus> allStatuses = Lists.newArrayList();
     while (!pathsToConsider.isEmpty()) {
       AlluxioURI nextPath = pathsToConsider.pop();
-      URIStatus status = mFileSystem.getStatus(nextPath);
+      URIStatus status = fs.getStatus(nextPath);
       allStatuses.add(status);
       if (status.isFolder()) {
-        List<URIStatus> childStatuses = mFileSystem.listStatus(nextPath);
+        List<URIStatus> childStatuses = fs.listStatus(nextPath);
         for (URIStatus childStatus : childStatuses) {
           if (childStatus.isFolder()) {
             pathsToConsider.push(new AlluxioURI(childStatus.getPath()));
@@ -292,13 +277,15 @@ public final class MigrateDefinition
         ? ServerConfiguration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
         : WriteType.valueOf(config.getWriteType());
     for (MigrateCommand command : commands) {
-      migrate(command, writeType.toProto(), config.isDeleteSource(), mFileSystem);
+      migrate(command, writeType.toProto(), config.isDeleteSource(),
+          jobWorkerContext.getFileSystem());
     }
     // Try to delete the source directory if it is empty.
-    if (config.isDeleteSource() && !hasFiles(new AlluxioURI(config.getSource()), mFileSystem)) {
+    if (config.isDeleteSource() && !hasFiles(new AlluxioURI(config.getSource()),
+        jobWorkerContext.getFileSystem())) {
       try {
         LOG.debug("Deleting {}", config.getSource());
-        mFileSystem.delete(new AlluxioURI(config.getSource()),
+        jobWorkerContext.getFileSystem().delete(new AlluxioURI(config.getSource()),
             DeletePOptions.newBuilder().setRecursive(true).build());
       } catch (FileDoesNotExistException e) {
         // It's already deleted, possibly by another worker.

--- a/job/server/src/main/java/alluxio/job/replicate/ReplicateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/replicate/ReplicateDefinition.java
@@ -12,10 +12,6 @@
 package alluxio.job.replicate;
 
 import alluxio.client.block.AlluxioBlockStore;
-import alluxio.client.file.BaseFileSystem;
-import alluxio.client.file.FileSystem;
-import alluxio.client.file.FileSystemContext;
-import alluxio.conf.ServerConfiguration;
 import alluxio.job.AbstractVoidJobDefinition;
 import alluxio.job.JobMasterContext;
 import alluxio.job.JobWorkerContext;
@@ -47,27 +43,11 @@ public final class ReplicateDefinition
     extends AbstractVoidJobDefinition<ReplicateConfig, SerializableVoid> {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicateDefinition.class);
 
-  private final FileSystem mFileSystem;
-  private final FileSystemContext mFsContext;
-
   /**
-   * Constructs a new {@link ReplicateDefinition} instance with FileSystem context and instance.
+   * Constructs a new {@link ReplicateDefinition}.
    *
    */
   public ReplicateDefinition() {
-    mFsContext = FileSystemContext.create(ServerConfiguration.global());
-    mFileSystem = BaseFileSystem.create(mFsContext);
-  }
-
-  /**
-   * Constructs a new {@link ReplicateDefinition} instance.
-   *
-   * @param fsContext the {@link FileSystemContext} used by the {@link FileSystem}
-   * @param fileSystem the {@link FileSystem} client
-   */
-  public ReplicateDefinition(FileSystemContext fsContext, FileSystem fileSystem) {
-    mFsContext = fsContext;
-    mFileSystem = fileSystem;
   }
 
   @Override
@@ -84,7 +64,7 @@ public final class ReplicateDefinition
     int numReplicas = config.getReplicas();
     Preconditions.checkArgument(numReplicas > 0);
 
-    AlluxioBlockStore blockStore = AlluxioBlockStore.create(mFsContext);
+    AlluxioBlockStore blockStore = AlluxioBlockStore.create(jobMasterContext.getFsContext());
     BlockInfo blockInfo = blockStore.getInfo(blockId);
 
     Set<String> hosts = new HashSet<>();
@@ -114,7 +94,8 @@ public final class ReplicateDefinition
   @Override
   public SerializableVoid runTask(ReplicateConfig config, SerializableVoid arg,
       JobWorkerContext jobWorkerContext) throws Exception {
-    JobUtils.loadBlock(mFileSystem, mFsContext, config.getPath(), config.getBlockId());
+    JobUtils.loadBlock(jobWorkerContext.getFileSystem(), jobWorkerContext.getFsContext(),
+        config.getPath(), config.getBlockId());
     return null;
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -96,13 +96,12 @@ public final class JobMaster extends AbstractMaster implements NoopJournaled {
   /**
    * The Filesystem context that the job master uses for its client.
    */
-  private final FileSystemContext mFsContext =
-      FileSystemContext.create(ServerConfiguration.global());
+  private final FileSystemContext mFsContext;
 
   /**
    * The FileSystem client the job master uses to select executors for jobs.
    */
-  private final FileSystem mFileSystem = FileSystem.Factory.create(mFsContext);
+  private final FileSystem mFileSystem;
 
   /**
    * The total number of jobs that the JobMaster may run at any moment.
@@ -156,11 +155,16 @@ public final class JobMaster extends AbstractMaster implements NoopJournaled {
    * Creates a new instance of {@link JobMaster}.
    *
    * @param masterContext the context for Alluxio master
+   * @param filesystem the Alluxio filesystem client the job master uses to communicate
+   * @param fsContext the filesystem client's underlying context
    * @param ufsManager the ufs manager
    */
-  public JobMaster(MasterContext masterContext, UfsManager ufsManager) {
+  public JobMaster(MasterContext masterContext, FileSystem filesystem,
+      FileSystemContext fsContext, UfsManager ufsManager) {
     super(masterContext, new SystemClock(),
         ExecutorServiceFactories.cachedThreadPool(Constants.JOB_MASTER_NAME));
+    mFileSystem = filesystem;
+    mFsContext = fsContext;
     mJobIdGenerator = new JobIdGenerator();
     mCommandManager = new CommandManager();
     mIdToJobCoordinator = new ConcurrentHashMap<>();

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
@@ -11,6 +11,8 @@
 
 package alluxio.worker;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
@@ -47,6 +49,12 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class AlluxioJobWorkerProcess implements JobWorkerProcess {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioJobWorkerProcess.class);
 
+  /** FileSystem client for jobs. */
+  private final FileSystem mFileSystem;
+
+  /** FileSystemContext for jobs. */
+  private final FileSystemContext mFsContext;
+
   /** The job worker. */
   private JobWorker mJobWorker;
 
@@ -81,9 +89,12 @@ public final class AlluxioJobWorkerProcess implements JobWorkerProcess {
    */
   AlluxioJobWorkerProcess() {
     try {
+      mFsContext = FileSystemContext.create(ServerConfiguration.global());
+      mFileSystem = FileSystem.Factory.create(mFsContext);
+
       mStartTimeMs = System.currentTimeMillis();
       mUfsManager = new JobUfsManager();
-      mJobWorker = new JobWorker(mUfsManager);
+      mJobWorker = new JobWorker(mFileSystem, mFsContext, mUfsManager);
 
       // Setup web server
       mWebServer = new JobWorkerWebServer(ServiceType.JOB_WORKER_WEB.getServiceName(),

--- a/job/server/src/main/java/alluxio/worker/JobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/JobWorker.java
@@ -12,6 +12,8 @@
 package alluxio.worker;
 
 import alluxio.ClientContext;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
@@ -51,6 +53,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class JobWorker extends AbstractWorker {
   private static final Logger LOG = LoggerFactory.getLogger(JobWorker.class);
 
+  /** FileSystem client for jobs. */
+  private final FileSystem mFileSystem;
+  /** FileSystemContext for jobs. */
+  private final FileSystemContext mFsContext;
   /** Client for job master communication. */
   private final JobMasterClient mJobMasterClient;
   /** The manager for the all the local task execution. */
@@ -65,9 +71,11 @@ public final class JobWorker extends AbstractWorker {
    *
    * @param ufsManager the ufs manager
    */
-  JobWorker(UfsManager ufsManager) {
+  JobWorker(FileSystem filesystem, FileSystemContext fsContext, UfsManager ufsManager) {
     super(
         Executors.newFixedThreadPool(1, ThreadFactoryUtils.build("job-worker-heartbeat-%d", true)));
+    mFileSystem = filesystem;
+    mFsContext = fsContext;
     mUfsManager = ufsManager;
     mJobMasterClient = JobMasterClient.Factory.create(JobMasterClientContext
         .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
@@ -103,8 +111,8 @@ public final class JobWorker extends AbstractWorker {
 
     mCommandHandlingService = getExecutorService().submit(
         new HeartbeatThread(HeartbeatContext.JOB_WORKER_COMMAND_HANDLING,
-            new CommandHandlingExecutor(mTaskExecutorManager, mUfsManager, mJobMasterClient,
-                address),
+            new CommandHandlingExecutor(mTaskExecutorManager, mFileSystem, mFsContext, mUfsManager,
+                mJobMasterClient, address),
             (int) ServerConfiguration.getMs(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL),
             ServerConfiguration.global()));
   }

--- a/job/server/src/test/java/alluxio/job/command/CommandHandlingExecutorTest.java
+++ b/job/server/src/test/java/alluxio/job/command/CommandHandlingExecutorTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.job.command;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.grpc.JobCommand;
 import alluxio.grpc.RunTaskCommand;
 import alluxio.grpc.TaskInfo;
@@ -44,24 +46,29 @@ import java.util.concurrent.TimeUnit;
  * Tests {@link CommandHandlingExecutor}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({TaskExecutorManager.class, WorkerNetAddress.class})
+@PrepareForTest({TaskExecutorManager.class, WorkerNetAddress.class, FileSystemContext.class})
 public final class CommandHandlingExecutorTest {
   private CommandHandlingExecutor mCommandHandlingExecutor;
   private JobMasterClient mJobMasterClient;
   private long mWorkerId;
   private TaskExecutorManager mTaskExecutorManager;
   private UfsManager mUfsManager;
+  private FileSystemContext mFileSystemContext;
+  private FileSystem mFileSystem;
 
   @Before
   public void before() {
+
     mWorkerId = 0;
     mJobMasterClient = Mockito.mock(JobMasterClient.class);
     mTaskExecutorManager = PowerMockito.mock(TaskExecutorManager.class);
     WorkerNetAddress workerNetAddress = PowerMockito.mock(WorkerNetAddress.class);
     mUfsManager = Mockito.mock(UfsManager.class);
+    mFileSystemContext = Mockito.mock(FileSystemContext.class);
+    mFileSystem = Mockito.mock(FileSystem.class);
     mCommandHandlingExecutor =
-        new CommandHandlingExecutor(mTaskExecutorManager, mUfsManager, mJobMasterClient,
-            workerNetAddress);
+        new CommandHandlingExecutor(mTaskExecutorManager, mFileSystem, mFileSystemContext,
+            mUfsManager, mJobMasterClient, workerNetAddress);
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/load/LoadDefinitionTest.java
@@ -86,6 +86,8 @@ public class LoadDefinitionTest {
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
     PowerMockito.when(mMockFsContext.getConf())
         .thenReturn(ServerConfiguration.global());
+    Mockito.when(mMockJobMasterContext.getFileSystem()).thenReturn(mMockFileSystem);
+    Mockito.when(mMockJobMasterContext.getFsContext()).thenReturn(mMockFsContext);
   }
 
   @Test
@@ -95,7 +97,7 @@ public class LoadDefinitionTest {
     createFileWithNoLocations(TEST_URI, numBlocks);
     LoadConfig config = new LoadConfig(TEST_URI, replication);
     Map<WorkerInfo, ArrayList<LoadTask>> assignments =
-        new LoadDefinition(mMockFsContext, mMockFileSystem).selectExecutors(config,
+        new LoadDefinition().selectExecutors(config,
             JOB_WORKERS, mMockJobMasterContext);
     // Check that we are loading the right number of blocks.
     int totalBlockLoads = 0;
@@ -113,7 +115,7 @@ public class LoadDefinitionTest {
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
     Map<WorkerInfo, ArrayList<LoadTask>> assignments =
-        new LoadDefinition(mMockFsContext, mMockFileSystem).selectExecutors(config,
+        new LoadDefinition().selectExecutors(config,
             JOB_WORKERS, mMockJobMasterContext);
     Assert.assertEquals(1, assignments.size());
     Assert.assertEquals(10, assignments.values().iterator().next().size());
@@ -124,7 +126,7 @@ public class LoadDefinitionTest {
     createFileWithNoLocations(TEST_URI, 1);
     LoadConfig config = new LoadConfig(TEST_URI, 5); // set replication to 5
     try {
-      new LoadDefinition(mMockFsContext, mMockFileSystem).selectExecutors(config,
+      new LoadDefinition().selectExecutors(config,
           JOB_WORKERS, mMockJobMasterContext);
       Assert.fail();
     } catch (Exception e) {
@@ -142,7 +144,7 @@ public class LoadDefinitionTest {
     createFileWithNoLocations(TEST_URI, 1);
     LoadConfig config = new LoadConfig(TEST_URI, 2); // set replication to 2
     try {
-      new LoadDefinition(mMockFsContext, mMockFileSystem).selectExecutors(config,
+      new LoadDefinition().selectExecutors(config,
           JOB_WORKERS, mMockJobMasterContext);
       Assert.fail();
     } catch (Exception e) {

--- a/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionRunTaskTest.java
@@ -189,9 +189,9 @@ public final class MigrateDefinitionRunTaskTest {
    */
   private void runTask(String configSource, String commandSource, String commandDestination,
       WriteType writeType) throws Exception {
-    new MigrateDefinition(mMockFileSystemContext, mMockFileSystem).runTask(
+    new MigrateDefinition().runTask(
         new MigrateConfig(configSource, "", writeType.toString(), false, mDeleteSource),
         Lists.newArrayList(new MigrateCommand(commandSource, commandDestination)),
-        new JobWorkerContext(1, 1, mMockUfsManager));
+        new JobWorkerContext(mMockFileSystem, mMockFileSystemContext, 1, 1, mMockUfsManager));
   }
 }

--- a/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -310,9 +310,10 @@ public final class MigrateDefinitionSelectExecutorsTest {
     setPathToNotExist("/dst");
 
     Map<WorkerInfo, ArrayList<MigrateCommand>> assignments =
-        new MigrateDefinition(mMockFileSystemContext, mMockFileSystem).selectExecutors(
+        new MigrateDefinition().selectExecutors(
             new MigrateConfig("/src", "/dst", "THROUGH", true, false),
-            ImmutableList.of(JOB_WORKER_3), new JobMasterContext(1, mMockUfsManager));
+            ImmutableList.of(JOB_WORKER_3), new JobMasterContext(mMockFileSystem,
+                mMockFileSystemContext, 1, mMockUfsManager));
 
     Assert.assertEquals(ImmutableMap.of(JOB_WORKER_3,
         new ArrayList<>(Arrays.asList(new MigrateCommand("/src", "/dst")))), assignments);
@@ -332,8 +333,9 @@ public final class MigrateDefinitionSelectExecutorsTest {
    */
   private Map<WorkerInfo, ArrayList<MigrateCommand>> assignMigrates(MigrateConfig config)
       throws Exception {
-    return new MigrateDefinition(mMockFileSystemContext, mMockFileSystem).selectExecutors(config,
-        JOB_WORKERS, new JobMasterContext(1, mMockUfsManager));
+    return new MigrateDefinition().selectExecutors(config,
+        JOB_WORKERS, new JobMasterContext(mMockFileSystem, mMockFileSystemContext, 1,
+            mMockUfsManager));
   }
 
   /**

--- a/job/server/src/test/java/alluxio/job/persist/PersistDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/persist/PersistDefinitionTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.job.persist;
 
+import static org.mockito.Mockito.when;
+
 import alluxio.AlluxioURI;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.file.FileSystem;
@@ -56,6 +58,8 @@ public final class PersistDefinitionTest {
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
+    when(mMockJobMasterContext.getFileSystem()).thenReturn(mMockFileSystem);
+    when(mMockJobMasterContext.getFsContext()).thenReturn(mMockFileSystemContext);
   }
 
   @Test
@@ -77,7 +81,7 @@ public final class PersistDefinitionTest {
     Mockito.when(mMockFileSystem.getStatus(uri)).thenReturn(new URIStatus(testFileInfo));
 
     Map<WorkerInfo, SerializableVoid> result =
-        new PersistDefinition(mMockFileSystemContext, mMockFileSystem).selectExecutors(config,
+        new PersistDefinition().selectExecutors(config,
             Lists.newArrayList(workerInfo), mMockJobMasterContext);
     Assert.assertEquals(1, result.size());
     Assert.assertEquals(workerInfo, result.keySet().iterator().next());
@@ -96,7 +100,7 @@ public final class PersistDefinitionTest {
     Mockito.when(mMockFileSystem.getStatus(uri)).thenReturn(new URIStatus(testFileInfo));
 
     try {
-      new PersistDefinition(mMockFileSystemContext, mMockFileSystem).selectExecutors(config,
+      new PersistDefinition().selectExecutors(config,
           Lists.newArrayList(new WorkerInfo()), mMockJobMasterContext);
     } catch (Exception e) {
       Assert.assertEquals("Block " + blockId + " does not exist", e.getMessage());

--- a/job/server/src/test/java/alluxio/job/replicate/EvictDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/replicate/EvictDefinitionTest.java
@@ -11,7 +11,10 @@
 
 package alluxio.job.replicate;
 
+import static org.mockito.Mockito.when;
+
 import alluxio.client.block.AlluxioBlockStore;
+import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.job.JobMasterContext;
 import alluxio.job.util.SerializableVoid;
@@ -53,6 +56,7 @@ public final class EvictDefinitionTest {
   private static final WorkerInfo WORKER_INFO_3 = new WorkerInfo().setAddress(ADDRESS_3);
   private static final Map<WorkerInfo, SerializableVoid> EMPTY = Maps.newHashMap();
 
+  private FileSystem mMockFileSystem;
   private FileSystemContext mMockFileSystemContext;
   private AlluxioBlockStore mMockBlockStore;
   private JobMasterContext mMockJobMasterContext;
@@ -61,7 +65,10 @@ public final class EvictDefinitionTest {
   public void before() {
     mMockJobMasterContext = Mockito.mock(JobMasterContext.class);
     mMockFileSystemContext = PowerMockito.mock(FileSystemContext.class);
+    mMockFileSystem = PowerMockito.mock(FileSystem.class);
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
+    when(mMockJobMasterContext.getFileSystem()).thenReturn(mMockFileSystem);
+    when(mMockJobMasterContext.getFsContext()).thenReturn(mMockFileSystemContext);
   }
 
   /**
@@ -77,12 +84,12 @@ public final class EvictDefinitionTest {
       throws Exception {
     BlockInfo blockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID);
     blockInfo.setLocations(blockLocations);
-    Mockito.when(mMockBlockStore.getInfo(TEST_BLOCK_ID)).thenReturn(blockInfo);
+    when(mMockBlockStore.getInfo(TEST_BLOCK_ID)).thenReturn(blockInfo);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
 
     EvictConfig config = new EvictConfig(TEST_BLOCK_ID, replicas);
-    EvictDefinition definition = new EvictDefinition(mMockFileSystemContext);
+    EvictDefinition definition = new EvictDefinition();
     return definition.selectExecutors(config, workerInfoList, mMockJobMasterContext);
   }
 

--- a/job/server/src/test/java/alluxio/job/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/replicate/ReplicateDefinitionTest.java
@@ -112,6 +112,8 @@ public final class ReplicateDefinitionTest {
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     mMockFileSystem = mock(FileSystem.class);
     mMockUfsManager = mock(UfsManager.class);
+    when(mMockJobMasterContext.getFileSystem()).thenReturn(mMockFileSystem);
+    when(mMockJobMasterContext.getFsContext()).thenReturn(mMockFileSystemContext);
   }
 
   /**
@@ -133,8 +135,7 @@ public final class ReplicateDefinitionTest {
 
     String path = "/test";
     ReplicateConfig config = new ReplicateConfig(path, TEST_BLOCK_ID, numReplicas);
-    ReplicateDefinition definition = new ReplicateDefinition(mMockFileSystemContext,
-        mMockFileSystem);
+    ReplicateDefinition definition = new ReplicateDefinition();
     return definition.selectExecutors(config, workerInfoList, mMockJobMasterContext);
   }
 
@@ -168,8 +169,9 @@ public final class ReplicateDefinitionTest {
 
     ReplicateConfig config = new ReplicateConfig(path, TEST_BLOCK_ID, 1 /* value not used */);
     ReplicateDefinition definition =
-        new ReplicateDefinition(mMockFileSystemContext, mMockFileSystem);
-    definition.runTask(config, null, new JobWorkerContext(1, 1, mMockUfsManager));
+        new ReplicateDefinition();
+    definition.runTask(config, null,
+        new JobWorkerContext(mMockFileSystem, mMockFileSystemContext, 1, 1, mMockUfsManager));
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.job;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
@@ -82,8 +84,10 @@ public final class JobMasterTest {
     JobCoordinator coordinator = PowerMockito.mock(JobCoordinator.class);
     PowerMockito.mockStatic(JobCoordinator.class);
     Mockito.when(
-        JobCoordinator.create(Mockito.any(CommandManager.class), Mockito.any(UfsManager.class),
-            Mockito.anyList(), Mockito.anyLong(), Mockito.any(JobConfig.class), Mockito.any(null)))
+        JobCoordinator.create(Mockito.any(CommandManager.class),
+            Mockito.any(FileSystem.class), Mockito.any(FileSystemContext.class),
+            Mockito.any(UfsManager.class), Mockito.anyList(), Mockito.anyLong(),
+            Mockito.any(JobConfig.class), Mockito.any(null)))
         .thenReturn(coordinator);
     TestJobConfig jobConfig = new TestJobConfig("/test");
     for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {
@@ -97,8 +101,10 @@ public final class JobMasterTest {
     JobCoordinator coordinator = PowerMockito.mock(JobCoordinator.class);
     PowerMockito.mockStatic(JobCoordinator.class);
     Mockito.when(
-        JobCoordinator.create(Mockito.any(CommandManager.class), Mockito.any(UfsManager.class),
-            Mockito.anyList(), Mockito.anyLong(), Mockito.any(JobConfig.class), Mockito.any(null)))
+        JobCoordinator.create(Mockito.any(CommandManager.class),
+            Mockito.any(FileSystem.class), Mockito.any(FileSystemContext.class),
+            Mockito.any(UfsManager.class), Mockito.anyList(), Mockito.anyLong(),
+            Mockito.any(JobConfig.class), Mockito.any(null)))
         .thenReturn(coordinator);
     TestJobConfig jobConfig = new TestJobConfig("/test");
     for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -45,7 +45,7 @@ import java.util.Map;
  * Tests {@link JobMaster}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JobCoordinator.class})
+@PrepareForTest({JobCoordinator.class, FileSystemContext.class})
 public final class JobMasterTest {
   private static final int TEST_JOB_MASTER_JOB_CAPACITY = 100;
   private JobMaster mJobMaster;
@@ -57,8 +57,9 @@ public final class JobMasterTest {
   public void before() throws Exception {
     // Can't use ConfigurationRule due to conflicts with PowerMock.
     ServerConfiguration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, TEST_JOB_MASTER_JOB_CAPACITY);
-    mJobMaster =
-        new JobMaster(new MasterContext(new NoopJournalSystem()), Mockito.mock(UfsManager.class));
+    mJobMaster = new JobMaster(new MasterContext(new NoopJournalSystem()),
+        Mockito.mock(FileSystem.class), Mockito.mock(FileSystemContext.class),
+        Mockito.mock(UfsManager.class));
     mJobMaster.start(true);
   }
 


### PR DESCRIPTION
This change moves the creation of FileSystem/Context out of
the job definitions and into the respective master/worker
processes. The processes should aim to create clients as few
times as possible because of all the underlying threadpools
and resources that are needed to instantiate a client.

The JobMaster and JobWorkers now pass in a single instance
of a filesystem client+context when selecting executors and
running tasks. This greatly reduces the amount of resources
that the job master and workers consume when there are lots
of jobs being executed.