### PR TITLE
Add an option to cp command to preserve file attributes

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -112,7 +112,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   private int mCopyFromLocalBufferSize = COPY_FROM_LOCAL_BUFFER_SIZE_DEFAULT;
   private int mCopyToLocalBufferSize = COPY_TO_LOCAL_BUFFER_SIZE_DEFAULT;
   private int mThread = Runtime.getRuntime().availableProcessors() * 2;
-  private boolean mPreserveAttributes = false;
+  private boolean mPreservePermissions = false;
 
   /**
    * A thread pool executor for asynchronous copy.
@@ -329,7 +329,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
       }
     }
     if (cl.hasOption(PRESERVE_OPTION.getLongOpt())) {
-      mPreserveAttributes = true;
+      mPreservePermissions = true;
     }
   }
 
@@ -556,7 +556,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
    */
   private void preserveAttributes(AlluxioURI srcPath, AlluxioURI dstPath)
       throws IOException, AlluxioException {
-    if (mPreserveAttributes) {
+    if (mPreservePermissions) {
       URIStatus srcStatus = mFileSystem.getStatus(srcPath);
       mFileSystem.setAttribute(dstPath, SetAttributePOptions.newBuilder()
           .setOwner(srcStatus.getOwner())

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -26,6 +26,9 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.status.InvalidArgumentException;
+import alluxio.grpc.SetAclAction;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.security.authorization.Mode;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Joiner;
@@ -98,10 +101,18 @@ public final class CpCommand extends AbstractFileSystemCommand {
               + "default is 8MB when copying from local, "
               + "and 64MB when copying to local")
           .build();
+  private static final Option PRESERVE_OPTION =
+      Option.builder("p")
+          .longOpt("preserve")
+          .required(false)
+          .desc("Preserve file attributes when copying files. "
+              + "All ownership, permissions and ACLs will be preserved")
+          .build();
 
   private int mCopyFromLocalBufferSize = COPY_FROM_LOCAL_BUFFER_SIZE_DEFAULT;
   private int mCopyToLocalBufferSize = COPY_TO_LOCAL_BUFFER_SIZE_DEFAULT;
   private int mThread = Runtime.getRuntime().availableProcessors() * 2;
+  private boolean mPreserveAttributes = false;
 
   /**
    * A thread pool executor for asynchronous copy.
@@ -317,12 +328,16 @@ public final class CpCommand extends AbstractFileSystemCommand {
             + " into an integer", e);
       }
     }
+    if (cl.hasOption(PRESERVE_OPTION.getLongOpt())) {
+      mPreserveAttributes = true;
+    }
   }
 
   @Override
   public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION)
-        .addOption(THREAD_OPTION);
+        .addOption(THREAD_OPTION)
+        .addOption(PRESERVE_OPTION);
   }
 
   @Override
@@ -493,6 +508,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
         System.out.println("Created directory: " + dstPath);
       }
 
+      preserveAttributes(srcPath, dstPath);
       List<String> errorMessages = new ArrayList<>();
       for (URIStatus status : statuses) {
         try {
@@ -528,6 +544,26 @@ public final class CpCommand extends AbstractFileSystemCommand {
         throw e;
       }
       System.out.println(String.format(COPY_SUCCEED_MESSAGE, srcPath, dstPath));
+    }
+    preserveAttributes(srcPath, dstPath);
+  }
+
+  /**
+   * Preserves attributes from the source file to the target file.
+   *
+   * @param srcPath the source path
+   * @param dstPath the destination path in the Alluxio filesystem
+   */
+  private void preserveAttributes(AlluxioURI srcPath, AlluxioURI dstPath)
+      throws IOException, AlluxioException {
+    if (mPreserveAttributes) {
+      URIStatus srcStatus = mFileSystem.getStatus(srcPath);
+      mFileSystem.setAttribute(dstPath, SetAttributePOptions.newBuilder()
+          .setOwner(srcStatus.getOwner())
+          .setGroup(srcStatus.getGroup())
+          .setMode(new Mode((short) srcStatus.getMode()).toProto())
+          .build());
+      mFileSystem.setAcl(dstPath, SetAclAction.REPLACE, srcStatus.getAcl().getEntries());
     }
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -105,7 +105,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
       Option.builder("p")
           .longOpt("preserve")
           .required(false)
-          .desc("Preserve file attributes when copying files. "
+          .desc("Preserve file permission attributes when copying files. "
               + "All ownership, permissions and ACLs will be preserved")
           .build();
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
@@ -18,83 +18,24 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
-import alluxio.security.group.GroupMappingService;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 /**
  * Tests for chown command.
  */
 public final class ChownCommandIntegrationTest extends AbstractFileSystemShellTest {
-  /*
-   * The user and group mappings for testing are:
-   *    alice -> alice,staff
-   *    bob   -> bob,staff
-   */
-  private static final TestUser TEST_USER_1 =
-      new TestUser("alice", "alice,staff");
-  private static final TestUser TEST_USER_2 =
-      new TestUser("bob", "bob,staff");
 
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()),
       ServerConfiguration.global());
-
-  /**
-   * A simple structure to represent a user and its groups.
-   */
-  private static final class TestUser {
-    private String mUser;
-    private String mGroup;
-
-    TestUser(String user, String group) {
-      mUser = user;
-      mGroup = group;
-    }
-
-    String getUser() {
-      return mUser;
-    }
-
-    String getGroup() {
-      return mGroup;
-    }
-  }
-
-  /**
-   * Test class implements {@link GroupMappingService} providing user-to-groups mapping.
-   */
-  public static class FakeUserGroupsMapping implements GroupMappingService {
-    private HashMap<String, String> mUserGroups = new HashMap<>();
-
-    /**
-     * Constructor of {@link FakeUserGroupsMapping} to put the user and groups in user-to-groups
-     * HashMap.
-     */
-    public FakeUserGroupsMapping() {
-      mUserGroups.put(TEST_USER_1.getUser(), TEST_USER_1.getGroup());
-      mUserGroups.put(TEST_USER_2.getUser(), TEST_USER_2.getGroup());
-    }
-
-    @Override
-    public List<String> getGroups(String user) throws IOException {
-      if (mUserGroups.containsKey(user)) {
-        return Lists.newArrayList(mUserGroups.get(user).split(","));
-      }
-      return new ArrayList<>();
-    }
-  }
 
   @Test
   public void chown() throws IOException, AlluxioException {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -14,28 +14,51 @@ package alluxio.client.cli.fs.command;
 import static org.hamcrest.CoreMatchers.containsString;
 
 import alluxio.AlluxioURI;
+import alluxio.ConfigurationRule;
+import alluxio.cli.fs.FileSystemShell;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
+import alluxio.grpc.SetAclAction;
+import alluxio.grpc.SetAclPOptions;
+import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
+import alluxio.security.authorization.AclAction;
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.AclEntryType;
+import alluxio.security.authorization.Mode;
 import alluxio.util.io.BufferUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for cp command.
  */
 public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest {
+
+  @Rule
+  public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
+      .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()),
+      ServerConfiguration.global());
 
   /**
    * Tests copying a file to a new location.
@@ -136,6 +159,86 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
         equals(new AlluxioURI("/copy/foobar2"), new AlluxioURI(testDir + "/foo/foobar2")));
     Assert.assertTrue(
         equals(new AlluxioURI("/copy/foobar3"), new AlluxioURI(testDir + "/bar/foobar3")));
+  }
+
+  /**
+   * Tests copying a file with attributes preserved.
+   */
+  @Test
+  public void copyFileWithPreservedAttributes() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    mFsShell = new FileSystemShell(conf);
+
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    AlluxioURI srcFile = new AlluxioURI(testDir + "/foobar4");
+    String owner = TEST_USER_1.getUser();
+    String group = "staff";
+    short mode = 0422;
+    List<AclEntry> entries = new ArrayList<>();
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+        .addAction(AclAction.EXECUTE).build());
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    mFileSystem.setAttribute(srcFile,
+        SetAttributePOptions.newBuilder()
+            .setOwner(owner).setGroup(group)
+            .setMode(new Mode(mode).toProto()).build());
+    mFileSystem.setAcl(srcFile, SetAclAction.MODIFY, entries);
+    int ret = mFsShell.run("cp", "-p", testDir + "/foobar4", testDir + "/bar");
+    AlluxioURI dstFile = new AlluxioURI(testDir + "/bar/foobar4");
+    Assert.assertEquals(0, ret);
+    Assert.assertTrue(mFileSystem.exists(dstFile));
+    verifyAttributes(srcFile, dstFile);
+  }
+
+  /**
+   * Tests copying a folder with attributes preserved.
+   */
+  @Test
+  public void copyDirectoryWithPreservedAttributes() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    mFsShell = new FileSystemShell(conf);
+
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    String newDir = "/copy";
+    String subDir = "/foo";
+    String file = "/foobar4";
+    String owner = TEST_USER_1.getUser();
+    String group = "staff";
+    short mode = 0422;
+    List<AclEntry> entries = new ArrayList<>();
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+        .addAction(AclAction.EXECUTE).build());
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    AlluxioURI srcDir = new AlluxioURI(testDir);
+    mFileSystem.setAttribute(srcDir,
+        SetAttributePOptions.newBuilder().setRecursive(true)
+            .setOwner(owner).setGroup(group)
+            .setMode(new Mode(mode).toProto()).build());
+    mFileSystem.setAcl(srcDir, SetAclAction.MODIFY, entries,
+        SetAclPOptions.newBuilder().setRecursive(true).build());
+    int ret = mFsShell.run("cp", "-R",  "-p", testDir, newDir);
+    AlluxioURI dstDir = new AlluxioURI(newDir);
+    Assert.assertEquals(0, ret);
+    Assert.assertTrue(mFileSystem.exists(dstDir));
+    verifyAttributes(srcDir, dstDir);
+    verifyAttributes(srcDir.join(subDir), dstDir.join(subDir));
+    verifyAttributes(srcDir.join(file), dstDir.join(file));
+  }
+
+  private void verifyAttributes(AlluxioURI src, AlluxioURI dst)
+      throws IOException, AlluxioException {
+    URIStatus srcStatus = mFileSystem.getStatus(src);
+    URIStatus dstStatus = mFileSystem.getStatus(dst);
+    Assert.assertEquals(srcStatus.getOwner(), dstStatus.getOwner());
+    Assert.assertEquals(srcStatus.getGroup(), dstStatus.getGroup());
+    Assert.assertEquals(srcStatus.getMode(), dstStatus.getMode());
+    Assert.assertEquals(srcStatus.getAcl(), dstStatus.getAcl());
   }
 
   /**


### PR DESCRIPTION
Sometimes user wants to preserve the original attributes of files and directories when using `cp` command. This change add a new `-p` option to the `cp` command to enable such functionality. Note that user will need to have the required permissions to perform the operation.

https://github.com/Alluxio/alluxio/issues/8685