### PR TITLE
Fix kerberos login for root mount

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -542,12 +542,14 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         // journaled, so the root will be re-mounted based on configuration whenever the master
         // starts.
         long rootUfsMountId = IdUtils.ROOT_MOUNT_ID;
+        ufsResource.get().connectFromMaster(
+            NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC));
         mMountTable.add(new AlluxioURI(MountTable.ROOT), new AlluxioURI(rootUfsUri), rootUfsMountId,
             MountOptions.defaults()
                 .setShared(ufsResource.get().isObjectStorage() && Configuration
                     .getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY))
                 .setProperties(rootUfsConf));
-      } catch (FileAlreadyExistsException | InvalidPathException e) {
+      } catch (FileAlreadyExistsException | InvalidPathException | IOException e) {
         throw new IllegalStateException(e);
       }
     }


### PR DESCRIPTION
#8236 

Alluxio master currently initiates login for UFS by calling `connectFromMaster` when a UFS is mounted. However, this is not called on the root mount, therefore user has to rely on `kinit` to enable Alluxio to talk to Kerberized HDFS.

This change ensures root mount also has a chance to log in the user with the credentials from Alluxio properties, which frees up user from having to use kinit and activates HDFS client relogin mechanism, so user does not have to periodically kinit to refresh the Kerberos ticket.

Note: this chance is targeted `branch-1.8`. Alluxio 2.0 has changed how root mount is added to the mount table thus might need a different fix.