### PR TITLE
Add an option to cp command to preserve file attributes (branch-1.8)

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -27,15 +27,7 @@ import alluxio.client.file.options.OpenFileOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.security.LoginUserTestUtils;
-<<<<<<< HEAD
-||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
-import alluxio.util.CommonUtils;
-import alluxio.util.WaitForOptions;
-=======
 import alluxio.security.group.GroupMappingService;
-import alluxio.util.CommonUtils;
-import alluxio.util.WaitForOptions;
->>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -27,9 +27,19 @@ import alluxio.client.file.options.OpenFileOptions;
 import alluxio.exception.AlluxioException;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.security.LoginUserTestUtils;
+<<<<<<< HEAD
+||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+=======
+import alluxio.security.group.GroupMappingService;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+>>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 
@@ -38,6 +48,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -48,6 +61,61 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
   public LocalAlluxioCluster mLocalAlluxioCluster = null;
   public FileSystem mFileSystem = null;
   public FileSystemShell mFsShell = null;
+
+  /*
+   * The user and group mappings for testing are:
+   *    alice -> alice,staff
+   *    bob   -> bob,staff
+   */
+  protected static final TestUser TEST_USER_1 =
+      new TestUser("alice", "alice,staff");
+  protected static final TestUser TEST_USER_2 =
+      new TestUser("bob", "bob,staff");
+
+  /**
+   * A simple structure to represent a user and its groups.
+   */
+  protected static final class TestUser {
+    private String mUser;
+    private String mGroup;
+
+    TestUser(String user, String group) {
+      mUser = user;
+      mGroup = group;
+    }
+
+    public String getUser() {
+      return mUser;
+    }
+
+    public String getGroup() {
+      return mGroup;
+    }
+  }
+
+  /**
+   * Test class implements {@link GroupMappingService} providing user-to-groups mapping.
+   */
+  public static class FakeUserGroupsMapping implements GroupMappingService {
+    private HashMap<String, String> mUserGroups = new HashMap<>();
+
+    /**
+     * Constructor of {@link FakeUserGroupsMapping} to put the user and groups in user-to-groups
+     * HashMap.
+     */
+    public FakeUserGroupsMapping() {
+      mUserGroups.put(TEST_USER_1.getUser(), TEST_USER_1.getGroup());
+      mUserGroups.put(TEST_USER_2.getUser(), TEST_USER_2.getGroup());
+    }
+
+    @Override
+    public List<String> getGroups(String user) throws IOException {
+      if (mUserGroups.containsKey(user)) {
+        return Lists.newArrayList(mUserGroups.get(user).split(","));
+      }
+      return new ArrayList<>();
+    }
+  }
 
   @Before
   public final void before() throws Exception {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
@@ -16,16 +16,8 @@ import alluxio.ConfigurationRule;
 import alluxio.PropertyKey;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.exception.AlluxioException;
-<<<<<<< HEAD
-import alluxio.security.group.GroupMappingService;
-||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
-import alluxio.grpc.WritePType;
-import alluxio.security.group.GroupMappingService;
-=======
-import alluxio.grpc.WritePType;
->>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.exception.AlluxioException;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;

--- a/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
@@ -17,82 +17,31 @@ import alluxio.PropertyKey;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.exception.AlluxioException;
+<<<<<<< HEAD
 import alluxio.security.group.GroupMappingService;
+||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
+import alluxio.grpc.WritePType;
+import alluxio.security.group.GroupMappingService;
+=======
+import alluxio.grpc.WritePType;
+>>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 /**
  * Tests for chown command.
  */
 public final class ChownCommandIntegrationTest extends AbstractFileSystemShellTest {
-  /*
-   * The user and group mappings for testing are:
-   *    alice -> alice,staff
-   *    bob   -> bob,staff
-   */
-  private static final TestUser TEST_USER_1 =
-      new TestUser("alice", "alice,staff");
-  private static final TestUser TEST_USER_2 =
-      new TestUser("bob", "bob,staff");
 
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()));
-
-  /**
-   * A simple structure to represent a user and its groups.
-   */
-  private static final class TestUser {
-    private String mUser;
-    private String mGroup;
-
-    TestUser(String user, String group) {
-      mUser = user;
-      mGroup = group;
-    }
-
-    String getUser() {
-      return mUser;
-    }
-
-    String getGroup() {
-      return mGroup;
-    }
-  }
-
-  /**
-   * Test class implements {@link GroupMappingService} providing user-to-groups mapping.
-   */
-  public static class FakeUserGroupsMapping implements GroupMappingService {
-    private HashMap<String, String> mUserGroups = new HashMap<>();
-
-    /**
-     * Constructor of {@link FakeUserGroupsMapping} to put the user and groups in user-to-groups
-     * HashMap.
-     */
-    public FakeUserGroupsMapping() {
-      mUserGroups.put(TEST_USER_1.getUser(), TEST_USER_1.getGroup());
-      mUserGroups.put(TEST_USER_2.getUser(), TEST_USER_2.getGroup());
-    }
-
-    @Override
-    public List<String> getGroups(String user) throws IOException {
-      if (mUserGroups.containsKey(user)) {
-        return Lists.newArrayList(mUserGroups.get(user).split(","));
-      }
-      return new ArrayList<>();
-    }
-  }
 
   @Test
   public void chown() throws IOException, AlluxioException {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -12,29 +12,71 @@
 package alluxio.client.cli.fs.command;
 
 import alluxio.AlluxioURI;
+<<<<<<< HEAD
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
+||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+=======
+import alluxio.ConfigurationRule;
+import alluxio.cli.fs.FileSystemShell;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+>>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
+<<<<<<< HEAD
 import alluxio.client.file.options.OpenFileOptions;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+||||||| parent of 0b76b474c2... Add an option to cp command to preserve file attributes
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.ReadPType;
+import alluxio.grpc.WritePType;
+=======
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.ReadPType;
+import alluxio.grpc.SetAclAction;
+import alluxio.grpc.SetAclPOptions;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.security.authorization.AclAction;
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.AclEntryType;
+import alluxio.security.authorization.Mode;
+>>>>>>> 0b76b474c2... Add an option to cp command to preserve file attributes
 import alluxio.util.io.BufferUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for cp command.
  */
 public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest {
+
+  @Rule
+  public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
+      .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()),
+      ServerConfiguration.global());
 
   /**
    * Tests copying a file to a new location.
@@ -135,6 +177,103 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
         equals(new AlluxioURI("/copy/foobar2"), new AlluxioURI(testDir + "/foo/foobar2")));
     Assert.assertTrue(
         equals(new AlluxioURI("/copy/foobar3"), new AlluxioURI(testDir + "/bar/foobar3")));
+  }
+
+  /**
+   * Tests copying a file with attributes preserved.
+   */
+  @Test
+  public void copyFileWithPreservedAttributes() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    // avoid chown on UFS since test might not be run with root
+    conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    mFsShell = new FileSystemShell(conf);
+
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    AlluxioURI srcFile = new AlluxioURI(testDir + "/foobar4");
+    String owner = TEST_USER_1.getUser();
+    String group = "staff";
+    short mode = 0422;
+    List<AclEntry> entries = new ArrayList<>();
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+        .addAction(AclAction.EXECUTE).build());
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    mFileSystem.setAttribute(srcFile,
+        SetAttributePOptions.newBuilder()
+            .setOwner(owner).setGroup(group)
+            .setMode(new Mode(mode).toProto())
+            .setPinned(true)
+            .setReplicationMin(2)
+            .setReplicationMax(4)
+            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
+            .build());
+    mFileSystem.setAcl(srcFile, SetAclAction.MODIFY, entries);
+    int ret = mFsShell.run("cp", "-p", testDir + "/foobar4", testDir + "/bar");
+    AlluxioURI dstFile = new AlluxioURI(testDir + "/bar/foobar4");
+    Assert.assertEquals(0, ret);
+    Assert.assertTrue(mFileSystem.exists(dstFile));
+    verifyPreservedAttributes(srcFile, dstFile);
+  }
+
+  /**
+   * Tests copying a folder with attributes preserved.
+   */
+  @Test
+  public void copyDirectoryWithPreservedAttributes() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    mFsShell = new FileSystemShell(conf);
+
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    String newDir = "/copy";
+    String subDir = "/foo";
+    String file = "/foobar4";
+    String owner = TEST_USER_1.getUser();
+    String group = "staff";
+    short mode = 0422;
+    List<AclEntry> entries = new ArrayList<>();
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+        .addAction(AclAction.EXECUTE).build());
+    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+    AlluxioURI srcDir = new AlluxioURI(testDir);
+    mFileSystem.setAttribute(srcDir,
+        SetAttributePOptions.newBuilder().setRecursive(true)
+            .setOwner(owner).setGroup(group)
+            .setMode(new Mode(mode).toProto())
+            .setPinned(true)
+            .setReplicationMin(2)
+            .setReplicationMax(4)
+            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
+            .build());
+    mFileSystem.setAcl(srcDir, SetAclAction.MODIFY, entries,
+        SetAclPOptions.newBuilder().setRecursive(true).build());
+    int ret = mFsShell.run("cp", "-R",  "-p", testDir, newDir);
+    AlluxioURI dstDir = new AlluxioURI(newDir);
+    Assert.assertEquals(0, ret);
+    Assert.assertTrue(mFileSystem.exists(dstDir));
+    verifyPreservedAttributes(srcDir, dstDir);
+    verifyPreservedAttributes(srcDir.join(subDir), dstDir.join(subDir));
+    verifyPreservedAttributes(srcDir.join(file), dstDir.join(file));
+  }
+
+  private void verifyPreservedAttributes(AlluxioURI src, AlluxioURI dst)
+      throws IOException, AlluxioException {
+    URIStatus srcStatus = mFileSystem.getStatus(src);
+    URIStatus dstStatus = mFileSystem.getStatus(dst);
+    Assert.assertEquals(srcStatus.getOwner(), dstStatus.getOwner());
+    Assert.assertEquals(srcStatus.getGroup(), dstStatus.getGroup());
+    Assert.assertEquals(srcStatus.getMode(), dstStatus.getMode());
+    Assert.assertEquals(srcStatus.getAcl(), dstStatus.getAcl());
+    Assert.assertNotEquals(srcStatus.getTtl(), dstStatus.getTtl());
+    if (!srcStatus.isFolder()) {
+      Assert.assertNotEquals(srcStatus.getReplicationMin(), dstStatus.getReplicationMin());
+      Assert.assertNotEquals(srcStatus.getReplicationMax(), dstStatus.getReplicationMax());
+    }
+    Assert.assertNotEquals(srcStatus.isPinned(), dstStatus.isPinned());
   }
 
   /**


### PR DESCRIPTION
#8685 
Porting of #8682 for `branch-1.8`. Support for ACL attributes preservation is removed because it does not exist in version 1.8.1