### PR TITLE
Fix authentication with kerberized HDFS

### DIFF
--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -127,9 +127,16 @@ public abstract class AbstractUfsManager implements UfsManager {
       UnderFileSystem fs = UnderFileSystem.Factory.create(ufsUri.toString(), ufsConf);
       mUnderFileSystemMap.putIfAbsent(key, fs);
       mCloser.register(fs);
+      try {
+        connectUfs(fs);
+      } catch (IOException e) {
+        LOG.warn("Failed to perform initial connect to UFS {}: {}", ufsUri, e.getMessage());
+      }
       return fs;
     }
   }
+
+  protected abstract void connectUfs(UnderFileSystem fs) throws IOException;
 
   @Override
   public void addMount(long mountId, final AlluxioURI ufsUri,

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -136,6 +136,11 @@ public abstract class AbstractUfsManager implements UfsManager {
     }
   }
 
+  /**
+   * Takes any necessary actions required to establish a connection to the under file system.
+   * The implementation will either call {@link UnderFileSystem#connectFromMaster(String)} or
+   *  {@link UnderFileSystem#connectFromWorker(String)} depending on the running process.
+   */
   protected abstract void connectUfs(UnderFileSystem fs) throws IOException;
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2775,9 +2775,6 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       try (CloseableResource<UnderFileSystem> ufsResource =
           mUfsManager.get(mountId).acquireUfsResource()) {
         UnderFileSystem ufs = ufsResource.get();
-        ufs.connectFromMaster(
-            NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
-                ServerConfiguration.global()));
         // Check that the ufsPath exists and is a directory
         if (!ufs.isDirectory(ufsPath.toString())) {
           throw new IOException(

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -154,7 +154,6 @@ import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
 import alluxio.util.interfaces.Scoped;
 import alluxio.util.io.PathUtils;
-import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;

--- a/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
+++ b/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
@@ -12,6 +12,7 @@
 package alluxio.underfs;
 
 import alluxio.AlluxioURI;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.DelegatingJournaled;
@@ -20,10 +21,12 @@ import alluxio.master.journal.Journaled;
 import alluxio.proto.journal.File;
 import alluxio.proto.journal.File.UpdateUfsModeEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.util.network.NetworkAddressUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -56,6 +59,13 @@ public final class MasterUfsManager extends AbstractUfsManager implements Delega
     mState = new State();
     mUfsRoots = new HashSet<>();
     mIdToRoot = new HashMap<>();
+  }
+
+  @Override
+  protected void connectUfs(UnderFileSystem fs) throws IOException {
+    fs.connectFromMaster(
+        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
+            ServerConfiguration.global()));
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -75,16 +75,13 @@ public final class WorkerUfsManager extends AbstractUfsManager {
             .setShared(info.getProperties().getShared())
             .createMountSpecificConf(info.getProperties().getPropertiesMap()));
     UfsClient ufsClient = super.get(mountId);
-    try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
-      UnderFileSystem ufs = ufsResource.get();
-      ufs.connectFromWorker(
-          NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC,
-              ServerConfiguration.global()));
-    } catch (IOException e) {
-      removeMount(mountId);
-      throw new UnavailableException(
-          String.format("Failed to connect to UFS %s with id %d", info.getUri(), mountId), e);
-    }
     return ufsClient;
+  }
+
+  @Override
+  protected void connectUfs(UnderFileSystem fs) throws IOException {
+    fs.connectFromWorker(
+        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC,
+            ServerConfiguration.global()));
   }
 }

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -18,7 +18,6 @@ import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.UfsInfo;
 import alluxio.master.MasterClientContext;
-import alluxio.resource.CloseableResource;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.file.FileSystemMasterClient;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -27,7 +27,6 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.IdUtils;
-import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -132,10 +132,6 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    * @param offset the position within the block to start the read
    */
   private void init(long offset) throws IOException {
-    UnderFileSystem ufs = mUfsResource.get();
-    ufs.connectFromWorker(
-        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC,
-            ServerConfiguration.global()));
     updateUnderFileSystemInputStream(offset);
     updateBlockWriter(offset);
   }

--- a/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
+++ b/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
@@ -50,6 +50,13 @@ public final class JobUfsManager extends AbstractUfsManager {
   }
 
   @Override
+  protected void connectUfs(UnderFileSystem fs) throws IOException {
+    fs.connectFromWorker(
+        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.JOB_WORKER_RPC,
+            ServerConfiguration.global()));
+  }
+
+  @Override
   public UfsClient get(long mountId) throws NotFoundException, UnavailableException {
     try {
       return super.get(mountId);


### PR DESCRIPTION
#8236

Alluxio master currently initiates login for UFS by calling connectFromMaster when a UFS is mounted through commandline. However, this is not called when root ufs is mounted or when nested ufs is remounted on restart, therefore user has to rely on kinit to enable Alluxio to talk to Kerberized HDFS.

This change ensures before connecting to a UFS, it always logs in the user with the credentials from Alluxio properties, which frees up user from having to use kinit and activates HDFS client relogin mechanism, so user does not have to periodically kinit to refresh the Kerberos ticket.