### PR TITLE
Supply the name of variable to Preconditions.checkNotNull

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
@@ -108,7 +108,7 @@ public final class JobCoordinator {
       FileSystemContext fsContext, UfsManager ufsManager,
       List<WorkerInfo> workerInfoList, Long jobId, JobConfig jobConfig,
       Function<JobInfo, Void> statusChangeCallback) throws JobDoesNotExistException {
-    Preconditions.checkNotNull(commandManager);
+    Preconditions.checkNotNull(commandManager, "commandManager");
     JobCoordinator jobCoordinator = new JobCoordinator(commandManager, filesystem, fsContext,
         ufsManager, workerInfoList, jobId, jobConfig, statusChangeCallback);
     jobCoordinator.start();


### PR DESCRIPTION
[SMALLFIX] Supply the name of variable to Preconditions.checkNotNull in /alluxio/job/server/src/main/java/alluxio/master/job/JobCoordinator.java line111