### PR TITLE
Add "pathConf show" command

### DIFF
--- a/core/common/src/main/java/alluxio/conf/AlluxioConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioConfiguration.java
@@ -82,6 +82,11 @@ public interface AlluxioConfiguration {
   Set<PropertyKey> keySet();
 
   /**
+   * @return the keys set by user
+   */
+  Set<PropertyKey> userKeySet();
+
+  /**
    * Gets the integer representation of the value for the given key.
    *
    * @param key the key to get the value for

--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -199,14 +200,14 @@ public class AlluxioProperties {
   public Set<PropertyKey> keySet() {
     Set<PropertyKey> keySet = new HashSet<>(PropertyKey.defaultKeys());
     keySet.addAll(mUserProps.keySet());
-    return keySet;
+    return Collections.unmodifiableSet(keySet);
   }
 
   /**
    * @return the key set of user set properties
    */
   public Set<PropertyKey> userKeySet() {
-    return new HashSet<>(mUserProps.keySet());
+    return Collections.unmodifiableSet(mUserProps.keySet());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -203,6 +203,13 @@ public class AlluxioProperties {
   }
 
   /**
+   * @return the key set of user set properties
+   */
+  public Set<PropertyKey> userKeySet() {
+    return new HashSet<>(mUserProps.keySet());
+  }
+
+  /**
    * Iterates over all the key value pairs and performs the given action.
    *
    * @param action the operation to perform on each key value pair

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -193,6 +193,11 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   }
 
   @Override
+  public Set<PropertyKey> userKeySet() {
+    return mProperties.userKeySet();
+  }
+
+  @Override
   public int getInt(PropertyKey key) {
     String rawValue = get(key);
 

--- a/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
@@ -40,7 +40,7 @@ public interface PathConfiguration {
    * @param path the Alluxio path
    * @return all property keys in the path level configuration that is applicable to path
    */
-  Set<PropertyKey> getAllPropertyKeys(AlluxioURI path);
+  Set<PropertyKey> getPropertyKeys(AlluxioURI path);
 
   /**
    * Factory method to create an implementation of {@link PathConfiguration}.

--- a/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -33,4 +34,14 @@ public interface PathConfiguration {
    * @return the chosen configuration matching the path and containing the key
    */
   Optional<AlluxioConfiguration> getConfiguration(AlluxioURI path, PropertyKey key);
+
+  /**
+   * Factory method to create an implementation of {@link PathConfiguration}.
+   *
+   * @param pathConf the map from paths to path level configurations
+   * @return the implementation of {@link PathConfiguration}
+   */
+  static PathConfiguration create(Map<String, AlluxioConfiguration> pathConf) {
+    return new PrefixPathConfiguration(pathConf);
+  }
 }

--- a/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PathConfiguration.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Path level configuration.
@@ -34,6 +35,12 @@ public interface PathConfiguration {
    * @return the chosen configuration matching the path and containing the key
    */
   Optional<AlluxioConfiguration> getConfiguration(AlluxioURI path, PropertyKey key);
+
+  /**
+   * @param path the Alluxio path
+   * @return all property keys in the path level configuration that is applicable to path
+   */
+  Set<PropertyKey> getAllPropertyKeys(AlluxioURI path);
 
   /**
    * Factory method to create an implementation of {@link PathConfiguration}.

--- a/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
@@ -81,9 +81,8 @@ public final class PrefixPathConfiguration implements PathConfiguration {
   @Override
   public Set<PropertyKey> getAllPropertyKeys(AlluxioURI path) {
     Set<PropertyKey> keys = new HashSet<>();
-    mMatcher.match(path).ifPresent(patterns ->
-      patterns.forEach(pattern ->
-          keys.addAll(mConf.get(pattern).userKeySet())));
+    mMatcher.match(path).ifPresent(patterns -> patterns.forEach(pattern ->
+        keys.addAll(mConf.get(pattern).userKeySet())));
     return keys;
   }
 }

--- a/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
@@ -79,7 +79,7 @@ public final class PrefixPathConfiguration implements PathConfiguration {
    * @return all property keys applicable to path including ancestor paths' configurations
    */
   @Override
-  public Set<PropertyKey> getAllPropertyKeys(AlluxioURI path) {
+  public Set<PropertyKey> getPropertyKeys(AlluxioURI path) {
     Set<PropertyKey> keys = new HashSet<>();
     mMatcher.match(path).ifPresent(patterns -> patterns.forEach(pattern ->
         keys.addAll(mConf.get(pattern).userKeySet())));

--- a/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
@@ -16,9 +16,11 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -70,5 +72,18 @@ public final class PrefixPathConfiguration implements PathConfiguration {
       }
     }
     return Optional.empty();
+  }
+
+  /**
+   * @param path the Alluxio path
+   * @return all property keys applicable to path including ancestor paths' configurations
+   */
+  @Override
+  public Set<PropertyKey> getAllPropertyKeys(AlluxioURI path) {
+    Set<PropertyKey> keys = new HashSet<>();
+    mMatcher.match(path).ifPresent(patterns ->
+      patterns.forEach(pattern ->
+          keys.addAll(mConf.get(pattern).userKeySet())));
+    return keys;
   }
 }

--- a/core/common/src/main/java/alluxio/conf/path/SpecificPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/SpecificPathConfiguration.java
@@ -95,7 +95,7 @@ public final class SpecificPathConfiguration implements AlluxioConfiguration {
 
   @Override
   public Set<PropertyKey> userKeySet() {
-    return mPathConf.getAllPropertyKeys(mPath);
+    return mPathConf.getPropertyKeys(mPath);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/conf/path/SpecificPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/SpecificPathConfiguration.java
@@ -94,6 +94,11 @@ public final class SpecificPathConfiguration implements AlluxioConfiguration {
   }
 
   @Override
+  public Set<PropertyKey> userKeySet() {
+    return mPathConf.getAllPropertyKeys(mPath);
+  }
+
+  @Override
   public int getInt(PropertyKey key) {
     return conf(key).getInt(key);
   }

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -23,7 +23,6 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.conf.path.PathConfiguration;
-import alluxio.conf.path.PrefixPathConfiguration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
@@ -582,7 +581,7 @@ public final class ConfigurationUtils {
       pathConfs.put(path, new InstancedConfiguration(properties, true));
     });
     LOG.info("Alluxio client has loaded path level configurations");
-    return new PrefixPathConfiguration(pathConfs);
+    return PathConfiguration.create(pathConfs);
   }
 
   private static boolean shouldLoadClusterConfiguration(AlluxioConfiguration conf) {

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
@@ -14,11 +14,13 @@ package alluxio.cli.fsadmin.command;
 import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.cli.fsadmin.pathconf.ListCommand;
+import alluxio.cli.fsadmin.pathconf.ShowCommand;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,6 +36,7 @@ public final class PathConfCommand extends AbstractFsAdminCommand {
 
   static {
     SUB_COMMANDS.put("list", ListCommand::new);
+    SUB_COMMANDS.put("show", ShowCommand::new);
   }
 
   private Context mContext;
@@ -57,6 +60,15 @@ public final class PathConfCommand extends AbstractFsAdminCommand {
   @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
     CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+  }
+
+  @Override
+  public Options getOptions() {
+    Options options = new Options();
+    SUB_COMMANDS.forEach((cmd, constructor) ->
+        constructor.apply(mContext, mConf).getOptions().getOptions().forEach(
+            option -> options.addOption(option)));
+    return options;
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
@@ -40,8 +40,8 @@ import java.util.Map;
  *
  * <p>
  * It has two modes:
- * 1. only show configurations for the specific path;
- * 2. show all configurations applicable to the path.
+ * 1. without option "--all", only show configurations for the specific path;
+ * 2. with option "--all", show all configurations applicable to the path.
  * <p>
  * For example, suppose there are two path level configurations:
  * /a: property1=value1
@@ -62,7 +62,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
           .build();
 
   /**
-   * @param context     fsadmin command context
+   * @param context fsadmin command context
    * @param alluxioConf Alluxio configuration
    */
   public ShowCommand(Context context, AlluxioConfiguration alluxioConf) {
@@ -76,8 +76,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
 
   @Override
   public Options getOptions() {
-    return new Options()
-        .addOption(ALL_OPTION);
+    return new Options().addOption(ALL_OPTION);
   }
 
   @Override
@@ -108,7 +107,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
       PathConfiguration pathConf = PathConfiguration.create(pathConfMap);
 
       AlluxioURI targetUri = new AlluxioURI(targetPath);
-      List<PropertyKey> propertyKeys = new ArrayList<>(pathConf.getAllPropertyKeys(targetUri));
+      List<PropertyKey> propertyKeys = new ArrayList<>(pathConf.getPropertyKeys(targetUri));
       propertyKeys.sort(Comparator.comparing(PropertyKey::getName));
       propertyKeys.forEach(key -> {
         pathConf.getConfiguration(targetUri, key).ifPresent(conf -> {

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
@@ -32,10 +32,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Show path level configurations.
@@ -97,14 +95,12 @@ public final class ShowCommand extends AbstractFsAdminCommand {
     Configuration configuration = mMetaConfigClient.getConfiguration();
 
     if (cl.hasOption(ALL_OPTION_NAME)) {
-      Set<PropertyKey> pathPropertyKeys = new HashSet<>();
       Map<String, AlluxioConfiguration> pathConfMap = new HashMap<>();
 
       configuration.getPathConf().forEach((path, conf) -> {
         AlluxioProperties properties = new AlluxioProperties();
         conf.forEach(property -> {
           PropertyKey key = PropertyKey.fromString(property.getName());
-          pathPropertyKeys.add(key);
           properties.set(key, property.getValue());
         });
         pathConfMap.put(path, new InstancedConfiguration(properties));
@@ -112,7 +108,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
       PathConfiguration pathConf = PathConfiguration.create(pathConfMap);
 
       AlluxioURI targetUri = new AlluxioURI(targetPath);
-      List<PropertyKey> propertyKeys = new ArrayList<>(pathPropertyKeys);
+      List<PropertyKey> propertyKeys = new ArrayList<>(pathConf.getAllPropertyKeys(targetUri));
       propertyKeys.sort(Comparator.comparing(PropertyKey::getName));
       propertyKeys.forEach(key -> {
         pathConf.getConfiguration(targetUri, key).ifPresent(conf -> {
@@ -132,8 +128,8 @@ public final class ShowCommand extends AbstractFsAdminCommand {
 
   @Override
   public String getUsage() {
-    return String.format("show [--%s] <path>\n"
-        + "\t--%s: %s\n",
+    return String.format("show [--%s] <path>%n"
+        + "\t--%s: %s%n",
         ALL_OPTION_NAME,
         ALL_OPTION_NAME, ALL_OPTION.getDescription());
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
@@ -1,0 +1,143 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.fsadmin.pathconf;
+
+import alluxio.AlluxioURI;
+import alluxio.cli.CommandUtils;
+import alluxio.cli.fsadmin.command.AbstractFsAdminCommand;
+import alluxio.cli.fsadmin.command.Context;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.path.PathConfiguration;
+import alluxio.exception.status.InvalidArgumentException;
+import alluxio.wire.Configuration;
+import alluxio.wire.Property;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Show path level configurations.
+ *
+ * <p>
+ * It has two modes:
+ * 1. only show configurations for the specific path;
+ * 2. show all configurations applicable to the path.
+ * <p>
+ * For example, suppose there are two path level configurations:
+ * /a: property1=value1
+ * /a/b: property2=value2
+ * Then in mode 1, only property2=value2 will be shown for /a/b,
+ * but in mode 2, since /a is the prefix of /a/b, both properties will be shown for /a/b.
+ */
+public final class ShowCommand extends AbstractFsAdminCommand {
+  public static final String RESOLVE_OPTION_NAME = "resolve";
+
+  private static final Option RESOLVE_OPTION =
+      Option.builder()
+          .longOpt(RESOLVE_OPTION_NAME)
+          .required(false)
+          .hasArg(false)
+          .desc("Whether to show all path level configurations applicable to the path")
+          .build();
+
+  /**
+   * @param context     fsadmin command context
+   * @param alluxioConf Alluxio configuration
+   */
+  public ShowCommand(Context context, AlluxioConfiguration alluxioConf) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "show";
+  }
+
+  @Override
+  public Options getOptions() {
+    return new Options()
+        .addOption(RESOLVE_OPTION);
+  }
+
+  @Override
+  public void validateArgs(CommandLine cl) throws InvalidArgumentException {
+    CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+  }
+
+  private String format(String key, String value) {
+    return key + " = " + value;
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    String targetPath = cl.getArgs()[1];
+    Configuration configuration = mMetaConfigClient.getConfiguration();
+
+    if (cl.hasOption(RESOLVE_OPTION_NAME)) {
+      Set<PropertyKey> pathPropertyKeys = new HashSet<>();
+      Map<String, AlluxioConfiguration> pathConfMap = new HashMap<>();
+
+      configuration.getPathConf().forEach((path, conf) -> {
+        AlluxioProperties properties = new AlluxioProperties();
+        conf.forEach(property -> {
+          pathPropertyKeys.add(PropertyKey.fromString(property.getName()));
+          properties.set(PropertyKey.fromString(property.getName()),
+              property.getValue());
+        });
+        pathConfMap.put(path, new InstancedConfiguration(properties));
+      });
+      PathConfiguration pathConf = PathConfiguration.create(pathConfMap);
+
+      AlluxioURI targetUri = new AlluxioURI(targetPath);
+      List<PropertyKey> propertyKeys = new ArrayList<>(pathPropertyKeys);
+      propertyKeys.sort(Comparator.comparing(PropertyKey::getName));
+      propertyKeys.forEach(key -> {
+        pathConf.getConfiguration(targetUri, key).ifPresent(conf -> {
+          mPrintStream.println(format(key.getName(), conf.get(key)));
+        });
+      });
+    } else {
+      if (configuration.getPathConf().containsKey(targetPath)) {
+        List<Property> properties = configuration.getPathConf().get(targetPath);
+        properties.sort(Comparator.comparing(Property::getName));
+        properties.forEach(property -> {
+          mPrintStream.println(format(property.getName(), property.getValue()));
+        });
+      }
+    }
+    mPrintStream.close();
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return "show [--" + RESOLVE_OPTION_NAME + "] <path>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Shows path level configurations.";
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
@@ -113,7 +113,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
   @Test
   public void showResolveDir0() throws Exception {
     try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
-      int ret = shell.run("pathConf", "show", "--resolve", DIR0);
+      int ret = shell.run("pathConf", "show", "--all", DIR0);
       Assert.assertEquals(0, ret);
       String output = mOutput.toString();
       Assert.assertEquals("", output);
@@ -123,7 +123,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
   @Test
   public void showResolveDir1() throws Exception {
     try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
-      int ret = shell.run("pathConf", "show", "--resolve", DIR1);
+      int ret = shell.run("pathConf", "show", "--all", DIR1);
       Assert.assertEquals(0, ret);
       String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
           + format(PROPERTY_KEY12, PROPERTY_VALUE12) + "\n";
@@ -135,7 +135,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
   @Test
   public void showResolveDir2() throws Exception {
     try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
-      int ret = shell.run("pathConf", "show", "--resolve", DIR2);
+      int ret = shell.run("pathConf", "show", "--all", DIR2);
       Assert.assertEquals(0, ret);
       String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
           + format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";
@@ -147,7 +147,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
   @Test
   public void showResolveDir3() throws Exception {
     try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
-      int ret = shell.run("pathConf", "show", "--resolve", DIR3);
+      int ret = shell.run("pathConf", "show", "--all", DIR3);
       Assert.assertEquals(0, ret);
       String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
           + format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
@@ -1,0 +1,158 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fsadmin.pathconf;
+
+import alluxio.cli.fsadmin.FileSystemAdminShell;
+import alluxio.client.ReadType;
+import alluxio.client.WriteType;
+import alluxio.client.cli.fs.AbstractShellIntegrationTest;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.meta.MetaMasterConfigClient;
+import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.master.MasterClientContext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Tests for pathConf show command.
+ */
+public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
+  private static final String DIR0 = "/a";
+  private static final String DIR1 = "/a/b/";
+  private static final PropertyKey PROPERTY_KEY11 = PropertyKey.USER_FILE_READ_TYPE_DEFAULT;
+  private static final String PROPERTY_VALUE11 = ReadType.NO_CACHE.toString();
+  private static final PropertyKey PROPERTY_KEY12 = PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT;
+  private static final String PROPERTY_VALUE12 = WriteType.MUST_CACHE.toString();
+  private static final String DIR2 = "/a/b/c/";
+  private static final PropertyKey PROPERTY_KEY2 = PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT;
+  private static final String PROPERTY_VALUE2 = WriteType.THROUGH.toString();
+  private static final String DIR3 = "/a/b/c/d";
+
+  /**
+   * Sets path level configurations through meta master client, and update client configurations
+   * from meta master afterwards.
+   *
+   * @return the configuration after updating from meta master
+   */
+  private InstancedConfiguration setPathConfigurations() throws Exception {
+    FileSystemContext metaCtx = FileSystemContext.create(ServerConfiguration.global());
+    MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
+        MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
+    client.setPathConfiguration(DIR1, PROPERTY_KEY11, PROPERTY_VALUE11);
+    client.setPathConfiguration(DIR1, PROPERTY_KEY12, PROPERTY_VALUE12);
+    client.setPathConfiguration(DIR2, PROPERTY_KEY2, PROPERTY_VALUE2);
+    InetSocketAddress address = mLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
+        .getAddress();
+    FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
+    fsCtx.getClientContext().updateConfigurationDefaults(address);
+    return (InstancedConfiguration) fsCtx.getConf();
+  }
+
+  private String format(PropertyKey key, String value) {
+    return key.getName() + " = " + value;
+  }
+
+  @Test
+  public void showDir0() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", DIR0);
+      Assert.assertEquals(0, ret);
+      String output = mOutput.toString();
+      Assert.assertEquals("", output);
+    }
+  }
+
+  @Test
+  public void showDir1() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", DIR1);
+      Assert.assertEquals(0, ret);
+      String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
+          + format(PROPERTY_KEY12, PROPERTY_VALUE12) + "\n";
+      String output = mOutput.toString();
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void showDir2() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", DIR2);
+      Assert.assertEquals(0, ret);
+      String expected = format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";
+      String output = mOutput.toString();
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void showDir3() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", DIR3);
+      Assert.assertEquals(0, ret);
+      String output = mOutput.toString();
+      Assert.assertEquals("", output);
+    }
+  }
+
+  @Test
+  public void showResolveDir0() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", "--resolve", DIR0);
+      Assert.assertEquals(0, ret);
+      String output = mOutput.toString();
+      Assert.assertEquals("", output);
+    }
+  }
+
+  @Test
+  public void showResolveDir1() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", "--resolve", DIR1);
+      Assert.assertEquals(0, ret);
+      String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
+          + format(PROPERTY_KEY12, PROPERTY_VALUE12) + "\n";
+      String output = mOutput.toString();
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void showResolveDir2() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", "--resolve", DIR2);
+      Assert.assertEquals(0, ret);
+      String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
+          + format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";
+      String output = mOutput.toString();
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void showResolveDir3() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(setPathConfigurations())) {
+      int ret = shell.run("pathConf", "show", "--resolve", DIR3);
+      Assert.assertEquals(0, ret);
+      String expected = format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n"
+          + format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";
+      String output = mOutput.toString();
+      Assert.assertEquals(expected, output);
+    }
+  }
+}


### PR DESCRIPTION
Adds "pathConf show" to show path level configurations.

It has two modes:
1. only show configurations for the specific path;
2. show all configurations applicable to the path.

For example, suppose there are two path level configurations:
/a: property1=value1
/a/b: property2=value2
Then in mode 1, only property2=value2 will be shown for /a/b,
but in mode 2, since /a is the prefix of /a/b, both properties will be shown for /a/b.