### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
@@ -11,7 +11,9 @@
 
 package alluxio.util.io;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -35,7 +37,7 @@ public final class BufferUtilsTest {
       buf.put(i);
     }
     ByteBuffer bufClone = BufferUtils.cloneByteBuffer(buf);
-    Assert.assertEquals(buf, bufClone);
+    assertEquals(buf, bufClone);
   }
 
   /**
@@ -54,9 +56,9 @@ public final class BufferUtilsTest {
       bufList.add(buf);
     }
     List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufList);
-    Assert.assertEquals(listLength, bufListClone.size());
+    assertEquals(listLength, bufListClone.size());
     for (int k = 0; k < listLength; k++) {
-      Assert.assertEquals(bufList.get(k), bufListClone.get(k));
+      assertEquals(bufList.get(k), bufListClone.get(k));
     }
   }
 
@@ -72,7 +74,7 @@ public final class BufferUtilsTest {
       bufDirect.put(i);
     }
     ByteBuffer bufClone = BufferUtils.cloneByteBuffer(bufDirect);
-    Assert.assertEquals(bufDirect, bufClone);
+    assertEquals(bufDirect, bufClone);
   }
 
   /**
@@ -92,9 +94,9 @@ public final class BufferUtilsTest {
       bufDirectList.add(bufDirect);
     }
     List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufDirectList);
-    Assert.assertEquals(listLength, bufListClone.size());
+    assertEquals(listLength, bufListClone.size());
     for (int k = 0; k < listLength; k++) {
-      Assert.assertEquals(bufDirectList.get(k), bufListClone.get(k));
+      assertEquals(bufDirectList.get(k), bufListClone.get(k));
     }
   }
 
@@ -123,7 +125,7 @@ public final class BufferUtilsTest {
     for (TestCase testCase : testCases) {
       ByteBuffer buf = ByteBuffer.allocate(1);
       BufferUtils.putIntByteBuffer(buf, testCase.mInput);
-      Assert.assertEquals(testCase.mExpected, buf.get(0));
+      assertEquals(testCase.mExpected, buf.get(0));
     }
   }
 
@@ -154,9 +156,9 @@ public final class BufferUtilsTest {
 
     for (TestCase testCase : testCases) {
       byte[] result = BufferUtils.getIncreasingByteArray(testCase.mStart, testCase.mLength);
-      Assert.assertEquals(testCase.mExpected.length, result.length);
+      assertEquals(testCase.mExpected.length, result.length);
       for (int k = 0; k < result.length; k++) {
-        Assert.assertEquals(testCase.mExpected[k], result[k]);
+        assertEquals(testCase.mExpected[k], result[k]);
       }
     }
   }
@@ -200,7 +202,7 @@ public final class BufferUtilsTest {
     for (TestCase testCase : testCases) {
       boolean result = BufferUtils.equalIncreasingByteArray(testCase.mStart, testCase.mLength,
           testCase.mArray);
-      Assert.assertEquals(testCase.mExpected, result);
+      assertEquals(testCase.mExpected, result);
     }
   }
 
@@ -231,9 +233,9 @@ public final class BufferUtilsTest {
 
     for (TestCase testCase : testCases) {
       ByteBuffer result = BufferUtils.getIncreasingByteBuffer(testCase.mStart, testCase.mLength);
-      Assert.assertEquals(testCase.mExpected.capacity(), result.capacity());
+      assertEquals(testCase.mExpected.capacity(), result.capacity());
       for (int k = 0; k < result.capacity(); k++) {
-        Assert.assertEquals(testCase.mExpected.get(k), result.get(k));
+        assertEquals(testCase.mExpected.get(k), result.get(k));
       }
     }
   }
@@ -277,7 +279,7 @@ public final class BufferUtilsTest {
     for (TestCase testCase : testCases) {
       boolean result = BufferUtils.equalIncreasingByteBuffer(testCase.mStart, testCase.mLength,
           testCase.mBuffer);
-      Assert.assertEquals(testCase.mExpected, result);
+      assertEquals(testCase.mExpected, result);
     }
   }
 
@@ -301,7 +303,7 @@ public final class BufferUtilsTest {
         BufferUtils.cleanDirectBuffer(buf);
       }
     } catch (OutOfMemoryError ooe) {
-      Assert.fail("cleanDirectBuffer is causing memory leak." + ooe.getMessage());
+      fail("cleanDirectBuffer is causing memory leak." + ooe.getMessage());
     }
   }
 
@@ -316,22 +318,22 @@ public final class BufferUtilsTest {
     for (int slicePosition : new int[] {0, 1, size / 2, size - 1}) {
       // Slice a ByteBuffer of length 1
       ByteBuffer slicedBuffer = BufferUtils.sliceByteBuffer(buf, slicePosition, 1);
-      Assert.assertEquals(0, slicedBuffer.position());
-      Assert.assertEquals(1, slicedBuffer.limit());
-      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, 1, slicedBuffer));
+      assertEquals(0, slicedBuffer.position());
+      assertEquals(1, slicedBuffer.limit());
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, 1, slicedBuffer));
 
       // Slice a ByteBuffer from the target position to the end
       int slicedBufferLength = size - slicePosition;
       ByteBuffer slicedBuffer1 = BufferUtils.sliceByteBuffer(buf, slicePosition,
           slicedBufferLength);
       ByteBuffer slicedBuffer2 = BufferUtils.sliceByteBuffer(buf, slicePosition);
-      Assert.assertEquals(0, slicedBuffer1.position());
-      Assert.assertEquals(0, slicedBuffer2.position());
-      Assert.assertEquals(slicedBufferLength, slicedBuffer1.limit());
-      Assert.assertEquals(slicedBufferLength, slicedBuffer2.limit());
-      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, slicedBufferLength,
+      assertEquals(0, slicedBuffer1.position());
+      assertEquals(0, slicedBuffer2.position());
+      assertEquals(slicedBufferLength, slicedBuffer1.limit());
+      assertEquals(slicedBufferLength, slicedBuffer2.limit());
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, slicedBufferLength,
           slicedBuffer1));
-      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, slicedBufferLength,
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(slicePosition, slicedBufferLength,
           slicedBuffer2));
     }
   }

--- a/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
@@ -14,6 +14,7 @@ package alluxio.util.io;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import org.junit.Test;
 
 import java.nio.ByteBuffer;


### PR DESCRIPTION
Change

    import org.junit.Assert;
to

    import static org.junit.Assert.assertEquals;
    import static org.junit.Assert.assertTrue;
    import static org.junit.Assert.fail;
AND

Update all

    Assert.{{ method }}*
to

    {{ method }}*