### PR TITLE
Fix authentication with kerberized HDFS

### DIFF
--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -127,9 +127,21 @@ public abstract class AbstractUfsManager implements UfsManager {
       UnderFileSystem fs = UnderFileSystem.Factory.create(ufsUri.toString(), ufsConf);
       mUnderFileSystemMap.putIfAbsent(key, fs);
       mCloser.register(fs);
+      try {
+        connectUfs(fs);
+      } catch (IOException e) {
+        LOG.warn("Failed to perform initial connect to UFS {}: {}", ufsUri, e.getMessage());
+      }
       return fs;
     }
   }
+
+  /**
+   * Takes any necessary actions required to establish a connection to the under file system.
+   * The implementation will either call {@link UnderFileSystem#connectFromMaster(String)} or
+   *  {@link UnderFileSystem#connectFromWorker(String)} depending on the running process.
+   */
+  protected abstract void connectUfs(UnderFileSystem fs) throws IOException;
 
   @Override
   public void addMount(long mountId, final AlluxioURI ufsUri,

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -126,7 +126,6 @@ import alluxio.util.SecurityUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
 import alluxio.util.io.PathUtils;
-import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.CommonOptions;
@@ -3000,8 +2999,6 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         try (CloseableResource<UnderFileSystem> ufsResource =
             mUfsManager.get(mountId).acquireUfsResource()) {
           UnderFileSystem ufs = ufsResource.get();
-          ufs.connectFromMaster(
-              NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC));
           // Check that the ufsPath exists and is a directory
           if (!ufs.isDirectory(ufsPath.toString())) {
             throw new IOException(

--- a/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
+++ b/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
@@ -20,10 +20,12 @@ import alluxio.proto.journal.File.UfsMode;
 import alluxio.proto.journal.File.UpdateUfsModeEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.resource.CloseableResource;
+import alluxio.util.network.NetworkAddressUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -102,6 +104,11 @@ public final class MasterUfsManager extends AbstractUfsManager implements Journa
    * Constructs the instance of {@link MasterUfsManager}.
    */
   public MasterUfsManager() {}
+
+  protected void connectUfs(UnderFileSystem fs) throws IOException {
+    fs.connectFromMaster(
+        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC));
+  }
 
   @Override
   public void addMount(long mountId, final AlluxioURI ufsUri,

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterClientConfig;
-import alluxio.resource.CloseableResource;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.file.FileSystemMasterClient;
 
@@ -70,15 +69,12 @@ public final class WorkerUfsManager extends AbstractUfsManager {
             .setShared(info.getProperties().isShared())
             .setUserSpecifiedConf(info.getProperties().getProperties()));
     UfsClient ufsClient = super.get(mountId);
-    try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
-      UnderFileSystem ufs = ufsResource.get();
-      ufs.connectFromWorker(
-          NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));
-    } catch (IOException e) {
-      removeMount(mountId);
-      throw new UnavailableException(
-          String.format("Failed to connect to UFS %s with id %d", info.getUri(), mountId), e);
-    }
     return ufsClient;
+  }
+
+  @Override
+  protected void connectUfs(UnderFileSystem fs) throws IOException {
+    fs.connectFromWorker(
+        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -27,7 +27,6 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.IdUtils;
-import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
@@ -132,9 +131,6 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    * @param offset the position within the block to start the read
    */
   private void init(long offset) throws IOException {
-    UnderFileSystem ufs = mUfsResource.get();
-    ufs.connectFromWorker(
-        NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC));
     updateUnderFileSystemInputStream(offset);
     updateBlockWriter(offset);
   }


### PR DESCRIPTION
This is to cherry pick the fix to branch-1.8

Alluxio master currently initiates login for UFS by calling
connectFromMaster when a UFS is mounted through commandline. However,
this is not called when root ufs is mounted or when nested ufs is
remounted on restart, therefore user has to rely on kinit to enable
Alluxio to talk to Kerberized HDFS.

This change ensures before connecting to a UFS, it always logs in the
user with the credentials from Alluxio properties, which frees up user
from having to use kinit and activates HDFS client relogin mechanism, so
user does not have to periodically kinit to refresh the Kerberos ticket.

pr-link: Alluxio/alluxio#8747
change-id: cid-14a889ec58bfd6e4cab8c35fc2e637ea68bbf252