### PR TITLE
[SMALLFIX]Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/util/UnderFileSystemUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/UnderFileSystemUtilsTest.java
@@ -13,22 +13,22 @@ package alluxio.util;
 
 import alluxio.AlluxioURI;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public final class UnderFileSystemUtilsTest {
 
   @Test
   public void getBucketName() throws Exception {
-    Assert.assertEquals("s3-bucket-name",
+    assertEquals("s3-bucket-name",
         UnderFileSystemUtils.getBucketName(new AlluxioURI("s3://s3-bucket-name/")));
-    Assert.assertEquals("s3a_bucket_name",
+    assertEquals("s3a_bucket_name",
         UnderFileSystemUtils.getBucketName(new AlluxioURI("s3a://s3a_bucket_name/")));
-    Assert.assertEquals("a.b.c",
+    assertEquals("a.b.c",
         UnderFileSystemUtils.getBucketName(new AlluxioURI("gs://a.b.c/folder/sub-folder/")));
-    Assert.assertEquals("container&",
+    assertEquals("container&",
         UnderFileSystemUtils.getBucketName(new AlluxioURI("swift://container&/folder/file")));
-    Assert.assertEquals("oss",
+    assertEquals("oss",
         UnderFileSystemUtils.getBucketName(new AlluxioURI("oss://oss/folder/.file")));
   }
 }

--- a/core/common/src/test/java/alluxio/util/UnderFileSystemUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/UnderFileSystemUtilsTest.java
@@ -11,9 +11,10 @@
 
 package alluxio.util;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.AlluxioURI;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public final class UnderFileSystemUtilsTest {


### PR DESCRIPTION
[SMALLFIX]Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/util/UnderFileSystemUtilsTest.java