### PR TITLE
[SMALLFIX] Use the @Nullable annotation for method filterInvalidPaths

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * This class forwards all calls to the {@link UnderFileSystem} interface to an internal
@@ -591,6 +592,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
     });
   }
 
+  @Nullable
   private UfsStatus[] filterInvalidPaths(UfsStatus[] statuses, String listedPath) {
     // This is a temporary fix to prevent us from choking on paths containing '?'.
     if (statuses == null) {


### PR DESCRIPTION
Use the @Nullable annotation for method filterInvalidPaths