### PR TITLE
[SMALLFIX]Replace collections.sort() with list.sort

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRFUEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRFUEvictor.java
@@ -141,7 +141,7 @@ public final class LRFUEvictor extends AbstractEvictor {
    */
   private List<Map.Entry<Long, Double>> getSortedCRF() {
     List<Map.Entry<Long, Double>> sortedCRF = new ArrayList<>(mBlockIdToCRFValue.entrySet());
-    Collections.sort(sortedCRF, new Comparator<Map.Entry<Long, Double>>() {
+    sortedCRF.sort(new Comparator<Map.Entry<Long, Double>>() {
       @Override
       public int compare(Entry<Long, Double> o1, Entry<Long, Double> o2) {
         return Double.compare(o1.getValue(), o2.getValue());


### PR DESCRIPTION
Change

    Collections.sort(sortedCRF, Comparator.comparingDouble(Entry::getValue));
to

    sortedCRF.sort(Comparator.comparingDouble(Entry::getValue));