### PR TITLE
[SMALLFIX] Use static imports for test utilities

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/evictor/LRUEvictorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/evictor/LRUEvictorTest.java
@@ -11,13 +11,16 @@
 
 package alluxio.worker.block.evictor;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
 import alluxio.conf.ServerConfiguration;
 import alluxio.worker.block.BlockStoreEventListener;
 import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,11 +72,11 @@ public class LRUEvictorTest extends EvictorTestBase {
     for (int i = nDir - 1; i >= 0; i--) {
       EvictionPlan plan =
           mEvictor.freeSpaceWithView(bottomTierDirCapacity[0], anyDirInBottomTier, mManagerView);
-      Assert.assertNotNull(plan);
-      Assert.assertTrue(plan.toMove().isEmpty());
-      Assert.assertEquals(1, plan.toEvict().size());
+      assertNotNull(plan);
+      assertTrue(plan.toMove().isEmpty());
+      assertEquals(1, plan.toEvict().size());
       long toEvictBlockId = plan.toEvict().get(0).getFirst();
-      Assert.assertEquals(BLOCK_ID + i, toEvictBlockId);
+      assertEquals(BLOCK_ID + i, toEvictBlockId);
 
       access(toEvictBlockId);
     }
@@ -100,11 +103,11 @@ public class LRUEvictorTest extends EvictorTestBase {
     for (int i = 0; i < nDir; i++) {
       EvictionPlan plan =
           mEvictor.freeSpaceWithView(smallestCapacity, anyDirInFirstTier, mManagerView);
-      Assert.assertTrue(EvictorTestUtils.validCascadingPlan(smallestCapacity, plan, mMetaManager));
-      Assert.assertEquals(0, plan.toEvict().size());
-      Assert.assertEquals(1, plan.toMove().size());
+      assertTrue(EvictorTestUtils.validCascadingPlan(smallestCapacity, plan, mMetaManager));
+      assertEquals(0, plan.toEvict().size());
+      assertEquals(1, plan.toMove().size());
       long blockId = plan.toMove().get(0).getBlockId();
-      Assert.assertEquals(BLOCK_ID + i, blockId);
+      assertEquals(BLOCK_ID + i, blockId);
 
       access(blockId);
     }
@@ -136,16 +139,16 @@ public class LRUEvictorTest extends EvictorTestBase {
     for (int i = 0; i < nDirInFirstTier; i++) {
       EvictionPlan plan =
           mEvictor.freeSpaceWithView(smallestCapacity, anyDirInFirstTier, mManagerView);
-      Assert.assertTrue(EvictorTestUtils.validCascadingPlan(smallestCapacity, plan, mMetaManager));
+      assertTrue(EvictorTestUtils.validCascadingPlan(smallestCapacity, plan, mMetaManager));
       // least recently used block in the first tier needs to be moved to the second tier
-      Assert.assertEquals(1, plan.toMove().size());
+      assertEquals(1, plan.toMove().size());
       long blockIdMovedInFirstTier = plan.toMove().get(0).getBlockId();
-      Assert.assertEquals(BLOCK_ID + i, blockIdMovedInFirstTier);
+      assertEquals(BLOCK_ID + i, blockIdMovedInFirstTier);
       // least recently used cached block in the second tier will be evicted to hold blocks moved
       // from first tier
-      Assert.assertEquals(1, plan.toEvict().size());
+      assertEquals(1, plan.toEvict().size());
       long blockIdEvictedInSecondTier = plan.toEvict().get(0).getFirst();
-      Assert.assertEquals(BLOCK_ID + nDirInFirstTier + i, blockIdEvictedInSecondTier);
+      assertEquals(BLOCK_ID + nDirInFirstTier + i, blockIdEvictedInSecondTier);
 
       access(blockIdMovedInFirstTier);
       access(blockIdEvictedInSecondTier);
@@ -176,22 +179,22 @@ public class LRUEvictorTest extends EvictorTestBase {
     BlockStoreLocation thirdDirSecondTier = new BlockStoreLocation("SSD", 2);
 
     EvictionPlan plan = mEvictor.freeSpaceWithView(blockSize * 2, anyDirInFirstTier, mManagerView);
-    Assert.assertNotNull(plan);
-    Assert.assertEquals(0, plan.toEvict().size());
-    Assert.assertEquals(2, plan.toMove().size());
+    assertNotNull(plan);
+    assertEquals(0, plan.toEvict().size());
+    assertEquals(2, plan.toMove().size());
 
     // 2 blocks to move. The first one should be moved the 3rd dir as it has max free space.
     long blockId = plan.toMove().get(0).getBlockId();
-    Assert.assertEquals(101, blockId);
+    assertEquals(101, blockId);
     BlockStoreLocation dstLocation = plan.toMove().get(0).getDstLocation();
-    Assert.assertEquals(thirdDirSecondTier, dstLocation);
+    assertEquals(thirdDirSecondTier, dstLocation);
 
     // The second one should be moved the 2nd dir because after the first move the second dir
     // has the max free space.
     blockId = plan.toMove().get(1).getBlockId();
-    Assert.assertEquals(102, blockId);
+    assertEquals(102, blockId);
     dstLocation = plan.toMove().get(1).getDstLocation();
-    Assert.assertEquals(secondDirSecondTier, dstLocation);
+    assertEquals(secondDirSecondTier, dstLocation);
 
     cache(SESSION_ID, 107, 10000, 1, 0);
     cache(SESSION_ID, 108, 20000, 1, 1);
@@ -202,29 +205,29 @@ public class LRUEvictorTest extends EvictorTestBase {
     // First Tier 0, 0
     // Second Tier 0, 0, 1500
     plan = mEvictor.freeSpaceWithView(blockSize * 3, anyDirInFirstTier, mManagerView);
-    Assert.assertNotNull(plan);
-    Assert.assertEquals(1, plan.toEvict().size());
-    Assert.assertEquals(3, plan.toMove().size());
+    assertNotNull(plan);
+    assertEquals(1, plan.toEvict().size());
+    assertEquals(3, plan.toMove().size());
 
     blockId = plan.toEvict().get(0).getFirst();
-    Assert.assertEquals(107, blockId);
+    assertEquals(107, blockId);
 
     // 3 blocks to move. The first one should be moved the 3rd dir as it has max free space.
     blockId = plan.toMove().get(0).getBlockId();
-    Assert.assertEquals(103, blockId);
+    assertEquals(103, blockId);
     dstLocation = plan.toMove().get(0).getDstLocation();
-    Assert.assertEquals(thirdDirSecondTier, dstLocation);
+    assertEquals(thirdDirSecondTier, dstLocation);
 
     // The other two should be moved the 1st dir because the 1st dir has the max free space
     // after evicting block 107.
     blockId = plan.toMove().get(1).getBlockId();
-    Assert.assertEquals(104, blockId);
+    assertEquals(104, blockId);
     dstLocation = plan.toMove().get(1).getDstLocation();
-    Assert.assertEquals(firstDirSecondTier, dstLocation);
+    assertEquals(firstDirSecondTier, dstLocation);
 
     blockId = plan.toMove().get(2).getBlockId();
-    Assert.assertEquals(105, blockId);
+    assertEquals(105, blockId);
     dstLocation = plan.toMove().get(1).getDstLocation();
-    Assert.assertEquals(firstDirSecondTier, dstLocation);
+    assertEquals(firstDirSecondTier, dstLocation);
   }
 }


### PR DESCRIPTION
I use static imports rather than Non-static imports for standard test utilities in alluxio/core/server/worker/src/test/java/alluxio/worker/block/evictor/LRUEvictorTest.java