### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
@@ -11,10 +11,12 @@
 
 package alluxio.underfs;
 
-//import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+
 import alluxio.util.CommonUtils;
+
 import org.junit.Test;
+
 import java.util.Random;
 
 /**

--- a/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
@@ -11,11 +11,10 @@
 
 package alluxio.underfs;
 
+//import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import alluxio.util.CommonUtils;
-
-import org.junit.Assert;
 import org.junit.Test;
-
 import java.util.Random;
 
 /**
@@ -36,15 +35,15 @@ public final class UfsFileStatusTest {
         new UfsFileStatus("name", contentHash, contentLength, lastModifiedTimeMs, "owner", "group",
             mode);
 
-    Assert.assertEquals("name", status.getName());
-    Assert.assertEquals(contentHash, status.getContentHash());
-    Assert.assertEquals(contentLength, status.getContentLength());
-    Assert.assertEquals(false, status.isDirectory());
-    Assert.assertEquals(true, status.isFile());
-    Assert.assertEquals(lastModifiedTimeMs, (long) status.getLastModifiedTime());
-    Assert.assertEquals("owner", status.getOwner());
-    Assert.assertEquals("group", status.getGroup());
-    Assert.assertEquals(mode, status.getMode());
+    assertEquals("name", status.getName());
+    assertEquals(contentHash, status.getContentHash());
+    assertEquals(contentLength, status.getContentLength());
+    assertEquals(false, status.isDirectory());
+    assertEquals(true, status.isFile());
+    assertEquals(lastModifiedTimeMs, (long) status.getLastModifiedTime());
+    assertEquals("owner", status.getOwner());
+    assertEquals("group", status.getGroup());
+    assertEquals(mode, status.getMode());
   }
 
   /**
@@ -61,6 +60,6 @@ public final class UfsFileStatusTest {
         new UfsFileStatus("name", contentHash, contentLength, lastModifiedTimeMs, "owner", "group",
             mode);
     UfsFileStatus status = new UfsFileStatus(statusToCopy);
-    Assert.assertEquals(statusToCopy, status);
+    assertEquals(statusToCopy, status);
   }
 }


### PR DESCRIPTION
Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java 