### PR TITLE
Implement RocksStore checkpoints using Rocks Checkpoints

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -221,9 +221,14 @@ public final class FileUtils {
   /**
    * Deletes a file or a directory, recursively if it is a directory.
    *
+   * If the path does not exist, nothing happens.
+   *
    * @param path pathname to be deleted
    */
   public static void deletePathRecursively(String path) throws IOException {
+    if (!exists(path)) {
+      return;
+    }
     Path root = Paths.get(path);
     Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
       @Override

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -62,9 +62,7 @@ public final class Format {
    */
   private static void formatWorkerDataFolder(String folder) throws IOException {
     Path path = Paths.get(folder);
-    if (Files.exists(path)) {
-      FileUtils.deletePathRecursively(folder);
-    }
+    FileUtils.deletePathRecursively(folder);
     Files.createDirectory(path);
     // For short-circuit read/write to work, others needs to be able to access this directory.
     // Therefore, default is 777 but if the user specifies the permissions, respect those instead.

--- a/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
@@ -36,10 +36,6 @@ public enum CheckpointType {
    */
   ROCKS(3, new TarballCheckpointFormat()),
   /**
-   * A RocksDB checkpoint in .tar.gz format.
-   */
-  ROCKS_CHECKPOINT(6, new TarballCheckpointFormat()),
-  /**
    * This format sequentially writes delimited InodeMeta.Inode protocol buffers one after another
    * using the protocol buffer writeDelimitedTo method.
    */

--- a/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
@@ -36,6 +36,10 @@ public enum CheckpointType {
    */
   ROCKS(3, new TarballCheckpointFormat()),
   /**
+   * A RocksDB checkpoint in .tar.gz format.
+   */
+  ROCKS_CHECKPOINT(6, new TarballCheckpointFormat()),
+  /**
    * This format sequentially writes delimited InodeMeta.Inode protocol buffers one after another
    * using the protocol buffer writeDelimitedTo method.
    */

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -126,7 +126,7 @@ public final class RocksStore implements Closeable {
           }
         });
         closer.register(() -> {
-          synchronized(this) {
+          synchronized (this) {
             mCheckpoint.close();
           }
         });

--- a/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
@@ -16,9 +16,23 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.meta.MutableInodeDirectory;
+import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.master.metastore.rocks.RocksInodeStore;
+import alluxio.util.CommonUtils;
 
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
@@ -32,10 +46,15 @@ import java.util.stream.IntStream;
  * Microbenchmarks for the inode store.
  */
 public class InodeStoreBench {
+  private static final int CHECKPOINT_INODES_MILLIONS = 1;
   private static InodeStore sStore;
   private static final AtomicInteger NEXT_INODE_ID = new AtomicInteger(1);
 
-  public static void main(String[] args) throws InterruptedException {
+  public static void main(String[] args) throws Exception {
+    // Enable logging to stdout.
+    Layout layout = new PatternLayout("%d [%t] %-5p %c %x - %m%n");
+    Logger.getRootLogger().addAppender(new ConsoleAppender(layout));
+
     System.out.printf("Running benchmarks for rocks inode store%n");
     sStore = new RocksInodeStore(ServerConfiguration.get(PropertyKey.MASTER_METASTORE_DIR));
     runBenchmarks();
@@ -45,8 +64,9 @@ public class InodeStoreBench {
     runBenchmarks();
   }
 
-  private static void runBenchmarks() throws InterruptedException {
+  private static void runBenchmarks() throws Exception {
     writeBenchmark();
+    checkpointBenchmark();
   }
 
   private static void writeBenchmark() throws InterruptedException {
@@ -72,6 +92,29 @@ public class InodeStoreBench {
     service.shutdownNow();
   }
 
+  private static void checkpointBenchmark() throws Exception {
+    sStore.clear();
+    System.out.printf("Writing %d million inodes ...", CHECKPOINT_INODES_MILLIONS);
+    for (int i = 0; i < 1e6 * CHECKPOINT_INODES_MILLIONS; i++) {
+      writeInode();
+    }
+    System.out.println(" done");
+
+    File f = File.createTempFile("checkpoint", "");
+    try (OutputStream out = new BufferedOutputStream(new FileOutputStream(f))) {
+      long start = System.nanoTime();
+      sStore.writeToCheckpoint(out);
+      System.out.printf("Wrote %d million inode checkpoint in %dms%n", CHECKPOINT_INODES_MILLIONS,
+          (System.nanoTime() - start) / Constants.MS_NANO);
+    }
+    try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+      long start = System.nanoTime();
+      sStore.restoreFromCheckpoint(new CheckpointInputStream(in));
+      System.out.printf("Restored %d million inode checkpoint in %dms%n",
+          CHECKPOINT_INODES_MILLIONS, (System.nanoTime() - start) / Constants.MS_NANO);
+    }
+  }
+
   private static int doForMs(long timeMs, Runnable action, CyclicBarrier barrier) {
     try {
       barrier.await();
@@ -91,7 +134,8 @@ public class InodeStoreBench {
   private static void writeInode() {
     int id = NEXT_INODE_ID.getAndIncrement();
     CreateDirectoryContext createContext = CreateDirectoryContext.defaults();
-    MutableInodeDirectory dir = MutableInodeDirectory.create(id, 0, "x", createContext);
+    MutableInodeDirectory dir =
+        MutableInodeDirectory.create(id, 0, CommonUtils.randomAlphaNumString(30), createContext);
     sStore.writeInode(dir);
   }
 }


### PR DESCRIPTION
Previously we used Rocks BackupEngine to create backups,
and build our checkpoints from those. That was slow because
backups require copying the full metastore. Checkpoints are
faster because they use hard links instead of copying. With
this change, the time needed to take checkpoints and restore
checkpoints is reduced by 40%.