### PR TITLE
Remove redundant log message

### DIFF
--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -484,8 +484,8 @@ public final class ConfigurationUtils {
       return response;
     } catch (io.grpc.StatusRuntimeException e) {
       throw new UnavailableException(String.format(
-          "Failed to handshake with master %s to load cluster default configuration values",
-          address), e);
+          "Failed to handshake with master %s to load cluster default configuration values: %s",
+          address, e.getMessage()), e);
     } catch (UnauthenticatedException e) {
       throw new RuntimeException(String.format(
           "Received authentication exception during boot-strap connect with host:%s", address),

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -483,7 +483,6 @@ public final class ConfigurationUtils {
       LOG.info("Alluxio client has loaded configuration from meta master {}", address);
       return response;
     } catch (io.grpc.StatusRuntimeException e) {
-      AlluxioStatusException ase = AlluxioStatusException.fromStatusRuntimeException(e);
       throw new UnavailableException(String.format(
           "Failed to handshake with master %s to load cluster default configuration values",
           address), e);

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -484,7 +484,6 @@ public final class ConfigurationUtils {
       return response;
     } catch (io.grpc.StatusRuntimeException e) {
       AlluxioStatusException ase = AlluxioStatusException.fromStatusRuntimeException(e);
-      LOG.warn("Failed to handshake with master {} : {}", address, ase.getMessage());
       throw new UnavailableException(String.format(
           "Failed to handshake with master %s to load cluster default configuration values",
           address), e);


### PR DESCRIPTION
We end up with logs like
```
2019-04-18 20:10:52,612 INFO  ConfigurationUtils - Alluxio client (version 2.0.0-SNAPSHOT) is trying to bootstrap-connect with masters-2:19998
2019-04-18 20:10:52,614 WARN  ConfigurationUtils - Failed to handshake with master masters-2:19998 : Network closed for unknown reason
2019-04-18 20:10:52,614 WARN  AbstractClient - Failed to connect (40) with MetaMasterMaster @ masters-2:19998: Failed to handshake with master masters-2:19998 to load cluster default configuration values
2019-04-18 20:10:55,748 INFO  ConfigurationUtils - Alluxio client (version 2.0.0-SNAPSHOT) is trying to bootstrap-connect with masters-2:19998
2019-04-18 20:10:55,750 WARN  ConfigurationUtils - Failed to handshake with master masters-2:19998 : Network closed for unknown reason
2019-04-18 20:10:55,751 WARN  AbstractClient - Failed to connect (41) with MetaMasterMaster @ masters-2:19998: Failed to handshake with master masters-2:19998 to load cluster default configuration values
```

In general it's an anti-pattern to both log and throw