### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/refresh/TimeoutRefreshTest.java
+++ b/core/common/src/test/java/alluxio/refresh/TimeoutRefreshTest.java
@@ -13,7 +13,8 @@ package alluxio.refresh;
 
 import alluxio.util.CommonUtils;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
 /**
@@ -30,14 +31,14 @@ public final class TimeoutRefreshTest {
     final long slackMs = 200;
     TimeoutRefresh timeoutRefresh = new TimeoutRefresh(timeoutMs);
     // First check, should attempt
-    Assert.assertTrue(timeoutRefresh.attempt());
+    assertTrue(timeoutRefresh.attempt());
     // Second check, should not attempt before refresh timeout
-    Assert.assertFalse(timeoutRefresh.attempt());
+    assertFalse(timeoutRefresh.attempt());
 
     CommonUtils.sleepMs(timeoutMs);
     CommonUtils.sleepMs(slackMs);
 
-    Assert.assertTrue(timeoutRefresh.attempt());
-    Assert.assertFalse(timeoutRefresh.attempt());
+    assertTrue(timeoutRefresh.attempt());
+    assertFalse(timeoutRefresh.attempt());
   }
 }


### PR DESCRIPTION
Put the static imports before non-static imports.