### PR TITLE
Reduce number of startup consistency check threads

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -644,9 +644,10 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
               (int) ServerConfiguration.getMs(PropertyKey.MASTER_METRICS_TIME_SERIES_INTERVAL),
               ServerConfiguration.global()));
       if (ServerConfiguration.getBoolean(PropertyKey.MASTER_STARTUP_CONSISTENCY_CHECK_ENABLED)) {
-        mStartupConsistencyCheck = getExecutorService().submit(() -> startupCheckConsistency(
-            ExecutorServiceFactories
-               .fixedThreadPool("startup-consistency-check", 32).create()));
+        int checkThreads = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        mStartupConsistencyCheck =
+            getExecutorService().submit(() -> startupCheckConsistency(ExecutorServiceFactories
+                .fixedThreadPool("startup-consistency-check", checkThreads).create()));
       }
       if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
         mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter();


### PR DESCRIPTION
It isn't good to pin all processors to consistency checking.