### PR TITLE
Add back retry in S3 read when failed to get key

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/MultiRangeObjectInputStream.java
@@ -117,7 +117,7 @@ public abstract class MultiRangeObjectInputStream extends InputStream {
   }
 
   /**
-   * Open a new stream reading a range. When endPos > content length, the returned stream should
+   * Opens a new stream reading a range. When endPos > content length, the returned stream should
    * read till the last valid byte of the input. The behaviour is undefined when (startPos < 0),
    * (startPos >= content length), or (endPos <= 0).
    *

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -535,8 +535,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   @Override
   public  UfsFileStatus getExistingFileStatus(String path) throws IOException {
-    return retryOnException(() -> getFileStatus(path),
-        () -> "get status of file " + path);
+    return retryOnException(() -> getFileStatus(path), () -> "get status of file " + path);
   }
 
   @Override
@@ -1075,7 +1074,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    *
    * @param key the key to open
    * @param options the open options
-   * @param retryPolicy the retry policy of the opened stream
+   * @param retryPolicy the retry policy of the opened stream to solve eventual consistency issue
    * @return an {@link InputStream} to read from key
    */
   protected abstract InputStream openObject(String key, OpenOptions options,

--- a/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
+++ b/core/common/src/test/java/alluxio/underfs/AbstractUnderFileSystemContractTest.java
@@ -199,6 +199,19 @@ public abstract class AbstractUnderFileSystemContractTest {
   }
 
   @Test
+  public void createOpenExistingLargeFile() throws IOException {
+    String testFile = PathUtils.concatPath(mUnderfsAddress, "createOpenExistingLargeFile");
+    int numCopies = prepareMultiBlockFile(testFile);
+    InputStream inputStream = mUfs.openExistingFile(testFile);
+    byte[] buf = new byte[numCopies * TEST_BYTES.length];
+    int bytesRead = inputStream.read(buf, 0, buf.length);
+    assertEquals(buf.length, bytesRead);
+    for (int i = 0; i < bytesRead; ++i) {
+      assertEquals(TEST_BYTES[i % TEST_BYTES.length], buf[i]);
+    }
+  }
+
+  @Test
   public void deleteFile() throws IOException {
     String testFile = PathUtils.concatPath(mUnderfsAddress, "deleteFile");
     createEmptyFile(testFile);

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -57,7 +57,7 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   COSInputStream(String bucketName, String key, COSClient client,
-      long multiRangeChunkSize, RetryPolicy retryPolicy) throws IOException {
+      RetryPolicy retryPolicy, long multiRangeChunkSize) throws IOException {
     this(bucketName, key, client, 0L, retryPolicy, multiRangeChunkSize);
   }
 
@@ -79,9 +79,9 @@ public class COSInputStream extends MultiRangeObjectInputStream {
     mKey = key;
     mCosClient = client;
     mPos = position;
+    mRetryPolicy = retryPolicy;
     ObjectMetadata meta = mCosClient.getObjectMetadata(mBucketName, key);
     mContentLength = meta == null ? 0 : meta.getContentLength();
-    mRetryPolicy = retryPolicy;
   }
 
   @Override

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -105,7 +105,7 @@ public class COSInputStream extends MultiRangeObjectInputStream {
         LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
         if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
-          throw e;
+          throw new IOException(e);
         }
         // Key does not exist
         lastException = e;

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -13,12 +13,15 @@ package alluxio.underfs.cos;
 
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.MultiRangeObjectInputStream;
-import alluxio.underfs.ObjectUnderFileSystem;
 
 import com.qcloud.cos.COSClient;
+import com.qcloud.cos.exception.CosServiceException;
 import com.qcloud.cos.model.COSObject;
 import com.qcloud.cos.model.GetObjectRequest;
 import com.qcloud.cos.model.ObjectMetadata;
+import org.apache.commons.httpclient.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.BufferedInputStream;
@@ -31,6 +34,7 @@ import java.io.InputStream;
  */
 @NotThreadSafe
 public class COSInputStream extends MultiRangeObjectInputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(COSInputStream.class);
 
   /** Bucket name of the Alluxio COS bucket. */
   private final String mBucketName;
@@ -44,7 +48,10 @@ public class COSInputStream extends MultiRangeObjectInputStream {
   /** The size of the object in bytes. */
   private final long mContentLength;
 
-  /** Policy determining the retry behavior to solve eventual consistency issue. */
+  /**
+   * Policy determining the retry behavior in case the key does not exist. The key may not exist
+   * because of eventual consistency.
+   */
   private final RetryPolicy mRetryPolicy;
 
   /**
@@ -53,7 +60,7 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param bucketName the name of the bucket
    * @param key the key of the file
    * @param client the client for COS
-   * @param retryPolicy the retry policy to solve eventual consistency issue
+   * @param retryPolicy retry policy in case the key does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   COSInputStream(String bucketName, String key, COSClient client,
@@ -68,9 +75,8 @@ public class COSInputStream extends MultiRangeObjectInputStream {
    * @param key the key of the file
    * @param client the client for COS
    * @param position the position to begin reading from
-   * @param retryPolicy the retry policy to use
+   * @param retryPolicy retry policy in case the key does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
-   *
    */
   COSInputStream(String bucketName, String key, COSClient client, long position,
       RetryPolicy retryPolicy, long multiRangeChunkSize) throws IOException {
@@ -87,27 +93,25 @@ public class COSInputStream extends MultiRangeObjectInputStream {
   @Override
   protected InputStream createStream(long startPos, long endPos)
       throws IOException {
-    // TODO(lu) only retry when object does not exist because of eventual consistency
-    if (mRetryPolicy == null) {
-      return createStreamOperation(startPos, endPos);
-    } else {
-      return ObjectUnderFileSystem.retryOnException(() -> createStreamOperation(startPos, endPos),
-          () -> "open key " + mKey + " in bucket " + mBucketName, mRetryPolicy);
-    }
-  }
-
-  /**
-   * Opens a new stream reading a range.
-   *
-   * @param startPos start position in bytes (inclusive)
-   * @param endPos end position in bytes (exclusive)
-   * @return a new {@link InputStream}
-   */
-  private InputStream createStreamOperation(long startPos, long endPos) {
     GetObjectRequest req = new GetObjectRequest(mBucketName, mKey);
     // COS returns entire object if we read past the end
     req.setRange(startPos, endPos < mContentLength ? endPos - 1 : mContentLength - 1);
-    COSObject object = mCosClient.getObject(req);
-    return new BufferedInputStream(object.getObjectContent());
+    CosServiceException lastException = null;
+    while (mRetryPolicy.attempt()) {
+      try {
+        COSObject object = mCosClient.getObject(req);
+        return new BufferedInputStream(object.getObjectContent());
+      } catch (CosServiceException e) {
+        LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
+            mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+        if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
+          throw e;
+        }
+        // Key does not exist
+        lastException = e;
+      }
+    }
+    // Failed after retrying key does not exist
+    throw new IOException(lastException);
   }
 }

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -301,9 +302,10 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options,
+      RetryPolicy retryPolicy) throws IOException {
     try {
-      return new COSInputStream(mBucketNameInternal, key, mClient, options.getOffset(),
+      return new COSInputStream(mBucketNameInternal, key, mClient, options.getOffset(), retryPolicy,
           mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (CosClientException e) {
       throw new IOException(e.getMessage());

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -65,7 +65,10 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   /** The name of the account owner. */
   private final String mAccountOwner;
 
-  /** The permission mode that the account owner has to the bucket. */
+  /**
+   * Policy determining the retry behavior in case the key does not exist. The key may not exist
+   * because of eventual consistency.
+   */
   private final short mBucketMode;
 
   static {
@@ -336,6 +339,10 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
       throws IOException {
-    return new GCSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
+    try {
+      return new GCSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
+    } catch (ServiceException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UfsDirectoryStatus;
 import alluxio.underfs.UnderFileSystem;
@@ -333,11 +334,8 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) throws IOException {
-    try {
-      return new GCSInputStream(mBucketName, key, mClient, options.getOffset());
-    } catch (ServiceException e) {
-      throw new IOException(e.getMessage());
-    }
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
+      throws IOException {
+    return new GCSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
   }
 }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -65,10 +65,7 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   /** The name of the account owner. */
   private final String mAccountOwner;
 
-  /**
-   * Policy determining the retry behavior in case the key does not exist. The key may not exist
-   * because of eventual consistency.
-   */
+  /** The permission mode that the account owner has to the bucket. */
   private final short mBucketMode;
 
   static {

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
@@ -24,6 +24,7 @@ import com.qiniu.util.Auth;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.commons.httpclient.HttpStatus;
 
 import java.io.File;
 import java.io.IOException;
@@ -114,7 +115,7 @@ public class KodoClient {
                 + String.valueOf(endPos < contentLength ? endPos - 1 : contentLength - 1))
         .addHeader("Host", mDownloadHost).get().build();
     Response response = mOkHttpClient.newCall(request).execute();
-    if (response.code() == 404) {
+    if (response.code() == HttpStatus.SC_NOT_FOUND) {
       throw new NotFoundException("Qiniu kodo: " + response.message());
     }
     if (response.code() != 200 && response.code() != 206) {

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
@@ -11,6 +11,8 @@
 
 package alluxio.underfs.kodo;
 
+import alluxio.exception.status.NotFoundException;
+
 import com.qiniu.common.QiniuException;
 import com.qiniu.storage.BucketManager;
 import com.qiniu.storage.Configuration;
@@ -112,6 +114,9 @@ public class KodoClient {
                 + String.valueOf(endPos < contentLength ? endPos - 1 : contentLength - 1))
         .addHeader("Host", mDownloadHost).get().build();
     Response response = mOkHttpClient.newCall(request).execute();
+    if (response.code() == 404) {
+      throw new NotFoundException("Qiniu kodo: " + response.message());
+    }
     if (response.code() != 200 && response.code() != 206) {
       throw new IOException(String.format("Qiniu kodo:get object failed errcode:%d,errmsg:%s",
           response.code(), response.message()));

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
@@ -52,8 +52,8 @@ public class KodoInputStream extends MultiRangeObjectInputStream {
     mKey = key;
     mKodoclent = kodoClient;
     mPos = position;
-    mContentLength = kodoClient.getFileInfo(key).fsize;
     mRetryPolicy = retryPolicy;
+    mContentLength = kodoClient.getFileInfo(key).fsize;
   }
 
   @Override

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -207,7 +207,7 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy) {
     try {
-      return new KodoInputStream(key, mKodoClinet, options.getOffset(),retryPolicy,
+      return new KodoInputStream(key, mKodoClinet, options.getOffset(), retryPolicy,
           mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (QiniuException e) {
       LOG.error("Failed to open Object {}, Msg: {}", key, e);

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -204,9 +205,9 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) {
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy) {
     try {
-      return new KodoInputStream(key, mKodoClinet, options.getOffset(),
+      return new KodoInputStream(key, mKodoClinet, options.getOffset(),retryPolicy,
           mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (QiniuException e) {
       LOG.error("Failed to open Object {}, Msg: {}", key, e);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -105,13 +105,13 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
         LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
         if (!e.getErrorCode().equals("NoSuchKey")) {
-          throw e;
+          throw new IOException(e);
         }
         // Key does not exist
         lastException = e;
       }
     }
     // Failed after retrying key does not exist
-    throw lastException;
+    throw new IOException(lastException);
   }
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -279,9 +280,10 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
+      throws IOException {
     try {
-      return new OSSInputStream(mBucketName, key, mClient, options.getOffset(),
+      return new OSSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy,
           mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
     } catch (ServiceException e) {
       throw new IOException(e.getMessage());

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -83,7 +83,7 @@ public class OSSInputStreamTest {
       mInputStreamSpy[i] = spy(new ByteArrayInputStream(mockInput));
       when(mOssObject[i].getObjectContent()).thenReturn(mInputStreamSpy[i]);
     }
-    mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient,
+    mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient, null,
         sConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
   }
 

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.retry.CountingRetry;
 import alluxio.util.ConfigurationUtils;
 
 import com.aliyun.oss.OSSClient;
@@ -83,7 +84,7 @@ public class OSSInputStreamTest {
       mInputStreamSpy[i] = spy(new ByteArrayInputStream(mockInput));
       when(mOssObject[i].getObjectContent()).thenReturn(mInputStreamSpy[i]);
     }
-    mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient, null,
+    mOssInputStream = new OSSInputStream(BUCKET_NAME, OBJECT_KEY, mOssClient, new CountingRetry(1),
         sConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -133,7 +133,7 @@ public class S3AInputStream extends InputStream {
   /**
    * Opens a new stream at mPos if the wrapped stream mIn is null.
    */
-  private void openStream() {
+  private void openStream() throws IOException {
     if (mIn != null) { // stream is already open
       return;
     }
@@ -151,14 +151,14 @@ public class S3AInputStream extends InputStream {
         LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
         if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
-          throw e;
+          throw new IOException(e);
         }
         // Key does not exist
         lastException = e;
       }
     }
     // Failed after retrying key does not exist
-    throw lastException;
+    throw new IOException(lastException);
   }
 
   /**

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -48,7 +48,6 @@ public class S3AInputStream extends InputStream {
    * Policy determining the retry behavior in case the key does not exist. The key may not exist
    * because of eventual consistency.
    */
-
   private final RetryPolicy mRetryPolicy;
 
   /**
@@ -79,8 +78,8 @@ public class S3AInputStream extends InputStream {
     mBucketName = bucketName;
     mKey = key;
     mClient = client;
-    mRetryPolicy = retryPolicy;
     mPos = position;
+    mRetryPolicy = retryPolicy;
   }
 
   @Override
@@ -132,7 +131,7 @@ public class S3AInputStream extends InputStream {
   }
 
   /**
-   * @return a new stream at mPos if the wrapped stream mIn is null
+   * Opens a new stream at mPos if the wrapped stream mIn is null.
    */
   private void openStream() {
     if (mIn != null) { // stream is already open

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -142,10 +142,6 @@ public class S3AInputStream extends InputStream {
     if (mPos > 0) {
       getReq.setRange(mPos);
     }
-    if (mRetryPolicy == null) {
-      mIn = mClient.getObject(getReq).getObjectContent();
-      return;
-    }
     AmazonS3Exception lastException = null;
     while (mRetryPolicy.attempt()) {
       try {

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -11,9 +11,15 @@
 
 package alluxio.underfs.s3a;
 
+import alluxio.retry.RetryPolicy;
+
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.commons.httpclient.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +30,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class S3AInputStream extends InputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(S3AInputStream.class);
+
   /** Client for operations with s3. */
   private final AmazonS3 mClient;
   /** Name of the bucket the object resides in. */
@@ -37,15 +45,22 @@ public class S3AInputStream extends InputStream {
   private long mPos;
 
   /**
+   * Policy determining the retry behavior in case the key does not exist. The key may not exist
+   * because of eventual consistency.
+   */
+  private final RetryPolicy mRetryPolicy;
+
+  /**
    * Constructor for an input stream of an object in s3 using the aws-sdk implementation to read
    * the data. The stream will be positioned at the start of the file.
    *
    * @param bucketName the bucket the object resides in
    * @param key the path of the object to read
    * @param client the s3 client to use for operations
+   * @param retryPolicy retry policy in case the key does not exist
    */
-  public S3AInputStream(String bucketName, String key, AmazonS3 client) {
-    this(bucketName, key, client, 0L);
+  public S3AInputStream(String bucketName, String key, AmazonS3 client, RetryPolicy retryPolicy) {
+    this(bucketName, key, client, retryPolicy, 0L);
   }
 
   /**
@@ -55,12 +70,15 @@ public class S3AInputStream extends InputStream {
    * @param bucketName the bucket the object resides in
    * @param key the path of the object to read
    * @param client the s3 client to use for operations
+   * @param retryPolicy retry policy in case the key does not exist
    * @param position the position to begin reading from
    */
-  public S3AInputStream(String bucketName, String key, AmazonS3 client, long position) {
+  public S3AInputStream(String bucketName, String key, AmazonS3 client,
+      RetryPolicy retryPolicy, long position) {
     mBucketName = bucketName;
     mKey = key;
     mClient = client;
+    mRetryPolicy = retryPolicy;
     mPos = position;
   }
 
@@ -124,7 +142,23 @@ public class S3AInputStream extends InputStream {
     if (mPos > 0) {
       getReq.setRange(mPos);
     }
-    mIn = mClient.getObject(getReq).getObjectContent();
+    AmazonS3Exception lastException = null;
+    while (mRetryPolicy.attempt()) {
+      try {
+        mIn = mClient.getObject(getReq).getObjectContent();
+        return;
+      } catch (AmazonS3Exception e) {
+        LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
+            mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+        if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
+          throw e;
+        }
+        // Key does not exist
+        lastException = e;
+      }
+    }
+    // Failed after retrying key does not exist
+    throw lastException;
   }
 
   /**

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
@@ -595,13 +594,10 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options,
+      RetryPolicy retryPolicy) throws IOException {
     try {
-      RetryPolicy retryPolicy = new ExponentialBackoffRetry(
-          (int) mUfsConf.getMs(PropertyKey.UNDERFS_EVENTUAL_CONSISTENCY_RETRY_BASE_SLEEP_MS),
-          (int) mUfsConf.getMs(PropertyKey.UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_SLEEP_MS),
-          mUfsConf.getInt(PropertyKey.UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_NUM));
-      return new S3AInputStream(mBucketName, key, mClient, retryPolicy, options.getOffset());
+      return new S3AInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
     } catch (AmazonClientException e) {
       throw new IOException(e);
     }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -42,8 +42,8 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
   /** The path of the object to read, without container prefix. */
   private final String mObjectPath;
   /**
-   * Policy determining the retry behavior in case the key does not exist. The key may not exist
-   * because of eventual consistency.
+   * Policy determining the retry behavior in case the object does not exist.
+   * The object may not exist because of eventual consistency.
    */
   private final RetryPolicy mRetryPolicy;
 
@@ -53,7 +53,7 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param account JOSS account with authentication credentials
    * @param container the name of container where the object resides
    * @param object path of the object in the container
-   * @param retryPolicy retry policy in case the key does not exist
+   * @param retryPolicy retry policy in case the object does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object,
@@ -68,7 +68,7 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param container the name of container where the object resides
    * @param object path of the object in the container
    * @param position the position to begin reading from
-   * @param retryPolicy retry policy in case the key does not exist
+   * @param retryPolicy retry policy in case the object does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object, long position,
@@ -94,11 +94,11 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
       } catch (NotFoundException e) {
         LOG.warn("Attempt {} to get object {} from container {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mObjectPath, mContainerName, e.toString());
-        // Key does not exist
+        // Object does not exist
         lastException = e;
       }
     }
-    // Failed after retrying key does not exist
+    // Failed after retrying object does not exist
     throw new IOException(lastException);
   }
 }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -99,6 +99,6 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
       }
     }
     // Failed after retrying object does not exist
-    throw new IOException(lastException);
+    throw lastException;
   }
 }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -11,7 +11,9 @@
 
 package alluxio.underfs.swift;
 
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.MultiRangeObjectInputStream;
+import alluxio.underfs.ObjectUnderFileSystem;
 
 import org.javaswift.joss.instructions.DownloadInstructions;
 import org.javaswift.joss.model.Account;
@@ -36,6 +38,8 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
   private final String mContainerName;
   /** The path of the object to read, without container prefix. */
   private final String mObjectPath;
+  /** Policy determining the retry behavior to solve eventual consistency issue. */
+  private final RetryPolicy mRetryPolicy;
 
   /**
    * Constructor for an input stream to an object in a Swift API based store.
@@ -43,11 +47,12 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param account JOSS account with authentication credentials
    * @param container the name of container where the object resides
    * @param object path of the object in the container
+   * @param retryPolicy the retry policy to solve eventual consistency issue
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object,
-      long multiRangeChunkSize) {
-    this(account, container, object, 0L, multiRangeChunkSize);
+      RetryPolicy retryPolicy, long multiRangeChunkSize) {
+    this(account, container, object, 0L, retryPolicy, multiRangeChunkSize);
   }
 
   /**
@@ -57,19 +62,39 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
    * @param container the name of container where the object resides
    * @param object path of the object in the container
    * @param position the position to begin reading from
+   * @param retryPolicy the retry policy to solve eventual consistency issue
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
   public SwiftInputStream(Account account, String container, String object, long position,
-      long multiRangeChunkSize) {
+      RetryPolicy retryPolicy, long multiRangeChunkSize) {
     super(multiRangeChunkSize);
     mAccount = account;
     mContainerName = container;
     mObjectPath = object;
     mPos = position;
+    mRetryPolicy = retryPolicy;
   }
 
   @Override
   protected InputStream createStream(long startPos, long endPos)
+      throws IOException {
+    // TODO(lu) only retry when object does not exist because of eventual consistency
+    if (mRetryPolicy == null) {
+      return createStreamOperation(startPos, endPos);
+    } else {
+      return ObjectUnderFileSystem.retryOnException(() -> createStreamOperation(startPos, endPos),
+          () -> "open object " + mObjectPath + " in container " + mContainerName, mRetryPolicy);
+    }
+  }
+
+  /**
+   * Opens a new stream reading a range.
+   *
+   * @param startPos start position in bytes (inclusive)
+   * @param endPos end position in bytes (exclusive)
+   * @return a new {@link InputStream}
+   */
+  private InputStream createStreamOperation(long startPos, long endPos)
       throws IOException {
     StoredObject storedObject = mAccount.getContainer(mContainerName).getObject(mObjectPath);
     DownloadInstructions downloadInstructions  = new DownloadInstructions();

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftUnderFileSystem.java
@@ -17,6 +17,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -368,8 +369,9 @@ public class SwiftUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options) throws IOException {
-    return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset(),
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
+      throws IOException {
+    return new SwiftInputStream(mAccount, mContainerName, key, options.getOffset(), retryPolicy,
         mAlluxioConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
   }
 }


### PR DESCRIPTION
Add back the retry in s3 read when failed to get object because key does not exist due to s3 eventual consistency issue.