### PR TITLE
Stop intercepting closed/cancelled server calls

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
@@ -77,9 +77,9 @@ public final class AuthenticatedUserInjector implements ServerInterceptor {
    * that is kept on auth-server.
    */
   private <ReqT, RespT> boolean authenticateCall(ServerCall<ReqT, RespT> call, Metadata headers) {
-    // Fail validation for closed/cancelled server calls.
-    if (!call.isReady() || call.isCancelled()) {
-      LOG.debug("Server call has been %s: %s", call.isCancelled() ? "cancelled" : "closed",
+    // Fail validation for cancelled server calls.
+    if (call.isCancelled()) {
+      LOG.debug("Server call has been cancelled: %s",
           call.getMethodDescriptor().getFullMethodName());
       return false;
     }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedUserInjector.java
@@ -77,6 +77,13 @@ public final class AuthenticatedUserInjector implements ServerInterceptor {
    * that is kept on auth-server.
    */
   private <ReqT, RespT> boolean authenticateCall(ServerCall<ReqT, RespT> call, Metadata headers) {
+    // Fail validation for closed/cancelled server calls.
+    if (!call.isReady() || call.isCancelled()) {
+      LOG.debug("Server call has been %s: %s", call.isCancelled() ? "cancelled" : "closed",
+          call.getMethodDescriptor().getFullMethodName());
+      return false;
+    }
+
     // Try to fetch channel Id from the metadata.
     UUID channelId = headers.get(ChannelIdInjector.S_CLIENT_ID_KEY);
     boolean callAuthenticated = false;


### PR DESCRIPTION
There are sporadic occurrences of "IllegalStateException: call already closed" in server logs. This PR fixes https://github.com/Alluxio/alluxio/issues/8857 by making sure we don't close an already closed or cancelled server call.