### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.client.block.policy;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -9,6 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
+
 package alluxio.client.block.policy;
 
 import static org.junit.Assert.assertNotEquals;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -12,6 +12,9 @@
 package alluxio.client.block.policy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.block.policy;
 
+import static org.junit.Assert.assertNotEquals;
+
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
@@ -20,7 +22,6 @@ import alluxio.test.util.CommonUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public final class RoundRobinPolicyTest {
 
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
-    Assert.assertNotEquals(
+    assertNotEquals(
         policy.getWorker(options).getHost(),
         policy.getWorker(options.setBlockInfo(options.getBlockInfo().setBlockId(123))).getHost());
 

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -21,6 +21,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.test.util.CommonUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
+
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -9,7 +9,6 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-
 package alluxio.client.block.policy;
 
 import static org.junit.Assert.assertNotEquals;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -21,7 +21,6 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.test.util.CommonUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
-
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -53,7 +53,7 @@ public final class RoundRobinPolicyTest {
         policy.getWorker(options).getHost(),
         policy.getWorker(options.setBlockInfo(options.getBlockInfo().setBlockId(123))).getHost());
 
-    Assert.assertEquals(
+    assertEquals(
         policy.getWorker(options.setBlockInfo(options.getBlockInfo().setBlockId(555))).getHost(),
         policy.getWorker(options.setBlockInfo(options.getBlockInfo().setBlockId(555))).getHost());
   }
@@ -66,7 +66,7 @@ public final class RoundRobinPolicyTest {
     RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(new ArrayList<>())
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
-    Assert.assertNull(policy.getWorker(options));
+    assertNull(policy.getWorker(options));
   }
 
   /**
@@ -82,9 +82,9 @@ public final class RoundRobinPolicyTest {
     RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength((long) Constants.MB));
-    Assert.assertNotNull(policy.getWorker(options));
+    assertNotNull(policy.getWorker(options));
     options.setBlockWorkerInfos(new ArrayList<>());
-    Assert.assertNull(policy.getWorker(options));
+    assertNull(policy.getWorker(options));
   }
 
   @Test


### PR DESCRIPTION
Use static imports for standard test utilities in alluxio/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
Change
```java
import org.junit.Assert;
```
to
```java
import static org.junit.Assert.assertNotEquals;
```
AND
Update
```java
    Assert.assertNotEquals(
```
to
```java
    assertNotEquals(
```