### PR TITLE
Remove source  when removing key from properties

### DIFF
--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -157,6 +157,7 @@ public class AlluxioProperties {
     // remove is a nop if the key doesn't already exist
     if (mUserProps.containsKey(key)) {
       mUserProps.remove(key);
+      mSources.remove(key);
     }
   }
 

--- a/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
+++ b/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
@@ -86,6 +86,7 @@ public class AlluxioPropertiesTest {
   public void remove() {
     mProperties.remove(mKeyWithValue);
     assertEquals(mKeyWithValue.getDefaultValue(), mProperties.get(mKeyWithValue));
+    assertEquals(Source.DEFAULT, mProperties.getSource(mKeyWithValue));
   }
 
   @Test


### PR DESCRIPTION
When a key is removed from AlluxioProperties, the source should also be removed. Otherwise, when getting the key, the default value will be returned, but getSource might not return Source.DEFAULT.