### PR TITLE
Add client profiler

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -11,11 +11,14 @@
 
 package alluxio.client.file;
 
+import static org.junit.Assert.fail;
+
 import alluxio.ClientContext;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.resource.CloseableResource;
 
 import com.google.common.io.Closer;
 import org.junit.Before;

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -11,16 +11,11 @@
 
 package alluxio.client.file;
 
-import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
-import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.FileDoesNotExistException;
-import alluxio.grpc.CreateDirectoryPOptions;
-import alluxio.grpc.DeletePOptions;
 
 import com.google.common.io.Closer;
 import org.junit.Before;
@@ -91,77 +86,6 @@ public final class FileSystemContextTest {
     public void run() {
       CloseableResource<FileSystemMasterClient> client = mFsCtx.acquireMasterClientResource();
       client.close();
-    }
-  }
-
-  @Test
-  public void excessWorkerGroupTest() throws Exception {
-    ArrayList<Thread> clients = new ArrayList<>();
-    int numClients = 25;
-    int numFiles = 10000;
-    int totalData = 50 * Constants.MB; // 50MB
-
-    int perFileSize = totalData / numClients / numFiles;
-    byte[] data = new byte[perFileSize];
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
-    String dirPrefix = "test";
-    FileSystem fs = FileSystem.Factory.create(conf);
-    try {
-      fs.delete(new AlluxioURI("/" + dirPrefix),
-          DeletePOptions.newBuilder().setRecursive(true).setAlluxioOnly(false).build());
-    } catch (FileDoesNotExistException e) {
-      // ok
-    }
-
-    for (int i = 0; i < numClients; i++) {
-      fs = FileSystem.Factory.create(conf);
-      String dir = String.format("/%s/", dirPrefix) + i;
-      clients.add(new Thread(new CreateOp(fs, numFiles, data, dir)));
-    }
-    long startTime = System.currentTimeMillis();
-    clients.forEach(Thread::start);
-    clients.forEach((client) -> {
-      try {
-        client.join();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
-    long endTime = System.currentTimeMillis();
-    System.out.println("Runtime: " + (endTime - startTime) + " millis");
-  }
-
-  class CreateOp implements Runnable {
-    private final int mNumFiles;
-    private final FileSystem mFs;
-    private final byte[] mData;
-    private final String mDir;
-
-    public CreateOp(FileSystem fs, int numFiles, byte[] data, String dir) {
-      mFs = fs;
-      mNumFiles = numFiles;
-      mData = data;
-      mDir = dir;
-    }
-
-    @Override
-    public void run() {
-      try {
-        try {
-          mFs.delete(new AlluxioURI(mDir), DeletePOptions.newBuilder().setRecursive(true).build());
-        } catch (FileDoesNotExistException e) {
-          // ok to continue
-        }
-        mFs.createDirectory(new AlluxioURI(mDir),
-            CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
-        for (int i = 0; i < mNumFiles; i++) {
-          try (FileOutStream out = mFs.createFile(new AlluxioURI(mDir + "/" + i))) {
-            out.write(mData);
-          }
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
     }
   }
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli;
 
 import alluxio.Constants;

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -11,11 +11,7 @@
 
 package alluxio.cli;
 
-import alluxio.Constants;
 import alluxio.cli.profiler.ProfilerClient;
-import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.JvmHeapDumper;
 
@@ -23,7 +19,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 
 import java.io.IOException;
-
 
 /**
  * Class to help profile clients with heapdumps. Combine with flamegraphs for full exploitabillty
@@ -33,12 +28,13 @@ public class ClientProfiler {
   private static final String DEFAULT_DIR = "/alluxio-profiling";
 
   enum ClientType {
+    abstractfs,
     alluxio,
     hadoop,
   }
 
   @Parameter(names = {"-c", "--client"},
-      description = "The type of client to profile. Must be one of [alluxio, hadoop].",
+      description = "The type of client to profile.",
       required = true)
   private ClientType mClientType;
 
@@ -79,15 +75,12 @@ public class ClientProfiler {
   public void profile() throws IOException, InterruptedException {
     ProfilerClient.sDryRun = mDryRun;
     ProfilerClient client = ProfilerClient.Factory.create(mClientType.toString());
-    System.out.println(System.getProperty("user.dir"));
-    mDumpInterval = "1s";
     JvmHeapDumper dumper = new JvmHeapDumper(FormatUtils.parseTimeSize(mDumpInterval), "dumps",
         "dump-" + mClientType.toString());
-    client.cleanup(mDataDir);
     dumper.start();
+    client.cleanup(mDataDir);
     client.createFiles(mDataDir, mNumFiles, 50, mDataSize / mNumFiles);
     dumper.stopDumps();
-    System.exit(0);
   }
 
   private int parseArgs(String[] args) {
@@ -103,7 +96,6 @@ public class ClientProfiler {
     }
     return 0;
   }
-
 
   /**
    * Run main.

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -39,7 +39,13 @@ public class ClientProfiler {
   }
 
   /**
-   * The operation type
+   * The operation type.
+   *
+   * - cleanup is a "fast" cleanup of all directories/files
+   * - createFiles creates lots of files
+   * - deleteFiles deletes lots of files
+   * - listFiles lists lots of files
+   * - readFiles reads lots of files
    */
   enum OperationType {
     cleanup,

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -1,0 +1,113 @@
+package alluxio.cli;
+
+import alluxio.Constants;
+import alluxio.cli.profiler.ProfilerClient;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.util.ConfigurationUtils;
+import alluxio.util.FormatUtils;
+import alluxio.util.JvmHeapDumper;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+
+import java.io.IOException;
+
+
+/**
+ * Class to help profile clients with heapdumps. Combine with flamegraphs for full exploitabillty
+ */
+public class ClientProfiler {
+
+  private static final String DEFAULT_DIR = "/alluxio-profiling";
+
+  private static final AlluxioConfiguration CONF =
+      new InstancedConfiguration(ConfigurationUtils.defaults());
+
+  enum ClientType {
+    alluxio,
+    hadoop,
+  }
+
+  @Parameter(names = {"-c", "--client"},
+      description = "The type of client to profile. Must be one of [alluxio, hadoop].",
+      required = true)
+  private ClientType mClientType;
+
+  /** The total number of files to create in the filesystem. */
+  @Parameter(names = {"-n"}, description = "total number of files to operate on in the filesystem.")
+  private int mNumFiles = 5000;
+
+  /** The total amount of data to write across all files in the filesystem. */
+  @Parameter(names = {"-s"}, description = "Amount of data to write to use when profiling.")
+  private String mDataParam = "128m";
+  private long mDataSize;
+
+  /** The number of threads performing concurrent client operations. */
+  @Parameter(names = {"-t"}, description = "total threads to perform operations concurrently")
+  private long mNumThreads = 1;
+
+  /** The base directory to store files. */
+  @Parameter(names = {"-d"}, description = "Base directory to store files")
+  private String mDataDir = DEFAULT_DIR;
+
+  @Parameter(names = {"--dump-interval"}, description = "Interval at which to collect heap dumps")
+  private String mDumpInterval = "10sec";
+
+  /**
+   * New client profiler.
+   * @param args command line arguments
+   */
+  public ClientProfiler(String[] args) {
+    parseArgs(args);
+  }
+
+  /**
+   * Profiles; creating heap dumps.
+   */
+  public void profile() throws IOException, InterruptedException {
+    ProfilerClient client = ProfilerClient.Factory.create(mClientType.toString());
+    System.out.println(System.getProperty("user.dir"));
+    mDumpInterval = "1s";
+    JvmHeapDumper dumper = new JvmHeapDumper(FormatUtils.parseTimeSize(mDumpInterval), "dumps",
+        "dump");
+    client.cleanup(mDataDir);
+    dumper.start();
+    client.createFiles(mDataDir, mNumFiles, 50, mDataSize / mNumFiles);
+    try {
+      Thread.sleep(5 * Constants.SECOND_MS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    dumper.stopDumps();
+    System.exit(0);
+  }
+
+  private int parseArgs(String[] args) {
+    JCommander jc = new JCommander(this);
+    jc.setProgramName("Client Profiler");
+    try {
+      jc.parse(args);
+      mDataSize = FormatUtils.parseSpaceSize(mDataParam);
+    } catch (Exception e) {
+      System.out.println(e.toString());
+      jc.usage();
+      System.exit(1);
+    }
+    return 0;
+  }
+
+
+  /**
+   * Run main.
+   * @param args arg
+   */
+  public static void main(String[] args) {
+    ClientProfiler profiler = new ClientProfiler(args);
+    try {
+      profiler.profile();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -121,7 +121,7 @@ public class ClientProfiler {
     JvmHeapDumper dumper = null;
     if (heapDumpEnabled) {
       dumper = new JvmHeapDumper(FormatUtils.parseTimeSize(mDumpInterval), "dumps",
-          "dump-" + mClientType.toString());
+          String.format("dump-%s-%s", mClientType.toString(), mOperation.toString()));
       dumper.start();
     }
     long startTime = System.currentTimeMillis();

--- a/examples/src/main/java/alluxio/cli/ClientProfiler.java
+++ b/examples/src/main/java/alluxio/cli/ClientProfiler.java
@@ -21,6 +21,9 @@ public class ClientProfiler {
 
   private static final String DEFAULT_DIR = "/alluxio-profiling";
 
+  private static final AlluxioConfiguration CONF =
+      new InstancedConfiguration(ConfigurationUtils.defaults());
+
   enum ClientType {
     alluxio,
     hadoop,
@@ -51,9 +54,6 @@ public class ClientProfiler {
   @Parameter(names = {"--dump-interval"}, description = "Interval at which to collect heap dumps")
   private String mDumpInterval = "10sec";
 
-  @Parameter(names = {"--dry"}, description = "Perform a dry run by simply printing all operations")
-  private boolean mDryRun = false;
-
   /**
    * New client profiler.
    * @param args command line arguments
@@ -66,15 +66,19 @@ public class ClientProfiler {
    * Profiles; creating heap dumps.
    */
   public void profile() throws IOException, InterruptedException {
-    ProfilerClient.sDryRun = mDryRun;
     ProfilerClient client = ProfilerClient.Factory.create(mClientType.toString());
     System.out.println(System.getProperty("user.dir"));
     mDumpInterval = "1s";
     JvmHeapDumper dumper = new JvmHeapDumper(FormatUtils.parseTimeSize(mDumpInterval), "dumps",
-        "dump-" + mClientType.toString());
+        "dump");
     client.cleanup(mDataDir);
     dumper.start();
     client.createFiles(mDataDir, mNumFiles, 50, mDataSize / mNumFiles);
+    try {
+      Thread.sleep(5 * Constants.SECOND_MS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
     dumper.stopDumps();
     System.exit(0);
   }

--- a/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
@@ -17,13 +17,8 @@ import java.util.Arrays;
 /**
  * Profiler client for Alluxio.
  */
-public class AlluxioProfilerClient implements ProfilerClient {
-  private static final int CHUNK_SIZE = 10 * Constants.MB;
-  private static final byte[] DATA = new byte[CHUNK_SIZE];
+public class AlluxioProfilerClient extends ProfilerClient {
 
-  static {
-    Arrays.fill(DATA, (byte)0xCF);
-  }
 
   private final FileSystem mClient;
 
@@ -36,14 +31,22 @@ public class AlluxioProfilerClient implements ProfilerClient {
     try {
       AlluxioURI path = new AlluxioURI(dir);
       try {
-        mClient.delete(path,
-            DeletePOptions.newBuilder().setRecursive(true).setAlluxioOnly(false).build());
+        if (!sDryRun) {
+          mClient.delete(path,
+              DeletePOptions.newBuilder().setRecursive(true).setAlluxioOnly(false).build());
+        } else {
+          System.out.println("Delete: " + path);
+        }
       } catch (FileDoesNotExistException e) {
         // ok if it doesn't exist already
       }
 
-      mClient.createDirectory(path,
-          CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+      if (!sDryRun) {
+        mClient.createDirectory(path,
+            CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+      } else {
+        System.out.println("create directory: " + path);
+      }
     } catch (AlluxioException e) {
       throw new IOException(e);
     }
@@ -58,16 +61,21 @@ public class AlluxioProfilerClient implements ProfilerClient {
       try {
         String subDir = PathUtils.concatPath(dir, createdFiles);
         AlluxioURI subUri = new AlluxioURI(subDir);
-        mClient.createDirectory(subUri,
-            CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+        if (!sDryRun) {
+          mClient.createDirectory(subUri,
+              CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+        } else {
+          System.out.println("Create directory: " + subUri);
+        }
         for (int j = 0; j < filesPerDir; j++) {
           AlluxioURI filePath = new AlluxioURI(PathUtils.concatPath(subUri.getPath(), j));
-          try (FileOutStream stream = mClient.createFile(filePath,
-              CreateFilePOptions.newBuilder().build())) {
-            for (int k = 0; k < fileSize / CHUNK_SIZE; k++) {
-              stream.write(DATA);
+          if (!sDryRun) {
+            try (FileOutStream stream = mClient.createFile(filePath,
+                CreateFilePOptions.newBuilder().build())) {
+              writeOutput(stream, fileSize);
             }
-            stream.write(DATA, 0, (int)(fileSize % CHUNK_SIZE)); // Write any remaining data
+          } else {
+            System.out.println("Create file: " + filePath);
           }
           createdFiles++;
         }

--- a/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli.profiler;
 
 import alluxio.AlluxioURI;

--- a/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
@@ -25,13 +25,16 @@ import alluxio.grpc.ListStatusPOptions;
 import java.io.IOException;
 
 /**
- * Profiler client for Alluxio.
+ * Implementation of {@link ProfilerClient} for using the Alluxio native java client.
  */
 public class AlluxioProfilerClient extends ProfilerClient {
 
-
   private final FileSystem mClient;
 
+  /**
+   * Creates a new Alluxio client capable of being profiled when performing common filesystem
+   * operations.
+   */
   public AlluxioProfilerClient() {
     mClient = FileSystem.Factory.get();
   }

--- a/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/AlluxioProfilerClient.java
@@ -1,0 +1,80 @@
+package alluxio.cli.profiler;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.DeletePOptions;
+import alluxio.util.io.PathUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Profiler client for Alluxio.
+ */
+public class AlluxioProfilerClient implements ProfilerClient {
+  private static final int CHUNK_SIZE = 10 * Constants.MB;
+  private static final byte[] DATA = new byte[CHUNK_SIZE];
+
+  static {
+    Arrays.fill(DATA, (byte)0xCF);
+  }
+
+  private final FileSystem mClient;
+
+  public AlluxioProfilerClient() {
+    mClient = FileSystem.Factory.get();
+  }
+
+  @Override
+  public void cleanup(String dir) throws IOException {
+    try {
+      AlluxioURI path = new AlluxioURI(dir);
+      try {
+        mClient.delete(path,
+            DeletePOptions.newBuilder().setRecursive(true).setAlluxioOnly(false).build());
+      } catch (FileDoesNotExistException e) {
+        // ok if it doesn't exist already
+      }
+
+      mClient.createDirectory(path,
+          CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+    } catch (AlluxioException e) {
+      throw new IOException(e);
+    }
+
+    return;
+  }
+
+  @Override
+  public void createFiles(String dir, long numFiles, long filesPerDir, long fileSize) throws IOException {
+
+    int createdFiles = 0;
+    while (createdFiles < numFiles) {
+      try {
+        String subDir = PathUtils.concatPath(dir, createdFiles);
+        AlluxioURI subUri = new AlluxioURI(subDir);
+        mClient.createDirectory(subUri,
+            CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
+        for (int j = 0; j < filesPerDir; j++) {
+          AlluxioURI filePath = new AlluxioURI(PathUtils.concatPath(subUri.getPath(), j));
+          try (FileOutStream stream = mClient.createFile(filePath,
+              CreateFilePOptions.newBuilder().build())) {
+            for (int k = 0; k < fileSize / CHUNK_SIZE; k++) {
+              stream.write(DATA);
+            }
+            stream.write(DATA, 0, (int)(fileSize % CHUNK_SIZE)); // Write any remaining data
+          }
+          createdFiles++;
+        }
+      } catch (AlluxioException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
@@ -1,0 +1,65 @@
+package alluxio.cli.profiler;
+
+import alluxio.util.io.PathUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class HadoopProfilerClient extends ProfilerClient {
+
+  private final FileSystem mClient;
+
+  public HadoopProfilerClient(String hadoopUri) {
+    try {
+      mClient = FileSystem.get(new URI(hadoopUri), new Configuration());
+    } catch (URISyntaxException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void cleanup(String dir) throws IOException {
+    if (!sDryRun) {
+      mClient.delete(new Path(dir), true);
+    } else {
+      System.out.println("delete: " + dir);
+    }
+
+    if (!sDryRun) {
+      mClient.mkdirs(new Path(dir));
+    } else {
+      System.out.println("create: " + dir);
+    }
+  }
+
+  @Override
+  public void createFiles(String dir, long numFiles, long filesPerDir, long fileSize)
+      throws IOException {
+    int createdFiles = 0;
+    while (createdFiles < numFiles) {
+      String subDir = PathUtils.concatPath(dir, createdFiles);
+      if (!sDryRun) {
+        mClient.create(new Path(subDir));
+      } else {
+        System.out.println("create: " + subDir);
+      }
+      for (int j = 0; j < filesPerDir; j++) {
+        Path filePath = new Path(PathUtils.concatPath(subDir, j));
+        if (!sDryRun) {
+          try (FSDataOutputStream stream = mClient.create(filePath)) {
+            writeOutput(stream, fileSize);
+          }
+        } else {
+          System.out.println("create: " + filePath);
+        }
+        createdFiles++;
+      }
+    }
+  }
+}

--- a/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
@@ -26,9 +26,9 @@ public class HadoopProfilerClient extends ProfilerClient {
 
   private final FileSystem mClient;
 
-  public HadoopProfilerClient(String hadoopUri) {
+  public HadoopProfilerClient(String hadoopUri, Configuration conf) {
     try {
-      mClient = FileSystem.get(new URI(hadoopUri), new Configuration());
+      mClient = FileSystem.get(new URI(hadoopUri), conf);
     } catch (URISyntaxException | IOException e) {
       throw new RuntimeException(e);
     }
@@ -56,7 +56,8 @@ public class HadoopProfilerClient extends ProfilerClient {
     while (createdFiles < numFiles) {
       String subDir = PathUtils.concatPath(dir, createdFiles);
       if (!sDryRun) {
-        mClient.create(new Path(subDir));
+        mClient.mkdirs(new Path(subDir));
+
       } else {
         System.out.println("create: " + subDir);
       }

--- a/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
@@ -12,6 +12,7 @@
 package alluxio.cli.profiler;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,60 +33,32 @@ public class HadoopProfilerClient extends ProfilerClient {
     }
   }
 
-  /**
-   * Delete an inode at the given path
-   *
-   * @param rawPath directory to clean
-   * @throws IOException
-   */
   @Override
   public void createFile(String rawPath, long fileSize) throws IOException {
-    Path filePath = new Path(rawPath);
-    if (!sDryRun) {
-      try (FSDataOutputStream stream = mClient.create(filePath)) {
-        writeOutput(stream, fileSize);
-      }
-    } else {
-      System.out.println("create: " + filePath);
+    try (FSDataOutputStream stream = mClient.create(new Path(rawPath))) {
+      writeOutput(stream, fileSize);
     }
   }
 
-  /**
-   * Delete an inode at the given path
-   *
-   * @param rawPath directory to clean
-   * @throws IOException
-   */
   @Override
   public void createDir(String rawPath) throws IOException {
-    if (!sDryRun) {
-      mClient.mkdirs(new Path(rawPath));
-    } else {
-      System.out.println("create: " + rawPath);
-    }
+    mClient.mkdirs(new Path(rawPath));
   }
 
-  /**
-   * Delete an inode at the given path
-   *
-   * @param rawPath directory to clean
-   * @throws IOException
-   */
   @Override
   public void delete(String rawPath) throws IOException {
-    if (!sDryRun) {
-      mClient.delete(new Path(rawPath), true);
-    } else {
-      System.out.println("delete: " + rawPath);
-    }
+    mClient.delete(new Path(rawPath), true);
   }
 
   @Override
   public void list(String rawPath) throws IOException {
-    if (!sDryRun) {
-      mClient.listStatus(new Path(rawPath));
-    } else {
-      System.out.println("listStatus: " + rawPath);
+    mClient.listStatus(new Path(rawPath));
+  }
+
+  @Override
+  public void read(String rawPath) throws IOException {
+    try (FSDataInputStream fis = mClient.open(new Path(rawPath))) {
+      readInput(fis);
     }
   }
 }

--- a/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
@@ -21,10 +21,19 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+/**
+ * Implementation of {@link ProfilerClient} for using the HDFS java client.
+ */
 public class HadoopProfilerClient extends ProfilerClient {
 
   private final FileSystem mClient;
 
+  /**
+   * Create a new client which is capable of being profiled while performing common filesystem
+   * operations.
+   * @param hadoopUri the uri used to initialize the client. Should point to the HDFS namenode
+   * @param conf the hadoop configuration
+   */
   public HadoopProfilerClient(String hadoopUri, Configuration conf) {
     try {
       mClient = FileSystem.get(new URI(hadoopUri), conf);

--- a/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/HadoopProfilerClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli.profiler;
 
 import alluxio.util.io.PathUtils;

--- a/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
@@ -1,31 +1,16 @@
 package alluxio.cli.profiler;
 
-import alluxio.Constants;
-import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
-
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Profiles operations.
  */
-public abstract class ProfilerClient {
-
-  protected static final int CHUNK_SIZE = 10 * Constants.MB;
-  protected static final byte[] DATA = new byte[CHUNK_SIZE];
-  public static boolean sDryRun = false;
+public interface ProfilerClient {
 
   /**
    * Create new.
    */
-  public static class Factory {
-
-    private static final AlluxioConfiguration CONF =
-        new InstancedConfiguration(ConfigurationUtils.defaults());
-
+  class Factory {
     /**
      * Profiler client.
      * @param type alluxio or hadoop
@@ -34,28 +19,12 @@ public abstract class ProfilerClient {
     public static ProfilerClient create(String type) {
       switch (type) {
         case "hadoop":
-          return new HadoopProfilerClient(CONF.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS));
         case "alluxio":
           return new AlluxioProfilerClient();
         default:
           throw new IllegalArgumentException(String.format("No profiler for %s", type));
       }
     }
-  }
-
-  protected void clientOperation(Runnable action, String msg) {
-    if(!sDryRun) {
-      action.run();
-    } else {
-      System.out.println(msg);
-    }
-  }
-
-  static void writeOutput(OutputStream os, long fileSize) throws IOException {
-    for (int k = 0; k < fileSize / CHUNK_SIZE; k++) {
-      os.write(DATA);
-    }
-    os.write(DATA, 0, (int)(fileSize % CHUNK_SIZE)); // Write any remaining data
   }
 
   /**
@@ -65,7 +34,7 @@ public abstract class ProfilerClient {
    * @param dir directory to clean
    * @throws IOException
    */
-  public abstract void cleanup(String dir) throws IOException;
+  void cleanup(String dir) throws IOException;
 
   /**
    * Makes sure the path exists without any existing inodes below. Essentially cleaning up any
@@ -77,5 +46,5 @@ public abstract class ProfilerClient {
    * @param fileSize the size in bytes of each file that will be created
    * @throws IOException
    */
-  public abstract void createFiles(String dir, long numFiles, long filesPerDir, long fileSize) throws IOException;
+  void createFiles(String dir, long numFiles, long filesPerDir, long fileSize) throws IOException;
 }

--- a/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
@@ -16,12 +16,18 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.RateLimiter;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Profiles operations.
@@ -74,7 +80,6 @@ public abstract class ProfilerClient {
     for (int k = 0; k < fileSize / CHUNK_SIZE; k++) {
       os.write(DATA);
     }
-
     os.write(Arrays.copyOf(DATA, (int)(fileSize % CHUNK_SIZE))); // Write any remaining data
   }
 
@@ -85,11 +90,71 @@ public abstract class ProfilerClient {
    * @param dir directory to clean
    * @throws IOException
    */
-  public abstract void cleanup(String dir) throws IOException;
+  public final void cleanup(String dir) throws IOException {
+    delete(dir);
+    createDir(dir);
+  }
 
   /**
-   * Makes sure the path exists without any existing inodes below. Essentially cleaning up any
-   * previous operations on the same location.
+   * Create a file with a given size at the path.
+   *
+   * @param rawPath directory to clean
+   * @throws IOException
+   */
+  public abstract void createFile(String rawPath, long fileSize) throws IOException;
+
+  /**
+   * Create a directory at the given path.
+   *
+   * @param rawPath directory to clean
+   * @throws IOException
+   */
+  public abstract void createDir(String rawPath) throws IOException;
+
+  /**
+   * Delete an inode at the given path
+   *
+   * @param rawPath directory to clean
+   * @throws IOException
+   */
+  public abstract void delete(String rawPath) throws IOException;
+
+  /**
+   * list the status of an inode at the path
+   *
+   * @param rawPath path of the inode to list
+   * @throws IOException
+   */
+  public abstract void list(String rawPath) throws IOException;
+
+  /**
+   * Lists the statuses files underneath the given dir in a directory structure determined by
+   * the number of files, threads, and files per directory.
+   *
+   * If numFiles doesn't divide evenly into numThreads, the remainder number of files is truncated.
+   *
+   * @param dir directory to clean
+   * @param numFiles the total number of files to create
+   * @param filesPerDir number of files to create in each directory
+   * @throws IOException
+   */
+  public final void listFiles(String dir, long numFiles, long filesPerDir, int numThreads,
+      int ratePerSecond)
+      throws IOException {
+    runOperation(dir, numFiles, filesPerDir, numThreads, ratePerSecond,
+        (dirName) -> {},
+        (fileName) -> {
+      try {
+        list(fileName);
+      } catch (IOException e) { }
+        });
+  }
+
+  /**
+   * Lists the statuses files underneath the given dir in a directory structure determined by
+   * the number of files, threads, and files per directory.
+   *
+   * If numFiles doesn't divide evenly into numThreads, the remainder number of files is truncated.
    *
    * @param dir directory to clean
    * @param numFiles the total number of files to create
@@ -97,5 +162,95 @@ public abstract class ProfilerClient {
    * @param fileSize the size in bytes of each file that will be created
    * @throws IOException
    */
-  public abstract void createFiles(String dir, long numFiles, long filesPerDir, long fileSize) throws IOException;
+  public final void createFiles(String dir, long numFiles, long filesPerDir, long fileSize,
+      int numThreads, int ratePerSecond) throws IOException {
+    runOperation(dir, numFiles, filesPerDir, numThreads, ratePerSecond,
+        (dirName) -> {
+      try {
+        createDir(dirName);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }},
+        (fileName) -> {
+      try {
+        createFile(fileName, fileSize);
+      } catch (IOException e) { }
+        });
+  }
+
+  /**
+   * Creates files underneath the given dir in a directory structure determined by the
+   *
+   * If numFiles doesn't divide evenly into numThreads, the remainder number of files is truncated.
+   *
+   * @param dir directory to clean
+   * @param numFiles the total number of files to create
+   * @param filesPerDir number of files to create in each directory
+   * @throws IOException
+   */
+  public final void deleteFiles(String dir, long numFiles, long filesPerDir, int numThreads,
+      int ratePerSecond)
+      throws IOException {
+    runOperation(dir, numFiles, filesPerDir, numThreads, ratePerSecond,
+        (deleteDir) -> {},
+        (deleteFile) ->  {
+      try {
+        delete(deleteFile);
+      } catch (IOException e) { }
+    });
+  }
+
+  /**
+   * Given a directory, will execute the provided operations when calculating each directory
+   * name and each file name. The number of operations on each file is rate limited to
+   * {@code ratePerSecond} operations per second.
+   *
+   * @param dir The directory to run operations in
+   * @param numFiles the number of files which is expected
+   * @param filesPerDir the number of expected files within each directory
+   * @param numThreads numThreads
+   * @param ratePerSecond the number of operations to allow per second
+   * @param dirRunnable the runnable which accepts a directory path and performs an operation
+   *        using it
+   * @param fileOpRunnable the runnable which accepts a file path and performs an operation using it
+   */
+  private static void runOperation(String dir, long numFiles, long filesPerDir,
+      int numThreads,
+      int ratePerSecond, Consumer<String> dirRunnable, Consumer<String> fileOpRunnable) {
+    Preconditions.checkState(numFiles >= numThreads, "number of files must be > num threads");
+
+    List<Thread> threads = new ArrayList<>();
+    RateLimiter limiter = RateLimiter.create(ratePerSecond);
+    for (int i = 0; i < numThreads; i++) {
+      int threadNum = i; //
+      // number of operations to perform on each thread
+      int numThreadFiles = (int)numFiles / numThreads;
+      threads.add(new Thread(() -> {
+        String threadDir = PathUtils.concatPath(dir, String.format("profilerThread-%d", threadNum));
+        int createdFiles = 0;
+        while (createdFiles < numThreadFiles) {
+          String subDir = PathUtils.concatPath(threadDir, createdFiles);
+          dirRunnable.accept(subDir);
+          for (int j = 0; j < filesPerDir && createdFiles < numThreadFiles; j++) {
+            String filePath = PathUtils.concatPath(subDir, j);
+            limiter.acquire();
+            fileOpRunnable.accept(filePath);
+            createdFiles++;
+          }
+        }
+      }));
+    }
+    threads.forEach(Thread::start);
+    waitForThreads(threads);
+  }
+
+  private static void waitForThreads(List<Thread> threads) {
+    threads.forEach((thread) -> {
+      try {
+        thread.join();
+      } catch (InterruptedException e) {
+        // do nothing
+      }
+    });
+  }
 }

--- a/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli.profiler;
 
 import alluxio.Constants;

--- a/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
+++ b/examples/src/main/java/alluxio/cli/profiler/ProfilerClient.java
@@ -1,0 +1,50 @@
+package alluxio.cli.profiler;
+
+import java.io.IOException;
+
+/**
+ * Profiles operations.
+ */
+public interface ProfilerClient {
+
+  /**
+   * Create new.
+   */
+  class Factory {
+    /**
+     * Profiler client.
+     * @param type alluxio or hadoop
+     * @return profiler client
+     */
+    public static ProfilerClient create(String type) {
+      switch (type) {
+        case "hadoop":
+        case "alluxio":
+          return new AlluxioProfilerClient();
+        default:
+          throw new IllegalArgumentException(String.format("No profiler for %s", type));
+      }
+    }
+  }
+
+  /**
+   * Makes sure the path exists without any existing inodes below. Essentially cleaning up any
+   * previous operations on the same location.
+   *
+   * @param dir directory to clean
+   * @throws IOException
+   */
+  void cleanup(String dir) throws IOException;
+
+  /**
+   * Makes sure the path exists without any existing inodes below. Essentially cleaning up any
+   * previous operations on the same location.
+   *
+   * @param dir directory to clean
+   * @param numFiles the total number of files to create
+   * @param filesPerDir number of files to create in each directory
+   * @param fileSize the size in bytes of each file that will be created
+   * @throws IOException
+   */
+  void createFiles(String dir, long numFiles, long filesPerDir, long fileSize) throws IOException;
+}

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -1,0 +1,97 @@
+package alluxio.util;
+
+import alluxio.util.io.FileUtils;
+
+import com.google.common.base.Preconditions;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.jvm.hotspot.tools.HeapDumper;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.NoSuchFileException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.management.MBeanServer;
+
+/**
+ * Dumps heaps on a separate thread on a fixes interval.
+ */
+public class JvmHeapDumper extends Thread {
+  private static final Logger LOG = LoggerFactory.getLogger(HeapDumper.class);
+  private static final String HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
+
+  private final MBeanServer mServer = ManagementFactory.getPlatformMBeanServer();
+  HotSpotDiagnosticMXBean mXBean;
+  private final long mInterval;
+  private final String mDirPath;
+  private final String mDumpPrefix;
+  private AtomicBoolean mStop = new AtomicBoolean(false);
+
+  /**
+   * Heap dumper.
+   * @param intervalMs interval to make dumps on
+   * @param dirPath path to store dumps
+   * @param prefix prefix for dumps
+   */
+  public JvmHeapDumper(long intervalMs, String dirPath, String prefix) {
+    super("Thread-Heap-Dumper");
+    Preconditions.checkArgument(intervalMs > 0);
+    mDumpPrefix = Preconditions.checkNotNull(prefix);
+    Preconditions.checkNotNull(dirPath);
+    mInterval = intervalMs;
+    try {
+      mXBean = ManagementFactory.newPlatformMXBeanProxy(mServer,
+          HOTSPOT_BEAN_NAME, HotSpotDiagnosticMXBean.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    File f = new File(String.format("%s/%s", System.getProperty("user.dir"), dirPath));
+    try {
+      FileUtils.deletePathRecursively(f.getAbsolutePath());
+    } catch (NoSuchFileException e) {
+      // It's ok if the path doesn't exist already
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    if (!f.mkdirs()) {
+      throw new RuntimeException("Couldn't create dirs " + f.getAbsolutePath());
+    }
+    mDirPath = f.getAbsolutePath();
+  }
+
+  public void stopDumps() throws InterruptedException {
+    mStop.set(true);
+    join();
+  }
+
+  @Override
+  public void run() {
+    int i = 0;
+    while (!mStop.get()) {
+      try {
+        dumpHeap(i);
+      } catch (IOException e) {
+        // ok
+        System.out.println(e.toString());
+        LOG.warn(e.toString());
+      }
+      try {
+        Thread.sleep(mInterval);
+      } catch (InterruptedException e) {
+        // ok
+        System.out.println(e.toString());
+        LOG.warn(e.toString());
+      }
+      i++;
+    }
+  }
+
+  private void dumpHeap(int num) throws IOException {
+    String dumpLocation = String.format("%s/%s-%d.hprof", mDirPath, mDumpPrefix, num);
+    mXBean.dumpHeap(dumpLocation, true);
+  }
+}
+

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.util;
 
 import alluxio.util.io.FileUtils;

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -34,7 +34,7 @@ public class JvmHeapDumper extends Thread {
   private static final String HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
 
   private final MBeanServer mServer = ManagementFactory.getPlatformMBeanServer();
-  HotSpotDiagnosticMXBean mXBean;
+  private final HotSpotDiagnosticMXBean mXBean;
   private final long mInterval;
   private final String mDirPath;
   private final String mDumpPrefix;

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.jvm.hotspot.tools.HeapDumper;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,7 +20,7 @@ import javax.management.MBeanServer;
  * Dumps heaps on a separate thread on a fixes interval.
  */
 public class JvmHeapDumper extends Thread {
-  private static final Logger LOG = LoggerFactory.getLogger(JvmHeapDumper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HeapDumper.class);
   private static final String HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
 
   private final MBeanServer mServer = ManagementFactory.getPlatformMBeanServer();

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -6,7 +6,6 @@ import com.google.common.base.Preconditions;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.jvm.hotspot.tools.HeapDumper;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,7 +19,7 @@ import javax.management.MBeanServer;
  * Dumps heaps on a separate thread on a fixes interval.
  */
 public class JvmHeapDumper extends Thread {
-  private static final Logger LOG = LoggerFactory.getLogger(HeapDumper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JvmHeapDumper.class);
   private static final String HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
 
   private final MBeanServer mServer = ManagementFactory.getPlatformMBeanServer();

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -98,7 +98,7 @@ public class JvmHeapDumper extends Thread {
 
   private void dumpHeap(int num) throws IOException {
     String dumpLocation = String.format("%s/%s-%02d.hprof", mDirPath, mDumpPrefix, num);
-    mXBean.dumpHeap(dumpLocation, true);
+    mXBean.dumpHeap(dumpLocation, false);
   }
 }
 

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -72,6 +72,11 @@ public class JvmHeapDumper extends Thread {
     mDirPath = f.getAbsolutePath();
   }
 
+  /**
+   * Stops the heap dumper thread.
+   *
+   * @throws InterruptedException
+   */
   public void stopDumps() throws InterruptedException {
     mStop.set(true);
     join();

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -59,15 +59,8 @@ public class JvmHeapDumper extends Thread {
       throw new RuntimeException(e);
     }
     File f = new File(String.format("%s/%s", System.getProperty("user.dir"), dirPath));
-    try {
-      FileUtils.deletePathRecursively(f.getAbsolutePath());
-    } catch (NoSuchFileException e) {
-      // It's ok if the path doesn't exist already
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    if (!f.mkdirs()) {
-      throw new RuntimeException("Couldn't create dirs " + f.getAbsolutePath());
+    if (!f.exists() && !f.mkdirs()) {
+        throw new RuntimeException("Couldn't create dirs " + f.getAbsolutePath());
     }
     mDirPath = f.getAbsolutePath();
   }
@@ -89,15 +82,14 @@ public class JvmHeapDumper extends Thread {
       try {
         dumpHeap(i);
       } catch (IOException e) {
-        // ok
-        System.out.println(e.toString());
+        // // Don't crash, but warn if we're not able to collect heap dumps
+        System.err.println(e.toString());
         LOG.warn(e.toString());
       }
       try {
         Thread.sleep(mInterval);
       } catch (InterruptedException e) {
-        // ok
-        System.out.println(e.toString());
+        System.err.println(e.toString());
         LOG.warn(e.toString());
       }
       i++;
@@ -105,7 +97,7 @@ public class JvmHeapDumper extends Thread {
   }
 
   private void dumpHeap(int num) throws IOException {
-    String dumpLocation = String.format("%s/%s-%d.hprof", mDirPath, mDumpPrefix, num);
+    String dumpLocation = String.format("%s/%s-%02d.hprof", mDirPath, mDumpPrefix, num);
     mXBean.dumpHeap(dumpLocation, true);
   }
 }

--- a/examples/src/main/java/alluxio/util/JvmHeapDumper.java
+++ b/examples/src/main/java/alluxio/util/JvmHeapDumper.java
@@ -11,8 +11,6 @@
 
 package alluxio.util;
 
-import alluxio.util.io.FileUtils;
-
 import com.google.common.base.Preconditions;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import org.slf4j.Logger;
@@ -21,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.NoSuchFileException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.management.MBeanServer;
@@ -42,6 +39,7 @@ public class JvmHeapDumper extends Thread {
 
   /**
    * Heap dumper.
+   *
    * @param intervalMs interval to make dumps on
    * @param dirPath path to store dumps
    * @param prefix prefix for dumps
@@ -60,7 +58,7 @@ public class JvmHeapDumper extends Thread {
     }
     File f = new File(String.format("%s/%s", System.getProperty("user.dir"), dirPath));
     if (!f.exists() && !f.mkdirs()) {
-        throw new RuntimeException("Couldn't create dirs " + f.getAbsolutePath());
+      throw new RuntimeException("Couldn't create dirs " + f.getAbsolutePath());
     }
     mDirPath = f.getAbsolutePath();
   }

--- a/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
+++ b/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
@@ -1,0 +1,50 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import alluxio.cli.profiler.HadoopProfilerClient;
+import alluxio.cli.profiler.ProfilerClient;
+import alluxio.util.JvmHeapDumper;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({JvmHeapDumper.class, ClientProfiler.class})
+@PowerMockIgnore("javax.management.*")
+public class ClientProfilerTest {
+
+  @Test
+  public void abstractFsTest() throws Exception {
+    UserGroupInformation.setLoginUser(UserGroupInformation.createUserForTesting("testUser",
+        new String[]{}));
+    JvmHeapDumper heapDumpMock = PowerMockito.mock(JvmHeapDumper.class);
+    whenNew(JvmHeapDumper.class).withAnyArguments().thenReturn(heapDumpMock);
+    try {
+      ClientProfiler.main(new String[]{"-c", "abstractfs", "--dry"});
+    } catch (Exception e) {
+      fail();
+    }
+  }
+
+}

--- a/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
+++ b/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 public class ClientProfilerTest {
 
-
   @Test
   public void abstractFsTest() {
     try {

--- a/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
+++ b/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
@@ -12,31 +12,17 @@
 package alluxio.cli;
 
 import static org.junit.Assert.fail;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-import alluxio.util.JvmHeapDumper;
-
-import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({JvmHeapDumper.class, ClientProfiler.class})
-@PowerMockIgnore("javax.management.*")
 public class ClientProfilerTest {
 
+
   @Test
-  public void abstractFsTest() throws Exception {
-    UserGroupInformation.setLoginUser(UserGroupInformation.createUserForTesting("testUser",
-        new String[]{}));
-    JvmHeapDumper heapDumpMock = PowerMockito.mock(JvmHeapDumper.class);
-    whenNew(JvmHeapDumper.class).withAnyArguments().thenReturn(heapDumpMock);
+  public void abstractFsTest() {
     try {
-      ClientProfiler.main(new String[]{"-c", "abstractfs", "--dry"});
+      ClientProfiler.main(new String[]{"-c", "abstractfs", "--dry", "-op", "createFiles", "-n",
+          "1"});
     } catch (Exception e) {
       fail();
     }

--- a/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
+++ b/examples/src/test/java/alluxio.cli/ClientProfilerTest.java
@@ -12,13 +12,8 @@
 package alluxio.cli;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-import alluxio.cli.profiler.HadoopProfilerClient;
-import alluxio.cli.profiler.ProfilerClient;
 import alluxio.util.JvmHeapDumper;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -46,5 +41,4 @@ public class ClientProfilerTest {
       fail();
     }
   }
-
 }


### PR DESCRIPTION
This PR adds a tool I've been using to profile Alluxio. It's been added under the examples module. It abstracts out client operations for alluxio, alluxio with the HDFS API, and pure HDFS. The profiler also includes functionality to grab heap dumps at specified intervals and print out the runtime of given operations.

To use it, run

```bash
./bin/alluxio runClass alluxio.cli.ClientProfiler
```

There are lots of parameters and a variety of different operations. See all of them with

```bash
./bin/alluxio runClass alluxio.cli.ClientProfiler --help
```