### PR TITLE
Remove non async eviction

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2290,17 +2290,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  /**
-   * @deprecated It will be removed in 2.0.0.
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_RESERVED_RATIO =
-      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 0)
-          .setDescription("Fraction of space reserved in the top storage tier. "
-              + "This has been deprecated, please use high and low watermark instead.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO =
       new Builder(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 0)
           .setDefaultValue(0.95)
@@ -2332,17 +2321,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_DIRS_QUOTA =
       new Builder(Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA, 1)
           .setDescription("The capacity of the second storage tier.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  /**
-   * @deprecated It will be removed in 2.0.0.
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_TIERED_STORE_LEVEL1_RESERVED_RATIO =
-      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 1)
-          .setDescription("Fraction of space reserved in the second storage tier. "
-              + "This has been deprecated, please use high and low watermark instead.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
@@ -2380,17 +2358,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  /**
-   * @deprecated It will be removed in 2.0.0.
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_RESERVED_RATIO =
-      new Builder(Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO, 2)
-          .setDescription("Fraction of space reserved in the third storage tier. "
-              + "This has been deprecated, please use high and low watermark instead.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_TIERED_STORE_LEVEL2_HIGH_WATERMARK_RATIO =
       new Builder(Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO, 2)
           .setDefaultValue(0.95)
@@ -2411,13 +2378,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.WORKER_TIERED_STORE_LEVELS)
           .setDefaultValue(1)
           .setDescription("The number of storage tiers on the worker.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  public static final PropertyKey WORKER_TIERED_STORE_RESERVER_ENABLED =
-      new Builder(Name.WORKER_TIERED_STORE_RESERVER_ENABLED)
-          .setDefaultValue(true)
-          .setDescription("Whether to enable tiered store reserver service or not.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
@@ -4062,8 +4022,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_TIERED_STORE_BLOCK_LOCKS =
         "alluxio.worker.tieredstore.block.locks";
     public static final String WORKER_TIERED_STORE_LEVELS = "alluxio.worker.tieredstore.levels";
-    public static final String WORKER_TIERED_STORE_RESERVER_ENABLED =
-        "alluxio.worker.tieredstore.reserver.enabled";
     public static final String WORKER_TIERED_STORE_RESERVER_INTERVAL_MS =
         "alluxio.worker.tieredstore.reserver.interval";
     public static final String WORKER_TIERED_STORE_RETRY = "alluxio.worker.tieredstore.retry";
@@ -4362,8 +4320,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio\\.worker\\.tieredstore\\.level(\\d+)\\.dirs\\.path"),
     WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA("alluxio.worker.tieredstore.level%d.dirs.quota",
         "alluxio\\.worker\\.tieredstore\\.level(\\d+)\\.dirs\\.quota"),
-    WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO("alluxio.worker.tieredstore.level%d.reserved.ratio",
-        "alluxio\\.worker\\.tieredstore\\.level(\\d+)\\.reserved\\.ratio"),
     WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO(
         "alluxio.worker.tieredstore.level%d.watermark.high.ratio",
         "alluxio\\.worker\\.tieredstore\\.level(\\d+)\\.watermark\\.high\\.ratio"),
@@ -4442,7 +4398,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
     /**
      * Converts a property key template (e.g.,
-     * {@link #WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO}) to a {@link PropertyKey} instance.
+     * {@link #WORKER_TIERED_STORE_LEVEL_ALIAS}) to a {@link PropertyKey} instance.
      *
      * @param params ordinal
      * @return corresponding property

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -219,13 +219,11 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
     mSessionCleaner = new SessionCleaner(mSessions, mBlockStore, mUnderFileSystemBlockStore);
 
     // Setup space reserver
-    if (ServerConfiguration.getBoolean(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED)) {
-      mSpaceReserver = new SpaceReserver(this);
-      getExecutorService().submit(
-          new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, mSpaceReserver,
-              (int) ServerConfiguration.getMs(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS),
-              ServerConfiguration.global()));
-    }
+    mSpaceReserver = new SpaceReserver(this);
+    getExecutorService().submit(
+        new HeartbeatThread(HeartbeatContext.WORKER_SPACE_RESERVER, mSpaceReserver,
+            (int) ServerConfiguration.getMs(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS),
+            ServerConfiguration.global()));
 
     getExecutorService()
         .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, mBlockMasterSync,

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -74,42 +74,33 @@ public class SpaceReserver implements HeartbeatExecutor {
     for (int ordinal = 0; ordinal < mStorageTierAssoc.size(); ordinal++) {
       String tierAlias = mStorageTierAssoc.getAlias(ordinal);
       long tierCapacity = tierCapacities.get(tierAlias);
-      long reservedSpace;
-      PropertyKey tierReservedSpaceProp =
-          PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_RESERVED_RATIO.format(ordinal);
-      if (ServerConfiguration.isSet(tierReservedSpaceProp)) {
-        LOG.warn("The property reserved.ratio is deprecated, use high/low watermark instead.");
-        reservedSpace = (long) (tierCapacity * ServerConfiguration
-            .getDouble(tierReservedSpaceProp));
-      } else {
-        // High watermark defines when to start the space reserving process
-        PropertyKey tierHighWatermarkProp =
-            PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(ordinal);
-        double tierHighWatermarkConf = ServerConfiguration.getDouble(tierHighWatermarkProp);
-        Preconditions.checkArgument(tierHighWatermarkConf > 0,
-            "The high watermark of tier %s should be positive, but is %s",
-            Integer.toString(ordinal), tierHighWatermarkConf);
-        Preconditions.checkArgument(tierHighWatermarkConf < 1,
-            "The high watermark of tier %s should be less than 1.0, but is %s",
-            Integer.toString(ordinal), tierHighWatermarkConf);
-        long highWatermark = (long) (tierCapacity * ServerConfiguration
-            .getDouble(tierHighWatermarkProp));
-        mHighWatermarks.put(tierAlias, highWatermark);
+      // High watermark defines when to start the space reserving process
+      PropertyKey tierHighWatermarkProp =
+          PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(ordinal);
+      double tierHighWatermarkConf = ServerConfiguration.getDouble(tierHighWatermarkProp);
+      Preconditions.checkArgument(tierHighWatermarkConf > 0,
+          "The high watermark of tier %s should be positive, but is %s", Integer.toString(ordinal),
+          tierHighWatermarkConf);
+      Preconditions.checkArgument(tierHighWatermarkConf < 1,
+          "The high watermark of tier %s should be less than 1.0, but is %s",
+          Integer.toString(ordinal), tierHighWatermarkConf);
+      long highWatermark =
+          (long) (tierCapacity * ServerConfiguration.getDouble(tierHighWatermarkProp));
+      mHighWatermarks.put(tierAlias, highWatermark);
 
-        // Low watermark defines when to stop the space reserving process if started
-        PropertyKey tierLowWatermarkProp =
-            PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(ordinal);
-        double tierLowWatermarkConf = ServerConfiguration.getDouble(tierLowWatermarkProp);
-        Preconditions.checkArgument(tierLowWatermarkConf >= 0,
-            "The low watermark of tier %s should not be negative, but is %s",
-            Integer.toString(ordinal), tierLowWatermarkConf);
-        Preconditions.checkArgument(tierLowWatermarkConf < tierHighWatermarkConf,
-            "The low watermark (%s) of tier %d should not be smaller than the high watermark (%s)",
-            tierLowWatermarkConf, ordinal, tierHighWatermarkConf);
-        reservedSpace =
-            (long) (tierCapacity - tierCapacity * ServerConfiguration
-                .getDouble(tierLowWatermarkProp));
-      }
+      // Low watermark defines when to stop the space reserving process if started
+      PropertyKey tierLowWatermarkProp =
+          PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(ordinal);
+      double tierLowWatermarkConf = ServerConfiguration.getDouble(tierLowWatermarkProp);
+      Preconditions.checkArgument(tierLowWatermarkConf >= 0,
+          "The low watermark of tier %s should not be negative, but is %s",
+          Integer.toString(ordinal), tierLowWatermarkConf);
+      Preconditions.checkArgument(tierLowWatermarkConf < tierHighWatermarkConf,
+          "The low watermark (%s) of tier %d should not be smaller than the high watermark (%s)",
+          tierLowWatermarkConf, ordinal, tierHighWatermarkConf);
+      long reservedSpace =
+          (long) (tierCapacity
+              - tierCapacity * ServerConfiguration.getDouble(tierLowWatermarkProp));
       lastTierReservedBytes += reservedSpace;
       // On each tier, we reserve no more than its capacity
       lastTierReservedBytes =
@@ -133,14 +124,6 @@ public class SpaceReserver implements HeartbeatExecutor {
             LOG.warn("SpaceReserver failed to free {} bytes on tier {} for high watermarks: {}",
                 reservedSpace, tierAlias, e.getMessage());
           }
-        }
-      } else {
-        try {
-          mBlockWorker.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, reservedSpace, tierAlias);
-        } catch (WorkerOutOfSpaceException | BlockDoesNotExistException
-            | BlockAlreadyExistsException | InvalidWorkerStateException | IOException e) {
-          LOG.warn("SpaceReserver failed to free {} bytes on tier {}: {}", reservedSpace,
-              tierAlias, e.getMessage());
         }
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -122,6 +122,8 @@ public class SpaceReserver implements HeartbeatExecutor {
                 reservedSpace, tierAlias, e.getMessage());
           }
         }
+      } else {
+        LOG.warn("No watermark set for tier {}, eviction will not be run.", tierAlias);
       }
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpaceReserver.java
@@ -84,8 +84,7 @@ public class SpaceReserver implements HeartbeatExecutor {
       Preconditions.checkArgument(tierHighWatermarkConf < 1,
           "The high watermark of tier %s should be less than 1.0, but is %s",
           Integer.toString(ordinal), tierHighWatermarkConf);
-      long highWatermark =
-          (long) (tierCapacity * ServerConfiguration.getDouble(tierHighWatermarkProp));
+      long highWatermark = (long) (tierCapacity * tierHighWatermarkConf);
       mHighWatermarks.put(tierAlias, highWatermark);
 
       // Low watermark defines when to stop the space reserving process if started
@@ -98,9 +97,7 @@ public class SpaceReserver implements HeartbeatExecutor {
       Preconditions.checkArgument(tierLowWatermarkConf < tierHighWatermarkConf,
           "The low watermark (%s) of tier %d should not be smaller than the high watermark (%s)",
           tierLowWatermarkConf, ordinal, tierHighWatermarkConf);
-      long reservedSpace =
-          (long) (tierCapacity
-              - tierCapacity * ServerConfiguration.getDouble(tierLowWatermarkProp));
+      long reservedSpace = (long) (tierCapacity - tierCapacity * tierLowWatermarkConf);
       lastTierReservedBytes += reservedSpace;
       // On each tier, we reserve no more than its capacity
       lastTierReservedBytes =

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -227,6 +227,8 @@ public class TieredBlockStore implements BlockStore {
         return tempBlockMeta;
       }
     }
+    // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
+    // other types of exception to indicate this case.
     throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION_TIMEOUT,
         initialBlockSize, location, FREE_SPACE_TIMEOUT_MS, blockId);
   }
@@ -295,6 +297,8 @@ public class TieredBlockStore implements BlockStore {
         return;
       }
     }
+    // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
+    // other types of exception to indicate this case.
     throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_REQUEST_SPACE_TIMEOUT,
         additionalBytes, FREE_SPACE_TIMEOUT_MS, blockId);
   }
@@ -326,6 +330,8 @@ public class TieredBlockStore implements BlockStore {
         return;
       }
     }
+    // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
+    // other types of exception to indicate this case.
     throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_MOVE_TIMEOUT,
         newLocation, blockId, FREE_SPACE_TIMEOUT_MS);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpaceReserverTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpaceReserverTest.java
@@ -71,7 +71,9 @@ public class SpaceReserverTest {
     BlockStoreMeta storeMeta = mock(BlockStoreMeta.class);
     when(blockWorker.getStoreMeta()).thenReturn(storeMeta);
     Map<String, Long> capacityBytesOnTiers = ImmutableMap.of("MEM", 400L, "HDD", 1000L);
+    Map<String, Long> usedCapacityBytesOnTiers = ImmutableMap.of("MEM", 390L, "HDD", 800L);
     when(storeMeta.getCapacityBytesOnTiers()).thenReturn(capacityBytesOnTiers);
+    when(storeMeta.getUsedBytesOnTiers()).thenReturn(usedCapacityBytesOnTiers);
 
     String tmpFolderPath = mTempFolder.newFolder().getAbsolutePath();
 
@@ -82,8 +84,10 @@ public class SpaceReserverTest {
         new long[][]{new long[]{0}, new long[]{0}}, "/");
 
     try (Closeable c = new ConfigurationRule(ImmutableMap.of(
-        PropertyKey.WORKER_TIERED_STORE_LEVEL0_RESERVED_RATIO, "0.2",
-        PropertyKey.WORKER_TIERED_STORE_LEVEL1_RESERVED_RATIO, "0.3"),
+        PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, "0.81",
+        PropertyKey.WORKER_TIERED_STORE_LEVEL0_LOW_WATERMARK_RATIO, "0.8",
+        PropertyKey.WORKER_TIERED_STORE_LEVEL1_HIGH_WATERMARK_RATIO, "0.71",
+        PropertyKey.WORKER_TIERED_STORE_LEVEL1_LOW_WATERMARK_RATIO, "0.7"),
         ServerConfiguration.global()).toResource()) {
       SpaceReserver spaceReserver = new SpaceReserver(blockWorker);
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -149,7 +149,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
 
   @Test
   @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.WORKER_TIERED_STORE_RESERVER_ENABLED, "false"})
+      confParams = {PropertyKey.Name.WORKER_NETWORK_NETTY_WATERMARK_HIGH, "1.0"})
   public void copyFromLocalLarge() throws IOException, AlluxioException {
     File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
     testFile.createNewFile();

--- a/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
@@ -20,6 +20,8 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.testutils.IntegrationTestUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -27,6 +29,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,10 +43,13 @@ import java.util.HashMap;
 /**
  * Integration tests for {@link FileOutStream} of under storage type being async
  * persist.
- *
  */
 @RunWith(Parameterized.class)
 public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStreamIntegrationTest {
+  @ClassRule
+  public static ManuallyScheduleHeartbeat sManuallyScheduleEviction =
+      new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_SPACE_RESERVER);
+
   protected static final int WORKER_MEMORY_SIZE = 1500;
   protected static final int BUFFER_BYTES = 100;
 

--- a/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
@@ -53,7 +53,7 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
         .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BUFFER_BYTES) // initial buffer for worker
         .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_MEMORY_SIZE)
         .setProperty(PropertyKey.USER_FILE_UFS_TIER_ENABLED, true)
-        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED, false);
+        .setProperty(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_HIGH, "1.0");
   }
 
   // varying the client side configuration

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -81,7 +81,6 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_MEMORY_SIZE_BYTES)
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED, false)
           .setNumWorkers(NUM_WORKERS)
           .build();
 

--- a/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
@@ -115,7 +115,6 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
   private void startClusterWithWorkerStorage(String ssdPath, String hddPath) throws Exception {
     mLocalAlluxioClusterResource
         .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "1KB")
-        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED, false)
         .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "3")
         .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
         .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), SSD_TIER)

--- a/tests/src/test/java/alluxio/server/tieredstore/SpecificTierWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/SpecificTierWriteIntegrationTest.java
@@ -45,7 +45,7 @@ import java.util.Map;
  * Integration tests for writing to various storage tiers.
  */
 public class SpecificTierWriteIntegrationTest extends BaseIntegrationTest {
-  private static final int CAPACITY_BYTES = Constants.KB;
+  private static final int CAPACITY_BYTES = Constants.KB * 10;
   private static final int FILE_SIZE = CAPACITY_BYTES;
   private static final String BLOCK_SIZE_BYTES = "1KB";
 
@@ -56,7 +56,6 @@ public class SpecificTierWriteIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
           .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "3")
-          .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED, false)
           .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
           .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(2), "HDD")
           .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
@@ -76,6 +75,10 @@ public class SpecificTierWriteIntegrationTest extends BaseIntegrationTest {
   @ClassRule
   public static ManuallyScheduleHeartbeat sManuallySchedule =
       new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_BLOCK_SYNC);
+
+  @ClassRule
+  public static ManuallyScheduleHeartbeat sManuallyScheduleEviction =
+      new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_SPACE_RESERVER);
 
   private FileSystem mFileSystem = null;
   private BlockMaster mBlockMaster;

--- a/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 @RunWith(Parameterized.class)
 public class TierPromoteIntegrationTest extends BaseIntegrationTest {
-  private static final int CAPACITY_BYTES = Constants.KB;
+  private static final int CAPACITY_BYTES = 10 * Constants.KB;
   private static final String BLOCK_SIZE_BYTES = "1KB";
 
   @Rule
@@ -81,7 +81,6 @@ public class TierPromoteIntegrationTest extends BaseIntegrationTest {
         .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
         .setProperty(PropertyKey.USER_SHORT_CIRCUIT_ENABLED, shortCircuitEnabled)
         .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
-        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_ENABLED, false)
         .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
         .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
             Files.createTempDir().getAbsolutePath())

--- a/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
@@ -12,7 +12,6 @@
 package alluxio.server.tieredstore;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
@@ -25,6 +24,7 @@ import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.FormatUtils;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 
@@ -43,8 +43,10 @@ import java.util.List;
 
 @RunWith(Parameterized.class)
 public class TierPromoteIntegrationTest extends BaseIntegrationTest {
-  private static final int CAPACITY_BYTES = 10 * Constants.KB;
+  private static final int BLOCKS_PER_TIER = 10;
   private static final String BLOCK_SIZE_BYTES = "1KB";
+  private static final long CAPACITY_BYTES =
+      BLOCKS_PER_TIER * FormatUtils.parseSpaceSize(BLOCK_SIZE_BYTES);
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource;
@@ -92,7 +94,7 @@ public class TierPromoteIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void promoteBlock() throws Exception {
-    final int size = CAPACITY_BYTES / 2;
+    final int size = (int) CAPACITY_BYTES / 2;
     AlluxioURI path1 = new AlluxioURI(PathUtils.uniqPath());
     AlluxioURI path2 = new AlluxioURI(PathUtils.uniqPath());
     AlluxioURI path3 = new AlluxioURI(PathUtils.uniqPath());


### PR DESCRIPTION
Removes the deprecated synchronous eviction code path.
Previously, Alluxio supported both synchronous and asynchronous eviction. Synchronous eviction was more straightforward but ultimately less efficient because each client request would evict a small amount of data (enough to satisfy the current request space call). Asynchronous eviction allows the evictor to use more information and do a more efficient batch eviction.