### PR TITLE
Replace lambda with method reference in DefaultAuthenticationServer

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -78,9 +78,8 @@ public class DefaultAuthenticationServer
     mChannels = new ConcurrentHashMap<>();
     mScheduler = Executors.newScheduledThreadPool(1,
         ThreadFactoryUtils.build("auth-cleanup", true));
-    mScheduler.scheduleAtFixedRate(() -> {
-      cleanupStaleClients();
-    }, mCleanupIntervalMs, mCleanupIntervalMs, TimeUnit.MILLISECONDS);
+    mScheduler.scheduleAtFixedRate(this::cleanupStaleClients, mCleanupIntervalMs,
+        mCleanupIntervalMs, TimeUnit.MILLISECONDS);
   }
 
   @Override


### PR DESCRIPTION
Java 8 improvement: replace lambda with method reference in /alluxio/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java#DefaultAuthenticationServer.