### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
+++ b/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
@@ -18,7 +18,7 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 
@@ -34,7 +34,7 @@ public class UnderFileSystemFactoryRegistryRuleTest {
   private Statement mStatement = new Statement() {
     @Override
     public void evaluate() throws Throwable {
-      Assert.assertEquals(mUnderFileSystemFactory, UnderFileSystemFactoryRegistry
+      assertEquals(mUnderFileSystemFactory, UnderFileSystemFactoryRegistry
           .find(UFS_PATH, mConfiguration));
     }
   };
@@ -44,10 +44,10 @@ public class UnderFileSystemFactoryRegistryRuleTest {
     mUnderFileSystemFactory = mock(UnderFileSystemFactory.class);
     when(mUnderFileSystemFactory.supportsPath(UFS_PATH, null)).thenReturn(true);
     // check before
-    Assert.assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
+    assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
     new UnderFileSystemFactoryRegistryRule(mUnderFileSystemFactory)
         .apply(mStatement, null).evaluate();
     // check after
-    Assert.assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
+    assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
   }
 }

--- a/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
+++ b/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
@@ -13,12 +13,12 @@ package alluxio;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
 
 import alluxio.conf.InstancedConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 


### PR DESCRIPTION
Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java