### PR TITLE
[SMALLFIX]Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/cli/CommandTest.java
+++ b/core/common/src/test/java/alluxio/cli/CommandTest.java
@@ -13,10 +13,12 @@ package alluxio.cli;
 
 import static alluxio.exception.ExceptionMessage.INVALID_ARGS_NUM;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.exception.status.InvalidArgumentException;
 
 import org.apache.commons.cli.CommandLine;
-import static org.junit.Assert.assertEquals;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/core/common/src/test/java/alluxio/cli/CommandTest.java
+++ b/core/common/src/test/java/alluxio/cli/CommandTest.java
@@ -16,7 +16,7 @@ import static alluxio.exception.ExceptionMessage.INVALID_ARGS_NUM;
 import alluxio.exception.status.InvalidArgumentException;
 
 import org.apache.commons.cli.CommandLine;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -66,7 +66,7 @@ public final class CommandTest {
   public void expectedNumArgs() throws Exception {
     TestCommand cmd = new TestCommand();
     CommandLine commandLine = cmd.parseAndValidateArgs("arg1");
-    Assert.assertEquals(1, commandLine.getArgs().length);
+    assertEquals(1, commandLine.getArgs().length);
   }
 
   @Test


### PR DESCRIPTION
Fixed [issue Alluxio/new-contributor-tasks#515](https://github.com/Alluxio/new-contributor-tasks/issues/515)

Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/cli/CommandTest.java


