### PR TITLE
Add eventual consistency support to createFile when creating ufs blocks

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -219,7 +219,7 @@ public final class UfsFallbackBlockWriteHandler
     UnderFileSystem ufs = ufsResource.get();
     // Set the atomic flag to be true to ensure only the creation of this file is atomic on close.
     OutputStream ufsOutputStream =
-        ufs.create(ufsPath,
+        ufs.createNonexistingFile(ufsPath,
             CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(true)
                 .setCreateParent(true));
     context.setOutputStream(ufsOutputStream);

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -87,8 +87,8 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsClient);
-    Mockito.when(mockUfs.create(Mockito.anyString(), Mockito.any(CreateOptions.class)))
-        .thenReturn(mOutputStream)
+    Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
+        Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)
         .thenReturn(new FileOutputStream(mFile, true));
 
     mResponseObserver = Mockito.mock(StreamObserver.class);


### PR DESCRIPTION
When creating ufs blocks, Alluxio knows from its metadata that the file does not exist and should retry creating files. Change from create to createNonexistingFile here to add eventual consistency support.