### PR TITLE
Hide credentials in mount command

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemConfiguration.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemConfiguration.java
@@ -16,13 +16,11 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.util.ConfigurationUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -130,16 +128,14 @@ public final class UnderFileSystemConfiguration extends InstancedConfiguration {
   }
 
   /**
-   * @param userPropertiesOnly  whether to use only the user properties
    * @param options options for formatting the configuration values
-   * @return a map from all configuration property names to their values; values may potentially be
-   *         null
+   * @return a map from all user configuration property names to their values; values may
+   * potentially be null
    */
-  public Map<String, String> toMap(boolean userPropertiesOnly, ConfigurationValueOptions options) {
+  public Map<String, String> toUserPropertyMap(ConfigurationValueOptions options) {
     Map<String, String> map = new HashMap<>();
-    Set<PropertyKey> keys = userPropertiesOnly ? userKeySet() : keySet();
     // Cannot use Collectors.toMap because we support null keys.
-    keys.forEach(key -> map.put(key.getName(), getOrDefault(key, null, options)));
+    userKeySet().forEach(key -> map.put(key.getName(), getOrDefault(key, null, options)));
     return map;
   }
 }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemConfiguration.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemConfiguration.java
@@ -14,12 +14,15 @@ package alluxio.underfs;
 import alluxio.annotation.PublicApi;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
+import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.util.ConfigurationUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -124,5 +127,19 @@ public final class UnderFileSystemConfiguration extends InstancedConfiguration {
     ufsConf.mReadOnly = mReadOnly;
     ufsConf.mShared = mShared;
     return ufsConf;
+  }
+
+  /**
+   * @param userPropertiesOnly  whether to use only the user properties
+   * @param options options for formatting the configuration values
+   * @return a map from all configuration property names to their values; values may potentially be
+   *         null
+   */
+  public Map<String, String> toMap(boolean userPropertiesOnly, ConfigurationValueOptions options) {
+    Map<String, String> map = new HashMap<>();
+    Set<PropertyKey> keys = userPropertiesOnly ? userKeySet() : keySet();
+    // Cannot use Collectors.toMap because we support null keys.
+    keys.forEach(key -> map.put(key.getName(), getOrDefault(key, null, options)));
+    return map;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1310,28 +1310,28 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   public Map<String, MountPointInfo> getMountTable() {
     SortedMap<String, MountPointInfo> mountPoints = new TreeMap<>();
     for (Map.Entry<String, MountInfo> mountPoint : mMountTable.getMountTable().entrySet()) {
-      mountPoints.put(mountPoint.getKey(), getMountPointInfo(mountPoint.getValue()));
+      mountPoints.put(mountPoint.getKey(), getDisplayMountPointInfo(mountPoint.getValue()));
     }
     return mountPoints;
   }
 
   @Override
-  public MountPointInfo getMountPointInfo(AlluxioURI path) throws InvalidPathException {
+  public MountPointInfo getDisplayMountPointInfo(AlluxioURI path) throws InvalidPathException {
     if (!mMountTable.isMountPoint(path)) {
       throw new InvalidPathException(
           ExceptionMessage.PATH_MUST_BE_MOUNT_POINT.getMessage(path));
     }
-    return getMountPointInfo(mMountTable.getMountTable().get(path.toString()));
+    return getDisplayMountPointInfo(mMountTable.getMountTable().get(path.toString()));
   }
 
   /**
-   * Gets the mount point information from a mount information.
+   * Gets the mount point information for display from a mount information.
    *
    * @param mountInfo the mount information to transform
    * @return the mount point information
    */
-  private MountPointInfo getMountPointInfo(MountInfo mountInfo) {
-    MountPointInfo info = mountInfo.toMountPointInfo();
+  private MountPointInfo getDisplayMountPointInfo(MountInfo mountInfo) {
+    MountPointInfo info = mountInfo.toDisplayMountPointInfo();
     try (CloseableResource<UnderFileSystem> ufsResource =
              mUfsManager.get(mountInfo.getMountId()).acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -216,12 +216,12 @@ public interface FileSystemMaster extends Master {
   Map<String, MountPointInfo>  getMountTable();
 
   /**
-   * Gets the mount point information of an Alluxio path.
+   * Gets the mount point information of an Alluxio path for display purpose.
    *
    * @param path an Alluxio path which must be a mount point
    * @return the mount point information
    */
-  MountPointInfo getMountPointInfo(AlluxioURI path) throws InvalidPathException;
+  MountPointInfo getDisplayMountPointInfo(AlluxioURI path) throws InvalidPathException;
 
   /**
    * @return the number of files and directories

--- a/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
@@ -100,7 +100,7 @@ public class MountInfo {
     UnderFileSystemConfiguration conf =
         UnderFileSystemConfiguration.defaults(new InstancedConfiguration(
             new AlluxioProperties())).createMountSpecificConf(info.getProperties());
-    Map<String, String> displayConf = conf.toMap(true,
+    Map<String, String> displayConf = conf.toUserPropertyMap(
         ConfigurationValueOptions.defaults().useDisplayValue(true));
     info.setProperties(displayConf);
     return info;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
@@ -12,11 +12,16 @@
 package alluxio.master.file.meta.options;
 
 import alluxio.AlluxioURI;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.ConfigurationValueOptions;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.grpc.MountPOptions;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.wire.MountPointInfo;
 
 import com.google.common.base.Preconditions;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -83,6 +88,21 @@ public class MountInfo {
     info.setReadOnly(mOptions.getReadOnly());
     info.setProperties(mOptions.getProperties());
     info.setShared(mOptions.getShared());
+    return info;
+  }
+
+  /**
+   * @return the {@link MountPointInfo} for the mount point. Some information is formatted
+   * for display purpose.
+   */
+  public MountPointInfo toDisplayMountPointInfo() {
+    MountPointInfo info = toMountPointInfo();
+    UnderFileSystemConfiguration conf =
+        UnderFileSystemConfiguration.defaults(new InstancedConfiguration(
+            new AlluxioProperties())).createMountSpecificConf(info.getProperties());
+    Map<String, String> displayConf = conf.toMap(true,
+        ConfigurationValueOptions.defaults().useDisplayValue(true));
+    info.setProperties(displayConf);
     return info;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -300,7 +300,7 @@ public final class AlluxioMasterRestServiceHandler {
 
       MountPointInfo mountInfo;
       try {
-        mountInfo = mFileSystemMaster.getMountPointInfo(new AlluxioURI(MountTable.ROOT));
+        mountInfo = mFileSystemMaster.getDisplayMountPointInfo(new AlluxioURI(MountTable.ROOT));
 
         long capacityBytes = mountInfo.getUfsCapacityBytes();
         long usedBytes = mountInfo.getUfsUsedBytes();

--- a/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
@@ -50,15 +50,21 @@ import java.util.Map;
 public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
   private static final String MOUNT_POINT1 = "/mnt1";
   private static final String MOUNT_POINT2 = "/mnt2";
+  private static final String MOUNT_POINT3 = "/mnt3";
   private static final Map<String, String> UFS_CONF1 = ImmutableMap.of("key1", "val1");
   private static final Map<String, String> UFS_CONF2 = ImmutableMap.of("key2", "val2");
+  private static final Map<String, String> UFS_CONF3 = ImmutableMap.of(
+      PropertyKey.Name.S3A_ACCESS_KEY, "testpass");
 
   private ConfExpectingUnderFileSystemFactory mUfsFactory1;
   private ConfExpectingUnderFileSystemFactory mUfsFactory2;
+  private ConfExpectingUnderFileSystemFactory mUfsFactory3;
   private AlluxioURI mMountPoint1 = new AlluxioURI(MOUNT_POINT1);
   private AlluxioURI mMountPoint2 = new AlluxioURI(MOUNT_POINT2);
+  private AlluxioURI mMountPoint3 = new AlluxioURI(MOUNT_POINT3);
   private String mUfsUri1;
   private String mUfsUri2;
+  private String mUfsUri3;
   private UnderFileSystem mLocalUfs;
   private FileSystem mFileSystem;
   private LocalAlluxioCluster mLocalAlluxioCluster;
@@ -76,11 +82,14 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
   public void before() throws Exception {
     mUfsFactory1 = new ConfExpectingUnderFileSystemFactory("ufs1", UFS_CONF1);
     mUfsFactory2 = new ConfExpectingUnderFileSystemFactory("ufs2", UFS_CONF2);
+    mUfsFactory3 = new ConfExpectingUnderFileSystemFactory("ufs3", UFS_CONF3);
     UnderFileSystemFactoryRegistry.register(mUfsFactory1);
     UnderFileSystemFactoryRegistry.register(mUfsFactory2);
+    UnderFileSystemFactoryRegistry.register(mUfsFactory3);
 
     mUfsUri1 = "ufs1://" + mFolder.newFolder().getAbsoluteFile();
     mUfsUri2 = "ufs2://" + mFolder.newFolder().getAbsoluteFile();
+    mUfsUri3 = "ufs3://" + mFolder.newFolder().getAbsoluteFile();
     mLocalUfs = new LocalUnderFileSystemFactory().create(mFolder.getRoot().getAbsolutePath(),
         UnderFileSystemConfiguration.defaults(), ServerConfiguration.global());
     mLocalAlluxioClusterResource.start();
@@ -98,6 +107,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
   public void after() throws Exception {
     UnderFileSystemFactoryRegistry.unregister(mUfsFactory1);
     UnderFileSystemFactoryRegistry.unregister(mUfsFactory2);
+    UnderFileSystemFactoryRegistry.unregister(mUfsFactory3);
   }
 
   @Test
@@ -261,5 +271,21 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     FileInStream inStream2 = mFileSystem.openFile(file2);
     Assert.assertNotNull(inStream2);
     inStream2.close();
+  }
+
+  @Test
+  public void mountWithCredentials() throws Exception {
+    MountPOptions options3 = MountPOptions.newBuilder().putAllProperties(UFS_CONF3).build();
+    mFileSystem.mount(mMountPoint3, new AlluxioURI(mUfsUri3), options3);
+    MasterRegistry registry = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    Map<String, MountPointInfo> mountTable = fsMaster.getMountTable();
+    Assert.assertTrue(mountTable.containsKey(MOUNT_POINT3));
+    MountPointInfo mountPointInfo3 = mountTable.get(MOUNT_POINT3);
+    Assert.assertEquals(mUfsUri3, mountPointInfo3.getUfsUri());
+    Assert.assertEquals(UFS_CONF3.size(), mountPointInfo3.getProperties().size());
+    Assert.assertTrue(mountPointInfo3.getProperties().containsKey(PropertyKey.Name.S3A_ACCESS_KEY));
+    Assert.assertNotEquals(UFS_CONF3.get(PropertyKey.Name.S3A_ACCESS_KEY),
+        mountPointInfo3.getProperties().get(PropertyKey.Name.S3A_ACCESS_KEY));
   }
 }


### PR DESCRIPTION
This fix changed the API so we hides values of mount options that are credentials.