### PR TITLE
[SMALLFIX] Use @Nullable annotation for methods which may return null

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -39,7 +39,6 @@ import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Throwables;
-import jdk.internal.jline.internal.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -39,6 +39,7 @@ import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Throwables;
+import jdk.internal.jline.internal.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +104,7 @@ public final class MountTable implements DelegatingJournaled {
    * @throws FileAlreadyExistsException if the mount point already exists
    * @throws InvalidPathException if an invalid path is encountered
    */
+  @Nullable
   public void add(Supplier<JournalContext> journalContext, AlluxioURI alluxioUri, AlluxioURI ufsUri,
       long mountId, MountPOptions options) throws FileAlreadyExistsException, InvalidPathException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
@@ -269,6 +271,7 @@ public final class MountTable implements DelegatingJournaled {
    * @param ufsUri an Ufs path URI
    * @return an Alluxio path URI
    */
+  @Nullable
   public AlluxioURI reverseResolve(AlluxioURI ufsUri) {
     AlluxioURI returnVal = null;
     for (Map.Entry<String, MountInfo> mountInfoEntry : getMountTable().entrySet()) {
@@ -293,6 +296,7 @@ public final class MountTable implements DelegatingJournaled {
    * @param mountId mount id to look up ufs client
    * @return ufsClient
    */
+  @Nullable
   public UfsManager.UfsClient getUfsClient(long mountId) {
     try {
       return mUfsManager.get(mountId);
@@ -349,6 +353,7 @@ public final class MountTable implements DelegatingJournaled {
    * @throws InvalidPathException if the Alluxio path is invalid
    * @throws AccessControlException if the Alluxio path is under a readonly mount point
    */
+  @Nullable
   public void checkUnderWritableMountPoint(AlluxioURI alluxioUri)
       throws InvalidPathException, AccessControlException {
     try (LockResource r = new LockResource(mReadLock)) {
@@ -458,6 +463,7 @@ public final class MountTable implements DelegatingJournaled {
      * @param context journal context
      * @param entry add mount point entry
      */
+    @Nullable
     public void applyAndJournal(Supplier<JournalContext> context, AddMountPointEntry entry) {
       applyAndJournal(context, JournalEntry.newBuilder().setAddMountPoint(entry).build());
     }
@@ -466,10 +472,12 @@ public final class MountTable implements DelegatingJournaled {
      * @param context journal context
      * @param entry delete mount point entry
      */
+    @Nullable
     public void applyAndJournal(Supplier<JournalContext> context, DeleteMountPointEntry entry) {
       applyAndJournal(context, JournalEntry.newBuilder().setDeleteMountPoint(entry).build());
     }
 
+    @Nullable
     private void applyAddMountPoint(AddMountPointEntry entry) {
       MountInfo mountInfo =
           new MountInfo(new AlluxioURI(entry.getAlluxioPath()), new AlluxioURI(entry.getUfsPath()),
@@ -477,6 +485,7 @@ public final class MountTable implements DelegatingJournaled {
       mMountTable.put(entry.getAlluxioPath(), mountInfo);
     }
 
+    @Nullable
     private void applyDeleteMountPoint(DeleteMountPointEntry entry) {
       mMountTable.remove(entry.getAlluxioPath());
     }
@@ -494,6 +503,7 @@ public final class MountTable implements DelegatingJournaled {
     }
 
     @Override
+    @Nullable
     public void resetState() {
       MountInfo mountInfo = mMountTable.get(ROOT);
       mMountTable.clear();
@@ -554,6 +564,7 @@ public final class MountTable implements DelegatingJournaled {
         }
 
         @Override
+        @Nullable
         public void remove() {
           throw new UnsupportedOperationException("Mountable#Iterator#remove is not supported.");
         }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -103,7 +103,6 @@ public final class MountTable implements DelegatingJournaled {
    * @throws FileAlreadyExistsException if the mount point already exists
    * @throws InvalidPathException if an invalid path is encountered
    */
-  @Nullable
   public void add(Supplier<JournalContext> journalContext, AlluxioURI alluxioUri, AlluxioURI ufsUri,
       long mountId, MountPOptions options) throws FileAlreadyExistsException, InvalidPathException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
@@ -352,7 +351,6 @@ public final class MountTable implements DelegatingJournaled {
    * @throws InvalidPathException if the Alluxio path is invalid
    * @throws AccessControlException if the Alluxio path is under a readonly mount point
    */
-  @Nullable
   public void checkUnderWritableMountPoint(AlluxioURI alluxioUri)
       throws InvalidPathException, AccessControlException {
     try (LockResource r = new LockResource(mReadLock)) {
@@ -462,7 +460,6 @@ public final class MountTable implements DelegatingJournaled {
      * @param context journal context
      * @param entry add mount point entry
      */
-    @Nullable
     public void applyAndJournal(Supplier<JournalContext> context, AddMountPointEntry entry) {
       applyAndJournal(context, JournalEntry.newBuilder().setAddMountPoint(entry).build());
     }
@@ -471,12 +468,10 @@ public final class MountTable implements DelegatingJournaled {
      * @param context journal context
      * @param entry delete mount point entry
      */
-    @Nullable
     public void applyAndJournal(Supplier<JournalContext> context, DeleteMountPointEntry entry) {
       applyAndJournal(context, JournalEntry.newBuilder().setDeleteMountPoint(entry).build());
     }
 
-    @Nullable
     private void applyAddMountPoint(AddMountPointEntry entry) {
       MountInfo mountInfo =
           new MountInfo(new AlluxioURI(entry.getAlluxioPath()), new AlluxioURI(entry.getUfsPath()),
@@ -484,7 +479,6 @@ public final class MountTable implements DelegatingJournaled {
       mMountTable.put(entry.getAlluxioPath(), mountInfo);
     }
 
-    @Nullable
     private void applyDeleteMountPoint(DeleteMountPointEntry entry) {
       mMountTable.remove(entry.getAlluxioPath());
     }
@@ -502,7 +496,6 @@ public final class MountTable implements DelegatingJournaled {
     }
 
     @Override
-    @Nullable
     public void resetState() {
       MountInfo mountInfo = mMountTable.get(ROOT);
       mMountTable.clear();
@@ -563,7 +556,6 @@ public final class MountTable implements DelegatingJournaled {
         }
 
         @Override
-        @Nullable
         public void remove() {
           throw new UnsupportedOperationException("Mountable#Iterator#remove is not supported.");
         }


### PR DESCRIPTION
[SMALLFIX] Use the @Nullable annotation for all methods which may return null in /alluxio/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java#reverseResolve