### PR TITLE
[SMALLFIX] Use @Nullable annotation for methods which may return null

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -66,6 +67,7 @@ public final class RoundRobinAllocator implements Allocator {
    *         otherwise
    * @throws IllegalArgumentException if block location is invalid
    */
+  @Nullable
   private StorageDirView allocateBlock(long sessionId, long blockSize,
       BlockStoreLocation location) {
     Preconditions.checkNotNull(location, "location");


### PR DESCRIPTION
[SMALLFIX] Use the @Nullable annotation for all methods which may return null in /alluxio/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java#allocateBlock #499