### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/wire/AlluxioWorkerInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/AlluxioWorkerInfoTest.java
@@ -12,6 +12,7 @@
 package alluxio.wire;
 
 import static org.junit.Assert.assertEquals;
+
 import alluxio.util.CommonUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/common/src/test/java/alluxio/wire/AlluxioWorkerInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/AlluxioWorkerInfoTest.java
@@ -11,10 +11,10 @@
 
 package alluxio.wire;
 
+import static org.junit.Assert.assertEquals;
 import alluxio.util.CommonUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -40,15 +40,15 @@ public final class AlluxioWorkerInfoTest {
   }
 
   private void checkEquality(AlluxioWorkerInfo a, AlluxioWorkerInfo b) {
-    Assert.assertEquals(a.getCapacity(), b.getCapacity());
-    Assert.assertEquals(a.getConfiguration(), b.getConfiguration());
-    Assert.assertEquals(a.getMetrics(), b.getMetrics());
-    Assert.assertEquals(a.getRpcAddress(), b.getRpcAddress());
-    Assert.assertEquals(a.getStartTimeMs(), b.getStartTimeMs());
-    Assert.assertEquals(a.getTierCapacity(), b.getTierCapacity());
-    Assert.assertEquals(a.getUptimeMs(), b.getUptimeMs());
-    Assert.assertEquals(a.getVersion(), b.getVersion());
-    Assert.assertEquals(a, b);
+    assertEquals(a.getCapacity(), b.getCapacity());
+    assertEquals(a.getConfiguration(), b.getConfiguration());
+    assertEquals(a.getMetrics(), b.getMetrics());
+    assertEquals(a.getRpcAddress(), b.getRpcAddress());
+    assertEquals(a.getStartTimeMs(), b.getStartTimeMs());
+    assertEquals(a.getTierCapacity(), b.getTierCapacity());
+    assertEquals(a.getUptimeMs(), b.getUptimeMs());
+    assertEquals(a.getVersion(), b.getVersion());
+    assertEquals(a, b);
   }
 
   private static AlluxioWorkerInfo createRandom() {


### PR DESCRIPTION
[SMALLFIX] Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/wire/AlluxioWorkerInfoTest.java#558