### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.worker.block.allocator;
 
-import static org.junit.Assert;
+import static org.junit.Assert.fail;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
@@ -11,12 +11,13 @@
 
 package alluxio.worker.block.allocator;
 
+import static org.junit.Assert;
+
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.Reflection;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public final class AllocatorContractTest extends AllocatorTestBase {
         }
       }
     } catch (Exception e) {
-      Assert.fail("Failed to find implementation of allocate strategy");
+      fail("Failed to find implementation of allocate strategy");
     }
   }
 


### PR DESCRIPTION
I alter the non-static import to a static import and rewrite all the corresponding assert statements for standard test utilities in alluxio/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java