### PR TITLE
Update metrics servlet to respond with valid Content-Type

### DIFF
--- a/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
@@ -56,7 +56,7 @@ public class MetricsServlet implements Sink {
       @Override
       protected void doGet(HttpServletRequest request, HttpServletResponse response)
           throws ServletException, IOException {
-        response.setContentType("text/json;charset=utf-8");
+        response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_OK);
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
         String result = mObjectMapper.writeValueAsString(mMetricsRegistry);


### PR DESCRIPTION
`text/json` is not a valid content type. See the following resource:
https://www.iana.org/assignments/media-types/media-types.xhtml

We should be using the standard `application/json` which also
defaults its charset to utf-8, so we won't need to specify it explicitly
either.