### PR TITLE
[SMALLFIX] Replace collections.sort() with list.sort

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
@@ -25,7 +25,6 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/DeterministicHashPolicy.java
@@ -70,7 +70,7 @@ public final class DeterministicHashPolicy implements BlockLocationPolicy {
   @Override
   public WorkerNetAddress getWorker(GetWorkerOptions options) {
     List<BlockWorkerInfo> workerInfos = Lists.newArrayList(options.getBlockWorkerInfos());
-    Collections.sort(workerInfos, new Comparator<BlockWorkerInfo>() {
+    workerInfos.sort(new Comparator<BlockWorkerInfo>() {
       @Override
       public int compare(BlockWorkerInfo o1, BlockWorkerInfo o2) {
         return o1.getNetAddress().toString().compareToIgnoreCase(o2.getNetAddress().toString());


### PR DESCRIPTION
Change

    Collections.sort(workerInfos, (o1, o2)
            -> o1.getNetAddress().toString().compareToIgnoreCase(o2.getNetAddress().toString()));
to

    workerInfos.sort((o1, o2)
            -> o1.getNetAddress().toString().compareToIgnoreCase(o2.getNetAddress().toString()));