### PR TITLE
Improve handling of errors when parsing pathConf commands

### DIFF
--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -99,9 +99,25 @@ public abstract class AbstractShell implements Closeable {
       }
     }
 
-    String[] args = Arrays.copyOfRange(argv, 1, argv.length);
     CommandLine cmdline;
     try {
+      String[] args;
+      if (command.hasSubCommand()) {
+        if (argv.length < 2) {
+          throw new InvalidArgumentException("No sub-command is specified");
+        }
+        if (!command.getSubCommands().containsKey(argv[1])) {
+          throw new InvalidArgumentException("Unknown sub-command: " + argv[1]);
+        }
+        command = command.getSubCommands().get(argv[1]);
+        if (argv.length > 2) {
+          args = Arrays.copyOfRange(argv, 2, argv.length);
+        } else {
+          args = new String[]{};
+        }
+      } else {
+        args = Arrays.copyOfRange(argv, 1, argv.length);
+      }
       cmdline = command.parseAndValidateArgs(args);
     } catch (InvalidArgumentException e) {
       System.out.println("Usage: " + command.getUsage());

--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -105,6 +105,7 @@ public abstract class AbstractShell implements Closeable {
       cmdline = command.parseAndValidateArgs(args);
     } catch (InvalidArgumentException e) {
       System.out.println("Usage: " + command.getUsage());
+      System.out.println(command.getDescription());
       LOG.error("Invalid arguments for command {}:", command.getCommandName(), e);
       return -1;
     }

--- a/core/common/src/main/java/alluxio/cli/Command.java
+++ b/core/common/src/main/java/alluxio/cli/Command.java
@@ -21,6 +21,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An interface for all the commands that can be run from a shell.
@@ -42,6 +44,23 @@ public interface Command {
   }
 
   /**
+   * If a command has sub-commands, the first argument should be the sub-command's name,
+   * all arguments and options will be parsed for the sub-command.
+   *
+   * @return whether this command has sub-commands
+   */
+  default boolean hasSubCommand() {
+    return false;
+  }
+
+  /**
+   * @return a map from sub-command names to sub-command instances
+   */
+  default Map<String, Command> getSubCommands() {
+    return new HashMap<>();
+  }
+
+  /**
    * Parses and validates the arguments.
    *
    * @param args the arguments for the command, excluding the command name
@@ -56,7 +75,7 @@ public interface Command {
       cmdline = parser.parse(opts, args);
     } catch (ParseException e) {
       throw new InvalidArgumentException(
-          String.format("Failed to parse args for %s", getCommandName()), e);
+          String.format("Failed to parse args for %s: %s", getCommandName(), e.getMessage()), e);
     }
     validateArgs(cmdline);
     return cmdline;
@@ -76,7 +95,9 @@ public interface Command {
    * @param cl the parsed command line for the arguments
    * @return the result of running the command
    */
-  int run(CommandLine cl) throws AlluxioException, IOException;
+  default int run(CommandLine cl) throws AlluxioException, IOException {
+    return 0;
+  }
 
   /**
    * @return the usage information of the command

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
@@ -75,6 +75,9 @@ public final class PathConfCommand extends AbstractFsAdminCommand {
     return usage.toString();
   }
 
+  /**
+   * @return command's description
+   */
   @VisibleForTesting
   public static String description() {
     return "Manage path level configuration, see sub-commands' descriptions for more details.";

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
@@ -19,6 +19,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.InvalidArgumentException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -65,12 +66,12 @@ public final class AddCommand extends AbstractFsAdminCommand {
 
   @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
-    CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+    CommandUtils.checkNumOfArgsEquals(this, cl, 1);
   }
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    AlluxioURI path = new AlluxioURI(cl.getArgs()[1]);
+    AlluxioURI path = new AlluxioURI(cl.getArgs()[0]);
     Map<PropertyKey, String> properties = new HashMap<>();
     if (cl.hasOption(PROPERTY_OPTION_NAME)) {
       Maps.fromProperties(cl.getOptionProperties(PROPERTY_OPTION_NAME)).forEach((key, value) ->
@@ -83,13 +84,18 @@ public final class AddCommand extends AbstractFsAdminCommand {
   @Override
   public String getUsage() {
     return String.format("%s [--%s <key=value>] [--%s <key=value>] <path>%n"
-        + "\t--%s: %s%n",
+        + "\t--%s: %s",
         getCommandName(), PROPERTY_OPTION_NAME, PROPERTY_OPTION_NAME,
         PROPERTY_OPTION_NAME, PROPERTY_OPTION.getDescription());
   }
 
+  @VisibleForTesting
+  public static String description() {
+    return "Adds properties to the path level configurations.";
+  }
+
   @Override
   public String getDescription() {
-    return "Adds properties to the path level configurations.";
+    return description();
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
@@ -102,8 +102,8 @@ public final class AddCommand extends AbstractFsAdminCommand {
    */
   @VisibleForTesting
   public static String description() {
-    return "Adds properties to the path level configurations, "
-        + "only client scope properties can be added.";
+    return "Adds properties to the path level configurations. "
+        + "Only client scope properties can be added.";
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ListCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ListCommand.java
@@ -65,6 +65,9 @@ public final class ListCommand extends AbstractFsAdminCommand {
     return "list";
   }
 
+  /**
+   * @return command's description
+   */
   @VisibleForTesting
   public static String description() {
     return "List paths that have path level configuration.";

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ListCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ListCommand.java
@@ -19,6 +19,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.wire.Configuration;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.CommandLine;
 
 import java.io.IOException;
@@ -64,8 +65,13 @@ public final class ListCommand extends AbstractFsAdminCommand {
     return "list";
   }
 
+  @VisibleForTesting
+  public static String description() {
+    return "List paths that have path level configuration.";
+  }
+
   @Override
   public String getDescription() {
-    return "List paths that have path level configuration.";
+    return description();
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
@@ -19,6 +19,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.InvalidArgumentException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -62,12 +63,12 @@ public final class RemoveCommand extends AbstractFsAdminCommand {
 
   @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
-    CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+    CommandUtils.checkNumOfArgsEquals(this, cl, 1);
   }
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    AlluxioURI path = new AlluxioURI(cl.getArgs()[1]);
+    AlluxioURI path = new AlluxioURI(cl.getArgs()[0]);
     if (cl.hasOption(KEYS_OPTION_NAME)) {
       String[] keys = cl.getOptionValue(KEYS_OPTION_NAME).split(",");
       Set<PropertyKey> propertyKeys = new HashSet<>();
@@ -84,13 +85,18 @@ public final class RemoveCommand extends AbstractFsAdminCommand {
   @Override
   public String getUsage() {
     return String.format("%s [--%s <key1,key2,key3>] <path>%n"
-        + "\t--%s: %s%n",
+        + "\t--%s: %s",
         getCommandName(), KEYS_OPTION_NAME,
         KEYS_OPTION_NAME, KEYS_OPTION.getDescription());
   }
 
+  @VisibleForTesting
+  public static String description() {
+    return "Removes all or specific properties from path's path level configurations.";
+  }
+
   @Override
   public String getDescription() {
-    return "Removes all or specific properties from path's path level configurations.";
+    return description();
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
@@ -90,6 +90,9 @@ public final class RemoveCommand extends AbstractFsAdminCommand {
         KEYS_OPTION_NAME, KEYS_OPTION.getDescription());
   }
 
+  /**
+   * @return command's description
+   */
   @VisibleForTesting
   public static String description() {
     return "Removes all or specific properties from path's path level configurations.";

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
@@ -24,6 +24,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.wire.Configuration;
 import alluxio.wire.Property;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -81,7 +82,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
 
   @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
-    CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+    CommandUtils.checkNumOfArgsEquals(this, cl, 1);
   }
 
   private String format(String key, String value) {
@@ -90,7 +91,7 @@ public final class ShowCommand extends AbstractFsAdminCommand {
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    String targetPath = cl.getArgs()[1];
+    String targetPath = cl.getArgs()[0];
     Configuration configuration = mMetaConfigClient.getConfiguration();
 
     if (cl.hasOption(ALL_OPTION_NAME)) {
@@ -127,13 +128,18 @@ public final class ShowCommand extends AbstractFsAdminCommand {
   @Override
   public String getUsage() {
     return String.format("show [--%s] <path>%n"
-        + "\t--%s: %s%n",
+        + "\t--%s: %s",
         ALL_OPTION_NAME,
         ALL_OPTION_NAME, ALL_OPTION.getDescription());
   }
 
+  @VisibleForTesting
+  public static String description() {
+    return "Shows path level configurations.";
+  }
+
   @Override
   public String getDescription() {
-    return "Shows path level configurations.";
+    return description();
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/pathconf/ShowCommand.java
@@ -133,6 +133,9 @@ public final class ShowCommand extends AbstractFsAdminCommand {
         ALL_OPTION_NAME, ALL_OPTION.getDescription());
   }
 
+  /**
+   * @return command's description
+   */
   @VisibleForTesting
   public static String description() {
     return "Shows path level configurations.";

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/PathConfCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/PathConfCommandIntegrationTest.java
@@ -72,6 +72,7 @@ public final class PathConfCommandIntegrationTest extends AbstractFsAdminShellTe
     String output = mOutput.toString();
     Assert.assertEquals(ListCommand.description(), lastLine(output));
   }
+
   @Test
   public void removeCommandWrongNumberOfArgs() {
     int ret = mFsAdminShell.run("pathConf", "remove", "1", "2");
@@ -87,6 +88,7 @@ public final class PathConfCommandIntegrationTest extends AbstractFsAdminShellTe
     String output = mOutput.toString();
     Assert.assertEquals(RemoveCommand.description(), lastLine(output));
   }
+
   @Test
   public void showCommandWrongNumberOfArgs() {
     int ret = mFsAdminShell.run("pathConf", "show", "1", "2");

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/PathConfCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/PathConfCommandIntegrationTest.java
@@ -1,0 +1,113 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fsadmin.command;
+
+import alluxio.cli.fsadmin.command.PathConfCommand;
+import alluxio.cli.fsadmin.pathconf.AddCommand;
+import alluxio.cli.fsadmin.pathconf.ListCommand;
+import alluxio.cli.fsadmin.pathconf.RemoveCommand;
+import alluxio.cli.fsadmin.pathconf.ShowCommand;
+import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for pathConf command.
+ */
+public final class PathConfCommandIntegrationTest extends AbstractFsAdminShellTest {
+  @Test
+  public void noArg() {
+    int ret = mFsAdminShell.run("pathConf");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(PathConfCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void unknownSubCommand() {
+    int ret = mFsAdminShell.run("pathConf", "unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(PathConfCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void addCommandWrongNumberOfArgs() {
+    int ret = mFsAdminShell.run("pathConf", "add", "1", "2");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(AddCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void addCommandUnknownOption() {
+    int ret = mFsAdminShell.run("pathConf", "add", "--unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(AddCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void listCommandWrongNumberOfArgs() {
+    int ret = mFsAdminShell.run("pathConf", "list", "1");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(ListCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void listCommandUnknownOption() {
+    int ret = mFsAdminShell.run("pathConf", "list", "--unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(ListCommand.description(), lastLine(output));
+  }
+  @Test
+  public void removeCommandWrongNumberOfArgs() {
+    int ret = mFsAdminShell.run("pathConf", "remove", "1", "2");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(RemoveCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void removeCommandUnknownOption() {
+    int ret = mFsAdminShell.run("pathConf", "remove", "--unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(RemoveCommand.description(), lastLine(output));
+  }
+  @Test
+  public void showCommandWrongNumberOfArgs() {
+    int ret = mFsAdminShell.run("pathConf", "show", "1", "2");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(ShowCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void showCommandUnknownOption() {
+    int ret = mFsAdminShell.run("pathConf", "show", "--unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(ShowCommand.description(), lastLine(output));
+  }
+
+  private String lastLine(String output) {
+    String[] lines = output.split("\n");
+    if (lines.length > 0) {
+      return lines[lines.length - 1];
+    }
+    return "";
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
@@ -47,6 +47,18 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
       Assert.assertEquals("", output);
 
       mOutput.reset();
+      ret = shell.run("pathConf", "show", DIR1);
+      Assert.assertEquals(0, ret);
+      output = mOutput.toString();
+      Assert.assertEquals("", output);
+
+      mOutput.reset();
+      ret = shell.run("pathConf", "show", DIR2);
+      Assert.assertEquals(0, ret);
+      output = mOutput.toString();
+      Assert.assertEquals("", output);
+
+      mOutput.reset();
       ret = shell.run("pathConf", "add", "--property", format(PROPERTY_KEY11, PROPERTY_VALUE11),
           "--property", format(PROPERTY_KEY12, PROPERTY_VALUE12), DIR1);
       Assert.assertEquals(0, ret);
@@ -86,6 +98,47 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
       expected = format(PROPERTY_KEY2, PROPERTY_VALUE2) + "\n";
       output = mOutput.toString();
       Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void invalidPropertyKey() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+      int ret = shell.run("pathConf", "add", "--property", "unknown=value", "/");
+      Assert.assertEquals(-1, ret);
+      String output = mOutput.toString();
+      Assert.assertEquals("Invalid property key unknown", output);
+    }
+  }
+
+  @Test
+  public void addNoProperty() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+      int ret = shell.run("pathConf", "add", "/");
+      Assert.assertEquals(0, ret);
+    }
+  }
+
+  @Test
+  public void overwriteProperty() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+      int ret = shell.run("pathConf", "add", "--property",
+          format(PROPERTY_KEY11, PROPERTY_VALUE11), "/");
+      Assert.assertEquals(0, ret);
+
+      mOutput.reset();
+      ret = shell.run("pathConf", "show", "/");
+      Assert.assertEquals(0, ret);
+      Assert.assertEquals(format(PROPERTY_KEY11, PROPERTY_VALUE11) + "\n", mOutput.toString());
+
+      ret = shell.run("pathConf", "add", "--property",
+          format(PROPERTY_KEY11, PROPERTY_VALUE12), "/");
+      Assert.assertEquals(0, ret);
+
+      mOutput.reset();
+      ret = shell.run("pathConf", "show", "/");
+      Assert.assertEquals(0, ret);
+      Assert.assertEquals(format(PROPERTY_KEY11, PROPERTY_VALUE12) + "\n", mOutput.toString());
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.cli.fsadmin.pathconf;
 
 import alluxio.cli.fsadmin.FileSystemAdminShell;
+import alluxio.cli.fsadmin.pathconf.AddCommand;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.cli.fs.AbstractShellIntegrationTest;
@@ -107,7 +108,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
       int ret = shell.run("pathConf", "add", "--property", "unknown=value", "/");
       Assert.assertEquals(-1, ret);
       String output = mOutput.toString();
-      Assert.assertEquals("Invalid property key unknown", output);
+      Assert.assertEquals("Invalid property key unknown\n", output);
     }
   }
 
@@ -139,6 +140,18 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
       ret = shell.run("pathConf", "show", "/");
       Assert.assertEquals(0, ret);
       Assert.assertEquals(format(PROPERTY_KEY11, PROPERTY_VALUE12) + "\n", mOutput.toString());
+    }
+  }
+
+  @Test
+  public void nonClientScopeKey() throws Exception {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+      PropertyKey key = PropertyKey.MASTER_GRPC_SERVER_SHUTDOWN_TIMEOUT;
+      int ret = shell.run("pathConf", "add", "--property",
+          format(key, "10ms"), "/");
+      Assert.assertEquals(-1, ret);
+      String output = mOutput.toString();
+      Assert.assertEquals(AddCommand.nonClientScopePropertyException(key) + "\n", output);
     }
   }
 }


### PR DESCRIPTION
Currently, if arguments or options are wrong, only the usage of `pathConf` will be displayed.
This PR makes sub-commands' help messages available when argument or option parsing fails.
A new integration test is added to enforce the new behavior.