### PR TITLE
Remove implicit inode locking

### DIFF
--- a/core/common/src/main/java/alluxio/collections/LockCache.java
+++ b/core/common/src/main/java/alluxio/collections/LockCache.java
@@ -252,6 +252,9 @@ public class LockCache<K> {
     return mSoftLimit;
   }
 
+  /**
+   * @return all entries in the cache, for debugging purposes
+   */
   @VisibleForTesting
   public Map<K, ReentrantReadWriteLock> getEntryMap() {
     Map<K, ReentrantReadWriteLock> entries = new HashMap<>();

--- a/core/common/src/main/java/alluxio/collections/LockCache.java
+++ b/core/common/src/main/java/alluxio/collections/LockCache.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -249,6 +250,15 @@ public class LockCache<K> {
   @VisibleForTesting
   public int getSoftLimit() {
     return mSoftLimit;
+  }
+
+  @VisibleForTesting
+  public Map<K, ReentrantReadWriteLock> getEntryMap() {
+    Map<K, ReentrantReadWriteLock> entries = new HashMap<>();
+    mCache.entrySet().forEach(entry -> {
+      entries.put(entry.getKey(), entry.getValue().mValue);
+    });
+    return entries;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -91,6 +91,7 @@ import alluxio.master.file.meta.InodePathPair;
 import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
+import alluxio.master.file.meta.LockedInodePathList;
 import alluxio.master.file.meta.LockingScheme;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.PersistenceState;
@@ -176,6 +177,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
@@ -1379,9 +1381,9 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
             createAuditContext("delete", path, null, inodePath.getInodeOrNull())) {
       mPermissionChecker.checkParentPermission(Mode.Bits.WRITE, inodePath);
       if (context.getOptions().getRecursive()) {
-        try {
-          List<String> failedChildren = new ArrayList<>();
-          for (LockedInodePath childPath : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
+        List<String> failedChildren = new ArrayList<>();
+        try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+          for (LockedInodePath childPath : descendants) {
             try {
               mPermissionChecker.checkPermission(Mode.Bits.WRITE, childPath);
             } catch (AccessControlException e) {
@@ -1456,93 +1458,95 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     // Add root of sub-tree to delete
     inodesToDelete.add(new Pair<>(inodePath.getUri(), inodePath));
 
-    for (LockedInodePath childPath : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
-      inodesToDelete.add(new Pair<>(mInodeTree.getPath(childPath.getInode()), childPath));
-    }
-    // Prepare to delete persisted inodes
-    UfsDeleter ufsDeleter = NoopUfsDeleter.INSTANCE;
-    if (!deleteContext.getOptions().getAlluxioOnly()) {
-      ufsDeleter = new SafeUfsDeleter(mMountTable, mInodeStore, inodesToDelete,
-          deleteContext.getOptions().build());
-    }
+    try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+      for (LockedInodePath childPath : descendants) {
+        inodesToDelete.add(new Pair<>(mInodeTree.getPath(childPath.getInode()), childPath));
+      }
+      // Prepare to delete persisted inodes
+      UfsDeleter ufsDeleter = NoopUfsDeleter.INSTANCE;
+      if (!deleteContext.getOptions().getAlluxioOnly()) {
+        ufsDeleter = new SafeUfsDeleter(mMountTable, mInodeStore, inodesToDelete,
+            deleteContext.getOptions().build());
+      }
 
-    // Inodes to delete from tree after attempting to delete from UFS
-    List<Pair<AlluxioURI, LockedInodePath>> revisedInodesToDelete = new ArrayList<>();
-    // Inodes that are not safe for recursive deletes
-    Set<Long> unsafeInodes = new HashSet<>();
-    // Alluxio URIs (and the reason for failure) which could not be deleted
-    List<Pair<String, String>> failedUris = new ArrayList<>();
+      // Inodes to delete from tree after attempting to delete from UFS
+      List<Pair<AlluxioURI, LockedInodePath>> revisedInodesToDelete = new ArrayList<>();
+      // Inodes that are not safe for recursive deletes
+      Set<Long> unsafeInodes = new HashSet<>();
+      // Alluxio URIs (and the reason for failure) which could not be deleted
+      List<Pair<String, String>> failedUris = new ArrayList<>();
 
-    // We go through each inode, removing it from its parent set and from mDelInodes. If it's a
-    // file, we deal with the checkpoints and blocks as well.
-    for (int i = inodesToDelete.size() - 1; i >= 0; i--) {
-      Pair<AlluxioURI, LockedInodePath> inodePairToDelete = inodesToDelete.get(i);
-      AlluxioURI alluxioUriToDelete = inodePairToDelete.getFirst();
-      Inode inodeToDelete = inodePairToDelete.getSecond().getInode();
+      // We go through each inode, removing it from its parent set and from mDelInodes. If it's a
+      // file, we deal with the checkpoints and blocks as well.
+      for (int i = inodesToDelete.size() - 1; i >= 0; i--) {
+        Pair<AlluxioURI, LockedInodePath> inodePairToDelete = inodesToDelete.get(i);
+        AlluxioURI alluxioUriToDelete = inodePairToDelete.getFirst();
+        Inode inodeToDelete = inodePairToDelete.getSecond().getInode();
 
-      String failureReason = null;
-      if (unsafeInodes.contains(inodeToDelete.getId())) {
-        failureReason = ExceptionMessage.DELETE_FAILED_DIR_NONEMPTY.getMessage();
-      } else if (inodeToDelete.isPersisted()) {
-        // If this is a mount point, we have deleted all the children and can unmount it
-        // TODO(calvin): Add tests (ALLUXIO-1831)
-        if (mMountTable.isMountPoint(alluxioUriToDelete)) {
-          mMountTable.delete(rpcContext, alluxioUriToDelete);
-        } else {
-          if (!deleteContext.getOptions().getAlluxioOnly()) {
-            try {
-              checkUfsMode(alluxioUriToDelete, OperationType.WRITE);
-              // Attempt to delete node if all children were deleted successfully
-              ufsDeleter.delete(alluxioUriToDelete, inodeToDelete);
-            } catch (AccessControlException e) {
-              // In case ufs is not writable, we will still attempt to delete other entries
-              // if any as they may be from a different mount point
-              LOG.warn(e.getMessage());
-              failureReason = e.getMessage();
-            } catch (IOException e) {
-              LOG.warn(e.getMessage());
-              failureReason = e.getMessage();
+        String failureReason = null;
+        if (unsafeInodes.contains(inodeToDelete.getId())) {
+          failureReason = ExceptionMessage.DELETE_FAILED_DIR_NONEMPTY.getMessage();
+        } else if (inodeToDelete.isPersisted()) {
+          // If this is a mount point, we have deleted all the children and can unmount it
+          // TODO(calvin): Add tests (ALLUXIO-1831)
+          if (mMountTable.isMountPoint(alluxioUriToDelete)) {
+            mMountTable.delete(rpcContext, alluxioUriToDelete);
+          } else {
+            if (!deleteContext.getOptions().getAlluxioOnly()) {
+              try {
+                checkUfsMode(alluxioUriToDelete, OperationType.WRITE);
+                // Attempt to delete node if all children were deleted successfully
+                ufsDeleter.delete(alluxioUriToDelete, inodeToDelete);
+              } catch (AccessControlException e) {
+                // In case ufs is not writable, we will still attempt to delete other entries
+                // if any as they may be from a different mount point
+                LOG.warn(e.getMessage());
+                failureReason = e.getMessage();
+              } catch (IOException e) {
+                LOG.warn(e.getMessage());
+                failureReason = e.getMessage();
+              }
             }
           }
         }
-      }
-      if (failureReason == null) {
-        if (inodeToDelete.isFile()) {
-          long fileId = inodeToDelete.getId();
-          // Remove the file from the set of files to persist.
-          mPersistRequests.remove(fileId);
-          // Cancel any ongoing jobs.
-          PersistJob job = mPersistJobs.get(fileId);
-          if (job != null) {
-            job.setCancelState(PersistJob.CancelState.TO_BE_CANCELED);
+        if (failureReason == null) {
+          if (inodeToDelete.isFile()) {
+            long fileId = inodeToDelete.getId();
+            // Remove the file from the set of files to persist.
+            mPersistRequests.remove(fileId);
+            // Cancel any ongoing jobs.
+            PersistJob job = mPersistJobs.get(fileId);
+            if (job != null) {
+              job.setCancelState(PersistJob.CancelState.TO_BE_CANCELED);
+            }
           }
+          revisedInodesToDelete.add(new Pair<>(alluxioUriToDelete, inodePairToDelete.getSecond()));
+        } else {
+          unsafeInodes.add(inodeToDelete.getId());
+          // Propagate 'unsafe-ness' to parent as one of its descendants can't be deleted
+          unsafeInodes.add(inodeToDelete.getParentId());
+          failedUris.add(new Pair<>(alluxioUriToDelete.toString(), failureReason));
         }
-        revisedInodesToDelete.add(new Pair<>(alluxioUriToDelete, inodePairToDelete.getSecond()));
-      } else {
-        unsafeInodes.add(inodeToDelete.getId());
-        // Propagate 'unsafe-ness' to parent as one of its descendants can't be deleted
-        unsafeInodes.add(inodeToDelete.getParentId());
-        failedUris.add(new Pair<>(alluxioUriToDelete.toString(), failureReason));
       }
-    }
 
-    MountTable.Resolution resolution = mSyncManager.resolveSyncPoint(inodePath.getUri());
-    if (resolution != null) {
-      mSyncManager.stopSyncInternal(inodePath.getUri(), resolution);
-    }
+      MountTable.Resolution resolution = mSyncManager.resolveSyncPoint(inodePath.getUri());
+      if (resolution != null) {
+        mSyncManager.stopSyncInternal(inodePath.getUri(), resolution);
+      }
 
-    // Delete Inodes
-    for (Pair<AlluxioURI, LockedInodePath> delInodePair : revisedInodesToDelete) {
-      LockedInodePath tempInodePath = delInodePair.getSecond();
-      mInodeTree.deleteInode(rpcContext, tempInodePath, opTimeMs);
-    }
+      // Delete Inodes
+      for (Pair<AlluxioURI, LockedInodePath> delInodePair : revisedInodesToDelete) {
+        LockedInodePath tempInodePath = delInodePair.getSecond();
+        mInodeTree.deleteInode(rpcContext, tempInodePath, opTimeMs);
+      }
 
-    if (!failedUris.isEmpty()) {
-      Collection<String> messages = failedUris.stream()
-          .map(pair -> String.format("%s (%s)", pair.getFirst(), pair.getSecond()))
-          .collect(Collectors.toList());
-      throw new FailedPreconditionException(
-          ExceptionMessage.DELETE_FAILED_UFS.getMessage(StringUtils.join(messages, ", ")));
+      if (!failedUris.isEmpty()) {
+        Collection<String> messages = failedUris.stream()
+            .map(pair -> String.format("%s (%s)", pair.getFirst(), pair.getSecond()))
+            .collect(Collectors.toList());
+        throw new FailedPreconditionException(
+            ExceptionMessage.DELETE_FAILED_UFS.getMessage(StringUtils.join(messages, ", ")));
+      }
     }
 
     Metrics.PATHS_DELETED.inc(inodesToDelete.size());
@@ -2175,28 +2179,29 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     long opTimeMs = System.currentTimeMillis();
     List<Inode> freeInodes = new ArrayList<>();
     freeInodes.add(inode);
-    List<LockedInodePath> descendants = mInodeTree.getImplicitlyLockedDescendants(inodePath);
-    descendants.add(inodePath);
-    for (LockedInodePath descedant : descendants) {
-      Inode freeInode = descedant.getInodeOrNull();
+    try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+      for (LockedInodePath descedant : Iterables.concat(descendants,
+          Collections.singleton(inodePath))) {
+        Inode freeInode = descedant.getInodeOrNull();
 
-      if (freeInode != null && freeInode.isFile()) {
-        if (freeInode.getPersistenceState() != PersistenceState.PERSISTED) {
-          throw new UnexpectedAlluxioException(ExceptionMessage.CANNOT_FREE_NON_PERSISTED_FILE
-              .getMessage(mInodeTree.getPath(freeInode)));
-        }
-        if (freeInode.isPinned()) {
-          if (!context.getOptions().getForced()) {
-            throw new UnexpectedAlluxioException(ExceptionMessage.CANNOT_FREE_PINNED_FILE
+        if (freeInode != null && freeInode.isFile()) {
+          if (freeInode.getPersistenceState() != PersistenceState.PERSISTED) {
+            throw new UnexpectedAlluxioException(ExceptionMessage.CANNOT_FREE_NON_PERSISTED_FILE
                 .getMessage(mInodeTree.getPath(freeInode)));
           }
+          if (freeInode.isPinned()) {
+            if (!context.getOptions().getForced()) {
+              throw new UnexpectedAlluxioException(ExceptionMessage.CANNOT_FREE_PINNED_FILE
+                  .getMessage(mInodeTree.getPath(freeInode)));
+            }
 
-          SetAttributeContext setAttributeContext = SetAttributeContext
-              .mergeFrom(SetAttributePOptions.newBuilder().setRecursive(false).setPinned(false));
-          setAttributeSingleFile(rpcContext, descedant, true, opTimeMs, setAttributeContext);
+            SetAttributeContext setAttributeContext = SetAttributeContext
+                .mergeFrom(SetAttributePOptions.newBuilder().setRecursive(false).setPinned(false));
+            setAttributeSingleFile(rpcContext, descedant, true, opTimeMs, setAttributeContext);
+          }
+          // Remove corresponding blocks from workers.
+          mBlockMaster.removeBlocks(freeInode.asFile().getBlockIds(), false /* delete */);
         }
-        // Remove corresponding blocks from workers.
-        mBlockMaster.removeBlocks(freeInode.asFile().getBlockIds(), false /* delete */);
       }
     }
 
@@ -2738,8 +2743,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
             createAuditContext("setAcl", path, null, inodePath.getInodeOrNull())) {
       mPermissionChecker.checkSetAttributePermission(inodePath, false, true);
       if (context.getOptions().getRecursive()) {
-        try {
-          for (LockedInodePath child : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
+        try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+          for (LockedInodePath child : descendants) {
             mPermissionChecker.checkSetAttributePermission(child, false, true);
           }
         } catch (AccessControlException e) {
@@ -2866,8 +2871,10 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     Preconditions.checkState(inodePath.getLockPattern().isWrite());
     setAclSingleInode(rpcContext, action, inodePath, entries, replay, opTimeMs);
     if (context.getOptions().getRecursive()) {
-      for (LockedInodePath childPath : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
-        setAclSingleInode(rpcContext, action, childPath, entries, replay, opTimeMs);
+      try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+        for (LockedInodePath childPath : descendants) {
+          setAclSingleInode(rpcContext, action, childPath, entries, replay, opTimeMs);
+        }
       }
     }
   }
@@ -2919,15 +2926,17 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       try {
         mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired);
         if (context.getOptions().getRecursive()) {
-          for (LockedInodePath childPath : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
-            mPermissionChecker.checkSetAttributePermission(childPath, rootRequired, ownerRequired);
+          try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+            for (LockedInodePath childPath : descendants) {
+              mPermissionChecker.checkSetAttributePermission(childPath, rootRequired,
+                  ownerRequired);
+            }
           }
         }
       } catch (AccessControlException e) {
         auditContext.setAllowed(false);
         throw e;
       }
-
       setAttributeInternal(rpcContext, inodePath, context);
       auditContext.setSucceeded(true);
     }
@@ -2962,8 +2971,10 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     Inode targetInode = inodePath.getInode();
     long opTimeMs = System.currentTimeMillis();
     if (context.getOptions().getRecursive() && targetInode.isDirectory()) {
-      for (LockedInodePath childPath : mInodeTree.getImplicitlyLockedDescendants(inodePath)) {
-        setAttributeSingleFile(rpcContext, childPath, true, opTimeMs, context);
+      try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
+        for (LockedInodePath childPath : descendants) {
+          setAttributeSingleFile(rpcContext, childPath, true, opTimeMs, context);
+        }
       }
     }
     setAttributeSingleFile(rpcContext, inodePath, true, opTimeMs, context);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
@@ -32,7 +32,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class CompositeInodeLockList implements InodeLockList {
   /** The base lock list for this composite list. */
   private final InodeLockList mBaseLockList;
+  /** An extension lock list for taking additional locks on top of the locks in mBaseLockList. */
   private final InodeLockList mSubLockList;
+
+  /** The size of the base lock list, saved for fast lookup. */
   private final int mBaseListSize;
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -12,366 +12,204 @@
 package alluxio.master.file.meta;
 
 import alluxio.concurrent.LockMode;
-import alluxio.resource.LockResource;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Represents a locked path within the inode tree. All lock lists must start with the root. Both
- * inodes and edges are locked along the path.
+ * Represents a locked path within the inode tree. Both inodes and edges are locked along the path.
+ * The path may start from either an edge or an inode.
  *
- * A lock list is either in read mode or write mode. In read mode, every lock in the list is a read
- * lock. In write mode, every lock is a read lock except for the final lock. In write mode, the
- * lock list cannot be extended (only the final lock is ever a write lock).
+ * A lock list always contains some number of read locks (possibly zero) followed by some number of
+ * write locks (possibly zero).
  *
- * For consistency across locking operations, lock lists begin with a fake edge leading to the root
- * inode. This enables the WRITE_EDGE pattern to be applied to the root.
+ * This class uses list notation to describe lock lists. Nodes are single letters, edges are
+ * parentName->childName, and write-locks are indicated with '*'. For example, a lock list for
+ * /a/b/c/d where the c->d edge is the first write-locked element:
  *
- * InodeLockLists are not thread safe and should not be passed across threads.
+ * [->/, /, /->a, a, a->b, b, b->c, c, c->d*, d*]
+ *
+ * The "->/" at the start is a pseudo-edge used to allow the WRITE_EDGE lock mode to be applied to
+ * the root. This edge can only be locked by calling lockRootEdge.
+ *
+ * Not all lock lists need to start from the root. Another example list could be
+ *
+ * [b, b->c, c->d*, d*]
+ *
+ * This allows us to create composite lock lists out of a "normal" lock list starting from the root,
+ * plus a non-root lock list.
  */
 @NotThreadSafe
-public class InodeLockList implements AutoCloseable {
-  private static final Logger LOG = LoggerFactory.getLogger(InodeLockList.class);
-
-  private static final int INITIAL_CAPACITY = 4;
-  private static final Edge ROOT_EDGE = new Edge(-1, "");
-
-  protected final InodeLockManager mInodeLockManager;
-
-  /** The inodes that have been locked by the lock list, ordered from the root. */
-  protected List<Inode> mLockedInodes;
-  /** Entries for each lock in the lock list, ordered from the root. */
-  protected List<Entry> mEntries;
-  /** The current lock mode for the lock list, either read or write. */
-  protected LockMode mLockMode;
-
+public interface InodeLockList extends AutoCloseable {
   /**
-   * Creates a new empty lock list.
+   * Locks the root edge in the specified mode.
    *
-   * @param inodeLockManager manager for inode locks
+   * The lock list must be empty to call this method.
+   *
+   * @param mode the mode to lock in
    */
-  public InodeLockList(InodeLockManager inodeLockManager) {
-    mInodeLockManager = inodeLockManager;
-    mLockedInodes = new ArrayList<>(INITIAL_CAPACITY);
-    mEntries = new ArrayList<>(INITIAL_CAPACITY);
-
-    mLockMode = LockMode.READ;
-  }
+  void lockRootEdge(LockMode mode);
 
   /**
    * Locks the given inode and adds it to the lock list. This method does *not* check that the inode
    * is still a child of the previous inode, or that the inode still exists. This method should only
    * be called when the edge leading to the inode is locked.
    *
-   * @param inode the inode to lock
-   * @param mode the mode to lock in
-   */
-  public void lockInode(Inode inode, LockMode mode) {
-    Preconditions.checkState(mLockMode == LockMode.READ);
-
-    lockInodeInternal(inode, mode);
-    mLockMode = mode;
-  }
-
-  /**
-   * Locks the next inode without checking or updating the mode.
+   * Example
+   * Starting from [a, a->b]
+   *
+   * lockInode(b, LockMode.READ) results in [a, a->b, b]
+   * lockInode(b, LockMode.WRITE) results in [a, a->b, b*]
    *
    * @param inode the inode to lock
    * @param mode the mode to lock in
    */
-  private void lockInodeInternal(Inode inode, LockMode mode) {
-    Preconditions.checkState(!endsInInode());
-    String lastEdgeName = ((EdgeEntry) lastEntry()).getEdge().getName();
-    Preconditions.checkState(inode.getName().equals(lastEdgeName),
-        "Expected to lock inode %s but locked inode %s", lastEdgeName, inode.getName());
-
-    mLockedInodes.add(inode);
-    mEntries.add(new InodeEntry(mInodeLockManager.lockInode(inode, mode), inode));
-  }
+  void lockInode(Inode inode, LockMode mode);
 
   /**
    * Locks an edge leading out of the last inode in the list.
    *
-   * For example, if the lock list is [a, a->b, b], lockEdge(c) will add b->c to the list, resulting
-   * in [a, a->b, b, b->c].
+   * Example
+   * Starting from [a, a->b, b]
    *
-   * @param childName the child to lock
+   * lockEdge(b, c, LockMode.READ) results in [a, a->b, b, b->c]
+   * lockEdge(b, c, LockMode.WRITE) results in [a, a->b, b, b->c*]
+   *
+   * @param inode the parent inode of the edge
+   * @param childName the child name of the edge
    * @param mode the mode to lock in
    */
-  public void lockEdge(String childName, LockMode mode) {
-    Preconditions.checkState(endsInInode());
-    Preconditions.checkState(mLockMode == LockMode.READ);
-
-    lockEdgeInternal(childName, mode);
-    mLockMode = mode;
-  }
-
-  /**
-   * Locks the next edge without checking or updating the mode.
-   *
-   * @param childName the child to lock
-   * @param mode the mode to lock in
-   */
-  public void lockEdgeInternal(String childName, LockMode mode) {
-    Preconditions.checkState(endsInInode());
-
-    Inode lastInode = get(numLockedInodes() - 1);
-    Edge edge = new Edge(lastInode.getId(), childName);
-    mEntries.add(new EdgeEntry(mInodeLockManager.lockEdge(edge, mode), edge));
-  }
-
-  /**
-   * Locks the root edge in the specified mode.
-   *
-   * @param mode the mode to lock in
-   */
-  public void lockRootEdge(LockMode mode) {
-    Preconditions.checkState(mEntries.isEmpty());
-
-    mEntries.add(new EdgeEntry(mInodeLockManager.lockEdge(ROOT_EDGE, mode), ROOT_EDGE));
-    mLockMode = mode;
-  }
-
-  /**
-   * Leapfrogs the edge write lock forward, reducing the lock list's write-locked scope.
-   *
-   * For example, if the lock list is in write mode with entries [a, a->b, b, b->c],
-   * pushWriteLockedEdge(c, d) will change the list to [a, a->b, b, b->c, c, c->d]. The c->d edge
-   * will be write locked instead of the b->c edge. At least a read lock on b->c will be maintained
-   * throughout the process so that other threads cannot interfere with creates, deletes, or
-   * renames.
-   *
-   * For composite lock lists, this method will do nothing if the base lock is is write locked.
-   *
-   * @param inode the inode to add to the lock list
-   * @param childName the child name for the edge to add to the lock list
-   */
-  public void pushWriteLockedEdge(Inode inode, String childName) {
-    Preconditions.checkState(!endsInInode());
-    Preconditions.checkState(mLockMode == LockMode.WRITE);
-
-    if (mEntries.isEmpty()) {
-      // Cannot modify the base lock list, and the new inode is already implicitly locked.
-      return;
-    }
-
-    int edgeIndex = mEntries.size() - 1;
-    lockInodeInternal(inode, LockMode.READ);
-    lockEdgeInternal(childName, LockMode.WRITE);
-    downgradeEdge(edgeIndex);
-  }
-
-  /**
-   * @return whether this lock list ends in an inode (as opposed to an edge)
-   */
-  public boolean endsInInode() {
-    return lastEntry() instanceof InodeEntry;
-  }
+  void lockEdge(Inode inode, String childName, LockMode mode);
 
   /**
    * Unlocks the last locked inode.
+   *
+   * Example
+   * Starting from [a, a->b, b]
+   *
+   * unlockLastInode() results in [a, a->b]
    */
-  public void unlockLastInode() {
-    Preconditions.checkState(endsInInode());
-    Preconditions.checkState(!mEntries.isEmpty());
-
-    mLockedInodes.remove(mLockedInodes.size() - 1);
-    mEntries.remove(mEntries.size() - 1).mLock.close();
-    mLockMode = LockMode.READ;
-  }
+  void unlockLastInode();
 
   /**
    * Unlocks the last locked edge.
+   *
+   * Example
+   * Starting from [a, a->b]
+   *
+   * unlockLastEdge results in [a]
    */
-  public void unlockLastEdge() {
-    Preconditions.checkState(!endsInInode());
-    Preconditions.checkState(!mEntries.isEmpty());
-
-    mEntries.remove(mEntries.size() - 1).mLock.close();
-    mLockMode = LockMode.READ;
-  }
+  void unlockLastEdge();
 
   /**
    * Downgrades the last inode from a write lock to a read lock. The read lock is acquired before
    * releasing the write lock.
+   *
+   * Example
+   * Starting from [a, a->b, b*]
+   *
+   * downgradeLastInode() results in [a, a->b, b]
+   *
+   * If the last inode is not the only write-locked inode, no downgrade occurs.
    */
-  public void downgradeLastInode() {
-    Preconditions.checkState(endsInInode());
-    Preconditions.checkState(!mEntries.isEmpty());
-    Preconditions.checkState(mLockMode == LockMode.WRITE);
-
-    InodeEntry last = (InodeEntry) mEntries.get(mEntries.size() - 1);
-    LockResource lock = mInodeLockManager.lockInode(last.getInode(), LockMode.READ);
-    last.getLock().close();
-    mEntries.set(mEntries.size() - 1, new InodeEntry(lock, last.mInode));
-    mLockMode = LockMode.READ;
-  }
+  void downgradeLastInode();
 
   /**
    * Downgrades the last edge lock in the lock list from WRITE lock to READ lock.
+   *
+   * Example
+   * Starting from [a, a->b*]
+   *
+   * downgradeLastEdge() results in [a, a->b]
    */
-  public void downgradeLastEdge() {
-    Preconditions.checkNotNull(!endsInInode());
-    Preconditions.checkState(!mEntries.isEmpty());
-    Preconditions.checkState(mLockMode == LockMode.WRITE);
+  void downgradeLastEdge();
 
-    downgradeEdge(mEntries.size() - 1);
-    mLockMode = LockMode.READ;
-  }
+  /**
+   * Leapfrogs the final edge write lock forward, reducing the lock list's write-locked scope.
+   *
+   * Example
+   * Starting from [a, a->b*]
+   *
+   * pushWriteLockedEdge(b, c) results in [a, a->b, b, b->c*]
+   *
+   * The read lock on a->b is acquired before releasing the write lock. This ensures that no other
+   * thread can take the write lock before the read lock is acquired.
+   *
+   * If this is a composite lock list and the final write lock is part of the base lock list, the
+   * new locks will be acquired but no downgrade will occur.
+   *
+   * @param inode the inode to add to the lock list
+   * @param childName the child name for the edge to add to the lock list
+   */
+  void pushWriteLockedEdge(Inode inode, String childName);
 
   /**
    * Downgrades from edge write-locking to inode write-locking. This reduces the scope of the write
    * lock by pushing it forward one entry.
    *
-   * For example, if the lock list is in write mode with entries [a, a->b, b, b->c],
-   * downgradeEdgeToInode(c, mode) will change the list to [a, a->b, b, b->c, c], with b->c
-   * downgraded to a read lock. c will be locked according to the mode.
+   * Example
+   * Starting from [a, a->b*]
    *
-   * The read lock on the final edge is taken before releasing the write lock.
+   * downgradeEdgeToInode(b, LockMode.READ) results in [a, a->b, b]
+   * downgradeEdgeToInode(b, LockMode.WRITE) results in [a, a->b, b*]
+   *
+   * The read lock on a->b is acquired before releasing the write lock. This ensures that no other
+   * thread can take the write lock before the read lock is acquired.
    *
    * @param inode the next inode in the lock list
    * @param mode the mode to downgrade to
    */
-  public void downgradeEdgeToInode(Inode inode, LockMode mode) {
-    Preconditions.checkState(!endsInInode());
-    Preconditions.checkState(!mEntries.isEmpty());
-    Preconditions.checkState(mLockMode == LockMode.WRITE);
-
-    EdgeEntry last = (EdgeEntry) mEntries.get(mEntries.size() - 1);
-    LockResource inodeLock = mInodeLockManager.lockInode(inode, mode);
-    LockResource edgeLock = mInodeLockManager.lockEdge(last.mEdge, LockMode.READ);
-    last.getLock().close();
-    mEntries.set(mEntries.size() - 1, new EdgeEntry(edgeLock, last.getEdge()));
-    mEntries.add(new InodeEntry(inodeLock, inode));
-    mLockedInodes.add(inode);
-    mLockMode = mode;
-  }
+  void downgradeEdgeToInode(Inode inode, LockMode mode);
 
   /**
-   * Downgrades the edge at the specified entry index.
+   * @return {@link LockMode#WRITE} if the last entry in the list is write-locked, otherwise
+   *         {@link LockMode#READ}
    */
-  private void downgradeEdge(int edgeEntryIndex) {
-    EdgeEntry entry = (EdgeEntry) mEntries.get(edgeEntryIndex);
-    LockResource lock = mInodeLockManager.lockEdge(entry.mEdge, LockMode.READ);
-    entry.getLock().close();
-    mEntries.set(edgeEntryIndex, new EdgeEntry(lock, entry.getEdge()));
-  }
+  LockMode getLockMode();
 
   /**
-   * @return the current lock mode for the lock list
+   * @return a copy of all locked inodes
    */
-  public LockMode getLockMode() {
-    return mLockMode;
-  }
+  List<Inode> getLockedInodes();
 
   /**
-   * @return a copy of the the list of inodes locked in this lock list, in order of when
-   * the inodes were locked
+   * @return a copy of all locked inodes
    */
-  // TODO(david): change this API to not return a copy
-  public List<Inode> getLockedInodes() {
-    return Lists.newArrayList(mLockedInodes);
+  default List<InodeView> getLockedInodeViews() {
+    return new ArrayList<>(getLockedInodes());
   }
 
   /**
    * @param index the index of the list
    * @return the inode at the specified index
    */
-  public Inode get(int index) {
-    return mLockedInodes.get(index);
-  }
+  Inode get(int index);
 
   /**
    * @return the size of the list in terms of locked inodes
    */
-  public int numLockedInodes() {
-    return mLockedInodes.size();
-  }
+  int numInodes();
+
+  /**
+   * @return whether this lock list ends in an inode (as opposed to an edge)
+   */
+  boolean endsInInode();
 
   /**
    * @return true if the locklist is empty
    */
-  public boolean isEmpty() {
-    return mEntries.isEmpty();
-  }
+  boolean isEmpty();
 
   /**
-   * @return the last lock entry in the lock list
+   * @return the inode lock manager for this lock list
    */
-  protected Entry lastEntry() {
-    return mEntries.get(mEntries.size() - 1);
-  }
+  InodeLockManager getInodeLockManager();
 
+  /**
+   * Closes the lock list, releasing all locks.
+   */
   @Override
-  public String toString() {
-    String path =
-        getLockedInodes().stream().map(Inode::getName).collect(Collectors.joining("/"));
-    return String.format("Locked Inodes: <%s>%n"
-        + "Entries: %s%n"
-        + "Lock Mode: %s", path, mEntries, mLockMode);
-  }
-
-  @Override
-  public void close() {
-    mLockedInodes.clear();
-    mEntries.forEach(entry -> entry.mLock.close());
-    mEntries.clear();
-  }
-
-  protected abstract static class Entry {
-    private final LockResource mLock;
-
-    protected Entry(LockResource lock) {
-      mLock = lock;
-    }
-
-    protected LockResource getLock() {
-      return mLock;
-    }
-  }
-
-  protected static class InodeEntry extends Entry {
-    private final Inode mInode;
-
-    private InodeEntry(LockResource lock, Inode inode) {
-      super(lock);
-      mInode = inode;
-    }
-
-    public Inode getInode() {
-      return mInode;
-    }
-
-    @Override
-    public String toString() {
-      return "\"" + mInode.getName() + "\"";
-    }
-  }
-
-  protected static class EdgeEntry extends Entry {
-    private final Edge mEdge;
-
-    private EdgeEntry(LockResource lock, Edge edge) {
-      super(lock);
-      mEdge = edge;
-    }
-
-    public Edge getEdge() {
-      return mEdge;
-    }
-
-    @Override
-    public String toString() {
-      return mEdge.toString();
-    }
-  }
+  void close();
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -24,6 +24,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.Striped;
 
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -109,6 +110,26 @@ public class InodeLockManager {
   @VisibleForTesting
   boolean edgeWriteLockedByCurrentThread(Edge edge) {
     return mEdgeLocks.getRawReadWriteLock(edge).getWriteHoldCount() > 0;
+  }
+
+  @VisibleForTesting
+  public void assertAllLocksReleased() {
+    assertAllLocksReleased(mEdgeLocks);
+    assertAllLocksReleased(mInodeLocks);
+  }
+
+  private <T> void assertAllLocksReleased(LockCache<T> cache) {
+    for (Entry<T, ReentrantReadWriteLock> entry : cache.getEntryMap().entrySet()) {
+      ReentrantReadWriteLock lock = entry.getValue();
+      if (lock.isWriteLocked()) {
+        throw new RuntimeException(
+            String.format("Found a write-locked lock for %s", entry.getKey()));
+      }
+      if (lock.getReadLockCount() > 0) {
+        throw new RuntimeException(
+            String.format("Found a read-locked lock for %s", entry.getKey()));
+      }
+    }
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -112,6 +112,9 @@ public class InodeLockManager {
     return mEdgeLocks.getRawReadWriteLock(edge).getWriteHoldCount() > 0;
   }
 
+  /**
+   * Asserts that all locks have been released, throwing an exception if any locks are still taken.
+   */
   @VisibleForTesting
   public void assertAllLocksReleased() {
     assertAllLocksReleased(mEdgeLocks);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -275,17 +275,11 @@ public class LockedInodePath implements Closeable {
         if (mLockPattern == LockPattern.WRITE_INODE) {
           mLockList.downgradeLastInode();
         } else if (mLockPattern == LockPattern.WRITE_EDGE) {
-          if (mLockList.endsInInode()) {
-            mLockList.unlockLastInode();
-          }
           downgradeEdgeToInode(LockMode.READ);
         }
         break;
       case WRITE_INODE:
         if (mLockPattern == LockPattern.WRITE_EDGE) {
-          if (mLockList.endsInInode()) {
-            mLockList.unlockLastInode();
-          }
           downgradeEdgeToInode(LockMode.WRITE);
         } else {
           Preconditions.checkState(mLockPattern == LockPattern.WRITE_INODE);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -243,7 +243,6 @@ public class LockedInodePath implements Closeable {
     Preconditions.checkState(fullPathExists());
 
     mLockList.unlockLastInode();
-    mLockList.unlockLastEdge();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -275,11 +275,17 @@ public class LockedInodePath implements Closeable {
         if (mLockPattern == LockPattern.WRITE_INODE) {
           mLockList.downgradeLastInode();
         } else if (mLockPattern == LockPattern.WRITE_EDGE) {
+          if (mLockList.endsInInode()) {
+            mLockList.unlockLastInode();
+          }
           downgradeEdgeToInode(LockMode.READ);
         }
         break;
       case WRITE_INODE:
         if (mLockPattern == LockPattern.WRITE_EDGE) {
+          if (mLockList.endsInInode()) {
+            mLockList.unlockLastInode();
+          }
           downgradeEdgeToInode(LockMode.WRITE);
         } else {
           Preconditions.checkState(mLockPattern == LockPattern.WRITE_INODE);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePathList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePathList.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.file.meta;
 
+import java.util.Iterator;
 import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -19,7 +20,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * This class represents a list of locked inodePaths.
  */
 @ThreadSafe
-public class LockedInodePathList implements AutoCloseable {
+public class LockedInodePathList implements AutoCloseable, Iterable<LockedInodePath> {
   private final List<LockedInodePath> mInodePathList;
 
   /**
@@ -44,5 +45,10 @@ public class LockedInodePathList implements AutoCloseable {
     for (LockedInodePath lockedInodePath : mInodePathList) {
       lockedInodePath.close();
     }
+  }
+
+  @Override
+  public Iterator<LockedInodePath> iterator() {
+    return getInodePathList().iterator();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class SimpleInodeLockList implements InodeLockList {
-  private static final Logger LOG = LoggerFactory.getLogger(InodeLockList.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleInodeLockList.class);
 
   private static final int INITIAL_CAPACITY = 8;
   private static final Edge ROOT_EDGE = new Edge(-1, "");

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -1,0 +1,365 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.meta;
+
+import alluxio.concurrent.LockMode;
+import alluxio.resource.LockResource;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A simple inode lock list.
+ */
+@NotThreadSafe
+public class SimpleInodeLockList implements InodeLockList {
+  private static final Logger LOG = LoggerFactory.getLogger(InodeLockList.class);
+
+  private static final int INITIAL_CAPACITY = 8;
+  private static final Edge ROOT_EDGE = new Edge(-1, "");
+
+  private final InodeLockManager mInodeLockManager;
+
+  /**
+   * Entries for each lock in the lock list. The entries always alternate between InodeEntry and
+   * EdgeEntry.
+   */
+  private List<Entry> mEntries;
+  /**
+   * The index of the first write lock entry. All locks before this index are read locks, and all
+   * locks after and including this index are write locks. If all locks are read locks,
+   * mFirstWriteLockIndex == mEntries.size().
+   */
+  private int mFirstWriteLockIndex;
+
+  /**
+   * Creates a new empty lock list.
+   *
+   * @param inodeLockManager manager for inode locks
+   */
+  public SimpleInodeLockList(InodeLockManager inodeLockManager) {
+    mInodeLockManager = inodeLockManager;
+    mEntries = new ArrayList<>(INITIAL_CAPACITY);
+    mFirstWriteLockIndex = 0;
+  }
+
+  @Override
+  public void lockInode(Inode inode, LockMode mode) {
+    mode = nextLockMode(mode);
+    if (!mEntries.isEmpty()) {
+      Preconditions.checkState(!endsInInode());
+      String lastEdgeName = ((EdgeEntry) lastEntry()).getEdge().getName();
+      Preconditions.checkState(inode.getName().equals(lastEdgeName),
+          "Expected to lock inode %s but locked inode %s", lastEdgeName, inode.getName());
+    }
+    addEntry(new InodeEntry(mInodeLockManager.lockInode(inode, mode), inode), mode);
+  }
+
+  @Override
+  public void lockEdge(Inode lastInode, String childName, LockMode mode) {
+    mode = nextLockMode(mode);
+    long edgeParentId = lastInode.getId();
+    if (!mEntries.isEmpty()) {
+      Preconditions.checkState(endsInInode());
+      Preconditions.checkState(lastInode().getId() == edgeParentId);
+    }
+    Edge edge = new Edge(edgeParentId, childName);
+    addEntry(new EdgeEntry(mInodeLockManager.lockEdge(edge, mode), edge), mode);
+  }
+
+  @Override
+  public void lockRootEdge(LockMode mode) {
+    Preconditions.checkState(mEntries.isEmpty());
+    addEntry(new EdgeEntry(mInodeLockManager.lockEdge(ROOT_EDGE, mode), ROOT_EDGE), mode);
+    if (mode == LockMode.WRITE) {
+      mFirstWriteLockIndex = 0;
+    }
+  }
+
+  @Override
+  public void pushWriteLockedEdge(Inode inode, String childName) {
+    Preconditions.checkState(!endsInInode());
+    Preconditions.checkState(endsInWriteLock());
+
+    int edgeIndex = mEntries.size() - 1;
+    if (mFirstWriteLockIndex < edgeIndex) {
+      // If the lock before the edge lock is already WRITE, we can just acquire more WRITE locks.
+      lockInode(inode, LockMode.WRITE);
+      lockEdge(inode, childName, LockMode.WRITE);
+    } else {
+      lockInode(inode, LockMode.READ);
+      lockEdge(inode, childName, LockMode.WRITE);
+      downgradeEdge(edgeIndex);
+    }
+  }
+
+  /**
+   * If the lock list is write locked, returns LockMode.WRITE. Otherwise, returns the given mode.
+   *
+   * @param mode a lock mode
+   * @return the mode
+   */
+  private LockMode nextLockMode(LockMode mode) {
+    if (endsInWriteLock()) {
+      return LockMode.WRITE;
+    }
+    return mode;
+  }
+
+  @Override
+  public void unlockLastInode() {
+    Preconditions.checkState(endsInInode());
+    Preconditions.checkState(!mEntries.isEmpty());
+    removeLastEntry();
+  }
+
+  @Override
+  public void unlockLastEdge() {
+    Preconditions.checkState(!endsInInode());
+    Preconditions.checkState(!mEntries.isEmpty());
+    removeLastEntry();
+  }
+
+  @Override
+  public void downgradeLastInode() {
+    Preconditions.checkState(endsInInode());
+    Preconditions.checkState(!mEntries.isEmpty());
+    Preconditions.checkState(endsInWriteLock());
+
+    if (endsInMultipleWriteLocks()) {
+      return; // No point in changing from write lock to read lock when the parent lock is WRITE.
+    }
+
+    Inode lastInode = lastInode();
+    LockResource lock = mInodeLockManager.lockInode(lastInode, LockMode.READ);
+    removeLastEntry();
+    addEntry(new InodeEntry(lock, lastInode), LockMode.READ);
+  }
+
+  @Override
+  public void downgradeLastEdge() {
+    Preconditions.checkState(!endsInInode());
+    Preconditions.checkState(!mEntries.isEmpty());
+    Preconditions.checkState(endsInWriteLock());
+
+    if (!endsInMultipleWriteLocks()) {
+      downgradeEdge(mEntries.size() - 1);
+    }
+  }
+
+  @Override
+  public void downgradeEdgeToInode(Inode inode, LockMode mode) {
+    Preconditions.checkState(!endsInInode());
+    Preconditions.checkState(!mEntries.isEmpty());
+    Preconditions.checkState(endsInWriteLock());
+
+    if (endsInMultipleWriteLocks()) {
+      lockInode(inode, LockMode.WRITE);
+      return;
+    }
+
+    Edge lastEdge = lastEdge();
+    LockResource inodeLock = mInodeLockManager.lockInode(inode, mode);
+    LockResource edgeLock = mInodeLockManager.lockEdge(lastEdge, LockMode.READ);
+    removeLastEntry();
+    addEntry(new EdgeEntry(edgeLock, lastEdge), nextLockMode(LockMode.READ));
+    addEntry(new InodeEntry(inodeLock, inode), nextLockMode(mode));
+  }
+
+  /**
+   * Adds an entry to mEntries.
+   *
+   * @param entry the entry to add
+   * @param mode the mode the entry is locked in
+   */
+  private void addEntry(Entry entry, LockMode mode) {
+    if (!endsInWriteLock() && mode == LockMode.READ) {
+      mFirstWriteLockIndex++;
+    }
+    mEntries.add(entry);
+  }
+
+  /**
+   * Removes and unlocks the last entry from mEntries.
+   */
+  private void removeLastEntry() {
+    mEntries.remove(mEntries.size() - 1).getLock().close();
+    if (mFirstWriteLockIndex > mEntries.size()) {
+      mFirstWriteLockIndex = mEntries.size();
+    }
+  }
+
+  /**
+   * Downgrades the edge at the specified entry index.
+   */
+  private void downgradeEdge(int edgeEntryIndex) {
+    EdgeEntry entry = (EdgeEntry) mEntries.get(edgeEntryIndex);
+    LockResource lock = mInodeLockManager.lockEdge(entry.getEdge(), LockMode.READ);
+    entry.getLock().close();
+    mEntries.set(edgeEntryIndex, new EdgeEntry(lock, entry.getEdge()));
+    if (mFirstWriteLockIndex == edgeEntryIndex) {
+      mFirstWriteLockIndex++;
+    }
+  }
+
+  @Override
+  public LockMode getLockMode() {
+    return endsInWriteLock() ? LockMode.WRITE : LockMode.READ;
+  }
+
+  @Override
+  public List<Inode> getLockedInodes() {
+    return mEntries.stream()
+        .filter(e -> e instanceof InodeEntry)
+        .map(e -> ((InodeEntry) e).getInode())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Inode get(int index) {
+    int entryIndex = mEntries.get(0) instanceof InodeEntry ? index * 2 : index * 2 + 1;
+    return ((InodeEntry) mEntries.get(entryIndex)).getInode();
+  }
+
+  @Override
+  public int numInodes() {
+    if (mEntries.isEmpty()) {
+      return 0;
+    }
+    if (mEntries.get(0) instanceof InodeEntry) {
+      return (mEntries.size() + 1) / 2;
+    }
+    return mEntries.size() / 2;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return mEntries.isEmpty();
+  }
+
+  @Override
+  public InodeLockManager getInodeLockManager() {
+    return mInodeLockManager;
+  }
+
+  @Override
+  public boolean endsInInode() {
+    return lastEntry() instanceof InodeEntry;
+  }
+
+  /**
+   * @return the last inode
+   */
+  private Inode lastInode() {
+    Preconditions.checkState(endsInInode());
+    return ((InodeEntry) lastEntry()).getInode();
+  }
+
+  /**
+   * @return the last edge
+   */
+  private Edge lastEdge() {
+    Preconditions.checkState(!endsInInode());
+    return ((EdgeEntry) lastEntry()).getEdge();
+  }
+
+  /**
+   * @return whether this lock list ends in a write lock
+   */
+  private boolean endsInWriteLock() {
+    return mFirstWriteLockIndex < mEntries.size();
+  }
+
+  private boolean endsInMultipleWriteLocks() {
+    return mFirstWriteLockIndex < mEntries.size() - 1;
+  }
+
+  /**
+   * @return the last entry in the lock list, or null if the lock list contains no entries
+   */
+  @Nullable
+  private Entry lastEntry() {
+    return mEntries.isEmpty() ? null : mEntries.get(mEntries.size() - 1);
+  }
+
+  @Override
+  public String toString() {
+    String path = mEntries.stream()
+        .filter(e -> e instanceof InodeEntry)
+        .map(e -> ((InodeEntry) e).getInode().getName())
+        .collect(Collectors.joining("/"));
+    return String.format("Path: <%s>%nEntries: %s%nFirst write-locked index: %s", path, mEntries,
+        mFirstWriteLockIndex);
+  }
+
+  @Override
+  public void close() {
+    mEntries.forEach(entry -> entry.getLock().close());
+    mEntries.clear();
+  }
+
+  private abstract static class Entry {
+    private final LockResource mLock;
+
+    protected Entry(LockResource lock) {
+      mLock = lock;
+    }
+
+    protected LockResource getLock() {
+      return mLock;
+    }
+  }
+
+  private static class InodeEntry extends Entry {
+    private final Inode mInode;
+
+    public InodeEntry(LockResource lock, Inode inode) {
+      super(lock);
+      mInode = inode;
+    }
+
+    public Inode getInode() {
+      return mInode;
+    }
+
+    @Override
+    public String toString() {
+      return "\"" + mInode.getName() + "\"";
+    }
+  }
+
+  private static class EdgeEntry extends Entry {
+    private final Edge mEdge;
+
+    public EdgeEntry(LockResource lock, Edge edge) {
+      super(lock);
+      mEdge = edge;
+    }
+
+    public Edge getEdge() {
+      return mEdge;
+    }
+
+    @Override
+    public String toString() {
+      return mEdge.toString();
+    }
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -527,7 +527,7 @@ public final class InodeTreeTest {
     // all inodes under root
     try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.WRITE_INODE)) {
       // /test, /nested, /nested/test, /nested/test/file
-      assertEquals(4, mTree.getImplicitlyLockedDescendants(inodePath).size());
+      assertEquals(4, mTree.getDescendants(inodePath).getInodePathList().size());
     }
   }
 
@@ -541,13 +541,13 @@ public final class InodeTreeTest {
     // all inodes under root
     try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.WRITE_INODE)) {
       // /nested, /nested/test
-      assertEquals(2, mTree.getImplicitlyLockedDescendants(inodePath).size());
+      assertEquals(2, mTree.getDescendants(inodePath).getInodePathList().size());
 
       // delete the nested inode
       deleteInodeByPath(mTree, NESTED_URI);
 
       // only /nested left
-      assertEquals(1, mTree.getImplicitlyLockedDescendants(inodePath).size());
+      assertEquals(1, mTree.getDescendants(inodePath).getInodePathList().size());
     }
   }
 
@@ -610,7 +610,7 @@ public final class InodeTreeTest {
     mTree.getRoot();
     try (LockedInodePath inodePath =
              mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.WRITE_INODE)) {
-      assertEquals(0, mTree.getImplicitlyLockedDescendants(inodePath).size());
+      assertEquals(0, mTree.getDescendants(inodePath).getInodePathList().size());
       mTree.processJournalEntry(nested.toJournalEntry());
       verifyChildrenNames(mTree, inodePath, Sets.newHashSet("nested"));
       mTree.processJournalEntry(test.toJournalEntry());
@@ -644,11 +644,11 @@ public final class InodeTreeTest {
     mTree.getRoot();
     try (LockedInodePath inodePath =
              mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.WRITE_INODE)) {
-      assertEquals(0, mTree.getImplicitlyLockedDescendants(inodePath).size());
+      assertEquals(0, mTree.getDescendants(inodePath).getInodePathList().size());
       mTree.processJournalEntry(nested.toJournalEntry());
       mTree.processJournalEntry(test.toJournalEntry());
       mTree.processJournalEntry(file.toJournalEntry());
-      List<LockedInodePath> descendants = mTree.getImplicitlyLockedDescendants(inodePath);
+      List<LockedInodePath> descendants = mTree.getDescendants(inodePath).getInodePathList();
       assertEquals(inodeChildren.length, descendants.size());
       for (LockedInodePath childPath : descendants) {
         Inode child = childPath.getInodeOrNull();
@@ -747,7 +747,7 @@ public final class InodeTreeTest {
   // verify that the tree has the given children
   private static void verifyChildrenNames(InodeTree tree, LockedInodePath inodePath,
       Set<String> childNames) throws Exception {
-    List<LockedInodePath> descendants = tree.getImplicitlyLockedDescendants(inodePath);
+    List<LockedInodePath> descendants = tree.getDescendants(inodePath).getInodePathList();
     assertEquals(childNames.size(), descendants.size());
     for (LockedInodePath childPath : descendants) {
       assertTrue(childNames.contains(childPath.getInode().getName()));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
@@ -259,7 +259,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
 
     checkOnlyNodesReadLocked(mRootDir);
     checkOnlyNodesWriteLocked();
-    checkOnlyIncomingEdgesReadLocked(mRootDir);
+    checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
     checkOnlyIncomingEdgesWriteLocked();
   }
 
@@ -276,7 +276,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     checkOnlyNodesReadLocked(mRootDir);
     checkOnlyNodesWriteLocked();
     checkOnlyIncomingEdgesReadLocked(mRootDir);
-    checkOnlyIncomingEdgesWriteLocked();
+    checkOnlyIncomingEdgesWriteLocked(mDirA);
   }
 
   @Test
@@ -292,7 +292,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     checkOnlyNodesReadLocked(mRootDir);
     checkOnlyNodesWriteLocked(mDirA, mDirB);
     checkOnlyIncomingEdgesReadLocked(mRootDir);
-    checkOnlyIncomingEdgesWriteLocked(mDirA, mDirB);
+    checkOnlyIncomingEdgesWriteLocked(mDirA, mDirB, mFileC);
 
     pathC.close();
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
@@ -96,7 +96,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(LockPattern.WRITE_EDGE, mPath.getLockPattern());
 
     checkOnlyNodesReadLocked(mRootDir, mDirA, mDirB);
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mFileC);
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA, mDirB);
     checkOnlyIncomingEdgesWriteLocked(mFileC);
   }
@@ -242,7 +242,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(1, mPath.getExistingInodeCount());
 
     checkOnlyNodesReadLocked();
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mRootDir);
     checkOnlyIncomingEdgesReadLocked();
     checkOnlyIncomingEdgesWriteLocked(mRootDir);
   }
@@ -276,7 +276,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     checkOnlyNodesReadLocked(mRootDir);
     checkOnlyNodesWriteLocked();
     checkOnlyIncomingEdgesReadLocked(mRootDir);
-    checkOnlyIncomingEdgesWriteLocked(mDirA);
+    checkOnlyIncomingEdgesWriteLocked();
   }
 
   @Test
@@ -290,14 +290,14 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(Arrays.asList(mRootDir, mDirA, mDirB), pathC.getInodeList());
 
     checkOnlyNodesReadLocked(mRootDir);
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mDirA, mDirB);
     checkOnlyIncomingEdgesReadLocked(mRootDir);
-    checkOnlyIncomingEdgesWriteLocked(mDirA);
+    checkOnlyIncomingEdgesWriteLocked(mDirA, mDirB);
 
     pathC.close();
 
     checkOnlyNodesReadLocked(mRootDir);
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mDirA);
     checkOnlyIncomingEdgesReadLocked(mRootDir);
     checkOnlyIncomingEdgesWriteLocked(mDirA);
   }
@@ -394,7 +394,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(mDirB, childPath.getInode());
 
     checkOnlyNodesReadLocked(mRootDir, mDirA);
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mDirB);
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
     checkOnlyIncomingEdgesWriteLocked(mDirB);
 
@@ -439,11 +439,10 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertTrue(childPath.fullPathExists());
     assertEquals(mDirB, childPath.getInode());
 
-    // No new locks are taken since we already have a write lock
     checkOnlyNodesReadLocked(mRootDir);
-    checkOnlyNodesWriteLocked(mDirA);
+    checkOnlyNodesWriteLocked(mDirA, mDirB);
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
-    checkOnlyIncomingEdgesWriteLocked();
+    checkOnlyIncomingEdgesWriteLocked(mDirB);
 
     childPath.close();
 
@@ -513,7 +512,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(Arrays.asList(mRootDir, mDirA, mDirB, mFileC), childPath.getInodeList());
 
     checkOnlyNodesReadLocked(mRootDir, mDirA, mDirB);
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mFileC);
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA, mDirB);
     checkOnlyIncomingEdgesWriteLocked(mFileC);
 
@@ -535,14 +534,14 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     assertEquals(Arrays.asList(mRootDir, mDirA, mDirB, mFileC), childPath.getInodeList());
 
     checkOnlyNodesReadLocked();
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mRootDir, mDirA, mDirB, mFileC);
     checkOnlyIncomingEdgesReadLocked();
-    checkOnlyIncomingEdgesWriteLocked(mRootDir);
+    checkOnlyIncomingEdgesWriteLocked(mRootDir, mDirA, mDirB, mFileC);
 
     childPath.close();
 
     checkOnlyNodesReadLocked();
-    checkOnlyNodesWriteLocked();
+    checkOnlyNodesWriteLocked(mRootDir);
     checkOnlyIncomingEdgesReadLocked();
     checkOnlyIncomingEdgesWriteLocked(mRootDir);
   }

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -142,6 +142,7 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
   @Override
   public void stop() throws Exception {
     super.stop();
+    TestUtils.assertAllLocksReleased(this);
     // clear HDFS client caching
     System.clearProperty("fs.hdfs.impl.disable.cache");
   }

--- a/minicluster/src/main/java/alluxio/master/TestUtils.java
+++ b/minicluster/src/main/java/alluxio/master/TestUtils.java
@@ -12,7 +12,11 @@
 package alluxio.master;
 
 import alluxio.Constants;
+import alluxio.master.file.FileSystemMaster;
+import alluxio.master.file.meta.InodeLockManager;
 import alluxio.util.ThreadUtils;
+
+import org.powermock.reflect.Whitebox;
 
 /**
  * Test utilities.
@@ -29,5 +33,17 @@ public class TestUtils {
       throw new RuntimeException(
           String.format("Timed out waiting for process %s to start", process));
     }
+  }
+
+  /**
+   * Verifies that all master inode tree locks have been released for the given cluster.
+   *
+   * @param cluster the cluster
+   */
+  public static void assertAllLocksReleased(LocalAlluxioCluster cluster) {
+    InodeLockManager lockManager =
+        (InodeLockManager) Whitebox.getInternalState(cluster.getLocalAlluxioMaster()
+            .getMasterProcess().getMaster(FileSystemMaster.class), "mInodeLockManager");
+    lockManager.assertAllLocksReleased();
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -12,22 +12,22 @@
 package alluxio.client.fs;
 
 import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.TtlAction;
 import alluxio.grpc.WritePType;
-import alluxio.security.authorization.Mode;
-import alluxio.testutils.PersistenceTestUtils;
-import alluxio.client.WriteType;
-import alluxio.client.file.FileOutStream;
-import alluxio.client.file.URIStatus;
-import alluxio.exception.AlluxioException;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.file.meta.PersistenceState;
+import alluxio.security.authorization.Mode;
 import alluxio.testutils.IntegrationTestUtils;
+import alluxio.testutils.PersistenceTestUtils;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
@@ -45,7 +45,9 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     extends AbstractFileOutStreamIntegrationTest {
   private static final int LEN = 1024;
   private static final FileSystemMasterCommonPOptions COMMON_OPTIONS =
-      FileSystemMasterCommonPOptions.newBuilder().setTtl(12345678L).setTtlAction(TtlAction.DELETE)
+      FileSystemMasterCommonPOptions.newBuilder()
+          .setTtl(12345678L).setTtlAction(TtlAction.DELETE)
+          .setSyncIntervalMs(-1)
           .build();
 
   private static final SetAttributePOptions TEST_OPTIONS =


### PR DESCRIPTION
Previously, we would skip taking "unnecessary" locks on inodes and edges. A lock was considered unnecessary if one of its ancestors was already write-locked, e.g. if we've write-locked /a/b, we don't need to acquire any more locks to lock /a/b/c/d. This is what we called implicit locking.

Implicit locking works well when all locks are taken starting from the root. However, we sometimes want to lock individual inodes without needing to lock their ancestors. In particular, CachingInodeStore needs to evict inodes from memory to RocksDB, which requires locking the inodes directly (locking their ancestors would be too expensive).

To support random locks, we remove the concept of implicit locking. With this PR, we replace implicit locks with explicit write locks. For the above example, we will now take write locks on all inodes and edges leading from /a/b to /a/b/c/d.

One new invariant we follow is that all lock lists contain some number of read-locked entries followed by some number of write-locked entries. In particular, we never take a read lock following a write lock. So if you've write-locked /a/b and then request to extend the path with a read-lock on /a/b/c, you will actually take a write lock.

