### PR TITLE
Fix ping service client

### DIFF
--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -650,11 +650,17 @@ public final class NetworkAddressUtils {
     Preconditions.checkNotNull(address, "address");
     Preconditions.checkNotNull(serviceType, "serviceType");
     GrpcChannel channel =
-        GrpcChannelBuilder.newBuilder(new GrpcServerAddress(address), conf).build();
-    ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
-        ServiceVersionClientServiceGrpc.newBlockingStub(channel);
-    versionClient.getServiceVersion(
-        GetServiceVersionPRequest.newBuilder().setServiceType(serviceType).build());
-    channel.shutdown();
+        GrpcChannelBuilder.newBuilder(new GrpcServerAddress(address), conf).disableAuthentication()
+            .build();
+    try {
+      ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
+          ServiceVersionClientServiceGrpc.newBlockingStub(channel);
+      versionClient.getServiceVersion(
+          GetServiceVersionPRequest.newBuilder().setServiceType(serviceType).build());
+    } catch (Throwable t) {
+      throw AlluxioStatusException.fromThrowable(t);
+    } finally {
+      channel.shutdown();
+    }
   }
 }


### PR DESCRIPTION
This PR fixes two issues:

- Alluxio client can use ping service to query the health of Alluxio services. On client the authentication was incorrectly enabled by default causing it to fail to start when there is no client credentials given.

- Another problem is that the client fails to retry because the gRPC `UnavailableException` is not converted to the `AlluxioStatusException`, effectively render the retry logic invalid.
