### PR TITLE
Add to be persisted files to pinned file list

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2227,6 +2227,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
   @Override
   public Set<Long> getPinIdList() {
+    // return both the explicitly pinned inodes and not persisted inodes which should not be evicted
     return Sets.union(mInodeTree.getPinIdSet(), mInodeTree.getToBePersistedIds());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2227,7 +2227,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
   @Override
   public Set<Long> getPinIdList() {
-    return mInodeTree.getPinIdSet();
+    return Sets.union(mInodeTree.getPinIdSet(), mInodeTree.getToBePersistedIds());
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManagerView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManagerView.java
@@ -52,7 +52,7 @@ public class BlockMetadataManagerView {
    */
   private final List<StorageTierView> mTierViews = new ArrayList<>();
 
-  /** A list of pinned inodes. */
+  /** A list of pinned inodes, including inodes which are scheduled for async persist. */
   private final Set<Long> mPinnedInodes = new HashSet<>();
 
   /** Indices of locks that are being used. */
@@ -97,7 +97,7 @@ public class BlockMetadataManagerView {
   }
 
   /**
-   * Tests if the block is pinned.
+   * Tests if the block is pinned either explicitly or because it is scheduled for async persist.
    *
    * @param blockId to be tested
    * @return boolean, true if block is pinned


### PR DESCRIPTION
Changes the semantic of `getPinIdList` to return both the explicitly pinned inodes and inodes which are in `TO_BE_PERSISTED` state. Inodes in that state should not be evicted or users can experience data loss.