### PR TITLE
Use static imports for standard test utilities

### DIFF
--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -12,13 +12,12 @@
 package alluxio.util.network;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Test;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
-
-import org.junit.Test;
 
 import java.net.InetSocketAddress;
 

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -18,7 +18,7 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
-import static org.junit.Test;
+import org.junit.Test;
 
 import java.net.InetSocketAddress;
 

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -11,12 +11,14 @@
 
 package alluxio.util.network;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
-import org.junit.Assert;
+//import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -44,23 +46,23 @@ public class GetMasterWorkerAddressTest {
     int defaultPort = Integer.parseInt(PropertyKey.MASTER_RPC_PORT.getDefaultValue());
     InetSocketAddress masterAddress =
         NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    Assert.assertEquals(new InetSocketAddress("RemoteMaster1", 10000), masterAddress);
+    assertEquals(new InetSocketAddress("RemoteMaster1", 10000), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // port only
     conf.set(PropertyKey.MASTER_RPC_PORT, "20000");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    Assert.assertEquals(new InetSocketAddress(defaultHostname, 20000), masterAddress);
+    assertEquals(new InetSocketAddress(defaultHostname, 20000), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // connect host only
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster3");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    Assert.assertEquals(new InetSocketAddress("RemoteMaster3", defaultPort), masterAddress);
+    assertEquals(new InetSocketAddress("RemoteMaster3", defaultPort), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // all default
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    Assert.assertEquals(new InetSocketAddress(defaultHostname, defaultPort), masterAddress);
+    assertEquals(new InetSocketAddress(defaultHostname, defaultPort), masterAddress);
   }
 }

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -12,12 +12,13 @@
 package alluxio.util.network;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Test;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
+
+import static org.junit.Test;
 
 import java.net.InetSocketAddress;
 

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.util.network;
 
-import org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -17,7 +17,9 @@ import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
+
 import org.junit.Test;
+
 import java.net.InetSocketAddress;
 
 /**

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -9,9 +9,9 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.util.network;
-
 import static org.junit.Assert.assertEquals;
+
+package alluxio.util.network;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
@@ -20,7 +20,6 @@ import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 //import org.junit.Assert;
 import org.junit.Test;
-
 import java.net.InetSocketAddress;
 
 /**

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.util.network;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -9,16 +9,14 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-import static org.junit.Assert.assertEquals;
-
 package alluxio.util.network;
+
+import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
-
-//import org.junit.Assert;
 import org.junit.Test;
 import java.net.InetSocketAddress;
 


### PR DESCRIPTION
Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java

Change
import org.junit.Assert;
to
import static org.junit.Assert.assertEquals;
Put the static imports before non-static imports.

AND

Update all
Assert.assertEquals*
to
assertEquals*