### PR TITLE
[SMALLFIX] Use static imports for standard test utilities

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -11,13 +11,14 @@
 
 package alluxio.client.file;
 
+import static org.junit.Assert.fail;
+
 import alluxio.ClientContext;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,7 +62,7 @@ public final class FileSystemContextTest {
     long start = System.currentTimeMillis();
     acquireThread.join(timeoutMs);
     if (System.currentTimeMillis() - start < timeoutMs) {
-      Assert.fail("Acquired a master client when the client pool was full.");
+      fail("Acquired a master client when the client pool was full.");
     }
 
     // Release all the clients
@@ -75,7 +76,7 @@ public final class FileSystemContextTest {
     start = System.currentTimeMillis();
     acquireThread.join(timeoutMs);
     if (System.currentTimeMillis() - start >= timeoutMs) {
-      Assert.fail("Failed to acquire a master client within " + timeoutMs + "ms. Deadlock?");
+      fail("Failed to acquire a master client within " + timeoutMs + "ms. Deadlock?");
     }
   }
 


### PR DESCRIPTION
change import org.junit.Assert; to import org.junit.Assert.fail;
modify all assert.fail(* to fail(*
Put the static imports before non-static imports.