### PR TITLE
Add option for skipping caching and eviction for scanning inode tree

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/DelegatingReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/DelegatingReadOnlyInodeStore.java
@@ -36,53 +36,53 @@ public class DelegatingReadOnlyInodeStore implements ReadOnlyInodeStore {
   }
 
   @Override
-  public Optional<Inode> get(long id) {
-    return mDelegate.get(id);
+  public Optional<Inode> get(long id, ReadOption option) {
+    return mDelegate.get(id, option);
   }
 
   @Override
-  public Iterable<Long> getChildIds(Long inodeId) {
-    return mDelegate.getChildIds(inodeId);
+  public Iterable<Long> getChildIds(Long inodeId, ReadOption option) {
+    return mDelegate.getChildIds(inodeId, option);
   }
 
   @Override
-  public Iterable<Long> getChildIds(InodeDirectoryView inode) {
-    return mDelegate.getChildIds(inode);
+  public Iterable<Long> getChildIds(InodeDirectoryView inode, ReadOption option) {
+    return mDelegate.getChildIds(inode, option);
   }
 
   @Override
-  public Iterable<? extends Inode> getChildren(Long inodeId) {
-    return mDelegate.getChildren(inodeId);
+  public Iterable<? extends Inode> getChildren(Long inodeId, ReadOption option) {
+    return mDelegate.getChildren(inodeId, option);
   }
 
   @Override
-  public Iterable<? extends Inode> getChildren(InodeDirectoryView inode) {
-    return mDelegate.getChildren(inode);
+  public Iterable<? extends Inode> getChildren(InodeDirectoryView inode, ReadOption option) {
+    return mDelegate.getChildren(inode, option);
   }
 
   @Override
-  public Optional<Long> getChildId(Long inodeId, String name) {
-    return mDelegate.getChildId(inodeId, name);
+  public Optional<Long> getChildId(Long inodeId, String name, ReadOption option) {
+    return mDelegate.getChildId(inodeId, name, option);
   }
 
   @Override
-  public Optional<Long> getChildId(InodeDirectoryView inode, String name) {
-    return mDelegate.getChildId(inode, name);
+  public Optional<Long> getChildId(InodeDirectoryView inode, String name, ReadOption option) {
+    return mDelegate.getChildId(inode, name, option);
   }
 
   @Override
-  public Optional<Inode> getChild(Long inodeId, String name) {
-    return mDelegate.getChild(inodeId, name);
+  public Optional<Inode> getChild(Long inodeId, String name, ReadOption option) {
+    return mDelegate.getChild(inodeId, name, option);
   }
 
   @Override
-  public Optional<Inode> getChild(InodeDirectoryView inode, String name) {
-    return mDelegate.getChild(inode, name);
+  public Optional<Inode> getChild(InodeDirectoryView inode, String name, ReadOption option) {
+    return mDelegate.getChild(inode, name, option);
   }
 
   @Override
-  public boolean hasChildren(InodeDirectoryView inode) {
-    return mDelegate.hasChildren(inode);
+  public boolean hasChildren(InodeDirectoryView inode, ReadOption option) {
+    return mDelegate.hasChildren(inode, option);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
@@ -45,13 +45,22 @@ public interface InodeStore extends ReadOnlyInodeStore, Checkpointed, Closeable 
    * inode.
    *
    * @param id an inode id
+   * @param option read options
    * @return the inode with the given id, if it exists
    */
-  Optional<MutableInode<?>> getMutable(long id);
+  Optional<MutableInode<?>> getMutable(long id, ReadOption option);
+
+  /**
+   * @param id an inode id
+   * @return the result of {@link #getMutable(long, ReadOption)} with default option
+   */
+  default Optional<MutableInode<?>> getMutable(long id) {
+    return getMutable(id, ReadOption.defaults());
+  }
 
   @Override
-  default Optional<Inode> get(long id) {
-    return getMutable(id).map(Inode::wrap);
+  default Optional<Inode> get(long id, ReadOption option) {
+    return getMutable(id, option).map(Inode::wrap);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
@@ -28,29 +28,114 @@ import java.util.Set;
  * Read-only access to the inode store.
  */
 public interface ReadOnlyInodeStore extends Closeable {
+  /**
+   * Options of reading from the inode store.
+   */
+  class ReadOption {
+    private static final ReadOption DEFAULT = new ReadOption(false);
+
+    private final boolean mSkipCachingAndEviction;
+
+    private ReadOption(boolean skipCachingAndEviction) {
+      mSkipCachingAndEviction = skipCachingAndEviction;
+    }
+
+    /**
+     * @return whether to skip the caching and eviction when reading from the inode store
+     */
+    public boolean shouldSkipCachingAndEviction() {
+      return mSkipCachingAndEviction;
+    }
+
+    /**
+     * @return a new builder
+     */
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    /**
+     * @return the singleton instance of the default option
+     */
+    public static ReadOption defaults() {
+      return DEFAULT;
+    }
+
+    /**
+     * Builder for {@link ReadOption}.
+     */
+    public static class Builder {
+      private boolean mSkipCachingAndEviction = false;
+
+      /**
+       * Sets whether to skip caching and eviction.
+       *
+       * @param skip skip or not
+       * @return the builder
+       */
+      public Builder setSkipCachingAndEviction(boolean skip) {
+        mSkipCachingAndEviction = skip;
+        return this;
+      }
+
+      /**
+       * @return the built option
+       */
+      public ReadOption build() {
+        return new ReadOption(mSkipCachingAndEviction);
+      }
+    }
+  }
 
   /**
    * @param id an inode id
+   * @param option the options
    * @return the inode with the given id, if it exists
    */
-  Optional<Inode> get(long id);
+  Optional<Inode> get(long id, ReadOption option);
+
+  /**
+   * @param id an inode id
+   * @return the result of {@link #get(long, ReadOption)} with default option
+   */
+  default Optional<Inode> get(long id) {
+    return get(id, ReadOption.defaults());
+  }
 
   /**
    * Returns an iterable for the ids of the children of the given directory.
    *
    * @param inodeId an inode id to list child ids for
+   * @param option the options
    * @return the child ids iterable
    */
-  Iterable<Long> getChildIds(Long inodeId);
+  Iterable<Long> getChildIds(Long inodeId, ReadOption option);
+
+  /**
+   * @param inodeId an inode id to list child ids for
+   * @return the result of {@link #getChildIds(Long, ReadOption)} with default option
+   */
+  default Iterable<Long> getChildIds(Long inodeId) {
+    return getChildIds(inodeId, ReadOption.defaults());
+  }
 
   /**
    * Returns an iterable for the ids of the children of the given directory.
    *
    * @param inode the inode to list child ids for
+   * @param option the options
    * @return the child ids iterable
    */
+  default Iterable<Long> getChildIds(InodeDirectoryView inode, ReadOption option) {
+    return getChildIds(inode.getId(), option);
+  }
+
+  /**
+   * @param inode the inode to list child ids for
+   * @return the result of {@link #getChildIds(InodeDirectoryView, ReadOption)} with default option
+   */
   default Iterable<Long> getChildIds(InodeDirectoryView inode) {
-    return getChildIds(inode.getId());
+    return getChildIds(inode, ReadOption.defaults());
   }
 
   /**
@@ -61,11 +146,12 @@ public interface ReadOnlyInodeStore extends Closeable {
    * concurrently added inodes will be included.
    *
    * @param inodeId an inode id
+   * @param option the options
    * @return an iterable over the children of the inode with the given id
    */
-  default Iterable<? extends Inode> getChildren(Long inodeId) {
+  default Iterable<? extends Inode> getChildren(Long inodeId, ReadOption option) {
     return () -> {
-      Iterator<Long> it = getChildIds(inodeId).iterator();
+      Iterator<Long> it = getChildIds(inodeId, option).iterator();
       return new Iterator<Inode>() {
         private Inode mNext = null;
 
@@ -90,7 +176,7 @@ public interface ReadOnlyInodeStore extends Closeable {
           while (mNext == null && it.hasNext()) {
             Long nextId = it.next();
             // Make sure the inode metadata still exists
-            Optional<Inode> nextInode = get(nextId);
+            Optional<Inode> nextInode = get(nextId, option);
             if (nextInode.isPresent()) {
               mNext = nextInode.get();
             }
@@ -101,50 +187,118 @@ public interface ReadOnlyInodeStore extends Closeable {
   }
 
   /**
+   * @param inodeId an inode id
+   * @return the result of {@link #getChildren(Long, ReadOption)} with default option
+   */
+  default Iterable<? extends Inode> getChildren(Long inodeId) {
+    return getChildren(inodeId, ReadOption.defaults());
+  }
+
+  /**
    * @param inode an inode directory
+   * @param option the options
    * @return an iterable over the children of the inode with the given id
    */
+  default Iterable<? extends Inode> getChildren(InodeDirectoryView inode, ReadOption option) {
+    return getChildren(inode.getId(), option);
+  }
+
+  /**
+   * @param inode an inode directory
+   * @return the result of {@link #getChildren(InodeDirectoryView, ReadOption)} with default option
+   */
   default Iterable<? extends Inode> getChildren(InodeDirectoryView inode) {
-    return getChildren(inode.getId());
+    return getChildren(inode.getId(), ReadOption.defaults());
   }
 
   /**
    * @param inodeId an inode id
    * @param name an inode name
+   * @param option the options
    * @return the id of the child of the inode with the given name
    */
-  Optional<Long> getChildId(Long inodeId, String name);
+  Optional<Long> getChildId(Long inodeId, String name, ReadOption option);
+
+  /**
+   * @param inodeId an inode id
+   * @param name an inode name
+   * @return the result of {@link #getChildId(Long, String, ReadOption)} with default option
+   */
+  default Optional<Long> getChildId(Long inodeId, String name) {
+    return getChildId(inodeId, name, ReadOption.defaults());
+  }
 
   /**
    * @param inode an inode directory
    * @param name an inode name
+   * @param option the options
    * @return the id of the child of the inode with the given name
+   */
+  default Optional<Long> getChildId(InodeDirectoryView inode, String name, ReadOption option) {
+    return getChildId(inode.getId(), name, option);
+  }
+
+  /**
+   * @param inode an inode directory
+   * @param name an inode name
+   * @return the result of {@link #getChildId(InodeDirectoryView, String, ReadOption)} with default
+   *    option
    */
   default Optional<Long> getChildId(InodeDirectoryView inode, String name) {
-    return getChildId(inode.getId(), name);
+    return getChildId(inode.getId(), name, ReadOption.defaults());
   }
 
   /**
    * @param inodeId an inode id
    * @param name an inode name
+   * @param option the options
    * @return the child of the inode with the given name
    */
-  Optional<Inode> getChild(Long inodeId, String name);
+  Optional<Inode> getChild(Long inodeId, String name, ReadOption option);
 
   /**
-   * @param inode an inode directory
+   * @param inodeId an inode id
    * @param name an inode name
-   * @return the child of the inode with the given name
+   * @return the result of {@link #getChild(Long, String, ReadOption)} with default option
    */
-  default Optional<Inode> getChild(InodeDirectoryView inode, String name) {
-    return getChild(inode.getId(), name);
+  default Optional<Inode> getChild(Long inodeId, String name) {
+    return getChild(inodeId, name, ReadOption.defaults());
   }
 
   /**
    * @param inode an inode directory
+   * @param name an inode name
+   * @param option the options
+   * @return the child of the inode with the given name
+   */
+  default Optional<Inode> getChild(InodeDirectoryView inode, String name, ReadOption option) {
+    return getChild(inode.getId(), name, option);
+  }
+
+  /**
+   * @param inode an inode directory
+   * @param name an inode name
+   * @return the result of {@link #getChild(InodeDirectoryView, String, ReadOption)} with default
+   *    option
+   */
+  default Optional<Inode> getChild(InodeDirectoryView inode, String name) {
+    return getChild(inode.getId(), name, ReadOption.defaults());
+  }
+
+  /**
+   * @param inode an inode directory
+   * @param option the options
    * @return whether the inode has any children
    */
-  boolean hasChildren(InodeDirectoryView inode);
+  boolean hasChildren(InodeDirectoryView inode, ReadOption option);
+
+  /**
+   * @param inode an inode directory
+   * @return the result of {@link #hasChildren(InodeDirectoryView, ReadOption)} with default option
+   */
+  default boolean hasChildren(InodeDirectoryView inode) {
+    return hasChildren(inode, ReadOption.defaults());
+  }
 
   /**
    * @return all edges in the inode store

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
@@ -29,65 +29,6 @@ import java.util.Set;
  */
 public interface ReadOnlyInodeStore extends Closeable {
   /**
-   * Options of reading from the inode store.
-   */
-  class ReadOption {
-    private static final ReadOption DEFAULT = new ReadOption(false);
-
-    private final boolean mSkipCachingAndEviction;
-
-    private ReadOption(boolean skipCachingAndEviction) {
-      mSkipCachingAndEviction = skipCachingAndEviction;
-    }
-
-    /**
-     * @return whether to skip the caching and eviction when reading from the inode store
-     */
-    public boolean shouldSkipCachingAndEviction() {
-      return mSkipCachingAndEviction;
-    }
-
-    /**
-     * @return a new builder
-     */
-    public static Builder newBuilder() {
-      return new Builder();
-    }
-
-    /**
-     * @return the singleton instance of the default option
-     */
-    public static ReadOption defaults() {
-      return DEFAULT;
-    }
-
-    /**
-     * Builder for {@link ReadOption}.
-     */
-    public static class Builder {
-      private boolean mSkipCachingAndEviction = false;
-
-      /**
-       * Sets whether to skip caching and eviction.
-       *
-       * @param skip skip or not
-       * @return the builder
-       */
-      public Builder setSkipCachingAndEviction(boolean skip) {
-        mSkipCachingAndEviction = skip;
-        return this;
-      }
-
-      /**
-       * @return the built option
-       */
-      public ReadOption build() {
-        return new ReadOption(mSkipCachingAndEviction);
-      }
-    }
-  }
-
-  /**
    * @param id an inode id
    * @param option the options
    * @return the inode with the given id, if it exists

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOption.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOption.java
@@ -1,0 +1,71 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore;
+
+/**
+ * Options for reading from the inode store.
+ */
+public class ReadOption {
+  private static final ReadOption DEFAULT = new ReadOption(false);
+
+  private final boolean mSkipCache;
+
+  private ReadOption(boolean skipCache) {
+    mSkipCache = skipCache;
+  }
+
+  /**
+   * @return whether to skip the caching and eviction when reading from the inode store
+   */
+  public boolean shouldSkipCache() {
+    return mSkipCache;
+  }
+
+  /**
+   * @return a new builder
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * @return the singleton instance of the default option
+   */
+  public static ReadOption defaults() {
+    return DEFAULT;
+  }
+
+  /**
+   * Builder for {@link ReadOption}.
+   */
+  public static class Builder {
+    private boolean mSkipCache = false;
+
+    /**
+     * Sets whether to skip caching and eviction.
+     *
+     * @param skip skip or not
+     * @return the builder
+     */
+    public Builder setSkipCache(boolean skip) {
+      mSkipCache = skip;
+      return this;
+    }
+
+    /**
+     * @return the built option
+     */
+    public ReadOption build() {
+      return new ReadOption(mSkipCache);
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOption.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOption.java
@@ -24,7 +24,7 @@ public class ReadOption {
   }
 
   /**
-   * @return whether to skip the caching and eviction when reading from the inode store
+   * @return whether to skip caching when reading from the inode store
    */
   public boolean shouldSkipCache() {
     return mSkipCache;
@@ -51,7 +51,7 @@ public class ReadOption {
     private boolean mSkipCache = false;
 
     /**
-     * Sets whether to skip caching and eviction.
+     * Sets whether to skip caching.
      *
      * @param skip skip or not
      * @return the builder

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -12,6 +12,8 @@
 package alluxio.master.metastore.caching;
 
 import alluxio.Constants;
+import alluxio.master.metastore.ReadOnlyInodeStore;
+import alluxio.master.metastore.ReadOnlyInodeStore.ReadOption;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.logging.SamplingLogger;
 
@@ -94,16 +96,16 @@ public abstract class Cache<K, V> implements Closeable {
    * If the value needs to be loaded, concurrent calls to get(key) will block while waiting for the
    * first call to finish loading the value.
    *
+   * If skipCachingAndEviction is true, then the value loaded from the backing store will not be
+   * cached and the eviction thread will not be woken up.
+   *
    * @param key the key to get the value for
+   * @param option the read options
    * @return the value, or empty if the key doesn't exist in the cache or in the backing store
    */
-  public Optional<V> get(K key) {
-    if (cacheIsFull()) {
-      Entry entry = mMap.get(key);
-      if (entry == null) {
-        return load(key);
-      }
-      return Optional.ofNullable(entry.mValue);
+  public Optional<V> get(K key, ReadOption option) {
+    if (option.shouldSkipCachingAndEviction() || cacheIsFull()) {
+      return getWithoutCachingAndEviction(key);
     }
     Entry result = mMap.compute(key, (k, entry) -> {
       if (entry != null) {
@@ -124,6 +126,29 @@ public abstract class Cache<K, V> implements Closeable {
     }
     wakeEvictionThreadIfNecessary();
     return Optional.of(result.mValue);
+  }
+
+  /**
+   * @param key the key to get the value for
+   * @return the result of {@link #get(Object, ReadOption)} with default option
+   */
+  public Optional<V> get(K key) {
+    return get(key, ReadOnlyInodeStore.ReadOption.defaults());
+  }
+
+  /**
+   * Retrieves a value from the cache if already cached, otherwise, loads from the backing store
+   * without caching the value. Eviction is not triggered.
+   *
+   * @param key the key to get the value for
+   * @return the value, or empty if the key doesn't exist in the cache or in the backing store
+   */
+  private Optional<V> getWithoutCachingAndEviction(K key) {
+    Entry entry = mMap.get(key);
+    if (entry == null) {
+      return load(key);
+    }
+    return Optional.ofNullable(entry.mValue);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -12,8 +12,7 @@
 package alluxio.master.metastore.caching;
 
 import alluxio.Constants;
-import alluxio.master.metastore.ReadOnlyInodeStore;
-import alluxio.master.metastore.ReadOnlyInodeStore.ReadOption;
+import alluxio.master.metastore.ReadOption;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.logging.SamplingLogger;
 
@@ -104,8 +103,8 @@ public abstract class Cache<K, V> implements Closeable {
    * @return the value, or empty if the key doesn't exist in the cache or in the backing store
    */
   public Optional<V> get(K key, ReadOption option) {
-    if (option.shouldSkipCachingAndEviction() || cacheIsFull()) {
-      return getWithoutCachingAndEviction(key);
+    if (option.shouldSkipCache() || cacheIsFull()) {
+      return getSkipCache(key);
     }
     Entry result = mMap.compute(key, (k, entry) -> {
       if (entry != null) {
@@ -133,7 +132,7 @@ public abstract class Cache<K, V> implements Closeable {
    * @return the result of {@link #get(Object, ReadOption)} with default option
    */
   public Optional<V> get(K key) {
-    return get(key, ReadOnlyInodeStore.ReadOption.defaults());
+    return get(key, ReadOption.defaults());
   }
 
   /**
@@ -143,7 +142,7 @@ public abstract class Cache<K, V> implements Closeable {
    * @param key the key to get the value for
    * @return the value, or empty if the key doesn't exist in the cache or in the backing store
    */
-  private Optional<V> getWithoutCachingAndEviction(K key) {
+  private Optional<V> getSkipCache(K key) {
     Entry entry = mMap.get(key);
     if (entry == null) {
       return load(key);

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -95,7 +95,7 @@ public abstract class Cache<K, V> implements Closeable {
    * If the value needs to be loaded, concurrent calls to get(key) will block while waiting for the
    * first call to finish loading the value.
    *
-   * If skipCachingAndEviction is true, then the value loaded from the backing store will not be
+   * If option.shouldSkipCache() is true, then the value loaded from the backing store will not be
    * cached and the eviction thread will not be woken up.
    *
    * @param key the key to get the value for

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -684,7 +684,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       if (entry != null && entry.mChildren != null) {
         return entry.mChildren.values();
       }
-      if (entry == null || !createdNewEntry.get()) {
+      if (entry == null || !createdNewEntry.get() || option.shouldSkipCache()) {
         // Skip caching if the cache is full or someone else is already caching.
         return mEdgeCache.getChildIds(inodeId, option).values();
       }

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -142,8 +142,8 @@ public final class CachingInodeStore implements InodeStore, Closeable {
   }
 
   @Override
-  public Optional<MutableInode<?>> getMutable(long id) {
-    return mInodeCache.get(id);
+  public Optional<MutableInode<?>> getMutable(long id, ReadOption option) {
+    return mInodeCache.get(id, option);
   }
 
   @Override
@@ -182,27 +182,28 @@ public final class CachingInodeStore implements InodeStore, Closeable {
   }
 
   @Override
-  public Iterable<Long> getChildIds(Long inodeId) {
-    return () -> mListingCache.getChildIds(inodeId).iterator();
+  public Iterable<Long> getChildIds(Long inodeId, ReadOption option) {
+    return () -> mListingCache.getChildIds(inodeId, option).iterator();
   }
 
   @Override
-  public Optional<Long> getChildId(Long inodeId, String name) {
-    return mEdgeCache.get(new Edge(inodeId, name));
+  public Optional<Long> getChildId(Long inodeId, String name, ReadOption option) {
+    return mEdgeCache.get(new Edge(inodeId, name), option);
   }
 
   @Override
-  public Optional<Inode> getChild(Long inodeId, String name) {
-    return mEdgeCache.get(new Edge(inodeId, name)).flatMap(this::get);
+  public Optional<Inode> getChild(Long inodeId, String name, ReadOption option) {
+    return mEdgeCache.get(new Edge(inodeId, name), option).flatMap(this::get);
   }
 
   @Override
-  public boolean hasChildren(InodeDirectoryView inode) {
+  public boolean hasChildren(InodeDirectoryView inode, ReadOption option) {
     Optional<Collection<Long>> cached = mListingCache.getCachedChildIds(inode.getId());
     if (cached.isPresent()) {
       return !cached.get().isEmpty();
     }
-    return !mEdgeCache.getChildIds(inode.getId()).isEmpty() || mBackingStore.hasChildren(inode);
+    return !mEdgeCache.getChildIds(inode.getId(), option).isEmpty()
+        || mBackingStore.hasChildren(inode);
   }
 
   @VisibleForTesting
@@ -273,7 +274,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       if (mBackingStoreEmpty) {
         return Optional.empty();
       }
-      return mBackingStore.getMutable(id);
+      return mBackingStore.getMutable(id, ReadOption.defaults());
     }
 
     @Override
@@ -369,13 +370,14 @@ public final class CachingInodeStore implements InodeStore, Closeable {
      * 1. getChildIds will return all children that existed before getChildIds was invoked. If a
      * child is concurrently removed during the call to getChildIds, it is undefined whether it gets
      * found. 2. getChildIds will never return a child that was removed before getChildIds was
-     * invoked. If a child is concurently added during the call to getChildIds, it is undefined
+     * invoked. If a child is concurrently added during the call to getChildIds, it is undefined
      * whether it gets found.
      *
      * @param inodeId the inode to get the children for
+     * @param option the read options
      * @return the children
      */
-    public Map<String, Long> getChildIds(Long inodeId) {
+    public Map<String, Long> getChildIds(Long inodeId, ReadOption option) {
       if (mBackingStoreEmpty) {
         return mIdToChildMap.getOrDefault(inodeId, Collections.emptyMap());
       }
@@ -393,7 +395,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       // Cannot use mBackingStore.getChildren because it only returns inodes cached in the backing
       // store, causing us to lose inodes stored only in the cache.
       mBackingStore.getChildIds(inodeId).forEach(childId -> {
-        CachingInodeStore.this.get(childId).map(inode -> {
+        CachingInodeStore.this.get(childId, option).map(inode -> {
           if (!unflushedDeletes.contains(inode.getName())) {
             childIds.put(inode.getName(), inode.getId());
           }
@@ -659,10 +661,13 @@ public final class CachingInodeStore implements InodeStore, Closeable {
      * Gets all children of an inode, falling back on the edge cache if the listing isn't cached.
      *
      * @param inodeId the inode directory id
+     * @param option the read options
      * @return the ids of all children of the directory
      */
-    public Collection<Long> getChildIds(Long inodeId) {
-      evictIfNecessary();
+    public Collection<Long> getChildIds(Long inodeId, ReadOption option) {
+      if (!option.shouldSkipCachingAndEviction()) {
+        evictIfNecessary();
+      }
       AtomicBoolean createdNewEntry = new AtomicBoolean(false);
       ListingCacheEntry entry = mMap.compute(inodeId, (key, value) -> {
         if (value == null) {
@@ -680,9 +685,9 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       }
       if (entry == null || !createdNewEntry.get()) {
         // Skip caching if the cache is full or someone else is already caching.
-        return mEdgeCache.getChildIds(inodeId).values();
+        return mEdgeCache.getChildIds(inodeId, option).values();
       }
-      return loadChildren(inodeId, entry).values();
+      return loadChildren(inodeId, entry, option).values();
     }
 
     public void clear() {
@@ -691,10 +696,13 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       mEvictionHead = mMap.entrySet().iterator();
     }
 
-    private Map<String, Long> loadChildren(Long inodeId, ListingCacheEntry entry) {
-      evictIfNecessary();
+    private Map<String, Long> loadChildren(Long inodeId, ListingCacheEntry entry,
+        ReadOption option) {
+      if (!option.shouldSkipCachingAndEviction()) {
+        evictIfNecessary();
+      }
       entry.mModified = false;
-      Map<String, Long> listing = mEdgeCache.getChildIds(inodeId);
+      Map<String, Long> listing = mEdgeCache.getChildIds(inodeId, option);
       mMap.computeIfPresent(inodeId, (key, value) -> {
         // Perform the update inside computeIfPresent to prevent concurrent modification to the
         // cache entry.

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -27,6 +27,7 @@ import alluxio.master.file.meta.MutableInode;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.metastore.InodeStore;
+import alluxio.master.metastore.ReadOption;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
@@ -665,7 +666,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
      * @return the ids of all children of the directory
      */
     public Collection<Long> getChildIds(Long inodeId, ReadOption option) {
-      if (!option.shouldSkipCachingAndEviction()) {
+      if (!option.shouldSkipCache()) {
         evictIfNecessary();
       }
       AtomicBoolean createdNewEntry = new AtomicBoolean(false);
@@ -698,7 +699,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
 
     private Map<String, Long> loadChildren(Long inodeId, ListingCacheEntry entry,
         ReadOption option) {
-      if (!option.shouldSkipCachingAndEviction()) {
+      if (!option.shouldSkipCache()) {
         evictIfNecessary();
       }
       entry.mModified = false;

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -666,9 +666,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
      * @return the ids of all children of the directory
      */
     public Collection<Long> getChildIds(Long inodeId, ReadOption option) {
-      if (!option.shouldSkipCache()) {
-        evictIfNecessary();
-      }
+      evictIfNecessary();
       AtomicBoolean createdNewEntry = new AtomicBoolean(false);
       ListingCacheEntry entry = mMap.compute(inodeId, (key, value) -> {
         if (value == null) {
@@ -699,9 +697,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
 
     private Map<String, Long> loadChildren(Long inodeId, ListingCacheEntry entry,
         ReadOption option) {
-      if (!option.shouldSkipCache()) {
-        evictIfNecessary();
-      }
+      evictIfNecessary();
       entry.mModified = false;
       Map<String, Long> listing = mEdgeCache.getChildIds(inodeId, option);
       mMap.computeIfPresent(inodeId, (key, value) -> {

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -69,17 +69,17 @@ public class HeapInodeStore implements InodeStore {
   }
 
   @Override
-  public Optional<MutableInode<?>> getMutable(long id) {
+  public Optional<MutableInode<?>> getMutable(long id, ReadOption option) {
     return Optional.ofNullable(mInodes.get(id));
   }
 
   @Override
-  public Iterable<Long> getChildIds(Long inodeId) {
+  public Iterable<Long> getChildIds(Long inodeId, ReadOption option) {
     return children(inodeId).values();
   }
 
   @Override
-  public Iterable<? extends Inode> getChildren(Long inodeId) {
+  public Iterable<? extends Inode> getChildren(Long inodeId, ReadOption option) {
     return children(inodeId).values().stream()
         .map(this::get)
         .filter(Optional::isPresent)
@@ -89,19 +89,19 @@ public class HeapInodeStore implements InodeStore {
   }
 
   @Override
-  public Optional<Long> getChildId(Long inodeId, String child) {
+  public Optional<Long> getChildId(Long inodeId, String child, ReadOption option) {
     return Optional.ofNullable(children(inodeId).get(child));
   }
 
   @Override
-  public Optional<Inode> getChild(Long inodeId, String child) {
+  public Optional<Inode> getChild(Long inodeId, String child, ReadOption option) {
     return getChildId(inodeId, child)
         .flatMap(this::get)
         .map(Inode::wrap);
   }
 
   @Override
-  public boolean hasChildren(InodeDirectoryView dir) {
+  public boolean hasChildren(InodeDirectoryView dir, ReadOption option) {
     return !children(dir.getId()).isEmpty();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -23,6 +23,7 @@ import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.master.metastore.InodeStore;
+import alluxio.master.metastore.ReadOption;
 import alluxio.proto.meta.InodeMeta;
 
 import com.google.common.base.Preconditions;

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -145,7 +145,7 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public Optional<MutableInode<?>> getMutable(long id) {
+  public Optional<MutableInode<?>> getMutable(long id, ReadOption option) {
     byte[] inode;
     try {
       inode = db().get(mInodesColumn.get(), Longs.toByteArray(id));
@@ -163,7 +163,7 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public Iterable<Long> getChildIds(Long inodeId) {
+  public Iterable<Long> getChildIds(Long inodeId, ReadOption option) {
     List<Long> ids = new ArrayList<>();
     try (RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart)) {
       iter.seek(Longs.toByteArray(inodeId));
@@ -176,7 +176,7 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public Optional<Long> getChildId(Long inodeId, String name) {
+  public Optional<Long> getChildId(Long inodeId, String name, ReadOption option) {
     byte[] id;
     try {
       id = db().get(mEdgesColumn.get(), RocksUtils.toByteArray(inodeId, name));
@@ -190,7 +190,7 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public Optional<Inode> getChild(Long inodeId, String name) {
+  public Optional<Inode> getChild(Long inodeId, String name, ReadOption option) {
     return getChildId(inodeId, name).flatMap(id -> {
       Optional<Inode> child = get(id);
       if (!child.isPresent()) {
@@ -202,7 +202,7 @@ public class RocksInodeStore implements InodeStore {
   }
 
   @Override
-  public boolean hasChildren(InodeDirectoryView inode) {
+  public boolean hasChildren(InodeDirectoryView inode, ReadOption option) {
     try (RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart)) {
       iter.seek(Longs.toByteArray(inode.getId()));
       return iter.isValid();
@@ -231,7 +231,7 @@ public class RocksInodeStore implements InodeStore {
     try (RocksIterator iter = db().newIterator(mInodesColumn.get())) {
       iter.seekToFirst();
       while (iter.isValid()) {
-        inodes.add(getMutable(Longs.fromByteArray(iter.key())).get());
+        inodes.add(getMutable(Longs.fromByteArray(iter.key()), ReadOption.defaults()).get());
         iter.next();
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -18,6 +18,7 @@ import alluxio.master.file.meta.MutableInode;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.metastore.InodeStore;
+import alluxio.master.metastore.ReadOption;
 import alluxio.proto.meta.InodeMeta;
 import alluxio.util.io.PathUtils;
 

--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
@@ -33,6 +33,7 @@ import alluxio.master.file.meta.MutableInodeDirectory;
 import alluxio.master.file.meta.MutableInodeFile;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.metastore.InodeStore;
+import alluxio.master.metastore.ReadOnlyInodeStore.ReadOption;
 import alluxio.master.metastore.heap.HeapInodeStore;
 
 import com.google.common.collect.ImmutableMap;
@@ -199,7 +200,7 @@ public class CachingInodeStoreMockedBackingStoreTest {
     for (int id = 100; id < 100 + CACHE_SIZE * 2; id++) {
       assertTrue(mStore.getChild(TEST_INODE_DIR, "child" + id).isPresent());
     }
-    verify(mBackingStore, Mockito.atLeastOnce()).getMutable(anyLong());
+    verify(mBackingStore, Mockito.atLeastOnce()).getMutable(anyLong(), any(ReadOption.class));
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
@@ -33,7 +33,7 @@ import alluxio.master.file.meta.MutableInodeDirectory;
 import alluxio.master.file.meta.MutableInodeFile;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.metastore.InodeStore;
-import alluxio.master.metastore.ReadOnlyInodeStore.ReadOption;
+import alluxio.master.metastore.ReadOption;
 import alluxio.master.metastore.heap.HeapInodeStore;
 
 import com.google.common.collect.ImmutableMap;
@@ -320,6 +320,17 @@ public class CachingInodeStoreMockedBackingStoreTest {
         new CheckpointInputStream(new ByteArrayInputStream(baos.toByteArray())));
     assertEquals(child.getName(), mStore.get(child.getId()).get().getName());
     assertEquals(child.getId(), mStore.getChild(0L, child.getName()).get().getId());
+  }
+
+  @Test
+  public void skipCache() throws Exception {
+    assertEquals(1, mStore.mInodeCache.getCacheMap().size());
+    mStore.mInodeCache.flush();
+    mStore.mInodeCache.clear();
+    assertEquals(0, mStore.mInodeCache.getCacheMap().size());
+    assertEquals(Inode.wrap(TEST_INODE_DIR),
+        mStore.get(TEST_INODE_ID, ReadOption.newBuilder().setSkipCache(true).build()).get());
+    assertEquals(0, mStore.mInodeCache.getCacheMap().size());
   }
 
   private void verifyNoBackingStoreReads() {


### PR DESCRIPTION
Scanning all a large portion of the inode tree can thrash metastore when using the CachingInodeStore. Frequent eviction would negatively impact the performance of the cache.

This PR introduces an option to disable caching and eviction when getting inodes from CachingInodeStore.