### PR TITLE
[SMALLFIX] Use @Nullable annotation for methods which may return null

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -263,6 +263,7 @@ public final class BlockMetadataManager {
    * @param blockId the id of the temp block
    * @return metadata of the block or null
    */
+
   @Nullable
   public TempBlockMeta getTempBlockMetaOrNull(long blockId) {
     for (StorageTier tier : mTiers) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -263,7 +263,6 @@ public final class BlockMetadataManager {
    * @param blockId the id of the temp block
    * @return metadata of the block or null
    */
-
   @Nullable
   public TempBlockMeta getTempBlockMetaOrNull(long blockId) {
     for (StorageTier tier : mTiers) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -263,6 +263,7 @@ public final class BlockMetadataManager {
    * @param blockId the id of the temp block
    * @return metadata of the block or null
    */
+  @Nullable
   public TempBlockMeta getTempBlockMetaOrNull(long blockId) {
     for (StorageTier tier : mTiers) {
       for (StorageDir dir : tier.getStorageDirs()) {


### PR DESCRIPTION
[SMALLFIX] Use the @Nullable annotation for all methods which may return null in /alluxio/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java#getTempBlockMetaOrNull