### PR TITLE
Fix a bug where last edge is not locked in WRITE_INODE pattern

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -347,9 +347,9 @@ public class InodeTree implements DelegatingJournaled {
         new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern);
     try {
       inodePath.traverse();
-    } catch (Throwable t) {
+    } catch (InvalidPathException e) {
       inodePath.close();
-      throw t;
+      throw e;
     }
     return inodePath;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -159,6 +159,26 @@ public class InodeTree implements DelegatingJournaled {
     public boolean isWrite() {
       return this == WRITE_INODE || this == WRITE_EDGE;
     }
+
+    /**
+     * If the full path exists, the last edge is the edge leading to the last inode.
+     * Otherwise, it is the edge leaving the last existing inode.
+     *
+     * Examples
+     *
+     * path to lock: /a/b/c
+     * existing inodes: /a/b/c
+     * last edge: b->c
+     *
+     * path to lock: /a/b/c
+     * existing inodes: /a
+     * last edge: a->b
+     *
+     * @return whether the last edge should be locked
+     */
+    public boolean shouldLockLastEdge() {
+      return this == WRITE_INODE || this == WRITE_EDGE;
+    }
   }
 
   /** Only the root inode should have the empty string as its name. */

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -174,9 +174,9 @@ public class InodeTree implements DelegatingJournaled {
      * existing inodes: /a
      * last edge: a->b
      *
-     * @return whether the last edge should be locked
+     * @return whether the last edge should be write locked
      */
-    public boolean shouldLockLastEdge() {
+    public boolean writeLockLastEdge() {
       return this == WRITE_INODE || this == WRITE_EDGE;
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -450,7 +450,7 @@ public class LockedInodePath implements Closeable {
           }
         }
         if (!nextInodeOpt.isPresent()) {
-          if (!mLockPattern.shouldLockLastEdge()) {
+          if (!mLockPattern.writeLockLastEdge()) {
             // Other lock patterns only lock up to the last existing inode.
             mLockList.unlockLastEdge();
           }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -409,7 +409,7 @@ public class LockedInodePath implements Closeable {
    * traversed, this method will pick up where the previous traversal left off.
    *
    * On return, all existing inodes in the path are added to mExistingInodes and the inodes are
-   * locked according to to {@link LockPattern}.
+   * locked according to {@link LockPattern}.
    */
   public void traverse() throws InvalidPathException {
     // This locks the root edge and inode.
@@ -421,7 +421,7 @@ public class LockedInodePath implements Closeable {
       String nextComponent = mPathComponents[lastInodeIndex + 1];
       boolean isFinalComponent = lastInodeIndex == mPathComponents.length - 2;
 
-      Inode lastInode = mLockList.get(mLockList.numInodes() - 1);
+      Inode lastInode = mLockList.get(lastInodeIndex);
       if (mLockList.endsInInode()) { // Lock an edge next.
         if (mLockPattern == LockPattern.WRITE_EDGE && isFinalComponent) {
           mLockList.lockEdge(lastInode, nextComponent, LockMode.WRITE);
@@ -450,7 +450,7 @@ public class LockedInodePath implements Closeable {
           }
         }
         if (!nextInodeOpt.isPresent()) {
-          if (mLockPattern != LockPattern.WRITE_EDGE) {
+          if (!mLockPattern.isWrite()) {
             // Other lock patterns only lock up to the last existing inode.
             mLockList.unlockLastEdge();
           }
@@ -458,7 +458,7 @@ public class LockedInodePath implements Closeable {
         }
         Inode nextInode = nextInodeOpt.get();
 
-        if (isFinalComponent && mLockPattern != LockPattern.READ) {
+        if (isFinalComponent && mLockPattern.isWrite()) {
           mLockList.lockInode(nextInode, LockMode.WRITE);
         } else {
           mLockList.lockInode(nextInode, LockMode.READ);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -450,7 +450,7 @@ public class LockedInodePath implements Closeable {
           }
         }
         if (!nextInodeOpt.isPresent()) {
-          if (!mLockPattern.isWrite()) {
+          if (!mLockPattern.shouldLockLastEdge()) {
             // Other lock patterns only lock up to the last existing inode.
             mLockList.unlockLastEdge();
           }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/BaseInodeLockingTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/BaseInodeLockingTest.java
@@ -126,6 +126,15 @@ public class BaseInodeLockingTest {
   }
 
   /**
+   * Checks that the specified edge is read-locked.
+   */
+  protected void checkIncomingEdgeReadLocked(long parentId, String childName) {
+    Edge edge = new Edge(parentId, childName);
+    assertTrue("Unexpected read lock state for edge " + edge,
+        mInodeLockManager.edgeReadLockedByCurrentThread(edge));
+  }
+
+  /**
    * Checks that the specified edge is write-locked.
    */
   protected void checkIncomingEdgeWriteLocked(long parentId, String childName) {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
@@ -136,6 +136,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
     checkOnlyNodesReadLocked(mRootDir, mDirA, mDirB);
     checkOnlyNodesWriteLocked();
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA, mDirB);
+    checkIncomingEdgeReadLocked(mDirB.getId(), "missing");
     checkOnlyIncomingEdgesWriteLocked();
   }
 


### PR DESCRIPTION
Suppose WRITE_INODE on path /a/b/c, and only /a exists, then both inode a and edge a->b should be read locked, otherwise, a concurrent rename from /a/c -> a/b will succeed.

See the enhanced unit test in LockedInodePathTest.