### PR TITLE
Use Swagger to generate rest docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,12 +40,14 @@
 /docs/api/
 /docs/serve/
 /extensions/
+/generated/
 /journal/
 /lib/
 /logs/*.log*
 /logs/*.out*
 /logs/user/*
 /metastore
+/templates/
 /underFSStorage/
 /underfs/hdfs/src/main/java/alluxio/UfsConstants.java
 /web/

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@
 /logs/*.out*
 /logs/user/*
 /metastore
-/templates/
 /underFSStorage/
 /underfs/hdfs/src/main/java/alluxio/UfsConstants.java
 /web/

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
     </dependency>

--- a/core/common/src/main/java/alluxio/wire/AlluxioJobMasterInfo.java
+++ b/core/common/src/main/java/alluxio/wire/AlluxioJobMasterInfo.java
@@ -13,6 +13,7 @@ package alluxio.wire;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the configuration
    */
+  @ApiModelProperty(value = "Configuration of the Job master")
   public Map<String, String> getConfiguration() {
     return mConfiguration;
   }
@@ -42,6 +44,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the start time (in milliseconds)
    */
+  @ApiModelProperty(value = "Job Master's start time in epoch time")
   public long getStartTimeMs() {
     return mStartTimeMs;
   }
@@ -49,6 +52,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the uptime (in milliseconds)
    */
+  @ApiModelProperty(value = "Number of milliseconds the Job master has been running")
   public long getUptimeMs() {
     return mUptimeMs;
   }
@@ -56,6 +60,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the version
    */
+  @ApiModelProperty(value = "Version of the Job master")
   public String getVersion() {
     return mVersion;
   }
@@ -63,6 +68,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the list of workers
    */
+  @ApiModelProperty(value = "List of workers that have registered with the Job master")
   public List<WorkerInfo> getWorkers() {
     return mWorkers;
   }

--- a/core/common/src/main/java/alluxio/wire/AlluxioJobMasterInfo.java
+++ b/core/common/src/main/java/alluxio/wire/AlluxioJobMasterInfo.java
@@ -36,7 +36,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the configuration
    */
-  @ApiModelProperty(value = "Configuration of the Job master")
+  @ApiModelProperty(value = "Configuration of the Job Master")
   public Map<String, String> getConfiguration() {
     return mConfiguration;
   }
@@ -52,7 +52,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the uptime (in milliseconds)
    */
-  @ApiModelProperty(value = "Number of milliseconds the Job master has been running")
+  @ApiModelProperty(value = "Number of milliseconds the Job Master has been running")
   public long getUptimeMs() {
     return mUptimeMs;
   }
@@ -60,7 +60,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the version
    */
-  @ApiModelProperty(value = "Version of the Job master")
+  @ApiModelProperty(value = "Version of the Job Master")
   public String getVersion() {
     return mVersion;
   }
@@ -68,7 +68,7 @@ public final class AlluxioJobMasterInfo {
   /**
    * @return the list of workers
    */
-  @ApiModelProperty(value = "List of workers that have registered with the Job master")
+  @ApiModelProperty(value = "List of Job Workers that have registered with the Job Master")
   public List<WorkerInfo> getWorkers() {
     return mWorkers;
   }

--- a/core/common/src/main/java/alluxio/wire/AlluxioJobWorkerInfo.java
+++ b/core/common/src/main/java/alluxio/wire/AlluxioJobWorkerInfo.java
@@ -13,6 +13,7 @@ package alluxio.wire;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Map;
 
@@ -33,6 +34,7 @@ public final class AlluxioJobWorkerInfo {
   /**
    * @return the configuration
    */
+  @ApiModelProperty(value = "Configuration of the Job Worker")
   public Map<String, String> getConfiguration() {
     return mConfiguration;
   }
@@ -40,6 +42,7 @@ public final class AlluxioJobWorkerInfo {
   /**
    * @return the start time (in milliseconds)
    */
+  @ApiModelProperty(value = "Job Worker's start time in epoch time")
   public long getStartTimeMs() {
     return mStartTimeMs;
   }
@@ -47,6 +50,7 @@ public final class AlluxioJobWorkerInfo {
   /**
    * @return the uptime (in milliseconds)
    */
+  @ApiModelProperty(value = "Number of milliseconds the Job Worker has been running")
   public long getUptimeMs() {
     return mUptimeMs;
   }
@@ -54,6 +58,7 @@ public final class AlluxioJobWorkerInfo {
   /**
    * @return the version
    */
+  @ApiModelProperty(value = "Version of the Job Worker")
   public String getVersion() {
     return mVersion;
   }

--- a/core/common/src/main/java/alluxio/wire/TieredIdentity.java
+++ b/core/common/src/main/java/alluxio/wire/TieredIdentity.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.io.Serializable;
 import java.util.List;
@@ -48,6 +49,7 @@ public final class TieredIdentity implements Serializable {
   /**
    * @return the tiers of the tier identity
    */
+  @ApiModelProperty(value = "Tiers included in the tier identity")
   public List<LocalityTier> getTiers() {
     return mTiers;
   }
@@ -116,6 +118,7 @@ public final class TieredIdentity implements Serializable {
     /**
      * @return the name of the tier
      */
+    @ApiModelProperty(value = "Name of the tier", example = "host")
     public String getTierName() {
       return mTierName;
     }
@@ -124,6 +127,7 @@ public final class TieredIdentity implements Serializable {
      * @return the value
      */
     @Nullable
+    @ApiModelProperty(value = "Value of the tier name", example = "localhost")
     public String getValue() {
       return mValue;
     }

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.qmino</groupId>
-      <artifactId>miredot-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
@@ -53,6 +49,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -154,18 +154,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <!-- REST API documentation -->
-      <plugin>
-        <groupId>com.qmino</groupId>
-        <artifactId>miredot-plugin</artifactId>
-        <configuration>
-          <!-- This following license only works for groupId org.alluxio and artifactId alluxio-core-server-master -->
-          <license>
-            cHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyLW1hc3RlcnwyMDE5LTAzLTMxfHRydWV8LTEjTUN3Q0ZEU09ZK0VaQjFaWSs3bkNtSXNQaThObkpEYVJBaFJ6aGVqU1BhV2FoVDhqaUJJdC9TK2tFQjl4M1E9PQ==
-          </license>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -155,6 +155,34 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- REST API documentation -->
+      <plugin>
+        <inherited>false</inherited>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>false</springmvc>
+              <schemes>http</schemes>
+              <host>[Alluxio Master Hostname]</host>
+              <basePath>/api/v1</basePath>
+              <info>
+                <version>v1</version>
+                <title>Alluxio Master REST API Documentation</title>
+                <description>
+                  The Alluxio Master is the central metadata service of the Alluxio System.
+                </description>
+              </info>
+              <locations>alluxio.master.meta</locations>
+              <templatePath>${project.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
+              <outputPath>${project.parent.parent.parent.basedir}/generated/master/index.html</outputPath>
+              <swaggerDirectory>${project.parent.parent.parent.basedir}/generated/master/swagger-ui</swaggerDirectory>
+            </apiSource>
+          </apiSources>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientRestServiceHandler.java
@@ -18,7 +18,6 @@ import alluxio.master.AlluxioMasterProcess;
 import alluxio.web.MasterWebServer;
 
 import com.google.common.base.Preconditions;
-import com.qmino.miredot.annotations.ReturnType;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
@@ -65,7 +64,7 @@ public final class BlockMasterClientRestServiceHandler {
    */
   @GET
   @Path(SERVICE_NAME)
-  @ReturnType("java.lang.String")
+  //@ReturnType("java.lang.String")
   public Response getServiceName() {
     return RestUtils.call(() -> Constants.BLOCK_MASTER_CLIENT_SERVICE_NAME,
         ServerConfiguration.global());
@@ -77,7 +76,7 @@ public final class BlockMasterClientRestServiceHandler {
    */
   @GET
   @Path(SERVICE_VERSION)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   public Response getServiceVersion() {
     return RestUtils.call(() -> Constants.BLOCK_MASTER_CLIENT_SERVICE_VERSION,
         ServerConfiguration.global());
@@ -90,7 +89,7 @@ public final class BlockMasterClientRestServiceHandler {
    */
   @GET
   @Path(GET_BLOCK_INFO)
-  @ReturnType("alluxio.wire.BlockInfo")
+  //@ReturnType("alluxio.wire.BlockInfo")
   public Response getBlockInfo(@QueryParam("blockId") final Long blockId) {
     return RestUtils.call(() -> {
       Preconditions.checkNotNull(blockId, "required 'blockId' parameter is missing");

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -85,6 +85,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
@@ -200,7 +201,8 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  //@ReturnType("alluxio.wire.AlluxioMasterInfo")
+  @ApiOperation(value = "Get general Alluxio Master service information",
+      response = alluxio.wire.AlluxioMasterInfo.class)
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {
@@ -227,7 +229,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_INIT)
-  //@ReturnType("alluxio.wire.MasterWebUIInit")
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       MasterWebUIInit response = new MasterWebUIInit();
@@ -259,7 +260,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_OVERVIEW)
-  //@ReturnType("alluxio.wire.MasterWebUIOverview")
   public Response getWebUIOverview() {
     return RestUtils.call(() -> {
       MasterWebUIOverview response = new MasterWebUIOverview();
@@ -348,7 +348,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_BROWSE)
-  //@ReturnType("alluxio.wire.MasterWebUIBrowse")
   public Response getWebUIBrowse(@DefaultValue("/") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("") @QueryParam("end") String requestEnd,
@@ -563,7 +562,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_DATA)
-  //@ReturnType("alluxio.wire.MasterWebUIData")
   public Response getWebUIData(@DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
@@ -639,7 +637,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_LOGS)
-  //@ReturnType("alluxio.wire.MasterWebUILogs")
   public Response getWebUILogs(@DefaultValue("") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("") @QueryParam("end") String requestEnd,
@@ -774,7 +771,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_CONFIG)
-  //@ReturnType("alluxio.wire.MasterWebUIConfiguration")
   public Response getWebUIConfiguration() {
     return RestUtils.call(() -> {
       MasterWebUIConfiguration response = new MasterWebUIConfiguration();
@@ -807,7 +803,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_WORKERS)
-  //@ReturnType("alluxio.wire.MasterWebUIWorkers")
   public Response getWebUIWorkers() {
     return RestUtils.call(() -> {
       MasterWebUIWorkers response = new MasterWebUIWorkers();
@@ -850,7 +845,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_METRICS)
-  //@ReturnType("alluxio.wire.MasterWebUIMetrics")
   public Response getWebUIMetrics() {
     return RestUtils.call(() -> {
       MasterWebUIMetrics response = new MasterWebUIMetrics();
@@ -1027,7 +1021,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CONFIGURATION)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
     return RestUtils.call(() -> getConfigurationInternal(true), ServerConfiguration.global());
@@ -1041,7 +1034,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_METRICS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getMetrics() {
     return RestUtils.call(this::getMetricsInternal, ServerConfiguration.global());
@@ -1055,7 +1047,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_RPC_ADDRESS)
-  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getRpcAddress() {
     return RestUtils
@@ -1070,7 +1061,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_START_TIME_MS)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getStartTimeMs() {
     return RestUtils.call(() -> mMasterProcess.getStartTimeMs(), ServerConfiguration.global());
@@ -1084,7 +1074,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UPTIME_MS)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUptimeMs() {
     return RestUtils.call(() -> mMasterProcess.getUptimeMs(), ServerConfiguration.global());
@@ -1098,7 +1087,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_VERSION)
-  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getVersion() {
     return RestUtils.call(() -> RuntimeConstants.VERSION, ServerConfiguration.global());
@@ -1112,7 +1100,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getCapacityBytes() {
     return RestUtils.call(() -> mBlockMaster.getCapacityBytes(), ServerConfiguration.global());
@@ -1126,7 +1113,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUsedBytes() {
     return RestUtils.call(() -> mBlockMaster.getUsedBytes(), ServerConfiguration.global());
@@ -1140,7 +1126,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_FREE_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getFreeBytes() {
     return RestUtils.call(() -> mBlockMaster.getCapacityBytes() - mBlockMaster.getUsedBytes(),
@@ -1156,7 +1141,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_CAPACITY_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsCapacityBytes() {
     return RestUtils.call(() -> getUfsCapacityInternal().getTotal(), ServerConfiguration.global());
@@ -1170,7 +1154,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_USED_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsUsedBytes() {
     return RestUtils.call(() -> getUfsCapacityInternal().getUsed(), ServerConfiguration.global());
@@ -1184,7 +1167,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_FREE_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsFreeBytes() {
     return RestUtils.call(() -> {
@@ -1219,7 +1201,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES_ON_TIERS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getCapacityBytesOnTiers() {
     return RestUtils.call((RestUtils.RestCallable<Map<String, Long>>) () -> {
@@ -1240,7 +1221,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES_ON_TIERS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getUsedBytesOnTiers() {
     return RestUtils.call((RestUtils.RestCallable<Map<String, Long>>) () -> {
@@ -1260,7 +1240,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_WORKER_COUNT)
-  //@ReturnType("java.lang.Integer")
   @Deprecated
   public Response getWorkerCount() {
     return RestUtils.call(() -> mBlockMaster.getWorkerCount(), ServerConfiguration.global());
@@ -1274,7 +1253,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_WORKER_INFO_LIST)
-  //@ReturnType("java.util.List<alluxio.wire.WorkerInfo>")
   @Deprecated
   public Response getWorkerInfoList() {
     return RestUtils.call(() -> mBlockMaster.getWorkerInfoList(), ServerConfiguration.global());
@@ -1345,7 +1323,6 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @POST
   @Path(LOG_LEVEL)
-  //@ReturnType("alluxio.wire.LogInfo")
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), ServerConfiguration.global());

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -84,7 +84,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import com.qmino.miredot.annotations.ReturnType;
+import io.swagger.annotations.Api;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
@@ -122,6 +122,7 @@ import javax.ws.rs.core.Response;
  * This class is a REST handler for requesting general master information.
  */
 @NotThreadSafe
+@Api(value = "/master", description = "Alluxio Master Rest Service")
 @Path(AlluxioMasterRestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_JSON)
 public final class AlluxioMasterRestServiceHandler {
@@ -199,7 +200,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  @ReturnType("alluxio.wire.AlluxioMasterInfo")
+  //@ReturnType("alluxio.wire.AlluxioMasterInfo")
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {
@@ -226,7 +227,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_INIT)
-  @ReturnType("alluxio.wire.MasterWebUIInit")
+  //@ReturnType("alluxio.wire.MasterWebUIInit")
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       MasterWebUIInit response = new MasterWebUIInit();
@@ -258,7 +259,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_OVERVIEW)
-  @ReturnType("alluxio.wire.MasterWebUIOverview")
+  //@ReturnType("alluxio.wire.MasterWebUIOverview")
   public Response getWebUIOverview() {
     return RestUtils.call(() -> {
       MasterWebUIOverview response = new MasterWebUIOverview();
@@ -347,7 +348,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_BROWSE)
-  @ReturnType("alluxio.wire.MasterWebUIBrowse")
+  //@ReturnType("alluxio.wire.MasterWebUIBrowse")
   public Response getWebUIBrowse(@DefaultValue("/") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("") @QueryParam("end") String requestEnd,
@@ -562,7 +563,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_DATA)
-  @ReturnType("alluxio.wire.MasterWebUIData")
+  //@ReturnType("alluxio.wire.MasterWebUIData")
   public Response getWebUIData(@DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
@@ -638,7 +639,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_LOGS)
-  @ReturnType("alluxio.wire.MasterWebUILogs")
+  //@ReturnType("alluxio.wire.MasterWebUILogs")
   public Response getWebUILogs(@DefaultValue("") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("") @QueryParam("end") String requestEnd,
@@ -773,7 +774,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_CONFIG)
-  @ReturnType("alluxio.wire.MasterWebUIConfiguration")
+  //@ReturnType("alluxio.wire.MasterWebUIConfiguration")
   public Response getWebUIConfiguration() {
     return RestUtils.call(() -> {
       MasterWebUIConfiguration response = new MasterWebUIConfiguration();
@@ -806,7 +807,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_WORKERS)
-  @ReturnType("alluxio.wire.MasterWebUIWorkers")
+  //@ReturnType("alluxio.wire.MasterWebUIWorkers")
   public Response getWebUIWorkers() {
     return RestUtils.call(() -> {
       MasterWebUIWorkers response = new MasterWebUIWorkers();
@@ -849,7 +850,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(WEBUI_METRICS)
-  @ReturnType("alluxio.wire.MasterWebUIMetrics")
+  //@ReturnType("alluxio.wire.MasterWebUIMetrics")
   public Response getWebUIMetrics() {
     return RestUtils.call(() -> {
       MasterWebUIMetrics response = new MasterWebUIMetrics();
@@ -1026,7 +1027,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CONFIGURATION)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
     return RestUtils.call(() -> getConfigurationInternal(true), ServerConfiguration.global());
@@ -1040,7 +1041,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_METRICS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getMetrics() {
     return RestUtils.call(this::getMetricsInternal, ServerConfiguration.global());
@@ -1054,7 +1055,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_RPC_ADDRESS)
-  @ReturnType("java.lang.String")
+  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getRpcAddress() {
     return RestUtils
@@ -1069,7 +1070,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_START_TIME_MS)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getStartTimeMs() {
     return RestUtils.call(() -> mMasterProcess.getStartTimeMs(), ServerConfiguration.global());
@@ -1083,7 +1084,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UPTIME_MS)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUptimeMs() {
     return RestUtils.call(() -> mMasterProcess.getUptimeMs(), ServerConfiguration.global());
@@ -1097,7 +1098,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_VERSION)
-  @ReturnType("java.lang.String")
+  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getVersion() {
     return RestUtils.call(() -> RuntimeConstants.VERSION, ServerConfiguration.global());
@@ -1111,7 +1112,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getCapacityBytes() {
     return RestUtils.call(() -> mBlockMaster.getCapacityBytes(), ServerConfiguration.global());
@@ -1125,7 +1126,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUsedBytes() {
     return RestUtils.call(() -> mBlockMaster.getUsedBytes(), ServerConfiguration.global());
@@ -1139,7 +1140,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_FREE_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getFreeBytes() {
     return RestUtils.call(() -> mBlockMaster.getCapacityBytes() - mBlockMaster.getUsedBytes(),
@@ -1155,7 +1156,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_CAPACITY_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsCapacityBytes() {
     return RestUtils.call(() -> getUfsCapacityInternal().getTotal(), ServerConfiguration.global());
@@ -1169,7 +1170,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_USED_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsUsedBytes() {
     return RestUtils.call(() -> getUfsCapacityInternal().getUsed(), ServerConfiguration.global());
@@ -1183,7 +1184,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_UFS_FREE_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUfsFreeBytes() {
     return RestUtils.call(() -> {
@@ -1218,7 +1219,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES_ON_TIERS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getCapacityBytesOnTiers() {
     return RestUtils.call((RestUtils.RestCallable<Map<String, Long>>) () -> {
@@ -1239,7 +1240,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES_ON_TIERS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getUsedBytesOnTiers() {
     return RestUtils.call((RestUtils.RestCallable<Map<String, Long>>) () -> {
@@ -1259,7 +1260,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_WORKER_COUNT)
-  @ReturnType("java.lang.Integer")
+  //@ReturnType("java.lang.Integer")
   @Deprecated
   public Response getWorkerCount() {
     return RestUtils.call(() -> mBlockMaster.getWorkerCount(), ServerConfiguration.global());
@@ -1273,7 +1274,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @GET
   @Path(GET_WORKER_INFO_LIST)
-  @ReturnType("java.util.List<alluxio.wire.WorkerInfo>")
+  //@ReturnType("java.util.List<alluxio.wire.WorkerInfo>")
   @Deprecated
   public Response getWorkerInfoList() {
     return RestUtils.call(() -> mBlockMaster.getWorkerInfoList(), ServerConfiguration.global());
@@ -1344,7 +1345,7 @@ public final class AlluxioMasterRestServiceHandler {
    */
   @POST
   @Path(LOG_LEVEL)
-  @ReturnType("alluxio.wire.LogInfo")
+  //@ReturnType("alluxio.wire.LogInfo")
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), ServerConfiguration.global());

--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -101,4 +101,36 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- REST API documentation -->
+      <plugin>
+        <inherited>false</inherited>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>false</springmvc>
+              <schemes>http</schemes>
+              <host>[Alluxio Proxy Hostname]</host>
+              <basePath>/api/v1</basePath>
+              <info>
+                <version>v1</version>
+                <title>Alluxio Proxy REST API Documentation</title>
+                <description>
+                  The Alluxio Proxy acts as a REST gateway for clients to communicate with the Alluxio system.
+                </description>
+              </info>
+              <locations>alluxio.proxy</locations>
+              <templatePath>${project.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
+              <outputPath>${project.parent.parent.parent.basedir}/generated/proxy/index.html</outputPath>
+              <swaggerDirectory>${project.parent.parent.parent.basedir}/generated/proxy/swagger-ui</swaggerDirectory>
+            </apiSource>
+          </apiSources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.qmino</groupId>
-      <artifactId>miredot-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -105,20 +101,4 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- REST API documentation -->
-      <plugin>
-        <groupId>com.qmino</groupId>
-        <artifactId>miredot-plugin</artifactId>
-        <configuration>
-          <!-- This following license only works for groupId org.alluxio and artifactId alluxio-core-server-proxy -->
-          <license>
-            cHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyLXByb3h5fDIwMTktMDMtMzF8dHJ1ZXwtMSNNQ3dDRkZHejBpT0t5UVdrbVJWUlNRWUNDQzVqemtIbUFoUUcrdktzSmg0WExsWGhWcTlzMDZ3MENkRHpBZz09
-          </license>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
@@ -17,6 +17,8 @@ import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.web.ProxyWebServer;
 import alluxio.wire.AlluxioProxyInfo;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -35,6 +37,7 @@ import javax.ws.rs.core.Response;
  * This class is a REST handler for requesting general proxy information.
  */
 @NotThreadSafe
+@Api(value = "/proxy", description = "Alluxio Proxy Rest Service")
 @Path(AlluxioProxyRestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_JSON)
 public final class AlluxioProxyRestServiceHandler {
@@ -68,7 +71,8 @@ public final class AlluxioProxyRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  //@ReturnType("alluxio.wire.AlluxioProxyInfo")
+  @ApiOperation(value = "Get general Alluxio Proxy service information",
+      response = alluxio.wire.AlluxioProxyInfo.class)
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
@@ -18,8 +18,6 @@ import alluxio.RuntimeConstants;
 import alluxio.web.ProxyWebServer;
 import alluxio.wire.AlluxioProxyInfo;
 
-import com.qmino.miredot.annotations.ReturnType;
-
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -70,7 +68,7 @@ public final class AlluxioProxyRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  @ReturnType("alluxio.wire.AlluxioProxyInfo")
+  //@ReturnType("alluxio.wire.AlluxioProxyInfo")
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
@@ -17,6 +17,7 @@ import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.web.ProxyWebServer;
 import alluxio.wire.AlluxioProxyInfo;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/PathsRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/PathsRestServiceHandler.java
@@ -34,7 +34,6 @@ import alluxio.grpc.UnmountPOptions;
 import alluxio.web.ProxyWebServer;
 
 import com.google.common.base.Preconditions;
-import com.qmino.miredot.annotations.ReturnType;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -103,7 +102,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + CREATE_DIRECTORY)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response createDirectory(@PathParam("path") final String path,
       final CreateDirectoryPOptions options) {
@@ -125,7 +124,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + CREATE_FILE)
-  @ReturnType("java.lang.Integer")
+  //@ReturnType("java.lang.Integer")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response createFile(@PathParam("path") final String path,
       final CreateFilePOptions options) {
@@ -151,7 +150,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + DELETE)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response delete(@PathParam("path") final String path, final DeletePOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
       @Override
@@ -173,7 +172,7 @@ public final class PathsRestServiceHandler {
    */
   @GET
   @Path(PATH_PARAM + DOWNLOAD_FILE)
-  @ReturnType("java.io.InputStream")
+  //@ReturnType("java.io.InputStream")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   public Response downloadFile(@PathParam("path") final String path) {
     AlluxioURI uri = new AlluxioURI(path);
@@ -199,7 +198,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + EXISTS)
-  @ReturnType("java.lang.Boolean")
+  //@ReturnType("java.lang.Boolean")
   public Response exists(@PathParam("path") final String path, final ExistsPOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Boolean>() {
       @Override
@@ -221,7 +220,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + FREE)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response free(@PathParam("path") final String path, final FreePOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
       @Override
@@ -244,7 +243,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + GET_STATUS)
-  @ReturnType("alluxio.client.file.URIStatus")
+  //@ReturnType("alluxio.client.file.URIStatus")
   public Response getStatus(@PathParam("path") final String path, final GetStatusPOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<URIStatus>() {
       @Override
@@ -266,7 +265,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + LIST_STATUS)
-  @ReturnType("java.util.List<alluxio.client.file.URIStatus>")
+  //@ReturnType("java.util.List<alluxio.client.file.URIStatus>")
   public Response listStatus(@PathParam("path") final String path,
       final ListStatusPOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<List<URIStatus>>() {
@@ -291,7 +290,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + MOUNT)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response mount(@PathParam("path") final String path, @QueryParam("src") final String src,
       final MountPOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
@@ -316,7 +315,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + OPEN_FILE)
-  @ReturnType("java.lang.Integer")
+  //@ReturnType("java.lang.Integer")
   @Produces(MediaType.APPLICATION_JSON)
   public Response openFile(@PathParam("path") final String path, final OpenFilePOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Integer>() {
@@ -342,7 +341,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + RENAME)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response rename(@PathParam("path") final String path, @QueryParam("dst") final String dst,
       final RenamePOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
@@ -367,7 +366,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + SET_ATTRIBUTE)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response setAttribute(@PathParam("path") final String path,
       final SetAttributePOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
@@ -391,7 +390,7 @@ public final class PathsRestServiceHandler {
    */
   @POST
   @Path(PATH_PARAM + UNMOUNT)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response unmount(@PathParam("path") final String path, final UnmountPOptions options) {
     return RestUtils.call(new RestUtils.RestCallable<Void>() {
       @Override

--- a/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
@@ -19,7 +19,6 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.web.ProxyWebServer;
 
 import com.google.common.io.ByteStreams;
-import com.qmino.miredot.annotations.ReturnType;
 
 import java.io.InputStream;
 
@@ -69,7 +68,7 @@ public final class StreamsRestServiceHandler {
    */
   @POST
   @Path(ID_PARAM + CLOSE)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response close(@PathParam("id") final Integer id) {
     return RestUtils.call((RestUtils.RestCallable<Void>) () -> {
       // When a stream is invalidated from the cache, the removal listener of the cache will
@@ -88,7 +87,7 @@ public final class StreamsRestServiceHandler {
    */
   @POST
   @Path(ID_PARAM + READ)
-  @ReturnType("java.io.InputStream")
+  //@ReturnType("java.io.InputStream")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   public Response read(@PathParam("id") final Integer id) {
     // TODO(jiri): Support reading a file range.
@@ -112,7 +111,7 @@ public final class StreamsRestServiceHandler {
    */
   @POST
   @Path(ID_PARAM + WRITE)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
   public Response write(@PathParam("id") final Integer id, final InputStream is) {
     return RestUtils.call(() -> {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -34,7 +34,6 @@ import alluxio.web.ProxyWebServer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
-import com.qmino.miredot.annotations.ReturnType;
 import org.apache.commons.codec.binary.Hex;
 
 import java.io.IOException;
@@ -107,7 +106,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(BUCKET_PARAM)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response createBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -135,7 +134,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(BUCKET_PARAM)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response deleteBucket(@PathParam("bucket") final String bucket) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
       @Override
@@ -169,7 +168,7 @@ public final class S3RestServiceHandler {
    */
   @GET
   @Path(BUCKET_PARAM)
-  @ReturnType("alluxio.proxy.s3.ListBucketResult")
+  //@ReturnType("alluxio.proxy.s3.ListBucketResult")
   // TODO(chaomin): consider supporting more request params like prefix and delimiter.
   public Response getBucket(@PathParam("bucket") final String bucket,
       @QueryParam("continuation-token") final String continuationToken,
@@ -212,7 +211,7 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(OBJECT_PARAM)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   @Consumes(MediaType.WILDCARD)
   public Response createObjectOrUploadPart(@HeaderParam("Content-MD5") final String contentMD5,
       @PathParam("bucket") final String bucket,
@@ -379,7 +378,7 @@ public final class S3RestServiceHandler {
    */
   @HEAD
   @Path(OBJECT_PARAM)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response getObjectMetadata(@PathParam("bucket") final String bucket,
       @PathParam("object") final String object) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
@@ -497,7 +496,7 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  @ReturnType("java.lang.Void")
+  //@ReturnType("java.lang.Void")
   public Response deleteObjectOrAbortMultipartUpload(@PathParam("bucket") final String bucket,
       @PathParam("object") final String object, @QueryParam("uploadId") final Long uploadId) {
     return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.qmino</groupId>
-      <artifactId>miredot-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
@@ -132,20 +128,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- REST API documentation -->
-      <plugin>
-        <groupId>com.qmino</groupId>
-        <artifactId>miredot-plugin</artifactId>
-        <configuration>
-          <!-- This following license only works for groupId org.alluxio and artifactId alluxio-core-server-worker -->
-          <license>
-            cHJvamVjdHxvcmcuYWxsdXhpby5hbGx1eGlvLWNvcmUtc2VydmVyLXdvcmtlcnwyMDE5LTAzLTMxfHRydWV8LTEjTUN3Q0ZHdEUzWjV6TlhPdkY2SXM3c3BWK3hGekhCZ0dBaFF6am5MdWJhSVNLRFBmSXhEV0FiN1V0VFd2U1E9PQ==
-          </license>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -128,4 +128,36 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- REST API documentation -->
+      <plugin>
+        <inherited>false</inherited>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>false</springmvc>
+              <schemes>http</schemes>
+              <host>[Alluxio Worker Hostname]</host>
+              <basePath>/api/v1</basePath>
+              <info>
+                <version>v1</version>
+                <title>Alluxio Worker REST API Documentation</title>
+                <description>
+                  The Alluxio Workers are processes which provide clients access to the data exposed by the Alluxio System.
+                </description>
+              </info>
+              <locations>alluxio.worker.AlluxioWorkerRestServiceHandler</locations>
+              <templatePath>${project.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
+              <outputPath>${project.parent.parent.parent.basedir}/generated/worker/index.html</outputPath>
+              <swaggerDirectory>${project.parent.parent.parent.basedir}/generated/worker/swagger-ui</swaggerDirectory>
+            </apiSource>
+          </apiSources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -56,7 +56,6 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.qmino.miredot.annotations.ReturnType;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,7 +155,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  @ReturnType("alluxio.wire.AlluxioWorkerInfo")
+  ////@ReturnType("alluxio.wire.AlluxioWorkerInfo")
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {
@@ -181,7 +180,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_INIT)
-  @ReturnType("alluxio.wire.WorkerWebUIInit")
+  ////@ReturnType("alluxio.wire.WorkerWebUIInit")
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       WorkerWebUIInit response = new WorkerWebUIInit();
@@ -207,7 +206,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_OVERVIEW)
-  @ReturnType("alluxio.wire.WorkerWebUIOverview")
+  //@ReturnType("alluxio.wire.WorkerWebUIOverview")
   public Response getWebUIOverview() {
     return RestUtils.call(() -> {
       WorkerWebUIOverview response = new WorkerWebUIOverview();
@@ -261,7 +260,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_BLOCKINFO)
-  @ReturnType("alluxio.wire.WorkerWebUIBlockInfo")
+  //@ReturnType("alluxio.wire.WorkerWebUIBlockInfo")
   public Response getWebUIBlockInfo(@QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
@@ -371,7 +370,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_METRICS)
-  @ReturnType("alluxio.wire.WorkerWebUIMetrics")
+  //@ReturnType("alluxio.wire.WorkerWebUIMetrics")
   public Response getWebUIMetrics() {
     return RestUtils.call(() -> {
       WorkerWebUIMetrics response = new WorkerWebUIMetrics();
@@ -437,7 +436,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_LOGS)
-  @ReturnType("alluxio.wire.WorkerWebUILogs")
+  //@ReturnType("alluxio.wire.WorkerWebUILogs")
   public Response getWebUILogs(@DefaultValue("") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @QueryParam("end") String requestEnd,
@@ -573,7 +572,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CONFIGURATION)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
     return RestUtils.call(() -> getConfigurationInternal(true), ServerConfiguration.global());
@@ -587,7 +586,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_RPC_ADDRESS)
-  @ReturnType("java.lang.String")
+  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getRpcAddress() {
     return RestUtils
@@ -602,7 +601,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getCapacityBytes() {
     return RestUtils.call(() -> mStoreMeta.getCapacityBytes(), ServerConfiguration.global());
@@ -616,7 +615,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUsedBytes() {
     return RestUtils.call(mStoreMeta::getUsedBytes, ServerConfiguration.global());
@@ -631,7 +630,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES_ON_TIERS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getCapacityBytesOnTiers() {
     return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
@@ -655,7 +654,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES_ON_TIERS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getUsedBytesOnTiers() {
     return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
@@ -678,7 +677,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_DIRECTORY_PATHS_ON_TIERS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.util.List<java.lang.String>>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.util.List<java.lang.String>>")
   @Deprecated
   public Response getDirectoryPathsOnTiers() {
     return RestUtils.call(() -> getTierPathsInternal(), ServerConfiguration.global());
@@ -692,7 +691,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_VERSION)
-  @ReturnType("java.lang.String")
+  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getVersion() {
     return RestUtils.call(() -> RuntimeConstants.VERSION, ServerConfiguration.global());
@@ -706,7 +705,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_START_TIME_MS)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getStartTimeMs() {
     return RestUtils.call(() -> mWorkerProcess.getStartTimeMs(), ServerConfiguration.global());
@@ -720,7 +719,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_UPTIME_MS)
-  @ReturnType("java.lang.Long")
+  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUptimeMs() {
     return RestUtils.call(() -> mWorkerProcess.getUptimeMs(), ServerConfiguration.global());
@@ -734,7 +733,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_METRICS)
-  @ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
+  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getMetrics() {
     return RestUtils.call(() -> getMetricsInternal(), ServerConfiguration.global());
@@ -811,7 +810,7 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @POST
   @Path(LOG_LEVEL)
-  @ReturnType("alluxio.wire.LogInfo")
+  //@ReturnType("alluxio.wire.LogInfo")
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(new RestUtils.RestCallable<LogInfo>() {

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -56,6 +56,8 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,6 +93,7 @@ import javax.ws.rs.core.Response;
  * This class is a REST handler for requesting general worker information.
  */
 @NotThreadSafe
+@Api(value = "/worker", description = "Alluxio Worker Rest Service")
 @Path(AlluxioWorkerRestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_JSON)
 public final class AlluxioWorkerRestServiceHandler {
@@ -155,7 +158,8 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  ////@ReturnType("alluxio.wire.AlluxioWorkerInfo")
+  @ApiOperation(value = "Get general Alluxio Worker service information",
+      response = alluxio.wire.AlluxioWorkerInfo.class)
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {
@@ -180,7 +184,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_INIT)
-  ////@ReturnType("alluxio.wire.WorkerWebUIInit")
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       WorkerWebUIInit response = new WorkerWebUIInit();
@@ -206,7 +209,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_OVERVIEW)
-  //@ReturnType("alluxio.wire.WorkerWebUIOverview")
   public Response getWebUIOverview() {
     return RestUtils.call(() -> {
       WorkerWebUIOverview response = new WorkerWebUIOverview();
@@ -260,7 +262,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_BLOCKINFO)
-  //@ReturnType("alluxio.wire.WorkerWebUIBlockInfo")
   public Response getWebUIBlockInfo(@QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
@@ -370,7 +371,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_METRICS)
-  //@ReturnType("alluxio.wire.WorkerWebUIMetrics")
   public Response getWebUIMetrics() {
     return RestUtils.call(() -> {
       WorkerWebUIMetrics response = new WorkerWebUIMetrics();
@@ -436,7 +436,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(WEBUI_LOGS)
-  //@ReturnType("alluxio.wire.WorkerWebUILogs")
   public Response getWebUILogs(@DefaultValue("") @QueryParam("path") String requestPath,
       @DefaultValue("0") @QueryParam("offset") String requestOffset,
       @QueryParam("end") String requestEnd,
@@ -572,7 +571,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CONFIGURATION)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.String>")
   @Deprecated
   public Response getConfiguration() {
     return RestUtils.call(() -> getConfigurationInternal(true), ServerConfiguration.global());
@@ -586,7 +584,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_RPC_ADDRESS)
-  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getRpcAddress() {
     return RestUtils
@@ -601,7 +598,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getCapacityBytes() {
     return RestUtils.call(() -> mStoreMeta.getCapacityBytes(), ServerConfiguration.global());
@@ -615,7 +611,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUsedBytes() {
     return RestUtils.call(mStoreMeta::getUsedBytes, ServerConfiguration.global());
@@ -630,7 +625,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_CAPACITY_BYTES_ON_TIERS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getCapacityBytesOnTiers() {
     return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
@@ -654,7 +648,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_USED_BYTES_ON_TIERS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getUsedBytesOnTiers() {
     return RestUtils.call(new RestUtils.RestCallable<Map<String, Long>>() {
@@ -677,7 +670,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_DIRECTORY_PATHS_ON_TIERS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.util.List<java.lang.String>>")
   @Deprecated
   public Response getDirectoryPathsOnTiers() {
     return RestUtils.call(() -> getTierPathsInternal(), ServerConfiguration.global());
@@ -691,7 +683,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_VERSION)
-  //@ReturnType("java.lang.String")
   @Deprecated
   public Response getVersion() {
     return RestUtils.call(() -> RuntimeConstants.VERSION, ServerConfiguration.global());
@@ -705,7 +696,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_START_TIME_MS)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getStartTimeMs() {
     return RestUtils.call(() -> mWorkerProcess.getStartTimeMs(), ServerConfiguration.global());
@@ -719,7 +709,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_UPTIME_MS)
-  //@ReturnType("java.lang.Long")
   @Deprecated
   public Response getUptimeMs() {
     return RestUtils.call(() -> mWorkerProcess.getUptimeMs(), ServerConfiguration.global());
@@ -733,7 +722,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_METRICS)
-  //@ReturnType("java.util.SortedMap<java.lang.String, java.lang.Long>")
   @Deprecated
   public Response getMetrics() {
     return RestUtils.call(() -> getMetricsInternal(), ServerConfiguration.global());
@@ -810,7 +798,6 @@ public final class AlluxioWorkerRestServiceHandler {
    */
   @POST
   @Path(LOG_LEVEL)
-  //@ReturnType("alluxio.wire.LogInfo")
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(new RestUtils.RestCallable<LogInfo>() {

--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -133,14 +133,17 @@
           <apiSource>
             <springmvc>false</springmvc>
             <schemes>http</schemes>
-            <host>[Alluxio Job Master Hostname]</host>
+            <host>[Alluxio Job Master or Job Worker Hostname]</host>
             <basePath>/api/v1</basePath>
             <info>
               <version>v1</version>
-              <title>Alluxio Job Master REST API Documentation</title>
-              <description>The Alluxio Job Master is a component of the Job Service that coordinates Alluxio Job Workers to execute distributed tasks scheduled by the Alluxio system.</description>
+              <title>Alluxio Job Service REST API Documentation</title>
+              <description>
+                The Alluxio Job Master is a component of the Job Service that coordinates Alluxio Job Workers to execute distributed tasks scheduled by the Alluxio system.
+                The Alluxio Job Worker is a component of the Job Service that executes various I/O intensive tasks scheduled by the Alluxio system.
+              </description>
             </info>
-            <locations>alluxio.master</locations>
+            <locations>alluxio.master;alluxio.worker</locations>
             <templatePath>${project.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
             <outputPath>${project.parent.parent.basedir}/generated/job/index.html</outputPath>
             <swaggerDirectory>${project.parent.parent.basedir}/generated/job/swagger-ui</swaggerDirectory>

--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -131,9 +131,18 @@
       <configuration>
         <apiSources>
           <apiSource>
+            <springmvc>false</springmvc>
+            <schemes>http</schemes>
+            <host>[Alluxio Job Master Hostname]</host>
+            <basePath>/api/v1</basePath>
+            <info>
+              <version>v1</version>
+              <title>Alluxio Job Master REST API Documentation</title>
+              <description>The Alluxio Job Master is a component of the Job Service that coordinates Alluxio Job Workers to execute distributed tasks scheduled by the Alluxio system.</description>
+            </info>
             <locations>alluxio.master</locations>
             <templatePath>${project.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
-            <outputPath>${project.parent.parent.basedir}/generated/job/document.html</outputPath>
+            <outputPath>${project.parent.parent.basedir}/generated/job/index.html</outputPath>
             <swaggerDirectory>${project.parent.parent.basedir}/generated/job/swagger-ui</swaggerDirectory>
           </apiSource>
         </apiSources>

--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -31,9 +31,8 @@
   <dependencies>
     <!-- External dependencies -->
     <dependency>
-      <groupId>com.qmino</groupId>
-      <artifactId>miredot-annotations</artifactId>
-      <version>1.4.0</version>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -123,6 +122,22 @@
           </goals>
         </execution>
       </executions>
+    </plugin>
+
+    <!-- REST API documentation -->
+    <plugin>
+      <groupId>com.github.kongchen</groupId>
+      <artifactId>swagger-maven-plugin</artifactId>
+      <configuration>
+        <apiSources>
+          <apiSource>
+            <locations>alluxio.master</locations>
+            <templatePath>${project.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
+            <outputPath>${project.parent.parent.basedir}/generated/job/document.html</outputPath>
+            <swaggerDirectory>${project.parent.parent.basedir}/generated/job/swagger-ui</swaggerDirectory>
+          </apiSource>
+        </apiSources>
+      </configuration>
     </plugin>
   </plugins>
   </build>

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
@@ -69,8 +69,7 @@ public final class AlluxioJobMasterRestServiceHandler {
   @GET
   @Path(GET_INFO)
   @ApiOperation(value = "Get general job master service information",
-      response = alluxio.wire.AlluxioJobMasterInfo.class
-  )
+      response = alluxio.wire.AlluxioJobMasterInfo.class)
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
@@ -18,7 +18,8 @@ import alluxio.RuntimeConstants;
 import alluxio.web.JobMasterWebServer;
 import alluxio.wire.AlluxioJobMasterInfo;
 
-import com.qmino.miredot.annotations.ReturnType;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 
 import java.util.Map;
 
@@ -36,6 +37,7 @@ import javax.ws.rs.core.Response;
  * This class is a REST handler for requesting general job master information.
  */
 @NotThreadSafe
+@Api(value = "/job_master", description = "Job Master Rest Service")
 @Path(AlluxioJobMasterRestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_JSON)
 public final class AlluxioJobMasterRestServiceHandler {
@@ -66,7 +68,9 @@ public final class AlluxioJobMasterRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  @ReturnType("alluxio.wire.AlluxioJobMasterInfo")
+  @ApiOperation(value = "Get general job master service information",
+      response = alluxio.wire.AlluxioJobMasterInfo.class
+  )
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
@@ -18,8 +18,6 @@ import alluxio.RuntimeConstants;
 import alluxio.web.JobWorkerWebServer;
 import alluxio.wire.AlluxioJobWorkerInfo;
 
-import com.qmino.miredot.annotations.ReturnType;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -69,7 +67,7 @@ public final class  AlluxioJobWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  @ReturnType("alluxio.wire.AlluxioJobWorkerInfo")
+  //@ReturnType("alluxio.wire.AlluxioJobWorkerInfo")
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
@@ -18,6 +18,9 @@ import alluxio.RuntimeConstants;
 import alluxio.web.JobWorkerWebServer;
 import alluxio.wire.AlluxioJobWorkerInfo;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -37,6 +40,7 @@ import javax.ws.rs.core.Response;
  * This class is a REST handler for requesting general job worker information.
  */
 @NotThreadSafe
+@Api(value = "/job_worker", description = "Job Worker Rest Service")
 @Path(AlluxioJobWorkerRestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_JSON)
 public final class  AlluxioJobWorkerRestServiceHandler {
@@ -67,7 +71,8 @@ public final class  AlluxioJobWorkerRestServiceHandler {
    */
   @GET
   @Path(GET_INFO)
-  //@ReturnType("alluxio.wire.AlluxioJobWorkerInfo")
+  @ApiOperation(value = "Get general job worker service information",
+      response = alluxio.wire.AlluxioJobWorkerInfo.class)
   public Response getInfo(@QueryParam(QUERY_RAW_CONFIGURATION) final Boolean rawConfiguration) {
     // TODO(jiri): Add a mechanism for retrieving only a subset of the fields.
     return RestUtils.call(() -> {

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>miredot</id>
-      <name>MireDot Releases</name>
-      <url>http://nexus.qmino.com/content/repositories/miredot</url>
-    </repository>
-    <repository>
       <id>alluxio.artifacts</id>
       <url>http://alluxio.artifacts.s3-website-us-east-1.amazonaws.com/release</url>
     </repository>
@@ -238,11 +233,6 @@
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
         <version>0.5.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.qmino</groupId>
-        <artifactId>miredot-annotations</artifactId>
-        <version>1.4.0</version>
       </dependency>
       <dependency>
         <!-- using older version to match dependency version from Hadoop -->
@@ -367,6 +357,11 @@
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_dropwizard</artifactId>
         <version>${prometheus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>1.5.22</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -849,14 +844,6 @@
     </dependency>
   </dependencies>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>miredot</id>
-      <name>MireDot Releases</name>
-      <url>http://nexus.qmino.com/content/repositories/miredot</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -874,53 +861,6 @@
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>2.9</version>
-        </plugin>
-        <plugin>
-          <groupId>com.qmino</groupId>
-          <artifactId>miredot-plugin</artifactId>
-          <version>2.0.3</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>restdoc</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <output>
-              <html>
-                <intro>${project.basedir}/src/main/resources/intro.html</intro>
-                <title>Alluxio ${project.version} REST API</title>
-                <baseUrl>http://host:port/api/v1</baseUrl>
-              </html>
-            </output>
-            <restModel>
-              <httpStatusCodes>
-                <httpStatusCode>
-                  <httpCode>200</httpCode>
-                  <document>always</document>
-                  <defaultMessage>The service call has completed successfully.</defaultMessage>
-                </httpStatusCode>
-                <httpStatusCode>
-                  <httpCode>412</httpCode>
-                  <document>put,post</document>
-                  <defaultMessage>Invalid JSON/XML input.</defaultMessage>
-                </httpStatusCode>
-                <httpStatusCode>
-                  <httpCode>500</httpCode>
-                  <document>always</document>
-                  <defaultMessage>The service call has not succeeded.</defaultMessage>
-                  <sticky>true</sticky> <!-- Document always, even if there is an @statuscode tag -->
-                </httpStatusCode>
-              </httpStatusCodes>
-            </restModel>
-            <analysis>
-              <checks>
-                <JAVADOC_MISSING_INTERFACEDOCUMENTATION>ignore</JAVADOC_MISSING_INTERFACEDOCUMENTATION>
-                <JAVADOC_MISSING_AUTHORS>ignore</JAVADOC_MISSING_AUTHORS>
-              </checks>
-            </analysis>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1033,6 +973,47 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>templating-maven-plugin</artifactId>
           <version>1.0.0</version>
+        </plugin>
+        <!-- REST Documentation plugin -->
+        <plugin>
+          <groupId>com.github.kongchen</groupId>
+          <artifactId>swagger-maven-plugin</artifactId>
+          <version>3.1.1</version>
+          <configuration>
+            <apiSources>
+              <apiSource>
+                <springmvc>false</springmvc>
+                <schemes>http,https</schemes>
+                <host>[Alluxio Master Hostname]</host>
+                <basePath>/api/v1</basePath>
+                <info>
+                  <title>Alluxio REST API Documentation</title>
+                  <version>v1</version>
+                  <termsOfService>
+                    http://www.github.com/alluxio/alluxio
+                  </termsOfService>
+                  <description>Documentation for Alluxio RESTful APIs</description>
+                  <contact>
+                    <email>haoyuan@alluxio.com</email>
+                    <name>Haoyuan Li</name>
+                    <url>www.alluxio.io</url>
+                  </contact>
+                  <license>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                    <name>Apache 2.0</name>
+                  </license>
+                </info>
+              </apiSource>
+            </apiSources>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -979,33 +979,6 @@
           <groupId>com.github.kongchen</groupId>
           <artifactId>swagger-maven-plugin</artifactId>
           <version>3.1.1</version>
-          <configuration>
-            <apiSources>
-              <apiSource>
-                <springmvc>false</springmvc>
-                <schemes>http,https</schemes>
-                <host>[Alluxio Master Hostname]</host>
-                <basePath>/api/v1</basePath>
-                <info>
-                  <title>Alluxio REST API Documentation</title>
-                  <version>v1</version>
-                  <termsOfService>
-                    http://www.github.com/alluxio/alluxio
-                  </termsOfService>
-                  <description>Documentation for Alluxio RESTful APIs</description>
-                  <contact>
-                    <email>haoyuan@alluxio.com</email>
-                    <name>Haoyuan Li</name>
-                    <url>www.alluxio.io</url>
-                  </contact>
-                  <license>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-                    <name>Apache 2.0</name>
-                  </license>
-                </info>
-              </apiSource>
-            </apiSources>
-          </configuration>
           <executions>
             <execution>
               <phase>compile</phase>

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -1,0 +1,103 @@
+#{{#info}}{{title}}
+
+
+## {{join schemes " | "}}://{{host}}{{basePath}}
+
+
+{{description}}
+
+{{#contact}}
+[**Contact the developer**](mailto:{{email}})
+{{/contact}}
+
+**Version** {{version}}
+
+[**Terms of Service**]({{termsOfService}})
+
+{{#license}}[**{{name}}**]({{url}}){{/license}}
+
+{{/info}}
+
+{{#if consumes}}**Consumes:** {{join consumes ", "}}{{/if}}
+
+{{#if produces}}**Produces:** {{join produces ", "}}{{/if}}
+
+# APIs
+
+{{#each paths}}
+## {{@key}}
+{{#this}}
+{{#get}}
+### GET
+{{> operation}}
+{{/get}}
+
+{{#put}}
+### PUT
+{{> operation}}
+{{/put}}
+
+{{#post}}
+### POST
+
+{{> operation}}
+
+{{/post}}
+
+{{#delete}}
+### DELETE
+{{> operation}}
+{{/delete}}
+
+{{#option}}
+### OPTION
+{{> operation}}
+{{/option}}
+
+{{#patch}}
+### PATCH
+{{> operation}}
+{{/patch}}
+
+{{#head}}
+### HEAD
+{{> operation}}
+{{/head}}
+
+{{/this}}
+{{/each}}
+
+# Definitions
+{{#each definitions}}
+## <a name="/definitions/{{key}}">{{@key}}</a>
+
+<table border="1">
+    <tr>
+        <th>name</th>
+        <th>type</th>
+        <th>required</th>
+        <th>description</th>
+        <th>example</th>
+    </tr>
+    {{#each this.properties}}
+        <tr>
+            <td>{{@key}}</td>
+            <td>
+                {{#ifeq type "array"}}
+                {{#items.$ref}}
+                    {{type}}[<a href="{{items.$ref}}">{{basename items.$ref}}</a>]
+                {{/items.$ref}}
+                {{^items.$ref}}{{type}}[{{items.type}}]{{/items.$ref}}
+                {{else}}
+                    {{#$ref}}<a href="{{$ref}}">{{basename $ref}}</a>{{/$ref}}
+                    {{^$ref}}{{type}}{{#format}} ({{format}}){{/format}}{{/$ref}}
+                {{/ifeq}}
+            </td>
+            <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
+            <td>{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}</td>
+            <td>{{example}}</td>
+        </tr>
+    {{/each}}
+</table>
+{{/each}}
+

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -1,20 +1,8 @@
-#{{#info}}{{title}}
+# {{#info}}{{title}}
 
-
-## {{join schemes " | "}}://{{host}}{{basePath}}
-
+{{join schemes " | "}}://{{host}}{{basePath}}
 
 {{description}}
-
-{{#contact}}
-[**Contact the developer**](mailto:{{email}})
-{{/contact}}
-
-**Version** {{version}}
-
-[**Terms of Service**]({{termsOfService}})
-
-{{#license}}[**{{name}}**]({{url}}){{/license}}
 
 {{/info}}
 

--- a/templates/operation.hbs
+++ b/templates/operation.hbs
@@ -1,0 +1,73 @@
+{{#deprecated}}-deprecated-{{/deprecated}}
+<a id="{{operationId}}">{{summary}}</a>
+
+{{description}}
+
+{{#if externalDocs.url}}{{externalDocs.description}}. [See external documents for more details]({{externalDocs.url}})
+{{/if}}
+
+{{#if security}}
+#### Security
+{{/if}}
+
+{{#security}}
+{{#each this}}
+* {{@key}}
+{{#this}}   * {{this}}
+{{/this}}
+{{/each}}
+{{/security}}
+
+#### Request
+
+{{#if consumes}}
+**Content-Type: ** {{join consumes ", "}}{{/if}}
+
+##### Parameters
+{{#if parameters}}
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+{{/if}}
+
+{{#parameters}}
+<tr>
+    <th>{{name}}</th>
+    <td>{{in}}</td>
+    <td>{{#if required}}yes{{else}}no{{/if}}</td>
+    <td>{{description}}{{#if pattern}} (**Pattern**: `{{pattern}}`){{/if}}</td>
+    <td> - </td>
+{{#ifeq in "body"}}
+    <td>
+    {{#ifeq schema.type "array"}}Array[<a href="{{schema.items.$ref}}">{{basename schema.items.$ref}}</a>]{{/ifeq}}
+    {{#schema.$ref}}<a href="{{schema.$ref}}">{{basename schema.$ref}}</a> {{/schema.$ref}}
+    </td>
+{{else}}
+    {{#ifeq type "array"}}
+            <td>Array[{{items.type}}] ({{collectionFormat}})</td>
+    {{else}}
+            <td>{{type}} {{#format}}({{format}}){{/format}}</td>
+    {{/ifeq}}
+{{/ifeq}}
+</tr>
+{{/parameters}}
+{{#if parameters}}
+</table>
+{{/if}}
+
+
+#### Response
+
+{{#if produces}}**Content-Type: ** {{join produces ", "}}{{/if}}
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+{{#each responses}}| {{@key}}    | {{description}} | {{#schema.$ref}}<a href="{{schema.$ref}}">{{basename schema.$ref}}</a>{{/schema.$ref}}{{#ifeq schema.type "array"}}Array[<a href="{{schema.items.$ref}}">{{basename schema.items.$ref}}</a>]{{/ifeq}}{{^schema}} - {{/schema}}|
+{{/each}}

--- a/templates/operation.hbs
+++ b/templates/operation.hbs
@@ -6,18 +6,6 @@
 {{#if externalDocs.url}}{{externalDocs.description}}. [See external documents for more details]({{externalDocs.url}})
 {{/if}}
 
-{{#if security}}
-#### Security
-{{/if}}
-
-{{#security}}
-{{#each this}}
-* {{@key}}
-{{#this}}   * {{this}}
-{{/this}}
-{{/each}}
-{{/security}}
-
 #### Request
 
 {{#if consumes}}

--- a/templates/strapdown.html.hbs
+++ b/templates/strapdown.html.hbs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<title>API Document</title>
+
+<xmp theme="united" style="display:none;">
+{{>markdown}}
+</xmp>
+
+<script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+</html>

--- a/templates/strapdown.html.hbs
+++ b/templates/strapdown.html.hbs
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
-
+<body>
 <xmp theme="cerulean" style="display:none;">
 {{>markdown}}
 </xmp>
 
 <script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+</body>
 </html>

--- a/templates/strapdown.html.hbs
+++ b/templates/strapdown.html.hbs
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
-<title>API Document</title>
 
-<xmp theme="united" style="display:none;">
+<xmp theme="cerulean" style="display:none;">
 {{>markdown}}
 </xmp>
 


### PR DESCRIPTION
Resulting documentation example is attached. We can change the styling to other bootswatch templates. I've chosen one that is similar to Alluxio colors (blue).

Docs are generated in `generated/<service>/index.html`. So far the job, master, worker, and proxy are supported. Deprecated APIs are not documented, and internal APIs (ie. for the web ui) are not documented because we do not want others to rely on them.
![Screen Shot 2019-05-16 at 5 47 20 PM](https://user-images.githubusercontent.com/2223813/57895890-b6950d00-7802-11e9-852e-11213ba0a748.png)
