### PR TITLE
Change Zookeeper path defaults

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
@@ -93,7 +93,7 @@ public class FileSystemFactoryTest {
     Map<String, String> sysProps = new HashMap<>();
     sysProps.put(PropertyKey.ZOOKEEPER_ENABLED.getName(), Boolean.toString(true));
     sysProps.put(PropertyKey.ZOOKEEPER_ADDRESS.getName(), "zk@192.168.0.5");
-    sysProps.put(PropertyKey.ZOOKEEPER_ELECTION_PATH.getName(), "/leader");
+    sysProps.put(PropertyKey.ZOOKEEPER_ELECTION_PATH.getName(), "/alluxio/leader");
 
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
       ConfigurationUtils.reloadProperties();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -467,7 +467,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey ZOOKEEPER_ELECTION_PATH =
       new Builder(Name.ZOOKEEPER_ELECTION_PATH)
-          .setDefaultValue("/election")
+          .setDefaultValue("/alluxio/election")
           .setDescription("Election directory in ZooKeeper.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .build();
@@ -485,7 +485,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey ZOOKEEPER_LEADER_PATH =
       new Builder(Name.ZOOKEEPER_LEADER_PATH)
-          .setDefaultValue("/leader")
+          .setDefaultValue("/alluxio/leader")
           .setDescription("Leader directory in ZooKeeper.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .build();

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -235,8 +235,8 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
   protected void startMasters() throws IOException {
     ServerConfiguration.set(PropertyKey.ZOOKEEPER_ENABLED, "true");
     ServerConfiguration.set(PropertyKey.ZOOKEEPER_ADDRESS, mCuratorServer.getConnectString());
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ELECTION_PATH, "/election");
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_LEADER_PATH, "/leader");
+    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ELECTION_PATH, "/alluxio/election");
+    ServerConfiguration.set(PropertyKey.ZOOKEEPER_LEADER_PATH, "/alluxio/leader");
 
     for (int k = 0; k < mNumOfMasters; k++) {
       ServerConfiguration.set(PropertyKey.MASTER_METASTORE_DIR,


### PR DESCRIPTION
Currently the default leader path is "/leader" and the default election path is "/election". These defaults make sense when Zookeeper is being used for Alluxio only, but in real-world deployments, there will often be multiple services making use of Zookeeper. Change the defaults to something like "/alluxio/leader" and "/alluxio/election" so that there's a better chance that users will not have to change them. It is especially annoying to use non-default paths because clients need to be configured with the leader path, and this configuration can't be specified through a centralized cluster config, or by adding something to the URI.