### PR TITLE
Use default options in HdfsFileInputStream

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -17,7 +17,6 @@ import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
-import alluxio.util.FileSystemOptions;
 
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.PositionedReadable;
@@ -58,7 +57,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
 
     mStatistics = stats;
     try {
-      mInputStream = fs.openFile(uri, FileSystemOptions.openFileDefaults(fs.getConf()));
+      mInputStream = fs.openFile(uri);
     } catch (FileDoesNotExistException e) {
       // Transform the Alluxio exception to a Java exception to satisfy the HDFS API contract.
       throw new FileNotFoundException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));


### PR DESCRIPTION
The original code will only use cluster configurations, which suppresses path configurations in openFile. This behavior will cause long running clients like Presto to never be able to use path level configurations even after restarting.