### PR TITLE
Run alluxio-start.sh local without creating alluxio-site.properties

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -516,6 +516,11 @@ main() {
       start_proxies
       ;;
     local)
+      ALLUXIO_MASTER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
+      ALLUXIO_WORKER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
+      ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
+      ALLUXIO_JOB_MASTER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
+      ALLUXIO_JOB_WORKER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
       start_master "${FORMAT}"
       ALLUXIO_MASTER_SECONDARY=true
       # We only start a secondary master when using a UFS journal.


### PR DESCRIPTION
Previously, it requires redudant steps to start a local & single node cluster:
- Set `alluxio.master.hostname=localhost` in `conf/alluxio-site.properties`
- Pass `local` as an arg to `alluxio-start.sh`

After this PR, running `alluxio-start.sh local` implies setting `alluxio.master.hostname=localhost`. Therefore reduce the steps to test-drive alluxio in a local mode