### PR TITLE
Fix generate-tarballs - exclude generated restdoc from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1154,6 +1154,7 @@
             <exclude>conf/workers</exclude>
             <exclude>dev/scripts/tarballs/**/*</exclude>
             <exclude>dev/scripts/workdir/**/*</exclude>
+            <exclude>generated/**</exclude>
             <exclude>**/.checkstyle</exclude>
             <exclude>**/src/main/assembly/*</exclude>
             <exclude>**/.idea/**</exclude>


### PR DESCRIPTION
If we don't exclude `./generated` the `generate-tarballs` script
will fail when building UFS modules because of the license check
after compiling the codebase