### PR TITLE
Improve k8s specs

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -85,6 +85,19 @@ case ${service,,} in
     integration/docker/bin/alluxio-master.sh &
     wait -n
     ;;
+  master-only)
+    if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
+      printUsage
+      exit 1
+    fi
+    if [[ ${options} != ${NO_FORMAT} ]]; then
+      bin/alluxio formatMaster
+    fi
+    integration/docker/bin/alluxio-master.sh
+    ;;
+  job-master-only)
+    integration/docker/bin/alluxio-job-master.sh
+    ;;
   worker)
     if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
       printUsage
@@ -96,6 +109,19 @@ case ${service,,} in
     integration/docker/bin/alluxio-job-worker.sh &
     integration/docker/bin/alluxio-worker.sh &
     wait -n
+    ;;
+  worker-only)
+    if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
+      printUsage
+      exit 1
+    fi
+    if [[ ${options} != ${NO_FORMAT} ]]; then
+      bin/alluxio formatWorker
+    fi
+    integration/docker/bin/alluxio-worker.sh
+    ;;
+  job-worker-only)
+    integration/docker/bin/alluxio-job-worker.sh
     ;;
   proxy)
     integration/docker/bin/alluxio-proxy.sh

--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -53,7 +53,6 @@ spec:
         app: alluxio-master
     spec:
       hostNetwork: true
-      hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: alluxio-master

--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -65,7 +65,7 @@ spec:
               cpu: "1"
               memory: "1024M"
           command: ["/entrypoint.sh"]
-          args: ["master", "--no-format"]
+          args: ["master-only", "--no-format"]
           envFrom:
           - configMapRef:
               name: alluxio-config
@@ -74,13 +74,28 @@ spec:
             name: rpc
           - containerPort: 19999
             name: web
+          volumeMounts:
+            - name: alluxio-journal
+              mountPath: /journal
+        - name: alluxio-job-master
+          image: alluxio/alluxio:latest
+          resources:
+            requests:
+              cpu: "0.5"
+              memory: "512M"
+            limits:
+              cpu: "1"
+              memory: "1024M"
+          command: ["/entrypoint.sh"]
+          args: ["job-master-only"]
+          envFrom:
+          - configMapRef:
+              name: alluxio-config
+          ports:
           - containerPort: 20001
             name: job-rpc
           - containerPort: 20002
             name: job-web
-          volumeMounts:
-            - name: alluxio-journal
-              mountPath: /journal
       restartPolicy: Always
       volumes:
         - name: alluxio-journal

--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -65,7 +65,7 @@ spec:
               cpu: "1"
               memory: "1024M"
           command: ["/entrypoint.sh"]
-          args: ["master"]
+          args: ["master", "--no-format"]
           envFrom:
           - configMapRef:
               name: alluxio-config

--- a/integration/kubernetes/alluxio-worker.yaml.template
+++ b/integration/kubernetes/alluxio-worker.yaml.template
@@ -36,7 +36,7 @@ spec:
               cpu: "1"
               memory: "2G"
           command: ["/entrypoint.sh"]
-          args: ["worker", "--no-format"]
+          args: ["worker-only", "--no-format"]
           env:
           - name: ALLUXIO_WORKER_HOSTNAME
             valueFrom:
@@ -52,6 +52,31 @@ spec:
             name: data
           - containerPort: 29996
             name: web
+          volumeMounts:
+            - name: alluxio-ramdisk
+              mountPath: /dev/shm
+            - name: alluxio-domain
+              mountPath: /opt/domain
+        - name: alluxio-job-worker
+          image: alluxio/alluxio:latest
+          resources:
+            requests:
+              cpu: "0.5"
+              memory: "2G"
+            limits:
+              cpu: "1"
+              memory: "2G"
+          command: ["/entrypoint.sh"]
+          args: ["job-worker-only"]
+          env:
+          - name: ALLUXIO_WORKER_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          envFrom:
+          - configMapRef:
+              name: alluxio-config
+          ports:
           - containerPort: 30001
             name: job-rpc
           - containerPort: 30002

--- a/integration/kubernetes/alluxio-worker.yaml.template
+++ b/integration/kubernetes/alluxio-worker.yaml.template
@@ -36,7 +36,7 @@ spec:
               cpu: "1"
               memory: "2G"
           command: ["/entrypoint.sh"]
-          args: ["worker"]
+          args: ["worker", "--no-format"]
           env:
           - name: ALLUXIO_WORKER_HOSTNAME
             valueFrom:

--- a/integration/kubernetes/alluxio-worker.yaml.template
+++ b/integration/kubernetes/alluxio-worker.yaml.template
@@ -24,7 +24,6 @@ spec:
         app: alluxio
     spec:
       hostNetwork: true
-      hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: alluxio-worker


### PR DESCRIPTION
- Remove unnecessary hostPID:true from default spec
- Do not format master or worker on restart
- Split job services into a separate container within the same pod