### PR TITLE
Fix locality in containerized environments

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -207,7 +207,8 @@ public final class AlluxioBlockStore {
           BlockLocationUtils.nearest(mTieredIdentity, tieredLocations, mContext.getClusterConf());
       if (nearest.isPresent()) {
         dataSource = nearest.get().getFirst();
-        dataSourceType = nearest.get().getSecond() ? BlockInStreamSource.LOCAL : BlockInStreamSource.REMOTE;
+        dataSourceType =
+            nearest.get().getSecond() ? BlockInStreamSource.LOCAL : BlockInStreamSource.REMOTE;
       }
     }
     // Can't get data from Alluxio, get it from the UFS instead

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -110,8 +110,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     builder.setOpenUfsBlockOptions(options.getOpenUfsBlockOptions(blockId));
     AlluxioConfiguration alluxioConf = context.getClusterConf();
     boolean shortCircuit = alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED);
-    boolean sourceSupportsDomainSocket = NettyUtils.isDomainSocketSupported(dataSource,
-        alluxioConf);
+    boolean sourceSupportsDomainSocket = NettyUtils.isDomainSocketSupported(dataSource);
     boolean sourceIsLocal = dataSourceType == BlockInStreamSource.LOCAL;
 
     // Short circuit

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
@@ -59,7 +59,7 @@ public interface DataWriter extends Closeable, Cancelable {
       AlluxioConfiguration alluxioConf = context.getClusterConf();
       if (CommonUtils.isLocalHost(address, alluxioConf) && alluxioConf
           .getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED) && !NettyUtils
-          .isDomainSocketSupported(address, alluxioConf)) {
+          .isDomainSocketSupported(address)) {
         if (options.getWriteType() == WriteType.ASYNC_THROUGH
             && alluxioConf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED)) {
           LOG.info("Creating UFS-fallback short circuit output stream for block {} @ {}", blockId,

--- a/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
@@ -48,7 +48,7 @@ public final class BlockLocationUtils {
     if (conf.getBoolean(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID)) {
       // Determine by inspecting the file system if worker is local
       for (WorkerNetAddress addr : addresses) {
-        if (NettyUtils.isDomainSocketSupported(addr, conf)) {
+        if (NettyUtils.isDomainSocketAccessible(addr, conf)) {
           LOG.debug("Found local worker by file system inspection of path {}",
               addr.getDomainSocketPath());
           // Returns the first local worker and does not shuffle

--- a/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
@@ -11,12 +11,6 @@
 
 package alluxio.client.block.util;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.annotation.concurrent.ThreadSafe;
-
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
@@ -25,6 +19,12 @@ import alluxio.util.TieredIdentityUtils;
 import alluxio.util.network.NettyUtils;
 import alluxio.wire.TieredIdentity;
 import alluxio.wire.WorkerNetAddress;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Utility functions for working with block locations.

--- a/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
@@ -1,0 +1,71 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.util;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import alluxio.Constants;
+import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.TieredIdentityUtils;
+import alluxio.util.network.NettyUtils;
+import alluxio.wire.TieredIdentity;
+import alluxio.wire.WorkerNetAddress;
+
+/**
+ * Utility functions for working with block locations.
+ */
+@ThreadSafe
+public final class BlockLocationUtils {
+
+  /**
+   * @param tieredIdentity the tiered identity
+   * @param addresses the candidate worker addresses
+   * @param conf Alluxio configuration
+   * @return the address closest to this one. If none of the identities match, the first address is
+   *         returned
+   */
+  public static Optional<Pair<WorkerNetAddress, Boolean>> nearest(TieredIdentity tieredIdentity,
+      List<WorkerNetAddress> addresses, AlluxioConfiguration conf) {
+    if (conf.getBoolean(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID)) {
+      // Determine by inspecting the file system if worker is local
+      for (WorkerNetAddress addr : addresses) {
+        if (NettyUtils.isDomainSocketSupported(addr, conf)) {
+          // Returns the first local worker and does not shuffle
+          return Optional.of(new Pair<>(addr, true));
+        }
+      }
+    }
+    // Find nearest tiered identity
+    Optional<TieredIdentity> nearestIdentity = TieredIdentityUtils.nearest(tieredIdentity,
+        addresses.stream().map(addr -> addr.getTieredIdentity()).collect(Collectors.toList()),
+        conf);
+    if (!nearestIdentity.isPresent()) {
+      return Optional.empty();
+    }
+    boolean isLocal = tieredIdentity.getTier(0).getTierName().equals(Constants.LOCALITY_NODE)
+        && tieredIdentity.topTiersMatch(nearestIdentity.get());
+    Optional<WorkerNetAddress> dataSource = addresses.stream()
+        .filter(addr -> addr.getTieredIdentity().equals(nearestIdentity.get())).findFirst();
+    if (!dataSource.isPresent()) {
+      return Optional.empty();
+    }
+    return Optional.of(new Pair<>(dataSource.get(), isLocal));
+  }
+
+  private BlockLocationUtils() {} // prevent instantiation
+}

--- a/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
@@ -40,8 +40,9 @@ public final class BlockLocationUtils {
    * @param tieredIdentity the tiered identity
    * @param addresses the candidate worker addresses
    * @param conf Alluxio configuration
-   * @return the address closest to this one. If none of the identities match, the first address is
-   *         returned
+   * @return the first in the pair indicates the address closest to this one. If none of the
+   *         identities match, the first address is returned. the second in the pair indicates
+   *         whether or not the location is local
    */
   public static Optional<Pair<WorkerNetAddress, Boolean>> nearest(TieredIdentity tieredIdentity,
       List<WorkerNetAddress> addresses, AlluxioConfiguration conf) {

--- a/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/util/BlockLocationUtils.java
@@ -20,6 +20,9 @@ import alluxio.util.network.NettyUtils;
 import alluxio.wire.TieredIdentity;
 import alluxio.wire.WorkerNetAddress;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -31,6 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class BlockLocationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(BlockLocationUtils.class);
 
   /**
    * @param tieredIdentity the tiered identity
@@ -45,6 +49,8 @@ public final class BlockLocationUtils {
       // Determine by inspecting the file system if worker is local
       for (WorkerNetAddress addr : addresses) {
         if (NettyUtils.isDomainSocketSupported(addr, conf)) {
+          LOG.debug("Found local worker by file system inspection of path {}",
+              addr.getDomainSocketPath());
           // Returns the first local worker and does not shuffle
           return Optional.of(new Pair<>(addr, true));
         }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -96,5 +96,4 @@ public class LocalFirstAvoidEvictionPolicyTest {
             new LocalFirstAvoidEvictionPolicy(mConf))
         .testEquals();
   }
-
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.block.policy;
 
+import static alluxio.client.util.ClientTestUtils.worker;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationTestUtils;
@@ -22,8 +23,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
-import alluxio.wire.TieredIdentity;
-import alluxio.wire.TieredIdentity.LocalityTier;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.testing.EqualsTester;
@@ -98,17 +97,5 @@ public class LocalFirstAvoidEvictionPolicyTest {
         .testEquals();
   }
 
-  private BlockWorkerInfo worker(long capacity, long used, String node, String rack) {
-    WorkerNetAddress address = new WorkerNetAddress();
-    List<LocalityTier> tiers = new ArrayList<>();
-    if (node != null && !node.isEmpty()) {
-      address.setHost(node);
-      tiers.add(new LocalityTier(Constants.LOCALITY_NODE, node));
-    }
-    if (rack != null && !rack.isEmpty()) {
-      tiers.add(new LocalityTier(Constants.LOCALITY_RACK, rack));
-    }
-    address.setTieredIdentity(new TieredIdentity(tiers));
-    return new BlockWorkerInfo(address, capacity, used);
-  }
+
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -97,5 +97,4 @@ public class LocalFirstAvoidEvictionPolicyTest {
         .testEquals();
   }
 
-
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
@@ -13,14 +13,19 @@ package alluxio.client.block.policy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.network.TieredIdentityFactory;
+import alluxio.util.network.NettyUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.TieredIdentity;
@@ -29,6 +34,10 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +45,8 @@ import java.util.List;
 /**
  * Tests {@link LocalFirstPolicy}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NettyUtils.class)
 public final class LocalFirstPolicyTest {
 
   private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
@@ -118,6 +129,33 @@ public final class LocalFirstPolicyTest {
         sConf);
     chosen = policy.getWorker(options);
     assertEquals("node4", chosen.getTieredIdentity().getTier(0).getValue());
+  }
+
+  @Test
+  public void chooseLocalAccessibleDomainSocket() throws Exception {
+    List<BlockWorkerInfo> workers = new ArrayList<>();
+    workers.add(worker(Constants.GB, "node2", "rack2"));
+    // create worker info with domain socket path
+    BlockWorkerInfo workerWithDomainSocket = worker(Constants.GB, "node3", "rack3");
+    String domainSocketPath = "/tmp/domain/uuid-node3";
+    workerWithDomainSocket.getNetAddress().setDomainSocketPath(domainSocketPath);
+    workers.add(workerWithDomainSocket);
+
+    // mock NettyUtils
+    PowerMockito.mockStatic(NettyUtils.class);
+    when(NettyUtils.isDomainSocketAccessible(eq(workerWithDomainSocket.getNetAddress()),
+        any(AlluxioConfiguration.class))).thenReturn(true);
+
+    // choose worker with domain socket accessible ignoring rack
+    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID, true);
+    LocalFirstPolicy policy = new LocalFirstPolicy(
+        TieredIdentityFactory.fromString("node=node1,rack=rack2", conf), conf);
+    GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workers)
+        .setBlockInfo(new BlockInfo().setLength(Constants.GB));
+    WorkerNetAddress chosen = policy.getWorker(options);
+    assertEquals(domainSocketPath, chosen.getDomainSocketPath());
+    assertEquals("node3", chosen.getHost());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -136,6 +136,8 @@ public class BlockInStreamTest {
     PowerMockito.when(NettyUtils.isDomainSocketAccessible(Matchers.any(WorkerNetAddress.class),
         Matchers.any(InstancedConfiguration.class)))
         .thenReturn(true);
+    PowerMockito.when(NettyUtils.isDomainSocketSupported(Matchers.any(WorkerNetAddress.class)))
+        .thenReturn(true);
     WorkerNetAddress dataSource = new WorkerNetAddress();
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.LOCAL;
     BlockInStream stream = BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType,

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -133,7 +133,7 @@ public class BlockInStreamTest {
   @Test
   public void createDomainSocketEnabled() throws Exception {
     PowerMockito.mockStatic(NettyUtils.class);
-    PowerMockito.when(NettyUtils.isDomainSocketSupported(Matchers.any(WorkerNetAddress.class),
+    PowerMockito.when(NettyUtils.isDomainSocketAccessible(Matchers.any(WorkerNetAddress.class),
         Matchers.any(InstancedConfiguration.class)))
         .thenReturn(true);
     WorkerNetAddress dataSource = new WorkerNetAddress();

--- a/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.util;
+
+import static alluxio.client.util.ClientTestUtils.worker;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import alluxio.ConfigurationTestUtils;
+import alluxio.Constants;
+import alluxio.client.block.BlockWorkerInfo;
+import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.network.TieredIdentityFactory;
+import alluxio.util.network.NettyUtils;
+import alluxio.wire.WorkerNetAddress;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Tests {@link BlockLocationUtils}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NettyUtils.class)
+public final class BlockLocationUtilsTest {
+
+  @Test
+  public void chooseLocalAccessibleDomainSocket() throws Exception {
+    List<BlockWorkerInfo> workers = new ArrayList<>();
+    workers.add(worker(Constants.GB, "node2", "rack2"));
+    // create worker info with domain socket path
+    BlockWorkerInfo workerWithDomainSocket = worker(Constants.GB, "node3", "rack3");
+    String domainSocketPath = "/tmp/domain/uuid-node3";
+    workerWithDomainSocket.getNetAddress().setDomainSocketPath(domainSocketPath);
+    workers.add(workerWithDomainSocket);
+
+    // mock NettyUtils
+    PowerMockito.mockStatic(NettyUtils.class);
+    when(NettyUtils.isDomainSocketAccessible(eq(workerWithDomainSocket.getNetAddress()),
+        any(AlluxioConfiguration.class))).thenReturn(true);
+
+    // choose worker with domain socket accessible ignoring rack
+    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID, true);
+    List<WorkerNetAddress> addresses = workers.stream()
+        .map(worker -> worker.getNetAddress())
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+    Optional<Pair<WorkerNetAddress, Boolean>> chosen = BlockLocationUtils
+        .nearest(TieredIdentityFactory.fromString("node=node1,rack=rack2", conf), addresses, conf);
+    assertTrue(chosen.isPresent());
+    assertTrue(chosen.get().getSecond());
+    assertEquals(domainSocketPath, chosen.get().getFirst().getDomainSocketPath());
+    assertEquals("node3", chosen.get().getFirst().getHost());
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/fs/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -11,10 +11,17 @@
 
 package alluxio.client.util;
 
+import alluxio.Constants;
+import alluxio.client.block.BlockWorkerInfo;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.wire.TieredIdentity;
+import alluxio.wire.TieredIdentity.LocalityTier;
+import alluxio.wire.WorkerNetAddress;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility methods for the client tests.
@@ -44,5 +51,23 @@ public final class ClientTestUtils {
 
   private static void resetContexts(InstancedConfiguration conf) throws IOException {
     conf.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
+  }
+
+  public static BlockWorkerInfo worker(long capacity, String node, String rack) {
+    return worker(capacity, 0, node, rack);
+  }
+
+  public static BlockWorkerInfo worker(long capacity, long used, String node, String rack) {
+    WorkerNetAddress address = new WorkerNetAddress();
+    List<LocalityTier> tiers = new ArrayList<>();
+    if (node != null && !node.isEmpty()) {
+      address.setHost(node);
+      tiers.add(new LocalityTier(Constants.LOCALITY_NODE, node));
+    }
+    if (rack != null && !rack.isEmpty()) {
+      tiers.add(new LocalityTier(Constants.LOCALITY_RACK, rack));
+    }
+    address.setTieredIdentity(new TieredIdentity(tiers));
+    return new BlockWorkerInfo(address, capacity, used);
   }
 }

--- a/core/common/src/main/java/alluxio/util/network/NettyUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NettyUtils.java
@@ -152,10 +152,9 @@ public final class NettyUtils {
    * @param conf Alluxio configuration
    * @return true if the domain socket is enabled on this client
    */
-  public static boolean isDomainSocketSupported(WorkerNetAddress workerNetAddress,
+  public static boolean isDomainSocketAccessible(WorkerNetAddress workerNetAddress,
       AlluxioConfiguration conf) {
-    if (workerNetAddress.getDomainSocketPath().isEmpty()
-        || getUserChannel(conf) != ChannelType.EPOLL) {
+    if (!isDomainSocketSupported(workerNetAddress) || getUserChannel(conf) != ChannelType.EPOLL) {
       return false;
     }
     if (conf.getBoolean(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID)) {
@@ -163,6 +162,15 @@ public final class NettyUtils {
     } else {
       return workerNetAddress.getHost().equals(NetworkAddressUtils.getClientHostName(conf));
     }
+  }
+
+  /**
+   * @param workerNetAddress the worker address
+   * @param conf Alluxio configuration
+   * @return true if the domain socket is supported by the worker
+   */
+  public static boolean isDomainSocketSupported(WorkerNetAddress workerNetAddress) {
+    return !workerNetAddress.getDomainSocketPath().isEmpty();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NettyUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NettyUtils.java
@@ -166,7 +166,6 @@ public final class NettyUtils {
 
   /**
    * @param workerNetAddress the worker address
-   * @param conf Alluxio configuration
    * @return true if the domain socket is supported by the worker
    */
   public static boolean isDomainSocketSupported(WorkerNetAddress workerNetAddress) {

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -623,7 +623,7 @@ public final class NetworkAddressUtils {
   public static SocketAddress getDataPortSocketAddress(WorkerNetAddress netAddress,
       AlluxioConfiguration conf) {
     SocketAddress address;
-    if (NettyUtils.isDomainSocketSupported(netAddress, conf)) {
+    if (NettyUtils.isDomainSocketAccessible(netAddress, conf)) {
       address = new DomainSocketAddress(netAddress.getDomainSocketPath());
     } else {
       String host = netAddress.getHost();

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -127,6 +127,8 @@ case ${service,,} in
     integration/docker/bin/alluxio-proxy.sh
     ;;
   fuse)
+    # Unmount first if cleanup failed and ignore error
+    ! integration/fuse/bin/alluxio-fuse unmount /alluxio-fuse
     integration/fuse/bin/alluxio-fuse mount -o allow_other /alluxio-fuse /
     tail -f /opt/alluxio/logs/fuse.log
     ;;

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -53,6 +53,8 @@ spec:
             - name: alluxio-fuse-mount
               mountPath: /alluxio-fuse
               mountPropagation: Bidirectional
+            - name: alluxio-domain
+              mountPath: /opt/domain
       restartPolicy: Always
       volumes:
         - name: alluxio-fuse-device
@@ -63,3 +65,7 @@ spec:
           hostPath:
             path: /alluxio-fuse
             type: DirectoryOrCreate
+        - name: alluxio-domain
+          hostPath:
+            path: /tmp/domain
+            type: ""


### PR DESCRIPTION
In a containerized env such as k8s, the worker and client hostname may not match. To determine if a worker is local, file system inspection is used instead when property `alluxio.worker.data.server.domain.socket.as.uuid=true` is set.

In this PR:
- update the method to choose a local worker for BlockInStream/OutStream
- if client container does not mount domain socket dir but has the same hostname as worker, do not attempt to open local file short circuit stream if worker supports domain socket (as /dev/shm is not accessible)
- unmount as part of fuse startup in case k8s shutdown hook is flaky