### PR TITLE
[SMALLFIX] Fix the class loader for hadoop getFileSystem

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -157,7 +157,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         // the org.apache.hadoop.fs.FileSystem is loaded by {@link ExtensionClassLoader},
         // but the org.apache.hadoop.fs.LocalFileSystem is loaded by {@link AppClassLoader}.
         // When an interface and associated implementation are each loaded
-        // by two separate class loaders. An instance of the class from one loader cannot
+        // by two separate class loaders, an instance of the class from one loader cannot
         // be recognized as implementing the interface from the other loader.
         ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         try {


### PR DESCRIPTION
If the `HdfsUnderFileSystemContractTest` is running from maven, the classloader will all be `AppClassLoader`. 
When running from `./bin/alluxio runUfsTests --path hdfs://<host>:<port>/dir`, the thread class loader is `ExtensionClassLoader`. However, when we are getting the filesystem, the class loader is `AppClassLoader`. 

We use `ExtensionClassLoader` to load `org.apache.hadoop.fs.FileSystem`, but use `AppClassLoader` to load `org.apache.hadoop.fs.LocalFileSystem`.  Because they are from two different class loader, `LocalFileSystem` cannot be recognized as implementing the interface `FileSystem`.

From https://www.ibm.com/developerworks/java/library/j-dyn0429/
```
 when an interface and associated implementation are each loaded by two separate class loaders. 
Even though the names and binary implementations of the interfaces and classes are the same, 
an instance of the class from one loader cannot be recognized as implementing the interface 
from the other loader. 
```