### PR TITLE
Implement authentication long polling

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3210,7 +3210,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD =
       new Builder(Name.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD)
-          .setDefaultValue("60min")
+          .setDefaultValue("3day")
           .setDescription("Interval for which client channels that have been inactive "
                   + "will be regarded as unauthenticated. Such channels will reauthenticate with "
                   + "their target master upon being used for new RPCs.")

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -34,6 +34,7 @@ public final class GrpcChannel extends Channel {
   private final GrpcManagedChannelPool.ChannelKey mChannelKey;
   private final Supplier<Boolean> mChannelHealthState;
   private Channel mChannel;
+  private Runnable mAuthCloseCallback;
   private boolean mChannelReleased;
   private boolean mChannelHealthy = true;
   private final long mShutdownTimeoutMs;
@@ -51,6 +52,11 @@ public final class GrpcChannel extends Channel {
     mChannelHealthState = channel instanceof AuthenticatedChannel
         ? () -> (((AuthenticatedChannel) channel).isAuthenticated() && mChannelHealthy)
             : () -> mChannelHealthy;
+    if (channel instanceof AuthenticatedChannel) {
+      // Store {@link AuthenticatedChannel::#close) for signaling end of
+      // authenticated session during shutdown.
+      mAuthCloseCallback = ((AuthenticatedChannel) channel)::close;
+    }
     mChannel = ClientInterceptors.intercept(channel, new ChannelResponseTracker((this)));
     mChannelReleased = false;
     mShutdownTimeoutMs = shutdownTimeoutMs;
@@ -79,6 +85,10 @@ public final class GrpcChannel extends Channel {
    * Shuts down the channel.
    */
   public void shutdown() {
+    if (mAuthCloseCallback != null) {
+      // Stop authenticated session with server.
+      mAuthCloseCallback.run();
+    }
     if (!mChannelReleased) {
       GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey, mShutdownTimeoutMs);
     }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -66,8 +66,7 @@ public final class GrpcChannel extends Channel {
       long shutdownTimeoutMs) {
     this(channelKey, (Channel) channel, shutdownTimeoutMs);
     // Update the channel health supplier for authenticated channel.
-    mChannelHealthState =
-        () -> (((AuthenticatedChannel) channel).isAuthenticated() && mChannelHealthy);
+    mChannelHealthState = () -> (channel.isAuthenticated() && mChannelHealthy);
 
     // Store {@link AuthenticatedChannel::#close) for signaling end of
     // authenticated session during shutdown.

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -17,7 +17,6 @@ import alluxio.exception.status.AlluxioStatusException;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.ChannelAuthenticator;
 
-import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.netty.channel.EventLoopGroup;
 
@@ -203,25 +202,25 @@ public final class GrpcChannelBuilder {
             mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS),
             mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     try {
-      Channel clientChannel = underlyingChannel;
-
       if (mAuthenticateChannel) {
         // Create channel authenticator based on provided content.
         ChannelAuthenticator channelAuthenticator;
         if (mUseSubject) {
           channelAuthenticator = new ChannelAuthenticator(mParentSubject, mConfiguration);
         } else {
-          channelAuthenticator =
-              new ChannelAuthenticator(mUserName, mPassword, mImpersonationUser,
-                  mConfiguration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class),
-                  mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_AUTH_TIMEOUT));
+          channelAuthenticator = new ChannelAuthenticator(mUserName, mPassword, mImpersonationUser,
+              mConfiguration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class),
+              mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_AUTH_TIMEOUT));
         }
-        // Get an authenticated wrapper channel over given managed channel.
-        clientChannel = channelAuthenticator.authenticate(mServerAddress, underlyingChannel);
+        // Return a wrapper over authenticated channel.
+        return new GrpcChannel(mChannelKey,
+            channelAuthenticator.authenticate(mServerAddress, underlyingChannel),
+            mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
+      } else {
+        // Return a wrapper over original channel.
+        return new GrpcChannel(mChannelKey, underlyingChannel,
+            mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
       }
-      // Create the channel after authentication with the target.
-      return new GrpcChannel(mChannelKey, clientChannel,
-          mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     } catch (Exception exc) {
       // Release the managed channel to the pool before throwing.
       GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey,

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -202,7 +202,9 @@ public final class GrpcChannelBuilder {
             mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT_MS),
             mConfiguration.getMs(PropertyKey.MASTER_GRPC_CHANNEL_SHUTDOWN_TIMEOUT));
     try {
-      if (mAuthenticateChannel) {
+      AuthType authType =
+          mConfiguration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
+      if (mAuthenticateChannel && authType != AuthType.NOSASL) {
         // Create channel authenticator based on provided content.
         ChannelAuthenticator channelAuthenticator;
         if (mUseSubject) {

--- a/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
@@ -251,7 +251,7 @@ public final class GrpcServerBuilder {
   public GrpcServer build() {
     addService(new GrpcService(new ServiceVersionClientServiceHandler(mServices))
         .disableAuthentication());
-    return new GrpcServer(mNettyServerBuilder.build(),
+    return new GrpcServer(mNettyServerBuilder.build(), mAuthenticationServer,
         mConfiguration.getMs(PropertyKey.MASTER_GRPC_SERVER_SHUTDOWN_TIMEOUT));
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
@@ -11,6 +11,8 @@
 
 package alluxio.security.authentication;
 
+import java.util.UUID;
+
 /**
  * A gRPC channel with authentication state.
  */
@@ -19,4 +21,14 @@ public interface AuthenticatedChannel {
    * @return whether the channel is authenticated
    */
   boolean isAuthenticated();
+
+  /**
+   * @return the channel Id used for authentication
+   */
+  UUID getChannelId();
+
+  /**
+   * Closes the authentication session with the server.
+   */
+  void close();
 }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannel.java
@@ -11,24 +11,26 @@
 
 package alluxio.security.authentication;
 
+import io.grpc.Channel;
+
 import java.util.UUID;
 
 /**
  * A gRPC channel with authentication state.
  */
-public interface AuthenticatedChannel {
+public abstract class AuthenticatedChannel extends Channel {
   /**
    * @return whether the channel is authenticated
    */
-  boolean isAuthenticated();
+  public abstract boolean isAuthenticated();
 
   /**
    * @return the channel Id used for authentication
    */
-  UUID getChannelId();
+  public abstract UUID getChannelId();
 
   /**
    * Closes the authentication session with the server.
    */
-  void close();
+  public abstract void close();
 }

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
@@ -46,8 +46,9 @@ public interface AuthenticationServer extends BindableService {
    * Unregisters given channel.
    *
    * @param channelId channel id
+   * @return {@code true} if channel was registered
    */
-  void unregisterChannel(UUID channelId);
+  boolean unregisterChannel(UUID channelId);
 
   /**
    * Creates server-side Sasl handler for given scheme.

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
@@ -29,9 +29,11 @@ public interface AuthenticationServer extends BindableService {
    *
    * @param channelId channel id
    * @param userInfo authanticated user info
+   * @param saslDriver sasl server driver
    * @param saslServer server that has been used for authentication
    */
-  void registerChannel(UUID channelId, AuthenticatedUserInfo userInfo, SaslServer saslServer);
+  void registerChannel(UUID channelId, AuthenticatedUserInfo userInfo,
+      SaslStreamServerDriver saslDriver, SaslServer saslServer);
 
   /**
    * @param channelId channel id
@@ -57,4 +59,9 @@ public interface AuthenticationServer extends BindableService {
    */
   SaslServerHandler createSaslHandler(ChannelAuthenticationScheme scheme)
       throws SaslException, UnauthenticatedException;
+
+  /**
+   * Closes the server, releases all authentication sessions.
+   */
+  void close();
 }

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -121,17 +121,22 @@ public class ChannelAuthenticator {
       return managedChannel;
     }
 
-    return new AuthenticatedManagedChannel(serverAddress, managedChannel);
+    return new DefaultAuthenticatedChannel(serverAddress, managedChannel);
   }
 
-  private class AuthenticatedManagedChannel extends Channel implements AuthenticatedChannel {
+  private class DefaultAuthenticatedChannel extends AuthenticatedChannel {
+    /** Target server for authentication.  */
     private final GrpcServerAddress mServerAddress;
+    /** Given managed channel reference. */
     private final ManagedChannel mManagedChannel;
+    /** Augmented channel with authentication interceptors. */
     private Channel mChannel;
+    /** Whether the channel is currently authenticated. */
     private AtomicBoolean mAuthenticated;
+    /** Sasl traffic driver for the client. */
     private SaslStreamClientDriver mClientDriver;
 
-    AuthenticatedManagedChannel(GrpcServerAddress serverAddress, ManagedChannel managedChannel)
+    DefaultAuthenticatedChannel(GrpcServerAddress serverAddress, ManagedChannel managedChannel)
         throws AlluxioStatusException {
       mServerAddress = serverAddress;
       mManagedChannel = managedChannel;
@@ -252,6 +257,7 @@ public class ChannelAuthenticator {
 
     @Override
     public void close() {
+      // Stopping client driver will close authentication with the server.
       mClientDriver.stop();
     }
   }

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -112,14 +112,10 @@ public class ChannelAuthenticator {
    * @return channel that is augmented for authentication
    * @throws UnauthenticatedException
    */
-  public Channel authenticate(GrpcServerAddress serverAddress, ManagedChannel managedChannel)
-      throws AlluxioStatusException {
+  public AuthenticatedChannel authenticate(GrpcServerAddress serverAddress,
+      ManagedChannel managedChannel) throws AlluxioStatusException {
     LOG.debug("Channel authentication initiated. ChannelId:{}, AuthType:{}, Target:{}", mChannelId,
             mAuthType, managedChannel.authority());
-
-    if (mAuthType == AuthType.NOSASL) {
-      return managedChannel;
-    }
 
     return new DefaultAuthenticatedChannel(serverAddress, managedChannel);
   }

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -129,8 +129,8 @@ public class DefaultAuthenticationServer
       try {
         channelInfo.getSaslServerDriver().onCompleted();
       } catch (Exception e) {
-        LOG.warn("Failed to authentication session for channel-Id: {}. Error: {}", channelId,
-            e.getMessage());
+        LOG.warn("Failed to complete the authentication session for channel-Id: {}. Error: {}",
+            channelId, e.getMessage());
       }
     }
   }

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -18,6 +18,7 @@ import alluxio.grpc.ChannelAuthenticationScheme;
 import alluxio.grpc.SaslAuthenticationServiceGrpc;
 import alluxio.grpc.SaslMessage;
 import alluxio.security.authentication.plain.SaslServerHandlerPlain;
+import alluxio.util.LogUtils;
 import alluxio.util.ThreadFactoryUtils;
 
 import io.grpc.Status;
@@ -122,15 +123,15 @@ public class DefaultAuthenticationServer
       try {
         channelInfo.getSaslServer().dispose();
       } catch (SaslException e) {
-        LOG.warn("Failed to dispose sasl client for channel-Id: {}. Error: {}", channelId,
-            e.getMessage());
+        LogUtils.warnWithException(LOG,
+            String.format("Failed to dispose sasl client for channel-Id: {}", channelId), e);
       }
 
       try {
         channelInfo.getSaslServerDriver().onCompleted();
       } catch (Exception e) {
-        LOG.warn("Failed to complete the authentication session for channel-Id: {}. Error: {}",
-            channelId, e.getMessage());
+        LogUtils.warnWithException(LOG, String.format(
+            "Failed to complete the authentication session for channel-Id: {}", channelId), e);
       }
     }
   }

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -123,15 +123,15 @@ public class DefaultAuthenticationServer
       try {
         channelInfo.getSaslServer().dispose();
       } catch (SaslException e) {
-        LogUtils.warnWithException(LOG,
-            String.format("Failed to dispose sasl client for channel-Id: {}", channelId), e);
+        LogUtils.warnWithException(LOG, "Failed to dispose sasl client for channel-Id: {}",
+            channelId, e);
       }
 
       try {
         channelInfo.getSaslServerDriver().onCompleted();
       } catch (Exception e) {
-        LogUtils.warnWithException(LOG, String.format(
-            "Failed to complete the authentication session for channel-Id: {}", channelId), e);
+        LogUtils.warnWithException(LOG,
+            "Failed to complete the authentication session for channel-Id: {}", channelId, e);
       }
     }
   }

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -73,11 +73,11 @@ public class DefaultAuthenticationServer
     mHostName = hostName;
     mConfiguration = conf;
     mCleanupIntervalMs =
-            conf.getMs(PropertyKey.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD);
+        conf.getMs(PropertyKey.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD);
     checkSupported(conf.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class));
     mChannels = new ConcurrentHashMap<>();
-    mScheduler = Executors.newScheduledThreadPool(1,
-        ThreadFactoryUtils.build("auth-cleanup", true));
+    mScheduler =
+        Executors.newScheduledThreadPool(1, ThreadFactoryUtils.build("auth-cleanup", true));
     mScheduler.scheduleAtFixedRate(this::cleanupStaleClients, mCleanupIntervalMs,
         mCleanupIntervalMs, TimeUnit.MILLISECONDS);
   }
@@ -92,10 +92,10 @@ public class DefaultAuthenticationServer
 
   @Override
   public void registerChannel(UUID channelId, AuthenticatedUserInfo userInfo,
-      SaslServer saslServer) {
+      SaslStreamServerDriver saslDriver, SaslServer saslServer) {
     LOG.debug("Registering new channel:{} for user:{}", channelId, userInfo);
     if (null != mChannels.putIfAbsent(channelId,
-        new AuthenticatedChannelInfo(userInfo, saslServer))) {
+        new AuthenticatedChannelInfo(userInfo, saslDriver, saslServer))) {
       AuthenticatedChannelInfo existingInfo = mChannels.remove(channelId);
       throw new RuntimeException(
           String.format("Channel: %s already exists in authentication registry for user: %s.",
@@ -106,12 +106,12 @@ public class DefaultAuthenticationServer
   @Override
   public AuthenticatedUserInfo getUserInfoForChannel(UUID channelId)
       throws UnauthenticatedException {
-    if (mChannels.containsKey(channelId)) {
-      AuthenticatedChannelInfo clientInfo = mChannels.get(channelId);
+    AuthenticatedChannelInfo clientInfo = mChannels.get(channelId);
+    if (clientInfo != null) {
       return clientInfo.getUserInfo();
     } else {
       throw new UnauthenticatedException(
-          String.format("Client:%s needs to be authenticated", channelId.toString()));
+          String.format("Channel:%s needs to be authenticated", channelId.toString()));
     }
   }
 
@@ -123,6 +123,13 @@ public class DefaultAuthenticationServer
         channelInfo.getSaslServer().dispose();
       } catch (SaslException e) {
         LOG.warn("Failed to dispose sasl client for channel-Id: {}. Error: {}", channelId,
+            e.getMessage());
+      }
+
+      try {
+        channelInfo.getSaslServerDriver().onCompleted();
+      } catch (Exception e) {
+        LOG.warn("Failed to authentication session for channel-Id: {}. Error: {}", channelId,
             e.getMessage());
       }
     }
@@ -141,6 +148,19 @@ public class DefaultAuthenticationServer
     }
   }
 
+  @Override
+  public void close() {
+    for (Map.Entry<UUID, AuthenticatedChannelInfo> entry : mChannels.entrySet()) {
+      try {
+        entry.getValue().getSaslServerDriver().onCompleted();
+        LOG.debug("Closed authentication session for channel:{}", entry.getKey());
+      } catch (Exception exc) {
+        LOG.debug("Failed closing authentication session for channel:{}. Error:{}", entry.getKey(),
+            exc);
+      }
+    }
+  }
+
   /**
    * Primitive that is invoked periodically for cleaning the registry from clients that has become
    * stale.
@@ -156,7 +176,6 @@ public class DefaultAuthenticationServer
         staleChannels.add(clientEntry.getKey());
       }
     }
-
     // Unregister stale clients.
     LOG.debug("Found {} stale channels for cleanup.", staleChannels.size());
     for (UUID clientId : staleChannels) {
@@ -191,14 +210,17 @@ public class DefaultAuthenticationServer
     private LocalTime mLastAccessTime;
     private SaslServer mAuthenticatedServer;
     private AuthenticatedUserInfo mUserInfo;
+    private SaslStreamServerDriver mSaslServerDriver;
 
     /**
      * @param userInfo authenticated user info
+     * @param saslServerDriver sasl server driver
      * @param authenticatedServer authenticated sasl server
      */
     public AuthenticatedChannelInfo(AuthenticatedUserInfo userInfo,
-        SaslServer authenticatedServer) {
+        SaslStreamServerDriver saslServerDriver, SaslServer authenticatedServer) {
       mUserInfo = userInfo;
+      mSaslServerDriver = saslServerDriver;
       mAuthenticatedServer = authenticatedServer;
       mLastAccessTime = LocalTime.now();
     }
@@ -215,7 +237,7 @@ public class DefaultAuthenticationServer
     }
 
     /**
-     * PS: Updates the last-access-time for this instance.
+     * Note: Updates the last-access-time for this instance.
      *
      * @return the sasl server
      */
@@ -225,13 +247,23 @@ public class DefaultAuthenticationServer
     }
 
     /**
-     * PS: Updates the last-access-time for this instance.
+     * Note: Updates the last-access-time for this instance.
      *
      * @return the user name
      */
     public AuthenticatedUserInfo getUserInfo() {
       updateLastAccessTime();
       return mUserInfo;
+    }
+
+    /**
+     * Note: Updates the last-access-time for this instance.
+     *
+     * @return the sasl server driver
+     */
+    public SaslStreamServerDriver getSaslServerDriver() {
+      updateLastAccessTime();
+      return mSaslServerDriver;
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslServerHandler.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslServerHandler.java
@@ -11,21 +11,12 @@
 
 package alluxio.security.authentication;
 
-import java.util.UUID;
-
 import javax.security.sasl.SaslServer;
 
 /**
  * Interface for authentication scheme specific {@link SaslServer} management.
  */
 public interface SaslServerHandler {
-  /**
-   * Callback that will be called when authentication complete.
-   *
-   * @param channelId channel that has been authenticated
-   * @param authenticationServer authentication server instance
-   */
-  void authenticationCompleted(UUID channelId, AuthenticationServer authenticationServer);
 
   /**
    * @return the {@link SaslServer} instance
@@ -38,4 +29,11 @@ public interface SaslServerHandler {
    * @param userinfo user info
    */
   void setAuthenticatedUserInfo(AuthenticatedUserInfo userinfo);
+
+  /**
+   * Used to get the authenticated user info after the completed session.
+   *
+   * @return the authenticated user info
+   */
+  AuthenticatedUserInfo getAuthenticatedUserInfo();
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -16,6 +16,7 @@ import alluxio.exception.status.UnauthenticatedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.exception.status.UnknownException;
 import alluxio.grpc.SaslMessage;
+import alluxio.util.LogUtils;
 
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Status;
@@ -156,7 +157,7 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
         mRequestObserver.onCompleted();
       }
     } catch (Exception exc) {
-      LOG.warn("Failed stopping authentication session with server.", exc);
+      LogUtils.warnWithException(LOG, "Failed stopping authentication session with server.", exc);
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
@@ -14,6 +14,7 @@ package alluxio.security.authentication;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.grpc.SaslMessage;
 import alluxio.grpc.SaslMessageType;
+import alluxio.util.LogUtils;
 
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -116,7 +117,7 @@ public class SaslStreamServerDriver implements StreamObserver<SaslMessage> {
       // Complete the client stream.
       mRequestObserver.onCompleted();
     } catch (Exception exc) {
-      LOG.error("Failed to complete the client stream.", exc);
+      LogUtils.warnWithException(LOG, "Failed to complete the client stream.", exc);
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
@@ -117,7 +117,8 @@ public class SaslStreamServerDriver implements StreamObserver<SaslMessage> {
       // Complete the client stream.
       mRequestObserver.onCompleted();
     } catch (Exception exc) {
-      LogUtils.warnWithException(LOG, "Failed to complete the client stream.", exc);
+      LogUtils.warnWithException(LOG, "Failed to complete the client stream for channel: {}.",
+          (mChannelId != null) ? mChannelId : "<NULL>", exc);
     }
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamServerDriver.java
@@ -109,10 +109,18 @@ public class SaslStreamServerDriver implements StreamObserver<SaslMessage> {
   @Override
   public void onCompleted() {
     // Client completes the stream when authenticated channel is being closed.
-    if (mChannelId != null) {
-      LOG.debug("Closing authenticated channel: {}", mChannelId);
-      mAuthenticationServer.unregisterChannel(mChannelId);
+    LOG.debug("Received completion for authenticated channel: {}", mChannelId);
+    // close() will be called by unregister channel if it was registered.
+    if (!mAuthenticationServer.unregisterChannel(mChannelId)) {
+      // Channel was not registered. Close stream explicitly.
+      close();
     }
+  }
+
+  /**
+   * Closes the authentication stream.
+   */
+  public void close() {
     try {
       // Complete the client stream.
       mRequestObserver.onCompleted();

--- a/core/common/src/main/java/alluxio/security/authentication/plain/SaslServerHandlerPlain.java
+++ b/core/common/src/main/java/alluxio/security/authentication/plain/SaslServerHandlerPlain.java
@@ -15,13 +15,11 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.AuthenticatedUserInfo;
 import alluxio.security.authentication.AuthenticationProvider;
-import alluxio.security.authentication.AuthenticationServer;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.SaslServerHandler;
 
 import java.security.Security;
 import java.util.HashMap;
-import java.util.UUID;
 
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
@@ -54,15 +52,14 @@ public class SaslServerHandlerPlain implements SaslServerHandler {
   }
 
   @Override
-  public void authenticationCompleted(UUID channelId, AuthenticationServer authenticationServer) {
-    authenticationServer.registerChannel(channelId,
-        new AuthenticatedUserInfo(mSaslServer.getAuthorizationID()), mSaslServer);
-  }
-
-  @Override
   public void setAuthenticatedUserInfo(AuthenticatedUserInfo userinfo) {
     // Plain authentication only needs authorized user name which is available in completed
     // SaslServer instance.
+  }
+
+  @Override
+  public AuthenticatedUserInfo getAuthenticatedUserInfo() {
+    return new AuthenticatedUserInfo(mSaslServer.getAuthorizationID());
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -177,7 +177,7 @@ public class GrpcSecurityTest {
   @Test
   public void testAuthenticationRevoked() throws Exception {
     mConfiguration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE.getAuthName());
-    mConfiguration.set(PropertyKey.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD, "2sec");
+    mConfiguration.set(PropertyKey.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD, "250ms");
     GrpcServer server = createServer(AuthType.SIMPLE);
     server.start();
     UserState us = UserState.Factory.create(mConfiguration);
@@ -192,7 +192,7 @@ public class GrpcSecurityTest {
      *
      * Sleep more than authentication revocation timeout.
      */
-    Thread.sleep(5000);
+    Thread.sleep(500);
     Assert.assertFalse(channel.isHealthy());
 
     server.shutdown();

--- a/tests/src/test/java/alluxio/client/fuse/FuseFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/FuseFileSystemIntegrationTest.java
@@ -257,8 +257,8 @@ public class FuseFileSystemIntegrationTest {
   }
 
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD, "3sec"})
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD, "250ms"})
   public void continueWithRevokedAuth() throws Exception {
     String testFile = "/tailTestFile";
     String content = "Alluxio Tail Test File Content";
@@ -275,7 +275,7 @@ public class FuseFileSystemIntegrationTest {
      *
      * Sleep more than authentication revocation timeout.
      */
-    Thread.sleep(6000);
+    Thread.sleep(500);
 
     result = ShellUtils.execCommand("tail", "-c", "17", sMountPoint + testFile);
     Assert.assertEquals("Test File Content\n", result);

--- a/tests/src/test/java/alluxio/client/fuse/FuseFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/FuseFileSystemIntegrationTest.java
@@ -257,6 +257,31 @@ public class FuseFileSystemIntegrationTest {
   }
 
   @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.AUTHENTICATION_INACTIVE_CHANNEL_REAUTHENTICATE_PERIOD, "3sec"})
+  public void continueWithRevokedAuth() throws Exception {
+    String testFile = "/tailTestFile";
+    String content = "Alluxio Tail Test File Content";
+    try (FileOutStream os = sFileSystem.createFile(new AlluxioURI(testFile))) {
+      os.write(content.getBytes());
+    }
+    String result = ShellUtils.execCommand("tail", "-c", "17", sMountPoint + testFile);
+    Assert.assertEquals("Test File Content\n", result);
+
+    /*
+     * Sleeping will ensure that authentication sessions for existing clients held by FUSE will
+     * expire on the server. This should have propagated back to the client and reauthentication
+     * should happen on the background for making the second call succeed.
+     *
+     * Sleep more than authentication revocation timeout.
+     */
+    Thread.sleep(6000);
+
+    result = ShellUtils.execCommand("tail", "-c", "17", sMountPoint + testFile);
+    Assert.assertEquals("Test File Content\n", result);
+  }
+
+  @Test
   public void touchAndLs() throws Exception {
     FileSystemTestUtils.createByteFile(sFileSystem, "/lsTestFile", WritePType.MUST_CACHE, 10);
     String touchTestFile = "/touchTestFile";


### PR DESCRIPTION
`AuthenticationServer` has a setting for revoking authentication after a period of inactivity. To handle that on the client side, metadata clients, after a period of inactivity, will retry after getting `Unauthenticated` code. However, due to nature of streaming, data clients can not retry after getting the error because they might have pipelined more data before seeing the error. And since this revocation will not change the connection state, they used to continue getting `Unauthenticated`. See https://github.com/Alluxio/alluxio/issues/9089 for an instance of this problem.

This PR introduces long polling to authentication handshake. Client and server will not complete streams used for authentication and instead will use it for notifying end of an authentication session. With this change, revocation on server will be propagated to client channel via health status, causing a client recreation for later use of the same channel. Also client closing the channel will notify server and it'll clean its state of the recently closed channel. 

Periodic cleanup has not been disabled in order to not prolong a duration for a channel to remain authenticated.