### PR TITLE
Prevent async eviction of ASYNC_THROUGH because of race condition

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -156,9 +156,7 @@ public final class GrpcDataWriter implements DataWriter {
       builder.setCreateUfsBlockOptions(ufsBlockOptions);
     }
     // check if we need to pin block on create
-    if (options.getWriteType() == WriteType.ASYNC_THROUGH) {
-      builder.setPinned(true);
-    }
+    builder.setPinOnCreate(options.getWriteType() == WriteType.ASYNC_THROUGH);
     mPartialRequest = builder.buildPartial();
     mChunkSize = chunkSize;
     mClient = client;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.block.stream;
 
+import alluxio.client.WriteType;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.conf.AlluxioConfiguration;
@@ -153,6 +154,10 @@ public final class GrpcDataWriter implements DataWriter {
           .setMountId(options.getMountId())
           .setFallback(alreadyFallback).build();
       builder.setCreateUfsBlockOptions(ufsBlockOptions);
+    }
+    // check if we need to pin block on create
+    if (options.getWriteType() == WriteType.ASYNC_THROUGH) {
+      builder.setPinned(true);
     }
     mPartialRequest = builder.buildPartial();
     mChunkSize = chunkSize;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -81,9 +81,9 @@ public final class LocalFileDataWriter implements DataWriter {
       long dataTimeout = conf.getMs(PropertyKey.USER_NETWORK_DATA_TIMEOUT_MS);
 
       CreateLocalBlockRequest.Builder builder =
-          CreateLocalBlockRequest.newBuilder().setBlockId(blockId)
-              .setTier(options.getWriteTier()).setSpaceToReserve(fileBufferByes)
-              .setMediumType(options.getMediumType());
+          CreateLocalBlockRequest.newBuilder().setBlockId(blockId).setTier(options.getWriteTier())
+              .setSpaceToReserve(fileBufferByes).setMediumType(options.getMediumType())
+              .setPinned(options.getWriteType() == WriteType.ASYNC_THROUGH);
       if (options.getWriteType() == WriteType.ASYNC_THROUGH
           && conf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED)) {
         builder.setCleanupOnFailure(false);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -83,7 +83,7 @@ public final class LocalFileDataWriter implements DataWriter {
       CreateLocalBlockRequest.Builder builder =
           CreateLocalBlockRequest.newBuilder().setBlockId(blockId).setTier(options.getWriteTier())
               .setSpaceToReserve(fileBufferByes).setMediumType(options.getMediumType())
-              .setPinned(options.getWriteType() == WriteType.ASYNC_THROUGH);
+              .setPinOnCreate(options.getWriteType() == WriteType.ASYNC_THROUGH);
       if (options.getWriteType() == WriteType.ASYNC_THROUGH
           && conf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED)) {
         builder.setCleanupOnFailure(false);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -77,12 +77,12 @@ public final class LocalFileDataWriter implements DataWriter {
       closer.register(() -> context.releaseBlockWorkerClient(address, blockWorker));
       int writerBufferSizeMessages =
           conf.getInt(PropertyKey.USER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES);
-      long fileBufferByes = conf.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
+      long fileBufferBytes = conf.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
       long dataTimeout = conf.getMs(PropertyKey.USER_NETWORK_DATA_TIMEOUT_MS);
 
       CreateLocalBlockRequest.Builder builder =
           CreateLocalBlockRequest.newBuilder().setBlockId(blockId).setTier(options.getWriteTier())
-              .setSpaceToReserve(fileBufferByes).setMediumType(options.getMediumType())
+              .setSpaceToReserve(fileBufferBytes).setMediumType(options.getMediumType())
               .setPinOnCreate(options.getWriteType() == WriteType.ASYNC_THROUGH);
       if (options.getWriteType() == WriteType.ASYNC_THROUGH
           && conf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED)) {
@@ -102,7 +102,7 @@ public final class LocalFileDataWriter implements DataWriter {
       LocalFileBlockWriter writer =
           closer.register(new LocalFileBlockWriter(response.getPath()));
       return new LocalFileDataWriter(chunkSize, blockWorker,
-          writer, createRequest, stream, closer, fileBufferByes,
+          writer, createRequest, stream, closer, fileBufferBytes,
           dataTimeout);
     } catch (Exception e) {
       throw CommonUtils.closeAndRethrow(closer, e);

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -212,7 +212,7 @@ public class AsyncCacheRequestManager {
         BlockWriter writer =
             mBlockWorker.getTempBlockWriterRemote(Sessions.ASYNC_CACHE_SESSION_ID, blockId)) {
       BufferUtils.fastCopy(reader.getChannel(), writer.getChannel());
-      mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId);
+      mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId, false);
       return true;
     } catch (AlluxioException | IOException e) {
       LOG.warn("Failed to async cache block {} from remote worker ({}) on copying the block: {}",

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -141,14 +141,15 @@ public interface BlockStore extends SessionCleanable {
    *
    * @param sessionId the id of the session
    * @param blockId the id of a temp block
+   * @param isPinned is block pinned on create
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
    * @throws InvalidWorkerStateException if block id does not belong to session id
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
-  void commitBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
-      BlockDoesNotExistException, InvalidWorkerStateException, IOException,
-      WorkerOutOfSpaceException;
+  void commitBlock(long sessionId, long blockId, boolean isPinned)
+      throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
+      IOException, WorkerOutOfSpaceException;
 
   /**
    * Aborts a temporary block. The metadata of this block will not be added, its data will be

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -141,13 +141,13 @@ public interface BlockStore extends SessionCleanable {
    *
    * @param sessionId the id of the session
    * @param blockId the id of a temp block
-   * @param isPinned is block pinned on create
+   * @param pinOnCreate whether to pin block on create
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
    * @throws InvalidWorkerStateException if block id does not belong to session id
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
-  void commitBlock(long sessionId, long blockId, boolean isPinned)
+  void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -67,17 +67,18 @@ public interface BlockWorker extends Worker, SessionCleanable {
 
   /**
    * Commits a block to Alluxio managed space. The block must be temporary. The block is persisted
-   * after {@link BlockStore#commitBlock(long, long)}. The block will not be accessible until
+   * after {@link BlockStore#commitBlock(long, long, boolean)}. The block will not be accessible until
    * {@link BlockMasterClient#commitBlock(long, long, String, String, long, long)} succeeds.
    *
    * @param sessionId the id of the client
    * @param blockId the id of the block to commit
+   * @param isPinned is block pinned on create
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block cannot be found
    * @throws InvalidWorkerStateException if blockId does not belong to sessionId
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
-  void commitBlock(long sessionId, long blockId)
+  void commitBlock(long sessionId, long blockId, boolean isPinned)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -72,13 +72,13 @@ public interface BlockWorker extends Worker, SessionCleanable {
    *
    * @param sessionId the id of the client
    * @param blockId the id of the block to commit
-   * @param isPinned is block pinned on create
+   * @param pinOnCreate whether to pin block on create
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block cannot be found
    * @throws InvalidWorkerStateException if blockId does not belong to sessionId
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
-  void commitBlock(long sessionId, long blockId, boolean isPinned)
+  void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException;
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -67,8 +67,8 @@ public interface BlockWorker extends Worker, SessionCleanable {
 
   /**
    * Commits a block to Alluxio managed space. The block must be temporary. The block is persisted
-   * after {@link BlockStore#commitBlock(long, long, boolean)}. The block will not be accessible until
-   * {@link BlockMasterClient#commitBlock(long, long, String, String, long, long)} succeeds.
+   * after {@link BlockStore#commitBlock(long, long, boolean)}. The block will not be accessible
+   * until {@link BlockMasterClient#commitBlock(long, long, String, String, long, long)} succeeds.
    *
    * @param sessionId the id of the client
    * @param blockId the id of the block to commit

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -300,13 +300,13 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  public void commitBlock(long sessionId, long blockId, boolean isPinned)
+  public void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException {
     // NOTE: this may be invoked multiple times due to retry on client side.
     // TODO(binfan): find a better way to handle retry logic
     try {
-      mBlockStore.commitBlock(sessionId, blockId, isPinned);
+      mBlockStore.commitBlock(sessionId, blockId, pinOnCreate);
     } catch (BlockAlreadyExistsException e) {
       LOG.debug("Block {} has been in block store, this could be a retry due to master-side RPC "
           + "failure, therefore ignore the exception", blockId, e);

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -300,13 +300,13 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  public void commitBlock(long sessionId, long blockId)
+  public void commitBlock(long sessionId, long blockId, boolean isPinned)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException {
     // NOTE: this may be invoked multiple times due to retry on client side.
     // TODO(binfan): find a better way to handle retry logic
     try {
-      mBlockStore.commitBlock(sessionId, blockId);
+      mBlockStore.commitBlock(sessionId, blockId, isPinned);
     } catch (BlockAlreadyExistsException e) {
       LOG.debug("Block {} has been in block store, this could be a retry due to master-side RPC "
           + "failure, therefore ignore the exception", blockId, e);
@@ -558,7 +558,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
       mUnderFileSystemBlockStore.closeReaderOrWriter(sessionId, blockId);
       if (mBlockStore.getTempBlockMeta(sessionId, blockId) != null) {
         try {
-          commitBlock(sessionId, blockId);
+          commitBlock(sessionId, blockId, false);
         } catch (BlockDoesNotExistException e) {
           // This can only happen if the session is expired. Ignore this exception if that happens.
           LOG.warn("Block {} does not exist while being committed.", blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -22,6 +22,7 @@ import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.WorkerOutOfSpaceException;
+import alluxio.master.block.BlockId;
 import alluxio.resource.LockResource;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.TimeoutRetry;
@@ -261,10 +262,11 @@ public class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void commitBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
-      InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+  public void commitBlock(long sessionId, long blockId, boolean isPinned)
+      throws BlockAlreadyExistsException, InvalidWorkerStateException, BlockDoesNotExistException,
+      IOException {
     LOG.debug("commitBlock: sessionId={}, blockId={}", sessionId, blockId);
-    BlockStoreLocation loc = commitBlockInternal(sessionId, blockId);
+    BlockStoreLocation loc = commitBlockInternal(sessionId, blockId, isPinned);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         listener.onCommitBlock(sessionId, blockId, loc);
@@ -515,12 +517,13 @@ public class TieredBlockStore implements BlockStore {
    *
    * @param sessionId the id of session
    * @param blockId the id of block
+   * @param isPinned is block pinned on create
    * @return destination location to move the block
    * @throws BlockDoesNotExistException if block id can not be found in temporary blocks
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws InvalidWorkerStateException if block id is not owned by session id
    */
-  private BlockStoreLocation commitBlockInternal(long sessionId, long blockId)
+  private BlockStoreLocation commitBlockInternal(long sessionId, long blockId, boolean isPinned)
       throws BlockAlreadyExistsException, InvalidWorkerStateException, BlockDoesNotExistException,
       IOException {
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.WRITE);
@@ -549,6 +552,12 @@ public class TieredBlockStore implements BlockStore {
           | WorkerOutOfSpaceException e) {
         throw Throwables.propagate(e); // we shall never reach here
       }
+
+      // Check if block is pinned on commit
+      if (isPinned) {
+        updatePinnedInodes(Collections.singleton(BlockId.getFileId(blockId)));
+      }
+
       return loc;
     } finally {
       mLockManager.unlockBlock(lockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -262,11 +262,11 @@ public class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void commitBlock(long sessionId, long blockId, boolean isPinned)
+  public void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, InvalidWorkerStateException, BlockDoesNotExistException,
       IOException {
     LOG.debug("commitBlock: sessionId={}, blockId={}", sessionId, blockId);
-    BlockStoreLocation loc = commitBlockInternal(sessionId, blockId, isPinned);
+    BlockStoreLocation loc = commitBlockInternal(sessionId, blockId, pinOnCreate);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         listener.onCommitBlock(sessionId, blockId, loc);
@@ -517,13 +517,13 @@ public class TieredBlockStore implements BlockStore {
    *
    * @param sessionId the id of session
    * @param blockId the id of block
-   * @param isPinned is block pinned on create
+   * @param pinOnCreate is block pinned on create
    * @return destination location to move the block
    * @throws BlockDoesNotExistException if block id can not be found in temporary blocks
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws InvalidWorkerStateException if block id is not owned by session id
    */
-  private BlockStoreLocation commitBlockInternal(long sessionId, long blockId, boolean isPinned)
+  private BlockStoreLocation commitBlockInternal(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, InvalidWorkerStateException, BlockDoesNotExistException,
       IOException {
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.WRITE);
@@ -554,7 +554,7 @@ public class TieredBlockStore implements BlockStore {
       }
 
       // Check if block is pinned on commit
-      if (isPinned) {
+      if (pinOnCreate) {
         addToPinnedInodes(BlockId.getFileId(blockId));
       }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -555,7 +555,7 @@ public class TieredBlockStore implements BlockStore {
 
       // Check if block is pinned on commit
       if (isPinned) {
-        updatePinnedInodes(Collections.singleton(BlockId.getFileId(blockId)));
+        addToPinnedInodes(BlockId.getFileId(blockId));
       }
 
       return loc;
@@ -889,6 +889,18 @@ public class TieredBlockStore implements BlockStore {
     synchronized (mPinnedInodes) {
       mPinnedInodes.clear();
       mPinnedInodes.addAll(Preconditions.checkNotNull(inodes));
+    }
+  }
+
+  /**
+   * Add a single inode to set of pinned ids.
+   *
+   * @param inode an inode that is pinned
+   */
+  private void addToPinnedInodes(Long inode) {
+    LOG.debug("addToPinnedInodes: inode={}", inode);
+    synchronized (mPinnedInodes) {
+      mPinnedInodes.add(Preconditions.checkNotNull(inode));
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
@@ -79,7 +79,7 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
     if (context.getBlockWriter() != null) {
       context.getBlockWriter().close();
     }
-    mWorker.commitBlock(request.getSessionId(), request.getId(), request.isPinned());
+    mWorker.commitBlock(request.getSessionId(), request.getId(), request.getPinOnCreate());
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
@@ -79,7 +79,7 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
     if (context.getBlockWriter() != null) {
       context.getBlockWriter().close();
     }
-    mWorker.commitBlock(request.getSessionId(), request.getId());
+    mWorker.commitBlock(request.getSessionId(), request.getId(), request.isPinned());
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
@@ -167,7 +167,7 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
           if (isCanceled) {
             mBlockWorker.abortBlock(mSessionId, mRequest.getBlockId());
           } else {
-            mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId(), mRequest.getPinned());
+            mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId(), mRequest.getPinOnCreate());
           }
         } finally {
           newContext.detach(previousContext);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandler.java
@@ -167,7 +167,7 @@ class ShortCircuitBlockWriteHandler implements StreamObserver<CreateLocalBlockRe
           if (isCanceled) {
             mBlockWorker.abortBlock(mSessionId, mRequest.getBlockId());
           } else {
-            mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId());
+            mBlockWorker.commitBlock(mSessionId, mRequest.getBlockId(), mRequest.getPinned());
           }
         } finally {
           newContext.detach(previousContext);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/WriteRequest.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/WriteRequest.java
@@ -25,15 +25,15 @@ public class WriteRequest {
   /** This ID can either be block ID or temp UFS file ID. */
   private final long mId;
 
-  /** Is block pinned to create. */
-  private boolean mIsPinned;
+  /** Whether to pin block on create. */
+  private boolean mPinOnCreate;
 
   /** The session id associated with all temporary resources of this request. */
   private final long mSessionId;
 
   WriteRequest(alluxio.grpc.WriteRequest request) {
     mId = request.getCommand().getId();
-    mIsPinned = request.getCommand().getPinned();
+    mPinOnCreate = request.getCommand().getPinOnCreate();
     mSessionId = IdUtils.createSessionId();
   }
 
@@ -45,10 +45,10 @@ public class WriteRequest {
   }
 
   /**
-   * @return is blocked pinned on create
+   * @return whether to pin block on create
    */
-  public boolean isPinned() {
-    return mIsPinned;
+  public boolean getPinOnCreate() {
+    return mPinOnCreate;
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/WriteRequest.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/WriteRequest.java
@@ -25,11 +25,15 @@ public class WriteRequest {
   /** This ID can either be block ID or temp UFS file ID. */
   private final long mId;
 
+  /** Is block pinned to create. */
+  private boolean mIsPinned;
+
   /** The session id associated with all temporary resources of this request. */
   private final long mSessionId;
 
   WriteRequest(alluxio.grpc.WriteRequest request) {
     mId = request.getCommand().getId();
+    mIsPinned = request.getCommand().getPinned();
     mSessionId = IdUtils.createSessionId();
   }
 
@@ -38,6 +42,13 @@ public class WriteRequest {
    */
   public long getId() {
     return mId;
+  }
+
+  /**
+   * @return is blocked pinned on create
+   */
+  public boolean isPinned() {
+    return mIsPinned;
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -189,7 +189,7 @@ public class BlockWorkerTest {
     when(blockMeta.getBlockSize()).thenReturn(length);
     when(blockStoreMeta.getUsedBytesOnTiers()).thenReturn(usedBytesOnTiers);
 
-    mBlockWorker.commitBlock(sessionId, blockId);
+    mBlockWorker.commitBlock(sessionId, blockId, false);
     verify(mBlockMasterClient).commitBlock(anyLong(), eq(usedBytes), eq(tierAlias), eq(mediumType),
         eq(blockId), eq(length));
     verify(mBlockStore).unlockBlock(lockId);
@@ -221,8 +221,8 @@ public class BlockWorkerTest {
     when(blockMeta.getBlockSize()).thenReturn(length);
     when(blockStoreMeta.getUsedBytesOnTiers()).thenReturn(usedBytesOnTiers);
 
-    doThrow(new BlockAlreadyExistsException("")).when(mBlockStore).commitBlock(sessionId, blockId);
-    mBlockWorker.commitBlock(sessionId, blockId);
+    doThrow(new BlockAlreadyExistsException("")).when(mBlockStore).commitBlock(sessionId, blockId, false);
+    mBlockWorker.commitBlock(sessionId, blockId, false);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -189,7 +189,7 @@ public class BlockWorkerTest {
     when(blockMeta.getBlockSize()).thenReturn(length);
     when(blockStoreMeta.getUsedBytesOnTiers()).thenReturn(usedBytesOnTiers);
 
-    mBlockWorker.commitBlock(sessionId, blockId, false);
+    mBlockWorker.commitBlock(sessionId, blockId, mRandom.nextBoolean());
     verify(mBlockMasterClient).commitBlock(anyLong(), eq(usedBytes), eq(tierAlias), eq(mediumType),
         eq(blockId), eq(length));
     verify(mBlockStore).unlockBlock(lockId);
@@ -223,7 +223,7 @@ public class BlockWorkerTest {
 
     doThrow(new BlockAlreadyExistsException("")).when(mBlockStore).commitBlock(sessionId, blockId,
         false);
-    mBlockWorker.commitBlock(sessionId, blockId, false);
+    mBlockWorker.commitBlock(sessionId, blockId, mRandom.nextBoolean());
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -221,7 +221,8 @@ public class BlockWorkerTest {
     when(blockMeta.getBlockSize()).thenReturn(length);
     when(blockStoreMeta.getUsedBytesOnTiers()).thenReturn(usedBytesOnTiers);
 
-    doThrow(new BlockAlreadyExistsException("")).when(mBlockStore).commitBlock(sessionId, blockId, false);
+    doThrow(new BlockAlreadyExistsException("")).when(mBlockStore).commitBlock(sessionId, blockId,
+        false);
     mBlockWorker.commitBlock(sessionId, blockId, false);
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -612,7 +612,7 @@ public final class TieredBlockStoreTest {
     mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
-    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID ,false);
+    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID , false);
     mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID, false);
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -375,6 +375,23 @@ public final class TieredBlockStoreTest {
   }
 
   /**
+   * Tests the {@link TieredBlockStore#freeSpace(long, long, BlockStoreLocation)} method.
+   */
+  @Test
+  public void freeSpaceWithPinnedBlocks() throws Exception {
+    // create a pinned block
+    TieredBlockStoreTestUtils.cache(SESSION_ID1, BLOCK_ID1, BLOCK_SIZE, mBlockStore,
+        mTestDir1.toBlockStoreLocation(), true);
+
+    // Expect an empty eviction plan is feasible
+    mThrown.expect(WorkerOutOfSpaceException.class);
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage(
+        mTestDir1.getCapacityBytes(), mTestDir1.toBlockStoreLocation().tierAlias()));
+    mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes(),
+        mTestDir1.toBlockStoreLocation());
+  }
+
+  /**
    * Tests the {@link TieredBlockStore#requestSpace(long, long, long)} method.
    */
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -187,7 +187,7 @@ public final class TieredBlockStoreTest {
   public void commitBlock() throws Exception {
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     assertFalse(mBlockStore.hasBlockMeta(TEMP_BLOCK_ID));
-    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID);
+    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID, false);
     assertTrue(mBlockStore.hasBlockMeta(TEMP_BLOCK_ID));
     assertFalse(
         FileUtils.exists(TempBlockMeta.tempPath(mTestDir1, SESSION_ID1, TEMP_BLOCK_ID)));
@@ -546,7 +546,7 @@ public final class TieredBlockStoreTest {
     mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
-    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID);
+    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID, false);
     mBlockStore.abortBlock(SESSION_ID1, TEMP_BLOCK_ID);
   }
 
@@ -612,8 +612,8 @@ public final class TieredBlockStoreTest {
     mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
-    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID);
-    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID);
+    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID ,false);
+    mBlockStore.commitBlock(SESSION_ID1, TEMP_BLOCK_ID, false);
   }
 
   /**
@@ -624,7 +624,7 @@ public final class TieredBlockStoreTest {
     mThrown.expect(BlockDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
 
-    mBlockStore.commitBlock(SESSION_ID1, BLOCK_ID1);
+    mBlockStore.commitBlock(SESSION_ID1, BLOCK_ID1, false);
   }
 
   /**
@@ -638,7 +638,7 @@ public final class TieredBlockStoreTest {
         SESSION_ID1, SESSION_ID2));
 
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
-    mBlockStore.commitBlock(SESSION_ID2, TEMP_BLOCK_ID);
+    mBlockStore.commitBlock(SESSION_ID2, TEMP_BLOCK_ID, false);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -270,18 +270,18 @@ public final class TieredBlockStoreTestUtils {
    * @param bytes size of the block in bytes
    * @param blockStore block store that the block is written into
    * @param location the location where the block resides
+   * @param pinOnCreate whether to pin block on create
    */
   public static void cache(long sessionId, long blockId, long bytes, BlockStore blockStore,
-      BlockStoreLocation location) throws Exception {
+      BlockStoreLocation location, boolean pinOnCreate) throws Exception {
     TempBlockMeta tempBlockMeta = blockStore.createBlock(sessionId, blockId, location, bytes);
     // write data
-    FileUtils.createFile(tempBlockMeta.getPath());
     BlockWriter writer = new LocalFileBlockWriter(tempBlockMeta.getPath());
     writer.append(BufferUtils.getIncreasingByteBuffer(Ints.checkedCast(bytes)));
     writer.close();
 
     // commit block
-    blockStore.commitBlock(sessionId, blockId, false);
+    blockStore.commitBlock(sessionId, blockId, pinOnCreate);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -281,7 +281,7 @@ public final class TieredBlockStoreTestUtils {
     writer.close();
 
     // commit block
-    blockStore.commitBlock(sessionId, blockId);
+    blockStore.commitBlock(sessionId, blockId, false);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -101,7 +101,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   private void checkTempBlock(long start, long length) throws Exception {
     Assert.assertNotNull(mAlluxioBlockStore.getTempBlockMeta(SESSION_ID, BLOCK_ID));
-    mAlluxioBlockStore.commitBlock(SESSION_ID, BLOCK_ID);
+    mAlluxioBlockStore.commitBlock(SESSION_ID, BLOCK_ID, false);
     long lockId = mAlluxioBlockStore.lockBlock(SESSION_ID, BLOCK_ID);
     BlockReader reader = mAlluxioBlockStore.getBlockReader(SESSION_ID, BLOCK_ID, lockId);
     Assert.assertEquals(length, reader.getLength());

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/BlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/BlockWriteHandlerTest.java
@@ -45,7 +45,8 @@ public final class BlockWriteHandlerTest extends AbstractWriteHandlerTest {
     Mockito.doNothing().when(mBlockWorker)
         .requestSpace(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
     Mockito.doNothing().when(mBlockWorker).abortBlock(Mockito.anyLong(), Mockito.anyLong());
-    Mockito.doNothing().when(mBlockWorker).commitBlock(Mockito.anyLong(), Mockito.anyLong());
+    Mockito.doNothing().when(mBlockWorker).commitBlock(Mockito.anyLong(), Mockito.anyLong(),
+        Mockito.anyBoolean());
     mBlockWriter = new LocalFileBlockWriter(mFile.getPath());
     Mockito.when(mBlockWorker.getTempBlockWriterRemote(Mockito.anyLong(), Mockito.anyLong()))
         .thenReturn(mBlockWriter)

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -127,7 +127,7 @@ message OpenLocalBlockResponse {
   optional string path = 1;
 }
 
-// next available id: 8
+// next available id: 9
 message CreateLocalBlockRequest {
   optional int64 block_id = 1;
   optional int32 tier = 3;
@@ -136,6 +136,7 @@ message CreateLocalBlockRequest {
   optional bool only_reserve_space = 5;
   optional bool cleanup_on_failure = 6;
   optional string medium_type = 7;
+  optional bool pinned = 8;
 }
 
 // next available id: 2

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -82,7 +82,7 @@ message WriteRequestCommand {
   optional alluxio.proto.dataserver.CreateUfsFileOptions create_ufs_file_options = 6;
   optional alluxio.proto.dataserver.CreateUfsBlockOptions create_ufs_block_options = 7;
   optional string medium_type = 8;
-  optional bool pinned = 9;
+  optional bool pin_on_create = 9;
 }
 
 // The write request.
@@ -136,7 +136,7 @@ message CreateLocalBlockRequest {
   optional bool only_reserve_space = 5;
   optional bool cleanup_on_failure = 6;
   optional string medium_type = 7;
-  optional bool pinned = 8;
+  optional bool pin_on_create = 8;
 }
 
 // next available id: 2

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -69,7 +69,7 @@ message ReadResponse {
 }
 
 // The write request command.
-// next available id: 9
+// next available id: 10
 message WriteRequestCommand {
   optional RequestType type = 1;
   // The block ID or UFS file ID.
@@ -82,6 +82,7 @@ message WriteRequestCommand {
   optional alluxio.proto.dataserver.CreateUfsFileOptions create_ufs_file_options = 6;
   optional alluxio.proto.dataserver.CreateUfsBlockOptions create_ufs_block_options = 7;
   optional string medium_type = 8;
+  optional bool pinned = 9;
 }
 
 // The write request.

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -143,35 +143,36 @@ public final class BlockWorkerProto {
       "\030\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025OpenLoca" +
       "lBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promo" +
       "te\030\002 \001(\010\"&\n\026OpenLocalBlockResponse\022\014\n\004pa" +
-      "th\030\001 \001(\t\"\240\001\n\027CreateLocalBlockRequest\022\020\n\010" +
+      "th\030\001 \001(\t\"\260\001\n\027CreateLocalBlockRequest\022\020\n\010" +
       "block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to" +
       "_reserve\030\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001" +
       "(\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\022\023\n\013medium" +
-      "_type\030\007 \001(\t\"(\n\030CreateLocalBlockResponse\022" +
-      "\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlockRequest\022\020\n\010b" +
-      "lock_id\030\001 \001(\003\"\025\n\023RemoveBlockResponse\"9\n\020" +
-      "MoveBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013me" +
-      "dium_type\030\002 \001(\t\"\023\n\021MoveBlockResponse*F\n\013" +
-      "RequestType\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FI" +
-      "LE\020\001\022\026\n\022UFS_FALLBACK_BLOCK\020\0022\257\005\n\013BlockWo" +
-      "rker\022R\n\tReadBlock\022\037.alluxio.grpc.block.R" +
-      "eadRequest\032 .alluxio.grpc.block.ReadResp" +
-      "onse(\0010\001\022U\n\nWriteBlock\022 .alluxio.grpc.bl" +
-      "ock.WriteRequest\032!.alluxio.grpc.block.Wr" +
-      "iteResponse(\0010\001\022k\n\016OpenLocalBlock\022).allu" +
-      "xio.grpc.block.OpenLocalBlockRequest\032*.a" +
-      "lluxio.grpc.block.OpenLocalBlockResponse" +
-      "(\0010\001\022q\n\020CreateLocalBlock\022+.alluxio.grpc." +
-      "block.CreateLocalBlockRequest\032,.alluxio." +
-      "grpc.block.CreateLocalBlockResponse(\0010\001\022" +
-      "[\n\nAsyncCache\022%.alluxio.grpc.block.Async" +
-      "CacheRequest\032&.alluxio.grpc.block.AsyncC" +
-      "acheResponse\022^\n\013RemoveBlock\022&.alluxio.gr" +
-      "pc.block.RemoveBlockRequest\032\'.alluxio.gr" +
-      "pc.block.RemoveBlockResponse\022X\n\tMoveBloc" +
-      "k\022$.alluxio.grpc.block.MoveBlockRequest\032" +
-      "%.alluxio.grpc.block.MoveBlockResponseB\"" +
-      "\n\014alluxio.grpcB\020BlockWorkerProtoP\001"
+      "_type\030\007 \001(\t\022\016\n\006pinned\030\010 \001(\010\"(\n\030CreateLoc" +
+      "alBlockResponse\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveB" +
+      "lockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023RemoveB" +
+      "lockResponse\"9\n\020MoveBlockRequest\022\020\n\010bloc" +
+      "k_id\030\001 \001(\003\022\023\n\013medium_type\030\002 \001(\t\"\023\n\021MoveB" +
+      "lockResponse*F\n\013RequestType\022\021\n\rALLUXIO_B" +
+      "LOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_BLO" +
+      "CK\020\0022\257\005\n\013BlockWorker\022R\n\tReadBlock\022\037.allu" +
+      "xio.grpc.block.ReadRequest\032 .alluxio.grp" +
+      "c.block.ReadResponse(\0010\001\022U\n\nWriteBlock\022 " +
+      ".alluxio.grpc.block.WriteRequest\032!.allux" +
+      "io.grpc.block.WriteResponse(\0010\001\022k\n\016OpenL" +
+      "ocalBlock\022).alluxio.grpc.block.OpenLocal" +
+      "BlockRequest\032*.alluxio.grpc.block.OpenLo" +
+      "calBlockResponse(\0010\001\022q\n\020CreateLocalBlock" +
+      "\022+.alluxio.grpc.block.CreateLocalBlockRe" +
+      "quest\032,.alluxio.grpc.block.CreateLocalBl" +
+      "ockResponse(\0010\001\022[\n\nAsyncCache\022%.alluxio." +
+      "grpc.block.AsyncCacheRequest\032&.alluxio.g" +
+      "rpc.block.AsyncCacheResponse\022^\n\013RemoveBl" +
+      "ock\022&.alluxio.grpc.block.RemoveBlockRequ" +
+      "est\032\'.alluxio.grpc.block.RemoveBlockResp" +
+      "onse\022X\n\tMoveBlock\022$.alluxio.grpc.block.M" +
+      "oveBlockRequest\032%.alluxio.grpc.block.Mov" +
+      "eBlockResponseB\"\n\014alluxio.grpcB\020BlockWor" +
+      "kerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -264,7 +265,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_CreateLocalBlockRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_CreateLocalBlockRequest_descriptor,
-        new java.lang.String[] { "BlockId", "Tier", "SpaceToReserve", "OnlyReserveSpace", "CleanupOnFailure", "MediumType", });
+        new java.lang.String[] { "BlockId", "Tier", "SpaceToReserve", "OnlyReserveSpace", "CleanupOnFailure", "MediumType", "Pinned", });
     internal_static_alluxio_grpc_block_CreateLocalBlockResponse_descriptor =
       getDescriptor().getMessageTypes().get(13);
     internal_static_alluxio_grpc_block_CreateLocalBlockResponse_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -123,7 +123,7 @@ public final class BlockWorkerProto {
       "ns\030\006 \001(\0132-.alluxio.proto.dataserver.Open" +
       "UfsBlockOptions\022\027\n\017offset_received\030\007 \001(\003" +
       "\"8\n\014ReadResponse\022(\n\005chunk\030\001 \001(\0132\031.alluxi" +
-      "o.grpc.block.Chunk\"\266\002\n\023WriteRequestComma" +
+      "o.grpc.block.Chunk\"\306\002\n\023WriteRequestComma" +
       "nd\022-\n\004type\030\001 \001(\0162\037.alluxio.grpc.block.Re" +
       "questType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n" +
       "\004tier\030\004 \001(\005\022\r\n\005flush\030\005 \001(\010\022O\n\027create_ufs" +
@@ -131,47 +131,47 @@ public final class BlockWorkerProto {
       "server.CreateUfsFileOptions\022Q\n\030create_uf" +
       "s_block_options\030\007 \001(\0132/.alluxio.proto.da" +
       "taserver.CreateUfsBlockOptions\022\023\n\013medium" +
-      "_type\030\010 \001(\t\"\177\n\014WriteRequest\022:\n\007command\030\001" +
-      " \001(\0132\'.alluxio.grpc.block.WriteRequestCo" +
-      "mmandH\000\022*\n\005chunk\030\002 \001(\0132\031.alluxio.grpc.bl" +
-      "ock.ChunkH\000B\007\n\005value\"\037\n\rWriteResponse\022\016\n" +
-      "\006offset\030\001 \001(\003\"\256\001\n\021AsyncCacheRequest\022\020\n\010b" +
-      "lock_id\030\001 \001(\003\022\023\n\013source_host\030\002 \001(\t\022\023\n\013so" +
-      "urce_port\030\003 \001(\005\022M\n\026open_ufs_block_option" +
-      "s\030\004 \001(\0132-.alluxio.proto.dataserver.OpenU" +
-      "fsBlockOptions\022\016\n\006length\030\005 \001(\003\"\024\n\022AsyncC" +
-      "acheResponse\":\n\025OpenLocalBlockRequest\022\020\n" +
-      "\010block_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"&\n\026Open" +
-      "LocalBlockResponse\022\014\n\004path\030\001 \001(\t\"\240\001\n\027Cre" +
-      "ateLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\014" +
-      "\n\004tier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032" +
-      "\n\022only_reserve_space\030\005 \001(\010\022\032\n\022cleanup_on" +
-      "_failure\030\006 \001(\010\022\023\n\013medium_type\030\007 \001(\t\"(\n\030C" +
-      "reateLocalBlockResponse\022\014\n\004path\030\001 \001(\t\"&\n" +
-      "\022RemoveBlockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n" +
-      "\023RemoveBlockResponse\"9\n\020MoveBlockRequest" +
-      "\022\020\n\010block_id\030\001 \001(\003\022\023\n\013medium_type\030\002 \001(\t\"" +
-      "\023\n\021MoveBlockResponse*F\n\013RequestType\022\021\n\rA" +
-      "LLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALL" +
-      "BACK_BLOCK\020\0022\257\005\n\013BlockWorker\022R\n\tReadBloc" +
-      "k\022\037.alluxio.grpc.block.ReadRequest\032 .all" +
-      "uxio.grpc.block.ReadResponse(\0010\001\022U\n\nWrit" +
-      "eBlock\022 .alluxio.grpc.block.WriteRequest" +
-      "\032!.alluxio.grpc.block.WriteResponse(\0010\001\022" +
-      "k\n\016OpenLocalBlock\022).alluxio.grpc.block.O" +
-      "penLocalBlockRequest\032*.alluxio.grpc.bloc" +
-      "k.OpenLocalBlockResponse(\0010\001\022q\n\020CreateLo" +
-      "calBlock\022+.alluxio.grpc.block.CreateLoca" +
-      "lBlockRequest\032,.alluxio.grpc.block.Creat" +
-      "eLocalBlockResponse(\0010\001\022[\n\nAsyncCache\022%." +
-      "alluxio.grpc.block.AsyncCacheRequest\032&.a" +
-      "lluxio.grpc.block.AsyncCacheResponse\022^\n\013" +
-      "RemoveBlock\022&.alluxio.grpc.block.RemoveB" +
-      "lockRequest\032\'.alluxio.grpc.block.RemoveB" +
-      "lockResponse\022X\n\tMoveBlock\022$.alluxio.grpc" +
-      ".block.MoveBlockRequest\032%.alluxio.grpc.b" +
-      "lock.MoveBlockResponseB\"\n\014alluxio.grpcB\020" +
-      "BlockWorkerProtoP\001"
+      "_type\030\010 \001(\t\022\016\n\006pinned\030\t \001(\010\"\177\n\014WriteRequ" +
+      "est\022:\n\007command\030\001 \001(\0132\'.alluxio.grpc.bloc" +
+      "k.WriteRequestCommandH\000\022*\n\005chunk\030\002 \001(\0132\031" +
+      ".alluxio.grpc.block.ChunkH\000B\007\n\005value\"\037\n\r" +
+      "WriteResponse\022\016\n\006offset\030\001 \001(\003\"\256\001\n\021AsyncC" +
+      "acheRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013source_" +
+      "host\030\002 \001(\t\022\023\n\013source_port\030\003 \001(\005\022M\n\026open_" +
+      "ufs_block_options\030\004 \001(\0132-.alluxio.proto." +
+      "dataserver.OpenUfsBlockOptions\022\016\n\006length" +
+      "\030\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025OpenLoca" +
+      "lBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promo" +
+      "te\030\002 \001(\010\"&\n\026OpenLocalBlockResponse\022\014\n\004pa" +
+      "th\030\001 \001(\t\"\240\001\n\027CreateLocalBlockRequest\022\020\n\010" +
+      "block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to" +
+      "_reserve\030\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001" +
+      "(\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\022\023\n\013medium" +
+      "_type\030\007 \001(\t\"(\n\030CreateLocalBlockResponse\022" +
+      "\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlockRequest\022\020\n\010b" +
+      "lock_id\030\001 \001(\003\"\025\n\023RemoveBlockResponse\"9\n\020" +
+      "MoveBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013me" +
+      "dium_type\030\002 \001(\t\"\023\n\021MoveBlockResponse*F\n\013" +
+      "RequestType\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FI" +
+      "LE\020\001\022\026\n\022UFS_FALLBACK_BLOCK\020\0022\257\005\n\013BlockWo" +
+      "rker\022R\n\tReadBlock\022\037.alluxio.grpc.block.R" +
+      "eadRequest\032 .alluxio.grpc.block.ReadResp" +
+      "onse(\0010\001\022U\n\nWriteBlock\022 .alluxio.grpc.bl" +
+      "ock.WriteRequest\032!.alluxio.grpc.block.Wr" +
+      "iteResponse(\0010\001\022k\n\016OpenLocalBlock\022).allu" +
+      "xio.grpc.block.OpenLocalBlockRequest\032*.a" +
+      "lluxio.grpc.block.OpenLocalBlockResponse" +
+      "(\0010\001\022q\n\020CreateLocalBlock\022+.alluxio.grpc." +
+      "block.CreateLocalBlockRequest\032,.alluxio." +
+      "grpc.block.CreateLocalBlockResponse(\0010\001\022" +
+      "[\n\nAsyncCache\022%.alluxio.grpc.block.Async" +
+      "CacheRequest\032&.alluxio.grpc.block.AsyncC" +
+      "acheResponse\022^\n\013RemoveBlock\022&.alluxio.gr" +
+      "pc.block.RemoveBlockRequest\032\'.alluxio.gr" +
+      "pc.block.RemoveBlockResponse\022X\n\tMoveBloc" +
+      "k\022$.alluxio.grpc.block.MoveBlockRequest\032" +
+      "%.alluxio.grpc.block.MoveBlockResponseB\"" +
+      "\n\014alluxio.grpcB\020BlockWorkerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -222,7 +222,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_WriteRequestCommand_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_WriteRequestCommand_descriptor,
-        new java.lang.String[] { "Type", "Id", "Offset", "Tier", "Flush", "CreateUfsFileOptions", "CreateUfsBlockOptions", "MediumType", });
+        new java.lang.String[] { "Type", "Id", "Offset", "Tier", "Flush", "CreateUfsFileOptions", "CreateUfsBlockOptions", "MediumType", "Pinned", });
     internal_static_alluxio_grpc_block_WriteRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_alluxio_grpc_block_WriteRequest_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -123,7 +123,7 @@ public final class BlockWorkerProto {
       "ns\030\006 \001(\0132-.alluxio.proto.dataserver.Open" +
       "UfsBlockOptions\022\027\n\017offset_received\030\007 \001(\003" +
       "\"8\n\014ReadResponse\022(\n\005chunk\030\001 \001(\0132\031.alluxi" +
-      "o.grpc.block.Chunk\"\306\002\n\023WriteRequestComma" +
+      "o.grpc.block.Chunk\"\315\002\n\023WriteRequestComma" +
       "nd\022-\n\004type\030\001 \001(\0162\037.alluxio.grpc.block.Re" +
       "questType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n" +
       "\004tier\030\004 \001(\005\022\r\n\005flush\030\005 \001(\010\022O\n\027create_ufs" +
@@ -131,48 +131,48 @@ public final class BlockWorkerProto {
       "server.CreateUfsFileOptions\022Q\n\030create_uf" +
       "s_block_options\030\007 \001(\0132/.alluxio.proto.da" +
       "taserver.CreateUfsBlockOptions\022\023\n\013medium" +
-      "_type\030\010 \001(\t\022\016\n\006pinned\030\t \001(\010\"\177\n\014WriteRequ" +
-      "est\022:\n\007command\030\001 \001(\0132\'.alluxio.grpc.bloc" +
-      "k.WriteRequestCommandH\000\022*\n\005chunk\030\002 \001(\0132\031" +
-      ".alluxio.grpc.block.ChunkH\000B\007\n\005value\"\037\n\r" +
-      "WriteResponse\022\016\n\006offset\030\001 \001(\003\"\256\001\n\021AsyncC" +
-      "acheRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013source_" +
-      "host\030\002 \001(\t\022\023\n\013source_port\030\003 \001(\005\022M\n\026open_" +
-      "ufs_block_options\030\004 \001(\0132-.alluxio.proto." +
-      "dataserver.OpenUfsBlockOptions\022\016\n\006length" +
-      "\030\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025OpenLoca" +
-      "lBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promo" +
-      "te\030\002 \001(\010\"&\n\026OpenLocalBlockResponse\022\014\n\004pa" +
-      "th\030\001 \001(\t\"\260\001\n\027CreateLocalBlockRequest\022\020\n\010" +
-      "block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to" +
-      "_reserve\030\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001" +
-      "(\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\022\023\n\013medium" +
-      "_type\030\007 \001(\t\022\016\n\006pinned\030\010 \001(\010\"(\n\030CreateLoc" +
-      "alBlockResponse\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveB" +
-      "lockRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023RemoveB" +
-      "lockResponse\"9\n\020MoveBlockRequest\022\020\n\010bloc" +
-      "k_id\030\001 \001(\003\022\023\n\013medium_type\030\002 \001(\t\"\023\n\021MoveB" +
-      "lockResponse*F\n\013RequestType\022\021\n\rALLUXIO_B" +
-      "LOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_BLO" +
-      "CK\020\0022\257\005\n\013BlockWorker\022R\n\tReadBlock\022\037.allu" +
-      "xio.grpc.block.ReadRequest\032 .alluxio.grp" +
-      "c.block.ReadResponse(\0010\001\022U\n\nWriteBlock\022 " +
-      ".alluxio.grpc.block.WriteRequest\032!.allux" +
-      "io.grpc.block.WriteResponse(\0010\001\022k\n\016OpenL" +
-      "ocalBlock\022).alluxio.grpc.block.OpenLocal" +
-      "BlockRequest\032*.alluxio.grpc.block.OpenLo" +
-      "calBlockResponse(\0010\001\022q\n\020CreateLocalBlock" +
-      "\022+.alluxio.grpc.block.CreateLocalBlockRe" +
-      "quest\032,.alluxio.grpc.block.CreateLocalBl" +
-      "ockResponse(\0010\001\022[\n\nAsyncCache\022%.alluxio." +
-      "grpc.block.AsyncCacheRequest\032&.alluxio.g" +
-      "rpc.block.AsyncCacheResponse\022^\n\013RemoveBl" +
-      "ock\022&.alluxio.grpc.block.RemoveBlockRequ" +
-      "est\032\'.alluxio.grpc.block.RemoveBlockResp" +
-      "onse\022X\n\tMoveBlock\022$.alluxio.grpc.block.M" +
-      "oveBlockRequest\032%.alluxio.grpc.block.Mov" +
-      "eBlockResponseB\"\n\014alluxio.grpcB\020BlockWor" +
-      "kerProtoP\001"
+      "_type\030\010 \001(\t\022\025\n\rpin_on_create\030\t \001(\010\"\177\n\014Wr" +
+      "iteRequest\022:\n\007command\030\001 \001(\0132\'.alluxio.gr" +
+      "pc.block.WriteRequestCommandH\000\022*\n\005chunk\030" +
+      "\002 \001(\0132\031.alluxio.grpc.block.ChunkH\000B\007\n\005va" +
+      "lue\"\037\n\rWriteResponse\022\016\n\006offset\030\001 \001(\003\"\256\001\n" +
+      "\021AsyncCacheRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013" +
+      "source_host\030\002 \001(\t\022\023\n\013source_port\030\003 \001(\005\022M" +
+      "\n\026open_ufs_block_options\030\004 \001(\0132-.alluxio" +
+      ".proto.dataserver.OpenUfsBlockOptions\022\016\n" +
+      "\006length\030\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025O" +
+      "penLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017" +
+      "\n\007promote\030\002 \001(\010\"&\n\026OpenLocalBlockRespons" +
+      "e\022\014\n\004path\030\001 \001(\t\"\267\001\n\027CreateLocalBlockRequ" +
+      "est\022\020\n\010block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020s" +
+      "pace_to_reserve\030\004 \001(\003\022\032\n\022only_reserve_sp" +
+      "ace\030\005 \001(\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\022\023\n" +
+      "\013medium_type\030\007 \001(\t\022\025\n\rpin_on_create\030\010 \001(" +
+      "\010\"(\n\030CreateLocalBlockResponse\022\014\n\004path\030\001 " +
+      "\001(\t\"&\n\022RemoveBlockRequest\022\020\n\010block_id\030\001 " +
+      "\001(\003\"\025\n\023RemoveBlockResponse\"9\n\020MoveBlockR" +
+      "equest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013medium_type\030" +
+      "\002 \001(\t\"\023\n\021MoveBlockResponse*F\n\013RequestTyp" +
+      "e\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UF" +
+      "S_FALLBACK_BLOCK\020\0022\257\005\n\013BlockWorker\022R\n\tRe" +
+      "adBlock\022\037.alluxio.grpc.block.ReadRequest" +
+      "\032 .alluxio.grpc.block.ReadResponse(\0010\001\022U" +
+      "\n\nWriteBlock\022 .alluxio.grpc.block.WriteR" +
+      "equest\032!.alluxio.grpc.block.WriteRespons" +
+      "e(\0010\001\022k\n\016OpenLocalBlock\022).alluxio.grpc.b" +
+      "lock.OpenLocalBlockRequest\032*.alluxio.grp" +
+      "c.block.OpenLocalBlockResponse(\0010\001\022q\n\020Cr" +
+      "eateLocalBlock\022+.alluxio.grpc.block.Crea" +
+      "teLocalBlockRequest\032,.alluxio.grpc.block" +
+      ".CreateLocalBlockResponse(\0010\001\022[\n\nAsyncCa" +
+      "che\022%.alluxio.grpc.block.AsyncCacheReque" +
+      "st\032&.alluxio.grpc.block.AsyncCacheRespon" +
+      "se\022^\n\013RemoveBlock\022&.alluxio.grpc.block.R" +
+      "emoveBlockRequest\032\'.alluxio.grpc.block.R" +
+      "emoveBlockResponse\022X\n\tMoveBlock\022$.alluxi" +
+      "o.grpc.block.MoveBlockRequest\032%.alluxio." +
+      "grpc.block.MoveBlockResponseB\"\n\014alluxio." +
+      "grpcB\020BlockWorkerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -223,7 +223,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_WriteRequestCommand_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_WriteRequestCommand_descriptor,
-        new java.lang.String[] { "Type", "Id", "Offset", "Tier", "Flush", "CreateUfsFileOptions", "CreateUfsBlockOptions", "MediumType", "Pinned", });
+        new java.lang.String[] { "Type", "Id", "Offset", "Tier", "Flush", "CreateUfsFileOptions", "CreateUfsBlockOptions", "MediumType", "PinOnCreate", });
     internal_static_alluxio_grpc_block_WriteRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_alluxio_grpc_block_WriteRequest_fieldAccessorTable = new
@@ -265,7 +265,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_CreateLocalBlockRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_CreateLocalBlockRequest_descriptor,
-        new java.lang.String[] { "BlockId", "Tier", "SpaceToReserve", "OnlyReserveSpace", "CleanupOnFailure", "MediumType", "Pinned", });
+        new java.lang.String[] { "BlockId", "Tier", "SpaceToReserve", "OnlyReserveSpace", "CleanupOnFailure", "MediumType", "PinOnCreate", });
     internal_static_alluxio_grpc_block_CreateLocalBlockResponse_descriptor =
       getDescriptor().getMessageTypes().get(13);
     internal_static_alluxio_grpc_block_CreateLocalBlockResponse_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequest.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequest.java
@@ -5,7 +5,7 @@ package alluxio.grpc;
 
 /**
  * <pre>
- * next available id: 8
+ * next available id: 9
  * </pre>
  *
  * Protobuf type {@code alluxio.grpc.block.CreateLocalBlockRequest}
@@ -26,6 +26,7 @@ private static final long serialVersionUID = 0L;
     onlyReserveSpace_ = false;
     cleanupOnFailure_ = false;
     mediumType_ = "";
+    pinned_ = false;
   }
 
   @java.lang.Override
@@ -88,6 +89,11 @@ private static final long serialVersionUID = 0L;
             com.google.protobuf.ByteString bs = input.readBytes();
             bitField0_ |= 0x00000020;
             mediumType_ = bs;
+            break;
+          }
+          case 64: {
+            bitField0_ |= 0x00000040;
+            pinned_ = input.readBool();
             break;
           }
         }
@@ -240,6 +246,21 @@ private static final long serialVersionUID = 0L;
     }
   }
 
+  public static final int PINNED_FIELD_NUMBER = 8;
+  private boolean pinned_;
+  /**
+   * <code>optional bool pinned = 8;</code>
+   */
+  public boolean hasPinned() {
+    return ((bitField0_ & 0x00000040) == 0x00000040);
+  }
+  /**
+   * <code>optional bool pinned = 8;</code>
+   */
+  public boolean getPinned() {
+    return pinned_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -269,6 +290,9 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000020) == 0x00000020)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 7, mediumType_);
+    }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      output.writeBool(8, pinned_);
     }
     unknownFields.writeTo(output);
   }
@@ -300,6 +324,10 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000020) == 0x00000020)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, mediumType_);
+    }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(8, pinned_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -347,6 +375,11 @@ private static final long serialVersionUID = 0L;
       result = result && getMediumType()
           .equals(other.getMediumType());
     }
+    result = result && (hasPinned() == other.hasPinned());
+    if (hasPinned()) {
+      result = result && (getPinned()
+          == other.getPinned());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -385,6 +418,11 @@ private static final long serialVersionUID = 0L;
     if (hasMediumType()) {
       hash = (37 * hash) + MEDIUM_TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getMediumType().hashCode();
+    }
+    if (hasPinned()) {
+      hash = (37 * hash) + PINNED_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getPinned());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -481,7 +519,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * next available id: 8
+   * next available id: 9
    * </pre>
    *
    * Protobuf type {@code alluxio.grpc.block.CreateLocalBlockRequest}
@@ -531,6 +569,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000010);
       mediumType_ = "";
       bitField0_ = (bitField0_ & ~0x00000020);
+      pinned_ = false;
+      bitField0_ = (bitField0_ & ~0x00000040);
       return this;
     }
 
@@ -579,6 +619,10 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000020;
       }
       result.mediumType_ = mediumType_;
+      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        to_bitField0_ |= 0x00000040;
+      }
+      result.pinned_ = pinned_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -640,6 +684,9 @@ private static final long serialVersionUID = 0L;
         bitField0_ |= 0x00000020;
         mediumType_ = other.mediumType_;
         onChanged();
+      }
+      if (other.hasPinned()) {
+        setPinned(other.getPinned());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -917,6 +964,38 @@ private static final long serialVersionUID = 0L;
   }
   bitField0_ |= 0x00000020;
       mediumType_ = value;
+      onChanged();
+      return this;
+    }
+
+    private boolean pinned_ ;
+    /**
+     * <code>optional bool pinned = 8;</code>
+     */
+    public boolean hasPinned() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional bool pinned = 8;</code>
+     */
+    public boolean getPinned() {
+      return pinned_;
+    }
+    /**
+     * <code>optional bool pinned = 8;</code>
+     */
+    public Builder setPinned(boolean value) {
+      bitField0_ |= 0x00000040;
+      pinned_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional bool pinned = 8;</code>
+     */
+    public Builder clearPinned() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      pinned_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequest.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequest.java
@@ -26,7 +26,7 @@ private static final long serialVersionUID = 0L;
     onlyReserveSpace_ = false;
     cleanupOnFailure_ = false;
     mediumType_ = "";
-    pinned_ = false;
+    pinOnCreate_ = false;
   }
 
   @java.lang.Override
@@ -93,7 +93,7 @@ private static final long serialVersionUID = 0L;
           }
           case 64: {
             bitField0_ |= 0x00000040;
-            pinned_ = input.readBool();
+            pinOnCreate_ = input.readBool();
             break;
           }
         }
@@ -246,19 +246,19 @@ private static final long serialVersionUID = 0L;
     }
   }
 
-  public static final int PINNED_FIELD_NUMBER = 8;
-  private boolean pinned_;
+  public static final int PIN_ON_CREATE_FIELD_NUMBER = 8;
+  private boolean pinOnCreate_;
   /**
-   * <code>optional bool pinned = 8;</code>
+   * <code>optional bool pin_on_create = 8;</code>
    */
-  public boolean hasPinned() {
+  public boolean hasPinOnCreate() {
     return ((bitField0_ & 0x00000040) == 0x00000040);
   }
   /**
-   * <code>optional bool pinned = 8;</code>
+   * <code>optional bool pin_on_create = 8;</code>
    */
-  public boolean getPinned() {
-    return pinned_;
+  public boolean getPinOnCreate() {
+    return pinOnCreate_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -292,7 +292,7 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.GeneratedMessageV3.writeString(output, 7, mediumType_);
     }
     if (((bitField0_ & 0x00000040) == 0x00000040)) {
-      output.writeBool(8, pinned_);
+      output.writeBool(8, pinOnCreate_);
     }
     unknownFields.writeTo(output);
   }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000040) == 0x00000040)) {
       size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(8, pinned_);
+        .computeBoolSize(8, pinOnCreate_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -375,10 +375,10 @@ private static final long serialVersionUID = 0L;
       result = result && getMediumType()
           .equals(other.getMediumType());
     }
-    result = result && (hasPinned() == other.hasPinned());
-    if (hasPinned()) {
-      result = result && (getPinned()
-          == other.getPinned());
+    result = result && (hasPinOnCreate() == other.hasPinOnCreate());
+    if (hasPinOnCreate()) {
+      result = result && (getPinOnCreate()
+          == other.getPinOnCreate());
     }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
@@ -419,10 +419,10 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + MEDIUM_TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getMediumType().hashCode();
     }
-    if (hasPinned()) {
-      hash = (37 * hash) + PINNED_FIELD_NUMBER;
+    if (hasPinOnCreate()) {
+      hash = (37 * hash) + PIN_ON_CREATE_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-          getPinned());
+          getPinOnCreate());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -569,7 +569,7 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000010);
       mediumType_ = "";
       bitField0_ = (bitField0_ & ~0x00000020);
-      pinned_ = false;
+      pinOnCreate_ = false;
       bitField0_ = (bitField0_ & ~0x00000040);
       return this;
     }
@@ -622,7 +622,7 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
         to_bitField0_ |= 0x00000040;
       }
-      result.pinned_ = pinned_;
+      result.pinOnCreate_ = pinOnCreate_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -685,8 +685,8 @@ private static final long serialVersionUID = 0L;
         mediumType_ = other.mediumType_;
         onChanged();
       }
-      if (other.hasPinned()) {
-        setPinned(other.getPinned());
+      if (other.hasPinOnCreate()) {
+        setPinOnCreate(other.getPinOnCreate());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -968,34 +968,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean pinned_ ;
+    private boolean pinOnCreate_ ;
     /**
-     * <code>optional bool pinned = 8;</code>
+     * <code>optional bool pin_on_create = 8;</code>
      */
-    public boolean hasPinned() {
+    public boolean hasPinOnCreate() {
       return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
-     * <code>optional bool pinned = 8;</code>
+     * <code>optional bool pin_on_create = 8;</code>
      */
-    public boolean getPinned() {
-      return pinned_;
+    public boolean getPinOnCreate() {
+      return pinOnCreate_;
     }
     /**
-     * <code>optional bool pinned = 8;</code>
+     * <code>optional bool pin_on_create = 8;</code>
      */
-    public Builder setPinned(boolean value) {
+    public Builder setPinOnCreate(boolean value) {
       bitField0_ |= 0x00000040;
-      pinned_ = value;
+      pinOnCreate_ = value;
       onChanged();
       return this;
     }
     /**
-     * <code>optional bool pinned = 8;</code>
+     * <code>optional bool pin_on_create = 8;</code>
      */
-    public Builder clearPinned() {
+    public Builder clearPinOnCreate() {
       bitField0_ = (bitField0_ & ~0x00000040);
-      pinned_ = false;
+      pinOnCreate_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequestOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequestOrBuilder.java
@@ -75,11 +75,11 @@ public interface CreateLocalBlockRequestOrBuilder extends
       getMediumTypeBytes();
 
   /**
-   * <code>optional bool pinned = 8;</code>
+   * <code>optional bool pin_on_create = 8;</code>
    */
-  boolean hasPinned();
+  boolean hasPinOnCreate();
   /**
-   * <code>optional bool pinned = 8;</code>
+   * <code>optional bool pin_on_create = 8;</code>
    */
-  boolean getPinned();
+  boolean getPinOnCreate();
 }

--- a/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequestOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/CreateLocalBlockRequestOrBuilder.java
@@ -73,4 +73,13 @@ public interface CreateLocalBlockRequestOrBuilder extends
    */
   com.google.protobuf.ByteString
       getMediumTypeBytes();
+
+  /**
+   * <code>optional bool pinned = 8;</code>
+   */
+  boolean hasPinned();
+  /**
+   * <code>optional bool pinned = 8;</code>
+   */
+  boolean getPinned();
 }

--- a/core/transport/src/main/java/alluxio/grpc/WriteRequestCommand.java
+++ b/core/transport/src/main/java/alluxio/grpc/WriteRequestCommand.java
@@ -27,7 +27,7 @@ private static final long serialVersionUID = 0L;
     tier_ = 0;
     flush_ = false;
     mediumType_ = "";
-    pinned_ = false;
+    pinOnCreate_ = false;
   }
 
   @java.lang.Override
@@ -126,7 +126,7 @@ private static final long serialVersionUID = 0L;
           }
           case 72: {
             bitField0_ |= 0x00000100;
-            pinned_ = input.readBool();
+            pinOnCreate_ = input.readBool();
             break;
           }
         }
@@ -342,19 +342,19 @@ private static final long serialVersionUID = 0L;
     }
   }
 
-  public static final int PINNED_FIELD_NUMBER = 9;
-  private boolean pinned_;
+  public static final int PIN_ON_CREATE_FIELD_NUMBER = 9;
+  private boolean pinOnCreate_;
   /**
-   * <code>optional bool pinned = 9;</code>
+   * <code>optional bool pin_on_create = 9;</code>
    */
-  public boolean hasPinned() {
+  public boolean hasPinOnCreate() {
     return ((bitField0_ & 0x00000100) == 0x00000100);
   }
   /**
-   * <code>optional bool pinned = 9;</code>
+   * <code>optional bool pin_on_create = 9;</code>
    */
-  public boolean getPinned() {
-    return pinned_;
+  public boolean getPinOnCreate() {
+    return pinOnCreate_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -394,7 +394,7 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.GeneratedMessageV3.writeString(output, 8, mediumType_);
     }
     if (((bitField0_ & 0x00000100) == 0x00000100)) {
-      output.writeBool(9, pinned_);
+      output.writeBool(9, pinOnCreate_);
     }
     unknownFields.writeTo(output);
   }
@@ -437,7 +437,7 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000100) == 0x00000100)) {
       size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(9, pinned_);
+        .computeBoolSize(9, pinOnCreate_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -494,10 +494,10 @@ private static final long serialVersionUID = 0L;
       result = result && getMediumType()
           .equals(other.getMediumType());
     }
-    result = result && (hasPinned() == other.hasPinned());
-    if (hasPinned()) {
-      result = result && (getPinned()
-          == other.getPinned());
+    result = result && (hasPinOnCreate() == other.hasPinOnCreate());
+    if (hasPinOnCreate()) {
+      result = result && (getPinOnCreate()
+          == other.getPinOnCreate());
     }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
@@ -545,10 +545,10 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + MEDIUM_TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getMediumType().hashCode();
     }
-    if (hasPinned()) {
-      hash = (37 * hash) + PINNED_FIELD_NUMBER;
+    if (hasPinOnCreate()) {
+      hash = (37 * hash) + PIN_ON_CREATE_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-          getPinned());
+          getPinOnCreate());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -710,7 +710,7 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000040);
       mediumType_ = "";
       bitField0_ = (bitField0_ & ~0x00000080);
-      pinned_ = false;
+      pinOnCreate_ = false;
       bitField0_ = (bitField0_ & ~0x00000100);
       return this;
     }
@@ -779,7 +779,7 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
         to_bitField0_ |= 0x00000100;
       }
-      result.pinned_ = pinned_;
+      result.pinOnCreate_ = pinOnCreate_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -848,8 +848,8 @@ private static final long serialVersionUID = 0L;
         mediumType_ = other.mediumType_;
         onChanged();
       }
-      if (other.hasPinned()) {
-        setPinned(other.getPinned());
+      if (other.hasPinOnCreate()) {
+        setPinOnCreate(other.getPinOnCreate());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1423,34 +1423,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean pinned_ ;
+    private boolean pinOnCreate_ ;
     /**
-     * <code>optional bool pinned = 9;</code>
+     * <code>optional bool pin_on_create = 9;</code>
      */
-    public boolean hasPinned() {
+    public boolean hasPinOnCreate() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
-     * <code>optional bool pinned = 9;</code>
+     * <code>optional bool pin_on_create = 9;</code>
      */
-    public boolean getPinned() {
-      return pinned_;
+    public boolean getPinOnCreate() {
+      return pinOnCreate_;
     }
     /**
-     * <code>optional bool pinned = 9;</code>
+     * <code>optional bool pin_on_create = 9;</code>
      */
-    public Builder setPinned(boolean value) {
+    public Builder setPinOnCreate(boolean value) {
       bitField0_ |= 0x00000100;
-      pinned_ = value;
+      pinOnCreate_ = value;
       onChanged();
       return this;
     }
     /**
-     * <code>optional bool pinned = 9;</code>
+     * <code>optional bool pin_on_create = 9;</code>
      */
-    public Builder clearPinned() {
+    public Builder clearPinOnCreate() {
       bitField0_ = (bitField0_ & ~0x00000100);
-      pinned_ = false;
+      pinOnCreate_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/WriteRequestCommand.java
+++ b/core/transport/src/main/java/alluxio/grpc/WriteRequestCommand.java
@@ -6,7 +6,7 @@ package alluxio.grpc;
 /**
  * <pre>
  * The write request command.
- * next available id: 9
+ * next available id: 10
  * </pre>
  *
  * Protobuf type {@code alluxio.grpc.block.WriteRequestCommand}
@@ -27,6 +27,7 @@ private static final long serialVersionUID = 0L;
     tier_ = 0;
     flush_ = false;
     mediumType_ = "";
+    pinned_ = false;
   }
 
   @java.lang.Override
@@ -121,6 +122,11 @@ private static final long serialVersionUID = 0L;
             com.google.protobuf.ByteString bs = input.readBytes();
             bitField0_ |= 0x00000080;
             mediumType_ = bs;
+            break;
+          }
+          case 72: {
+            bitField0_ |= 0x00000100;
+            pinned_ = input.readBool();
             break;
           }
         }
@@ -336,6 +342,21 @@ private static final long serialVersionUID = 0L;
     }
   }
 
+  public static final int PINNED_FIELD_NUMBER = 9;
+  private boolean pinned_;
+  /**
+   * <code>optional bool pinned = 9;</code>
+   */
+  public boolean hasPinned() {
+    return ((bitField0_ & 0x00000100) == 0x00000100);
+  }
+  /**
+   * <code>optional bool pinned = 9;</code>
+   */
+  public boolean getPinned() {
+    return pinned_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -371,6 +392,9 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000080) == 0x00000080)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 8, mediumType_);
+    }
+    if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      output.writeBool(9, pinned_);
     }
     unknownFields.writeTo(output);
   }
@@ -410,6 +434,10 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000080) == 0x00000080)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(8, mediumType_);
+    }
+    if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(9, pinned_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -466,6 +494,11 @@ private static final long serialVersionUID = 0L;
       result = result && getMediumType()
           .equals(other.getMediumType());
     }
+    result = result && (hasPinned() == other.hasPinned());
+    if (hasPinned()) {
+      result = result && (getPinned()
+          == other.getPinned());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -511,6 +544,11 @@ private static final long serialVersionUID = 0L;
     if (hasMediumType()) {
       hash = (37 * hash) + MEDIUM_TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getMediumType().hashCode();
+    }
+    if (hasPinned()) {
+      hash = (37 * hash) + PINNED_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getPinned());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -608,7 +646,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * The write request command.
-   * next available id: 9
+   * next available id: 10
    * </pre>
    *
    * Protobuf type {@code alluxio.grpc.block.WriteRequestCommand}
@@ -672,6 +710,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000040);
       mediumType_ = "";
       bitField0_ = (bitField0_ & ~0x00000080);
+      pinned_ = false;
+      bitField0_ = (bitField0_ & ~0x00000100);
       return this;
     }
 
@@ -736,6 +776,10 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000080;
       }
       result.mediumType_ = mediumType_;
+      if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+        to_bitField0_ |= 0x00000100;
+      }
+      result.pinned_ = pinned_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -803,6 +847,9 @@ private static final long serialVersionUID = 0L;
         bitField0_ |= 0x00000080;
         mediumType_ = other.mediumType_;
         onChanged();
+      }
+      if (other.hasPinned()) {
+        setPinned(other.getPinned());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1372,6 +1419,38 @@ private static final long serialVersionUID = 0L;
   }
   bitField0_ |= 0x00000080;
       mediumType_ = value;
+      onChanged();
+      return this;
+    }
+
+    private boolean pinned_ ;
+    /**
+     * <code>optional bool pinned = 9;</code>
+     */
+    public boolean hasPinned() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional bool pinned = 9;</code>
+     */
+    public boolean getPinned() {
+      return pinned_;
+    }
+    /**
+     * <code>optional bool pinned = 9;</code>
+     */
+    public Builder setPinned(boolean value) {
+      bitField0_ |= 0x00000100;
+      pinned_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional bool pinned = 9;</code>
+     */
+    public Builder clearPinned() {
+      bitField0_ = (bitField0_ & ~0x00000100);
+      pinned_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/WriteRequestCommandOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/WriteRequestCommandOrBuilder.java
@@ -121,11 +121,11 @@ public interface WriteRequestCommandOrBuilder extends
       getMediumTypeBytes();
 
   /**
-   * <code>optional bool pinned = 9;</code>
+   * <code>optional bool pin_on_create = 9;</code>
    */
-  boolean hasPinned();
+  boolean hasPinOnCreate();
   /**
-   * <code>optional bool pinned = 9;</code>
+   * <code>optional bool pin_on_create = 9;</code>
    */
-  boolean getPinned();
+  boolean getPinOnCreate();
 }

--- a/core/transport/src/main/java/alluxio/grpc/WriteRequestCommandOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/WriteRequestCommandOrBuilder.java
@@ -119,4 +119,13 @@ public interface WriteRequestCommandOrBuilder extends
    */
   com.google.protobuf.ByteString
       getMediumTypeBytes();
+
+  /**
+   * <code>optional bool pinned = 9;</code>
+   */
+  boolean hasPinned();
+  /**
+   * <code>optional bool pinned = 9;</code>
+   */
+  boolean getPinned();
 }

--- a/tests/src/test/java/alluxio/client/rest/BlockMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/BlockMasterClientRestApiTest.java
@@ -65,7 +65,7 @@ public final class BlockMasterClientRestApiTest extends RestApiTest {
     FileOutputStream outStream = new FileOutputStream(file);
     outStream.write("abc".getBytes());
     outStream.close();
-    blockWorker.commitBlock(sessionId, blockId);
+    blockWorker.commitBlock(sessionId, blockId, false);
 
     Map<String, String> params = new HashMap<>();
     params.put("blockId", Long.toString(blockId));


### PR DESCRIPTION
When a new block is written to Alluxio it becomes a candidate for eviction. The worker fetches the pinned list (including to be persisted file ids) from the master in a heartbeat to prevent eviction of files which are not yet persisted. If a worker is running near storage capacity, a to be persisted block may be evicted before the worker heartbeat fetches the pinned list from the master.

To overcome this issue, let’s look at different scenarios when a block is created on the worker TieredBlockStore. For each of these scenarios if the block create request contains the pinned flag at create time, we can prevent eviction.
 
- Client short-circuit writes to local worker: alluxio.grpc.CreateLocalBlockRequest will need an additional field
- Client remote writes to worker: alluxio.grpc.WriteRequest will need an additional field
- Worker reads from remote worker: We do not inherit the pinned flag from a remote worker.
- Worker reads from ufs: No changes are required for this case as block was already persisted

Proposed Solution:
- When a block is created in TieredBlockStore, the BlockMetadataManagerView is updated with an additional pinned id if the flag was set
- On the next heartbeat, the pinned list is overwritten with the list from the master => the create request flag only impacts current heartbeat interval
