### PR TITLE
Fix a NPE issue for a corner case of S3 compatible UFS

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUtils.java
@@ -54,7 +54,7 @@ public final class S3AUtils {
   }
 
   private static boolean isUserIdInGrantee(Grantee grantee, String userId) {
-    return grantee.getIdentifier().equals(userId)
+    return grantee.getIdentifier() != null && grantee.getIdentifier().equals(userId)
         || grantee.equals(GroupGrantee.AllUsers)
         || grantee.equals(GroupGrantee.AuthenticatedUsers);
   }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUtilsTest.java
@@ -115,4 +115,12 @@ public final class S3AUtilsTest {
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, ID));
     Assert.assertEquals((short) 0700, S3AUtils.translateBucketAcl(mAcl, OTHER_ID));
   }
+
+  @Test
+  public void translatePermissionWithNullId() {
+    // Emulate a corner case when returned grantee does not have ID from some S3 compatible UFS
+    mUserGrantee.setIdentifier(null);
+    mAcl.grantPermission(mUserGrantee, Permission.Read);
+    Assert.assertEquals((short) 0000, S3AUtils.translateBucketAcl(mAcl, OTHER_ID));
+  }
 }


### PR DESCRIPTION
User reported when testing 2.0.0-RC1, S3 compatible UFS like minio may return user grantee without a ID associated, introducing NPE like

```
java.lang.NullPointerException
    at alluxio.underfs.s3a.S3AUtils.isUserIdInGrantee(S3AUtils.java:57)
    at alluxio.underfs.s3a.S3AUtils.translateBucketAcl(S3AUtils.java:47)
    at alluxio.underfs.s3a.S3AUnderFileSystem.getPermissionsInternal(S3AUnderFileSystem.java:573)
    at alluxio.underfs.s3a.S3AUnderFileSystem$1.firstTime(S3AUnderFileSystem.java:120)
    at alluxio.underfs.s3a.S3AUnderFileSystem$1.get(S3AUnderFileSystem.java:115)
    at alluxio.underfs.s3a.S3AUnderFileSystem.getPermissions(S3AUnderFileSystem.java:552)
    at alluxio.underfs.ObjectUnderFileSystem.listInternal(ObjectUnderFileSystem.java:998)
    at alluxio.underfs.ObjectUnderFileSystem.listStatus(ObjectUnderFileSystem.java:600)
    at alluxio.underfs.UnderFileSystemWithLogging$32.call(UnderFileSystemWithLogging.java:584)
    at alluxio.underfs.UnderFileSystemWithLogging$32.call(UnderFileSystemWithLogging.java:581)
    at alluxio.underfs.UnderFileSystemWithLogging.call(UnderFileSystemWithLogging.java:949)
    at alluxio.underfs.UnderFileSystemWithLogging.listStatus(UnderFileSystemWithLogging.java:581)
    at alluxio.concurrent.ManagedBlockingUfsForwarder$27.execute(ManagedBlockingUfsForwarder.java:374)
    at alluxio.concurrent.ManagedBlockingUfsForwarder$27.execute(ManagedBlockingUfsForwarder.java:371)
    at alluxio.concurrent.ManagedBlockingUfsForwarder$ManagedBlockingUfsMethod.block(ManagedBlockingUfsForwarder.java:596)
    at alluxio.concurrent.jsr.ForkJoinPool.managedBlock(ForkJoinPool.java:1004)
    at alluxio.concurrent.ManagedBlockingUfsForwarder$ManagedBlockingUfsMethod.get(ManagedBlockingUfsForwarder.java:582)
    at alluxio.concurrent.ManagedBlockingUfsForwarder.listStatus(ManagedBlockingUfsForwarder.java:376)
    at alluxio.master.file.DefaultFileSystemMaster.loadMetadataInternal(DefaultFileSystemMaster.java:2336)
    at alluxio.master.file.DefaultFileSystemMaster.loadMetadataIfNotExist(DefaultFileSystemMaster.java:2581)
    at alluxio.master.file.DefaultFileSystemMaster.listStatus(DefaultFileSystemMaster.java:863)
```