### PR TITLE
[SMALLFIX] Improve runUfsTests console message and tests

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -317,7 +317,6 @@ function main {
   "runUfsTests")
     CLASS="alluxio.cli.UnderFileSystemContractTest"
     CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
-    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
     runJavaClass "$@"
   ;;
   "readJournal")

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -84,28 +84,25 @@ public final class CommonUtils {
 
   /**
    * Creates a thread which will write "." to the given print stream at the given interval. The
-   * created thread is not started by this method. The created thread will be daemonic and will
-   * halt when interrupted.
+   * created thread is not started by this method. The created thread will be a daemon thread
+   * and will halt when interrupted.
    *
    * @param intervalMs the time interval in milliseconds between writes
    * @param stream the print stream to write to
    * @return the thread
    */
   public static Thread createProgressThread(final long intervalMs, final PrintStream stream) {
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        while (true) {
-          CommonUtils.sleepMs(intervalMs);
-          if (Thread.interrupted()) {
-            return;
-          }
-          stream.print(".");
+    Thread t = new Thread(() -> {
+      while (true) {
+        CommonUtils.sleepMs(intervalMs);
+        if (Thread.interrupted()) {
+          return;
         }
+        stream.print(".");
       }
     });
-    thread.setDaemon(true);
-    return thread;
+    t.setDaemon(true);
+    return t;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
@@ -69,6 +70,43 @@ public final class CommonUtils {
   private static final String ALPHANUM =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   private static final Random RANDOM = new Random();
+
+  /**
+   * Convenience method for calling {@link #createProgressThread(long, PrintStream)} with an
+   * interval of 2 seconds.
+   *
+   * @param stream the print stream to write to
+   * @return the thread
+   */
+  public static Thread createProgressThread(PrintStream stream) {
+    return createProgressThread(2 * Constants.SECOND_MS, stream);
+  }
+
+  /**
+   * Creates a thread which will write "." to the given print stream at the given interval. The
+   * created thread is not started by this method. The created thread will be daemonic and will
+   * halt when interrupted.
+   *
+   * @param intervalMs the time interval in milliseconds between writes
+   * @param stream the print stream to write to
+   * @return the thread
+   */
+  public static Thread createProgressThread(final long intervalMs, final PrintStream stream) {
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          CommonUtils.sleepMs(intervalMs);
+          if (Thread.interrupted()) {
+            return;
+          }
+          stream.print(".");
+        }
+      }
+    });
+    thread.setDaemon(true);
+    return thread;
+  }
 
   /**
    * @return current time in milliseconds

--- a/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli;
 
-import alluxio.Constants;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.examples.RelatedS3Operations;
@@ -125,7 +124,7 @@ public final class UnderFileSystemContractTest {
         String testName = test.getName();
         if (testName.endsWith("Test")) {
           System.out.printf("Running test: %s...", testName);
-          Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+          Thread thread = CommonUtils.createProgressThread(System.out);
           thread.start();
           try {
             test.invoke(operations);

--- a/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -23,7 +23,6 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 import alluxio.underfs.options.DeleteOptions;
-import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
@@ -124,8 +123,6 @@ public final class UnderFileSystemContractTest {
         String testName = test.getName();
         if (testName.endsWith("Test")) {
           System.out.printf("Running test: %s...", testName);
-          Thread thread = CommonUtils.createProgressThread(System.out);
-          thread.start();
           try {
             test.invoke(operations);
           } catch (InvocationTargetException e) {
@@ -133,8 +130,6 @@ public final class UnderFileSystemContractTest {
               logRelatedS3Operations(test);
             }
             throw new IOException(e.getTargetException());
-          } finally {
-            thread.interrupt();
           }
           System.out.println("Test Passed!");
           cleanupUfs(testDir);

--- a/examples/src/main/java/alluxio/examples/S3ASpecificOperations.java
+++ b/examples/src/main/java/alluxio/examples/S3ASpecificOperations.java
@@ -19,9 +19,6 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,7 +29,6 @@ import java.util.Arrays;
  * S3A specific operations like streaming upload.
  */
 public final class S3ASpecificOperations {
-  private static final Logger LOG = LoggerFactory.getLogger(S3ASpecificOperations.class);
   // A safe test wait time to wait for all parts upload
   private static final long TEST_WAIT_TIME = 10000;
   private static final byte[] TEST_BYTES = "TestBytesInS3AFiles".getBytes();
@@ -143,11 +139,10 @@ public final class S3ASpecificOperations {
       outputStream.write(TEST_BYTES);
     }
 
-    LOG.info("Waiting for the in progress upload to be finished so that we can abort it. "
+    System.out.println("Waiting for the in progress upload to be finished so that we can abort it. "
         + "This file may need longer time to upload which may cause test to fail.");
     CommonUtils.sleepMs(TEST_WAIT_TIME);
 
-    LOG.info("Expected to see aborted multipart upload and failed to upload last part message");
     mUfs.cleanup();
 
     boolean getS3ExpectedError = false;

--- a/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
+++ b/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
@@ -240,16 +240,15 @@ public final class UnderFileSystemCommonOperations {
     int offset = 0;
     while (offset < buf.length) {
       int bytesRead = inputStream.read(buf, offset, buf.length - offset);
-      if (bytesRead != -1) {
-        for (int i = 0; i < bytesRead; ++i) {
-          if (TEST_BYTES[(offset + i) % TEST_BYTES.length] != buf[offset + i]) {
-            throw new IOException(FILE_CONTENT_INCORRECT);
-          }
-        }
-        offset += bytesRead;
-      } else {
+      if (bytesRead == -1) {
         break;
       }
+      for (int i = 0; i < bytesRead; ++i) {
+        if (TEST_BYTES[(offset + i) % TEST_BYTES.length] != buf[offset + i]) {
+          throw new IOException(FILE_CONTENT_INCORRECT);
+        }
+      }
+      offset += bytesRead;
     }
     if (buf.length != offset) {
       throw new IOException(FILE_CONTENT_INCORRECT);

--- a/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
+++ b/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
@@ -237,14 +237,22 @@ public final class UnderFileSystemCommonOperations {
     int numCopies = prepareMultiBlockFile(testFile);
     InputStream inputStream = mUfs.openExistingFile(testFile);
     byte[] buf = new byte[numCopies * TEST_BYTES.length];
-    int bytesRead = inputStream.read(buf, 0, buf.length);
-    if (buf.length != bytesRead) {
-      throw new IOException(FILE_CONTENT_INCORRECT);
-    }
-    for (int i = 0; i < bytesRead; ++i) {
-      if (TEST_BYTES[i % TEST_BYTES.length] != buf[i]) {
-        throw new IOException(FILE_CONTENT_INCORRECT);
+    int offset = 0;
+    while (offset < buf.length) {
+      int bytesRead = inputStream.read(buf, offset, buf.length - offset);
+      if (bytesRead != -1) {
+        for (int i = 0; i < bytesRead; ++i) {
+          if (TEST_BYTES[(offset + i) % TEST_BYTES.length] != buf[offset + i]) {
+            throw new IOException(FILE_CONTENT_INCORRECT);
+          }
+        }
+        offset += bytesRead;
+      } else {
+        break;
       }
+    }
+    if (buf.length != offset) {
+      throw new IOException(FILE_CONTENT_INCORRECT);
     }
   }
 

--- a/job/client/src/main/java/alluxio/client/job/JobGrpcClientUtils.java
+++ b/job/client/src/main/java/alluxio/client/job/JobGrpcClientUtils.java
@@ -12,7 +12,6 @@
 package alluxio.client.job;
 
 import alluxio.ClientContext;
-import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.job.JobConfig;
 import alluxio.job.wire.JobInfo;
@@ -26,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -72,43 +70,6 @@ public final class JobGrpcClientUtils {
       LOG.warn("Job {} failed to complete: {}", jobId, jobInfo.getErrorMessage());
     }
     throw new RuntimeException("Failed to successfully complete the job.");
-  }
-
-  /**
-   * Convenience method for calling {@link #createProgressThread(long, PrintStream)} with an
-   * interval of 2 seconds.
-   *
-   * @param stream the print stream to write to
-   * @return the thread
-   */
-  public static Thread createProgressThread(PrintStream stream) {
-    return createProgressThread(2 * Constants.SECOND_MS, stream);
-  }
-
-  /**
-   * Creates a thread which will write "." to the given print stream at the given interval. The
-   * created thread is not started by this method. The created thread will be daemonic and will
-   * halt when interrupted.
-   *
-   * @param intervalMs the time interval in milliseconds between writes
-   * @param stream the print stream to write to
-   * @return the thread
-   */
-  public static Thread createProgressThread(final long intervalMs, final PrintStream stream) {
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        while (true) {
-          CommonUtils.sleepMs(intervalMs);
-          if (Thread.interrupted()) {
-            return;
-          }
-          stream.print(".");
-        }
-      }
-    });
-    thread.setDaemon(true);
-    return thread;
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -19,6 +19,7 @@ import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.migrate.MigrateConfig;
+import alluxio.util.CommonUtils;
 
 import org.apache.commons.cli.CommandLine;
 
@@ -54,7 +55,7 @@ public final class DistributedCpCommand extends AbstractFileSystemCommand {
     String[] args = cl.getArgs();
     AlluxioURI srcPath = new AlluxioURI(args[0]);
     AlluxioURI dstPath = new AlluxioURI(args[1]);
-    Thread thread = JobGrpcClientUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+    Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
     thread.start();
     try {
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(), null, true,

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -12,6 +12,7 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
@@ -19,6 +20,7 @@ import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.load.LoadConfig;
+import alluxio.util.CommonUtils;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -99,7 +101,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         load(newPath, replication);
       }
     } else {
-      Thread thread = JobGrpcClientUtils.createProgressThread(System.out);
+      Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
       thread.start();
       try {
         JobGrpcClientUtils.run(new LoadConfig(filePath.getPath(), replication), 3,

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -12,7 +12,6 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
@@ -101,7 +100,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         load(newPath, replication);
       }
     } else {
-      Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+      Thread thread = CommonUtils.createProgressThread(System.out);
       thread.start();
       try {
         JobGrpcClientUtils.run(new LoadConfig(filePath.getPath(), replication), 3,

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
@@ -12,13 +12,13 @@
 package alluxio.cli.fs.command;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.migrate.MigrateConfig;
+import alluxio.util.CommonUtils;
 
 import org.apache.commons.cli.CommandLine;
 
@@ -57,7 +57,7 @@ public final class DistributedMvCommand extends AbstractFileSystemCommand {
     if (mFileSystem.exists(dstPath)) {
       throw new RuntimeException(dstPath + " already exists");
     }
-    Thread thread = JobGrpcClientUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+    Thread thread = CommonUtils.createProgressThread(System.out);
     thread.start();
     try {
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(), null, true,

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/CheckpointCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/CheckpointCommand.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli.fsadmin.command;
 
-import alluxio.Constants;
 import alluxio.cli.CommandUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.InvalidArgumentException;
@@ -41,7 +40,7 @@ public class CheckpointCommand extends AbstractFsAdminCommand {
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+    Thread thread = CommonUtils.createProgressThread(System.out);
     thread.start();
     try {
       String masterHostname = mMetaClient.checkpoint();

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/CheckpointCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/CheckpointCommand.java
@@ -13,9 +13,9 @@ package alluxio.cli.fsadmin.command;
 
 import alluxio.Constants;
 import alluxio.cli.CommandUtils;
-import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.InvalidArgumentException;
+import alluxio.util.CommonUtils;
 
 import org.apache.commons.cli.CommandLine;
 
@@ -41,7 +41,7 @@ public class CheckpointCommand extends AbstractFsAdminCommand {
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    Thread thread = JobGrpcClientUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
+    Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
     thread.start();
     try {
       String masterHostname = mMetaClient.checkpoint();


### PR DESCRIPTION
Previously, the `./bin/alluxio runUfsTests` will log all the messages on the console. When running against object stores, many retry messages will show on the console to make users confusing. Moving the logs to user.log. Fix one UFS test.