### PR TITLE
Add metrics for domain socket access

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/WorkerMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/WorkerMetrics.java
@@ -68,6 +68,10 @@ public final class WorkerMetrics {
   public static final String BYTES_READ_ALLUXIO_THROUGHPUT = "BytesReadAlluxioThroughput";
   public static final String BYTES_WRITTEN_ALLUXIO = "BytesWrittenAlluxio";
   public static final String BYTES_WRITTEN_ALLUXIO_THROUGHPUT = "BytesWrittenAlluxioThroughput";
+  public static final String BYTES_READ_DOMAIN = "BytesReadDomain";
+  public static final String BYTES_READ_DOMAIN_THROUGHPUT = "BytesReadDomainThroughput";
+  public static final String BYTES_WRITTEN_DOMAIN = "BytesWrittenDomain";
+  public static final String BYTES_WRITTEN_DOMAIN_THROUGHPUT = "BytesWrittenDomainThroughput";
 
   /** Total number of bytes read/written from UFS through this worker. */
   public static final String BYTES_READ_UFS = "BytesReadPerUfs";

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -62,6 +62,8 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
   /** The Block Worker. */
   private final BlockWorker mWorker;
 
+  private final boolean mDomainSocketEnabled;
+
   /**
    * The data reader to read from a local block worker.
    */
@@ -153,11 +155,7 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
           try {
             BlockReader reader =
                 mWorker.readBlockRemote(request.getSessionId(), request.getId(), lockId);
-            String counterName = WorkerMetrics.BYTES_READ_ALLUXIO;
             context.setBlockReader(reader);
-            context.setCounter(MetricsSystem.counter(counterName));
-            String meterName = WorkerMetrics.BYTES_READ_ALLUXIO_THROUGHPUT;
-            context.setMeter(MetricsSystem.meter(meterName));
             mWorker.accessBlock(request.getSessionId(), request.getId());
             ((FileChannel) reader.getChannel()).position(request.getStart());
             return;
@@ -207,16 +205,27 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
    * @param blockWorker the block worker
    * @param responseObserver the response observer of the gRPC stream
    * @param userInfo the authenticated user info
+   * @param domainSocketEnabled whether reading block over domain socket
    */
   public BlockReadHandler(ExecutorService executorService, BlockWorker blockWorker,
-      StreamObserver<ReadResponse> responseObserver, AuthenticatedUserInfo userInfo) {
+      StreamObserver<ReadResponse> responseObserver, AuthenticatedUserInfo userInfo,
+      boolean domainSocketEnabled) {
     super(executorService, responseObserver, userInfo);
     mWorker = blockWorker;
+    mDomainSocketEnabled = domainSocketEnabled;
   }
 
   @Override
   protected BlockReadRequestContext createRequestContext(alluxio.grpc.ReadRequest request) {
-    return new BlockReadRequestContext(request);
+    BlockReadRequestContext context = new BlockReadRequestContext(request);
+    if (mDomainSocketEnabled) {
+      context.setCounter(MetricsSystem.counter(WorkerMetrics.BYTES_READ_DOMAIN));
+      context.setMeter(MetricsSystem.meter(WorkerMetrics.BYTES_READ_DOMAIN_THROUGHPUT));
+    } else {
+      context.setCounter(MetricsSystem.counter(WorkerMetrics.BYTES_READ_ALLUXIO));
+      context.setMeter(MetricsSystem.meter(WorkerMetrics.BYTES_READ_ALLUXIO_THROUGHPUT));
+    }
+    return context;
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -123,8 +123,8 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
       responseObserver =
           new DataMessageServerRequestObserver<>(responseObserver, mWriteRequestMarshaller, null);
     }
-    DelegationWriteHandler handler =
-        new DelegationWriteHandler(mWorkerProcess, responseObserver, getAuthenticatedUserInfo());
+    DelegationWriteHandler handler = new DelegationWriteHandler(mWorkerProcess, responseObserver,
+        getAuthenticatedUserInfo(), mDomainSocketEnabled);
     serverResponseObserver.setOnCancelHandler(handler::onCancel);
     return handler;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerImpl.java
@@ -65,18 +65,22 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
   private final AsyncCacheRequestManager mRequestManager;
   private ReadResponseMarshaller mReadResponseMarshaller = new ReadResponseMarshaller();
   private WriteRequestMarshaller mWriteRequestMarshaller = new WriteRequestMarshaller();
+  private final boolean mDomainSocketEnabled;
 
   /**
    * Creates a new implementation of gRPC BlockWorker interface.
    *
    * @param workerProcess the worker process
    * @param fsContext context used to read blocks
+   * @param domainSocketEnabled is using domain sockets
    */
-  public BlockWorkerImpl(WorkerProcess workerProcess, FileSystemContext fsContext) {
+  public BlockWorkerImpl(WorkerProcess workerProcess, FileSystemContext fsContext,
+      boolean domainSocketEnabled) {
     mWorkerProcess = workerProcess;
     mRequestManager = new AsyncCacheRequestManager(
         GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class),
         fsContext);
+    mDomainSocketEnabled = domainSocketEnabled;
   }
 
   /**
@@ -105,7 +109,7 @@ public class BlockWorkerImpl extends BlockWorkerGrpc.BlockWorkerImplBase {
     }
     BlockReadHandler readHandler = new BlockReadHandler(GrpcExecutors.BLOCK_READER_EXECUTOR,
         mWorkerProcess.getWorker(BlockWorker.class), callStreamObserver,
-        getAuthenticatedUserInfo());
+        getAuthenticatedUserInfo(), mDomainSocketEnabled);
     callStreamObserver.setOnReadyHandler(readHandler::onReady);
     return readHandler;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
@@ -49,17 +49,21 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
   /** An object storing the mapping of tier aliases to ordinals. */
   private final StorageTierAssoc mStorageTierAssoc = new WorkerStorageTierAssoc();
 
+  private final boolean mDomainSocketEnabled;
+
   /**
    * Creates an instance of {@link BlockWriteHandler}.
    *
    * @param blockWorker the block worker
    * @param responseObserver the stream observer for the write response
    * @param userInfo the authenticated user info
+   * @param domainSocketEnabled whether reading block over domain socket
    */
   BlockWriteHandler(BlockWorker blockWorker, StreamObserver<WriteResponse> responseObserver,
-      AuthenticatedUserInfo userInfo) {
+      AuthenticatedUserInfo userInfo, boolean domainSocketEnabled) {
     super(responseObserver, userInfo);
     mWorker = blockWorker;
+    mDomainSocketEnabled = domainSocketEnabled;
   }
 
   @Override
@@ -70,6 +74,13 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
     mWorker.createBlockRemote(request.getSessionId(), request.getId(),
         mStorageTierAssoc.getAlias(request.getTier()),
         request.getMediumType(), FILE_BUFFER_SIZE);
+    if (mDomainSocketEnabled) {
+      context.setCounter(MetricsSystem.counter(WorkerMetrics.BYTES_WRITTEN_DOMAIN));
+      context.setMeter(MetricsSystem.meter(WorkerMetrics.BYTES_WRITTEN_DOMAIN_THROUGHPUT));
+    } else {
+      context.setCounter(MetricsSystem.counter(WorkerMetrics.BYTES_WRITTEN_ALLUXIO));
+      context.setMeter(MetricsSystem.meter(WorkerMetrics.BYTES_WRITTEN_ALLUXIO_THROUGHPUT));
+    }
     return context;
   }
 
@@ -116,11 +127,8 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
       context.setBytesReserved(bytesReserved + bytesToReserve);
     }
     if (context.getBlockWriter() == null) {
-      String metricName = WorkerMetrics.BYTES_WRITTEN_ALLUXIO;
       context.setBlockWriter(
           mWorker.getTempBlockWriterRemote(request.getSessionId(), request.getId()));
-      context.setCounter(MetricsSystem.counter(metricName));
-      context.setMeter(MetricsSystem.meter(WorkerMetrics.BYTES_WRITTEN_ALLUXIO_THROUGHPUT));
     }
     Preconditions.checkState(context.getBlockWriter() != null);
     int sz = buf.readableBytes();

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DelegationWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DelegationWriteHandler.java
@@ -31,14 +31,16 @@ public class DelegationWriteHandler implements StreamObserver<alluxio.grpc.Write
   private final DataMessageMarshaller<WriteRequest> mMarshaller;
   private AbstractWriteHandler mWriteHandler;
   private AuthenticatedUserInfo mUserInfo;
+  private final boolean mDomainSocketEnabled;
 
   /**
    * @param workerProcess the worker process instance
    * @param responseObserver the response observer of the gRPC stream
    * @param userInfo the authenticated user info
+   * @param domainSocketEnabled whether using a domain socket
    */
   public DelegationWriteHandler(WorkerProcess workerProcess,
-      StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo) {
+      StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo, boolean domainSocketEnabled) {
     mWorkerProcess = workerProcess;
     mResponseObserver = responseObserver;
     mUserInfo = userInfo;
@@ -48,19 +50,20 @@ public class DelegationWriteHandler implements StreamObserver<alluxio.grpc.Write
     } else {
       mMarshaller = null;
     }
+    mDomainSocketEnabled = domainSocketEnabled;
   }
 
   private AbstractWriteHandler createWriterHandler(alluxio.grpc.WriteRequest request) {
     switch (request.getCommand().getType()) {
       case ALLUXIO_BLOCK:
         return new BlockWriteHandler(mWorkerProcess.getWorker(BlockWorker.class), mResponseObserver,
-            mUserInfo);
+            mUserInfo, mDomainSocketEnabled);
       case UFS_FILE:
         return new UfsFileWriteHandler(mWorkerProcess.getUfsManager(), mResponseObserver,
             mUserInfo);
       case UFS_FALLBACK_BLOCK:
         return new UfsFallbackBlockWriteHandler(mWorkerProcess.getWorker(BlockWorker.class),
-            mWorkerProcess.getUfsManager(), mResponseObserver, mUserInfo);
+            mWorkerProcess.getUfsManager(), mResponseObserver, mUserInfo, mDomainSocketEnabled);
       default:
         throw new IllegalArgumentException(String.format("Invalid request type %s",
             request.getCommand().getType().name()));

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -90,7 +90,8 @@ public final class GrpcDataServer implements DataServer {
       if (bindAddress instanceof DomainSocketAddress) {
         mDomainSocketAddress = (DomainSocketAddress) bindAddress;
       }
-      BlockWorkerImpl blockWorkerService = new BlockWorkerImpl(workerProcess, mFsContext, mDomainSocketAddress != null);
+      BlockWorkerImpl blockWorkerService =
+          new BlockWorkerImpl(workerProcess, mFsContext, mDomainSocketAddress != null);
       mServer = createServerBuilder(hostName, bindAddress, NettyUtils.getWorkerChannel(
           ServerConfiguration.global()))
           .addService(ServiceType.FILE_SYSTEM_WORKER_WORKER_SERVICE, new GrpcService(

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -69,13 +69,16 @@ public final class UfsFallbackBlockWriteHandler
    *
    * @param blockWorker the block worker
    * @param userInfo the authenticated user info
+   * @param domainSocketEnabled whether using a domain socket
    */
   UfsFallbackBlockWriteHandler(BlockWorker blockWorker, UfsManager ufsManager,
-      StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo) {
+      StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo,
+      boolean domainSocketEnabled) {
     super(responseObserver, userInfo);
     mWorker = blockWorker;
     mUfsManager = ufsManager;
-    mBlockWriteHandler = new BlockWriteHandler(blockWorker, responseObserver, userInfo);
+    mBlockWriteHandler =
+        new BlockWriteHandler(blockWorker, responseObserver, userInfo, domainSocketEnabled);
   }
 
   @Override


### PR DESCRIPTION
In order to debug if short circuit access is working, the metric for reading from the worker over grpc is split b/w domain socket and remote access