### PR TITLE
[SMALLFIX] Deflake cannotInitializeWithoutMasterHostname test

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -166,18 +166,9 @@ public class AbstractFileSystemTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void cannotInitializeWithoutMasterHostname() throws Exception {
-    String previousValue = "";
-    if (alluxio.Configuration.isSet(PropertyKey.MASTER_HOSTNAME)) {
-      previousValue = alluxio.Configuration.get(PropertyKey.MASTER_HOSTNAME);
-      alluxio.Configuration.unset(PropertyKey.MASTER_HOSTNAME);
-    }
-    try {
+    try (Closeable c = new ConfigurationRule(PropertyKey.MASTER_HOSTNAME, null).toResource()) {
       URI uri = URI.create(Constants.HEADER + "/tmp/path.txt");
       org.apache.hadoop.fs.FileSystem.get(uri, getConf());
-    } finally {
-      if (!previousValue.isEmpty()) {
-        alluxio.Configuration.set(PropertyKey.MASTER_HOSTNAME, previousValue);
-      }
     }
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -166,8 +166,19 @@ public class AbstractFileSystemTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void cannotInitializeWithoutMasterHostname() throws Exception {
-    URI uri = URI.create(Constants.HEADER + "/tmp/path.txt");
-    org.apache.hadoop.fs.FileSystem.get(uri, getConf());
+    String previousValue = "";
+    if (alluxio.Configuration.isSet(PropertyKey.MASTER_HOSTNAME)) {
+      previousValue = alluxio.Configuration.get(PropertyKey.MASTER_HOSTNAME);
+      alluxio.Configuration.unset(PropertyKey.MASTER_HOSTNAME);
+    }
+    try {
+      URI uri = URI.create(Constants.HEADER + "/tmp/path.txt");
+      org.apache.hadoop.fs.FileSystem.get(uri, getConf());
+    } finally {
+      if (!previousValue.isEmpty()) {
+        alluxio.Configuration.set(PropertyKey.MASTER_HOSTNAME, previousValue);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
The MASTER_HOSTNAME maybe set by other tests. In this unit test, I make sure the MASTER_HOSTNAME is unset before the test