### PR TITLE
Improve GCS UFS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -535,6 +535,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey UNDERFS_GCS_DEFAULT_MODE =
+      new Builder(Name.UNDERFS_GCS_DEFAULT_MODE)
+          .setDefaultValue("0700")
+          .setDescription("Mode (in octal notation) for GCS objects if mode cannot be discovered.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_GCS_DIRECTORY_SUFFIX =
       new Builder(Name.UNDERFS_GCS_DIRECTORY_SUFFIX)
           .setDefaultValue("/")
@@ -3617,6 +3624,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_SLEEP_MS =
         "alluxio.underfs.eventual.consistency.retry.max.sleep";
     public static final String UNDERFS_LISTING_LENGTH = "alluxio.underfs.listing.length";
+    public static final String UNDERFS_GCS_DEFAULT_MODE = "alluxio.underfs.gcs.default.mode";
     public static final String UNDERFS_GCS_DIRECTORY_SUFFIX =
         "alluxio.underfs.gcs.directory.suffix";
     public static final String UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING =

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -17,6 +17,7 @@ import alluxio.underfs.options.DeleteOptions;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -143,6 +144,32 @@ public final class UnderFileSystemUtils {
    */
   public static String getBucketName(AlluxioURI uri) {
     return uri.getAuthority().toString();
+  }
+
+  /**
+   * Memoize implementation for java.util.function.supplier.
+   *
+   * @param original the original supplier
+   * @param <T> the object type
+   * @return the supplier with memorization
+   */
+  public static <T> Supplier<T> memoize(Supplier<T> original) {
+    return new Supplier<T>() {
+      Supplier<T> mDelegate = this::firstTime;
+      boolean mInitialized;
+      public T get() {
+        return mDelegate.get();
+      }
+
+      private synchronized T firstTime() {
+        if (!mInitialized) {
+          T value = original.get();
+          mDelegate = () -> value;
+          mInitialized = true;
+        }
+        return mDelegate.get();
+      }
+    };
   }
 
   /**

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
@@ -162,8 +162,8 @@ public final class GCSInputStream extends InputStream {
         mInputStream = new BufferedInputStream(object.getDataInputStream());
         return;
       } catch (ServiceException e) {
-        LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
-            mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+        LOG.warn("Attempt {} to open key {} on position {} in bucket {} failed with exception : {}",
+            mRetryPolicy.getAttemptCount(), mKey, mPos, mBucketName, e.toString());
         if (e.getResponseCode() != HttpStatus.SC_NOT_FOUND) {
           throw new IOException(e);
         }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
@@ -65,7 +65,7 @@ public final class GCSInputStream extends InputStream {
    * @param retryPolicy retry policy in case the key does not exist
    */
   GCSInputStream(String bucketName, String key, GoogleStorageService client,
-      RetryPolicy retryPolicy) throws ServiceException {
+      RetryPolicy retryPolicy) {
     this(bucketName, key, client, 0L, retryPolicy);
   }
 
@@ -79,41 +79,12 @@ public final class GCSInputStream extends InputStream {
    * @param retryPolicy retry policy in case the key does not exist
    */
   GCSInputStream(String bucketName, String key, GoogleStorageService client,
-      long pos, RetryPolicy retryPolicy) throws ServiceException {
+      long pos, RetryPolicy retryPolicy) {
     mBucketName = bucketName;
     mKey = key;
     mClient = client;
     mPos = pos;
     mRetryPolicy = retryPolicy;
-  }
-
-  /**
-   * Retries getting a {@link GSObject}.
-   *
-   * @param retryPolicy the retry policy to solve eventual consistency issue
-   * @return the {@link GSObject}
-   */
-  private GSObject getObjectWithRetry(RetryPolicy retryPolicy) throws ServiceException {
-    ServiceException lastException = null;
-    while (retryPolicy.attempt()) {
-      try {
-        if (mPos > 0) {
-          return mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
-        } else {
-          return mClient.getObject(mBucketName, mKey);
-        }
-      } catch (ServiceException e) {
-        LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
-            retryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
-        if (e.getResponseCode() != HttpStatus.SC_NOT_FOUND) {
-          throw e;
-        }
-        // Key does not exist
-        lastException = e;
-      }
-    }
-    // Failed after retrying key does not exist
-    throw lastException;
   }
 
   @Override
@@ -176,7 +147,7 @@ public final class GCSInputStream extends InputStream {
   }
 
   /**
-   * Opens a new stream at mPos if the wrapped stream mIn is null.
+   * Opens a new stream at mPos if the wrapped stream mInputStream is null.
    */
   private void openStream() throws IOException {
     ServiceException lastException = null;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -352,12 +352,7 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
-      throws IOException {
-    try {
-      return new GCSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
-    } catch (ServiceException e) {
-      throw new IOException(e.getMessage());
-    }
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy) {
+    return new GCSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
   }
 }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -56,6 +56,9 @@ import javax.annotation.concurrent.ThreadSafe;
 public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(GCSUnderFileSystem.class);
 
+  /** Default owner of objects if owner cannot be determined. */
+  private static final String DEFAULT_OWNER = "";
+
   private static final byte[] DIR_HASH;
 
   /** Jets3t GCS client. */
@@ -310,8 +313,8 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
     // getAccountOwner() can return null even when the account is authenticated.
     // TODO(chaomin): investigate the root cause why Google cloud service is returning
     // null StorageOwner.
-    String accountOwnerId = "unknown";
-    String accountOwner = "unknown";
+    String accountOwnerId = DEFAULT_OWNER;
+    String accountOwner = DEFAULT_OWNER;
     try {
       StorageOwner storageOwner = mClient.getAccountOwner();
       if (storageOwner != null) {

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -51,7 +51,6 @@ public class GCSUnderFileSystemTest {
     mClient = mock(GoogleStorageService.class);
 
     mGCSUnderFileSystem = new GCSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        BUCKET_MODE, ACCOUNT_OWNER,
         UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -104,30 +104,8 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   private final boolean mStreamingUploadEnabled;
 
   /** The permissions associated with the bucket. Fetched once and assumed to be immutable. */
-  private final Supplier<ObjectPermissions> mPermissions = memoize(this::getPermissionsInternal);
-
-  /** Memoize implementation for java.util.function.supplier. */
-  private static <T> Supplier<T> memoize(Supplier<T> original) {
-    return new Supplier<T>() {
-      Supplier<T> mDelegate = this::firstTime;
-      boolean mInitialized;
-      public T get() {
-        return mDelegate.get();
-      }
-
-      private synchronized T firstTime() {
-        if (!mInitialized) {
-          T value = original.get();
-          mDelegate = () -> value;
-          mInitialized = true;
-        }
-        return mDelegate.get();
-      }
-    };
-  }
-
-  /** The configuration for ufs. */
-  private final UnderFileSystemConfiguration mConf;
+  private final Supplier<ObjectPermissions> mPermissions
+      = UnderFileSystemUtils.memoize(this::getPermissionsInternal);
 
   static {
     byte[] dirByteHash = DigestUtils.md5(new byte[0]);
@@ -260,7 +238,6 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     mBucketName = bucketName;
     mExecutor = MoreExecutors.listeningDecorator(executor);
     mManager = transferManager;
-    mConf = conf;
     mStreamingUploadEnabled = streamingUploadEnabled;
   }
 
@@ -279,8 +256,8 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   public void cleanup() {
-    long cleanAge = mConf.isSet(PropertyKey.UNDERFS_S3A_INTERMEDIATE_UPLOAD_CLEAN_AGE)
-        ? mConf.getMs(PropertyKey.UNDERFS_S3A_INTERMEDIATE_UPLOAD_CLEAN_AGE)
+    long cleanAge = mUfsConf.isSet(PropertyKey.UNDERFS_S3A_INTERMEDIATE_UPLOAD_CLEAN_AGE)
+        ? mUfsConf.getMs(PropertyKey.UNDERFS_S3A_INTERMEDIATE_UPLOAD_CLEAN_AGE)
         : FormatUtils.parseTimeSize(PropertyKey.UNDERFS_S3A_INTERMEDIATE_UPLOAD_CLEAN_AGE
         .getDefaultValue());
     Date cleanBefore = new Date(new Date().getTime() - cleanAge);
@@ -296,7 +273,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       try {
         CopyObjectRequest request = new CopyObjectRequest(mBucketName, src, mBucketName, dst);
         if (Boolean.parseBoolean(
-            mConf.get(PropertyKey.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED))) {
+            mUfsConf.get(PropertyKey.UNDERFS_S3A_SERVER_SIDE_ENCRYPTION_ENABLED))) {
           ObjectMetadata meta = new ObjectMetadata();
           meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
           request.setNewObjectMetadata(meta);
@@ -392,7 +369,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     key = PathUtils.normalizePath(key, PATH_SEPARATOR);
     // In case key is root (empty string) do not normalize prefix.
     key = key.equals(PATH_SEPARATOR) ? "" : key;
-    if (mConf.isSet(PropertyKey.UNDERFS_S3A_LIST_OBJECTS_VERSION_1) && mConf
+    if (mUfsConf.isSet(PropertyKey.UNDERFS_S3A_LIST_OBJECTS_VERSION_1) && mUfsConf
         .get(PropertyKey.UNDERFS_S3A_LIST_OBJECTS_VERSION_1).equals(Boolean.toString(true))) {
       ListObjectsRequest request =
           new ListObjectsRequest().withBucketName(mBucketName).withPrefix(key)
@@ -565,15 +542,15 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     String accountOwner = DEFAULT_OWNER;
 
     // if ACL enabled try to inherit bucket acl for all the objects.
-    if (Boolean.parseBoolean(mConf.get(PropertyKey.UNDERFS_S3A_INHERIT_ACL))) {
+    if (Boolean.parseBoolean(mUfsConf.get(PropertyKey.UNDERFS_S3A_INHERIT_ACL))) {
       try {
         Owner owner = mClient.getS3AccountOwner();
         AccessControlList acl = mClient.getBucketAcl(mBucketName);
 
         bucketMode = S3AUtils.translateBucketAcl(acl, owner.getId());
-        if (mConf.isSet(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING)) {
+        if (mUfsConf.isSet(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING)) {
           accountOwner = CommonUtils.getValueFromStaticMapping(
-              mConf.get(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING), owner.getId());
+              mUfsConf.get(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING), owner.getId());
         } else {
           // If there is no user-defined mapping, use display name or id.
           accountOwner = owner.getDisplayName() != null ? owner.getDisplayName() : owner.getId();

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -570,11 +570,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   protected InputStream openObject(String key, OpenOptions options,
-      RetryPolicy retryPolicy) throws IOException {
-    try {
-      return new S3AInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
-    } catch (AmazonClientException e) {
-      throw new IOException(e);
-    }
+      RetryPolicy retryPolicy) {
+    return new S3AInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy);
   }
 }


### PR DESCRIPTION
This PR improves the GCS UFS similar to our previous improvements to S3A UFS.
(1) move all permission related code to `GCSUnderFileSystem.getPermissionInternal()` and memorize the permission (only get the permission for once and remember it). This change mocks what S3A UFS does.
(2) In `GCSInputStream`, mainly reorganize the codes. Move create `inputStream` related codes in the `openStream()` other than in the constructor. The constructor suppose to not throw exceptions.  Use `openStream()` and `closeStream()` similar to what S3A UFS does.
(3) remove the `UnderFileSystemConfiguration mConf` in `S3AUnderFileSystem` since its super class `BaseUnderFileSystem` already have the member `UnderFileSystemConfiguration mUfsConf`.