### PR TITLE
Improve detecting FUSE installation for test

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -134,7 +134,8 @@ public final class AlluxioFuseUtils {
         String result = ShellUtils.execCommand("fusermount", "-V");
         return !result.isEmpty();
       } else if (OSUtils.isMacOS()) {
-        String result = ShellUtils.execCommand("bash", "-c", "mount | grep FUSE");
+        String result = ShellUtils.execCommand("bash", "-c",
+            "pkgutil --pkgs | grep -i com.github.osxfuse.pkg.Core");
         return !result.isEmpty();
       }
     } catch (Exception e) {


### PR DESCRIPTION
This PR corrects detection of FUSE installation on MacOS. It used be checking presence of installer in mounted list, now it validates the installed package list.