### PR TITLE
Fix remove function for ControllableQueue

### DIFF
--- a/core/common/src/main/java/alluxio/util/executor/ControllableQueue.java
+++ b/core/common/src/main/java/alluxio/util/executor/ControllableQueue.java
@@ -89,7 +89,7 @@ public class ControllableQueue<T> {
    * @return true if the element removed successfully, false otherwise
    */
   public boolean remove(T element) {
-    return mQueue.removeIf(x -> x.mValue == element);
+    return mQueue.removeIf(x -> x.getValue() == element);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/util/executor/ControllableQueue.java
+++ b/core/common/src/main/java/alluxio/util/executor/ControllableQueue.java
@@ -89,7 +89,7 @@ public class ControllableQueue<T> {
    * @return true if the element removed successfully, false otherwise
    */
   public boolean remove(T element) {
-    return mQueue.remove(element);
+    return mQueue.removeIf(x -> x.mValue == element);
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/util/executor/ControllableSchedulerTest.java
+++ b/core/common/src/test/java/alluxio/util/executor/ControllableSchedulerTest.java
@@ -15,6 +15,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Random;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -61,6 +62,17 @@ public class ControllableSchedulerTest {
     scheduler.jumpAndExecute(daysToJump, TimeUnit.DAYS);
     Assert.assertEquals(daysToJump / periodDays + 1, task.runTimes());
     Assert.assertTrue(scheduler.schedulerIsIdle());
+  }
+
+  @Test
+  public void cancel() {
+    CountTask task = new CountTask();
+    ControllableScheduler scheduler = new ControllableScheduler();
+    ScheduledFuture<?> future = scheduler.schedule(task, 5, TimeUnit.HOURS);
+    Assert.assertTrue(scheduler.schedulerIsIdle());
+    future.cancel(true);
+    scheduler.jumpAndExecute(5, TimeUnit.HOURS);
+    Assert.assertEquals(0, task.runTimes());
   }
 
   /**


### PR DESCRIPTION
There is a bug in `ControllableQueue.remove` where it is trying to remove the item from priority queue which holds a list of wrappers. This change fixed it by comparing the value of the wrapper to the item instead.