### PR TITLE
[SMALLFIX] Change INFO to DEBUG logging of removed block information

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -907,7 +907,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
       try (LockResource lr = lockBlock(removedBlockId)) {
         Optional<BlockMeta> block = mBlockStore.getBlock(removedBlockId);
         if (block.isPresent()) {
-          LOG.info("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
+          LOG.debug("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
           mBlockStore.removeLocation(removedBlockId, workerInfo.getId());
           if (mBlockStore.getLocations(removedBlockId).size() == 0) {
             mLostBlocks.add(removedBlockId);


### PR DESCRIPTION
The master log is easy to be full of the removed block information if we use INFO logging.
