### PR TITLE
Run alluxio-start.sh local without SSH

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -520,7 +520,11 @@ main() {
       ALLUXIO_PROXY_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
       ALLUXIO_JOB_MASTER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
       ALLUXIO_JOB_WORKER_JAVA_OPTS+=" -Dalluxio.master.hostname=localhost"
-      start_master "${FORMAT}"
+      if [[ "${FORMAT}" == "-f" ]]; then
+        ${LAUNCHER} ${BIN}/alluxio formatJournal
+        ${LAUNCHER} ${BIN}/alluxio formatWorker
+      fi
+      start_master
       ALLUXIO_MASTER_SECONDARY=true
       # We only start a secondary master when using a UFS journal.
       local journal_type=$(${BIN}/alluxio getConf ${ALLUXIO_MASTER_JAVA_OPTS} \


### PR DESCRIPTION
Fix #9185

After this PR running `$ bin/alluxio-start.sh local` with SSH  disabled on my local laptop:
```
[10:01:40]binfan@:alluxio (smallfix2)$ bin/alluxio-start.sh local
Assuming NoMount by default.
Killed 1 processes on MacBook-Pro-5
Killed 1 processes on MacBook-Pro-5
Killed 1 processes on MacBook-Pro-5
Killed 1 processes on MacBook-Pro-5
Killed 0 processes on MacBook-Pro-5
Killed 1 processes on MacBook-Pro-5
Starting master @ MacBook-Pro-5. Logging to /Users/binfan/Dropbox/Work/alluxio/alluxio/logs
Starting job master @ MacBook-Pro-5. Logging to /Users/binfan/Dropbox/Work/alluxio/alluxio/logs
Starting worker @ MacBook-Pro-5. Logging to /Users/binfan/Dropbox/Work/alluxio/alluxio/logs
Starting job worker @ MacBook-Pro-5. Logging to /Users/binfan/Dropbox/Work/alluxio/alluxio/logs
Starting proxy @ MacBook-Pro-5. Logging to /Users/binfan/Dropbox/Work/alluxio/alluxio/logs
-----------------------------------------
Starting to monitor all local services.
-----------------------------------------
--- [ OK ] The master service @ MacBook-Pro-5 is in a healthy state.
--- [ OK ] The job_master service @ MacBook-Pro-5 is in a healthy state.
--- [ OK ] The worker service @ MacBook-Pro-5 is in a healthy state.
--- [ OK ] The job_worker service @ MacBook-Pro-5 is in a healthy state.
--- [ OK ] The proxy service @ MacBook-Pro-5 is in a healthy state.
[10:02:30]binfan@:alluxio (smallfix2)$ jps
3953 AlluxioJobMaster
3956 AlluxioWorker
1940 
3958 AlluxioJobWorker
3926 AlluxioMaster
3960 AlluxioProxy
4013 Jps
```