### PR TITLE
Add XAttr to FileInfo

### DIFF
--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -24,8 +24,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -69,6 +71,7 @@ public final class FileInfo implements Serializable {
 
   private AccessControlList mAcl = AccessControlList.EMPTY_ACL;
   private DefaultAccessControlList mDefaultAcl = DefaultAccessControlList.EMPTY_DEFAULT_ACL;
+  private Map<String, byte[]> mXAttr;
 
   /**
    * Creates a new instance of {@link FileInfo}.
@@ -306,6 +309,14 @@ public final class FileInfo implements Serializable {
    */
   public Set<String> getMediumTypes() {
     return mMediumTypes;
+  }
+
+  /**
+   * @return the extended attributes
+   */
+  @Nullable
+  public Map<String, byte[]> getXAttr() {
+    return mXAttr;
   }
 
   /**
@@ -591,6 +602,15 @@ public final class FileInfo implements Serializable {
    */
   public FileInfo setMediumTypes(Set<String> mediumTypes) {
     mMediumTypes = mediumTypes;
+    return this;
+  }
+
+  /**
+   * @param xAttr the extended attributes to use
+   * @return the updated {@link FileInfo}
+   */
+  public FileInfo setXAttr(Map<String, byte[]> xAttr) {
+    mXAttr = xAttr;
     return this;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -778,6 +778,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
         throw new FileDoesNotExistException(e.getMessage(), e);
       }
     }
+    fileInfo.setXAttr(inode.getXAttr());
     MountTable.Resolution resolution;
     try {
       resolution = mMountTable.resolve(uri);


### PR DESCRIPTION
Cherry-picked to 2.0 branch.

Expose `XAttr` on `FileInfo` so internal services can use it.

pr-link: Alluxio/alluxio#9200
change-id: cid-e22fd5ac4d5e0ba05034834f948cb6a9a317e8f9