### PR TITLE
[SMALLFIX] Clean up the remaining pom code about ufs contract test

### DIFF
--- a/underfs/cos/pom.xml
+++ b/underfs/cos/pom.xml
@@ -57,38 +57,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testCOSBucket</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/underfs/gcs/pom.xml
+++ b/underfs/gcs/pom.xml
@@ -52,40 +52,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testGCSBucket</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestGCSBucket="gs://bucketName/testDir" is specified -->
-            <exclude>**/GCSUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -114,26 +114,6 @@
     </profile>
 
     <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testHdfsBaseDir</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>hdfsAcl</id>
       <build>
         <plugins>
@@ -177,10 +157,6 @@
             <exclude>**/SupportedHdfsAclProvider.java</exclude>
             <exclude>**/SupportedHdfsActiveSyncProvider.java</exclude>
           </excludes>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestHdfsBaseDir="hdfs://ip:port/alluxio_test" is specified -->
-            <exclude>**/HdfsUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
         </configuration>
       </plugin>
       <plugin>

--- a/underfs/kodo/pom.xml
+++ b/underfs/kodo/pom.xml
@@ -59,16 +59,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <testExcludes>
-                        <!-- Skip UFS contract tests unless -DtestKodoBucket="kodo://bucketName/testDir" is specified -->
-                        <exclude>**/KodoUnderFileSystemContractTest.java</exclude>
-                    </testExcludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
             </plugin>
             <plugin>

--- a/underfs/oss/pom.xml
+++ b/underfs/oss/pom.xml
@@ -56,40 +56,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testOSSBucket</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestOSSBucket="oss://bucketName/testDir" is specified -->
-            <exclude>**/OSSUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/underfs/s3a/pom.xml
+++ b/underfs/s3a/pom.xml
@@ -60,40 +60,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testS3ABucket</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestS3ABucket="s3a://my-bucket/alluxio-test" is specified -->
-            <exclude>**/S3AUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -52,40 +52,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testSwiftContainerKey</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestSwiftContainerKey=swift://container/folder is specified -->
-            <exclude>**/SwiftUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -77,41 +77,8 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>ufsContractTest</id>
-      <activation>
-        <property>
-          <name>testWasbBaseDir</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes combine.self="override" />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!-- Skip UFS contract tests unless -DtestWasbBaseDir="wasb://AZURE_CONTAINER@AZURE_ACCOUNT.blob.core.windows.net/AZURE_DIRECTORY/"
-                 is specified -->
-            <exclude>**/WasbUnderFileSystemContractTest.java</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
the ufs contract test is moved from test scope to `./bin/alluxio runUfsTests`. The `UfsContractTest` profile is not needed any more