### PR TITLE
Implement close() for BlockStore interface

### DIFF
--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -140,12 +140,22 @@ public class Registry<T extends Server<U>, U> {
   }
 
   /**
-   * Stops all {@link Server}s in reverse dependency order. If A depends on B, B is stopped
-   * before A.
+   * Stops all {@link Server}s in reverse dependency order. If A depends on B, A is stopped
+   * before B.
    */
   public void stop() throws IOException {
     for (T server : Lists.reverse(getServers())) {
       server.stop();
+    }
+  }
+
+  /**
+   * Closes all {@link Server}s in reverse dependency order. If A depends on B, A is closed
+   * before B.
+   */
+  public void close() throws IOException {
+    for (T server : Lists.reverse(getServers())) {
+      server.close();
     }
   }
 

--- a/core/server/common/src/main/java/alluxio/Server.java
+++ b/core/server/common/src/main/java/alluxio/Server.java
@@ -52,4 +52,9 @@ public interface Server<T> {
    * cleaned up and shutdown.
    */
   void stop() throws IOException;
+
+  /**
+   * Closes the server.
+   */
+  void close() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -140,4 +140,9 @@ public abstract class AbstractMaster implements Master {
       return mJournal.createJournalContext();
     }
   }
+
+  @Override
+  public void close() throws IOException {
+    stop();
+  }
 }

--- a/core/server/common/src/main/java/alluxio/master/NoopMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/NoopMaster.java
@@ -67,6 +67,10 @@ public class NoopMaster implements Master, NoopJournaled {
   }
 
   @Override
+  public void close() {
+  }
+
+  @Override
   public JournalContext createJournalContext() {
     throw new IllegalStateException("Cannot create journal contexts for NoopMaster");
   }

--- a/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
+++ b/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
@@ -13,6 +13,7 @@ package alluxio.worker;
 
 import com.google.common.base.Preconditions;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -37,5 +38,10 @@ public abstract class AbstractWorker implements Worker {
    */
   protected ExecutorService getExecutorService() {
     return mExecutorService;
+  }
+
+  @Override
+  public void close() throws IOException {
+    stop();
   }
 }

--- a/core/server/common/src/test/java/alluxio/master/RegistryTest.java
+++ b/core/server/common/src/test/java/alluxio/master/RegistryTest.java
@@ -49,6 +49,9 @@ public final class RegistryTest {
 
     @Override
     public void stop() throws IOException {}
+
+    @Override
+    public void close() throws IOException {}
   }
 
   public class ServerA extends TestServer {

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -156,7 +156,7 @@ public class AlluxioMasterProcess extends MasterProcess {
   public void stop() throws Exception {
     stopRejectingServers();
     if (isServing()) {
-      stopMasters(true);
+      closeMasters();
       stopServing();
       mJournalSystem.stop();
     }
@@ -208,16 +208,21 @@ public class AlluxioMasterProcess extends MasterProcess {
 
   /**
    * Stops all masters, including block master, fileSystem master and additional masters.
-   *
-   * @param isClose {@code true} if process is exiting
    */
-  protected void stopMasters(boolean isClose) {
+  protected void stopMasters() {
     try {
-      if (isClose) {
-        mRegistry.close();
-      } else {
-        mRegistry.stop();
-      }
+      mRegistry.stop();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Closes all masters, including block master, fileSystem master and additional masters.
+   */
+  protected void closeMasters() {
+    try {
+      mRegistry.close();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -156,7 +156,7 @@ public class AlluxioMasterProcess extends MasterProcess {
   public void stop() throws Exception {
     stopRejectingServers();
     if (isServing()) {
-      stopMasters();
+      stopMasters(true);
       stopServing();
       mJournalSystem.stop();
     }
@@ -208,10 +208,16 @@ public class AlluxioMasterProcess extends MasterProcess {
 
   /**
    * Stops all masters, including block master, fileSystem master and additional masters.
+   *
+   * @param isClose {@code true} if process is exiting
    */
-  protected void stopMasters() {
+  protected void stopMasters(boolean isClose) {
     try {
-      mRegistry.stop();
+      if (isClose) {
+        mRegistry.close();
+      } else {
+        mRegistry.stop();
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -89,6 +89,7 @@ public final class AlluxioSecondaryMaster implements Process {
     mRunning = true;
     mLatch.await();
     mJournalSystem.stop();
+    mRegistry.close();
     mRunning = false;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -109,7 +109,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       if (mLeaderSelector.getState() != State.PRIMARY) {
         unstable.set(true);
       }
-      stopMasters(false);
+      stopMasters();
       LOG.info("Secondary stopped");
       mJournalSystem.gainPrimacy();
       // We only check unstable here because mJournalSystem.gainPrimacy() is the only slow method
@@ -156,7 +156,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
             mServingThreadTimeoutMs, ThreadUtils.formatStackTrace(mServingThread));
       }
       mServingThread = null;
-      stopMasters(false);
+      stopMasters();
       LOG.info("Primary stopped");
     }
     startMasters(false);

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -109,7 +109,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       if (mLeaderSelector.getState() != State.PRIMARY) {
         unstable.set(true);
       }
-      stopMasters();
+      stopMasters(false);
       LOG.info("Secondary stopped");
       mJournalSystem.gainPrimacy();
       // We only check unstable here because mJournalSystem.gainPrimacy() is the only slow method
@@ -156,7 +156,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
             mServingThreadTimeoutMs, ThreadUtils.formatStackTrace(mServingThread));
       }
       mServingThread = null;
-      stopMasters();
+      stopMasters(false);
       LOG.info("Primary stopped");
     }
     startMasters(false);

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -353,6 +353,17 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
   }
 
   @Override
+  public void stop() throws IOException {
+    super.stop();
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    mBlockStore.close();
+  }
+
+  @Override
   public int getWorkerCount() {
     return mWorkers.size();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -669,6 +669,12 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   @Override
+  public void close() throws IOException {
+    super.close();
+    mInodeTree.close();
+  }
+
+  @Override
   public void validateInodeBlocks(boolean repair) throws UnavailableException {
     mBlockMaster.validateBlocks((blockId) -> {
       long fileId = IdUtils.fileIdFromBlockId(blockId);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1157,4 +1157,13 @@ public class InodeTree implements DelegatingJournaled {
     }
     return Optional.empty();
   }
+
+  /**
+   * Close resources associated with this tree instance.
+   *
+   * @throws IOException
+   */
+  public void close() throws IOException {
+    mInodeStore.close();
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
@@ -79,6 +79,11 @@ public interface BlockStore extends Iterable<Block> {
   void removeLocation(long blockId, long workerId);
 
   /**
+   * Closes the block store and releases all resources.
+   */
+  void close();
+
+  /**
    * Block metadata.
    */
   class Block {

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -78,6 +78,11 @@ public class HeapBlockStore implements BlockStore {
   }
 
   @Override
+  public void close() {
+    // Nothing to close for HEAP store.
+  }
+
+  @Override
   public List<BlockLocation> getLocations(long blockid) {
     if (!mBlockLocations.containsKey(blockid)) {
       return Collections.emptyList();

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -127,6 +127,11 @@ public class RocksBlockStore implements BlockStore {
   }
 
   @Override
+  public void close() {
+    mRocksStore.close();
+  }
+
+  @Override
   public List<BlockLocation> getLocations(long id) {
     try (RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
         new ReadOptions().setPrefixSameAsStart(true))) {

--- a/core/server/master/src/test/java/alluxio/master/MockMaster.java
+++ b/core/server/master/src/test/java/alluxio/master/MockMaster.java
@@ -61,6 +61,9 @@ public final class MockMaster implements Master {
   public void stop() {}
 
   @Override
+  public void close() {}
+
+  @Override
   public boolean processJournalEntry(Journal.JournalEntry entry) {
     mEntries.add(entry);
     return true;


### PR DESCRIPTION
Leaving `RocksBlockStore` unclosed, will block creating further stores at the same path. This prevents running fail-over scenarios in single process tests with ROCKS meta-store. This PR makes necessary plumbing to make sure `RocksBlockStore` is closed during master shutdown.