### PR TITLE
Reduce noice level on DEBUG logging

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -171,4 +171,4 @@ log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
 log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Disable noisy DEBUG logs
-log4j.logger.org.apache.thrift.transport.TSaslTransport=OFF
+log4j.logger.io.grpc.netty.NettyServerHandler=OFF

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -422,7 +422,6 @@ public class InstancedConfiguration implements AlluxioConfiguration {
         throw new UnresolvablePropertyException(ExceptionMessage
             .UNDEFINED_CONFIGURATION_KEY.getMessage(match));
       }
-      LOG.debug("Replacing {} with {}", matcher.group(1), value);
       resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
     }
     return resolved;


### PR DESCRIPTION
- `org.apache.thrift.transport.TSaslTransport` is no more relevant but `io.grpc.netty.NettyServerHandler` becomes the new noisy logger
- `LOG.debug("Replacing {} with {}", matcher.group(1), value);` is very noisy during startup