### PR TITLE
Apply a few shell improvement in start scripts

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -58,7 +58,6 @@ function bootstrapConf {
   fi
   local master=${1}
 
-  ALLUXIO_CONF_DIR="${BIN}/../conf"
   local dst="${ALLUXIO_CONF_DIR}/alluxio-site.properties"
 
   if [[ -e ${dst} ]]; then
@@ -187,13 +186,6 @@ function main {
   COMMAND=$1
   shift
 
-  # bootstrap to create conf/alluxio-env.sh. This commands needs to be processed
-  # before sourcing libexec/alluxio-conf.sh which requires conf/alluxio-env.sh
-  if [[ "${COMMAND}" == "bootstrapConf" || "${COMMAND}" == "bootstrap-conf" ]]; then
-    bootstrapConf "$@"
-    exit 0
-  fi
-
   DEFAULT_LIBEXEC_DIR="${BIN}"/../libexec
   ALLUXIO_LIBEXEC_DIR=${ALLUXIO_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
@@ -201,6 +193,9 @@ function main {
   PARAMETER=""
 
   case ${COMMAND} in
+  "bootstrapConf")
+    bootstrapConf "$@"
+  ;;
   "extensions")
     CLASS="alluxio.cli.extensions.ExtensionsShell"
     CLASSPATH=${ALLUXIO_SERVER_CLASSPATH}

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -47,7 +47,7 @@ MOPT (Mount Option) is one of:
              set ALLUXIO_RAM_FOLDER=/dev/shm on each worker and use NoMount.
   NoMount is assumed if MOPT is not specified.
 
--a         asynchonously start all processes. The script may exit before all
+-a         asynchronously start all processes. The script may exit before all
            processes have been started.
 -f         format Journal, UnderFS Data and Workers Folder on master.
 -h         display this help.

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -46,7 +46,7 @@ if [[ -z "${JAVA}" ]]; then
   elif [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
     JAVA="${JAVA_HOME}/bin/java"
   else
-    echo "Error: Cannot find 'java' on path on under \$JAVA_HOME/bin/."
+    echo "Error: Cannot find 'java' on path or under \$JAVA_HOME/bin/."
     exit 1
   fi
 fi

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -39,18 +39,23 @@ if [[ -e "${ALLUXIO_CONF_DIR}/alluxio-env.sh" ]]; then
   . "${ALLUXIO_CONF_DIR}/alluxio-env.sh"
 fi
 
-if [[ -z "$(which java)" ]]; then
-  echo "Cannot find the 'java' command."
-  exit 1
+# Check if java is found
+if [[ -z "${JAVA}" ]]; then
+  if [[ -n "$(which java)" ]]; then
+    JAVA=$(which java)
+  elif [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
+    JAVA="${JAVA_HOME}/bin/java"
+  else
+    echo "Error: Cannot find 'java' on path on under \$JAVA_HOME/bin/."
+    exit 1
+  fi
 fi
 
-JAVA_HOME=${JAVA_HOME:-"$(dirname $(which java))/.."}
-JAVA=${JAVA:-"${JAVA_HOME}/bin/java"}
-
-if [[ -n "${ALLUXIO_MASTER_ADDRESS}" ]]; then
-  echo "ALLUXIO_MASTER_ADDRESS is deprecated since version 1.1 and will be remove in version 2.0."
-  echo "Please use \"ALLUXIO_MASTER_HOSTNAME\" instead."
-  ALLUXIO_MASTER_HOSTNAME=${ALLUXIO_MASTER_ADDRESS}
+# Check Java version == 1.8
+JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ $(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}') != 001008 ]]; then
+  echo "Error: Alluxio requires Java 8, currently Java $JAVA_VERSION found."
+  exit 1
 fi
 
 if [[ -n "${ALLUXIO_HOME}" ]]; then
@@ -69,6 +74,10 @@ if [[ -n "${ALLUXIO_MASTER_HOSTNAME}" ]]; then
 fi
 
 if [[ -n "${ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS}" ]]; then
+  ALLUXIO_JAVA_OPTS+=" -Dalluxio.master.mount.table.root.ufs=${ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS}"
+elif [[ -n "${ALLUXIO_UNDERFS_ADDRESS}" ]]; then
+  echo "Warning: ALLUXIO_UNDERFS_ADDRESS is deprecated by ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS"
+  ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS="${ALLUXIO_UNDERFS_ADDRESS}"
   ALLUXIO_JAVA_OPTS+=" -Dalluxio.master.mount.table.root.ufs=${ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS}"
 fi
 


### PR DESCRIPTION
- Move `bootstrapConf` to `case` as other commands in `bin/alluxio`. The reason is we no more change `conf/alluxio-env.sh` inside `bootstrapConf`
- Add more Java version check in `libexec/alluxio-config.sh` --- we require Java 1.8 to run Alluxio at least for now
- Continue support of `ALLUXIO_UNDERFS_ADDRESS` and add warning about deprecation