### PR TITLE
[DOCFIX] Add a property in the fuse property table

### DIFF
--- a/docs/_data/table/Alluxio-FUSE-parameter.csv
+++ b/docs/_data/table/Alluxio-FUSE-parameter.csv
@@ -1,5 +1,6 @@
 parameter,defaultValue
-alluxio.fuse.maxwrite.bytes,131072
-alluxio.fuse.debug.enabled,false
 alluxio.fuse.cachedpaths.max,500
+alluxio.fuse.debug.enabled,false
 alluxio.fuse.fs.name,alluxio-fuse
+alluxio.fuse.maxwrite.bytes,131072
+alluxio.fuse.user.group.translation.enabled,false

--- a/docs/_data/table/cn/Alluxio-FUSE-parameter.yml
+++ b/docs/_data/table/cn/Alluxio-FUSE-parameter.yml
@@ -1,8 +1,11 @@
-alluxio.fuse.maxwrite.bytes:
-  FUSE写操作的粒度（bytes），注意目前128KB是linux内核限制的上界。
-alluxio.fuse.debug.enabled:
-  允许FUSE调试输出， 该输出会被重定向到`alluxio.logs.dir`指定目录中的`fuse.out`日志文件。
 alluxio.fuse.cachedpaths.max:
   定义Alluxio-FUSE内部缓存的大小，该缓存用于存储最频繁使用的本地文件系统路径与Alluxio文件URI的对应关系。
+alluxio.fuse.debug.enabled:
+  允许FUSE调试输出， 该输出会被重定向到`alluxio.logs.dir`指定目录中的`fuse.out`日志文件。
 alluxio.fuse.fs.name:
   FUSE挂载文件系统使用的描述性名称。
+alluxio.fuse.maxwrite.bytes:
+  FUSE写操作的粒度（bytes），注意目前128KB是linux内核限制的上界。
+alluxio.fuse.user.group.translation.enabled:
+  是否在FUSE API中将Alluxio的用户与组转化为对应的Unix用户与组。当设为false时，所有FUSE文件的用户与组
+  将会显示为挂载alluxio-fuse线程的用户与组。

--- a/docs/_data/table/en/Alluxio-FUSE-parameter.yml
+++ b/docs/_data/table/en/Alluxio-FUSE-parameter.yml
@@ -1,11 +1,15 @@
-alluxio.fuse.maxwrite.bytes:
-  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
-  bound imposed by the linux kernel.
-alluxio.fuse.debug.enabled:
-  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
-  `alluxio.logs.dir`.
 alluxio.fuse.cachedpaths.max:
   Defines the size of the internal Alluxio-FUSE cache that maintains the most frequently used
   translations between local file system paths and Alluxio file URIs.
+alluxio.fuse.debug.enabled:
+  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
+  `alluxio.logs.dir`.
 alluxio.fuse.fs.name:
   Descriptive name used by FUSE to mount the file system.
+alluxio.fuse.maxwrite.bytes:
+  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
+  bound imposed by the linux kernel.
+alluxio.fuse.user.group.translation.enabled:
+  Whether to translate Alluxio users and groups into Unix users and groups when exposing Alluxio files
+  through the FUSE API. When this property is set to false, the user and group for all FUSE files
+  will match the user who started the alluxio-fuse process


### PR DESCRIPTION
Add the missing property `alluxio.fuse.user.group.translation.enabled` to the fuse property table.