### PR TITLE
Fix slashes get converted to underscores in the metrics UI page

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -357,8 +357,9 @@ public final class MetricsSystem {
   }
 
   /**
-   * Escapes a URI, replacing "." with "%2E" and "/" with "%2F".
-   * Replaces "%" with "%25" as well.
+   * Escapes a URI, replacing "/" with "%2F".
+   * Replaces "." with "%2E" because dots are used as tag separators in metric names.
+   * Replaces "%" with "%25" because it now has special use.
    * So when the URI is used in a metric name, the "." and "/" won't be interpreted as
    * path separators unescaped and interfere with the internal logic of AlluxioURI.
    *

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -357,14 +357,24 @@ public final class MetricsSystem {
   }
 
   /**
-   * Escapes a URI, replacing "." with "_" so that when the URI is used in a metric name,
-   * the "." won't be interpreted as path separators.
+   * Escapes a URI, replacing "." with "\\." and "/" with "\\/" so that when the URI is used in a metric name,
+   * the "." and "/" won't be interpreted as path separators unescaped.
    *
    * @param uri the URI to escape
    * @return the string representing the escaped URI
    */
   public static String escape(AlluxioURI uri) {
-    return uri.toString().replace(".", "_");
+    return uri.toString().replace("/", "\\/").replace(".", "\\.");
+  }
+
+  /**
+   * Unescapes a URI, replacing "\\." with "." and "\\/" with "/" to revert URI to the unescaped form.
+   *
+   * @param uri the escaped URI to unescape
+   * @return the string representing the unescaped original URI
+   */
+  public static String unescape(String uri){
+    return uri.replace("\\.", ".").replace("\\/","/");
   }
 
   // Some helper functions.

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -365,7 +365,7 @@ public final class MetricsSystem {
    * @return the string representing the escaped URI
    */
   public static String escape(AlluxioURI uri) {
-    return uri.toString().replace("/", "\\/").replace(".", "\\.");
+    return uri.toString().replace("%", "%25").replace("/", "%2F").replace(".", "%2E");
   }
 
   /**
@@ -376,7 +376,7 @@ public final class MetricsSystem {
    * @return the string representing the unescaped original URI
    */
   public static String unescape(String uri) {
-    return uri.replace("\\.", ".").replace("\\/", "/");
+    return uri.replace("%2F", "/").replace("%2E", ".").replace("%25", "%");
   }
 
   // Some helper functions.

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -357,9 +357,10 @@ public final class MetricsSystem {
   }
 
   /**
-   * Escapes a URI, replacing "." with "\\." and "/" with "\\/".
+   * Escapes a URI, replacing "." with "%2E" and "/" with "%2F".
+   * Replaces "%" with "%25" as well.
    * So when the URI is used in a metric name, the "." and "/" won't be interpreted as
-   * path separators unescaped.
+   * path separators unescaped and interfere with the internal logic of AlluxioURI.
    *
    * @param uri the URI to escape
    * @return the string representing the escaped URI
@@ -369,8 +370,7 @@ public final class MetricsSystem {
   }
 
   /**
-   * Unescapes a URI, replacing "\\." with "." and "\\/" with "/" to revert URI to
-   * the unescaped form.
+   * Unescapes a URI, reverts it to before the escape, to display it correctly.
    *
    * @param uri the escaped URI to unescape
    * @return the string representing the unescaped original URI

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -357,8 +357,9 @@ public final class MetricsSystem {
   }
 
   /**
-   * Escapes a URI, replacing "." with "\\." and "/" with "\\/" so that when the URI is used in a metric name,
-   * the "." and "/" won't be interpreted as path separators unescaped.
+   * Escapes a URI, replacing "." with "\\." and "/" with "\\/".
+   * So when the URI is used in a metric name, the "." and "/" won't be interpreted as
+   * path separators unescaped.
    *
    * @param uri the URI to escape
    * @return the string representing the escaped URI
@@ -368,13 +369,14 @@ public final class MetricsSystem {
   }
 
   /**
-   * Unescapes a URI, replacing "\\." with "." and "\\/" with "/" to revert URI to the unescaped form.
+   * Unescapes a URI, replacing "\\." with "." and "\\/" with "/" to revert URI to
+   * the unescaped form.
    *
    * @param uri the escaped URI to unescape
    * @return the string representing the unescaped original URI
    */
-  public static String unescape(String uri){
-    return uri.replace("\\.", ".").replace("\\/","/");
+  public static String unescape(String uri) {
+    return uri.replace("\\.", ".").replace("\\/", "/");
   }
 
   // Some helper functions.

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -357,14 +357,14 @@ public final class MetricsSystem {
   }
 
   /**
-   * Escapes a URI, replacing "/" and "." with "_" so that when the URI is used in a metric name,
-   * the "/" and "." won't be interpreted as path separators.
+   * Escapes a URI, replacing "." with "_" so that when the URI is used in a metric name,
+   * the "." won't be interpreted as path separators.
    *
    * @param uri the URI to escape
    * @return the string representing the escaped URI
    */
   public static String escape(AlluxioURI uri) {
-    return uri.toString().replace("/", "_").replace(".", "_");
+    return uri.toString().replace(".", "_");
   }
 
   // Some helper functions.

--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -12,7 +12,6 @@
 package alluxio.metrics;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import alluxio.AlluxioURI;
 

--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -26,7 +26,8 @@ import java.util.Properties;
  */
 public final class MetricsSystemTest {
   private MetricsConfig mMetricsConfig;
-  private static Counter sCounter = MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
+  private static Counter sCounter =
+          MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
 
   /**
    * Sets up the properties for the configuration of the metrics before a test runs.

--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -27,8 +27,7 @@ import java.util.Properties;
  */
 public final class MetricsSystemTest {
   private MetricsConfig mMetricsConfig;
-  private static Counter sCounter =
-          MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
+  private static Counter sCounter = MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
 
   /**
    * Sets up the properties for the configuration of the metrics before a test runs.
@@ -67,26 +66,21 @@ public final class MetricsSystemTest {
     String localUriEscaped1 = MetricsSystem.escape(localUri1);
     assertEquals("%2Ffoo%2Falluxio%2FunderFSStorage",
             localUriEscaped1);
-    assertFalse(localUriEscaped1.contains("/"));
 
     AlluxioURI localUri2 = new AlluxioURI("/.alluxio.wololo/alluxio/underFSStorage");
     String localUriEscaped2 = MetricsSystem.escape(localUri2);
     assertEquals("%2F%2Ealluxio%2Ewololo%2Falluxio%2FunderFSStorage",
             localUriEscaped2);
-    assertFalse(localUriEscaped2.contains("/"));
-    assertFalse(localUriEscaped2.contains("."));
 
     AlluxioURI localUri3 = new AlluxioURI("/%25alluxio%20user%2Ffoo%2Ebar/alluxio/underFSStorage");
     String localUriEscaped3 = MetricsSystem.escape(localUri3);
     assertEquals("%2F%2525alluxio%2520user%252Ffoo%252Ebar%2Falluxio%2FunderFSStorage",
             localUriEscaped3);
-    assertFalse(localUriEscaped3.contains("/"));
 
     AlluxioURI localUri4 = new AlluxioURI("s3a://test/Tasks+Export+%282017–11–05+06%3A10+PM%2Ecsv");
     String localUriEscaped4 = MetricsSystem.escape(localUri4);
     assertEquals("s3a:%2F%2Ftest%2FTasks+Export+%25282017–11–05+06%253A10+PM%252Ecsv",
             localUriEscaped4);
-    assertFalse(localUriEscaped4.contains("/"));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 public final class MetricsSystemTest {
   private MetricsConfig mMetricsConfig;
   private static Counter sCounter =
-          MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
+      MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
 
   /**
    * Sets up the properties for the configuration of the metrics before a test runs.

--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -12,6 +12,9 @@
 package alluxio.metrics;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import alluxio.AlluxioURI;
 
 import com.codahale.metrics.Counter;
 import org.junit.Before;
@@ -25,7 +28,7 @@ import java.util.Properties;
 public final class MetricsSystemTest {
   private MetricsConfig mMetricsConfig;
   private static Counter sCounter =
-      MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
+          MetricsSystem.METRIC_REGISTRY.counter(MetricsSystem.getMetricName("counter"));
 
   /**
    * Sets up the properties for the configuration of the metrics before a test runs.
@@ -53,5 +56,62 @@ public final class MetricsSystemTest {
     // Make sure it doesn't crash.
     sCounter.inc();
     MetricsSystem.stopSinks();
+  }
+
+  /**
+   * Tests the "/" "." and "%" special characters can be escaped.
+   */
+  @Test
+  public void testEscape() {
+    AlluxioURI localUri1 = new AlluxioURI("/foo/alluxio/underFSStorage");
+    String localUriEscaped1 = MetricsSystem.escape(localUri1);
+    assertEquals("%2Ffoo%2Falluxio%2FunderFSStorage",
+            localUriEscaped1);
+    assertFalse(localUriEscaped1.contains("/"));
+
+    AlluxioURI localUri2 = new AlluxioURI("/.alluxio.wololo/alluxio/underFSStorage");
+    String localUriEscaped2 = MetricsSystem.escape(localUri2);
+    assertEquals("%2F%2Ealluxio%2Ewololo%2Falluxio%2FunderFSStorage",
+            localUriEscaped2);
+    assertFalse(localUriEscaped2.contains("/"));
+    assertFalse(localUriEscaped2.contains("."));
+
+    AlluxioURI localUri3 = new AlluxioURI("/%25alluxio%20user%2Ffoo%2Ebar/alluxio/underFSStorage");
+    String localUriEscaped3 = MetricsSystem.escape(localUri3);
+    assertEquals("%2F%2525alluxio%2520user%252Ffoo%252Ebar%2Falluxio%2FunderFSStorage",
+            localUriEscaped3);
+    assertFalse(localUriEscaped3.contains("/"));
+
+    AlluxioURI localUri4 = new AlluxioURI("s3a://test/Tasks+Export+%282017–11–05+06%3A10+PM%2Ecsv");
+    String localUriEscaped4 = MetricsSystem.escape(localUri4);
+    assertEquals("s3a:%2F%2Ftest%2FTasks+Export+%25282017–11–05+06%253A10+PM%252Ecsv",
+            localUriEscaped4);
+    assertFalse(localUriEscaped4.contains("/"));
+  }
+
+  /**
+   * Tests the escaped strings can be safely unescaped.
+   */
+  @Test
+  public void testUnescape() {
+    AlluxioURI localUri1 = new AlluxioURI("/foo/alluxio/underFSStorage");
+    String localUriEscaped1 = MetricsSystem.escape(localUri1);
+    String localUriUnescaped1 = MetricsSystem.unescape(localUriEscaped1);
+    assertEquals(localUri1.toString(), localUriUnescaped1);
+
+    AlluxioURI localUri2 = new AlluxioURI("/.alluxio.wololo/alluxio/underFSStorage");
+    String localUriEscaped2 = MetricsSystem.escape(localUri2);
+    String localUriUnescaped2 = MetricsSystem.unescape(localUriEscaped2);
+    assertEquals(localUri2.toString(), localUriUnescaped2);
+
+    AlluxioURI localUri3 = new AlluxioURI("/%25alluxio%20user%2Ffoo%2Ebar/alluxio/underFSStorage");
+    String localUriEscaped3 = MetricsSystem.escape(localUri3);
+    String localUriUnescaped3 = MetricsSystem.unescape(localUriEscaped3);
+    assertEquals(localUri3.toString(), localUriUnescaped3);
+
+    AlluxioURI localUri4 = new AlluxioURI("s3a://test/Tasks+Export+%282017–11–05+06%3A10+PM%2Ecsv");
+    String localUriEscaped4 = MetricsSystem.escape(localUri4);
+    String localUriUnescaped4 = MetricsSystem.unescape(localUriEscaped4);
+    assertEquals(localUri4.toString(), localUriUnescaped4);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -997,9 +997,10 @@ public final class AlluxioMasterRestServiceHandler {
         }
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
         if (isMounted(ufs)) {
+          // Unescape the URI for display
           Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
-          perUfsMap.put(ufs, (long) metric.getValue());
-          ufsOpsMap.put(ufs, perUfsMap);
+          perUfsMap.put(MetricsSystem.unescape(ufs), (long) metric.getValue());
+          ufsOpsMap.put(MetricsSystem.unescape(ufs), perUfsMap);
         }
       }
       response.setUfsOps(ufsOpsMap);

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -998,9 +998,10 @@ public final class AlluxioMasterRestServiceHandler {
         String ufs = metric.getTags().get(WorkerMetrics.TAG_UFS);
         if (isMounted(ufs)) {
           // Unescape the URI for display
+          String ufsUnescaped = MetricsSystem.unescape(ufs);
           Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
-          perUfsMap.put(MetricsSystem.unescape(ufs), (long) metric.getValue());
-          ufsOpsMap.put(MetricsSystem.unescape(ufs), perUfsMap);
+          perUfsMap.put(ufsUnescaped, (long) metric.getValue());
+          ufsOpsMap.put(ufsUnescaped, perUfsMap);
         }
       }
       response.setUfsOps(ufsOpsMap);


### PR DESCRIPTION
Removed escape() logic in alluxio.metrics.MetricsSystem of replacing "/" with "_".
Now the escape only replaces "." with "_".
