### PR TITLE
Add non-root user to Docker Image

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -27,4 +27,7 @@ RUN cd /opt && \
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /
 
+RUN adduser -u 1000 -S alluxio -G root
+USER 1000
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -12,8 +12,12 @@
 FROM openjdk:8-jdk-alpine
 
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/1.8.1/alluxio-1.8.1-bin.tar.gz
+ARG ALLUXIO_USERNAME=alluxio
+ARG ALLUXIO_GROUP=alluxio
+ARG ALLUXIO_UID=1000
+ARG ALLUXIO_GID=1000
 
-RUN apk add --update bash libc6-compat && \
+RUN apk --no-cache --update add bash libc6-compat shadow && \
     rm -rf /var/cache/apk/*
 
 ADD ${ALLUXIO_TARBALL} /opt/
@@ -27,7 +31,12 @@ RUN cd /opt && \
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /
 
-RUN adduser -u 1000 -S alluxio -G root
-USER 1000
+RUN addgroup -g ${ALLUXIO_GID} -S ${ALLUXIO_GROUP} && \
+    adduser -u ${ALLUXIO_UID} -S ${ALLUXIO_USERNAME} -G ${ALLUXIO_GROUP} && \
+    usermod -a -G root ${ALLUXIO_USERNAME} && \
+    chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /opt/alluxio* && \
+    chmod -R g=u /opt/alluxio*
+
+USER ${ALLUXIO_UID}
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -34,7 +34,7 @@ RUN cd /opt && \
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /
 
-RUN adduser -u 1000 -S alluxio -G root
+RUN useradd -r -u 1000 -s /bin/false alluxio -G root
 USER 1000
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -34,4 +34,7 @@ RUN cd /opt && \
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /
 
+RUN adduser -u 1000 -S alluxio -G root
+USER 1000
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -12,6 +12,10 @@
 FROM ubuntu:16.04
 
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/1.8.1/alluxio-1.8.1-bin.tar.gz
+ARG ALLUXIO_USERNAME=alluxio
+ARG ALLUXIO_GROUP=alluxio
+ARG ALLUXIO_UID=1000
+ARG ALLUXIO_GID=1000
 
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
@@ -34,7 +38,12 @@ RUN cd /opt && \
 COPY conf /opt/alluxio/conf/
 COPY entrypoint.sh /
 
-RUN useradd -r -u 1000 -s /bin/false alluxio -G root
-USER 1000
+RUN groupadd -g ${ALLUXIO_GID} -r ${ALLUXIO_GROUP} && \
+    useradd -u ${ALLUXIO_UID} -r ${ALLUXIO_USERNAME} -g ${ALLUXIO_GROUP} && \
+    usermod -a -G root ${ALLUXIO_USERNAME} && \
+    chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /opt/alluxio* && \
+    chmod -R g=u /opt/alluxio*
+
+USER ${ALLUXIO_UID}
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
* Added a non-root user to the image called `alluxio` 
with uid `1000`and root group membership
* Allows users to run the Alluxio Docker image as a non-root user