### PR TITLE
Change journal backup default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .port_coordination/
 .project
 .settings/
+/alluxio_backups/
 /client/
 /conf/alluxio-env.sh
 /conf/alluxio-env.sh.bootstrap.bk

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1136,7 +1136,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_BACKUP_DIRECTORY =
       new Builder(Name.MASTER_BACKUP_DIRECTORY)
-          .setDefaultValue("/alluxio_backups")
+          .setDefaultValue(String.format("${%s}/alluxio_backups", Name.WORK_DIR))
           .setDescription("Default directory for writing master metadata backups. This path is "
               + "an absolute path of the root UFS. For example, if the root ufs "
               + "directory is hdfs://host:port/alluxio/data, the default backup directory will be "

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -268,7 +268,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     String dir = options.hasTargetDirectory() ? options.getTargetDirectory()
         : ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY);
     UnderFileSystem ufs = mUfs;
-    if (options.getLocalFileSystem() && !ufs.getUnderFSType().equals("local")) {
+    if ((options.getLocalFileSystem() && !ufs.getUnderFSType().equals("local")) || !options.hasTargetDirectory()) {
       ufs = UnderFileSystem.Factory.create("/",
           UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
       LOG.info("Backing up to local filesystem in directory {}", dir);

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -268,7 +268,8 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     String dir = options.hasTargetDirectory() ? options.getTargetDirectory()
         : ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY);
     UnderFileSystem ufs = mUfs;
-    if ((options.getLocalFileSystem() && !ufs.getUnderFSType().equals("local")) || !options.hasTargetDirectory()) {
+    if ((options.getLocalFileSystem() && !ufs.getUnderFSType().equals("local"))
+            || !options.hasTargetDirectory()) {
       ufs = UnderFileSystem.Factory.create("/",
           UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
       LOG.info("Backing up to local filesystem in directory {}", dir);

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -268,8 +268,8 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     String dir = options.hasTargetDirectory() ? options.getTargetDirectory()
         : ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY);
     UnderFileSystem ufs = mUfs;
-    if ((options.getLocalFileSystem() && !ufs.getUnderFSType().equals("local"))
-            || !options.hasTargetDirectory()) {
+    if ((options.getLocalFileSystem() || !options.hasTargetDirectory())
+            && !ufs.getUnderFSType().equals("local")) {
       ufs = UnderFileSystem.Factory.create("/",
           UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
       LOG.info("Backing up to local filesystem in directory {}", dir);


### PR DESCRIPTION
Change the default backup directory to be '/opt/alluxio/alluxio_backups' on the current Alluxio Primary Master
If a path is provided via CLI, then fall back to using UFS (same behaviour)
If a path is provided via CLI with the --local option, then backup to the specified directory on the primary master (same behaviour)
