### PR TITLE
Improve UFS journal flush/replay failure handling

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -12,6 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.Configuration;
+import alluxio.ProcessUtils;
 import alluxio.PropertyKey;
 import alluxio.exception.InvalidJournalEntryException;
 import alluxio.master.journal.JournalEntryStateMachine;
@@ -121,9 +122,9 @@ public final class UfsJournalCheckpointThread extends Thread {
   public void run() {
     try {
       runInternal();
-    } catch (RuntimeException e) {
-      LOG.error("{}: Failed to run journal checkpoint thread, crashing.", mMaster.getName(), e);
-      throw e;
+    } catch (Throwable e) {
+      ProcessUtils.fatalError(LOG, e, "%s: Failed to run journal checkpoint thread, crashing.",
+          mMaster.getName());
     }
   }
 


### PR DESCRIPTION
For v1 UFS journals, flush failure handling will leave journal system in
a state where
- current log file is uncompleted.
- subsequent journal writes will cause a new log file creation.
Since secondary journal skips incomplete files, this will create a gap
in journal sequences it sees and its background thread will crash.

This PR:
- fixes flush failure handling.
- crashes secondary process crashes when journal replaying encounters an
issue.

pr-link: Alluxio/alluxio#9274
change-id: cid-f79108067ab5a4e427b5155e35ed57d9d14ba871