### PR TITLE
Fix job-master gRPC context cascading

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -49,6 +49,7 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import io.grpc.Context;
 import net.jcip.annotations.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,46 +206,54 @@ public final class JobMaster extends AbstractMaster implements NoopJournaled {
    */
   public synchronized long run(JobConfig jobConfig)
       throws JobDoesNotExistException, ResourceExhaustedException {
-    if (mIdToJobCoordinator.size() == mCapacity) {
-      if (mFinishedJobs.isEmpty()) {
-        // The job master is at full capacity and no job has finished.
-        throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
-      }
-      // Discard old jobs that have completion time beyond retention policy
-      Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
-      // Used to denote whether space could be reserved for the new job
-      // It's 'true' if job master is at full capacity
-      boolean isfull = true;
-      while (jobIterator.hasNext()) {
-        JobInfo oldestJob = jobIterator.next();
-        long completedBeforeMs = CommonUtils.getCurrentMs() - oldestJob.getLastStatusChangeMs();
-        if (completedBeforeMs < RETENTION_MS) {
-          // mFinishedJobs is sorted. Can't iterate to a job within retention policy
-          break;
+    // This RPC service implementation triggers another RPC.
+    // Run the implementation under forked context to avoid interference.
+    // Then restore the current context at the end.
+    Context forkedCtx = Context.current().fork();
+    Context prevCtx = forkedCtx.attach();
+    try {
+      if (mIdToJobCoordinator.size() == mCapacity) {
+        if (mFinishedJobs.isEmpty()) {
+          // The job master is at full capacity and no job has finished.
+          throw new ResourceExhaustedException(
+              ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
         }
-        jobIterator.remove();
-        mIdToJobCoordinator.remove(oldestJob.getId());
-        isfull = false;
-      }
-      if (isfull) {
-        throw new ResourceExhaustedException(
-            ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
-      }
-    }
-    long jobId = mJobIdGenerator.getNewJobId();
-    JobCoordinator jobCoordinator = JobCoordinator.create(mCommandManager, mJobServerContext,
-        getWorkerInfoList(), jobId, jobConfig,
-        (jobInfo) -> {
-          Status status = jobInfo.getStatus();
-          mFinishedJobs.remove(jobInfo);
-          if (status.isFinished()) {
-            mFinishedJobs.add(jobInfo);
+        // Discard old jobs that have completion time beyond retention policy
+        Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
+        // Used to denote whether space could be reserved for the new job
+        // It's 'true' if job master is at full capacity
+        boolean isfull = true;
+        while (jobIterator.hasNext()) {
+          JobInfo oldestJob = jobIterator.next();
+          long completedBeforeMs = CommonUtils.getCurrentMs() - oldestJob.getLastStatusChangeMs();
+          if (completedBeforeMs < RETENTION_MS) {
+            // mFinishedJobs is sorted. Can't iterate to a job within retention policy
+            break;
           }
-          return null;
-        });
-    mIdToJobCoordinator.put(jobId, jobCoordinator);
-    return jobId;
+          jobIterator.remove();
+          mIdToJobCoordinator.remove(oldestJob.getId());
+          isfull = false;
+        }
+        if (isfull) {
+          throw new ResourceExhaustedException(
+              ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
+        }
+      }
+      long jobId = mJobIdGenerator.getNewJobId();
+      JobCoordinator jobCoordinator = JobCoordinator.create(mCommandManager, mJobServerContext,
+          getWorkerInfoList(), jobId, jobConfig, (jobInfo) -> {
+            Status status = jobInfo.getStatus();
+            mFinishedJobs.remove(jobInfo);
+            if (status.isFinished()) {
+              mFinishedJobs.add(jobInfo);
+            }
+            return null;
+          });
+      mIdToJobCoordinator.put(jobId, jobCoordinator);
+      return jobId;
+    } finally {
+      forkedCtx.detach(prevCtx);
+    }
   }
 
   /**

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -222,7 +222,7 @@ public final class JobMaster extends AbstractMaster implements NoopJournaled {
         Iterator<JobInfo> jobIterator = mFinishedJobs.iterator();
         // Used to denote whether space could be reserved for the new job
         // It's 'true' if job master is at full capacity
-        boolean isfull = true;
+        boolean isFull = true;
         while (jobIterator.hasNext()) {
           JobInfo oldestJob = jobIterator.next();
           long completedBeforeMs = CommonUtils.getCurrentMs() - oldestJob.getLastStatusChangeMs();
@@ -232,9 +232,9 @@ public final class JobMaster extends AbstractMaster implements NoopJournaled {
           }
           jobIterator.remove();
           mIdToJobCoordinator.remove(oldestJob.getId());
-          isfull = false;
+          isFull = false;
         }
-        if (isfull) {
+        if (isFull) {
           throw new ResourceExhaustedException(
               ExceptionMessage.JOB_MASTER_FULL_CAPACITY.getMessage(mCapacity));
         }


### PR DESCRIPTION
gRPC requires `io.grpc.Context` instance to be forked if an RPC implementation calls another RPC. Because termination of first call will invalidate context of the cascaded calls. Even if calls are contained within each other, with authentication long polling, authentication stream opened for the second call will be canceled after first call returns. That means every call to first RPC will cause tearing up of channel used for the second RPC. 

This PR forks gRPC context inside `JobMaster:run RPC call` since some job definitions require RPC calls during initialization.