### PR TITLE
Fix behavior of get*Status in LocalUnderFileSystem

### DIFF
--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -181,6 +181,9 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
     try {
       PosixFileAttributes attr =
           Files.readAttributes(Paths.get(file.getPath()), PosixFileAttributes.class);
+      if (!attr.isDirectory()) {
+        throw new IOException(String.format("path %s is not directory", path));
+      }
       return new UfsDirectoryStatus(path, attr.owner().getName(), attr.group().getName(),
           FileUtils.translatePosixPermissionToMode(attr.permissions()), file.lastModified());
     } catch (FileSystemException e) {

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -211,6 +211,9 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
     try {
       PosixFileAttributes attr =
           Files.readAttributes(Paths.get(file.getPath()), PosixFileAttributes.class);
+      if (attr.isDirectory()) {
+        throw new IOException(String.format("path %s is not a file", path));
+      }
       String contentHash =
           UnderFileSystemUtils.approximateContentHash(file.length(), file.lastModified());
       return new UfsFileStatus(path, contentHash, file.length(), file.lastModified(),

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -21,6 +21,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
 import alluxio.underfs.UfsMode;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -240,6 +241,25 @@ public class LocalUnderFileSystemTest {
       assertFalse(s.isFile());
 
       mLocalUfs.getDirectoryStatus(file);
+      fail("Should have failed to get dir status on file");
+    } catch (IOException e) {
+      // Expect exception
+    }
+  }
+
+  @Test
+  public void getFileStatus() throws IOException {
+    String file = PathUtils.concatPath(mLocalUfsRoot, getUniqueFileName());
+    String dir = PathUtils.concatPath(mLocalUfsRoot, getUniqueFileName());
+
+    mLocalUfs.create(file).close();
+    mLocalUfs.mkdirs(dir);
+    try {
+      UfsFileStatus s = mLocalUfs.getFileStatus(file);
+      assertFalse(s.isDirectory());
+      assertTrue(s.isFile());
+
+      mLocalUfs.getDirectoryStatus(dir);
       fail("Should have failed to get dir status on file");
     } catch (IOException e) {
       // Expect exception

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -14,11 +14,13 @@ package alluxio.underfs.local;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.underfs.UfsDirectoryStatus;
 import alluxio.underfs.UfsMode;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -223,6 +225,25 @@ public class LocalUnderFileSystemTest {
     is.close();
 
     Assert.assertArrayEquals(bytes, bytes1);
+  }
+
+  @Test
+  public void getDirStatus() throws IOException {
+    String file = PathUtils.concatPath(mLocalUfsRoot, getUniqueFileName());
+    String dir = PathUtils.concatPath(mLocalUfsRoot, getUniqueFileName());
+
+    mLocalUfs.create(file).close();
+    mLocalUfs.mkdirs(dir);
+    try {
+      UfsDirectoryStatus s = mLocalUfs.getDirectoryStatus(dir);
+      assertTrue(s.isDirectory());
+      assertFalse(s.isFile());
+
+      mLocalUfs.getDirectoryStatus(file);
+      fail("Should have failed to get dir status on file");
+    } catch (IOException e) {
+      // Expect exception
+    }
   }
 
   private byte[] getBytes() {


### PR DESCRIPTION
In the getDirectoryStatus javadoc:
 - If a path is a file, this method should throw an exception

In the getFileStatus javadoc:
 - If a path is a directory, this method should throw an
  exception

Unit tests added for behavior verification.