### PR TITLE
Unify completing a file and scheduling persistence

### DIFF
--- a/core/transport/src/grpc/file_system_master.proto
+++ b/core/transport/src/grpc/file_system_master.proto
@@ -51,7 +51,8 @@ message CheckConsistencyPRequest {
 message CompleteFilePResponse {}
 message CompleteFilePOptions {
   optional int64 ufsLength = 1;
-  optional FileSystemMasterCommonPOptions commonOptions = 2;
+  optional ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;
+  optional FileSystemMasterCommonPOptions commonOptions = 3;
 }
 message CompleteFilePRequest {
   /** the path of the file */

--- a/core/transport/src/main/java/alluxio/grpc/CompleteFilePOptions.java
+++ b/core/transport/src/main/java/alluxio/grpc/CompleteFilePOptions.java
@@ -56,8 +56,21 @@ private static final long serialVersionUID = 0L;
             break;
           }
           case 18: {
-            alluxio.grpc.FileSystemMasterCommonPOptions.Builder subBuilder = null;
+            alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder subBuilder = null;
             if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              subBuilder = asyncPersistOptions_.toBuilder();
+            }
+            asyncPersistOptions_ = input.readMessage(alluxio.grpc.ScheduleAsyncPersistencePOptions.PARSER, extensionRegistry);
+            if (subBuilder != null) {
+              subBuilder.mergeFrom(asyncPersistOptions_);
+              asyncPersistOptions_ = subBuilder.buildPartial();
+            }
+            bitField0_ |= 0x00000002;
+            break;
+          }
+          case 26: {
+            alluxio.grpc.FileSystemMasterCommonPOptions.Builder subBuilder = null;
+            if (((bitField0_ & 0x00000004) == 0x00000004)) {
               subBuilder = commonOptions_.toBuilder();
             }
             commonOptions_ = input.readMessage(alluxio.grpc.FileSystemMasterCommonPOptions.PARSER, extensionRegistry);
@@ -65,7 +78,7 @@ private static final long serialVersionUID = 0L;
               subBuilder.mergeFrom(commonOptions_);
               commonOptions_ = subBuilder.buildPartial();
             }
-            bitField0_ |= 0x00000002;
+            bitField0_ |= 0x00000004;
             break;
           }
         }
@@ -108,22 +121,43 @@ private static final long serialVersionUID = 0L;
     return ufsLength_;
   }
 
-  public static final int COMMONOPTIONS_FIELD_NUMBER = 2;
-  private alluxio.grpc.FileSystemMasterCommonPOptions commonOptions_;
+  public static final int ASYNCPERSISTOPTIONS_FIELD_NUMBER = 2;
+  private alluxio.grpc.ScheduleAsyncPersistencePOptions asyncPersistOptions_;
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
    */
-  public boolean hasCommonOptions() {
+  public boolean hasAsyncPersistOptions() {
     return ((bitField0_ & 0x00000002) == 0x00000002);
   }
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+   */
+  public alluxio.grpc.ScheduleAsyncPersistencePOptions getAsyncPersistOptions() {
+    return asyncPersistOptions_ == null ? alluxio.grpc.ScheduleAsyncPersistencePOptions.getDefaultInstance() : asyncPersistOptions_;
+  }
+  /**
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+   */
+  public alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder getAsyncPersistOptionsOrBuilder() {
+    return asyncPersistOptions_ == null ? alluxio.grpc.ScheduleAsyncPersistencePOptions.getDefaultInstance() : asyncPersistOptions_;
+  }
+
+  public static final int COMMONOPTIONS_FIELD_NUMBER = 3;
+  private alluxio.grpc.FileSystemMasterCommonPOptions commonOptions_;
+  /**
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
+   */
+  public boolean hasCommonOptions() {
+    return ((bitField0_ & 0x00000004) == 0x00000004);
+  }
+  /**
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   public alluxio.grpc.FileSystemMasterCommonPOptions getCommonOptions() {
     return commonOptions_ == null ? alluxio.grpc.FileSystemMasterCommonPOptions.getDefaultInstance() : commonOptions_;
   }
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   public alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder getCommonOptionsOrBuilder() {
     return commonOptions_ == null ? alluxio.grpc.FileSystemMasterCommonPOptions.getDefaultInstance() : commonOptions_;
@@ -145,7 +179,10 @@ private static final long serialVersionUID = 0L;
       output.writeInt64(1, ufsLength_);
     }
     if (((bitField0_ & 0x00000002) == 0x00000002)) {
-      output.writeMessage(2, getCommonOptions());
+      output.writeMessage(2, getAsyncPersistOptions());
+    }
+    if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      output.writeMessage(3, getCommonOptions());
     }
     unknownFields.writeTo(output);
   }
@@ -161,7 +198,11 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000002) == 0x00000002)) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getCommonOptions());
+        .computeMessageSize(2, getAsyncPersistOptions());
+    }
+    if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(3, getCommonOptions());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -184,6 +225,11 @@ private static final long serialVersionUID = 0L;
       result = result && (getUfsLength()
           == other.getUfsLength());
     }
+    result = result && (hasAsyncPersistOptions() == other.hasAsyncPersistOptions());
+    if (hasAsyncPersistOptions()) {
+      result = result && getAsyncPersistOptions()
+          .equals(other.getAsyncPersistOptions());
+    }
     result = result && (hasCommonOptions() == other.hasCommonOptions());
     if (hasCommonOptions()) {
       result = result && getCommonOptions()
@@ -204,6 +250,10 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + UFSLENGTH_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getUfsLength());
+    }
+    if (hasAsyncPersistOptions()) {
+      hash = (37 * hash) + ASYNCPERSISTOPTIONS_FIELD_NUMBER;
+      hash = (53 * hash) + getAsyncPersistOptions().hashCode();
     }
     if (hasCommonOptions()) {
       hash = (37 * hash) + COMMONOPTIONS_FIELD_NUMBER;
@@ -334,6 +384,7 @@ private static final long serialVersionUID = 0L;
     private void maybeForceBuilderInitialization() {
       if (com.google.protobuf.GeneratedMessageV3
               .alwaysUseFieldBuilders) {
+        getAsyncPersistOptionsFieldBuilder();
         getCommonOptionsFieldBuilder();
       }
     }
@@ -341,12 +392,18 @@ private static final long serialVersionUID = 0L;
       super.clear();
       ufsLength_ = 0L;
       bitField0_ = (bitField0_ & ~0x00000001);
+      if (asyncPersistOptionsBuilder_ == null) {
+        asyncPersistOptions_ = null;
+      } else {
+        asyncPersistOptionsBuilder_.clear();
+      }
+      bitField0_ = (bitField0_ & ~0x00000002);
       if (commonOptionsBuilder_ == null) {
         commonOptions_ = null;
       } else {
         commonOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000002);
+      bitField0_ = (bitField0_ & ~0x00000004);
       return this;
     }
 
@@ -377,6 +434,14 @@ private static final long serialVersionUID = 0L;
       result.ufsLength_ = ufsLength_;
       if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
         to_bitField0_ |= 0x00000002;
+      }
+      if (asyncPersistOptionsBuilder_ == null) {
+        result.asyncPersistOptions_ = asyncPersistOptions_;
+      } else {
+        result.asyncPersistOptions_ = asyncPersistOptionsBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        to_bitField0_ |= 0x00000004;
       }
       if (commonOptionsBuilder_ == null) {
         result.commonOptions_ = commonOptions_;
@@ -427,6 +492,9 @@ private static final long serialVersionUID = 0L;
       if (other == alluxio.grpc.CompleteFilePOptions.getDefaultInstance()) return this;
       if (other.hasUfsLength()) {
         setUfsLength(other.getUfsLength());
+      }
+      if (other.hasAsyncPersistOptions()) {
+        mergeAsyncPersistOptions(other.getAsyncPersistOptions());
       }
       if (other.hasCommonOptions()) {
         mergeCommonOptions(other.getCommonOptions());
@@ -491,17 +559,135 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private alluxio.grpc.ScheduleAsyncPersistencePOptions asyncPersistOptions_ = null;
+    private com.google.protobuf.SingleFieldBuilderV3<
+        alluxio.grpc.ScheduleAsyncPersistencePOptions, alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder, alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder> asyncPersistOptionsBuilder_;
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public boolean hasAsyncPersistOptions() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public alluxio.grpc.ScheduleAsyncPersistencePOptions getAsyncPersistOptions() {
+      if (asyncPersistOptionsBuilder_ == null) {
+        return asyncPersistOptions_ == null ? alluxio.grpc.ScheduleAsyncPersistencePOptions.getDefaultInstance() : asyncPersistOptions_;
+      } else {
+        return asyncPersistOptionsBuilder_.getMessage();
+      }
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public Builder setAsyncPersistOptions(alluxio.grpc.ScheduleAsyncPersistencePOptions value) {
+      if (asyncPersistOptionsBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        asyncPersistOptions_ = value;
+        onChanged();
+      } else {
+        asyncPersistOptionsBuilder_.setMessage(value);
+      }
+      bitField0_ |= 0x00000002;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public Builder setAsyncPersistOptions(
+        alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder builderForValue) {
+      if (asyncPersistOptionsBuilder_ == null) {
+        asyncPersistOptions_ = builderForValue.build();
+        onChanged();
+      } else {
+        asyncPersistOptionsBuilder_.setMessage(builderForValue.build());
+      }
+      bitField0_ |= 0x00000002;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public Builder mergeAsyncPersistOptions(alluxio.grpc.ScheduleAsyncPersistencePOptions value) {
+      if (asyncPersistOptionsBuilder_ == null) {
+        if (((bitField0_ & 0x00000002) == 0x00000002) &&
+            asyncPersistOptions_ != null &&
+            asyncPersistOptions_ != alluxio.grpc.ScheduleAsyncPersistencePOptions.getDefaultInstance()) {
+          asyncPersistOptions_ =
+            alluxio.grpc.ScheduleAsyncPersistencePOptions.newBuilder(asyncPersistOptions_).mergeFrom(value).buildPartial();
+        } else {
+          asyncPersistOptions_ = value;
+        }
+        onChanged();
+      } else {
+        asyncPersistOptionsBuilder_.mergeFrom(value);
+      }
+      bitField0_ |= 0x00000002;
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public Builder clearAsyncPersistOptions() {
+      if (asyncPersistOptionsBuilder_ == null) {
+        asyncPersistOptions_ = null;
+        onChanged();
+      } else {
+        asyncPersistOptionsBuilder_.clear();
+      }
+      bitField0_ = (bitField0_ & ~0x00000002);
+      return this;
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder getAsyncPersistOptionsBuilder() {
+      bitField0_ |= 0x00000002;
+      onChanged();
+      return getAsyncPersistOptionsFieldBuilder().getBuilder();
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    public alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder getAsyncPersistOptionsOrBuilder() {
+      if (asyncPersistOptionsBuilder_ != null) {
+        return asyncPersistOptionsBuilder_.getMessageOrBuilder();
+      } else {
+        return asyncPersistOptions_ == null ?
+            alluxio.grpc.ScheduleAsyncPersistencePOptions.getDefaultInstance() : asyncPersistOptions_;
+      }
+    }
+    /**
+     * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        alluxio.grpc.ScheduleAsyncPersistencePOptions, alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder, alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder> 
+        getAsyncPersistOptionsFieldBuilder() {
+      if (asyncPersistOptionsBuilder_ == null) {
+        asyncPersistOptionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            alluxio.grpc.ScheduleAsyncPersistencePOptions, alluxio.grpc.ScheduleAsyncPersistencePOptions.Builder, alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder>(
+                getAsyncPersistOptions(),
+                getParentForChildren(),
+                isClean());
+        asyncPersistOptions_ = null;
+      }
+      return asyncPersistOptionsBuilder_;
+    }
+
     private alluxio.grpc.FileSystemMasterCommonPOptions commonOptions_ = null;
     private com.google.protobuf.SingleFieldBuilderV3<
         alluxio.grpc.FileSystemMasterCommonPOptions, alluxio.grpc.FileSystemMasterCommonPOptions.Builder, alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder> commonOptionsBuilder_;
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public boolean hasCommonOptions() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public alluxio.grpc.FileSystemMasterCommonPOptions getCommonOptions() {
       if (commonOptionsBuilder_ == null) {
@@ -511,7 +697,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public Builder setCommonOptions(alluxio.grpc.FileSystemMasterCommonPOptions value) {
       if (commonOptionsBuilder_ == null) {
@@ -523,11 +709,11 @@ private static final long serialVersionUID = 0L;
       } else {
         commonOptionsBuilder_.setMessage(value);
       }
-      bitField0_ |= 0x00000002;
+      bitField0_ |= 0x00000004;
       return this;
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public Builder setCommonOptions(
         alluxio.grpc.FileSystemMasterCommonPOptions.Builder builderForValue) {
@@ -537,15 +723,15 @@ private static final long serialVersionUID = 0L;
       } else {
         commonOptionsBuilder_.setMessage(builderForValue.build());
       }
-      bitField0_ |= 0x00000002;
+      bitField0_ |= 0x00000004;
       return this;
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public Builder mergeCommonOptions(alluxio.grpc.FileSystemMasterCommonPOptions value) {
       if (commonOptionsBuilder_ == null) {
-        if (((bitField0_ & 0x00000002) == 0x00000002) &&
+        if (((bitField0_ & 0x00000004) == 0x00000004) &&
             commonOptions_ != null &&
             commonOptions_ != alluxio.grpc.FileSystemMasterCommonPOptions.getDefaultInstance()) {
           commonOptions_ =
@@ -557,11 +743,11 @@ private static final long serialVersionUID = 0L;
       } else {
         commonOptionsBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000002;
+      bitField0_ |= 0x00000004;
       return this;
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public Builder clearCommonOptions() {
       if (commonOptionsBuilder_ == null) {
@@ -570,19 +756,19 @@ private static final long serialVersionUID = 0L;
       } else {
         commonOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000002);
+      bitField0_ = (bitField0_ & ~0x00000004);
       return this;
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public alluxio.grpc.FileSystemMasterCommonPOptions.Builder getCommonOptionsBuilder() {
-      bitField0_ |= 0x00000002;
+      bitField0_ |= 0x00000004;
       onChanged();
       return getCommonOptionsFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     public alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder getCommonOptionsOrBuilder() {
       if (commonOptionsBuilder_ != null) {
@@ -593,7 +779,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+     * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         alluxio.grpc.FileSystemMasterCommonPOptions, alluxio.grpc.FileSystemMasterCommonPOptions.Builder, alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder> 

--- a/core/transport/src/main/java/alluxio/grpc/CompleteFilePOptionsOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/CompleteFilePOptionsOrBuilder.java
@@ -17,15 +17,28 @@ public interface CompleteFilePOptionsOrBuilder extends
   long getUfsLength();
 
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+   */
+  boolean hasAsyncPersistOptions();
+  /**
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+   */
+  alluxio.grpc.ScheduleAsyncPersistencePOptions getAsyncPersistOptions();
+  /**
+   * <code>optional .alluxio.grpc.file.ScheduleAsyncPersistencePOptions asyncPersistOptions = 2;</code>
+   */
+  alluxio.grpc.ScheduleAsyncPersistencePOptionsOrBuilder getAsyncPersistOptionsOrBuilder();
+
+  /**
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   boolean hasCommonOptions();
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   alluxio.grpc.FileSystemMasterCommonPOptions getCommonOptions();
   /**
-   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 2;</code>
+   * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder getCommonOptionsOrBuilder();
 }

--- a/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
@@ -495,313 +495,315 @@ public final class FileSystemMasterProto {
       "ons\"f\n\030CheckConsistencyPRequest\022\014\n\004path\030" +
       "\001 \001(\t\022<\n\007options\030\002 \001(\0132+.alluxio.grpc.fi" +
       "le.CheckConsistencyPOptions\"\027\n\025CompleteF" +
-      "ilePResponse\"s\n\024CompleteFilePOptions\022\021\n\t" +
-      "ufsLength\030\001 \001(\003\022H\n\rcommonOptions\030\002 \001(\01321" +
-      ".alluxio.grpc.file.FileSystemMasterCommo" +
-      "nPOptions\"^\n\024CompleteFilePRequest\022\014\n\004pat" +
-      "h\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.alluxio.grpc." +
-      "file.CompleteFilePOptions\"\253\001\n\020OpenFilePO" +
-      "ptions\022.\n\010readType\030\001 \001(\0162\034.alluxio.grpc." +
-      "file.ReadPType\022\035\n\025maxUfsReadConcurrency\030" +
-      "\002 \001(\005\022H\n\rcommonOptions\030\003 \001(\01321.alluxio.g" +
+      "ilePResponse\"\305\001\n\024CompleteFilePOptions\022\021\n" +
+      "\tufsLength\030\001 \001(\003\022P\n\023asyncPersistOptions\030" +
+      "\002 \001(\01323.alluxio.grpc.file.ScheduleAsyncP" +
+      "ersistencePOptions\022H\n\rcommonOptions\030\003 \001(" +
+      "\01321.alluxio.grpc.file.FileSystemMasterCo" +
+      "mmonPOptions\"^\n\024CompleteFilePRequest\022\014\n\004" +
+      "path\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.alluxio.gr" +
+      "pc.file.CompleteFilePOptions\"\253\001\n\020OpenFil" +
+      "ePOptions\022.\n\010readType\030\001 \001(\0162\034.alluxio.gr" +
+      "pc.file.ReadPType\022\035\n\025maxUfsReadConcurren" +
+      "cy\030\002 \001(\005\022H\n\rcommonOptions\030\003 \001(\01321.alluxi" +
+      "o.grpc.file.FileSystemMasterCommonPOptio" +
+      "ns\"\032\n\030CreateDirectoryPResponse\"\340\001\n\027Creat" +
+      "eDirectoryPOptions\022\021\n\trecursive\030\001 \001(\010\022\023\n" +
+      "\013allowExists\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.allux" +
+      "io.grpc.PMode\0220\n\twriteType\030\004 \001(\0162\035.allux" +
+      "io.grpc.file.WritePType\022H\n\rcommonOptions" +
+      "\030\005 \001(\01321.alluxio.grpc.file.FileSystemMas" +
+      "terCommonPOptions\"d\n\027CreateDirectoryPReq" +
+      "uest\022\014\n\004path\030\001 \001(\t\022;\n\007options\030\002 \001(\0132*.al" +
+      "luxio.grpc.file.CreateDirectoryPOptions\"" +
+      "D\n\023CreateFilePResponse\022-\n\010fileInfo\030\001 \001(\013" +
+      "2\033.alluxio.grpc.file.FileInfo\"\332\002\n\022Create" +
+      "FilePOptions\022\026\n\016blockSizeBytes\030\001 \001(\003\022\021\n\t" +
+      "recursive\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio." +
+      "grpc.PMode\022\026\n\016replicationMax\030\004 \001(\005\022\026\n\016re" +
+      "plicationMin\030\005 \001(\005\022\032\n\022replicationDurable" +
+      "\030\006 \001(\005\022\021\n\twriteTier\030\007 \001(\005\0220\n\twriteType\030\010" +
+      " \001(\0162\035.alluxio.grpc.file.WritePType\022H\n\rc" +
+      "ommonOptions\030\t \001(\01321.alluxio.grpc.file.F" +
+      "ileSystemMasterCommonPOptions\022\033\n\023persist" +
+      "enceWaitTime\030\n \001(\003\"Z\n\022CreateFilePRequest" +
+      "\022\014\n\004path\030\001 \001(\t\0226\n\007options\030\002 \001(\0132%.alluxi" +
+      "o.grpc.file.CreateFilePOptions\"\021\n\017Delete" +
+      "PResponse\"\225\001\n\016DeletePOptions\022\021\n\trecursiv" +
+      "e\030\001 \001(\010\022\023\n\013alluxioOnly\030\002 \001(\010\022\021\n\tunchecke" +
+      "d\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(\01321.alluxio" +
+      ".grpc.file.FileSystemMasterCommonPOption" +
+      "s\"R\n\016DeletePRequest\022\014\n\004path\030\001 \001(\t\0222\n\007opt" +
+      "ions\030\002 \001(\0132!.alluxio.grpc.file.DeletePOp" +
+      "tions\"\017\n\rFreePResponse\"{\n\014FreePOptions\022\021" +
+      "\n\trecursive\030\001 \001(\010\022\016\n\006forced\030\002 \001(\010\022H\n\rcom" +
+      "monOptions\030\003 \001(\01321.alluxio.grpc.file.Fil" +
+      "eSystemMasterCommonPOptions\"N\n\014FreePRequ" +
+      "est\022\014\n\004path\030\001 \001(\t\0220\n\007options\030\002 \001(\0132\037.all" +
+      "uxio.grpc.file.FreePOptions\"+\n\035GetNewBlo" +
+      "ckIdForFilePResponse\022\n\n\002id\030\001 \001(\003\"h\n\034GetN" +
+      "ewBlockIdForFilePOptions\022H\n\rcommonOption" +
+      "s\030\001 \001(\01321.alluxio.grpc.file.FileSystemMa" +
+      "sterCommonPOptions\"n\n\034GetNewBlockIdForFi" +
+      "lePRequest\022\014\n\004path\030\001 \001(\t\022@\n\007options\030\002 \001(" +
+      "\0132/.alluxio.grpc.file.GetNewBlockIdForFi" +
+      "lePOptions\"C\n\022GetStatusPResponse\022-\n\010file" +
+      "Info\030\001 \001(\0132\033.alluxio.grpc.file.FileInfo\"" +
+      "\235\001\n\021GetStatusPOptions\022>\n\020loadMetadataTyp" +
+      "e\030\001 \001(\0162$.alluxio.grpc.file.LoadMetadata" +
+      "PType\022H\n\rcommonOptions\030\002 \001(\01321.alluxio.g" +
       "rpc.file.FileSystemMasterCommonPOptions\"" +
-      "\032\n\030CreateDirectoryPResponse\"\340\001\n\027CreateDi" +
-      "rectoryPOptions\022\021\n\trecursive\030\001 \001(\010\022\023\n\013al" +
-      "lowExists\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio." +
-      "grpc.PMode\0220\n\twriteType\030\004 \001(\0162\035.alluxio." +
-      "grpc.file.WritePType\022H\n\rcommonOptions\030\005 " +
+      "X\n\021GetStatusPRequest\022\014\n\004path\030\001 \001(\t\0225\n\007op" +
+      "tions\030\002 \001(\0132$.alluxio.grpc.file.GetStatu" +
+      "sPOptions\"\232\001\n\016ExistsPOptions\022>\n\020loadMeta" +
+      "dataType\030\001 \001(\0162$.alluxio.grpc.file.LoadM" +
+      "etadataPType\022H\n\rcommonOptions\030\002 \001(\01321.al" +
+      "luxio.grpc.file.FileSystemMasterCommonPO" +
+      "ptions\"]\n\rSyncPointInfo\022\024\n\014syncPointUri\030" +
+      "\001 \001(\t\0226\n\nsyncStatus\030\002 \001(\0162\".alluxio.grpc" +
+      ".file.SyncPointStatus\"O\n\030GetSyncPathList" +
+      "PResponse\0223\n\tsyncPaths\030\001 \003(\0132 .alluxio.g" +
+      "rpc.file.SyncPointInfo\"\031\n\027GetSyncPathLis" +
+      "tPRequest\"E\n\023ListStatusPResponse\022.\n\tfile" +
+      "Infos\030\001 \003(\0132\033.alluxio.grpc.file.FileInfo" +
+      "\"\315\001\n\022ListStatusPOptions\022\032\n\022loadDirectChi" +
+      "ldren\030\001 \001(\010\022>\n\020loadMetadataType\030\002 \001(\0162$." +
+      "alluxio.grpc.file.LoadMetadataPType\022H\n\rc" +
+      "ommonOptions\030\003 \001(\01321.alluxio.grpc.file.F" +
+      "ileSystemMasterCommonPOptions\022\021\n\trecursi" +
+      "ve\030\004 \001(\010\"Z\n\022ListStatusPRequest\022\014\n\004path\030\001" +
+      " \001(\t\0226\n\007options\030\002 \001(\0132%.alluxio.grpc.fil" +
+      "e.ListStatusPOptions\"\324\001\n\024LoadMetadataPOp" +
+      "tions\022\021\n\trecursive\030\001 \001(\010\022\027\n\017createAncest" +
+      "ors\030\002 \001(\010\022F\n\022loadDescendantType\030\003 \001(\0162*." +
+      "alluxio.grpc.fscommon.LoadDescendantPTyp" +
+      "e\022H\n\rcommonOptions\030\004 \001(\01321.alluxio.grpc." +
+      "file.FileSystemMasterCommonPOptions\"\217\001\n\t" +
+      "PAclEntry\022.\n\004type\030\001 \001(\0162 .alluxio.grpc.f" +
+      "ile.PAclEntryType\022\017\n\007subject\030\002 \001(\t\022.\n\007ac" +
+      "tions\030\003 \003(\0162\035.alluxio.grpc.file.PAclActi" +
+      "on\022\021\n\tisDefault\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030" +
+      "\001 \001(\t\022\023\n\013owningGroup\030\002 \001(\t\022-\n\007entries\030\003 " +
+      "\003(\0132\034.alluxio.grpc.file.PAclEntry\022\014\n\004mod" +
+      "e\030\004 \001(\005\022\021\n\tisDefault\030\005 \001(\010\022\026\n\016isDefaultE" +
+      "mpty\030\006 \001(\010\"\235\001\n\rFileBlockInfo\022*\n\tblockInf" +
+      "o\030\001 \001(\0132\027.alluxio.grpc.BlockInfo\022\016\n\006offs" +
+      "et\030\002 \001(\003\0224\n\014ufsLocations\030\003 \003(\0132\036.alluxio" +
+      ".grpc.WorkerNetAddress\022\032\n\022ufsStringLocat" +
+      "ions\030\004 \003(\t\"\304\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022" +
+      "\014\n\004name\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004" +
+      " \001(\t\022\016\n\006length\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006" +
+      " \001(\003\022\026\n\016creationTimeMs\030\007 \001(\003\022\021\n\tcomplete" +
+      "d\030\010 \001(\010\022\016\n\006folder\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022" +
+      "\021\n\tcacheable\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n" +
+      "\010blockIds\030\r \003(\003\022\036\n\026lastModificationTimeM" +
+      "s\030\016 \001(\003\022\013\n\003ttl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005g" +
+      "roup\030\021 \001(\t\022\014\n\004mode\030\022 \001(\005\022\030\n\020persistenceS" +
+      "tate\030\023 \001(\t\022\022\n\nmountPoint\030\024 \001(\010\0228\n\016fileBl" +
+      "ockInfos\030\025 \003(\0132 .alluxio.grpc.file.FileB" +
+      "lockInfo\022*\n\tttlAction\030\026 \001(\0162\027.alluxio.gr" +
+      "pc.TtlAction\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAllux" +
+      "ioPercentage\030\030 \001(\005\022\032\n\022inMemoryPercentage" +
+      "\030\031 \001(\005\022\026\n\016ufsFingerprint\030\032 \001(\t\022$\n\003acl\030\033 " +
+      "\001(\0132\027.alluxio.grpc.file.PAcl\022+\n\ndefaultA" +
+      "cl\030\034 \001(\0132\027.alluxio.grpc.file.PAcl\022\026\n\016rep" +
+      "licationMax\030\035 \001(\005\022\026\n\016replicationMin\030\036 \001(" +
+      "\005\"$\n\024GetFilePathPResponse\022\014\n\004path\030\001 \001(\t\"" +
+      "%\n\023GetFilePathPRequest\022\016\n\006fileId\030\001 \001(\003\"\020" +
+      "\n\016MountPResponse\"\364\001\n\rMountPOptions\022\020\n\010re" +
+      "adOnly\030\001 \001(\010\022D\n\nproperties\030\002 \003(\01320.allux" +
+      "io.grpc.file.MountPOptions.PropertiesEnt" +
+      "ry\022\016\n\006shared\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(" +
+      "\01321.alluxio.grpc.file.FileSystemMasterCo" +
+      "mmonPOptions\0321\n\017PropertiesEntry\022\013\n\003key\030\001" +
+      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"h\n\rMountPRequest" +
+      "\022\023\n\013alluxioPath\030\001 \001(\t\022\017\n\007ufsPath\030\002 \001(\t\0221" +
+      "\n\007options\030\003 \001(\0132 .alluxio.grpc.file.Moun" +
+      "tPOptions\"\300\001\n\026GetMountTablePResponse\022O\n\013" +
+      "mountPoints\030\001 \003(\0132:.alluxio.grpc.file.Ge" +
+      "tMountTablePResponse.MountPointsEntry\032U\n" +
+      "\020MountPointsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030" +
+      "\002 \001(\0132!.alluxio.grpc.file.MountPointInfo" +
+      ":\0028\001\"\027\n\025GetMountTablePRequest\"\205\002\n\016MountP" +
+      "ointInfo\022\016\n\006ufsUri\030\001 \001(\t\022\017\n\007ufsType\030\002 \001(" +
+      "\t\022\034\n\020ufsCapacityBytes\030\003 \001(\003:\002-1\022\030\n\014ufsUs" +
+      "edBytes\030\004 \001(\003:\002-1\022\020\n\010readOnly\030\005 \001(\010\022E\n\np" +
+      "roperties\030\006 \003(\01321.alluxio.grpc.file.Moun" +
+      "tPointInfo.PropertiesEntry\022\016\n\006shared\030\007 \001" +
+      "(\010\0321\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va" +
+      "lue\030\002 \001(\t:\0028\001\"\\\n\030FileSystemCommandOption" +
+      "s\022@\n\016persistOptions\030\001 \001(\0132(.alluxio.grpc" +
+      ".file.PersistCommandOptions\"M\n\025PersistCo" +
+      "mmandOptions\0224\n\014persistFiles\030\001 \003(\0132\036.all" +
+      "uxio.grpc.file.PersistFile\"/\n\013PersistFil" +
+      "e\022\016\n\006fileId\030\001 \001(\003\022\020\n\010blockIds\030\002 \003(\003\"\210\001\n\021" +
+      "FileSystemCommand\022.\n\013commandType\030\001 \001(\0162\031" +
+      ".alluxio.grpc.CommandType\022C\n\016commandOpti" +
+      "ons\030\002 \001(\0132+.alluxio.grpc.file.FileSystem" +
+      "CommandOptions\"\021\n\017RenamePResponse\"k\n\016Ren" +
+      "amePOptions\022H\n\rcommonOptions\030\001 \001(\01321.all" +
+      "uxio.grpc.file.FileSystemMasterCommonPOp" +
+      "tions\022\017\n\007persist\030\002 \001(\010\"c\n\016RenamePRequest" +
+      "\022\014\n\004path\030\001 \001(\t\022\017\n\007dstPath\030\002 \001(\t\0222\n\007optio" +
+      "ns\030\003 \001(\0132!.alluxio.grpc.file.RenamePOpti" +
+      "ons\"\027\n\025SetAttributePResponse\"\234\002\n\024SetAttr" +
+      "ibutePOptions\022\016\n\006pinned\030\001 \001(\010\022\021\n\tpersist" +
+      "ed\030\002 \001(\010\022\r\n\005owner\030\003 \001(\t\022\r\n\005group\030\004 \001(\t\022!" +
+      "\n\004mode\030\005 \001(\0132\023.alluxio.grpc.PMode\022\021\n\trec" +
+      "ursive\030\006 \001(\010\022\026\n\016replicationMax\030\007 \001(\005\022\026\n\016" +
+      "replicationMin\030\010 \001(\005\022H\n\rcommonOptions\030\t " +
       "\001(\01321.alluxio.grpc.file.FileSystemMaster" +
-      "CommonPOptions\"d\n\027CreateDirectoryPReques" +
-      "t\022\014\n\004path\030\001 \001(\t\022;\n\007options\030\002 \001(\0132*.allux" +
-      "io.grpc.file.CreateDirectoryPOptions\"D\n\023" +
-      "CreateFilePResponse\022-\n\010fileInfo\030\001 \001(\0132\033." +
-      "alluxio.grpc.file.FileInfo\"\332\002\n\022CreateFil" +
-      "ePOptions\022\026\n\016blockSizeBytes\030\001 \001(\003\022\021\n\trec" +
-      "ursive\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio.grp" +
-      "c.PMode\022\026\n\016replicationMax\030\004 \001(\005\022\026\n\016repli" +
-      "cationMin\030\005 \001(\005\022\032\n\022replicationDurable\030\006 " +
-      "\001(\005\022\021\n\twriteTier\030\007 \001(\005\0220\n\twriteType\030\010 \001(" +
-      "\0162\035.alluxio.grpc.file.WritePType\022H\n\rcomm" +
-      "onOptions\030\t \001(\01321.alluxio.grpc.file.File" +
-      "SystemMasterCommonPOptions\022\033\n\023persistenc" +
-      "eWaitTime\030\n \001(\003\"Z\n\022CreateFilePRequest\022\014\n" +
-      "\004path\030\001 \001(\t\0226\n\007options\030\002 \001(\0132%.alluxio.g" +
-      "rpc.file.CreateFilePOptions\"\021\n\017DeletePRe" +
-      "sponse\"\225\001\n\016DeletePOptions\022\021\n\trecursive\030\001" +
-      " \001(\010\022\023\n\013alluxioOnly\030\002 \001(\010\022\021\n\tunchecked\030\003" +
-      " \001(\010\022H\n\rcommonOptions\030\004 \001(\01321.alluxio.gr" +
-      "pc.file.FileSystemMasterCommonPOptions\"R" +
-      "\n\016DeletePRequest\022\014\n\004path\030\001 \001(\t\0222\n\007option" +
-      "s\030\002 \001(\0132!.alluxio.grpc.file.DeletePOptio" +
-      "ns\"\017\n\rFreePResponse\"{\n\014FreePOptions\022\021\n\tr" +
-      "ecursive\030\001 \001(\010\022\016\n\006forced\030\002 \001(\010\022H\n\rcommon" +
-      "Options\030\003 \001(\01321.alluxio.grpc.file.FileSy" +
-      "stemMasterCommonPOptions\"N\n\014FreePRequest" +
-      "\022\014\n\004path\030\001 \001(\t\0220\n\007options\030\002 \001(\0132\037.alluxi" +
-      "o.grpc.file.FreePOptions\"+\n\035GetNewBlockI" +
-      "dForFilePResponse\022\n\n\002id\030\001 \001(\003\"h\n\034GetNewB" +
-      "lockIdForFilePOptions\022H\n\rcommonOptions\030\001" +
-      " \001(\01321.alluxio.grpc.file.FileSystemMaste" +
-      "rCommonPOptions\"n\n\034GetNewBlockIdForFileP" +
-      "Request\022\014\n\004path\030\001 \001(\t\022@\n\007options\030\002 \001(\0132/" +
-      ".alluxio.grpc.file.GetNewBlockIdForFileP" +
-      "Options\"C\n\022GetStatusPResponse\022-\n\010fileInf" +
-      "o\030\001 \001(\0132\033.alluxio.grpc.file.FileInfo\"\235\001\n" +
-      "\021GetStatusPOptions\022>\n\020loadMetadataType\030\001" +
-      " \001(\0162$.alluxio.grpc.file.LoadMetadataPTy" +
-      "pe\022H\n\rcommonOptions\030\002 \001(\01321.alluxio.grpc" +
-      ".file.FileSystemMasterCommonPOptions\"X\n\021" +
-      "GetStatusPRequest\022\014\n\004path\030\001 \001(\t\0225\n\007optio" +
-      "ns\030\002 \001(\0132$.alluxio.grpc.file.GetStatusPO" +
-      "ptions\"\232\001\n\016ExistsPOptions\022>\n\020loadMetadat" +
-      "aType\030\001 \001(\0162$.alluxio.grpc.file.LoadMeta" +
-      "dataPType\022H\n\rcommonOptions\030\002 \001(\01321.allux" +
-      "io.grpc.file.FileSystemMasterCommonPOpti" +
-      "ons\"]\n\rSyncPointInfo\022\024\n\014syncPointUri\030\001 \001" +
-      "(\t\0226\n\nsyncStatus\030\002 \001(\0162\".alluxio.grpc.fi" +
-      "le.SyncPointStatus\"O\n\030GetSyncPathListPRe" +
-      "sponse\0223\n\tsyncPaths\030\001 \003(\0132 .alluxio.grpc" +
-      ".file.SyncPointInfo\"\031\n\027GetSyncPathListPR" +
-      "equest\"E\n\023ListStatusPResponse\022.\n\tfileInf" +
-      "os\030\001 \003(\0132\033.alluxio.grpc.file.FileInfo\"\315\001" +
-      "\n\022ListStatusPOptions\022\032\n\022loadDirectChildr" +
-      "en\030\001 \001(\010\022>\n\020loadMetadataType\030\002 \001(\0162$.all" +
-      "uxio.grpc.file.LoadMetadataPType\022H\n\rcomm" +
-      "onOptions\030\003 \001(\01321.alluxio.grpc.file.File" +
-      "SystemMasterCommonPOptions\022\021\n\trecursive\030" +
-      "\004 \001(\010\"Z\n\022ListStatusPRequest\022\014\n\004path\030\001 \001(" +
-      "\t\0226\n\007options\030\002 \001(\0132%.alluxio.grpc.file.L" +
-      "istStatusPOptions\"\324\001\n\024LoadMetadataPOptio" +
-      "ns\022\021\n\trecursive\030\001 \001(\010\022\027\n\017createAncestors" +
-      "\030\002 \001(\010\022F\n\022loadDescendantType\030\003 \001(\0162*.all" +
-      "uxio.grpc.fscommon.LoadDescendantPType\022H" +
-      "\n\rcommonOptions\030\004 \001(\01321.alluxio.grpc.fil" +
-      "e.FileSystemMasterCommonPOptions\"\217\001\n\tPAc" +
-      "lEntry\022.\n\004type\030\001 \001(\0162 .alluxio.grpc.file" +
-      ".PAclEntryType\022\017\n\007subject\030\002 \001(\t\022.\n\007actio" +
-      "ns\030\003 \003(\0162\035.alluxio.grpc.file.PAclAction\022" +
-      "\021\n\tisDefault\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030\001 \001" +
-      "(\t\022\023\n\013owningGroup\030\002 \001(\t\022-\n\007entries\030\003 \003(\013" +
-      "2\034.alluxio.grpc.file.PAclEntry\022\014\n\004mode\030\004" +
-      " \001(\005\022\021\n\tisDefault\030\005 \001(\010\022\026\n\016isDefaultEmpt" +
-      "y\030\006 \001(\010\"\235\001\n\rFileBlockInfo\022*\n\tblockInfo\030\001" +
-      " \001(\0132\027.alluxio.grpc.BlockInfo\022\016\n\006offset\030" +
-      "\002 \001(\003\0224\n\014ufsLocations\030\003 \003(\0132\036.alluxio.gr" +
-      "pc.WorkerNetAddress\022\032\n\022ufsStringLocation" +
-      "s\030\004 \003(\t\"\304\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022\014\n\004" +
-      "name\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004 \001(" +
-      "\t\022\016\n\006length\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006 \001(" +
-      "\003\022\026\n\016creationTimeMs\030\007 \001(\003\022\021\n\tcompleted\030\010" +
-      " \001(\010\022\016\n\006folder\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022\021\n\t" +
-      "cacheable\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n\010bl" +
-      "ockIds\030\r \003(\003\022\036\n\026lastModificationTimeMs\030\016" +
-      " \001(\003\022\013\n\003ttl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005grou" +
-      "p\030\021 \001(\t\022\014\n\004mode\030\022 \001(\005\022\030\n\020persistenceStat" +
-      "e\030\023 \001(\t\022\022\n\nmountPoint\030\024 \001(\010\0228\n\016fileBlock" +
-      "Infos\030\025 \003(\0132 .alluxio.grpc.file.FileBloc" +
-      "kInfo\022*\n\tttlAction\030\026 \001(\0162\027.alluxio.grpc." +
-      "TtlAction\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAlluxioP" +
-      "ercentage\030\030 \001(\005\022\032\n\022inMemoryPercentage\030\031 " +
-      "\001(\005\022\026\n\016ufsFingerprint\030\032 \001(\t\022$\n\003acl\030\033 \001(\013" +
-      "2\027.alluxio.grpc.file.PAcl\022+\n\ndefaultAcl\030" +
-      "\034 \001(\0132\027.alluxio.grpc.file.PAcl\022\026\n\016replic" +
-      "ationMax\030\035 \001(\005\022\026\n\016replicationMin\030\036 \001(\005\"$" +
-      "\n\024GetFilePathPResponse\022\014\n\004path\030\001 \001(\t\"%\n\023" +
-      "GetFilePathPRequest\022\016\n\006fileId\030\001 \001(\003\"\020\n\016M" +
-      "ountPResponse\"\364\001\n\rMountPOptions\022\020\n\010readO" +
-      "nly\030\001 \001(\010\022D\n\nproperties\030\002 \003(\01320.alluxio." +
-      "grpc.file.MountPOptions.PropertiesEntry\022" +
-      "\016\n\006shared\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(\01321" +
-      ".alluxio.grpc.file.FileSystemMasterCommo" +
-      "nPOptions\0321\n\017PropertiesEntry\022\013\n\003key\030\001 \001(" +
-      "\t\022\r\n\005value\030\002 \001(\t:\0028\001\"h\n\rMountPRequest\022\023\n" +
-      "\013alluxioPath\030\001 \001(\t\022\017\n\007ufsPath\030\002 \001(\t\0221\n\007o" +
-      "ptions\030\003 \001(\0132 .alluxio.grpc.file.MountPO" +
-      "ptions\"\300\001\n\026GetMountTablePResponse\022O\n\013mou" +
-      "ntPoints\030\001 \003(\0132:.alluxio.grpc.file.GetMo" +
-      "untTablePResponse.MountPointsEntry\032U\n\020Mo" +
-      "untPointsEntry\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001" +
-      "(\0132!.alluxio.grpc.file.MountPointInfo:\0028" +
-      "\001\"\027\n\025GetMountTablePRequest\"\205\002\n\016MountPoin" +
-      "tInfo\022\016\n\006ufsUri\030\001 \001(\t\022\017\n\007ufsType\030\002 \001(\t\022\034" +
-      "\n\020ufsCapacityBytes\030\003 \001(\003:\002-1\022\030\n\014ufsUsedB" +
-      "ytes\030\004 \001(\003:\002-1\022\020\n\010readOnly\030\005 \001(\010\022E\n\nprop" +
-      "erties\030\006 \003(\01321.alluxio.grpc.file.MountPo" +
-      "intInfo.PropertiesEntry\022\016\n\006shared\030\007 \001(\010\032" +
-      "1\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value" +
-      "\030\002 \001(\t:\0028\001\"\\\n\030FileSystemCommandOptions\022@" +
-      "\n\016persistOptions\030\001 \001(\0132(.alluxio.grpc.fi" +
-      "le.PersistCommandOptions\"M\n\025PersistComma" +
-      "ndOptions\0224\n\014persistFiles\030\001 \003(\0132\036.alluxi" +
-      "o.grpc.file.PersistFile\"/\n\013PersistFile\022\016" +
-      "\n\006fileId\030\001 \001(\003\022\020\n\010blockIds\030\002 \003(\003\"\210\001\n\021Fil" +
-      "eSystemCommand\022.\n\013commandType\030\001 \001(\0162\031.al" +
-      "luxio.grpc.CommandType\022C\n\016commandOptions" +
-      "\030\002 \001(\0132+.alluxio.grpc.file.FileSystemCom" +
-      "mandOptions\"\021\n\017RenamePResponse\"k\n\016Rename" +
+      "CommonPOptions\022\023\n\013pinnedMedia\030\n \003(\t\"^\n\024S" +
+      "etAttributePRequest\022\014\n\004path\030\001 \001(\t\0228\n\007opt" +
+      "ions\030\002 \001(\0132\'.alluxio.grpc.file.SetAttrib" +
+      "utePOptions\"\021\n\017SetAclPResponse\"m\n\016SetAcl" +
       "POptions\022H\n\rcommonOptions\030\001 \001(\01321.alluxi" +
       "o.grpc.file.FileSystemMasterCommonPOptio" +
-      "ns\022\017\n\007persist\030\002 \001(\010\"c\n\016RenamePRequest\022\014\n" +
-      "\004path\030\001 \001(\t\022\017\n\007dstPath\030\002 \001(\t\0222\n\007options\030" +
-      "\003 \001(\0132!.alluxio.grpc.file.RenamePOptions" +
-      "\"\027\n\025SetAttributePResponse\"\234\002\n\024SetAttribu" +
-      "tePOptions\022\016\n\006pinned\030\001 \001(\010\022\021\n\tpersisted\030" +
-      "\002 \001(\010\022\r\n\005owner\030\003 \001(\t\022\r\n\005group\030\004 \001(\t\022!\n\004m" +
-      "ode\030\005 \001(\0132\023.alluxio.grpc.PMode\022\021\n\trecurs" +
-      "ive\030\006 \001(\010\022\026\n\016replicationMax\030\007 \001(\005\022\026\n\016rep" +
-      "licationMin\030\010 \001(\005\022H\n\rcommonOptions\030\t \001(\013" +
-      "21.alluxio.grpc.file.FileSystemMasterCom" +
-      "monPOptions\022\023\n\013pinnedMedia\030\n \003(\t\"^\n\024SetA" +
-      "ttributePRequest\022\014\n\004path\030\001 \001(\t\0228\n\007option" +
-      "s\030\002 \001(\0132\'.alluxio.grpc.file.SetAttribute" +
-      "POptions\"\021\n\017SetAclPResponse\"m\n\016SetAclPOp" +
-      "tions\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.g" +
-      "rpc.file.FileSystemMasterCommonPOptions\022" +
-      "\021\n\trecursive\030\002 \001(\010\"\262\001\n\016SetAclPRequest\022\014\n" +
-      "\004path\030\001 \001(\t\022/\n\006action\030\002 \001(\0162\037.alluxio.gr" +
-      "pc.file.SetAclAction\022-\n\007entries\030\003 \003(\0132\034." +
-      "alluxio.grpc.file.PAclEntry\0222\n\007options\030\004" +
-      " \001(\0132!.alluxio.grpc.file.SetAclPOptions\"" +
-      "#\n!ScheduleAsyncPersistencePResponse\"\211\001\n" +
-      " ScheduleAsyncPersistencePOptions\022H\n\rcom" +
-      "monOptions\030\001 \001(\01321.alluxio.grpc.file.Fil" +
-      "eSystemMasterCommonPOptions\022\033\n\023persisten" +
-      "ceWaitTime\030\002 \001(\003\"v\n ScheduleAsyncPersist" +
-      "encePRequest\022\014\n\004path\030\001 \001(\t\022D\n\007options\030\002 " +
-      "\001(\01323.alluxio.grpc.file.ScheduleAsyncPer" +
-      "sistencePOptions\"\024\n\022StartSyncPResponse\"]" +
-      "\n\021StartSyncPOptions\022H\n\rcommonOptions\030\001 \001" +
-      "(\01321.alluxio.grpc.file.FileSystemMasterC" +
-      "ommonPOptions\"X\n\021StartSyncPRequest\022\014\n\004pa" +
-      "th\030\001 \001(\t\0225\n\007options\030\002 \001(\0132$.alluxio.grpc" +
-      ".file.StartSyncPOptions\"\023\n\021StopSyncPResp" +
-      "onse\"\\\n\020StopSyncPOptions\022H\n\rcommonOption" +
-      "s\030\001 \001(\01321.alluxio.grpc.file.FileSystemMa" +
-      "sterCommonPOptions\"V\n\020StopSyncPRequest\022\014" +
-      "\n\004path\030\001 \001(\t\0224\n\007options\030\002 \001(\0132#.alluxio." +
-      "grpc.file.StopSyncPOptions\"\022\n\020UnmountPRe" +
-      "sponse\"[\n\017UnmountPOptions\022H\n\rcommonOptio" +
-      "ns\030\001 \001(\01321.alluxio.grpc.file.FileSystemM" +
-      "asterCommonPOptions\"[\n\017UnmountPRequest\022\023" +
-      "\n\013alluxioPath\030\001 \001(\t\0223\n\007options\030\002 \001(\0132\".a" +
-      "lluxio.grpc.file.UnmountPOptions\"L\n\007UfsI" +
-      "nfo\022\013\n\003uri\030\001 \001(\t\0224\n\nproperties\030\002 \001(\0132 .a" +
-      "lluxio.grpc.file.MountPOptions\"]\n\023Update" +
-      "MountPRequest\022\023\n\013alluxioPath\030\001 \001(\t\0221\n\007op" +
-      "tions\030\003 \001(\0132 .alluxio.grpc.file.MountPOp" +
-      "tions\"\026\n\024UpdateMountPResponse\"\030\n\026UpdateU" +
-      "fsModePResponse\"E\n\025UpdateUfsModePOptions" +
-      "\022,\n\007ufsMode\030\001 \001(\0162\033.alluxio.grpc.file.Uf" +
-      "sPMode\"c\n\025UpdateUfsModePRequest\022\017\n\007ufsPa" +
-      "th\030\001 \001(\t\0229\n\007options\030\002 \001(\0132(.alluxio.grpc" +
-      ".file.UpdateUfsModePOptions\"U\n\034FileSyste" +
-      "mHeartbeatPResponse\0225\n\007command\030\001 \001(\0132$.a" +
-      "lluxio.grpc.file.FileSystemCommand\"@\n\033Fi" +
-      "leSystemHeartbeatPOptions\022!\n\031persistedFi" +
-      "leFingerprints\030\001 \003(\t\"\210\001\n\033FileSystemHeart" +
-      "beatPRequest\022\020\n\010workerId\030\001 \001(\003\022\026\n\016persis" +
-      "tedFiles\030\002 \003(\003\022?\n\007options\030\003 \001(\0132..alluxi" +
-      "o.grpc.file.FileSystemHeartbeatPOptions\"" +
-      "E\n\024GetFileInfoPResponse\022-\n\010fileInfo\030\001 \001(" +
-      "\0132\033.alluxio.grpc.file.FileInfo\"\025\n\023GetFil" +
-      "eInfoPOptions\"^\n\023GetFileInfoPRequest\022\016\n\006" +
-      "fileId\030\001 \001(\003\0227\n\007options\030\002 \001(\0132&.alluxio." +
-      "grpc.file.GetFileInfoPOptions\"2\n\031GetPinn" +
-      "edFileIdsPResponse\022\025\n\rpinnedFileIds\030\001 \003(" +
-      "\003\"\032\n\030GetPinnedFileIdsPOptions\"X\n\030GetPinn" +
-      "edFileIdsPRequest\022<\n\007options\030\001 \001(\0132+.all" +
-      "uxio.grpc.file.GetPinnedFileIdsPOptions\"" +
-      "B\n\023GetUfsInfoPResponse\022+\n\007ufsInfo\030\001 \001(\0132" +
-      "\032.alluxio.grpc.file.UfsInfo\"\024\n\022GetUfsInf" +
-      "oPOptions\"]\n\022GetUfsInfoPRequest\022\017\n\007mount" +
-      "Id\030\001 \001(\003\0226\n\007options\030\002 \001(\0132%.alluxio.grpc" +
-      ".file.GetUfsInfoPOptions*h\n\nWritePType\022\016" +
-      "\n\nMUST_CACHE\020\001\022\r\n\tTRY_CACHE\020\002\022\021\n\rCACHE_T" +
-      "HROUGH\020\003\022\013\n\007THROUGH\020\004\022\021\n\rASYNC_THROUGH\020\005" +
-      "\022\010\n\004NONE\020\006*7\n\tReadPType\022\014\n\010NO_CACHE\020\001\022\t\n" +
-      "\005CACHE\020\002\022\021\n\rCACHE_PROMOTE\020\003*4\n\021LoadMetad" +
-      "ataPType\022\t\n\005NEVER\020\000\022\010\n\004ONCE\020\001\022\n\n\006ALWAYS\020" +
-      "\002*N\n\017SyncPointStatus\022\030\n\024Not_Initially_Sy" +
-      "nced\020\000\022\013\n\007Syncing\020\001\022\024\n\020Initially_Synced\020" +
-      "\002*_\n\rPAclEntryType\022\t\n\005Owner\020\000\022\r\n\tNamedUs" +
-      "er\020\001\022\017\n\013OwningGroup\020\002\022\016\n\nNamedGroup\020\003\022\010\n" +
-      "\004Mask\020\004\022\t\n\005Other\020\005*.\n\nPAclAction\022\010\n\004Read" +
-      "\020\000\022\t\n\005Write\020\001\022\013\n\007Execute\020\002*W\n\014SetAclActi" +
-      "on\022\013\n\007REPLACE\020\000\022\n\n\006MODIFY\020\001\022\n\n\006REMOVE\020\002\022" +
-      "\016\n\nREMOVE_ALL\020\003\022\022\n\016REMOVE_DEFAULT\020\004*8\n\010U" +
-      "fsPMode\022\r\n\tNO_ACCESS\020\001\022\r\n\tREAD_ONLY\020\002\022\016\n" +
-      "\nREAD_WRITE\020\0032\342\020\n\035FileSystemMasterClient" +
-      "Service\022m\n\020CheckConsistency\022+.alluxio.gr" +
-      "pc.file.CheckConsistencyPRequest\032,.allux" +
-      "io.grpc.file.CheckConsistencyPResponse\022a" +
-      "\n\014CompleteFile\022\'.alluxio.grpc.file.Compl" +
-      "eteFilePRequest\032(.alluxio.grpc.file.Comp" +
-      "leteFilePResponse\022j\n\017CreateDirectory\022*.a" +
-      "lluxio.grpc.file.CreateDirectoryPRequest" +
-      "\032+.alluxio.grpc.file.CreateDirectoryPRes" +
-      "ponse\022[\n\nCreateFile\022%.alluxio.grpc.file." +
-      "CreateFilePRequest\032&.alluxio.grpc.file.C" +
-      "reateFilePResponse\022I\n\004Free\022\037.alluxio.grp" +
-      "c.file.FreePRequest\032 .alluxio.grpc.file." +
-      "FreePResponse\022^\n\013GetFilePath\022&.alluxio.g" +
-      "rpc.file.GetFilePathPRequest\032\'.alluxio.g" +
-      "rpc.file.GetFilePathPResponse\022d\n\rGetMoun" +
-      "tTable\022(.alluxio.grpc.file.GetMountTable" +
-      "PRequest\032).alluxio.grpc.file.GetMountTab" +
-      "lePResponse\022j\n\017GetSyncPathList\022*.alluxio" +
-      ".grpc.file.GetSyncPathListPRequest\032+.all" +
-      "uxio.grpc.file.GetSyncPathListPResponse\022" +
-      "y\n\024GetNewBlockIdForFile\022/.alluxio.grpc.f" +
-      "ile.GetNewBlockIdForFilePRequest\0320.allux" +
-      "io.grpc.file.GetNewBlockIdForFilePRespon" +
-      "se\022X\n\tGetStatus\022$.alluxio.grpc.file.GetS" +
-      "tatusPRequest\032%.alluxio.grpc.file.GetSta" +
-      "tusPResponse\022]\n\nListStatus\022%.alluxio.grp" +
-      "c.file.ListStatusPRequest\032&.alluxio.grpc" +
-      ".file.ListStatusPResponse0\001\022L\n\005Mount\022 .a" +
-      "lluxio.grpc.file.MountPRequest\032!.alluxio" +
-      ".grpc.file.MountPResponse\022O\n\006Remove\022!.al" +
-      "luxio.grpc.file.DeletePRequest\032\".alluxio" +
-      ".grpc.file.DeletePResponse\022O\n\006Rename\022!.a" +
-      "lluxio.grpc.file.RenamePRequest\032\".alluxi" +
-      "o.grpc.file.RenamePResponse\022\205\001\n\030Schedule" +
-      "AsyncPersistence\0223.alluxio.grpc.file.Sch" +
-      "eduleAsyncPersistencePRequest\0324.alluxio." +
-      "grpc.file.ScheduleAsyncPersistencePRespo" +
-      "nse\022O\n\006SetAcl\022!.alluxio.grpc.file.SetAcl" +
-      "PRequest\032\".alluxio.grpc.file.SetAclPResp" +
-      "onse\022a\n\014SetAttribute\022\'.alluxio.grpc.file" +
-      ".SetAttributePRequest\032(.alluxio.grpc.fil" +
-      "e.SetAttributePResponse\022X\n\tStartSync\022$.a" +
-      "lluxio.grpc.file.StartSyncPRequest\032%.all" +
-      "uxio.grpc.file.StartSyncPResponse\022U\n\010Sto" +
-      "pSync\022#.alluxio.grpc.file.StopSyncPReque" +
-      "st\032$.alluxio.grpc.file.StopSyncPResponse" +
-      "\022R\n\007Unmount\022\".alluxio.grpc.file.UnmountP" +
-      "Request\032#.alluxio.grpc.file.UnmountPResp" +
-      "onse\022^\n\013UpdateMount\022&.alluxio.grpc.file." +
-      "UpdateMountPRequest\032\'.alluxio.grpc.file." +
-      "UpdateMountPResponse\022d\n\rUpdateUfsMode\022(." +
-      "alluxio.grpc.file.UpdateUfsModePRequest\032" +
-      ").alluxio.grpc.file.UpdateUfsModePRespon" +
-      "se2\303\003\n\035FileSystemMasterWorkerService\022v\n\023" +
-      "FileSystemHeartbeat\022..alluxio.grpc.file." +
-      "FileSystemHeartbeatPRequest\032/.alluxio.gr" +
-      "pc.file.FileSystemHeartbeatPResponse\022^\n\013" +
-      "GetFileInfo\022&.alluxio.grpc.file.GetFileI" +
-      "nfoPRequest\032\'.alluxio.grpc.file.GetFileI" +
-      "nfoPResponse\022m\n\020GetPinnedFileIds\022+.allux" +
-      "io.grpc.file.GetPinnedFileIdsPRequest\032,." +
-      "alluxio.grpc.file.GetPinnedFileIdsPRespo" +
-      "nse\022[\n\nGetUfsInfo\022%.alluxio.grpc.file.Ge" +
-      "tUfsInfoPRequest\032&.alluxio.grpc.file.Get" +
-      "UfsInfoPResponse2\331\001\n\032FileSystemMasterJob" +
-      "Service\022^\n\013GetFileInfo\022&.alluxio.grpc.fi" +
-      "le.GetFileInfoPRequest\032\'.alluxio.grpc.fi" +
-      "le.GetFileInfoPResponse\022[\n\nGetUfsInfo\022%." +
-      "alluxio.grpc.file.GetUfsInfoPRequest\032&.a" +
-      "lluxio.grpc.file.GetUfsInfoPResponseB\'\n\014" +
-      "alluxio.grpcB\025FileSystemMasterProtoP\001"
+      "ns\022\021\n\trecursive\030\002 \001(\010\"\262\001\n\016SetAclPRequest" +
+      "\022\014\n\004path\030\001 \001(\t\022/\n\006action\030\002 \001(\0162\037.alluxio" +
+      ".grpc.file.SetAclAction\022-\n\007entries\030\003 \003(\013" +
+      "2\034.alluxio.grpc.file.PAclEntry\0222\n\007option" +
+      "s\030\004 \001(\0132!.alluxio.grpc.file.SetAclPOptio" +
+      "ns\"#\n!ScheduleAsyncPersistencePResponse\"" +
+      "\211\001\n ScheduleAsyncPersistencePOptions\022H\n\r" +
+      "commonOptions\030\001 \001(\01321.alluxio.grpc.file." +
+      "FileSystemMasterCommonPOptions\022\033\n\023persis" +
+      "tenceWaitTime\030\002 \001(\003\"v\n ScheduleAsyncPers" +
+      "istencePRequest\022\014\n\004path\030\001 \001(\t\022D\n\007options" +
+      "\030\002 \001(\01323.alluxio.grpc.file.ScheduleAsync" +
+      "PersistencePOptions\"\024\n\022StartSyncPRespons" +
+      "e\"]\n\021StartSyncPOptions\022H\n\rcommonOptions\030" +
+      "\001 \001(\01321.alluxio.grpc.file.FileSystemMast" +
+      "erCommonPOptions\"X\n\021StartSyncPRequest\022\014\n" +
+      "\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\0132$.alluxio.g" +
+      "rpc.file.StartSyncPOptions\"\023\n\021StopSyncPR" +
+      "esponse\"\\\n\020StopSyncPOptions\022H\n\rcommonOpt" +
+      "ions\030\001 \001(\01321.alluxio.grpc.file.FileSyste" +
+      "mMasterCommonPOptions\"V\n\020StopSyncPReques" +
+      "t\022\014\n\004path\030\001 \001(\t\0224\n\007options\030\002 \001(\0132#.allux" +
+      "io.grpc.file.StopSyncPOptions\"\022\n\020Unmount" +
+      "PResponse\"[\n\017UnmountPOptions\022H\n\rcommonOp" +
+      "tions\030\001 \001(\01321.alluxio.grpc.file.FileSyst" +
+      "emMasterCommonPOptions\"[\n\017UnmountPReques" +
+      "t\022\023\n\013alluxioPath\030\001 \001(\t\0223\n\007options\030\002 \001(\0132" +
+      "\".alluxio.grpc.file.UnmountPOptions\"L\n\007U" +
+      "fsInfo\022\013\n\003uri\030\001 \001(\t\0224\n\nproperties\030\002 \001(\0132" +
+      " .alluxio.grpc.file.MountPOptions\"]\n\023Upd" +
+      "ateMountPRequest\022\023\n\013alluxioPath\030\001 \001(\t\0221\n" +
+      "\007options\030\003 \001(\0132 .alluxio.grpc.file.Mount" +
+      "POptions\"\026\n\024UpdateMountPResponse\"\030\n\026Upda" +
+      "teUfsModePResponse\"E\n\025UpdateUfsModePOpti" +
+      "ons\022,\n\007ufsMode\030\001 \001(\0162\033.alluxio.grpc.file" +
+      ".UfsPMode\"c\n\025UpdateUfsModePRequest\022\017\n\007uf" +
+      "sPath\030\001 \001(\t\0229\n\007options\030\002 \001(\0132(.alluxio.g" +
+      "rpc.file.UpdateUfsModePOptions\"U\n\034FileSy" +
+      "stemHeartbeatPResponse\0225\n\007command\030\001 \001(\0132" +
+      "$.alluxio.grpc.file.FileSystemCommand\"@\n" +
+      "\033FileSystemHeartbeatPOptions\022!\n\031persiste" +
+      "dFileFingerprints\030\001 \003(\t\"\210\001\n\033FileSystemHe" +
+      "artbeatPRequest\022\020\n\010workerId\030\001 \001(\003\022\026\n\016per" +
+      "sistedFiles\030\002 \003(\003\022?\n\007options\030\003 \001(\0132..all" +
+      "uxio.grpc.file.FileSystemHeartbeatPOptio" +
+      "ns\"E\n\024GetFileInfoPResponse\022-\n\010fileInfo\030\001" +
+      " \001(\0132\033.alluxio.grpc.file.FileInfo\"\025\n\023Get" +
+      "FileInfoPOptions\"^\n\023GetFileInfoPRequest\022" +
+      "\016\n\006fileId\030\001 \001(\003\0227\n\007options\030\002 \001(\0132&.allux" +
+      "io.grpc.file.GetFileInfoPOptions\"2\n\031GetP" +
+      "innedFileIdsPResponse\022\025\n\rpinnedFileIds\030\001" +
+      " \003(\003\"\032\n\030GetPinnedFileIdsPOptions\"X\n\030GetP" +
+      "innedFileIdsPRequest\022<\n\007options\030\001 \001(\0132+." +
+      "alluxio.grpc.file.GetPinnedFileIdsPOptio" +
+      "ns\"B\n\023GetUfsInfoPResponse\022+\n\007ufsInfo\030\001 \001" +
+      "(\0132\032.alluxio.grpc.file.UfsInfo\"\024\n\022GetUfs" +
+      "InfoPOptions\"]\n\022GetUfsInfoPRequest\022\017\n\007mo" +
+      "untId\030\001 \001(\003\0226\n\007options\030\002 \001(\0132%.alluxio.g" +
+      "rpc.file.GetUfsInfoPOptions*h\n\nWritePTyp" +
+      "e\022\016\n\nMUST_CACHE\020\001\022\r\n\tTRY_CACHE\020\002\022\021\n\rCACH" +
+      "E_THROUGH\020\003\022\013\n\007THROUGH\020\004\022\021\n\rASYNC_THROUG" +
+      "H\020\005\022\010\n\004NONE\020\006*7\n\tReadPType\022\014\n\010NO_CACHE\020\001" +
+      "\022\t\n\005CACHE\020\002\022\021\n\rCACHE_PROMOTE\020\003*4\n\021LoadMe" +
+      "tadataPType\022\t\n\005NEVER\020\000\022\010\n\004ONCE\020\001\022\n\n\006ALWA" +
+      "YS\020\002*N\n\017SyncPointStatus\022\030\n\024Not_Initially" +
+      "_Synced\020\000\022\013\n\007Syncing\020\001\022\024\n\020Initially_Sync" +
+      "ed\020\002*_\n\rPAclEntryType\022\t\n\005Owner\020\000\022\r\n\tName" +
+      "dUser\020\001\022\017\n\013OwningGroup\020\002\022\016\n\nNamedGroup\020\003" +
+      "\022\010\n\004Mask\020\004\022\t\n\005Other\020\005*.\n\nPAclAction\022\010\n\004R" +
+      "ead\020\000\022\t\n\005Write\020\001\022\013\n\007Execute\020\002*W\n\014SetAclA" +
+      "ction\022\013\n\007REPLACE\020\000\022\n\n\006MODIFY\020\001\022\n\n\006REMOVE" +
+      "\020\002\022\016\n\nREMOVE_ALL\020\003\022\022\n\016REMOVE_DEFAULT\020\004*8" +
+      "\n\010UfsPMode\022\r\n\tNO_ACCESS\020\001\022\r\n\tREAD_ONLY\020\002" +
+      "\022\016\n\nREAD_WRITE\020\0032\342\020\n\035FileSystemMasterCli" +
+      "entService\022m\n\020CheckConsistency\022+.alluxio" +
+      ".grpc.file.CheckConsistencyPRequest\032,.al" +
+      "luxio.grpc.file.CheckConsistencyPRespons" +
+      "e\022a\n\014CompleteFile\022\'.alluxio.grpc.file.Co" +
+      "mpleteFilePRequest\032(.alluxio.grpc.file.C" +
+      "ompleteFilePResponse\022j\n\017CreateDirectory\022" +
+      "*.alluxio.grpc.file.CreateDirectoryPRequ" +
+      "est\032+.alluxio.grpc.file.CreateDirectoryP" +
+      "Response\022[\n\nCreateFile\022%.alluxio.grpc.fi" +
+      "le.CreateFilePRequest\032&.alluxio.grpc.fil" +
+      "e.CreateFilePResponse\022I\n\004Free\022\037.alluxio." +
+      "grpc.file.FreePRequest\032 .alluxio.grpc.fi" +
+      "le.FreePResponse\022^\n\013GetFilePath\022&.alluxi" +
+      "o.grpc.file.GetFilePathPRequest\032\'.alluxi" +
+      "o.grpc.file.GetFilePathPResponse\022d\n\rGetM" +
+      "ountTable\022(.alluxio.grpc.file.GetMountTa" +
+      "blePRequest\032).alluxio.grpc.file.GetMount" +
+      "TablePResponse\022j\n\017GetSyncPathList\022*.allu" +
+      "xio.grpc.file.GetSyncPathListPRequest\032+." +
+      "alluxio.grpc.file.GetSyncPathListPRespon" +
+      "se\022y\n\024GetNewBlockIdForFile\022/.alluxio.grp" +
+      "c.file.GetNewBlockIdForFilePRequest\0320.al" +
+      "luxio.grpc.file.GetNewBlockIdForFilePRes" +
+      "ponse\022X\n\tGetStatus\022$.alluxio.grpc.file.G" +
+      "etStatusPRequest\032%.alluxio.grpc.file.Get" +
+      "StatusPResponse\022]\n\nListStatus\022%.alluxio." +
+      "grpc.file.ListStatusPRequest\032&.alluxio.g" +
+      "rpc.file.ListStatusPResponse0\001\022L\n\005Mount\022" +
+      " .alluxio.grpc.file.MountPRequest\032!.allu" +
+      "xio.grpc.file.MountPResponse\022O\n\006Remove\022!" +
+      ".alluxio.grpc.file.DeletePRequest\032\".allu" +
+      "xio.grpc.file.DeletePResponse\022O\n\006Rename\022" +
+      "!.alluxio.grpc.file.RenamePRequest\032\".all" +
+      "uxio.grpc.file.RenamePResponse\022\205\001\n\030Sched" +
+      "uleAsyncPersistence\0223.alluxio.grpc.file." +
+      "ScheduleAsyncPersistencePRequest\0324.allux" +
+      "io.grpc.file.ScheduleAsyncPersistencePRe" +
+      "sponse\022O\n\006SetAcl\022!.alluxio.grpc.file.Set" +
+      "AclPRequest\032\".alluxio.grpc.file.SetAclPR" +
+      "esponse\022a\n\014SetAttribute\022\'.alluxio.grpc.f" +
+      "ile.SetAttributePRequest\032(.alluxio.grpc." +
+      "file.SetAttributePResponse\022X\n\tStartSync\022" +
+      "$.alluxio.grpc.file.StartSyncPRequest\032%." +
+      "alluxio.grpc.file.StartSyncPResponse\022U\n\010" +
+      "StopSync\022#.alluxio.grpc.file.StopSyncPRe" +
+      "quest\032$.alluxio.grpc.file.StopSyncPRespo" +
+      "nse\022R\n\007Unmount\022\".alluxio.grpc.file.Unmou" +
+      "ntPRequest\032#.alluxio.grpc.file.UnmountPR" +
+      "esponse\022^\n\013UpdateMount\022&.alluxio.grpc.fi" +
+      "le.UpdateMountPRequest\032\'.alluxio.grpc.fi" +
+      "le.UpdateMountPResponse\022d\n\rUpdateUfsMode" +
+      "\022(.alluxio.grpc.file.UpdateUfsModePReque" +
+      "st\032).alluxio.grpc.file.UpdateUfsModePRes" +
+      "ponse2\303\003\n\035FileSystemMasterWorkerService\022" +
+      "v\n\023FileSystemHeartbeat\022..alluxio.grpc.fi" +
+      "le.FileSystemHeartbeatPRequest\032/.alluxio" +
+      ".grpc.file.FileSystemHeartbeatPResponse\022" +
+      "^\n\013GetFileInfo\022&.alluxio.grpc.file.GetFi" +
+      "leInfoPRequest\032\'.alluxio.grpc.file.GetFi" +
+      "leInfoPResponse\022m\n\020GetPinnedFileIds\022+.al" +
+      "luxio.grpc.file.GetPinnedFileIdsPRequest" +
+      "\032,.alluxio.grpc.file.GetPinnedFileIdsPRe" +
+      "sponse\022[\n\nGetUfsInfo\022%.alluxio.grpc.file" +
+      ".GetUfsInfoPRequest\032&.alluxio.grpc.file." +
+      "GetUfsInfoPResponse2\331\001\n\032FileSystemMaster" +
+      "JobService\022^\n\013GetFileInfo\022&.alluxio.grpc" +
+      ".file.GetFileInfoPRequest\032\'.alluxio.grpc" +
+      ".file.GetFileInfoPResponse\022[\n\nGetUfsInfo" +
+      "\022%.alluxio.grpc.file.GetUfsInfoPRequest\032" +
+      "&.alluxio.grpc.file.GetUfsInfoPResponseB" +
+      "\'\n\014alluxio.grpcB\025FileSystemMasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -852,7 +854,7 @@ public final class FileSystemMasterProto {
     internal_static_alluxio_grpc_file_CompleteFilePOptions_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_file_CompleteFilePOptions_descriptor,
-        new java.lang.String[] { "UfsLength", "CommonOptions", });
+        new java.lang.String[] { "UfsLength", "AsyncPersistOptions", "CommonOptions", });
     internal_static_alluxio_grpc_file_CompleteFilePRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_alluxio_grpc_file_CompleteFilePRequest_fieldAccessorTable = new


### PR DESCRIPTION
Current `FileOutStream` schedules async persistence after completing the file. In case of an error while scheduling persist job, content will be lost for `ASYNC_THROUGH`. This PS introduces a flag tot completeFile RPC for scheduling async persistence before returning the call. 

Removing extra RPC also gives about %10 throughput increase for ASYNC_THROUGH create.