### PR TITLE
Close shell resources properly after command execution

### DIFF
--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -14,6 +14,7 @@ package alluxio.cli;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.status.InvalidArgumentException;
 
+import com.google.common.io.Closer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -43,6 +44,7 @@ public abstract class AbstractShell implements Closeable {
   private Set<String> mUnstableAlias;
   private Map<String, Command> mCommands;
   protected InstancedConfiguration mConfiguration;
+  protected Closer mCloser;
 
   /**
    * Creates a new instance of {@link AbstractShell}.
@@ -58,6 +60,7 @@ public abstract class AbstractShell implements Closeable {
     mUnstableAlias = unstableAlias;
     mCommandAlias = commandAlias;
     mCommands = loadCommands();
+    mCloser = Closer.create();
   }
 
   /**
@@ -145,6 +148,7 @@ public abstract class AbstractShell implements Closeable {
 
   @Override
   public void close() throws IOException {
+    mCloser.close();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -55,12 +55,12 @@ public abstract class AbstractShell implements Closeable {
    */
   public AbstractShell(Map<String, String[]> commandAlias,
       Set<String> unstableAlias, InstancedConfiguration conf) {
+    mCloser = Closer.create();
     mConfiguration = conf; // This needs to go first in case loadCommands() uses the reference to
     // the configuration
     mUnstableAlias = unstableAlias;
     mCommandAlias = commandAlias;
     mCommands = loadCommands();
-    mCloser = Closer.create();
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -47,11 +47,6 @@ public final class FileSystemShell extends AbstractShell {
       .build();
 
   /**
-   * Shared context for loaded commands.
-   */
-  private FileSystemContext mContext;
-
-  /**
    * Main method, starts a new FileSystemShell.
    *
    * @param argv array of arguments given by the user's input from the terminal
@@ -89,13 +84,8 @@ public final class FileSystemShell extends AbstractShell {
 
   @Override
   protected Map<String, Command> loadCommands() {
-    mContext = FileSystemContext.create(mConfiguration);
-    return FileSystemShellUtils.loadCommands(mContext);
-  }
-
-  @Override
-  public void close() throws IOException {
-    super.close();
-    mContext.close();
+    return FileSystemShellUtils
+        .loadCommands(
+          mCloser.register(FileSystemContext.create(mConfiguration)));
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -47,6 +47,11 @@ public final class FileSystemShell extends AbstractShell {
       .build();
 
   /**
+   * Shared context for loaded commands.
+   */
+  private FileSystemContext mContext;
+
+  /**
    * Main method, starts a new FileSystemShell.
    *
    * @param argv array of arguments given by the user's input from the terminal
@@ -84,6 +89,13 @@ public final class FileSystemShell extends AbstractShell {
 
   @Override
   protected Map<String, Command> loadCommands() {
-    return FileSystemShellUtils.loadCommands(FileSystemContext.create(mConfiguration));
+    mContext = FileSystemContext.create(mConfiguration);
+    return FileSystemShellUtils.loadCommands(mContext);
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    mContext.close();
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
@@ -40,11 +40,6 @@ public final class FileSystemAdminShell extends AbstractShell {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemAdminShell.class);
 
   /**
-   * Context shared with fsadmin commands.
-   */
-  private Context mContext;
-
-  /**
    * Construct a new instance of {@link FileSystemAdminShell}.
    *
    * @param alluxioConf Alluxio configuration
@@ -83,7 +78,7 @@ public final class FileSystemAdminShell extends AbstractShell {
   protected Map<String, Command> loadCommands() {
     ClientContext ctx = ClientContext.create(mConfiguration);
     MasterClientContext masterConfig = MasterClientContext.newBuilder(ctx).build();
-    mContext = new Context(
+    Context adminContext = new Context(
         new RetryHandlingFileSystemMasterClient(masterConfig),
         new RetryHandlingBlockMasterClient(masterConfig),
         new RetryHandlingMetaMasterClient(masterConfig),
@@ -91,16 +86,7 @@ public final class FileSystemAdminShell extends AbstractShell {
         System.out
     );
     return CommandUtils.loadCommands(FileSystemAdminShell.class.getPackage().getName(),
-        new Class[] {Context.class, AlluxioConfiguration.class}, new Object[] {mContext,
-            mConfiguration});
-  }
-
-  @Override
-  public void close() throws IOException {
-    super.close();
-    mContext.getBlockClient().close();
-    mContext.getFsClient().close();
-    mContext.getMetaClient().close();
-    mContext.getMetaConfigClient().close();
+        new Class[] {Context.class, AlluxioConfiguration.class},
+        new Object[] {mCloser.register(adminContext), mConfiguration});
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
@@ -56,14 +56,13 @@ public final class FileSystemAdminShellUtils {
    * @param alluxioConf Alluxio configuration
    */
   public static void checkMasterClientService(AlluxioConfiguration alluxioConf) throws IOException {
-    try (CloseableResource<FileSystemMasterClient> client =
-      FileSystemContext.create(ClientContext.create(alluxioConf))
-          .acquireMasterClientResource()) {
+    try (FileSystemContext context = FileSystemContext.create(ClientContext.create(alluxioConf));
+        CloseableResource<FileSystemMasterClient> client = context.acquireMasterClientResource()) {
       InetSocketAddress address = client.get().getAddress();
 
       List<InetSocketAddress> addresses = Arrays.asList(address);
-      MasterInquireClient inquireClient = new PollingMasterInquireClient(addresses, () ->
-          new ExponentialBackoffRetry(50, 100, 2), alluxioConf);
+      MasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
+          () -> new ExponentialBackoffRetry(50, 100, 2), alluxioConf);
       inquireClient.getPrimaryRpcAddress();
     } catch (UnavailableException e) {
       throw new IOException("Cannot connect to Alluxio leader master.");

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/Context.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/Context.java
@@ -18,12 +18,14 @@ import alluxio.client.meta.MetaMasterConfigClient;
 
 import com.google.common.base.Preconditions;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.PrintStream;
 
 /**
  * Context for running an fsadmin command.
  */
-public final class Context {
+public final class Context implements Closeable {
   private final FileSystemMasterClient mFsClient;
   private final BlockMasterClient mBlockClient;
   private final MetaMasterClient mMetaClient;
@@ -80,5 +82,13 @@ public final class Context {
    */
   public PrintStream getPrintStream() {
     return mPrintStream;
+  }
+
+  @Override
+  public void close() throws IOException {
+    getBlockClient().close();
+    getFsClient().close();
+    getMetaClient().close();
+    getMetaConfigClient().close();
   }
 }

--- a/shell/src/main/java/alluxio/cli/job/JobShell.java
+++ b/shell/src/main/java/alluxio/cli/job/JobShell.java
@@ -38,11 +38,6 @@ public final class JobShell extends AbstractShell {
       .build();
 
   /**
-   * Shared context for loaded commands.
-   */
-  private FileSystemContext mContext;
-
-  /**
    * Main method, starts a new JobShell.
    *
    * @param argv array of arguments given by the user's input from the terminal
@@ -79,15 +74,8 @@ public final class JobShell extends AbstractShell {
 
   @Override
   protected Map<String, Command> loadCommands() {
-    mContext = FileSystemContext.create(mConfiguration);
     return CommandUtils.loadCommands(JobShell.class.getPackage().getName(),
         new Class[] {FileSystemContext.class},
-        new Object[] {mContext});
-  }
-
-  @Override
-  public void close() throws IOException {
-    super.close();
-    mContext.close();
+        new Object[] {mCloser.register(FileSystemContext.create(mConfiguration))});
   }
 }

--- a/shell/src/main/java/alluxio/cli/job/JobShell.java
+++ b/shell/src/main/java/alluxio/cli/job/JobShell.java
@@ -38,6 +38,11 @@ public final class JobShell extends AbstractShell {
       .build();
 
   /**
+   * Shared context for loaded commands.
+   */
+  private FileSystemContext mContext;
+
+  /**
    * Main method, starts a new JobShell.
    *
    * @param argv array of arguments given by the user's input from the terminal
@@ -74,8 +79,15 @@ public final class JobShell extends AbstractShell {
 
   @Override
   protected Map<String, Command> loadCommands() {
+    mContext = FileSystemContext.create(mConfiguration);
     return CommandUtils.loadCommands(JobShell.class.getPackage().getName(),
         new Class[] {FileSystemContext.class},
-        new Object[] {FileSystemContext.create(mConfiguration)});
+        new Object[] {mContext});
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    mContext.close();
   }
 }


### PR DESCRIPTION
Failure to close resources that has gRPC channels will cause abrupt channel termination, thus annoying `CANCELLED` exception in the master logs.