### PR TITLE
Reset the counter in MetricsSystemTest

### DIFF
--- a/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricsSystemTest.java
@@ -41,6 +41,8 @@ public final class MetricsSystemTest {
     metricsProps.setProperty("sink.console.unit", "minutes");
     metricsProps.setProperty("sink.jmx.class", "alluxio.metrics.sink.JmxSink");
     mMetricsConfig = new MetricsConfig(metricsProps);
+    // Clear the counter
+    sCounter.dec(sCounter.getCount());
   }
 
   /**


### PR DESCRIPTION
The counter needs to be reset to 0 if we don't want tests stepping on each other.