### PR TITLE
Fix fuse docs and script

### DIFF
--- a/docs/en/api/POSIX-API.md
+++ b/docs/en/api/POSIX-API.md
@@ -56,6 +56,7 @@ For example, the following command will mount the Alluxio path `/people` to the 
 in the local file system.
 
 ```bash
+bin/alluxio fs mkdir /people
 sudo mkdir -p /mnt/people
 sudo chown $(whoami) /mnt/people
 chmod 755 /mnt/people
@@ -64,8 +65,8 @@ integration/fuse/bin/alluxio-fuse mount /mnt/people /people
 
 When `alluxio_path` is not given, Alluxio-FUSE defaults it to root (`/`). Note that the
 `mount_point` must be an existing and empty path in your local file system hierarchy and that the
-user that runs the `alluxio-fuse.sh` script must own the mount point and have read and write
-permissions on it. You can mount Alluxio to multiple mount points. All of these alluxio-fuse
+user that runs the `integration/fuse/bin/alluxio-fuse` script must own the mount point and have read and write
+permissions on it. You can mount Alluxio to multiple mount points. All of these `AlluxioFuse`
 processes share the same log output at `$ALLUXIO_HOME\logs\fuse.log`, which is useful for
 troubleshooting when errors happen on operations under the mounting point.
 

--- a/docs/en/compute/Tensorflow.md
+++ b/docs/en/compute/Tensorflow.md
@@ -60,7 +60,7 @@ just created:
 ./integration/fuse/bin/alluxio-fuse mount /mnt/fuse /training-data
 ```
 
-The above CLI spawns a background user-space java process (`alluxio-fuse`) that mounts the Alluxio path specified at `/training-data` 
+The above CLI spawns a background user-space java process (`AlluxioFuse`) that mounts the Alluxio path specified at `/training-data` 
 to the local file system on the specified mount point `/mnt/alluxio`. Please refer to [POSIX API documentation]({{ '/en/api/POSIX-API.html' | relativize_url }}) 
 for details about how to mount Alluxio-FUSE and set up fuse related options. 
 

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -96,7 +96,11 @@ umount_fuse() {
 }
 
 fuse_stat() {
-  local fuse_info=$("${JAVA_HOME}/bin/jps" | grep AlluxioFuse)
+  local jps="jps"
+  if [[ ! -z ${JAVA_HOME} ]]; then
+    jps="${JAVA_HOME}/bin/jps"
+  fi
+  local fuse_info=$("${jps}" | grep AlluxioFuse)
   if [[ -z ${fuse_info} ]]; then
     echo "AlluxioFuse: not running"
     return 1


### PR DESCRIPTION
Remove the solid requirement for setting of JAVA_HOME in alluxio-fuse script