### PR TITLE
[DOCFIX] Fix namespace mgmt and storage mgmt docs

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2001,7 +2001,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "storage layer runs out of space. Valid options include "
               + "`alluxio.worker.block.evictor.LRFUEvictor`, "
               + "`alluxio.worker.block.evictor.GreedyEvictor`, "
-              + "`alluxio.worker.block.evictor.LRUEvictor`.")
+              + "`alluxio.worker.block.evictor.LRUEvictor`, "
+              + "`alluxio.worker.block.evictor.PartialLRUEvictor`.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/docs/en/advanced/Namespace-Management.md
+++ b/docs/en/advanced/Namespace-Management.md
@@ -201,9 +201,10 @@ Here are some other methods for loading files:
 * `alluxio.user.file.metadata.load.type`: This property can be set to either
 `ALWAYS`, `ONCE`, or `NEVER`. It acts similar to `alluxio.user.file.metadata.sync.interval`,
 but with two caveats:
-    1. It only discovers new files and does not reload modified or deleted files
-    1. It only applies to the `exists`, `list`, and `getStatus` RPCs
-`ALWAYS` will always check the UFS for new files, `ONCE` will use the default
+    1. It only discovers new files and does not reload modified or deleted files.
+    1. It only applies to the `exists`, `list`, and `getStatus` RPCs.
+    
+    `ALWAYS` will always check the UFS for new files, `ONCE` will use the default
 behavior of only scanning each directory once ever, and `NEVER` will prevent Alluxio
 from scanning for new files at all.
 


### PR DESCRIPTION
1. Updated PropertyKey.java description for 1 key
2. Updated Namespace-Management.md fixing 1 indentation.