### PR TITLE
Load EMPTY_URI lazy in class AlluxioURI

### DIFF
--- a/core/base/src/main/java/alluxio/AlluxioURI.java
+++ b/core/base/src/main/java/alluxio/AlluxioURI.java
@@ -61,7 +61,19 @@ public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
   public static final String CUR_DIR = ".";
   public static final String WILDCARD = "*";
 
-  public static final AlluxioURI EMPTY_URI = new AlluxioURI("");
+  /**
+   * @return empty alluxio uri
+   */
+  public static AlluxioURI EMPTY_URI() {
+    return Handler.EMPTY_URI;
+  }
+
+  /**
+   * Inner static class for lazy load empty uri.
+   */
+  private static class Handler {
+    private static final AlluxioURI EMPTY_URI = new AlluxioURI("");
+  }
 
   /** A {@link URI} is used to hold the URI components. */
   private final URI mUri;

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -52,7 +52,7 @@ public final class MountTableTest {
   public void before() throws Exception {
     UfsManager ufsManager = mock(UfsManager.class);
     UfsClient ufsClient =
-        new UfsManager.UfsClient(() -> mTestUfs, AlluxioURI.EMPTY_URI);
+        new UfsManager.UfsClient(() -> mTestUfs, AlluxioURI.EMPTY_URI());
     when(ufsManager.get(anyLong())).thenReturn(ufsClient);
     mMountTable = new MountTable(ufsManager,
         new MountInfo(new AlluxioURI(MountTable.ROOT), new AlluxioURI(ROOT_UFS),

--- a/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/file/FileDataManagerTest.java
@@ -80,7 +80,7 @@ public final class FileDataManagerTest {
     mManager = new FileDataManager(mBlockWorker, mMockRateLimiter.getGuavaRateLimiter(),
         mUfsManager, () -> mMockFileSystem, (r, w) -> mCopyCounter.incrementAndGet());
     mMockFileSystem = PowerMockito.mock(FileSystem.class);
-    UfsClient ufsClient = new UfsClient(() -> mUfs, AlluxioURI.EMPTY_URI);
+    UfsClient ufsClient = new UfsClient(() -> mUfs, AlluxioURI.EMPTY_URI());
     when(mUfs.isDirectory(anyString())).thenReturn(true);
     when(mUfsManager.get(anyLong())).thenReturn(ufsClient);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -85,7 +85,8 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
         new AtomicReference<>(TEST_WORKER_ID));
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
+    UfsManager.UfsClient ufsClient =
+            new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI());
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsClient);
     Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
@@ -47,7 +47,7 @@ public final class UfsFileWriteHandlerTest extends AbstractWriteHandlerTest {
     mOutputStream = new FileOutputStream(mFile);
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
-    UfsClient ufsClient = new UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
+    UfsClient ufsClient = new UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI());
     Mockito.when(ufsManager.get(TEST_MOUNT_ID)).thenReturn(ufsClient);
     Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -286,7 +286,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         mFsMaster.listStatus(ROOT_PATH, ListStatusContext.defaults()).size();
 
     ConcurrentRenamer concurrentRenamer = new ConcurrentRenamer(DEPTH, CONCURRENCY_DEPTH, ROOT_PATH,
-        ROOT_PATH2, AlluxioURI.EMPTY_URI);
+        ROOT_PATH2, AlluxioURI.EMPTY_URI());
     concurrentRenamer.call();
 
     Assert.assertEquals(numFiles,


### PR DESCRIPTION
**Description**
AlluxioURI and URI are depend on each other, becuse AlluxioURI.EMPTY_URI is a static final variable.

**Improvement**
Adjust EMPTY_URI to lazy load with inner static class.
When other class need AlluxioURI.EMPTY_URI, AlluxioURI will really load EMPTY_URI instance.