### PR TITLE
Fix a regression in priting StackTrace on exception

### DIFF
--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -11,8 +11,8 @@
 
 package alluxio;
 
-import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -28,7 +28,7 @@ public final class ProcessUtils {
    * Runs the given {@link Process}. This method should only be called from {@code main()} methods.
    *
    * @param process the {@link Process} to run
-'   */
+   */
   public static void run(Process process) {
     try {
       LOG.info("Starting {}.", process);
@@ -37,14 +37,14 @@ public final class ProcessUtils {
       System.exit(0);
     } catch (Throwable t) {
       LOG.error("Uncaught exception while running {}, stopping it and exiting. "
-              + "Exception {}, Root Cause {}", process, t, ExceptionUtils.getRootCause(t));
+          + "Exception \"{}\", Root Cause \"{}\"", process, t, ExceptionUtils.getRootCause(t), t);
       try {
         process.stop();
       } catch (Throwable t2) {
         // continue to exit
         LOG.error("Uncaught exception while stopping {}, simply exiting. "
-                + "Exception {}, Root Cause {}",
-            process, t2, ExceptionUtils.getRootCause(t2));
+            + "Exception \"{}\", Root Cause \"{}\"", process, t2, ExceptionUtils.getRootCause(t2),
+            t2);
       }
       System.exit(-1);
     }


### PR DESCRIPTION
Stack trace info was lost due to https://github.com/Alluxio/alluxio/pull/9343 on exceptions starting the process.  That pr introduced a side-effect that the stack trace is lost from the log. Note that the original logging will output the entire exception including stack trace of `t`:
```
LOG.error("Uncaught exception while running {}, stopping it and exiting.", process, t)
```
After this PR, one will see sth like, to me it actually becomes harder to debug.
```
ERROR ProcessUtils - Uncaught exception while stopping Alluxio worker, simply exiting. Exception java.lang.NullPointerException, Root Cause null
```
as supposed to

```
ProcessUtils - Uncaught exception while stopping Alluxio worker, simply exiting.
java.lang.NullPointerException
	at alluxio.worker.block.DefaultBlockWorker.stop(DefaultBlockWorker.java:263)
	at alluxio.Registry.stop(Registry.java:148)
	at alluxio.worker.AlluxioWorkerProcess.stopWorkers(AlluxioWorkerProcess.java:287)
	at alluxio.worker.AlluxioWorkerProcess.stop(AlluxioWorkerProcess.java:274)
	at alluxio.ProcessUtils.run(ProcessUtils.java:41)
	at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:69)`
```
This PR puts back `t` in the end as the last arg of `LOG.error`
