### PR TITLE
Fix version string in shaded-hadoop module

### DIFF
--- a/shaded/hadoop/pom.xml
+++ b/shaded/hadoop/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>alluxio-shaded-hadoop</artifactId>
   <packaging>jar</packaging>
   <name>Alluxio Shaded Libraries - Hadoop</name>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>${ufs.hadoop.version}</version>
   <description>Shaded Hadoop Module</description>
 
   <properties>


### PR DESCRIPTION
This is the quick fix for #9416 thanks to @asin929 in 2.0 branch.
This version string is correct to be `${ufs.hadoop.version}` in master (2.1.0-SNAPSHOT) branch but was updated and hardcoded to be `2.2.1-SNAPSHOT` in branch-2.0 due to maven release plugin.

Talked to @calvinjia , we should modify the POM to mark this module to be skipped during release process.
