### PR TITLE
Fix leaking zk servers during various multi-master tests

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
@@ -40,7 +40,7 @@ public final class JobServiceFaultToleranceShellTest extends BaseIntegrationTest
 
   @Before
   public void before() throws Exception {
-    mLocalAlluxioCluster = new MultiMasterLocalAlluxioCluster(1);
+    mLocalAlluxioCluster = new MultiMasterLocalAlluxioCluster(2);
     mLocalAlluxioCluster.initConfiguration();
     mLocalAlluxioCluster.start();
     mLocalAlluxioJobCluster = new LocalAlluxioJobCluster();

--- a/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
@@ -51,8 +51,12 @@ public final class JobServiceFaultToleranceShellTest extends BaseIntegrationTest
 
   @After
   public void after() throws Exception {
-    mLocalAlluxioJobCluster.stop();
-    mLocalAlluxioCluster.stop();
+    if (mLocalAlluxioJobCluster != null) {
+      mLocalAlluxioJobCluster.stop();
+    }
+    if (mLocalAlluxioCluster != null) {
+      mLocalAlluxioCluster.stop();
+    }
     System.setOut(System.out);
     ServerConfiguration.reset();
   }

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -278,11 +278,12 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     // Stop the default cluster.
     after();
 
-    // Create a new cluster, with no workers initially
-    final MultiMasterLocalAlluxioCluster cluster = new MultiMasterLocalAlluxioCluster(2, 0);
-    cluster.initConfiguration();
-    cluster.start();
+    MultiMasterLocalAlluxioCluster cluster = null;
     try {
+      // Create a new cluster, with no workers initially
+      cluster = new MultiMasterLocalAlluxioCluster(2, 0);
+      cluster.initConfiguration();
+      cluster.start();
       // Get the first block master
       BlockMaster blockMaster1 =
           cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(BlockMaster.class);
@@ -343,7 +344,9 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
           Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
           RegisterWorkerPOptions.getDefaultInstance());
     } finally {
-      cluster.stop();
+      if (cluster != null) {
+        cluster.stop();
+      }
     }
 
     // Start the default cluster.

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
@@ -47,8 +47,8 @@ public final class JournalMigrationIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
         // Masters become primary faster
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec").build();
-    cluster.start();
     try {
+      cluster.start();
       FileSystem fs = cluster.getFileSystemClient();
       MetaMasterClient metaClient = new RetryHandlingMetaMasterClient(
           MasterClientContext.newBuilder(ClientContext.create(ServerConfiguration.global()))

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -183,7 +183,8 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
     try {
       cluster = new MultiMasterLocalAlluxioCluster(TEST_NUM_MASTERS);
       cluster.initConfiguration();
-      cluster.stop();
+      cluster.start();
+      cluster.stopLeader();
       factory = mountUnmount(cluster.getClient());
       // Kill the leader one by one.
       for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -178,15 +178,24 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void multiMasterMountUnmountJournal() throws Exception {
-    MultiMasterLocalAlluxioCluster cluster = setupMultiMasterCluster();
-    UnderFileSystemFactory factory = mountUnmount(cluster.getClient());
-    // Kill the leader one by one.
-    for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {
-      cluster.waitForNewMaster(120 * Constants.SECOND_MS);
-      assertTrue(cluster.stopLeader());
+    MultiMasterLocalAlluxioCluster cluster = null;
+    UnderFileSystemFactory factory = null;
+    try {
+      cluster = new MultiMasterLocalAlluxioCluster(TEST_NUM_MASTERS);
+      cluster.initConfiguration();
+      cluster.stop();
+      factory = mountUnmount(cluster.getClient());
+      // Kill the leader one by one.
+      for (int kills = 0; kills < TEST_NUM_MASTERS; kills++) {
+        cluster.waitForNewMaster(120 * Constants.SECOND_MS);
+        assertTrue(cluster.stopLeader());
+      }
+    } finally {
+      // Shutdown the cluster
+      if (cluster != null) {
+        cluster.stopFS();
+      }
     }
-    // Shutdown the cluster
-    cluster.stopFS();
     CommonUtils.sleepMs(TEST_TIME_MS);
     awaitClientTermination();
     // Fail the creation of UFS
@@ -227,17 +236,6 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
    */
   private MasterRegistry createFsMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
-  }
-
-  /**
-   * Sets up and starts a multi-master cluster.
-   */
-  private MultiMasterLocalAlluxioCluster setupMultiMasterCluster() throws Exception {
-    // Setup and start the alluxio-ft cluster.
-    MultiMasterLocalAlluxioCluster cluster = new MultiMasterLocalAlluxioCluster(TEST_NUM_MASTERS);
-    cluster.initConfiguration();
-    cluster.start();
-    return cluster;
   }
 
   /**

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
@@ -28,6 +28,7 @@ import alluxio.testutils.IntegrationTestUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class MultiMasterJournalTest extends BaseIntegrationTest {
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
     mCluster.start();
+  }
+
+  @After
+  public void after() throws Exception {
+    mCluster.stop();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
@@ -44,8 +44,8 @@ public class MultiProcessCheckpointTest {
         .setNumMasters(2)
         .setNumWorkers(0)
         .build();
-    cluster.start();
     try {
+      cluster.start();
       cluster.waitForAllNodesRegistered(20 * Constants.SECOND_MS);
       String journal = cluster.getJournalDir();
       FileSystem fs = cluster.getFileSystemClient();

--- a/tests/src/test/java/alluxio/server/ft/journal/TriggeredCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TriggeredCheckpointTest.java
@@ -45,8 +45,8 @@ public class TriggeredCheckpointTest {
         .setNumMasters(1)
         .setNumWorkers(1)
         .build();
-    cluster.start();
     try {
+      cluster.start();
       cluster.waitForAllNodesRegistered(20 * Constants.SECOND_MS);
 
       // Get enough journal entries


### PR DESCRIPTION
Multi master test clusters makes use of embedded zookeeper server. This PR is an attempt to stabilize cluster initialization/termination code on some tests for making sure we don't leak embedded zookeeper servers, which could adversely effect following tests.

Since multi-master tests are usually run on a same JVM, one flake was causing whole bunch of tests to fail.