### PR TITLE
Fix hostname resolution for HA in k8s

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -210,16 +210,6 @@ public abstract class AbstractClient implements Client {
             getServiceName(), retryPolicy.getAttemptCount(), e.toString());
         continue;
       }
-      if (mAddress.isUnresolved()) {
-        // Sometimes the acquired addressed wasn't resolved, retry resolving before
-        // using it to connect.
-        LOG.debug("Retry resolving address {}", mAddress);
-        // Creates a new InetSocketAddress to force resolving the hostname again.
-        mAddress = new InetSocketAddress(mAddress.getHostName(), mAddress.getPort());
-        if (mAddress.isUnresolved()) {
-          LOG.debug("Failed to resolve address on retry {}", mAddress);
-        }
-      }
       try {
         beforeConnect();
         LOG.debug("Alluxio client (version {}) is trying to connect with {} @ {}",

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -222,7 +222,14 @@ public class GrpcManagedChannelPool {
    */
   private ManagedChannel createManagedChannel(ChannelKey channelKey) {
     NettyChannelBuilder channelBuilder;
-    channelBuilder = NettyChannelBuilder.forAddress(channelKey.mAddress);
+    if (channelKey.mAddress instanceof InetSocketAddress) {
+      InetSocketAddress inetServerAddress = (InetSocketAddress) channelKey.mAddress;
+      // This constructor delays DNS lookup to detect changes
+      channelBuilder = NettyChannelBuilder.forAddress(inetServerAddress.getHostName(),
+          inetServerAddress.getPort());
+    } else {
+      channelBuilder = NettyChannelBuilder.forAddress(channelKey.mAddress);
+    }
 
     if (channelKey.mKeepAliveTime.isPresent()) {
       channelBuilder.keepAliveTime(channelKey.mKeepAliveTime.get().getFirst(),

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -222,15 +222,7 @@ public class GrpcManagedChannelPool {
    */
   private ManagedChannel createManagedChannel(ChannelKey channelKey) {
     NettyChannelBuilder channelBuilder;
-    // Use constructor that resolves address if given an unresolved inet address.
-    if (channelKey.mAddress instanceof InetSocketAddress
-        && ((InetSocketAddress) channelKey.mAddress).isUnresolved()) {
-      InetSocketAddress inetServerAddress = (InetSocketAddress) channelKey.mAddress;
-      channelBuilder = NettyChannelBuilder.forAddress(inetServerAddress.getHostName(),
-          inetServerAddress.getPort());
-    } else {
-      channelBuilder = NettyChannelBuilder.forAddress(channelKey.mAddress);
-    }
+    channelBuilder = NettyChannelBuilder.forAddress(channelKey.mAddress);
 
     if (channelKey.mKeepAliveTime.isPresent()) {
       channelBuilder.keepAliveTime(channelKey.mKeepAliveTime.get().getFirst(),

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -170,7 +170,8 @@ public final class ConfigurationUtils {
   }
 
   private static List<InetSocketAddress> overridePort(List<InetSocketAddress> addrs, int port) {
-    return StreamUtils.map(addr -> new InetSocketAddress(addr.getHostString(), port), addrs);
+    return StreamUtils.map(addr -> InetSocketAddress.createUnresolved(addr.getHostString(), port),
+        addrs);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -236,7 +236,7 @@ public final class NetworkAddressUtils {
    */
   public static InetSocketAddress getConnectAddress(ServiceType service,
       AlluxioConfiguration conf) {
-    return new InetSocketAddress(getConnectHost(service, conf), getPort(service, conf));
+    return InetSocketAddress.createUnresolved(getConnectHost(service, conf), getPort(service, conf));
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -604,7 +604,7 @@ public final class NetworkAddressUtils {
     if (strArr.length != 2) {
       throw new IOException("Invalid InetSocketAddress " + address);
     }
-    return new InetSocketAddress(strArr[0], Integer.parseInt(strArr[1]));
+    return InetSocketAddress.createUnresolved(strArr[0], Integer.parseInt(strArr[1]));
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -236,7 +236,8 @@ public final class NetworkAddressUtils {
    */
   public static InetSocketAddress getConnectAddress(ServiceType service,
       AlluxioConfiguration conf) {
-    return InetSocketAddress.createUnresolved(getConnectHost(service, conf), getPort(service, conf));
+    return InetSocketAddress.createUnresolved(getConnectHost(service, conf),
+        getPort(service, conf));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -61,7 +61,7 @@ public final class MasterInquireClientTest {
         put(PropertyKey.MASTER_RPC_PORT, Integer.toString(port));
       }
     }, mConfiguration).toResource()) {
-      ConnectDetails cs = new SingleMasterConnectDetails(new InetSocketAddress(host, port));
+      ConnectDetails cs = new SingleMasterConnectDetails(InetSocketAddress.createUnresolved(host, port));
       assertCurrentConnectString(cs);
       assertEquals("testhost:123", cs.toString());
     }

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -61,7 +61,8 @@ public final class MasterInquireClientTest {
         put(PropertyKey.MASTER_RPC_PORT, Integer.toString(port));
       }
     }, mConfiguration).toResource()) {
-      ConnectDetails cs = new SingleMasterConnectDetails(InetSocketAddress.createUnresolved(host, port));
+      ConnectDetails cs =
+          new SingleMasterConnectDetails(InetSocketAddress.createUnresolved(host, port));
       assertCurrentConnectString(cs);
       assertEquals("testhost:123", cs.toString());
     }

--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -39,8 +39,8 @@ public class PollingMasterInquireClientTest {
     int port = mPort.getPort();
     RejectingServer s = new RejectingServer(port);
     s.start();
-    List<InetSocketAddress> addrs = Arrays.asList(
-        new InetSocketAddress(NetworkAddressUtils.getLocalHostName(Constants.SECOND_MS), port));
+    List<InetSocketAddress> addrs = Arrays.asList(InetSocketAddress
+        .createUnresolved(NetworkAddressUtils.getLocalHostName(Constants.SECOND_MS), port));
     PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
         () -> new CountingRetry(0), new ConfigurationBuilder().build());
     try {

--- a/core/common/src/test/java/alluxio/master/ZkMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/ZkMasterInquireClientTest.java
@@ -98,13 +98,13 @@ public class ZkMasterInquireClientTest {
     CuratorFramework client = CuratorFrameworkFactory.newClient(mZkServer.getConnectString(),
         new ExponentialBackoffRetry(Constants.SECOND_MS, INQUIRE_RETRY_COUNT));
     // Create the leader path with single(localhost) participant.
-    InetSocketAddress localLeader = new InetSocketAddress(LOOPBACK_IP, 12345);
+    InetSocketAddress localLeader = InetSocketAddress.createUnresolved(LOOPBACK_IP, 12345);
     client.start();
     client.create().forPath(LEADER_PATH);
     client.create().forPath(LEADER_PATH + localLeader);
     client.close();
     // Verify that leader is fetched.
-    Assert.assertEquals(localLeader, zkInquirer.getPrimaryRpcAddress());
+    Assert.assertEquals(localLeader.getAddress(), zkInquirer.getPrimaryRpcAddress());
   }
 
   @Test
@@ -116,8 +116,8 @@ public class ZkMasterInquireClientTest {
     CuratorFramework client = CuratorFrameworkFactory.newClient(mZkServer.getConnectString(),
         new ExponentialBackoffRetry(Constants.SECOND_MS, INQUIRE_RETRY_COUNT));
     // Create the leader path with multiple participants.
-    InetSocketAddress localLeader1 = new InetSocketAddress(LOOPBACK_IP, 12345);
-    InetSocketAddress localLeader2 = new InetSocketAddress(LOOPBACK_IP, 54321);
+    InetSocketAddress localLeader1 = InetSocketAddress.createUnresolved(LOOPBACK_IP, 12345);
+    InetSocketAddress localLeader2 = InetSocketAddress.createUnresolved(LOOPBACK_IP, 54321);
     client.start();
     client.create().forPath(LEADER_PATH);
     client.create().forPath(LEADER_PATH + localLeader1);

--- a/core/common/src/test/java/alluxio/master/ZkMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/ZkMasterInquireClientTest.java
@@ -14,6 +14,7 @@ package alluxio.master;
 import alluxio.AlluxioTestDirectory;
 import alluxio.Constants;
 import alluxio.exception.status.UnavailableException;
+import alluxio.util.io.PathUtils;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -101,10 +102,10 @@ public class ZkMasterInquireClientTest {
     InetSocketAddress localLeader = InetSocketAddress.createUnresolved(LOOPBACK_IP, 12345);
     client.start();
     client.create().forPath(LEADER_PATH);
-    client.create().forPath(LEADER_PATH + localLeader);
+    client.create().forPath(PathUtils.concatPath(LEADER_PATH, localLeader));
     client.close();
     // Verify that leader is fetched.
-    Assert.assertEquals(localLeader.getAddress(), zkInquirer.getPrimaryRpcAddress());
+    Assert.assertEquals(localLeader, zkInquirer.getPrimaryRpcAddress());
   }
 
   @Test
@@ -120,8 +121,8 @@ public class ZkMasterInquireClientTest {
     InetSocketAddress localLeader2 = InetSocketAddress.createUnresolved(LOOPBACK_IP, 54321);
     client.start();
     client.create().forPath(LEADER_PATH);
-    client.create().forPath(LEADER_PATH + localLeader1);
-    client.create().forPath(LEADER_PATH + localLeader2);
+    client.create().forPath(PathUtils.concatPath(LEADER_PATH, localLeader1));
+    client.create().forPath(PathUtils.concatPath(LEADER_PATH, localLeader2));
     client.close();
     // Verify that the latest written value is fetched.
     Assert.assertEquals(localLeader2, zkInquirer.getPrimaryRpcAddress());

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -37,7 +37,7 @@ public final class ConfigurationUtilsTest {
     AlluxioConfiguration conf = createConf(ImmutableMap.of(
         PropertyKey.MASTER_HOSTNAME, "testhost",
         PropertyKey.MASTER_RPC_PORT, "1000"));
-    assertEquals(Arrays.asList(new InetSocketAddress("testhost", 1000)),
+    assertEquals(Arrays.asList(InetSocketAddress.createUnresolved("testhost", 1000)),
         ConfigurationUtils.getMasterRpcAddresses(conf));
   }
 
@@ -46,7 +46,8 @@ public final class ConfigurationUtilsTest {
     AlluxioConfiguration conf =
         createConf(ImmutableMap.of(PropertyKey.MASTER_RPC_ADDRESSES, "host1:99,host2:100"));
     assertEquals(
-        Arrays.asList(new InetSocketAddress("host1", 99), new InetSocketAddress("host2", 100)),
+        Arrays.asList(InetSocketAddress.createUnresolved("host1", 99),
+            InetSocketAddress.createUnresolved("host2", 100)),
         ConfigurationUtils.getMasterRpcAddresses(conf));
   }
 
@@ -57,7 +58,8 @@ public final class ConfigurationUtilsTest {
             PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES, "host1:99,host2:100",
             PropertyKey.MASTER_RPC_PORT, "50"));
     assertEquals(
-        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        Arrays.asList(InetSocketAddress.createUnresolved("host1", 50),
+            InetSocketAddress.createUnresolved("host2", 50)),
         ConfigurationUtils.getMasterRpcAddresses(conf));
   }
 
@@ -65,7 +67,7 @@ public final class ConfigurationUtilsTest {
   public void getMasterRpcAddressesDefault() {
     AlluxioConfiguration conf = createConf(Collections.emptyMap());
     String host = NetworkAddressUtils.getLocalHostName(5 * Constants.SECOND_MS);
-    assertEquals(Arrays.asList(new InetSocketAddress(host, 19998)),
+    assertEquals(Arrays.asList(InetSocketAddress.createUnresolved(host, 19998)),
         ConfigurationUtils.getMasterRpcAddresses(conf));
   }
 
@@ -74,7 +76,7 @@ public final class ConfigurationUtilsTest {
     AlluxioConfiguration conf = createConf(ImmutableMap.of(
         PropertyKey.JOB_MASTER_HOSTNAME, "testhost",
         PropertyKey.JOB_MASTER_RPC_PORT, "1000"));
-    assertEquals(Arrays.asList(new InetSocketAddress("testhost", 1000)),
+    assertEquals(Arrays.asList(InetSocketAddress.createUnresolved("testhost", 1000)),
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
@@ -83,7 +85,8 @@ public final class ConfigurationUtilsTest {
     AlluxioConfiguration conf =
         createConf(ImmutableMap.of(PropertyKey.JOB_MASTER_RPC_ADDRESSES, "host1:99,host2:100"));
     assertEquals(
-        Arrays.asList(new InetSocketAddress("host1", 99), new InetSocketAddress("host2", 100)),
+        Arrays.asList(InetSocketAddress.createUnresolved("host1", 99),
+            InetSocketAddress.createUnresolved("host2", 100)),
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
@@ -94,7 +97,8 @@ public final class ConfigurationUtilsTest {
             PropertyKey.MASTER_RPC_ADDRESSES, "host1:99,host2:100",
             PropertyKey.JOB_MASTER_RPC_PORT, "50"));
     assertEquals(
-        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        Arrays.asList(InetSocketAddress.createUnresolved("host1", 50),
+            InetSocketAddress.createUnresolved("host2", 50)),
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
@@ -105,7 +109,8 @@ public final class ConfigurationUtilsTest {
             PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES, "host1:99,host2:100",
             PropertyKey.JOB_MASTER_RPC_PORT, "50"));
     assertEquals(
-        Arrays.asList(new InetSocketAddress("host1", 50), new InetSocketAddress("host2", 50)),
+        Arrays.asList(InetSocketAddress.createUnresolved("host1", 50),
+            InetSocketAddress.createUnresolved("host2", 50)),
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 
@@ -113,7 +118,7 @@ public final class ConfigurationUtilsTest {
   public void getJobMasterRpcAddressesDefault() {
     AlluxioConfiguration conf = createConf(Collections.emptyMap());
     String host = NetworkAddressUtils.getLocalHostName(5 * Constants.SECOND_MS);
-    assertEquals(Arrays.asList(new InetSocketAddress(host, 20001)),
+    assertEquals(Arrays.asList(InetSocketAddress.createUnresolved(host, 20001)),
         ConfigurationUtils.getJobMasterRpcAddresses(conf));
   }
 

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -57,11 +57,11 @@ public class GetMasterWorkerAddressTest {
     // connect host only
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster3");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    assertEquals(new InetSocketAddress("RemoteMaster3", defaultPort), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("RemoteMaster3", defaultPort), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // all default
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    assertEquals(new InetSocketAddress(defaultHostname, defaultPort), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved(defaultHostname, defaultPort), masterAddress);
   }
 }

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -45,13 +45,13 @@ public class GetMasterWorkerAddressTest {
     int defaultPort = Integer.parseInt(PropertyKey.MASTER_RPC_PORT.getDefaultValue());
     InetSocketAddress masterAddress =
         NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    assertEquals(new InetSocketAddress("RemoteMaster1", 10000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("RemoteMaster1", 10000), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // port only
     conf.set(PropertyKey.MASTER_RPC_PORT, "20000");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
-    assertEquals(new InetSocketAddress(defaultHostname, 20000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved(defaultHostname, 20000), masterAddress);
     conf = ConfigurationTestUtils.defaults();
 
     // connect host only

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -81,7 +81,8 @@ public class NetworkAddressUtilsTest {
     mConfiguration.unset(service.getHostNameKey());
     mConfiguration.set(service.getBindHostKey(), "bind.host");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()),
+        masterAddress);
 
     // connect host and bind host
     mConfiguration.set(service.getHostNameKey(), "connect.host");
@@ -92,7 +93,8 @@ public class NetworkAddressUtilsTest {
     // wildcard connect host and bind host
     mConfiguration.set(service.getHostNameKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()),
+        masterAddress);
 
     // wildcard connect host and wildcard bind host
     mConfiguration.set(service.getBindHostKey(), NetworkAddressUtils.WILDCARD_ADDRESS);

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -81,50 +81,50 @@ public class NetworkAddressUtilsTest {
     mConfiguration.unset(service.getHostNameKey());
     mConfiguration.set(service.getBindHostKey(), "bind.host");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()), masterAddress);
 
     // connect host and bind host
     mConfiguration.set(service.getHostNameKey(), "connect.host");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("connect.host", service.getDefaultPort()),
+    assertEquals(InetSocketAddress.createUnresolved("connect.host", service.getDefaultPort()),
         masterAddress);
 
     // wildcard connect host and bind host
     mConfiguration.set(service.getHostNameKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", service.getDefaultPort()), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("bind.host", service.getDefaultPort()), masterAddress);
 
     // wildcard connect host and wildcard bind host
     mConfiguration.set(service.getBindHostKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress(localHostName, service.getDefaultPort()),
+    assertEquals(InetSocketAddress.createUnresolved(localHostName, service.getDefaultPort()),
         masterAddress);
 
     // connect host and wildcard bind host
     mConfiguration.set(service.getHostNameKey(), "connect.host");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("connect.host", service.getDefaultPort()),
+    assertEquals(InetSocketAddress.createUnresolved("connect.host", service.getDefaultPort()),
         masterAddress);
 
     // connect host and wildcard bind host with port
     mConfiguration.set(service.getPortKey(), "10000");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("connect.host", 10000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("connect.host", 10000), masterAddress);
 
     // connect host and bind host with port
     mConfiguration.set(service.getBindHostKey(), "bind.host");
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("connect.host", 10000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("connect.host", 10000), masterAddress);
 
     // empty connect host and bind host with port
     mConfiguration.unset(service.getHostNameKey());
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress("bind.host", 10000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved("bind.host", 10000), masterAddress);
 
     // empty connect host and wildcard bind host with port
     mConfiguration.set(service.getBindHostKey(), NetworkAddressUtils.WILDCARD_ADDRESS);
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress(localHostName, 10000), masterAddress);
+    assertEquals(InetSocketAddress.createUnresolved(localHostName, 10000), masterAddress);
   }
 
    /**

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -74,7 +74,7 @@ public class NetworkAddressUtilsTest {
 
     // all default
     masterAddress = NetworkAddressUtils.getConnectAddress(service, mConfiguration);
-    assertEquals(new InetSocketAddress(localHostName, service.getDefaultPort()),
+    assertEquals(InetSocketAddress.createUnresolved(localHostName, service.getDefaultPort()),
         masterAddress);
 
     // bind host only

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalConfigurationTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalConfigurationTest.java
@@ -82,9 +82,9 @@ public final class RaftJournalConfigurationTest {
     ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "host1");
     ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 5);
     RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
-    assertEquals(Sets.newHashSet(new InetSocketAddress("host1", 5),
-        new InetSocketAddress("host2", 5),
-        new InetSocketAddress("host3", 5)),
+    assertEquals(Sets.newHashSet(InetSocketAddress.createUnresolved("host1", 5),
+        InetSocketAddress.createUnresolved("host2", 5),
+        InetSocketAddress.createUnresolved("host3", 5)),
         new HashSet<>(conf.getClusterAddresses()));
   }
 
@@ -95,9 +95,9 @@ public final class RaftJournalConfigurationTest {
     ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, "host1");
     ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 10);
     RaftJournalConfiguration conf = getConf(ServiceType.JOB_MASTER_RAFT);
-    assertEquals(Sets.newHashSet(new InetSocketAddress("host1", 10),
-        new InetSocketAddress("host2", 20),
-        new InetSocketAddress("host3", 10)),
+    assertEquals(Sets.newHashSet(InetSocketAddress.createUnresolved("host1", 10),
+        InetSocketAddress.createUnresolved("host2", 20),
+        InetSocketAddress.createUnresolved("host3", 10)),
         new HashSet<>(conf.getClusterAddresses()));
   }
 

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -76,6 +76,12 @@ function writeConf {
 
 writeConf
 
+function disableDNSCache {
+  echo "networkaddress.cache.ttl=0" >> $JAVA_HOME/jre/lib/security/java.security
+}
+
+disableDNSCache
+
 function formatMasterIfSpecified {
   if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
     printUsage

--- a/tests/src/test/java/alluxio/server/web/ServiceSocketBindIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/web/ServiceSocketBindIntegrationTest.java
@@ -82,9 +82,10 @@ public class ServiceSocketBindIntegrationTest extends BaseIntegrationTest {
     // connect Master Web service
     InetSocketAddress masterWebAddr =
         NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_WEB, ServerConfiguration.global());
-    mMasterWebService = (HttpURLConnection) new URL(
-        "http://" + masterWebAddr.getAddress().getHostAddress() + ":" + masterWebAddr.getPort()
-            + "/index.html").openConnection();
+    mMasterWebService = (HttpURLConnection) new URL("http://"
+        + (masterWebAddr.isUnresolved() ? masterWebAddr.toString()
+            : masterWebAddr.getAddress().getHostAddress() + ":" + masterWebAddr.getPort())
+        + "/index.html").openConnection();
     mMasterWebService.connect();
 
     // connect Worker Web service


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/9448 by delaying hostname resolution so that stale DNS entries can be refreshed.

Note: Client side InetSocketAddress should be created unresolved to tolerate DNS changes. Server bind socket addresses are an exception as those do not change during the lifetime of the JVM.