### PR TITLE
Fix failed Pin on readonly mount

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3146,12 +3146,16 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       }
     }
     String commandName;
+    boolean checkWritableMountPoint = false;
     if (options.getOwner() != null) {
       commandName = "chown";
+      checkWritableMountPoint = true;
     } else if (options.getGroup() != null) {
       commandName = "chgrp";
+      checkWritableMountPoint = true;
     } else if (options.getMode() != null) {
       commandName = "chmod";
+      checkWritableMountPoint = true;
     } else {
       commandName = "setAttribute";
     }
@@ -3168,7 +3172,9 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         auditContext.setAllowed(false);
         throw e;
       }
-      mMountTable.checkUnderWritableMountPoint(path);
+      if (checkWritableMountPoint) {
+        mMountTable.checkUnderWritableMountPoint(path);
+      }
       // Force recursive sync metadata if it is a pinning and unpinning operation
       boolean recursiveSync = (options.getPinned() != null) || options.isRecursive();
       // Possible ufs sync.

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3153,7 +3153,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     } else if (options.getGroup() != null) {
       commandName = "chgrp";
       checkWritableMountPoint = true;
-    } else if (options.getMode() != null) {
+    } else if (options.getMode() != Constants.INVALID_MODE) {
       commandName = "chmod";
       checkWritableMountPoint = true;
     } else {

--- a/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
@@ -293,6 +293,7 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
   @Test
   public void setAttribute() throws IOException, AlluxioException {
     AlluxioURI fileUri = new AlluxioURI(FILE_PATH);
+    mFileSystem.getStatus(fileUri); // load metadata first
     mFileSystem.setAttribute(fileUri, SetAttributeOptions.defaults().setPinned(true).setTtl(10));
   }
 

--- a/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
@@ -13,17 +13,19 @@ package alluxio.client.fs;
 
 import alluxio.AlluxioURI;
 import alluxio.Configuration;
-import alluxio.client.WriteType;
 import alluxio.PropertyKey;
+import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.options.CreateFileOptions;
 import alluxio.client.file.options.LoadMetadataOptions;
 import alluxio.client.file.options.MountOptions;
+import alluxio.client.file.options.SetAttributeOptions;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.master.LocalAlluxioCluster;
+import alluxio.security.authorization.Mode;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
@@ -286,5 +288,47 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
     inStream = mFileSystem.openFile(fileUri);
     Assert.assertNotNull(inStream);
     inStream.close();
+  }
+
+  @Test
+  public void setAttribute() throws IOException, AlluxioException {
+    AlluxioURI fileUri = new AlluxioURI(FILE_PATH);
+    mFileSystem.setAttribute(fileUri, SetAttributeOptions.defaults().setPinned(true).setTtl(10));
+  }
+
+  @Test
+  public void chmod() throws IOException, AlluxioException {
+    AlluxioURI uri = new AlluxioURI(FILE_PATH + "_chmod");
+    try {
+      mFileSystem.setAttribute(uri, SetAttributeOptions.defaults().setMode(new Mode((short) 0555)));
+      Assert.fail("chomd should not succeed under a readonly mount.");
+    } catch (AccessControlException e) {
+      Assert.assertEquals(e.getMessage(),
+          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+    }
+  }
+
+  @Test
+  public void chgrp() throws IOException, AlluxioException {
+    AlluxioURI uri = new AlluxioURI(FILE_PATH + "_chgrp");
+    try {
+      mFileSystem.setAttribute(uri, SetAttributeOptions.defaults().setGroup("foo"));
+      Assert.fail("chgrp should not succeed under a readonly mount.");
+    } catch (AccessControlException e) {
+      Assert.assertEquals(e.getMessage(),
+          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+    }
+  }
+
+  @Test
+  public void chown() throws IOException, AlluxioException {
+    AlluxioURI uri = new AlluxioURI(FILE_PATH + "_chown");
+    try {
+      mFileSystem.setAttribute(uri, SetAttributeOptions.defaults().setOwner("foo"));
+      Assert.fail("chown should not succeed under a readonly mount.");
+    } catch (AccessControlException e) {
+      Assert.assertEquals(e.getMessage(),
+          ExceptionMessage.MOUNT_READONLY.getMessage(uri, MOUNT_PATH));
+    }
   }
 }


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/9399 where `pin` failed
due to readonly mount
Also fix a bug on wrong command name in audit log

pr-link: Alluxio/alluxio#9460
change-id: cid-2e62e472a4aa270b838fc419c2b5d6fbc71252c0