### PR TITLE
Add metadataSyncInterval to client RPCs by default

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -478,11 +478,9 @@ public class BaseFileSystem implements FileSystem {
     // Specifically set and override *only* the metadata sync interval
     // Setting other attributes by default will make the server think the user is intentionally
     // setting the values. Most fields withinSetAttributePOptions are set by inclusion.
-    SetAttributePOptions mergedOptions = SetAttributePOptions.newBuilder()
-        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
-            .setSyncIntervalMs(mFsContext.getPathConf(path)
-                .getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL)).build())
-        .mergeFrom(options).build();
+    SetAttributePOptions mergedOptions =
+        FileSystemOptions.setAttributeClientDefaults(mFsContext.getPathConf(path))
+            .toBuilder().mergeFrom(options).build();
     rpc(client -> {
       client.setAttribute(path, mergedOptions);
       LOG.debug("Set attributes for {}, options: {}", path.getPath(), options);

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -41,7 +41,6 @@ import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.ExistsPOptions;
-import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.GrpcUtils;

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -474,9 +474,6 @@ public class BaseFileSystem implements FileSystem {
   public void setAttribute(AlluxioURI path, SetAttributePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
-    // Specifically set and override *only* the metadata sync interval
-    // Setting other attributes by default will make the server think the user is intentionally
-    // setting the values. Most fields withinSetAttributePOptions are set by inclusion.
     SetAttributePOptions mergedOptions =
         FileSystemOptions.setAttributeClientDefaults(mFsContext.getPathConf(path))
             .toBuilder().mergeFrom(options).build();

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
@@ -261,6 +261,9 @@ public class FileSystemOptions {
    * @return options based on the configuration
    */
   public static SetAttributePOptions setAttributeClientDefaults(AlluxioConfiguration conf) {
+    // Specifically set and override *only* the metadata sync interval
+    // Setting other attributes by default will make the server think the user is intentionally
+    // setting the values. Most fields withinSetAttributePOptions are set by inclusion
     return SetAttributePOptions.newBuilder()
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
             .setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
@@ -256,7 +256,8 @@ public class FileSystemOptions {
   }
 
   /**
-   * Sets the defaults for the SetAttribute RPC which should be used on the client side.
+   * Defaults for the SetAttribute RPC which should only be used on the client side.
+   *
    * @param conf Alluxio configuration
    * @return options based on the configuration
    */

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
@@ -256,6 +256,19 @@ public class FileSystemOptions {
   }
 
   /**
+   * Sets the defaults for the SetAttribute RPC which should be used on the client side.
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  public static SetAttributePOptions setAttributeClientDefaults(AlluxioConfiguration conf) {
+    return SetAttributePOptions.newBuilder()
+        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+            .setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
+            .build())
+        .build();
+  }
+
+  /**
    * @param conf Alluxio configuration
    * @return options based on the configuration
    */

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -482,25 +482,20 @@ public final class BaseFileSystemTest {
   @Test
   public void setAttribute() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    SetAttributePOptions setAttributeOptions = SetAttributePOptions.getDefaultInstance();
+    SetAttributePOptions setAttributeOptions =
+        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
     mFileSystem.setAttribute(file, setAttributeOptions);
     verify(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
   }
 
   /**
-   * Tests for the {@link BaseFileSystem#setAttribute(AlluxioURI, SetAttributePOptions)} method.
+   * Tests that the metadata sync interval is included on setAttributePOptions by default.
    */
   @Test
   public void setAttributeSyncMetadataInterval() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions opt =
-        SetAttributePOptions.newBuilder().setCommonOptions(
-            FileSystemMasterCommonPOptions.newBuilder()
-                .setSyncIntervalMs(
-                    mFileContext.getPathConf(file)
-                        .getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
-                .build())
-            .build();
+        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
     // Check that metadata sync interval from configuration is used when options are omitted
     mFileSystem.setAttribute(file);
     verify(mFileSystemMasterClient).setAttribute(file, opt);
@@ -512,7 +507,8 @@ public final class BaseFileSystemTest {
   @Test
   public void setStateException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    SetAttributePOptions setAttributeOptions = SetAttributePOptions.getDefaultInstance();
+    SetAttributePOptions setAttributeOptions =
+        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
     doThrow(EXCEPTION).when(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
     try {
       mFileSystem.setAttribute(file, setAttributeOptions);

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -33,7 +33,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
-import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -33,6 +33,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
@@ -484,6 +485,25 @@ public final class BaseFileSystemTest {
     SetAttributePOptions setAttributeOptions = SetAttributePOptions.getDefaultInstance();
     mFileSystem.setAttribute(file, setAttributeOptions);
     verify(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
+  }
+
+  /**
+   * Tests for the {@link BaseFileSystem#setAttribute(AlluxioURI, SetAttributePOptions)} method.
+   */
+  @Test
+  public void setAttributeSyncMetadataInterval() throws Exception {
+    AlluxioURI file = new AlluxioURI("/file");
+    SetAttributePOptions opt =
+        SetAttributePOptions.newBuilder().setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder()
+                .setSyncIntervalMs(
+                    mFileContext.getPathConf(file)
+                        .getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
+                .build())
+            .build();
+    // Check that metadata sync interval from configuration is used when options are omitted
+    mFileSystem.setAttribute(file);
+    verify(mFileSystemMasterClient).setAttribute(file, opt);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4540,8 +4540,11 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
   private LockingScheme createLockingScheme(AlluxioURI path, FileSystemMasterCommonPOptions options,
       LockPattern desiredLockMode) {
-    boolean shouldSync =
-        mUfsSyncPathCache.shouldSyncPath(path.getPath(), options.getSyncIntervalMs());
+    // If client options didn't specify the interval, fallback to whatever the server has
+    // configured to prevent unnecessary syncing due to the default value being 0
+    long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
+        ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+    boolean shouldSync = mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval);
     return new LockingScheme(path, desiredLockMode, shouldSync);
   }
 

--- a/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
@@ -23,6 +23,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
@@ -291,6 +292,7 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
   public void setAttribute() throws IOException, AlluxioException {
     AlluxioURI fileUri = new AlluxioURI(FILE_PATH);
     mFileSystem.setAttribute(fileUri, SetAttributePOptions.newBuilder()
+        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build())
         .setPinned(true)
         .setReplicationMax(10)
         .setReplicationMin(1)


### PR DESCRIPTION
The SetAttribute RPC in the client works via omission of
properties. If a property is included within the RPC options
object, then it is assumed the user set this property and
should then be set on the inode. This works for all fields
within the SetAttribute call except for the sync interval.

The metadata sync interval must be included on client RPCs.
Otherwise, if it is not included, then the
DefaultFileSystemMaster will assume that the user has
implicitly set a sync interval of 0 - which results in syncing
metadata for every RPC. Users can still override this value
from their configuration. However, by default it should be
sending a value of -1 (the default for the property key).

This change makes sure that the interval is set and adds a
small unit test.

Fixes #9470