### PR TITLE
Fix unencoded paths for the web ui

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -96,6 +96,7 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -367,8 +368,8 @@ public final class AlluxioMasterRestServiceHandler {
           ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
           .setMasterNodeAddress(mMasterProcess.getRpcAddress().toString()).setInvalidPathError("");
       List<FileInfo> filesInfo;
-      String path = requestPath;
-      if (path == null || path.isEmpty()) {
+      String path = URLDecoder.decode(requestPath, "UTF-8");
+      if (path.isEmpty()) {
         path = AlluxioURI.SEPARATOR;
       }
       AlluxioURI currentPath = new AlluxioURI(path);

--- a/webui/common/src/components/FileView/FileView.tsx
+++ b/webui/common/src/components/FileView/FileView.tsx
@@ -81,7 +81,8 @@ export class FileView extends React.PureComponent<IFileViewProps> {
             <Label for="viewDataFileOffset" className="mr-sm-2">Display from byte offset</Label>
             <Input className="col-3" type="number" id="viewDataFileOffset" placeholder="Enter an offset"
                    value={offset} onChange={offsetInputHandler}
-                   onKeyUp={this.createInputEnterHandler(history, () => `${queryStringPrefix}?path=${path}${queryStringSuffix}`)}/>
+                   onKeyUp={this.createInputEnterHandler(history, () =>
+                   `${queryStringPrefix}?path=${path}${queryStringSuffix}`)}/>
           </FormGroup>
           <FormGroup className="col-5">
             <Label for="viewDataFileEnd" className="mr-sm-2">Relative to</Label>
@@ -124,7 +125,7 @@ export class FileView extends React.PureComponent<IFileViewProps> {
     if (allowDownload && proxyDownloadApiUrl && path) {
       return (
         <FormGroup className="col-4 mt-2">
-          <a href={`${proxyDownloadApiUrl.prefix}${encodeURIComponent(path)}${proxyDownloadApiUrl.suffix}`}>
+          <a href={`${proxyDownloadApiUrl.prefix}${path}${proxyDownloadApiUrl.suffix}`}>
             Download via Alluxio Proxy
           </a>
         </FormGroup>

--- a/webui/common/src/utilities/misc/renderFileNameLink.tsx
+++ b/webui/common/src/utilities/misc/renderFileNameLink.tsx
@@ -1,18 +1,20 @@
 import {Link} from 'react-router-dom';
 import React from 'react';
 
-export const renderFileNameLink = function (this: any, path: string, url: string) {
+export const renderFileNameLink = function (this: any, path: string, urlPrefix: string) {
   const {lastFetched} = this.state;
   if (path === lastFetched.path) {
     return (
       path
     );
   }
+  const encodedPath = encodeURIComponent(path) || "";
+  const encodedUrl = urlPrefix + encodedPath;
 
   return (
     <pre className="mb-0">
       <code>
-      <Link to={url}>
+      <Link to={encodedUrl}>
         {path}
       </Link>
     </code>

--- a/webui/master/src/containers/pages/Browse/Browse.tsx
+++ b/webui/master/src/containers/pages/Browse/Browse.tsx
@@ -214,11 +214,12 @@ export class Browse extends React.Component<AllProps, IBrowseState> {
             <Label for="browsePath" className="mr-sm-2">Path</Label>
             <Input type="text" id="browsePath" placeholder="Enter a Path" value={path || '/'}
                    onChange={pathInputHandler}
-                   onKeyUp={this.createInputEnterHandler(history, () => `/browse?path=${path}${queryStringSuffix}`)}/>
+                   onKeyUp={this.createInputEnterHandler(history, () =>
+                   `/browse?path=${path}${queryStringSuffix}`)}/>
           </FormGroup>
           <FormGroup className="mb-2 mr-sm-2">
-            <Button tag={Link} to={`/browse?path=${path}${queryStringSuffix}`} color="secondary"
-                    disabled={path === lastFetched.path}>Go</Button>
+            <Button tag={Link} to={`/browse?path=${encodeURIComponent(path || "/")}${queryStringSuffix}`}
+            color="secondary" disabled={path === lastFetched.path}>Go</Button>
           </FormGroup>
         </Form>
         <Table hover={true}>
@@ -256,7 +257,7 @@ export class Browse extends React.Component<AllProps, IBrowseState> {
             <tr key={fileInfo.absolutePath}>
               <td><FontAwesomeIcon icon={fileInfo.isDirectory ? faFolder : faFile}/></td>
               <td>
-                {renderFileNameLink.call(this, fileInfo.absolutePath, `/browse?path=${fileInfo.absolutePath}`)}
+                {renderFileNameLink.call(this, fileInfo.absolutePath, `/browse?path=`)}
               </td>
               <td>{fileInfo.size}</td>
               <td>{fileInfo.blockSizeBytes}</td>

--- a/webui/master/src/containers/pages/Browse/__snapshots__/Browse.test.tsx.snap
+++ b/webui/master/src/containers/pages/Browse/__snapshots__/Browse.test.tsx.snap
@@ -1129,7 +1129,7 @@ exports[`Browse Shallow component Matches snapshot 1`] = `
               color="secondary"
               disabled={true}
               tag={[Function]}
-              to="/browse?path=/&offset=0"
+              to="/browse?path=%2F&offset=0"
             >
               Go
             </Button>

--- a/webui/master/src/containers/pages/Logs/Logs.tsx
+++ b/webui/master/src/containers/pages/Logs/Logs.tsx
@@ -167,7 +167,7 @@ export class Logs extends React.Component<AllProps, ILogsState> {
         {fileInfos && fileInfos.map((fileInfo: IFileInfo) => (
           <tr key={fileInfo.absolutePath}>
             <td>
-              {renderFileNameLink.call(this, fileInfo.absolutePath, `/logs?path=${fileInfo.absolutePath}`)}
+              {renderFileNameLink.call(this, fileInfo.absolutePath, `/logs?path=`)}
             </td>
             <td>{fileInfo.size}</td>
             <td>{fileInfo.blockSizeBytes}</td>

--- a/webui/worker/src/containers/pages/BlockInfo/BlockInfo.tsx
+++ b/webui/worker/src/containers/pages/BlockInfo/BlockInfo.tsx
@@ -170,7 +170,7 @@ export class BlockInfo extends React.Component<AllProps, IBlockInfoState> {
           <tbody>
           {fileInfos && fileInfos.map((fileInfo: IFileInfo) => (
             <tr key={fileInfo.absolutePath}>
-              <td>{renderFileNameLink.call(this, fileInfo.absolutePath, `/blockInfo?path=${fileInfo.absolutePath}`)}</td>
+              <td>{renderFileNameLink.call(this, fileInfo.absolutePath, `/blockInfo?path=`)}</td>
               {tierAliases.map((tierAlias: string) => (
                 <td key={tierAlias}>{`${fileInfo.inAlluxioPercentage}%`}</td>
               ))}

--- a/webui/worker/src/containers/pages/Logs/Logs.tsx
+++ b/webui/worker/src/containers/pages/Logs/Logs.tsx
@@ -167,7 +167,7 @@ export class Logs extends React.Component<AllProps, ILogsState> {
         {fileInfos && fileInfos.map((fileInfo: IFileInfo) => (
           <tr key={fileInfo.absolutePath}>
             <td>
-              {renderFileNameLink.call(this, fileInfo.absolutePath, `/logs?path=${fileInfo.absolutePath}`)}
+              {renderFileNameLink.call(this, fileInfo.absolutePath, `/logs?path=`)}
             </td>
             <td>{fileInfo.size}</td>
             <td>{fileInfo.blockSizeBytes}</td>


### PR DESCRIPTION
Fixes #9465 

Invariants -
Paths presented to the user are not encoded.
Paths in URLs/links are encoded, except for specific references to the root path (a constant `/`).