### PR TITLE
Fix 'Display from byte offset' input

### DIFF
--- a/webui/master/src/containers/pages/Browse/Browse.tsx
+++ b/webui/master/src/containers/pages/Browse/Browse.tsx
@@ -87,7 +87,8 @@ export class Browse extends React.Component<AllProps, IBrowseState> {
     const {refresh, location: {search}} = this.props;
     const {refresh: prevRefresh, location: {search: prevSearch}} = prevProps;
     if (search !== prevSearch) {
-      const {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+      let {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+      offset = offset || '0';
       this.setState({path, offset, limit, end});
       this.fetchData(path, offset, limit, end);
     } else if (refresh !== prevRefresh) {
@@ -162,7 +163,7 @@ export class Browse extends React.Component<AllProps, IBrowseState> {
     return (
       <React.Fragment>
         <FileView allowDownload={true} beginInputHandler={beginInputHandler} end={end} endInputHandler={endInputHandler}
-                  lastFetched={lastFetched} offset={offset || '0'} offsetInputHandler={offsetInputHandler} path={path}
+                  lastFetched={lastFetched} offset={offset} offsetInputHandler={offsetInputHandler} path={path}
                   queryStringPrefix="/browse" queryStringSuffix={queryStringSuffix} textAreaHeight={textAreaHeight}
                   viewData={browseData} history={history} proxyDownloadApiUrl={initData.proxyDownloadFileApiUrl}/>
         <hr/>

--- a/webui/master/src/containers/pages/Logs/Logs.tsx
+++ b/webui/master/src/containers/pages/Logs/Logs.tsx
@@ -64,7 +64,8 @@ export class Logs extends React.Component<AllProps, ILogsState> {
   constructor(props: AllProps) {
     super(props);
 
-    const {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+    let {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+    offset = offset || '0';
     this.state = {end, limit, offset, path, lastFetched: {}};
   }
 
@@ -72,7 +73,8 @@ export class Logs extends React.Component<AllProps, ILogsState> {
     const {refresh, location: {search}} = this.props;
     const {refresh: prevRefresh, location: {search: prevSearch}} = prevProps;
     if (search !== prevSearch) {
-      const {path, offset, limit, end} = parseQuerystring(search);
+      let {path, offset, limit, end} = parseQuerystring(search);
+      offset = offset || '0';
       this.setState({path, offset, limit, end});
       this.fetchData(path, offset, limit, end);
     }
@@ -143,7 +145,7 @@ export class Logs extends React.Component<AllProps, ILogsState> {
     const endInputHandler = this.createButtonHandler('end', value => '1').bind(this);
     return (
       <FileView beginInputHandler={beginInputHandler} end={end} endInputHandler={endInputHandler}
-                lastFetched={lastFetched} offset={offset || '0'} offsetInputHandler={offsetInputHandler} path={path}
+                lastFetched={lastFetched} offset={offset} offsetInputHandler={offsetInputHandler} path={path}
                 queryStringPrefix="/logs" queryStringSuffix={queryStringSuffix} textAreaHeight={textAreaHeight}
                 viewData={logs} history={history}/>
     );

--- a/webui/worker/src/containers/pages/Logs/Logs.tsx
+++ b/webui/worker/src/containers/pages/Logs/Logs.tsx
@@ -64,7 +64,8 @@ export class Logs extends React.Component<AllProps, ILogsState> {
   constructor(props: AllProps) {
     super(props);
 
-    const {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+    let {path, offset, limit, end} = parseQuerystring(this.props.location.search);
+    offset = offset || '0';
     this.state = {end, limit, offset, path, lastFetched: {}};
   }
 
@@ -72,7 +73,8 @@ export class Logs extends React.Component<AllProps, ILogsState> {
     const {refresh, location: {search}} = this.props;
     const {refresh: prevRefresh, location: {search: prevSearch}} = prevProps;
     if (search !== prevSearch) {
-      const {path, offset, limit, end} = parseQuerystring(search);
+      let {path, offset, limit, end} = parseQuerystring(search);
+      offset = offset || '0';
       this.setState({path, offset, limit, end});
       this.fetchData(path, offset, limit, end);
     }
@@ -143,7 +145,7 @@ export class Logs extends React.Component<AllProps, ILogsState> {
     const endInputHandler = this.createButtonHandler('end', value => '1').bind(this);
     return (
       <FileView beginInputHandler={beginInputHandler} end={end} endInputHandler={endInputHandler}
-                lastFetched={lastFetched} offset={offset || '0'} offsetInputHandler={offsetInputHandler} path={path}
+                lastFetched={lastFetched} offset={offset} offsetInputHandler={offsetInputHandler} path={path}
                 queryStringPrefix="/logs" queryStringSuffix={queryStringSuffix} textAreaHeight={textAreaHeight}
                 viewData={logs} history={history}/>
     );


### PR DESCRIPTION
- Fixes #9483
- making sure we initialize the field with `0` offset even if parsed query has `undefined` offset