### PR TITLE
Fix Unmount failure by Alluxio FUSE

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.serce.jnrfuse.FuseException;
 
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,9 +72,14 @@ public final class AlluxioFuse {
     try {
       fs.mount(Paths.get(opts.getMountPoint()), true, opts.isDebug(),
           fuseOpts.toArray(new String[0]));
+      tfs.close();
     } catch (FuseException e) {
-      //only try to umount file system when exception occurred
+      //only try to umount file system when exception occurred.
+      //but jnr-fuse also registers shutdown hook to ensure fs.umount()
+      //can be executed when this process is exiting.
       fs.umount();
+    } catch (IOException e) {
+      //ignore this exception, since this process is exiting.
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ru.serce.jnrfuse.FuseException;
 
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -70,7 +71,8 @@ public final class AlluxioFuse {
     try {
       fs.mount(Paths.get(opts.getMountPoint()), true, opts.isDebug(),
           fuseOpts.toArray(new String[0]));
-    } finally {
+    } catch (FuseException e) {
+      //only try to umount file system when exception occurred
       fs.umount();
     }
   }


### PR DESCRIPTION
Fix #9461

If umount an Alluxio FUSE mount point,
fs.mount() returns without any exception.
but fs.umount() will conflict with the running umount command,
that results in "target is busy" error and umount command failing.

Signed-off-by: liuhongtong <hongtongliu@126.com>