### PR TITLE
Enable owner to chmod, even without write privilege

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3168,7 +3168,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
          FileSystemMasterAuditContext auditContext =
              createAuditContext(commandName, path, null, inodePath.getInodeOrNull())) {
       try {
-        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired, writeRequired);
+        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired,
+            writeRequired);
       } catch (AccessControlException e) {
         auditContext.setAllowed(false);
         throw e;
@@ -3185,7 +3186,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
       }
 
-      setAttributeAndJournal(rpcContext, inodePath, rootRequired, ownerRequired, options);
+      setAttributeAndJournal(rpcContext, inodePath, rootRequired, ownerRequired, writeRequired,
+          options);
       auditContext.setSucceeded(true);
     }
   }
@@ -3221,7 +3223,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
    * @throws AccessControlException if permission checking fails
    */
   private void setAttributeAndJournal(RpcContext rpcContext, LockedInodePath inodePath,
-      boolean rootRequired, boolean ownerRequired, SetAttributeOptions options)
+      boolean rootRequired, boolean ownerRequired, boolean writeRequired,
+      SetAttributeOptions options)
       throws InvalidPathException, FileDoesNotExistException, AccessControlException, IOException {
     Inode<?> targetInode = inodePath.getInode();
     long opTimeMs = System.currentTimeMillis();
@@ -3229,7 +3232,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
       try (LockedInodePathList descendants = mInodeTree.lockDescendants(inodePath,
           InodeTree.LockMode.WRITE)) {
         for (LockedInodePath childPath : descendants.getInodePathList()) {
-          mPermissionChecker.checkSetAttributePermission(childPath, rootRequired, ownerRequired);
+          mPermissionChecker.checkSetAttributePermission(childPath, rootRequired, ownerRequired,
+              writeRequired);
         }
         for (LockedInodePath childPath : descendants.getInodePathList()) {
           List<Inode<?>> persistedInodes =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3137,6 +3137,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     // for chgrp, chmod
     boolean ownerRequired =
         (options.getGroup() != null) || (options.getMode() != Constants.INVALID_MODE);
+    boolean writeRequired = !rootRequired && !ownerRequired;
     if (options.getOwner() != null && options.getGroup() != null) {
       try {
         checkUserBelongsToGroup(options.getOwner(), options.getGroup());
@@ -3167,7 +3168,7 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
          FileSystemMasterAuditContext auditContext =
              createAuditContext(commandName, path, null, inodePath.getInodeOrNull())) {
       try {
-        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired);
+        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired, writeRequired);
       } catch (AccessControlException e) {
         auditContext.setAllowed(false);
         throw e;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
@@ -126,7 +126,8 @@ public class DefaultPermissionChecker implements PermissionChecker {
 
   @Override
   public void checkSetAttributePermission(LockedInodePath inodePath, boolean superuserRequired,
-      boolean ownerRequired) throws AccessControlException, InvalidPathException {
+      boolean ownerRequired, boolean writeRequired)
+      throws AccessControlException, InvalidPathException {
     if (!mPermissionCheckEnabled) {
       return;
     }
@@ -139,7 +140,10 @@ public class DefaultPermissionChecker implements PermissionChecker {
     if (ownerRequired) {
       checkOwner(inodePath);
     }
-    checkPermission(Mode.Bits.WRITE, inodePath);
+    // For other non-permission related attributes
+    if (writeRequired) {
+      checkPermission(Mode.Bits.WRITE, inodePath);
+    }
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -60,9 +60,11 @@ public interface PermissionChecker {
    * @param inodePath the path to check permission on
    * @param superuserRequired indicates whether it requires to be the superuser
    * @param ownerRequired indicates whether it requires to be the owner of this path
+   * @param writeRequired indicates whether it requires to have write permissions
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   void checkSetAttributePermission(LockedInodePath inodePath, boolean superuserRequired,
-      boolean ownerRequired) throws AccessControlException, InvalidPathException;
+      boolean ownerRequired, boolean writeRequired)
+      throws AccessControlException, InvalidPathException;
 }

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -1132,6 +1132,55 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     fsMaster.createFile(alluxioFile, CreateFileOptions.defaults().setPersisted(true));
   }
 
+  @Test
+  public void setModeOwnerNoWritePermission() throws Exception {
+    AlluxioURI root = new AlluxioURI("/");
+    mFsMaster.setAttribute(root, SetAttributeContext
+        .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+      AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
+      FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
+
+      long opTimeMs = TEST_TIME_MS;
+      mFsMaster.completeFile(alluxioFile, CompleteFileContext
+          .mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(0))
+          .setOperationTimeMs(opTimeMs));
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0407).toProto())));
+      Assert.assertEquals(0407, mFsMaster.getFileInfo(file.getFileId()).getMode());
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+      Assert.assertEquals(0777, mFsMaster.getFileInfo(file.getFileId()).getMode());
+    }
+  }
+
+  @Test
+  public void setModeNoOwner() throws Exception {
+    AlluxioURI root = new AlluxioURI("/");
+    mFsMaster.setAttribute(root, SetAttributeContext
+        .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+    AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+      FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
+
+      long opTimeMs = TEST_TIME_MS;
+      mFsMaster.completeFile(alluxioFile, CompleteFileContext
+          .mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(0))
+          .setOperationTimeMs(opTimeMs));
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+      Assert.assertEquals(0777, mFsMaster.getFileInfo(file.getFileId()).getMode());
+    }
+    mThrown.expect(AccessControlException.class);
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("bar", ServerConfiguration.global()).toResource()) {
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0677).toProto())));
+    }
+  }
+
   /**
    * Tests creating a directory in a nested directory load the UFS status of Inodes on the path.
    */


### PR DESCRIPTION
Cherry-pick https://github.com/Alluxio/alluxio/pull/9456 to `branch-1.8`

Currently owner of file/directory cannot change permission when they
don't have write privilege. This is inconsistent with Unix and HDFS.
This fix updated the permission requirement so the user should be able
to perform chmod if and only if the user is the owner or super user.

pr-link: Alluxio/alluxio#9456
change-id: cid-1de7dc5511daf2b91761db8014560f07b0bfd746
