### PR TITLE
Fix UI issue with unused var

### DIFF
--- a/webui/common/src/utilities/misc/renderFileNameLink.tsx
+++ b/webui/common/src/utilities/misc/renderFileNameLink.tsx
@@ -1,13 +1,7 @@
 import {Link} from 'react-router-dom';
 import React from 'react';
 
-export const renderFileNameLink = function (this: any, path: string, urlPrefix: string) {
-  const {lastFetched} = this.state;
-  if (path === lastFetched.path) {
-    return (
-      path
-    );
-  }
+export const renderFileNameLink = function (path: string, urlPrefix: string): JSX.Element {
   const encodedPath = encodeURIComponent(path) || "";
   const encodedUrl = urlPrefix + encodedPath;
 


### PR DESCRIPTION
- `lastFetched` was used to visually show which link was previously clicked on. Didn't seem to work since when we switch from file view to directory view, we always send out a new fetch request, so `lastFetched` keeps getting cleared
- it's best to just remove it since it has no real usage