### PR TITLE
Enable owner to chmod, even without write privilege

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2859,11 +2859,11 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
             mInodeTree.lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern());
         FileSystemMasterAuditContext auditContext =
             createAuditContext("setAcl", path, null, inodePath.getInodeOrNull())) {
-      mPermissionChecker.checkSetAttributePermission(inodePath, false, true);
+      mPermissionChecker.checkSetAttributePermission(inodePath, false, true, false);
       if (context.getOptions().getRecursive()) {
         try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
           for (LockedInodePath child : descendants) {
-            mPermissionChecker.checkSetAttributePermission(child, false, true);
+            mPermissionChecker.checkSetAttributePermission(child, false, true, false);
           }
         } catch (AccessControlException e) {
           auditContext.setAllowed(false);
@@ -3015,6 +3015,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     boolean rootRequired = options.hasOwner();
     // for chgrp, chmod
     boolean ownerRequired = (options.hasGroup()) || (options.hasMode());
+    // for other attributes
+    boolean writeRequired = !rootRequired && !ownerRequired;
     if (options.hasOwner() && options.hasGroup()) {
       try {
         checkUserBelongsToGroup(options.getOwner(), options.getGroup());
@@ -3057,12 +3059,13 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
         throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
       }
       try {
-        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired);
+        mPermissionChecker.checkSetAttributePermission(inodePath, rootRequired, ownerRequired,
+            writeRequired);
         if (context.getOptions().getRecursive()) {
           try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
             for (LockedInodePath childPath : descendants) {
               mPermissionChecker.checkSetAttributePermission(childPath, rootRequired,
-                  ownerRequired);
+                  ownerRequired, writeRequired);
             }
           }
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
@@ -124,7 +124,8 @@ public class DefaultPermissionChecker implements PermissionChecker {
 
   @Override
   public void checkSetAttributePermission(LockedInodePath inodePath, boolean superuserRequired,
-      boolean ownerRequired) throws AccessControlException, InvalidPathException {
+      boolean ownerRequired, boolean writeRequired)
+      throws AccessControlException, InvalidPathException {
     if (!mPermissionCheckEnabled) {
       return;
     }
@@ -137,7 +138,10 @@ public class DefaultPermissionChecker implements PermissionChecker {
     if (ownerRequired) {
       checkOwner(inodePath);
     }
-    checkPermission(Mode.Bits.WRITE, inodePath);
+    // For other non-permission related attributes
+    if (writeRequired) {
+      checkPermission(Mode.Bits.WRITE, inodePath);
+    }
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -60,9 +60,11 @@ public interface PermissionChecker {
    * @param inodePath the path to check permission on
    * @param superuserRequired indicates whether it requires to be the superuser
    * @param ownerRequired indicates whether it requires to be the owner of this path
+   * @param writeRequired indicates whether it requires to have write permissions
    * @throws AccessControlException if permission checking fails
    * @throws InvalidPathException if the path is invalid
    */
   void checkSetAttributePermission(LockedInodePath inodePath, boolean superuserRequired,
-      boolean ownerRequired) throws AccessControlException, InvalidPathException;
+      boolean ownerRequired, boolean writeRequired)
+      throws AccessControlException, InvalidPathException;
 }

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -1173,6 +1173,55 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     fsMaster.createFile(alluxioFile, CreateFileContext.defaults().setPersisted(true));
   }
 
+  @Test
+  public void setModeOwnerNoWritePermission() throws Exception {
+    AlluxioURI root = new AlluxioURI("/");
+    mFsMaster.setAttribute(root, SetAttributeContext
+        .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+      AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
+      FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
+
+      long opTimeMs = TEST_TIME_MS;
+      mFsMaster.completeFile(alluxioFile, CompleteFileContext
+          .mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(0))
+          .setOperationTimeMs(opTimeMs));
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0407).toProto())));
+      Assert.assertEquals(0407, mFsMaster.getFileInfo(file.getFileId()).getMode());
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+      Assert.assertEquals(0777, mFsMaster.getFileInfo(file.getFileId()).getMode());
+    }
+  }
+
+  @Test
+  public void setModeNoOwner() throws Exception {
+    AlluxioURI root = new AlluxioURI("/");
+    mFsMaster.setAttribute(root, SetAttributeContext
+        .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+    AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+      FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
+
+      long opTimeMs = TEST_TIME_MS;
+      mFsMaster.completeFile(alluxioFile, CompleteFileContext
+          .mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(0))
+          .setOperationTimeMs(opTimeMs));
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
+      Assert.assertEquals(0777, mFsMaster.getFileInfo(file.getFileId()).getMode());
+    }
+    mThrown.expect(AccessControlException.class);
+    try (AutoCloseable closeable =
+             new AuthenticatedUserRule("bar", ServerConfiguration.global()).toResource()) {
+      mFsMaster.setAttribute(alluxioFile, SetAttributeContext
+          .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0677).toProto())));
+    }
+  }
+
   /**
    * Tests creating a directory in a nested directory load the UFS status of Inodes on the path.
    */


### PR DESCRIPTION
Cherry-pick #9456 to `branch-2.0`

Currently owner of file/directory cannot change permission when they
don't have write privilege. This is inconsistent with Unix and HDFS.
This fix updated the permission requirement so the user should be able
to perform chmod if and only if the user is the owner or super user.

pr-link: Alluxio/alluxio#9456
change-id: cid-1de7dc5511daf2b91761db8014560f07b0bfd746