### PR TITLE
Remove close because there is no close API in 1.8

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -74,12 +74,6 @@ public final class AlluxioFuse {
       // jnr-fuse registers JVM shutdown hook to ensure fs.umount()
       // will be executed when this process is exiting.
       fs.umount();
-    } finally {
-      try {
-        tfs.close();
-      } catch (Exception e) {
-        LOG.error("Failed to close Alluxio file system", e);
-      }
     }
   }
 


### PR DESCRIPTION
Changed introduced from #9500 