### PR TITLE
Add check on tiered storage configuration and avoid NPE

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -19,6 +19,7 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.FormatUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
@@ -282,6 +283,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkUserFileBufferBytes();
     checkZkConfiguration();
     checkTieredLocality();
+    checkTieredStorage();
   }
 
   /**
@@ -435,6 +437,34 @@ public class InstancedConfiguration implements AlluxioConfiguration {
                   + "configured by %s", tierName, key, tiers, PropertyKey.LOCALITY_ORDER));
         }
       }
+    }
+  }
+
+  /**
+   * Checks that tiered storage configuration on worker is consistent with the global configuration.
+   *
+   * @throws IllegalStateException if invalid tiered storage configuration is encountered
+   */
+  @VisibleForTesting
+  void checkTieredStorage() {
+    int globalTiers = getInt(PropertyKey.MASTER_TIERED_STORE_GLOBAL_LEVELS);
+    Set<String> globalTierAliasSet = new HashSet<>();
+    for (int i = 0; i < globalTiers; i++) {
+      globalTierAliasSet
+          .add(get(PropertyKey.Template.MASTER_TIERED_STORE_GLOBAL_LEVEL_ALIAS.format(i)));
+    }
+    int workerTiers = getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
+    Preconditions.checkState(workerTiers <= globalTiers,
+        "%s tiers on worker (configured by %s), larger than global %s tiers (configured by %s) ",
+        workerTiers, PropertyKey.WORKER_TIERED_STORE_LEVELS,
+        globalTiers, PropertyKey.MASTER_TIERED_STORE_GLOBAL_LEVELS);
+    for (int i = 0; i < workerTiers; i++) {
+      PropertyKey key = Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(i);
+      String alias = get(key);
+      Preconditions.checkState(globalTierAliasSet.contains(alias),
+          "Alias \"%s\" on tier %s on worker (configured by %s) is not found in global tiered "
+              + "storage setting: %s",
+          alias, i, key, String.join(", ", globalTierAliasSet));
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/9020 and
https://github.com/Alluxio/alluxio/issues/8997

When users specify a unknown storage alias (e.g., "ssd" rather than
"SSD"), they will see the following error message on NPE:
```
2019-05-13 14:29:07,034 ERROR ProcessUtils - Uncaught exception while
stopping Alluxio worker, simply exiting.
java.lang.NullPointerException
at
alluxio.worker.block.DefaultBlockWorker.stop(DefaultBlockWorker.java:262)
at alluxio.Registry.stop(Registry.java:149)
at
alluxio.worker.AlluxioWorkerProcess.stopWorkers(AlluxioWorkerProcess.java:287)
at
alluxio.worker.AlluxioWorkerProcess.stop(AlluxioWorkerProcess.java:274)
at alluxio.ProcessUtils.run(ProcessUtils.java:41)
at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:69)
```

This PR makes alluxio service fail explicitly and early with the
following error message:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
at alluxio.proxy.AlluxioProxy.main(AlluxioProxy.java:44)
Caused by: java.lang.IllegalStateException: Alias "ssd" on tier 0 on
worker (configured by alluxio.worker.tieredstore.level0.alias) is not
found in global tiered storage setting: MEM,SSD,HDD
at
com.google.common.base.Preconditions.checkState(Preconditions.java:862)
at
alluxio.conf.InstancedConfiguration.checkTieredStorage(InstancedConfiguration.java:544)
at
alluxio.conf.InstancedConfiguration.validate(InstancedConfiguration.java:363)
at
alluxio.util.ConfigurationUtils.reloadProperties(ConfigurationUtils.java:443)
at alluxio.conf.ServerConfiguration.reset(ServerConfiguration.java:68)
at
alluxio.conf.ServerConfiguration.<clinit>(ServerConfiguration.java:60)
... 1 more
```

pr-link: Alluxio/alluxio#9090
change-id: cid-48a08546422a9c9f3510f2315b23612e6ca38b05