### PR TITLE
Change journal tool test to use must cache instead of async

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -80,7 +80,8 @@ public class JournalToolTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
           .setProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES,
               Integer.toString(CHECKPOINT_SIZE))
-          .setProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "100").build();
+          .setProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "100")
+          .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE").build();
 
   private File mDumpDir;
   private FileSystem mFs;


### PR DESCRIPTION
When using async through there can be timing related issues with the persist step