### PR TITLE
Add to be persisted files to pinned file list

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2531,7 +2531,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
 
   @Override
   public Set<Long> getPinIdList() {
-    return mInodeTree.getPinIdSet();
+    // return both the explicitly pinned inodes and not persisted inodes which should not be evicted
+    return Sets.union(mInodeTree.getPinIdSet(), mInodeTree.getToBePersistedIds());
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManagerView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManagerView.java
@@ -52,7 +52,7 @@ public class BlockMetadataManagerView {
    */
   private final List<StorageTierView> mTierViews = new ArrayList<>();
 
-  /** A list of pinned inodes. */
+  /** A list of pinned inodes, including inodes which are scheduled for async persist. */
   private final Set<Long> mPinnedInodes = new HashSet<>();
 
   /** Indices of locks that are being used. */
@@ -97,7 +97,7 @@ public class BlockMetadataManagerView {
   }
 
   /**
-   * Tests if the block is pinned.
+   * Tests if the block is pinned either explicitly or because it is scheduled for async persist.
    *
    * @param blockId to be tested
    * @return boolean, true if block is pinned

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteIntegrationTest.java
@@ -14,8 +14,10 @@ package alluxio.client.fs;
 import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.CreateFileOptions;
+import alluxio.master.MasterClientConfig;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.testutils.IntegrationTestUtils;
 import alluxio.util.CommonUtils;
@@ -34,7 +36,6 @@ public final class FileOutStreamAsyncWriteIntegrationTest
 
   @Test
   public void asyncWrite() throws Exception {
-
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     final int length = 2;
     FileOutStream os = mFileSystem.createFile(filePath,
@@ -56,6 +57,19 @@ public final class FileOutStreamAsyncWriteIntegrationTest
 
     checkFileInAlluxio(filePath, length);
     checkFileInUnderStorage(filePath, length);
+  }
+
+  @Test
+  public void asyncWriteTemporaryPin() throws Exception {
+    AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
+    FileSystemTestUtils.createByteFile(mFileSystem, filePath, WriteType.ASYNC_THROUGH, 100);
+    URIStatus status = mFileSystem.getStatus(filePath);
+    alluxio.worker.file.FileSystemMasterClient fsMasterClient = new
+        alluxio.worker.file.FileSystemMasterClient(MasterClientConfig.defaults());
+
+    Assert.assertTrue(fsMasterClient.getPinList().contains(status.getFileId()));
+    IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+    Assert.assertFalse(fsMasterClient.getPinList().contains(status.getFileId()));
   }
 
   @Test


### PR DESCRIPTION
Changes the semantic of `getPinIdList` to return both the explicitly
pinned inodes and inodes which are in `TO_BE_PERSISTED` state. Inodes in
that state should not be evicted or users can experience data loss.

pr-link: Alluxio/alluxio#9052
change-id: cid-3d03eca419de07c8efc4f238d095b8c58c2b2c41