### PR TITLE
Fix log file with 0 byte offset from end

### DIFF
--- a/webui/master/src/containers/pages/Logs/Logs.tsx
+++ b/webui/master/src/containers/pages/Logs/Logs.tsx
@@ -122,8 +122,9 @@ export class Logs extends React.Component<AllProps, ILogsState> {
         <div className="container-fluid">
           <div className="row">
             <div className="col-12">
-              {data.fileData && this.renderFileView(data, queryStringSuffix)}
-              {!data.fileData && this.renderDirectoryListing(data.fileInfos, queryStringSuffix)}
+              {data.fileData !== null
+                  ? this.renderFileView(data, queryStringSuffix)
+                  : this.renderDirectoryListing(data.fileInfos, queryStringSuffix)}
             </div>
           </div>
         </div>

--- a/webui/master/src/containers/pages/Logs/__snapshots__/Logs.test.tsx.snap
+++ b/webui/master/src/containers/pages/Logs/__snapshots__/Logs.test.tsx.snap
@@ -1029,38 +1029,47 @@ exports[`Logs Shallow component Matches snapshot 1`] = `
       <div
         className="col-12"
       >
-        <Table
-          hover={true}
-          responsiveTag="div"
-          tag="table"
-        >
-          <thead>
-            <tr>
-              <th>
-                File Name
-              </th>
-              <th>
-                Size
-              </th>
-              <th>
-                Block Size
-              </th>
-              <th>
-                In-Alluxio
-              </th>
-              <th>
-                Persistence State
-              </th>
-              <th>
-                Pin
-              </th>
-              <th>
-                Modification Time
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </Table>
+        <FileView
+          beginInputHandler={[Function]}
+          endInputHandler={[Function]}
+          history={
+            Object {
+              "action": "PUSH",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 2,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/logs",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
+          offset="0"
+          offsetInputHandler={[Function]}
+          queryStringPrefix="/logs"
+          queryStringSuffix="&offset=0"
+          textAreaHeight={384}
+          viewData={
+            Object {
+              "currentPath": "",
+              "debug": false,
+              "fatalError": "",
+              "fileData": "",
+              "fileInfos": Array [],
+              "invalidPathError": "",
+              "ntotalFile": 0,
+              "viewingOffset": 0,
+            }
+          }
+        />
       </div>
     </div>
   </div>

--- a/webui/worker/src/containers/pages/Logs/Logs.tsx
+++ b/webui/worker/src/containers/pages/Logs/Logs.tsx
@@ -122,8 +122,9 @@ export class Logs extends React.Component<AllProps, ILogsState> {
         <div className="container-fluid">
           <div className="row">
             <div className="col-12">
-              {data.fileData && this.renderFileView(data, queryStringSuffix)}
-              {!data.fileData && this.renderDirectoryListing(data.fileInfos, queryStringSuffix)}
+              {data.fileData !== null
+                  ? this.renderFileView(data, queryStringSuffix)
+                  : this.renderDirectoryListing(data.fileInfos, queryStringSuffix)}
             </div>
           </div>
         </div>

--- a/webui/worker/src/containers/pages/Logs/__snapshots__/Logs.test.tsx.snap
+++ b/webui/worker/src/containers/pages/Logs/__snapshots__/Logs.test.tsx.snap
@@ -965,38 +965,47 @@ exports[`Logs Shallow component Matches snapshot 1`] = `
       <div
         className="col-12"
       >
-        <Table
-          hover={true}
-          responsiveTag="div"
-          tag="table"
-        >
-          <thead>
-            <tr>
-              <th>
-                File Name
-              </th>
-              <th>
-                Size
-              </th>
-              <th>
-                Block Size
-              </th>
-              <th>
-                In-Alluxio
-              </th>
-              <th>
-                Persistence State
-              </th>
-              <th>
-                Pin
-              </th>
-              <th>
-                Modification Time
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </Table>
+        <FileView
+          beginInputHandler={[Function]}
+          endInputHandler={[Function]}
+          history={
+            Object {
+              "action": "PUSH",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 2,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/logs",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            }
+          }
+          offset="0"
+          offsetInputHandler={[Function]}
+          queryStringPrefix="/logs"
+          queryStringSuffix="&offset=0"
+          textAreaHeight={384}
+          viewData={
+            Object {
+              "currentPath": "",
+              "debug": false,
+              "fatalError": "",
+              "fileData": "",
+              "fileInfos": Array [],
+              "invalidPathError": "",
+              "ntotalFile": 0,
+              "viewingOffset": 0,
+            }
+          }
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Fixes #9482
- shouldn't use truthy/falsy values for this check - `data.fileData =
''` is still valid for a real file

pr-link: Alluxio/alluxio#9494
change-id: cid-8892b12e3380b4312b577706ac2ab7d5d2ecb496