### PR TITLE
Add : space for exception message

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3721,7 +3721,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       long mountId = resolution.getMountId();
       try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
         if (!ufsResource.get().supportsActiveSync()) {
-          throw new UnsupportedOperationException("Active Syncing is not supported on this UFS type: "
+          throw new UnsupportedOperationException(
+              "Active Syncing is not supported on this UFS type: "
               + ufsResource.get().getUnderFSType());
         }
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3721,7 +3721,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       long mountId = resolution.getMountId();
       try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
         if (!ufsResource.get().supportsActiveSync()) {
-          throw new UnsupportedOperationException("Active Syncing is not supported on this UFS type"
+          throw new UnsupportedOperationException("Active Syncing is not supported on this UFS type: "
               + ufsResource.get().getUnderFSType());
         }
       }


### PR DESCRIPTION
**Description**
The exception message "Active Syncing is not supported on this UFS type" + ufsResource.get().getUnderFSType() will get the result "Active Syncing is not supported on this UFS types3" for s3.
![image](https://user-images.githubusercontent.com/19620810/61782905-7d4bcf80-ae39-11e9-8aed-3e02f2df23ba.png)

**Improvement**
Append : space for the message: "Active Syncing is not supported on this UFS type: ", And the result will be "Active Syncing is not supported on this UFS type: s3" for s3.