### PR TITLE
Update alluxio-env templete to contain proxy opts

### DIFF
--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -37,7 +37,7 @@
 # E.g. "-Dalluxio.worker.rpc.port=49999" to set worker port, "-Xms2048M -Xmx2048M" to limit the heap size of worker.
 # ALLUXIO_WORKER_JAVA_OPTS
 
-# Config properties set for Alluxio worker daemon. (Default: "")
+# Config properties set for Alluxio proxy daemon. (Default: "")
 # E.g. "-Xms2048M -Xmx2048M" to limit the heap size of worker.
 # ALLUXIO_PROXY_JAVA_OPTS
 

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -37,6 +37,10 @@
 # E.g. "-Dalluxio.worker.rpc.port=49999" to set worker port, "-Xms2048M -Xmx2048M" to limit the heap size of worker.
 # ALLUXIO_WORKER_JAVA_OPTS
 
+# Config properties set for Alluxio worker daemon. (Default: "")
+# E.g. "-Xms2048M -Xmx2048M" to limit the heap size of worker.
+# ALLUXIO_PROXY_JAVA_OPTS
+
 # Config properties set for Alluxio shell. (Default: "")
 # E.g. "-Dalluxio.user.file.writetype.default=CACHE_THROUGH"
 # ALLUXIO_USER_JAVA_OPTS

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -38,7 +38,7 @@
 # ALLUXIO_WORKER_JAVA_OPTS
 
 # Config properties set for Alluxio proxy daemon. (Default: "")
-# E.g. "-Xms2048M -Xmx2048M" to limit the heap size of worker.
+# E.g. "-Xms2048M -Xmx2048M" to limit the heap size of proxy.
 # ALLUXIO_PROXY_JAVA_OPTS
 
 # Config properties set for Alluxio shell. (Default: "")


### PR DESCRIPTION
The `ALLUXIO_PROXY_JAVA_OPTS` is missing from this template.