### PR TITLE
Parallelize checkConsistency repairs

### DIFF
--- a/core/base/src/main/java/alluxio/exception/AggregateException.java
+++ b/core/base/src/main/java/alluxio/exception/AggregateException.java
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+import java.util.Collection;
+
+/**
+ * Represents a collection of exceptions.
+ */
+public class AggregateException extends Exception {
+  private final Collection<Exception> mExceptions;
+
+  /**
+   * Creates a new instance of {@link AggregateException}.
+   *
+   * @param exceptions the nested exceptions
+   */
+  public AggregateException(Collection<Exception> exceptions) {
+    mExceptions = exceptions;
+  }
+
+  @Override
+  public String getMessage() {
+    return toString();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    int i = 0;
+    for (Exception e : mExceptions) {
+      sb.append("Exception #").append(++i).append(":\n");
+      sb.append(e.toString()).append("\n");
+    }
+    return sb.toString();
+  }
+}

--- a/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
@@ -16,6 +16,8 @@ import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
+import alluxio.collections.ConcurrentHashSet;
+import alluxio.exception.AggregateException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.CheckConsistencyPOptions;
@@ -28,9 +30,13 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Command for checking the consistency of a file or folder between Alluxio and the under storage.
@@ -44,6 +50,18 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
           .desc("repair inconsistent files")
           .build();
 
+  private static final Option THREADS_OPTION =
+      Option.builder("t")
+          .longOpt("threads")
+          .required(false)
+          .hasArg(true)
+          .desc("Number of threads used when repairing consistency. Defaults to <number of cores>"
+              + " * 2. This option has no effect if -r is not specified")
+          .build();
+
+  private static final String PARSE_THREADS_FAILURE_FMT = "The threads option must be a positive "
+      + "integer but was \"%s\"";
+
   /**
    * @param fsContext the filesystem of Alluxio
    */
@@ -54,7 +72,18 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
       throws AlluxioException, IOException {
-    runConsistencyCheck(plainPath, cl.hasOption("r"));
+    int threads;
+    try {
+      threads = cl.hasOption(THREADS_OPTION.getOpt())
+          ? Integer.parseInt(cl.getOptionValue(THREADS_OPTION.getOpt())) :
+          Runtime.getRuntime().availableProcessors() * 2;
+      if (threads < 1) {
+        throw new IOException(String.format(PARSE_THREADS_FAILURE_FMT, THREADS_OPTION.getOpt()));
+      }
+    } catch (NumberFormatException e) {
+      throw new IOException(String.format(PARSE_THREADS_FAILURE_FMT, THREADS_OPTION.getOpt()));
+    }
+    runConsistencyCheck(plainPath, cl.hasOption("r"), threads);
   }
 
   @Override
@@ -64,7 +93,7 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(REPAIR_OPTION);
+    return new Options().addOption(REPAIR_OPTION).addOption(THREADS_OPTION);
   }
 
   @Override
@@ -105,8 +134,8 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
    * @throws AlluxioException
    * @throws IOException
    */
-  private void runConsistencyCheck(AlluxioURI path, boolean repairConsistency) throws
-      AlluxioException, IOException {
+  private void runConsistencyCheck(AlluxioURI path, boolean repairConsistency, int repairThreads)
+      throws AlluxioException, IOException {
     List<AlluxioURI> inconsistentUris =
         checkConsistency(path, FileSystemOptions.checkConsistencyDefaults(
             mFsContext.getPathConf(path)));
@@ -122,43 +151,86 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
       }
     } else {
       Collections.sort(inconsistentUris);
-      System.out.println(path + " has: " + inconsistentUris.size() + " inconsistent files.");
-      List<AlluxioURI> inconsistentDirs = new ArrayList<AlluxioURI>();
+      System.out.println(String.format("%s has: %d inconsistent files. Repairing with %d threads.",
+          path, inconsistentUris.size(), repairThreads));
+      ConcurrentHashSet<AlluxioURI> inconsistentDirs = new ConcurrentHashSet<>();
+
+      ExecutorService svc = Executors.newFixedThreadPool(repairThreads);
+      CompletionService<Boolean> completionService = new ExecutorCompletionService<>(svc);
+      ConcurrentHashSet<Exception> exceptions = new ConcurrentHashSet<>();
+
+      int totalUris = inconsistentUris.size();
       for (AlluxioURI inconsistentUri : inconsistentUris) {
-        URIStatus status = mFileSystem.getStatus(inconsistentUri);
-        if (status.isFolder()) {
-          inconsistentDirs.add(inconsistentUri);
-          continue;
-        }
-        System.out.println("repairing path: " + inconsistentUri);
-        DeletePOptions deleteOptions = DeletePOptions.newBuilder().setAlluxioOnly(true).build();
-        mFileSystem.delete(inconsistentUri, deleteOptions);
-        mFileSystem.exists(inconsistentUri);
-        System.out.println(inconsistentUri + " repaired");
-        System.out.println();
+        completionService.submit(() -> {
+          try {
+            URIStatus status = mFileSystem.getStatus(inconsistentUri);
+            if (status.isFolder()) {
+              inconsistentDirs.add(inconsistentUri);
+              return;
+            }
+            System.out.println("repairing path: " + inconsistentUri);
+            DeletePOptions deleteOptions = DeletePOptions.newBuilder().setAlluxioOnly(true).build();
+            mFileSystem.delete(inconsistentUri, deleteOptions);
+            mFileSystem.exists(inconsistentUri);
+            System.out.println(inconsistentUri + " repaired");
+            System.out.println();
+          } catch (AlluxioException | IOException e) {
+            exceptions.add(e);
+          }
+        }, true);
       }
+
+      waitForTasks(completionService, totalUris, exceptions);
+
+      int totalDirs = inconsistentDirs.size();
       for (AlluxioURI uri : inconsistentDirs) {
-        DeletePOptions deleteOptions =
-            DeletePOptions.newBuilder().setAlluxioOnly(true).setRecursive(true).build();
-        System.out.println("repairing path: " + uri);
-        mFileSystem.delete(uri, deleteOptions);
-        mFileSystem.exists(uri);
-        System.out.println(uri + "repaired");
-        System.out.println();
+        completionService.submit(() -> {
+          try {
+            DeletePOptions deleteOptions =
+                DeletePOptions.newBuilder().setAlluxioOnly(true).setRecursive(true).build();
+            System.out.println("repairing path: " + uri);
+            mFileSystem.delete(uri, deleteOptions);
+            mFileSystem.exists(uri);
+            System.out.println(uri + "repaired");
+            System.out.println();
+          } catch (AlluxioException | IOException e) {
+            exceptions.add(e);
+          }
+        }, true);
       }
+      waitForTasks(completionService, totalDirs, exceptions);
+      svc.shutdown();
+    }
+  }
+
+  private void waitForTasks(CompletionService svc, int nTasks, Collection<Exception> exceptions)
+      throws IOException {
+    for (int i = 0; i < nTasks; i++) {
+      try {
+        svc.take();
+      } catch (InterruptedException e) {
+        throw new IOException("Failed to wait for all URIs to complete");
+      }
+    }
+
+    if (exceptions.size() > 0) {
+      AggregateException e = new AggregateException(exceptions);
+      throw new IOException("Failed to successfully repair all paths", e);
     }
   }
 
   @Override
   public String getUsage() {
-    return "checkConsistency [-r] <Alluxio path>";
+    return "checkConsistency [-r] [-t|--threads <threads>] <Alluxio path>";
   }
 
   @Override
   public String getDescription() {
     return "Checks the consistency of a persisted file or directory in Alluxio. Any files or "
         + "directories which only exist in Alluxio or do not match the metadata of files in the "
-        + "under storage will be returned. An administrator should then reconcile the differences."
-        + "Specify -r to repair the inconsistent files.";
+        + "under storage will be returned. An administrator should then reconcile the  "
+        + "differences. Specify -r to repair the inconsistent files. Use -t or --threads to "
+        + "specify the number of threads that should be used when repairing. Defaults to "
+        + "2*<number of CPU cores>";
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
@@ -11,20 +11,27 @@
 
 package alluxio.client.cli.fs.command;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.WritePType;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.DeleteOptions;
 
-import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Integration tests for checkConsistency command.
@@ -41,10 +48,10 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
         WritePType.CACHE_THROUGH, 20);
     mFsShell.run("checkConsistency", "/testRoot");
     String expected = "/testRoot is consistent with the under storage system.\n";
-    Assert.assertEquals(expected, mOutput.toString());
+    assertEquals(expected, mOutput.toString());
     mOutput.reset();
     mFsShell.run("checkConsistency", "-r", "/testRoot");
-    Assert.assertEquals(expected, mOutput.toString());
+    assertEquals(expected, mOutput.toString());
   }
 
   /**
@@ -64,16 +71,16 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
     expected.append("The following files are inconsistent:\n");
     expected.append("/testRoot/testDir\n");
     expected.append("/testRoot/testDir/testFileB\n");
-    Assert.assertEquals(expected.toString(), mOutput.toString());
+    assertEquals(expected.toString(), mOutput.toString());
 
     mOutput.reset();
     mFsShell.run("checkConsistency", "-r", "/testRoot");
     String res = mOutput.toString();
-    Assert.assertTrue(res.contains("/testRoot" + " has: " + "2 inconsistent files.\n")
+    assertTrue(res.contains("/testRoot" + " has: " + "2 inconsistent files.")
         && res.contains("repairing path: " + "/testRoot/testDir\n")
         && res.contains("repairing path: " + "/testRoot/testDir/testFileB\n"));
-    Assert.assertTrue(!mFileSystem.exists(new AlluxioURI("/testRoot/testDir")));
-    Assert.assertTrue(!mFileSystem.exists(new AlluxioURI("/testRoot/testDir/testFileB")));
+    assertFalse(mFileSystem.exists(new AlluxioURI("/testRoot/testDir")));
+    assertFalse(mFileSystem.exists(new AlluxioURI("/testRoot/testDir/testFileB")));
 
     FileSystemTestUtils.createByteFile(mFileSystem, "/testRoot/testDir/testFileB",
             WritePType.CACHE_THROUGH, 20);
@@ -86,11 +93,11 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
     mOutput.reset();
     mFsShell.run("checkConsistency", "-r", "/testRoot");
     res = mOutput.toString();
-    Assert.assertTrue(res.contains("/testRoot" + " has: " + "1 inconsistent files.\n")
+    assertTrue(res.contains("/testRoot" + " has: " + "1 inconsistent files.")
         && res.contains("repairing path: " + "/testRoot/testDir/testFileB\n"));
-    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/testRoot/testDir/testFileB"),
+    assertTrue(mFileSystem.exists(new AlluxioURI("/testRoot/testDir/testFileB"),
         ExistsPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ALWAYS).build()));
-    Assert.assertTrue(3 == mFileSystem.getStatus(new AlluxioURI("/testRoot/testDir/testFileB"))
+    assertEquals(3, mFileSystem.getStatus(new AlluxioURI("/testRoot/testDir/testFileB"))
         .getLength());
   }
 
@@ -108,6 +115,34 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
     String expected = "/testRoot/testDir/testFileB is consistent with the under storage system.\n"
             + "/testRoot/testDir2/testFileA is consistent "
             + "with the under storage system.\n";
-    Assert.assertEquals(expected, mOutput.toString());
+    assertEquals(expected, mOutput.toString());
+  }
+
+  @Test
+  public void multiThreaded() throws Exception {
+
+    makeInconsistentFiles("/testRoot", 1);
+    mFsShell.run("checkConsistency -r -t 1 /testRoot".split(" "));
+    String res = mOutput.toString();
+    assertTrue(res.contains("Repairing with 1 threads."));
+    mOutput.reset();
+
+    makeInconsistentFiles("/testRoot", 2);
+    mFsShell.run("checkConsistency -r -t 2 /testRoot".split(" "));
+    res = mOutput.toString();
+    assertTrue(res.contains("Repairing with 2 threads."));
+  }
+
+  void makeInconsistentFiles(String rootDir, int nFiles) throws AlluxioException, IOException {
+    List<String> filenames = new ArrayList<>();
+    for (int i = 0; i < nFiles; i++) {
+      filenames.add(String.format("%s/testDir/testFile%d", rootDir, i));
+    }
+    filenames.forEach((path) -> FileSystemTestUtils
+        .createByteFile(mFileSystem, path, WritePType.CACHE_THROUGH, 10));
+
+    String ufsPath = mFileSystem.getStatus(new AlluxioURI("/testRoot/testDir")).getUfsPath();
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    ufs.deleteDirectory(ufsPath, DeleteOptions.defaults().setRecursive(true));
   }
 }


### PR DESCRIPTION
Instead of serially repairing each URI from the list of
inconsistent URIs this PR utilizes an ExecutorService on the
client to run the repairs in parallel. The default number of
threads to use is `2*<number of cpu cores>` but users can
optionally specify their own number with the `-t` or
`--threads` option

Fixes #9527

pr-link: Alluxio/alluxio#9555
change-id: cid-57899fc2ac10c1c739b249ad33e08243003a4710