### PR TITLE
Change default TTLAction to null instead of DELETE for SetAttribute

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/SetAttributeOptions.java
@@ -53,7 +53,7 @@ public final class SetAttributeOptions {
     mCommonOptions = CommonOptions.defaults();
     mPinned = null;
     mTtl = null;
-    mTtlAction = TtlAction.DELETE;
+    mTtlAction = null;
     mPersisted = null;
     mOwner = null;
     mGroup = null;
@@ -235,8 +235,12 @@ public final class SetAttributeOptions {
     if (mPinned != null) {
       options.setPinned(mPinned);
     }
+
     if (mTtl != null) {
       options.setTtl(mTtl);
+    }
+
+    if (mTtlAction != null) {
       options.setTtlAction(TtlAction.toThrift(mTtlAction));
     }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/options/SetAttributeOptionsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 import alluxio.security.authorization.Mode;
 import alluxio.test.util.CommonUtils;
 import alluxio.thrift.SetAttributeTOptions;
+import alluxio.thrift.TTtlAction;
 import alluxio.wire.TtlAction;
 
 import org.junit.Test;
@@ -42,7 +43,7 @@ public final class SetAttributeOptionsTest {
     assertNull(options.getPersisted());
     assertNull(options.getPinned());
     assertNull(options.getTtl());
-    assertEquals(TtlAction.DELETE, options.getTtlAction());
+    assertNull(options.getTtlAction());
     assertNull(options.getOwner());
     assertNull(options.getGroup());
     assertNull(options.getMode());
@@ -100,6 +101,7 @@ public final class SetAttributeOptionsTest {
     options.setPersisted(persisted);
     options.setPinned(pinned);
     options.setTtl(ttl);
+    options.setTtlAction(TtlAction.FREE);
     SetAttributeTOptions thriftOptions = options.toThrift();
 
     assertTrue(thriftOptions.isSetPersisted());
@@ -107,7 +109,7 @@ public final class SetAttributeOptionsTest {
     assertTrue(thriftOptions.isSetPinned());
     assertEquals(pinned, thriftOptions.isPinned());
     assertTrue(thriftOptions.isSetTtl());
-    assertEquals(alluxio.thrift.TTtlAction.Delete, thriftOptions.getTtlAction());
+    assertEquals(TTtlAction.Free, thriftOptions.getTtlAction());
     assertEquals(ttl, thriftOptions.getTtl());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3275,9 +3275,10 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     }
     if (options.getTtl() != null) {
       builder.setTtl(options.getTtl());
+    }
+    if (options.getTtlAction() != null) {
       builder.setTtlAction(ProtobufUtils.toProtobuf(options.getTtlAction()));
     }
-
     if (options.getPersisted() != null) {
       builder.setPersisted(options.getPersisted());
     }
@@ -3749,6 +3750,8 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
     }
     if (entry.hasTtl()) {
       options.setTtl(entry.getTtl());
+    }
+    if (entry.hasTtlAction()) {
       options.setTtlAction(ProtobufUtils.fromProtobuf(entry.getTtlAction()));
     }
     if (entry.hasPersisted()) {

--- a/core/server/master/src/main/java/alluxio/master/file/options/SetAttributeOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/options/SetAttributeOptions.java
@@ -57,7 +57,7 @@ public final class SetAttributeOptions {
       }
       mPinned = options.isSetPinned() ? options.isPinned() : null;
       mTtl = options.isSetTtl() ? options.getTtl() : null;
-      mTtlAction = TtlAction.fromThrift(options.getTtlAction());
+      mTtlAction = options.isSetTtlAction() ? TtlAction.fromThrift(options.getTtlAction()) : null;
       mPersisted = options.isSetPersisted() ? options.isPersisted() : null;
       mOwner = options.isSetOwner() ? options.getOwner() : null;
       mGroup = options.isSetGroup() ? options.getGroup() : null;
@@ -72,7 +72,7 @@ public final class SetAttributeOptions {
     mCommonOptions = CommonOptions.defaults();
     mPinned = null;
     mTtl = null;
-    mTtlAction = TtlAction.DELETE;
+    mTtlAction = null;
     mPersisted = null;
     mOwner = null;
     mGroup = null;

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -735,7 +735,7 @@ public final class PermissionCheckTest {
       FileInfo fileInfo =
           mFileSystemMaster.getFileInfo(new AlluxioURI(path), GetStatusOptions.defaults());
       return SetAttributeOptions.defaults().setPinned(fileInfo.isPinned()).setTtl(fileInfo.getTtl())
-          .setPersisted(fileInfo.isPersisted());
+          .setTtlAction(fileInfo.getTtlAction()).setPersisted(fileInfo.isPersisted());
     }
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/options/SetAttributeOptionsTest.java
@@ -32,7 +32,7 @@ public final class SetAttributeOptionsTest {
 
     Assert.assertNull(options.getPinned());
     Assert.assertNull(options.getTtl());
-    Assert.assertEquals(TtlAction.DELETE, options.getTtlAction());
+    Assert.assertNull(options.getTtlAction());
     Assert.assertNull(options.getPersisted());
   }
 


### PR DESCRIPTION
TTL action in Alluxio create file/directory, set attribute are all default to `TtlAction.DELETE`.
Even after the file is created and users manually set ttl action to Free, some unrelated to setTtl set attribute operations will change the TtlAction back to DELETE.

In the workflow
```
createFile(path) .  <-- TtlAction = DELETE
setAttribute(TtlAction=FREE) .   
setAttribute(owner=new Owner) .  <-- TtlAction will change to DELETE because that's the default!
```

An example of `setAttributeOption` is 
```
SetAttributeOptions{commonOptions=CommonOptions{syncIntervalMs=-1}, pinned=null, ttl=null, ttlAction=DELETE, persisted=null, owner=NewOwner, group=null, mode=-1, recursive=false, operationTimeMs=1564102662737, ufsFingerprint=}
```

This PR change the default ttl action in setAttributeOptions to null instead of DELETE.

The issue only exist in 1.8. Master and 2.0 don't have this problem because we directly use `SetAttributePOptions` in `DefaultFileSytemMaster.setAttributeSingleFile`.
The `TtlAction` default in `SetAttributePOptions` is `null` (In 1.8, the default is `DELETE`). 

We will only set the `TtlAction` back to `DELETE` when users explicitly set the `ttlAction=DELETE` in `SetAttributePOptions` when calling the `fileSystemMasterClient.setAttribute(path, SetAttributePOptions.setTtlAction(DELETE)`.
