### PR TITLE
Improve k8s short-circuit documentation

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -255,13 +255,13 @@ To disable short-circuit operations, set the property `alluxio.user.short.circui
 
 ##### Hostname Introspection
 
-Short-circuit operations between the Alluxio client and enabled by default worker are enabled if the client
-hostname matches the worker hostname.
+Short-circuit operations between the Alluxio client and worker are enabled if the client hostname
+matches the worker hostname.
 This may not be true if the client is running as part of a container with virtual networking.
 In such a scenario, set the following property to use filesystem inspection to enable short-circuit
-and **make sure the client container mounts the directory specified as the domain socket path**.
-Short-circuit writes are then enabled if the worker UUID is located on the
-client filesystem.
+operations and **make sure the client container mounts the directory specified as the domain socket
+path**.
+Short-circuit writes are then enabled if the worker UUID is located on the client filesystem.
 
 > Note: This property should be set on all workers
 
@@ -276,6 +276,7 @@ The domain socket is a volume which should be mounted on:
 - All Alluxio workers
 - All application containers which intend to read/write through Alluxio
 
+<<<<<<< HEAD
 The exact path of the domain socket is defined in the Kubernetes templates at
 `${ALLUXIO_HOME}/integration/kubernetes/alluxio-worker.yaml.template` and
 `${ALLUXIO_HOME}/integration/kubernetes/alluxio-fuse.yaml.template`.
@@ -285,10 +286,24 @@ As part of the Alluxio worker pod creation, a directory
 is created on the host at `/tmp/domain` for the shared domain socket.
 Alluxio containers **and compute application** containers should mount this volume to the
 **same path**.
+=======
+The exact path of the domain socket on the host is defined in the helm chart at
+`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/values.yml`.
+On the worker the path where the domain socket is mounted can be found within
+`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yml`
+
+As part of the Alluxio worker pod creation, a directory
+is created on the host at `/tmp/alluxio-domain` for the shared domain socket.
+The workers then mount `/tmp/alluxio-domain` to `/opt/domain` within the
+container.
+>>>>>>> a68f311c18... Fix typos
 
 ```properties
 alluxio.worker.data.server.domain.socket.address=/opt/domain
 ```
+
+Compute application containers **must** mount the domain socket volume to the same path
+(`/opt/domain`) as configured for the Alluxio workers.
 
 #### Verify
 

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -276,27 +276,13 @@ The domain socket is a volume which should be mounted on:
 - All Alluxio workers
 - All application containers which intend to read/write through Alluxio
 
-<<<<<<< HEAD
-The exact path of the domain socket is defined in the Kubernetes templates at
-`${ALLUXIO_HOME}/integration/kubernetes/alluxio-worker.yaml.template` and
-`${ALLUXIO_HOME}/integration/kubernetes/alluxio-fuse.yaml.template`.
-By default this value is `/opt/domain`.
+The exact path of the domain socket on the host and container is defined in the kubernetes template
+at `${ALLUXIO_HOME}/integration/kubernetes/allluxio-worker.yaml.template`.
 
 As part of the Alluxio worker pod creation, a directory
 is created on the host at `/tmp/domain` for the shared domain socket.
-Alluxio containers **and compute application** containers should mount this volume to the
-**same path**.
-=======
-The exact path of the domain socket on the host is defined in the helm chart at
-`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/values.yml`.
-On the worker the path where the domain socket is mounted can be found within
-`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yml`
-
-As part of the Alluxio worker pod creation, a directory
-is created on the host at `/tmp/alluxio-domain` for the shared domain socket.
-The workers then mount `/tmp/alluxio-domain` to `/opt/domain` within the
+The workers then mount `/tmp/domain` to `/opt/domain` within the
 container.
->>>>>>> a68f311c18... Fix typos
 
 ```properties
 alluxio.worker.data.server.domain.socket.address=/opt/domain

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -276,15 +276,18 @@ The domain socket is a volume which should be mounted on:
 - All Alluxio workers
 - All application containers which intend to read/write through Alluxio
 
-The exact path of the domain socket is defined in the helm chart at
-`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/values.yml`.
-By default this value is `/tmp/alluxio-domain`.
+The exact path of the domain socket is defined in the Kubernetes templates at
+`${ALLUXIO_HOME}/integration/kubernetes/alluxio-worker.yaml.template` and
+`${ALLUXIO_HOME}/integration/kubernetes/alluxio-fuse.yaml.template`.
+By default this value is `/opt/domain`.
 
 As part of the Alluxio worker pod creation, a directory
-is created on the host at `/tmp/alluxio-domain` for the shared domain socket.
+is created on the host at `/tmp/domain` for the shared domain socket.
+Alluxio containers **and compute application** containers should mount this volume to the
+**same path**.
 
 ```properties
-alluxio.worker.data.server.domain.socket.address=/tmp/alluxio-domain
+alluxio.worker.data.server.domain.socket.address=/opt/domain
 ```
 
 #### Verify

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -242,21 +242,52 @@ kubectl logs -f alluxio-worker-<id> -c alluxio-job-worker
 ### Short-circuit Access
 
 Short-circuit access enables clients to perform read and write operations directly against the
-worker bypassing the networking interface. As part of the Alluxio worker pod creation, a directory
-is created on the host at `/tmp/domain` for the shared domain socket.
+worker bypassing the networking interface.
+For performance-critical applications it is recommended to enable short-circuit operations
+against Alluxio because it can increase a client's read and write throughput when co-located with
+an Alluxio worker.
 
-To disable this feature, set the property `alluxio.user.short.circuit.enabled=false`. By default,
-short-circuit operations between the Alluxio client and worker are enabled if the client hostname
-matches the worker hostname. This may not be true if the client is running as part of a container
-with virtual networking. In such a scenario, set the following property to use filesystem inspection
-to enable short-circuit and make sure the client container mounts the directory specified as the
-domain socket address. Short-circuit writes are then enabled if the worker UUID is located on the
+#### Properties to Enable Short-Circuit Operations
+
+This feature is enabled by default, however requires extra configuration to work properly in
+Kubernetes environments.
+To disable short-circuit operations, set the property `alluxio.user.short.circuit.enabled=false`.
+
+##### Hostname Introspection
+
+Short-circuit operations between the Alluxio client and enabled by default worker are enabled if the client
+hostname matches the worker hostname.
+This may not be true if the client is running as part of a container with virtual networking.
+In such a scenario, set the following property to use filesystem inspection to enable short-circuit
+and **make sure the client container mounts the directory specified as the domain socket path**.
+Short-circuit writes are then enabled if the worker UUID is located on the
 client filesystem.
+
+> Note: This property should be set on all workers
 
 ```properties
 alluxio.worker.data.server.domain.socket.as.uuid=true
-alluxio.worker.data.server.domain.socket.address=/opt/domain
 ```
+
+##### Domain Socket Path
+
+The domain socket is a volume which should be mounted on:
+
+- All Alluxio workers
+- All application containers which intend to read/write through Alluxio
+
+The exact path of the domain socket is defined in the helm chart at
+`${ALLUXIO_HOME}/integration/kubernetes/helm/alluxio/values.yml`.
+By default this value is `/tmp/alluxio-domain`.
+
+As part of the Alluxio worker pod creation, a directory
+is created on the host at `/tmp/alluxio-domain` for the shared domain socket.
+
+```properties
+alluxio.worker.data.server.domain.socket.address=/tmp/alluxio-domain
+```
+
+#### Verify
 
 To verify short-circuit reads and writes monitor the metrics displayed under:
 1. the metrics tab of the web UI as `Domain Socket Alluxio Read` and `Domain Socket Alluxio Write`


### PR DESCRIPTION
- Made the explanations more explicit
- Highlight where domain socket must be mounted

Closes #9574

pr-link: #9575
change-id: cid-64d9819d9dc0a440b0b0a53de119761f27a42214

Also includes changes from #9586 
- Misleading information and typos were introduced in #9575

Resolving typos and misleading information

pr-link: #9586
change-id: cid-f1a439f8925533693ee2b5d540f524cfec45332b
