### PR TITLE
Validate only last line for leader command test

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
@@ -33,7 +33,15 @@ public final class LeaderCommandIntegrationTest extends AbstractFileSystemShellT
   public void leaderAddressNotAvailable() throws Exception {
     mLocalAlluxioCluster.stopMasters();
     mFsShell.run("leader");
-    String expected = "The leader is not currently serving requests.\n";
-    Assert.assertEquals(expected, mErrOutput.toString());
+    String expected = "The leader is not currently serving requests.";
+    Assert.assertEquals(expected, lastLine(mErrOutput.toString()));
+  }
+
+  private String lastLine(String output) {
+    String[] lines = output.split("\n");
+    if (lines.length > 0) {
+      return lines[lines.length - 1];
+    }
+    return "";
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
@@ -34,14 +34,6 @@ public final class LeaderCommandIntegrationTest extends AbstractFileSystemShellT
     mLocalAlluxioCluster.stopMasters();
     mFsShell.run("leader");
     String expected = "The leader is not currently serving requests.";
-    Assert.assertEquals(expected, lastLine(mErrOutput.toString()));
-  }
-
-  private String lastLine(String output) {
-    String[] lines = output.split("\n");
-    if (lines.length > 0) {
-      return lines[lines.length - 1];
-    }
-    return "";
+    Assert.assertTrue(mErrOutput.toString().contains(expected));
   }
 }


### PR DESCRIPTION
This is to deflake leader command integration test.

The reason for failure is that error output contains some netty error trace that we can't control. When netty receives a command for a stream that is closed or being closed, such traces are written to sys::err. In this case, it's the latter, that some stream is about to be closed when leader command hits the server. This flake is introduced by gRPC long polling. Reason for that is now that servers keep an open stream, closing a server attempts to close those as well. However that takes some time after actual complete call is called on the stream. Hence it increased exposure to receive cancelled/closed stream errors from netty.