### PR TITLE
Read checkpointing start time before enabling snopshots

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -341,9 +341,9 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void checkpoint() throws IOException {
     try {
+      long start = System.currentTimeMillis();
       mSnapshotAllowed.set(true);
       CopycatClient client = createAndConnectClient();
-      long start = System.currentTimeMillis();
       LOG.info("Submitting empty journal entry to trigger snapshot");
       // New snapshot requires new segments (segment size is controlled by
       // {@link PropertyKey#MASTER_JOURNAL_LOG_SIZE_BYTES_MAX}).


### PR DESCRIPTION
This is to fix random flakes to `TriggeredCheckpointTest::embeddedJournal`, which becomes more common with upcoming gRPC transport due to slightly increased cost of creating new copycat clients.

This might deflake `JournalToolTest::dumpHeapCheckpointFromEmbeddedJournal` test as well considering it mostly fails during checkpoint command.