### PR TITLE
Throw an exception on interrupt for DynamicResourcePool

### DIFF
--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -342,7 +342,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
             throw new TimeoutException("Acquire resource times out.");
           }
         } catch (InterruptedException e) {
-          throw new IOException("Thread interrupted while acquiring client.");
+          throw new IOException("Thread interrupted while acquiring client in pool: " + this);
         }
       }
     } finally {

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -342,7 +342,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
             throw new TimeoutException("Acquire resource times out.");
           }
         } catch (InterruptedException e) {
-          throw new IOException("Thread interrupted while acquiring client in pool: " + this);
+          throw new IOException("Thread interrupted while acquiring client from pool: " + this);
         }
       }
     } finally {

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -302,6 +302,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
    * @param unit the unit to use for time
    * @return a resource taken from the pool
    * @throws TimeoutException if it fails to acquire because of time out
+   * @throws IOException if the thread is interrupted while acquiring the resource
    */
   @Override
   public T acquire(long time, TimeUnit unit) throws TimeoutException, IOException {
@@ -341,8 +342,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
             throw new TimeoutException("Acquire resource times out.");
           }
         } catch (InterruptedException e) {
-          // Restore the interrupt flag so that it can be handled later.
-          Thread.currentThread().interrupt();
+          throw new IOException("Thread interrupted while acquiring client.");
         }
       }
     } finally {


### PR DESCRIPTION
Await checks for the interrupted flag which will lead to an infinite loop. 