### PR TITLE
Fix NPE in UFS journal when shutting down journal fails

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -189,7 +189,11 @@ public class UfsJournal implements Journal {
       // We throw UnavailableException here so that clients will retry with the next primary master.
       throw new UnavailableException("Failed to write to journal: journal is in state " + mState);
     }
-    return new MasterJournalContext(mAsyncWriter);
+    AsyncJournalWriter writer = mAsyncWriter;
+    if (writer == null) {
+      throw new UnavailableException("Failed to write to journal: journal is shutdown.");
+    }
+    return new MasterJournalContext(writer);
   }
 
   private synchronized UfsJournalLogWriter writer() {


### PR DESCRIPTION
Sometimes shutting down journal can fail, causing journal writer to close incompletely, when this happens, any request to create a new journal context will end up with an NPE. This change add a defensive fix by checking the async writer first and throw `UnavailableException` instead. 