### PR TITLE
Remove missing test call for marking cluster as success

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
@@ -114,6 +114,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       }, WaitForOptions.defaults().setTimeoutMs(2
           * (int) ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)));
     }
+    mCluster.notifySuccess();
   }
 
   @Test
@@ -178,6 +179,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       // Verify cluster is reachable.
       Assert.assertTrue(mCluster.getFileSystemClient().exists(testDir));
     }
+    mCluster.notifySuccess();
   }
 
   @Test
@@ -245,6 +247,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       output = mOutput.toString().trim();
       Assert.assertEquals(ExceptionMessage.INVALID_ADDRESS_VALUE.getMessage(), output);
     }
+    mCluster.notifySuccess();
   }
 
   private String lastLine(String output) {

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -172,7 +172,6 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     assertTrue(fs.exists(testDir));
     restartMasters();
     assertTrue(fs.exists(testDir));
-    mCluster.saveWorkdir();
     mCluster.notifySuccess();
   }
 


### PR DESCRIPTION
Jenkins was keeping an artifact for these tests even when they were successful.