### PR TITLE
Implement a ConcurrentIdentityHashMap

### DIFF
--- a/core/base/src/main/java/alluxio/collections/ConcurrentIdentityHashMap.java
+++ b/core/base/src/main/java/alluxio/collections/ConcurrentIdentityHashMap.java
@@ -1,0 +1,347 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.collections;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class ConcurrentIdentityHashMap<K, V> implements ConcurrentMap<K, V> {
+
+  private final ConcurrentHashMap<IdentityObject<K>, V> mInternalMap;
+
+  /**
+   * Creates a new, empty map with the default initial table size (16).
+   */
+  public ConcurrentIdentityHashMap() {
+    mInternalMap = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Creates a new, empty map with an initial table size
+   * accommodating the specified number of elements without the need
+   * to dynamically resize.
+   *
+   * @param initialCapacity The implementation performs internal
+   * sizing to accommodate this many elements.
+   * @throws IllegalArgumentException if the initial capacity of
+   * elements is negative
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity) {
+    mInternalMap = new ConcurrentHashMap<>(initialCapacity);
+  }
+
+  /**
+   * Creates a new, empty map with an initial table size based on
+   * the given number of elements ({@code initialCapacity}) and
+   * initial table density ({@code loadFactor}).
+   *
+   * @param initialCapacity the initial capacity. The implementation
+   * performs internal sizing to accommodate this many elements,
+   * given the specified load factor.
+   * @param loadFactor the load factor (table density) for
+   * establishing the initial table size
+   * @throws IllegalArgumentException if the initial capacity of
+   * elements is negative or the load factor is nonpositive
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity, float loadFactor) {
+    this(initialCapacity, loadFactor, 1);
+  }
+
+  /**
+   * Creates a new, empty map with an initial table size based on
+   * the given number of elements ({@code initialCapacity}), table
+   * density ({@code loadFactor}), and number of concurrently
+   * updating threads ({@code concurrencyLevel}).
+   *
+   * @param initialCapacity the initial capacity. The implementation
+   * performs internal sizing to accommodate this many elements,
+   * given the specified load factor.
+   * @param loadFactor the load factor (table density) for
+   * establishing the initial table size
+   * @param concurrencyLevel the estimated number of concurrently
+   * updating threads. The implementation may use this value as
+   * a sizing hint.
+   * @throws IllegalArgumentException if the initial capacity is
+   * negative or the load factor or concurrencyLevel are
+   * nonpositive
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity,
+      float loadFactor, int concurrencyLevel) {
+    mInternalMap = new ConcurrentHashMap<>(initialCapacity, loadFactor, concurrencyLevel);
+  }
+
+  @Override
+  public boolean containsKey(Object k) {
+    return mInternalMap.containsKey(new IdentityObject<>(k));
+  }
+
+  @Override
+  public V put(K k, V v) {
+    return mInternalMap.put(new IdentityObject<>(k), v);
+  }
+
+  @Override
+  public V putIfAbsent(K k, V v) {
+    return mInternalMap.putIfAbsent(new IdentityObject<>(k), v);
+  }
+
+  @Override
+  public boolean remove(Object k, Object v) {
+    return mInternalMap.remove(new IdentityObject<>(k), v);
+  }
+
+  @Override
+  public V remove(Object k) {
+    return mInternalMap.remove(new IdentityObject<>(k));
+  }
+
+  @Override
+  public boolean replace(K k, V v1, V v2) {
+    return mInternalMap.replace(new IdentityObject<>(k), v1, v2);
+  }
+
+  @Override
+  public V replace(K k, V v) {
+    return mInternalMap.replace(new IdentityObject<>(k), v);
+  }
+
+  @Override
+  public V get(Object k) {
+    return mInternalMap.get(new IdentityObject<>(k));
+  }
+
+  @Override
+  public Collection<V> values() {
+    return mInternalMap.values();
+  }
+
+  @Override
+  public void clear() {
+    mInternalMap.clear();
+  }
+
+  /**
+   * Return a set representing the entries of this map at the time of calling.
+   *
+   * Note, this method will create a copy of the map's entry set at creation time. Standard
+   * behavior in the {@link ConcurrentHashMap} says that the entry set backed by the map is
+   * updated when the underlying map is updated. This is not the case for this class.
+   *
+   * @return The set of entries in the map at time of calling.
+   */
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    return mInternalMap.entrySet().stream().map(IdentityEntry<K, V>::new)
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> map) {
+    map.forEach((k, v) -> mInternalMap.put(new IdentityObject<>(k), v));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return mInternalMap.isEmpty();
+  }
+
+  @Override
+  public int size() {
+    return mInternalMap.size();
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return mInternalMap.containsValue(value);
+  }
+
+  /**
+   * Retrieves a set representing all keys contained within the map at time of calling.
+   *
+   * Note this method departs slightly from the standard {@link ConcurrentHashMap} implementation
+   * by providing its own implementation of a Set for {@link IdentityObject}. Not all methods
+   * have been implemented. Namely the {@code toArray} and {@code add*}.
+   *
+   * @return The set of keys in the map.
+   */
+  @Override
+  public Set<K> keySet() {
+    Set<IdentityObject<K>> set = mInternalMap.keySet();
+    return new Set<K>() {
+      @Override
+      public int size() {
+        return set.size();
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return set.isEmpty();
+      }
+
+      @Override
+      public boolean contains(Object o) {
+        return set.contains(new IdentityObject<>(o));
+      }
+
+      @Override
+      public Iterator<K> iterator() {
+        return set.stream().map(IdentityObject::get).iterator();
+      }
+
+      @Override
+      public Object[] toArray() {
+        throw new UnsupportedOperationException("toArray not supported in identity keySet");
+      }
+
+      @Override
+      public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException("toArray not supported in identity keySet");
+      }
+
+      @Override
+      public boolean add(K k) {
+        throw new UnsupportedOperationException("add not supported in keySet");
+      }
+
+      @Override
+      public boolean remove(Object o) {
+        return set.remove(new IdentityObject<>(o));
+      }
+
+      @Override
+      public boolean containsAll(Collection<?> c) {
+        return set.containsAll(c);
+      }
+
+      @Override
+      public boolean addAll(Collection<? extends K> c) {
+        throw new UnsupportedOperationException("addAll not supported in keySet");
+      }
+
+      @Override
+      public boolean retainAll(Collection<?> c) {
+        return set.retainAll(c);
+      }
+
+      @Override
+      public boolean removeAll(Collection<?> c) {
+        return set.retainAll(c);
+      }
+
+      @Override
+      public void clear() {
+        set.clear();
+      }
+    };
+  }
+
+
+  private class IdentityObject<T> {
+    private T mObj;
+
+    public IdentityObject(T o) {
+      this.mObj = o;
+    }
+
+    public T get() {
+      return mObj;
+    }
+
+    @Override
+    public int hashCode() {
+      // Robert Jenkins 32-bit integer hash
+      int a = System.identityHashCode(mObj);
+      a = (a+0x7ed55d16) + (a<<12);
+      a = (a^0xc761c23c) ^ (a>>19);
+      a = (a+0x165667b1) + (a<<5);
+      a = (a+0xd3a2646c) ^ (a<<9);
+      a = (a+0xfd7046c5) + (a<<3);
+      a = (a^0xb55a4f09) ^ (a>>16);
+      return a;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof IdentityObject)) {
+        // If it isn't an instance of an identity object, compare our internal pointer with the arg
+        // A form of "auto unboxing" when performing comparisons
+        return mObj == o;
+      }
+
+      try {
+        IdentityObject<T> other = (IdentityObject<T>) o;
+        return mObj == other.mObj;
+      } catch (ClassCastException e) {
+        return false;
+      }
+    }
+  }
+
+  private class IdentityEntry<T, P> implements Map.Entry<T, P> {
+    private final IdentityObject<T> mKey;
+    private P mValue;
+    IdentityEntry(Map.Entry<IdentityObject<T>, P> e) {
+      mKey = e.getKey();
+      mValue = e.getValue();
+    }
+
+    @Override
+    public T getKey() {
+      return mKey.get();
+    }
+
+    @Override
+    public P getValue() {
+      return mValue;
+    }
+
+    @Override
+    public P setValue(P v) {
+      P old = mValue;
+      mValue = v;
+      return old;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(mKey, mValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof IdentityEntry)) {
+        return false;
+      }
+
+      try {
+        IdentityEntry<T, P> other = (IdentityEntry<T, P>) o;
+        return mKey.equals(other.mKey)
+            && mValue.equals(other.mValue);
+      } catch (ClassCastException e) {
+        return false;
+      }
+    }
+  }
+
+}

--- a/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
+++ b/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
@@ -1,0 +1,142 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class ConcurrentIdentityHashMapTest {
+
+
+  private ConcurrentIdentityHashMap<String, String> mMap;
+
+  @Before
+  public void before() {
+    mMap = new ConcurrentIdentityHashMap<>();
+  }
+
+  @Test
+  public void testIdentitySemantics() {
+    ConcurrentIdentityHashMap<String, Boolean> m = new ConcurrentIdentityHashMap<>();
+    String k = new String("test");
+    String k2 = new String("test");
+    m.put(k, true);
+    m.put(k2, false);
+    assertFalse(m.isEmpty());
+    assertEquals(2, m.size());
+    assertTrue(m.containsKey(k));
+    assertTrue(m.containsKey(k2));
+    assertEquals(2, m.entrySet().size());
+    for(Map.Entry e : m.entrySet()) {
+      assertTrue(e.getKey() == k || e.getKey() == k2);
+    }
+    m.remove("test"); // Should not remove, because it doesn't have the correct obj ref
+    assertEquals(2, m.size());
+    m.remove(k); // remove with correct identity ref
+    assertEquals(1, m.size());
+    m.remove(k); // Remove twice should not work
+    m.remove(k2);
+    assertEquals(0, m.size()); // remove with correct identity ref
+  }
+
+  @Test
+  public void putIfAbsent() {
+    String t = new String("test");
+    mMap.putIfAbsent(t, "v1");
+    assertEquals(1, mMap.size());
+    assertEquals("v1", mMap.get(t));
+    assertFalse(mMap.containsKey("test"));
+  }
+
+  @Test
+  public void keySet() {
+    String x = new String("x");
+    String xx = new String("x");
+    mMap.put(x, "x");
+    mMap.put(xx, "x2");
+    assertEquals(2, mMap.size());
+    Set<String> km = mMap.keySet();
+    assertEquals(2, km.size());
+    assertTrue(km.contains(x));
+    assertTrue(km.contains(xx));
+    mMap.remove(x);
+    assertEquals(1, km.size());
+    assertTrue(km.remove(xx));
+    assertEquals(0, km.size());
+    assertEquals(0, mMap.size());
+  }
+
+  @Test
+  public void replace() {
+    String x = new String("x");
+    String x2 = new String("x");
+    mMap.put(x, "x");
+    mMap.replace(x2, "x");
+    assertEquals(1, mMap.size());
+    assertEquals("x", mMap.replace(x, "y"));
+    mMap.replace(x, "noreplace", "z"); // shouldn't replace
+    assertEquals("y", mMap.get(x));
+  }
+
+  @Test
+  public void remove() {
+    String x = new String("x");
+    String x2 = new String("x");
+    mMap.put(x, "y");
+    assertEquals(1, mMap.size());
+    assertNull(mMap.remove(x2));
+    assertEquals(1, mMap.size());
+    assertEquals("y", mMap.remove(x));
+    assertEquals(0, mMap.size());
+
+    mMap.put(x2, "z");
+    assertEquals(1, mMap.size());
+    assertFalse(mMap.remove(x2, "a"));
+    assertTrue(mMap.remove(x2, "z"));
+    assertEquals(0, mMap.size());
+  }
+
+  @Test
+  public void values() {
+    String x1 = new String("x");
+    String x2 = new String("x");
+    mMap.put(x1, "z");
+    mMap.put(x2, "z");
+    Collection<String> v = mMap.values();
+    assertEquals(2, v.size());
+    v.forEach(val -> assertEquals("z", val));
+    mMap.remove(x1);
+    assertEquals(1, v.size());
+  }
+
+  @Test
+  public void clear() {
+    String x1 = new String("x");
+    String x2 = new String("x");
+    mMap.put(x1, "z");
+    mMap.put(x2, "z");
+    assertEquals(2, mMap.size());
+    mMap.clear();
+    assertEquals(0, mMap.size());
+    assertEquals(0, mMap.keySet().size());
+    assertEquals(0, mMap.entrySet().size());
+  }
+}

--- a/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
+++ b/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +26,6 @@ import java.util.Set;
 
 public class ConcurrentIdentityHashMapTest {
 
-
   private ConcurrentIdentityHashMap<String, String> mMap;
 
   @Before
@@ -35,26 +35,31 @@ public class ConcurrentIdentityHashMapTest {
 
   @Test
   public void testIdentitySemantics() {
-    ConcurrentIdentityHashMap<String, Boolean> m = new ConcurrentIdentityHashMap<>();
     String k = new String("test");
     String k2 = new String("test");
-    m.put(k, true);
-    m.put(k2, false);
-    assertFalse(m.isEmpty());
-    assertEquals(2, m.size());
-    assertTrue(m.containsKey(k));
-    assertTrue(m.containsKey(k2));
-    assertEquals(2, m.entrySet().size());
-    for(Map.Entry e : m.entrySet()) {
-      assertTrue(e.getKey() == k || e.getKey() == k2);
+    mMap.put(k, "true");
+    mMap.put(k2, "false");
+    assertFalse(mMap.isEmpty());
+    assertEquals(2, mMap.size());
+    assertTrue(mMap.containsKey(k));
+    assertTrue(mMap.containsKey(k2));
+    assertEquals(2, mMap.entrySet().size());
+    for (Map.Entry e : mMap.entrySet()) {
+      if (e.getKey() == k) {
+        assertEquals("true", e.getValue());
+      } else if (e.getKey() == k2) {
+        assertEquals("false", e.getValue());
+      } else {
+        fail("Should not have reached this condition");
+      }
     }
-    m.remove("test"); // Should not remove, because it doesn't have the correct obj ref
-    assertEquals(2, m.size());
-    m.remove(k); // remove with correct identity ref
-    assertEquals(1, m.size());
-    m.remove(k); // Remove twice should not work
-    m.remove(k2);
-    assertEquals(0, m.size()); // remove with correct identity ref
+    mMap.remove("test"); // Should not remove, because it doesn't have the correct obj ref
+    assertEquals(2, mMap.size());
+    assertEquals("true", mMap.remove(k)); // remove with correct identity ref
+    assertEquals(1, mMap.size());
+    assertNull(mMap.remove(k)); // Remove twice should not work
+    assertEquals("false", mMap.remove(k2));
+    assertEquals(0, mMap.size()); // remove with correct identity ref
   }
 
   @Test
@@ -100,14 +105,14 @@ public class ConcurrentIdentityHashMapTest {
   public void remove() {
     String x = new String("x");
     String x2 = new String("x");
-    mMap.put(x, "y");
+    assertNull(mMap.put(x, "y"));
     assertEquals(1, mMap.size());
     assertNull(mMap.remove(x2));
     assertEquals(1, mMap.size());
     assertEquals("y", mMap.remove(x));
     assertEquals(0, mMap.size());
 
-    mMap.put(x2, "z");
+    assertNull(mMap.put(x2, "z"));
     assertEquals(1, mMap.size());
     assertFalse(mMap.remove(x2, "a"));
     assertTrue(mMap.remove(x2, "z"));
@@ -118,12 +123,12 @@ public class ConcurrentIdentityHashMapTest {
   public void values() {
     String x1 = new String("x");
     String x2 = new String("x");
-    mMap.put(x1, "z");
-    mMap.put(x2, "z");
+    assertNull(mMap.put(x1, "z"));
+    assertNull(mMap.put(x2, "z"));
     Collection<String> v = mMap.values();
     assertEquals(2, v.size());
     v.forEach(val -> assertEquals("z", val));
-    mMap.remove(x1);
+    assertEquals("z", mMap.remove(x1));
     assertEquals(1, v.size());
   }
 
@@ -131,8 +136,8 @@ public class ConcurrentIdentityHashMapTest {
   public void clear() {
     String x1 = new String("x");
     String x2 = new String("x");
-    mMap.put(x1, "z");
-    mMap.put(x2, "z");
+    assertNull(mMap.put(x1, "z"));
+    assertNull(mMap.put(x2, "z"));
     assertEquals(2, mMap.size());
     mMap.clear();
     assertEquals(0, mMap.size());

--- a/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
+++ b/core/base/src/test/java/alluxio/collections/ConcurrentIdentityHashMapTest.java
@@ -37,8 +37,8 @@ public class ConcurrentIdentityHashMapTest {
   public void testIdentitySemantics() {
     String k = new String("test");
     String k2 = new String("test");
-    mMap.put(k, "true");
-    mMap.put(k2, "false");
+    assertNull(mMap.put(k, "true"));
+    assertNull(mMap.put(k2, "false"));
     assertFalse(mMap.isEmpty());
     assertEquals(2, mMap.size());
     assertTrue(mMap.containsKey(k));
@@ -53,7 +53,7 @@ public class ConcurrentIdentityHashMapTest {
         fail("Should not have reached this condition");
       }
     }
-    mMap.remove("test"); // Should not remove, because it doesn't have the correct obj ref
+    assertNull(mMap.remove("test")); // Don't remove, because it doesn't have the correct obj ref
     assertEquals(2, mMap.size());
     assertEquals("true", mMap.remove(k)); // remove with correct identity ref
     assertEquals(1, mMap.size());
@@ -65,24 +65,26 @@ public class ConcurrentIdentityHashMapTest {
   @Test
   public void putIfAbsent() {
     String t = new String("test");
-    mMap.putIfAbsent(t, "v1");
+    assertNull(mMap.putIfAbsent(t, "v1"));
     assertEquals(1, mMap.size());
     assertEquals("v1", mMap.get(t));
     assertFalse(mMap.containsKey("test"));
+    assertEquals("v1", mMap.putIfAbsent(t, "v2"));
+    assertEquals("v1", mMap.get(t));
   }
 
   @Test
   public void keySet() {
     String x = new String("x");
     String xx = new String("x");
-    mMap.put(x, "x");
-    mMap.put(xx, "x2");
+    assertNull(mMap.put(x, "x"));
+    assertNull(mMap.put(xx, "x2"));
     assertEquals(2, mMap.size());
     Set<String> km = mMap.keySet();
     assertEquals(2, km.size());
     assertTrue(km.contains(x));
     assertTrue(km.contains(xx));
-    mMap.remove(x);
+    assertEquals("x", mMap.remove(x));
     assertEquals(1, km.size());
     assertTrue(km.remove(xx));
     assertEquals(0, km.size());
@@ -93,11 +95,11 @@ public class ConcurrentIdentityHashMapTest {
   public void replace() {
     String x = new String("x");
     String x2 = new String("x");
-    mMap.put(x, "x");
-    mMap.replace(x2, "x");
+    assertNull(mMap.put(x, "x"));
+    assertNull(mMap.replace(x2, "x"));
     assertEquals(1, mMap.size());
     assertEquals("x", mMap.replace(x, "y"));
-    mMap.replace(x, "noreplace", "z"); // shouldn't replace
+    assertFalse(mMap.replace(x, "noreplace", "z")); // shouldn't replace
     assertEquals("y", mMap.get(x));
   }
 
@@ -111,7 +113,6 @@ public class ConcurrentIdentityHashMapTest {
     assertEquals(1, mMap.size());
     assertEquals("y", mMap.remove(x));
     assertEquals(0, mMap.size());
-
     assertNull(mMap.put(x2, "z"));
     assertEquals(1, mMap.size());
     assertFalse(mMap.remove(x2, "a"));

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -76,11 +76,6 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>3.7.0.Final</version>
-    </dependency>
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>

--- a/core/common/src/main/java/alluxio/grpc/DataMessageMarshaller.java
+++ b/core/common/src/main/java/alluxio/grpc/DataMessageMarshaller.java
@@ -13,6 +13,7 @@ package alluxio.grpc;
 
 import static alluxio.grpc.GrpcSerializationUtils.addBuffersToStream;
 
+import alluxio.collections.ConcurrentIdentityHashMap;
 import alluxio.network.protocol.databuffer.DataBuffer;
 
 import io.grpc.Drainable;
@@ -21,7 +22,6 @@ import io.grpc.internal.CompositeReadableBuffer;
 import io.grpc.internal.ReadableBuffer;
 import io.grpc.internal.ReadableBuffers;
 import io.netty.buffer.ByteBuf;
-import org.jboss.netty.util.internal.ConcurrentIdentityHashMap;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
- Implementation of a ConcurrentIdentityHashMap to avoid using
Netty dependencies

- Removed the `io.netty` dependency in the core-common
module. The rest of the dependency cleanup throughout the POMs
is occurring in https://github.com/Alluxio/alluxio/pull/9455

Closes #9449