### PR TITLE
Fix Job master monitor in HA mode to use correct class name

### DIFF
--- a/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
+++ b/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
@@ -50,7 +50,7 @@ public class MasterHealthCheckClient implements HealthCheckClient {
    */
   public enum MasterType {
     MASTER("alluxio.master.AlluxioMaster"),
-    JOB_MASTER("alluxio.master.job.JobMaster")
+    JOB_MASTER("alluxio.master.AlluxioJobMaster")
     ;
 
     private String mClassName;


### PR DESCRIPTION
The MasterHealthCheckClient uses a hard-coded fully-qualified
class name in order to do a ps -ef to check for the process on
another node.

The class name of the job master was previously updated, but the
enum with the value here was not. This change fixes the class
name so that the health check can pass when running in HA
mode.

Fixes #9526

Initially reported by github user @lodocj

pr-link: Alluxio/alluxio#9556
change-id: cid-9788b2be2a987122a9087d9ff80453aed3a1b0e3