### PR TITLE
Do selective tracing for client stream errors

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -111,8 +111,26 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
 
   @Override
   public void onError(Throwable throwable) {
-    LOG.warn("Received error on client driver for channel: {}. Error: {}", mChannelId, throwable);
     mHandshakeFuture.setException(throwable);
+
+    // Whether to trace the error as debug.
+    boolean traceDebug = false;
+    // UNAVAILABLE is quite common while cluster is booting up.
+    // Tracing it as warning will pollute logs as onError() will be called per retry.
+    if (throwable instanceof StatusRuntimeException) {
+      if (((StatusRuntimeException) throwable).getStatus().getCode() == Status.UNAVAILABLE
+          .getCode()) {
+        traceDebug = true;
+      }
+    }
+
+    String errorMsg = String.format("Received error on client driver for channel: %s. Error: %s",
+        mChannelId, throwable);
+    if (traceDebug) {
+      LOG.debug(errorMsg);
+    } else {
+      LOG.warn(errorMsg);
+    }
   }
 
   @Override


### PR DESCRIPTION
This is popping up quite often while bringing a cluster online and it's not very intuitive for users.
Stream errors are received asynchronous to channel building, which makes them harder to debug. Ignoring it for common case of UNAVAILABLE should be safe.