### PR TITLE
Prevent persist job from updating last access time

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -412,8 +412,11 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     return rpc(client -> {
       AlluxioConfiguration conf = mFsContext.getPathConf(path);
-      URIStatus status = client.getStatus(path, FileSystemOptions.getStatusDefaults(conf)
-          .toBuilder().setAccessMode(Bits.READ).build());
+      URIStatus status = client.getStatus(path,
+          FileSystemOptions.getStatusDefaults(conf).toBuilder()
+              .setAccessMode(Bits.READ)
+              .setUpdateTimestamps(options.getUpdateLastAccessTime())
+              .build());
       if (status.isFolder()) {
         throw new FileDoesNotExistException(
             ExceptionMessage.CANNOT_READ_DIRECTORY.getMessage(status.getName()));

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -627,7 +627,8 @@ public final class BaseFileSystemTest {
 
   private GetStatusPOptions getOpenOptions(GetStatusPOptions getStatusOptions) {
     return FileSystemOptions.getStatusDefaults(mConf)
-        .toBuilder().setAccessMode(Bits.READ).mergeFrom(getStatusOptions).build();
+        .toBuilder().setAccessMode(Bits.READ).setUpdateTimestamps(true)
+        .mergeFrom(getStatusOptions).build();
   }
 
   private void assertBadAuthority(String authority, String failureMessage) throws Exception {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -769,7 +769,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       }
       FileInfo fileInfo = getFileInfoInternal(inodePath);
       Mode.Bits accessMode = Mode.Bits.fromProto(context.getOptions().getAccessMode());
-      if (context.getOptions().hasAccessMode()
+      if (context.getOptions().getUpdateTimestamps() && context.getOptions().hasAccessMode()
            && (accessMode.imply(Mode.Bits.READ) || accessMode.imply(Mode.Bits.WRITE))) {
         mAccessTimeUpdater.updateAccessTime(rpcContext.getJournalContext(),
             inodePath.getInode(), opTimeMs);

--- a/core/transport/src/grpc/file_system_master.proto
+++ b/core/transport/src/grpc/file_system_master.proto
@@ -64,6 +64,7 @@ message OpenFilePOptions {
   optional ReadPType readType = 1;
   optional int32 maxUfsReadConcurrency = 2;
   optional FileSystemMasterCommonPOptions commonOptions = 3;
+  optional bool updateLastAccessTime = 4 [default = true];
 }
 
 message CreateDirectoryPResponse {}
@@ -145,6 +146,7 @@ message GetStatusPOptions {
   optional LoadMetadataPType loadMetadataType = 1;
   optional FileSystemMasterCommonPOptions commonOptions = 2;
   optional Bits accessMode = 3;
+  optional bool updateTimestamps = 4 [default = true];
 }
 message GetStatusPRequest {
   /** the path of the file or directory */

--- a/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/FileSystemMasterProto.java
@@ -502,310 +502,312 @@ public final class FileSystemMasterProto {
       "\01321.alluxio.grpc.file.FileSystemMasterCo" +
       "mmonPOptions\"^\n\024CompleteFilePRequest\022\014\n\004" +
       "path\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.alluxio.gr" +
-      "pc.file.CompleteFilePOptions\"\253\001\n\020OpenFil" +
+      "pc.file.CompleteFilePOptions\"\317\001\n\020OpenFil" +
       "ePOptions\022.\n\010readType\030\001 \001(\0162\034.alluxio.gr" +
       "pc.file.ReadPType\022\035\n\025maxUfsReadConcurren" +
       "cy\030\002 \001(\005\022H\n\rcommonOptions\030\003 \001(\01321.alluxi" +
       "o.grpc.file.FileSystemMasterCommonPOptio" +
-      "ns\"\032\n\030CreateDirectoryPResponse\"\340\001\n\027Creat" +
-      "eDirectoryPOptions\022\021\n\trecursive\030\001 \001(\010\022\023\n" +
-      "\013allowExists\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.allux" +
-      "io.grpc.PMode\0220\n\twriteType\030\004 \001(\0162\035.allux" +
-      "io.grpc.file.WritePType\022H\n\rcommonOptions" +
-      "\030\005 \001(\01321.alluxio.grpc.file.FileSystemMas" +
-      "terCommonPOptions\"d\n\027CreateDirectoryPReq" +
-      "uest\022\014\n\004path\030\001 \001(\t\022;\n\007options\030\002 \001(\0132*.al" +
-      "luxio.grpc.file.CreateDirectoryPOptions\"" +
-      "D\n\023CreateFilePResponse\022-\n\010fileInfo\030\001 \001(\013" +
-      "2\033.alluxio.grpc.file.FileInfo\"\332\002\n\022Create" +
-      "FilePOptions\022\026\n\016blockSizeBytes\030\001 \001(\003\022\021\n\t" +
-      "recursive\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio." +
-      "grpc.PMode\022\026\n\016replicationMax\030\004 \001(\005\022\026\n\016re" +
-      "plicationMin\030\005 \001(\005\022\032\n\022replicationDurable" +
-      "\030\006 \001(\005\022\021\n\twriteTier\030\007 \001(\005\0220\n\twriteType\030\010" +
-      " \001(\0162\035.alluxio.grpc.file.WritePType\022H\n\rc" +
-      "ommonOptions\030\t \001(\01321.alluxio.grpc.file.F" +
-      "ileSystemMasterCommonPOptions\022\033\n\023persist" +
-      "enceWaitTime\030\n \001(\003\"Z\n\022CreateFilePRequest" +
-      "\022\014\n\004path\030\001 \001(\t\0226\n\007options\030\002 \001(\0132%.alluxi" +
-      "o.grpc.file.CreateFilePOptions\"\021\n\017Delete" +
-      "PResponse\"\225\001\n\016DeletePOptions\022\021\n\trecursiv" +
-      "e\030\001 \001(\010\022\023\n\013alluxioOnly\030\002 \001(\010\022\021\n\tunchecke" +
-      "d\030\003 \001(\010\022H\n\rcommonOptions\030\004 \001(\01321.alluxio" +
-      ".grpc.file.FileSystemMasterCommonPOption" +
-      "s\"R\n\016DeletePRequest\022\014\n\004path\030\001 \001(\t\0222\n\007opt" +
-      "ions\030\002 \001(\0132!.alluxio.grpc.file.DeletePOp" +
-      "tions\"\017\n\rFreePResponse\"{\n\014FreePOptions\022\021" +
-      "\n\trecursive\030\001 \001(\010\022\016\n\006forced\030\002 \001(\010\022H\n\rcom" +
-      "monOptions\030\003 \001(\01321.alluxio.grpc.file.Fil" +
-      "eSystemMasterCommonPOptions\"N\n\014FreePRequ" +
-      "est\022\014\n\004path\030\001 \001(\t\0220\n\007options\030\002 \001(\0132\037.all" +
-      "uxio.grpc.file.FreePOptions\"+\n\035GetNewBlo" +
-      "ckIdForFilePResponse\022\n\n\002id\030\001 \001(\003\"h\n\034GetN" +
-      "ewBlockIdForFilePOptions\022H\n\rcommonOption" +
-      "s\030\001 \001(\01321.alluxio.grpc.file.FileSystemMa" +
-      "sterCommonPOptions\"n\n\034GetNewBlockIdForFi" +
-      "lePRequest\022\014\n\004path\030\001 \001(\t\022@\n\007options\030\002 \001(" +
-      "\0132/.alluxio.grpc.file.GetNewBlockIdForFi" +
-      "lePOptions\"C\n\022GetStatusPResponse\022-\n\010file" +
-      "Info\030\001 \001(\0132\033.alluxio.grpc.file.FileInfo\"" +
-      "\305\001\n\021GetStatusPOptions\022>\n\020loadMetadataTyp" +
-      "e\030\001 \001(\0162$.alluxio.grpc.file.LoadMetadata" +
-      "PType\022H\n\rcommonOptions\030\002 \001(\01321.alluxio.g" +
-      "rpc.file.FileSystemMasterCommonPOptions\022" +
-      "&\n\naccessMode\030\003 \001(\0162\022.alluxio.grpc.Bits\"" +
-      "X\n\021GetStatusPRequest\022\014\n\004path\030\001 \001(\t\0225\n\007op" +
-      "tions\030\002 \001(\0132$.alluxio.grpc.file.GetStatu" +
-      "sPOptions\"\232\001\n\016ExistsPOptions\022>\n\020loadMeta" +
-      "dataType\030\001 \001(\0162$.alluxio.grpc.file.LoadM" +
-      "etadataPType\022H\n\rcommonOptions\030\002 \001(\01321.al" +
-      "luxio.grpc.file.FileSystemMasterCommonPO" +
-      "ptions\"]\n\rSyncPointInfo\022\024\n\014syncPointUri\030" +
-      "\001 \001(\t\0226\n\nsyncStatus\030\002 \001(\0162\".alluxio.grpc" +
-      ".file.SyncPointStatus\"O\n\030GetSyncPathList" +
-      "PResponse\0223\n\tsyncPaths\030\001 \003(\0132 .alluxio.g" +
-      "rpc.file.SyncPointInfo\"\031\n\027GetSyncPathLis" +
-      "tPRequest\"E\n\023ListStatusPResponse\022.\n\tfile" +
-      "Infos\030\001 \003(\0132\033.alluxio.grpc.file.FileInfo" +
-      "\"\315\001\n\022ListStatusPOptions\022\032\n\022loadDirectChi" +
-      "ldren\030\001 \001(\010\022>\n\020loadMetadataType\030\002 \001(\0162$." +
-      "alluxio.grpc.file.LoadMetadataPType\022H\n\rc" +
-      "ommonOptions\030\003 \001(\01321.alluxio.grpc.file.F" +
-      "ileSystemMasterCommonPOptions\022\021\n\trecursi" +
-      "ve\030\004 \001(\010\"Z\n\022ListStatusPRequest\022\014\n\004path\030\001" +
-      " \001(\t\0226\n\007options\030\002 \001(\0132%.alluxio.grpc.fil" +
-      "e.ListStatusPOptions\"\324\001\n\024LoadMetadataPOp" +
-      "tions\022\021\n\trecursive\030\001 \001(\010\022\027\n\017createAncest" +
-      "ors\030\002 \001(\010\022F\n\022loadDescendantType\030\003 \001(\0162*." +
-      "alluxio.grpc.fscommon.LoadDescendantPTyp" +
-      "e\022H\n\rcommonOptions\030\004 \001(\01321.alluxio.grpc." +
-      "file.FileSystemMasterCommonPOptions\"\217\001\n\t" +
-      "PAclEntry\022.\n\004type\030\001 \001(\0162 .alluxio.grpc.f" +
-      "ile.PAclEntryType\022\017\n\007subject\030\002 \001(\t\022.\n\007ac" +
-      "tions\030\003 \003(\0162\035.alluxio.grpc.file.PAclActi" +
-      "on\022\021\n\tisDefault\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030" +
-      "\001 \001(\t\022\023\n\013owningGroup\030\002 \001(\t\022-\n\007entries\030\003 " +
-      "\003(\0132\034.alluxio.grpc.file.PAclEntry\022\014\n\004mod" +
-      "e\030\004 \001(\005\022\021\n\tisDefault\030\005 \001(\010\022\026\n\016isDefaultE" +
-      "mpty\030\006 \001(\010\"\235\001\n\rFileBlockInfo\022*\n\tblockInf" +
-      "o\030\001 \001(\0132\027.alluxio.grpc.BlockInfo\022\016\n\006offs" +
-      "et\030\002 \001(\003\0224\n\014ufsLocations\030\003 \003(\0132\036.alluxio" +
-      ".grpc.WorkerNetAddress\022\032\n\022ufsStringLocat" +
-      "ions\030\004 \003(\t\"\336\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022" +
-      "\014\n\004name\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004" +
-      " \001(\t\022\016\n\006length\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006" +
-      " \001(\003\022\026\n\016creationTimeMs\030\007 \001(\003\022\021\n\tcomplete" +
-      "d\030\010 \001(\010\022\016\n\006folder\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022" +
-      "\021\n\tcacheable\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n" +
-      "\010blockIds\030\r \003(\003\022\036\n\026lastModificationTimeM" +
-      "s\030\016 \001(\003\022\013\n\003ttl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005g" +
-      "roup\030\021 \001(\t\022\014\n\004mode\030\022 \001(\005\022\030\n\020persistenceS" +
-      "tate\030\023 \001(\t\022\022\n\nmountPoint\030\024 \001(\010\0228\n\016fileBl" +
-      "ockInfos\030\025 \003(\0132 .alluxio.grpc.file.FileB" +
-      "lockInfo\022*\n\tttlAction\030\026 \001(\0162\027.alluxio.gr" +
-      "pc.TtlAction\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAllux" +
-      "ioPercentage\030\030 \001(\005\022\032\n\022inMemoryPercentage" +
-      "\030\031 \001(\005\022\026\n\016ufsFingerprint\030\032 \001(\t\022$\n\003acl\030\033 " +
-      "\001(\0132\027.alluxio.grpc.file.PAcl\022+\n\ndefaultA" +
-      "cl\030\034 \001(\0132\027.alluxio.grpc.file.PAcl\022\026\n\016rep" +
-      "licationMax\030\035 \001(\005\022\026\n\016replicationMin\030\036 \001(" +
-      "\005\022\030\n\020lastAccessTimeMs\030\037 \001(\003\"$\n\024GetFilePa" +
-      "thPResponse\022\014\n\004path\030\001 \001(\t\"%\n\023GetFilePath" +
-      "PRequest\022\016\n\006fileId\030\001 \001(\003\"\020\n\016MountPRespon" +
-      "se\"\364\001\n\rMountPOptions\022\020\n\010readOnly\030\001 \001(\010\022D" +
-      "\n\nproperties\030\002 \003(\01320.alluxio.grpc.file.M" +
-      "ountPOptions.PropertiesEntry\022\016\n\006shared\030\003" +
-      " \001(\010\022H\n\rcommonOptions\030\004 \001(\01321.alluxio.gr" +
-      "pc.file.FileSystemMasterCommonPOptions\0321" +
-      "\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030" +
-      "\002 \001(\t:\0028\001\"h\n\rMountPRequest\022\023\n\013alluxioPat" +
-      "h\030\001 \001(\t\022\017\n\007ufsPath\030\002 \001(\t\0221\n\007options\030\003 \001(" +
-      "\0132 .alluxio.grpc.file.MountPOptions\"\300\001\n\026" +
-      "GetMountTablePResponse\022O\n\013mountPoints\030\001 " +
-      "\003(\0132:.alluxio.grpc.file.GetMountTablePRe" +
-      "sponse.MountPointsEntry\032U\n\020MountPointsEn" +
-      "try\022\013\n\003key\030\001 \001(\t\0220\n\005value\030\002 \001(\0132!.alluxi" +
-      "o.grpc.file.MountPointInfo:\0028\001\"\027\n\025GetMou" +
-      "ntTablePRequest\"\205\002\n\016MountPointInfo\022\016\n\006uf" +
-      "sUri\030\001 \001(\t\022\017\n\007ufsType\030\002 \001(\t\022\034\n\020ufsCapaci" +
-      "tyBytes\030\003 \001(\003:\002-1\022\030\n\014ufsUsedBytes\030\004 \001(\003:" +
-      "\002-1\022\020\n\010readOnly\030\005 \001(\010\022E\n\nproperties\030\006 \003(" +
-      "\01321.alluxio.grpc.file.MountPointInfo.Pro" +
-      "pertiesEntry\022\016\n\006shared\030\007 \001(\010\0321\n\017Properti" +
-      "esEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"" +
-      "\\\n\030FileSystemCommandOptions\022@\n\016persistOp" +
-      "tions\030\001 \001(\0132(.alluxio.grpc.file.PersistC" +
-      "ommandOptions\"M\n\025PersistCommandOptions\0224" +
-      "\n\014persistFiles\030\001 \003(\0132\036.alluxio.grpc.file" +
-      ".PersistFile\"/\n\013PersistFile\022\016\n\006fileId\030\001 " +
-      "\001(\003\022\020\n\010blockIds\030\002 \003(\003\"\210\001\n\021FileSystemComm" +
-      "and\022.\n\013commandType\030\001 \001(\0162\031.alluxio.grpc." +
-      "CommandType\022C\n\016commandOptions\030\002 \001(\0132+.al" +
-      "luxio.grpc.file.FileSystemCommandOptions" +
-      "\"\021\n\017RenamePResponse\"k\n\016RenamePOptions\022H\n" +
-      "\rcommonOptions\030\001 \001(\01321.alluxio.grpc.file" +
-      ".FileSystemMasterCommonPOptions\022\017\n\007persi" +
-      "st\030\002 \001(\010\"c\n\016RenamePRequest\022\014\n\004path\030\001 \001(\t" +
-      "\022\017\n\007dstPath\030\002 \001(\t\0222\n\007options\030\003 \001(\0132!.all" +
-      "uxio.grpc.file.RenamePOptions\"\027\n\025SetAttr" +
-      "ibutePResponse\"\234\002\n\024SetAttributePOptions\022" +
-      "\016\n\006pinned\030\001 \001(\010\022\021\n\tpersisted\030\002 \001(\010\022\r\n\005ow" +
-      "ner\030\003 \001(\t\022\r\n\005group\030\004 \001(\t\022!\n\004mode\030\005 \001(\0132\023" +
-      ".alluxio.grpc.PMode\022\021\n\trecursive\030\006 \001(\010\022\026" +
-      "\n\016replicationMax\030\007 \001(\005\022\026\n\016replicationMin" +
-      "\030\010 \001(\005\022H\n\rcommonOptions\030\t \001(\01321.alluxio." +
-      "grpc.file.FileSystemMasterCommonPOptions" +
-      "\022\023\n\013pinnedMedia\030\n \003(\t\"^\n\024SetAttributePRe" +
-      "quest\022\014\n\004path\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.a" +
-      "lluxio.grpc.file.SetAttributePOptions\"\021\n" +
-      "\017SetAclPResponse\"m\n\016SetAclPOptions\022H\n\rco" +
-      "mmonOptions\030\001 \001(\01321.alluxio.grpc.file.Fi" +
-      "leSystemMasterCommonPOptions\022\021\n\trecursiv" +
-      "e\030\002 \001(\010\"\262\001\n\016SetAclPRequest\022\014\n\004path\030\001 \001(\t" +
-      "\022/\n\006action\030\002 \001(\0162\037.alluxio.grpc.file.Set" +
-      "AclAction\022-\n\007entries\030\003 \003(\0132\034.alluxio.grp" +
-      "c.file.PAclEntry\0222\n\007options\030\004 \001(\0132!.allu" +
-      "xio.grpc.file.SetAclPOptions\"#\n!Schedule" +
-      "AsyncPersistencePResponse\"\211\001\n ScheduleAs" +
-      "yncPersistencePOptions\022H\n\rcommonOptions\030" +
+      "ns\022\"\n\024updateLastAccessTime\030\004 \001(\010:\004true\"\032" +
+      "\n\030CreateDirectoryPResponse\"\340\001\n\027CreateDir" +
+      "ectoryPOptions\022\021\n\trecursive\030\001 \001(\010\022\023\n\013all" +
+      "owExists\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio.g" +
+      "rpc.PMode\0220\n\twriteType\030\004 \001(\0162\035.alluxio.g" +
+      "rpc.file.WritePType\022H\n\rcommonOptions\030\005 \001" +
+      "(\01321.alluxio.grpc.file.FileSystemMasterC" +
+      "ommonPOptions\"d\n\027CreateDirectoryPRequest" +
+      "\022\014\n\004path\030\001 \001(\t\022;\n\007options\030\002 \001(\0132*.alluxi" +
+      "o.grpc.file.CreateDirectoryPOptions\"D\n\023C" +
+      "reateFilePResponse\022-\n\010fileInfo\030\001 \001(\0132\033.a" +
+      "lluxio.grpc.file.FileInfo\"\332\002\n\022CreateFile" +
+      "POptions\022\026\n\016blockSizeBytes\030\001 \001(\003\022\021\n\trecu" +
+      "rsive\030\002 \001(\010\022!\n\004mode\030\003 \001(\0132\023.alluxio.grpc" +
+      ".PMode\022\026\n\016replicationMax\030\004 \001(\005\022\026\n\016replic" +
+      "ationMin\030\005 \001(\005\022\032\n\022replicationDurable\030\006 \001" +
+      "(\005\022\021\n\twriteTier\030\007 \001(\005\0220\n\twriteType\030\010 \001(\016" +
+      "2\035.alluxio.grpc.file.WritePType\022H\n\rcommo" +
+      "nOptions\030\t \001(\01321.alluxio.grpc.file.FileS" +
+      "ystemMasterCommonPOptions\022\033\n\023persistence" +
+      "WaitTime\030\n \001(\003\"Z\n\022CreateFilePRequest\022\014\n\004" +
+      "path\030\001 \001(\t\0226\n\007options\030\002 \001(\0132%.alluxio.gr" +
+      "pc.file.CreateFilePOptions\"\021\n\017DeletePRes" +
+      "ponse\"\225\001\n\016DeletePOptions\022\021\n\trecursive\030\001 " +
+      "\001(\010\022\023\n\013alluxioOnly\030\002 \001(\010\022\021\n\tunchecked\030\003 " +
+      "\001(\010\022H\n\rcommonOptions\030\004 \001(\01321.alluxio.grp" +
+      "c.file.FileSystemMasterCommonPOptions\"R\n" +
+      "\016DeletePRequest\022\014\n\004path\030\001 \001(\t\0222\n\007options" +
+      "\030\002 \001(\0132!.alluxio.grpc.file.DeletePOption" +
+      "s\"\017\n\rFreePResponse\"{\n\014FreePOptions\022\021\n\tre" +
+      "cursive\030\001 \001(\010\022\016\n\006forced\030\002 \001(\010\022H\n\rcommonO" +
+      "ptions\030\003 \001(\01321.alluxio.grpc.file.FileSys" +
+      "temMasterCommonPOptions\"N\n\014FreePRequest\022" +
+      "\014\n\004path\030\001 \001(\t\0220\n\007options\030\002 \001(\0132\037.alluxio" +
+      ".grpc.file.FreePOptions\"+\n\035GetNewBlockId" +
+      "ForFilePResponse\022\n\n\002id\030\001 \001(\003\"h\n\034GetNewBl" +
+      "ockIdForFilePOptions\022H\n\rcommonOptions\030\001 " +
+      "\001(\01321.alluxio.grpc.file.FileSystemMaster" +
+      "CommonPOptions\"n\n\034GetNewBlockIdForFilePR" +
+      "equest\022\014\n\004path\030\001 \001(\t\022@\n\007options\030\002 \001(\0132/." +
+      "alluxio.grpc.file.GetNewBlockIdForFilePO" +
+      "ptions\"C\n\022GetStatusPResponse\022-\n\010fileInfo" +
+      "\030\001 \001(\0132\033.alluxio.grpc.file.FileInfo\"\345\001\n\021" +
+      "GetStatusPOptions\022>\n\020loadMetadataType\030\001 " +
+      "\001(\0162$.alluxio.grpc.file.LoadMetadataPTyp" +
+      "e\022H\n\rcommonOptions\030\002 \001(\01321.alluxio.grpc." +
+      "file.FileSystemMasterCommonPOptions\022&\n\na" +
+      "ccessMode\030\003 \001(\0162\022.alluxio.grpc.Bits\022\036\n\020u" +
+      "pdateTimestamps\030\004 \001(\010:\004true\"X\n\021GetStatus" +
+      "PRequest\022\014\n\004path\030\001 \001(\t\0225\n\007options\030\002 \001(\0132" +
+      "$.alluxio.grpc.file.GetStatusPOptions\"\232\001" +
+      "\n\016ExistsPOptions\022>\n\020loadMetadataType\030\001 \001" +
+      "(\0162$.alluxio.grpc.file.LoadMetadataPType" +
+      "\022H\n\rcommonOptions\030\002 \001(\01321.alluxio.grpc.f" +
+      "ile.FileSystemMasterCommonPOptions\"]\n\rSy" +
+      "ncPointInfo\022\024\n\014syncPointUri\030\001 \001(\t\0226\n\nsyn" +
+      "cStatus\030\002 \001(\0162\".alluxio.grpc.file.SyncPo" +
+      "intStatus\"O\n\030GetSyncPathListPResponse\0223\n" +
+      "\tsyncPaths\030\001 \003(\0132 .alluxio.grpc.file.Syn" +
+      "cPointInfo\"\031\n\027GetSyncPathListPRequest\"E\n" +
+      "\023ListStatusPResponse\022.\n\tfileInfos\030\001 \003(\0132" +
+      "\033.alluxio.grpc.file.FileInfo\"\315\001\n\022ListSta" +
+      "tusPOptions\022\032\n\022loadDirectChildren\030\001 \001(\010\022" +
+      ">\n\020loadMetadataType\030\002 \001(\0162$.alluxio.grpc" +
+      ".file.LoadMetadataPType\022H\n\rcommonOptions" +
+      "\030\003 \001(\01321.alluxio.grpc.file.FileSystemMas" +
+      "terCommonPOptions\022\021\n\trecursive\030\004 \001(\010\"Z\n\022" +
+      "ListStatusPRequest\022\014\n\004path\030\001 \001(\t\0226\n\007opti" +
+      "ons\030\002 \001(\0132%.alluxio.grpc.file.ListStatus" +
+      "POptions\"\324\001\n\024LoadMetadataPOptions\022\021\n\trec" +
+      "ursive\030\001 \001(\010\022\027\n\017createAncestors\030\002 \001(\010\022F\n" +
+      "\022loadDescendantType\030\003 \001(\0162*.alluxio.grpc" +
+      ".fscommon.LoadDescendantPType\022H\n\rcommonO" +
+      "ptions\030\004 \001(\01321.alluxio.grpc.file.FileSys" +
+      "temMasterCommonPOptions\"\217\001\n\tPAclEntry\022.\n" +
+      "\004type\030\001 \001(\0162 .alluxio.grpc.file.PAclEntr" +
+      "yType\022\017\n\007subject\030\002 \001(\t\022.\n\007actions\030\003 \003(\0162" +
+      "\035.alluxio.grpc.file.PAclAction\022\021\n\tisDefa" +
+      "ult\030\004 \001(\010\"\222\001\n\004PAcl\022\r\n\005owner\030\001 \001(\t\022\023\n\013own" +
+      "ingGroup\030\002 \001(\t\022-\n\007entries\030\003 \003(\0132\034.alluxi" +
+      "o.grpc.file.PAclEntry\022\014\n\004mode\030\004 \001(\005\022\021\n\ti" +
+      "sDefault\030\005 \001(\010\022\026\n\016isDefaultEmpty\030\006 \001(\010\"\235" +
+      "\001\n\rFileBlockInfo\022*\n\tblockInfo\030\001 \001(\0132\027.al" +
+      "luxio.grpc.BlockInfo\022\016\n\006offset\030\002 \001(\003\0224\n\014" +
+      "ufsLocations\030\003 \003(\0132\036.alluxio.grpc.Worker" +
+      "NetAddress\022\032\n\022ufsStringLocations\030\004 \003(\t\"\336" +
+      "\005\n\010FileInfo\022\016\n\006fileId\030\001 \001(\003\022\014\n\004name\030\002 \001(" +
+      "\t\022\014\n\004path\030\003 \001(\t\022\017\n\007ufsPath\030\004 \001(\t\022\016\n\006leng" +
+      "th\030\005 \001(\003\022\026\n\016blockSizeBytes\030\006 \001(\003\022\026\n\016crea" +
+      "tionTimeMs\030\007 \001(\003\022\021\n\tcompleted\030\010 \001(\010\022\016\n\006f" +
+      "older\030\t \001(\010\022\016\n\006pinned\030\n \001(\010\022\021\n\tcacheable" +
+      "\030\013 \001(\010\022\021\n\tpersisted\030\014 \001(\010\022\020\n\010blockIds\030\r " +
+      "\003(\003\022\036\n\026lastModificationTimeMs\030\016 \001(\003\022\013\n\003t" +
+      "tl\030\017 \001(\003\022\r\n\005owner\030\020 \001(\t\022\r\n\005group\030\021 \001(\t\022\014" +
+      "\n\004mode\030\022 \001(\005\022\030\n\020persistenceState\030\023 \001(\t\022\022" +
+      "\n\nmountPoint\030\024 \001(\010\0228\n\016fileBlockInfos\030\025 \003" +
+      "(\0132 .alluxio.grpc.file.FileBlockInfo\022*\n\t" +
+      "ttlAction\030\026 \001(\0162\027.alluxio.grpc.TtlAction" +
+      "\022\017\n\007mountId\030\027 \001(\003\022\033\n\023inAlluxioPercentage" +
+      "\030\030 \001(\005\022\032\n\022inMemoryPercentage\030\031 \001(\005\022\026\n\016uf" +
+      "sFingerprint\030\032 \001(\t\022$\n\003acl\030\033 \001(\0132\027.alluxi" +
+      "o.grpc.file.PAcl\022+\n\ndefaultAcl\030\034 \001(\0132\027.a" +
+      "lluxio.grpc.file.PAcl\022\026\n\016replicationMax\030" +
+      "\035 \001(\005\022\026\n\016replicationMin\030\036 \001(\005\022\030\n\020lastAcc" +
+      "essTimeMs\030\037 \001(\003\"$\n\024GetFilePathPResponse\022" +
+      "\014\n\004path\030\001 \001(\t\"%\n\023GetFilePathPRequest\022\016\n\006" +
+      "fileId\030\001 \001(\003\"\020\n\016MountPResponse\"\364\001\n\rMount" +
+      "POptions\022\020\n\010readOnly\030\001 \001(\010\022D\n\nproperties" +
+      "\030\002 \003(\01320.alluxio.grpc.file.MountPOptions" +
+      ".PropertiesEntry\022\016\n\006shared\030\003 \001(\010\022H\n\rcomm" +
+      "onOptions\030\004 \001(\01321.alluxio.grpc.file.File" +
+      "SystemMasterCommonPOptions\0321\n\017Properties" +
+      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"h\n" +
+      "\rMountPRequest\022\023\n\013alluxioPath\030\001 \001(\t\022\017\n\007u" +
+      "fsPath\030\002 \001(\t\0221\n\007options\030\003 \001(\0132 .alluxio." +
+      "grpc.file.MountPOptions\"\300\001\n\026GetMountTabl" +
+      "ePResponse\022O\n\013mountPoints\030\001 \003(\0132:.alluxi" +
+      "o.grpc.file.GetMountTablePResponse.Mount" +
+      "PointsEntry\032U\n\020MountPointsEntry\022\013\n\003key\030\001" +
+      " \001(\t\0220\n\005value\030\002 \001(\0132!.alluxio.grpc.file." +
+      "MountPointInfo:\0028\001\"\027\n\025GetMountTablePRequ" +
+      "est\"\205\002\n\016MountPointInfo\022\016\n\006ufsUri\030\001 \001(\t\022\017" +
+      "\n\007ufsType\030\002 \001(\t\022\034\n\020ufsCapacityBytes\030\003 \001(" +
+      "\003:\002-1\022\030\n\014ufsUsedBytes\030\004 \001(\003:\002-1\022\020\n\010readO" +
+      "nly\030\005 \001(\010\022E\n\nproperties\030\006 \003(\01321.alluxio." +
+      "grpc.file.MountPointInfo.PropertiesEntry" +
+      "\022\016\n\006shared\030\007 \001(\010\0321\n\017PropertiesEntry\022\013\n\003k" +
+      "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\\\n\030FileSyste" +
+      "mCommandOptions\022@\n\016persistOptions\030\001 \001(\0132" +
+      "(.alluxio.grpc.file.PersistCommandOption" +
+      "s\"M\n\025PersistCommandOptions\0224\n\014persistFil" +
+      "es\030\001 \003(\0132\036.alluxio.grpc.file.PersistFile" +
+      "\"/\n\013PersistFile\022\016\n\006fileId\030\001 \001(\003\022\020\n\010block" +
+      "Ids\030\002 \003(\003\"\210\001\n\021FileSystemCommand\022.\n\013comma" +
+      "ndType\030\001 \001(\0162\031.alluxio.grpc.CommandType\022" +
+      "C\n\016commandOptions\030\002 \001(\0132+.alluxio.grpc.f" +
+      "ile.FileSystemCommandOptions\"\021\n\017RenamePR" +
+      "esponse\"k\n\016RenamePOptions\022H\n\rcommonOptio" +
+      "ns\030\001 \001(\01321.alluxio.grpc.file.FileSystemM" +
+      "asterCommonPOptions\022\017\n\007persist\030\002 \001(\010\"c\n\016" +
+      "RenamePRequest\022\014\n\004path\030\001 \001(\t\022\017\n\007dstPath\030" +
+      "\002 \001(\t\0222\n\007options\030\003 \001(\0132!.alluxio.grpc.fi" +
+      "le.RenamePOptions\"\027\n\025SetAttributePRespon" +
+      "se\"\234\002\n\024SetAttributePOptions\022\016\n\006pinned\030\001 " +
+      "\001(\010\022\021\n\tpersisted\030\002 \001(\010\022\r\n\005owner\030\003 \001(\t\022\r\n" +
+      "\005group\030\004 \001(\t\022!\n\004mode\030\005 \001(\0132\023.alluxio.grp" +
+      "c.PMode\022\021\n\trecursive\030\006 \001(\010\022\026\n\016replicatio" +
+      "nMax\030\007 \001(\005\022\026\n\016replicationMin\030\010 \001(\005\022H\n\rco" +
+      "mmonOptions\030\t \001(\01321.alluxio.grpc.file.Fi" +
+      "leSystemMasterCommonPOptions\022\023\n\013pinnedMe" +
+      "dia\030\n \003(\t\"^\n\024SetAttributePRequest\022\014\n\004pat" +
+      "h\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\'.alluxio.grpc." +
+      "file.SetAttributePOptions\"\021\n\017SetAclPResp" +
+      "onse\"m\n\016SetAclPOptions\022H\n\rcommonOptions\030" +
       "\001 \001(\01321.alluxio.grpc.file.FileSystemMast" +
-      "erCommonPOptions\022\033\n\023persistenceWaitTime\030" +
-      "\002 \001(\003\"v\n ScheduleAsyncPersistencePReques" +
-      "t\022\014\n\004path\030\001 \001(\t\022D\n\007options\030\002 \001(\01323.allux" +
-      "io.grpc.file.ScheduleAsyncPersistencePOp" +
-      "tions\"\024\n\022StartSyncPResponse\"]\n\021StartSync" +
-      "POptions\022H\n\rcommonOptions\030\001 \001(\01321.alluxi" +
-      "o.grpc.file.FileSystemMasterCommonPOptio" +
-      "ns\"X\n\021StartSyncPRequest\022\014\n\004path\030\001 \001(\t\0225\n" +
-      "\007options\030\002 \001(\0132$.alluxio.grpc.file.Start" +
-      "SyncPOptions\"\023\n\021StopSyncPResponse\"\\\n\020Sto" +
-      "pSyncPOptions\022H\n\rcommonOptions\030\001 \001(\01321.a" +
-      "lluxio.grpc.file.FileSystemMasterCommonP" +
-      "Options\"V\n\020StopSyncPRequest\022\014\n\004path\030\001 \001(" +
-      "\t\0224\n\007options\030\002 \001(\0132#.alluxio.grpc.file.S" +
-      "topSyncPOptions\"\022\n\020UnmountPResponse\"[\n\017U" +
-      "nmountPOptions\022H\n\rcommonOptions\030\001 \001(\01321." +
-      "alluxio.grpc.file.FileSystemMasterCommon" +
-      "POptions\"[\n\017UnmountPRequest\022\023\n\013alluxioPa" +
-      "th\030\001 \001(\t\0223\n\007options\030\002 \001(\0132\".alluxio.grpc" +
-      ".file.UnmountPOptions\"L\n\007UfsInfo\022\013\n\003uri\030" +
-      "\001 \001(\t\0224\n\nproperties\030\002 \001(\0132 .alluxio.grpc" +
-      ".file.MountPOptions\"]\n\023UpdateMountPReque" +
-      "st\022\023\n\013alluxioPath\030\001 \001(\t\0221\n\007options\030\003 \001(\013" +
-      "2 .alluxio.grpc.file.MountPOptions\"\026\n\024Up" +
-      "dateMountPResponse\"\030\n\026UpdateUfsModePResp" +
-      "onse\"E\n\025UpdateUfsModePOptions\022,\n\007ufsMode" +
-      "\030\001 \001(\0162\033.alluxio.grpc.file.UfsPMode\"c\n\025U" +
-      "pdateUfsModePRequest\022\017\n\007ufsPath\030\001 \001(\t\0229\n" +
-      "\007options\030\002 \001(\0132(.alluxio.grpc.file.Updat" +
-      "eUfsModePOptions\"U\n\034FileSystemHeartbeatP" +
-      "Response\0225\n\007command\030\001 \001(\0132$.alluxio.grpc" +
-      ".file.FileSystemCommand\"@\n\033FileSystemHea" +
-      "rtbeatPOptions\022!\n\031persistedFileFingerpri" +
-      "nts\030\001 \003(\t\"\210\001\n\033FileSystemHeartbeatPReques" +
-      "t\022\020\n\010workerId\030\001 \001(\003\022\026\n\016persistedFiles\030\002 " +
-      "\003(\003\022?\n\007options\030\003 \001(\0132..alluxio.grpc.file" +
-      ".FileSystemHeartbeatPOptions\"E\n\024GetFileI" +
-      "nfoPResponse\022-\n\010fileInfo\030\001 \001(\0132\033.alluxio" +
-      ".grpc.file.FileInfo\"\025\n\023GetFileInfoPOptio" +
-      "ns\"^\n\023GetFileInfoPRequest\022\016\n\006fileId\030\001 \001(" +
-      "\003\0227\n\007options\030\002 \001(\0132&.alluxio.grpc.file.G" +
-      "etFileInfoPOptions\"2\n\031GetPinnedFileIdsPR" +
-      "esponse\022\025\n\rpinnedFileIds\030\001 \003(\003\"\032\n\030GetPin" +
-      "nedFileIdsPOptions\"X\n\030GetPinnedFileIdsPR" +
-      "equest\022<\n\007options\030\001 \001(\0132+.alluxio.grpc.f" +
-      "ile.GetPinnedFileIdsPOptions\"B\n\023GetUfsIn" +
-      "foPResponse\022+\n\007ufsInfo\030\001 \001(\0132\032.alluxio.g" +
-      "rpc.file.UfsInfo\"\024\n\022GetUfsInfoPOptions\"]" +
-      "\n\022GetUfsInfoPRequest\022\017\n\007mountId\030\001 \001(\003\0226\n" +
-      "\007options\030\002 \001(\0132%.alluxio.grpc.file.GetUf" +
-      "sInfoPOptions*h\n\nWritePType\022\016\n\nMUST_CACH" +
-      "E\020\001\022\r\n\tTRY_CACHE\020\002\022\021\n\rCACHE_THROUGH\020\003\022\013\n" +
-      "\007THROUGH\020\004\022\021\n\rASYNC_THROUGH\020\005\022\010\n\004NONE\020\006*" +
-      "7\n\tReadPType\022\014\n\010NO_CACHE\020\001\022\t\n\005CACHE\020\002\022\021\n" +
-      "\rCACHE_PROMOTE\020\003*4\n\021LoadMetadataPType\022\t\n" +
-      "\005NEVER\020\000\022\010\n\004ONCE\020\001\022\n\n\006ALWAYS\020\002*N\n\017SyncPo" +
-      "intStatus\022\030\n\024Not_Initially_Synced\020\000\022\013\n\007S" +
-      "yncing\020\001\022\024\n\020Initially_Synced\020\002*_\n\rPAclEn" +
-      "tryType\022\t\n\005Owner\020\000\022\r\n\tNamedUser\020\001\022\017\n\013Own" +
-      "ingGroup\020\002\022\016\n\nNamedGroup\020\003\022\010\n\004Mask\020\004\022\t\n\005" +
-      "Other\020\005*.\n\nPAclAction\022\010\n\004Read\020\000\022\t\n\005Write" +
-      "\020\001\022\013\n\007Execute\020\002*W\n\014SetAclAction\022\013\n\007REPLA" +
-      "CE\020\000\022\n\n\006MODIFY\020\001\022\n\n\006REMOVE\020\002\022\016\n\nREMOVE_A" +
-      "LL\020\003\022\022\n\016REMOVE_DEFAULT\020\004*8\n\010UfsPMode\022\r\n\t" +
-      "NO_ACCESS\020\001\022\r\n\tREAD_ONLY\020\002\022\016\n\nREAD_WRITE" +
-      "\020\0032\342\020\n\035FileSystemMasterClientService\022m\n\020" +
-      "CheckConsistency\022+.alluxio.grpc.file.Che" +
-      "ckConsistencyPRequest\032,.alluxio.grpc.fil" +
-      "e.CheckConsistencyPResponse\022a\n\014CompleteF" +
-      "ile\022\'.alluxio.grpc.file.CompleteFilePReq" +
-      "uest\032(.alluxio.grpc.file.CompleteFilePRe" +
-      "sponse\022j\n\017CreateDirectory\022*.alluxio.grpc" +
-      ".file.CreateDirectoryPRequest\032+.alluxio." +
-      "grpc.file.CreateDirectoryPResponse\022[\n\nCr" +
-      "eateFile\022%.alluxio.grpc.file.CreateFileP" +
-      "Request\032&.alluxio.grpc.file.CreateFilePR" +
-      "esponse\022I\n\004Free\022\037.alluxio.grpc.file.Free" +
-      "PRequest\032 .alluxio.grpc.file.FreePRespon" +
-      "se\022^\n\013GetFilePath\022&.alluxio.grpc.file.Ge" +
-      "tFilePathPRequest\032\'.alluxio.grpc.file.Ge" +
-      "tFilePathPResponse\022d\n\rGetMountTable\022(.al" +
-      "luxio.grpc.file.GetMountTablePRequest\032)." +
-      "alluxio.grpc.file.GetMountTablePResponse" +
-      "\022j\n\017GetSyncPathList\022*.alluxio.grpc.file." +
-      "GetSyncPathListPRequest\032+.alluxio.grpc.f" +
-      "ile.GetSyncPathListPResponse\022y\n\024GetNewBl" +
-      "ockIdForFile\022/.alluxio.grpc.file.GetNewB" +
-      "lockIdForFilePRequest\0320.alluxio.grpc.fil" +
-      "e.GetNewBlockIdForFilePResponse\022X\n\tGetSt" +
-      "atus\022$.alluxio.grpc.file.GetStatusPReque" +
-      "st\032%.alluxio.grpc.file.GetStatusPRespons" +
-      "e\022]\n\nListStatus\022%.alluxio.grpc.file.List" +
-      "StatusPRequest\032&.alluxio.grpc.file.ListS" +
-      "tatusPResponse0\001\022L\n\005Mount\022 .alluxio.grpc" +
-      ".file.MountPRequest\032!.alluxio.grpc.file." +
-      "MountPResponse\022O\n\006Remove\022!.alluxio.grpc." +
-      "file.DeletePRequest\032\".alluxio.grpc.file." +
-      "DeletePResponse\022O\n\006Rename\022!.alluxio.grpc" +
-      ".file.RenamePRequest\032\".alluxio.grpc.file" +
-      ".RenamePResponse\022\205\001\n\030ScheduleAsyncPersis" +
-      "tence\0223.alluxio.grpc.file.ScheduleAsyncP" +
-      "ersistencePRequest\0324.alluxio.grpc.file.S" +
-      "cheduleAsyncPersistencePResponse\022O\n\006SetA" +
-      "cl\022!.alluxio.grpc.file.SetAclPRequest\032\"." +
-      "alluxio.grpc.file.SetAclPResponse\022a\n\014Set" +
-      "Attribute\022\'.alluxio.grpc.file.SetAttribu" +
-      "tePRequest\032(.alluxio.grpc.file.SetAttrib" +
-      "utePResponse\022X\n\tStartSync\022$.alluxio.grpc" +
-      ".file.StartSyncPRequest\032%.alluxio.grpc.f" +
-      "ile.StartSyncPResponse\022U\n\010StopSync\022#.all" +
-      "uxio.grpc.file.StopSyncPRequest\032$.alluxi" +
-      "o.grpc.file.StopSyncPResponse\022R\n\007Unmount" +
-      "\022\".alluxio.grpc.file.UnmountPRequest\032#.a" +
-      "lluxio.grpc.file.UnmountPResponse\022^\n\013Upd" +
-      "ateMount\022&.alluxio.grpc.file.UpdateMount" +
-      "PRequest\032\'.alluxio.grpc.file.UpdateMount" +
-      "PResponse\022d\n\rUpdateUfsMode\022(.alluxio.grp" +
-      "c.file.UpdateUfsModePRequest\032).alluxio.g" +
-      "rpc.file.UpdateUfsModePResponse2\303\003\n\035File" +
-      "SystemMasterWorkerService\022v\n\023FileSystemH" +
-      "eartbeat\022..alluxio.grpc.file.FileSystemH" +
-      "eartbeatPRequest\032/.alluxio.grpc.file.Fil" +
-      "eSystemHeartbeatPResponse\022^\n\013GetFileInfo" +
-      "\022&.alluxio.grpc.file.GetFileInfoPRequest" +
-      "\032\'.alluxio.grpc.file.GetFileInfoPRespons" +
-      "e\022m\n\020GetPinnedFileIds\022+.alluxio.grpc.fil" +
-      "e.GetPinnedFileIdsPRequest\032,.alluxio.grp" +
-      "c.file.GetPinnedFileIdsPResponse\022[\n\nGetU" +
-      "fsInfo\022%.alluxio.grpc.file.GetUfsInfoPRe" +
-      "quest\032&.alluxio.grpc.file.GetUfsInfoPRes" +
-      "ponse2\331\001\n\032FileSystemMasterJobService\022^\n\013" +
-      "GetFileInfo\022&.alluxio.grpc.file.GetFileI" +
-      "nfoPRequest\032\'.alluxio.grpc.file.GetFileI" +
-      "nfoPResponse\022[\n\nGetUfsInfo\022%.alluxio.grp" +
-      "c.file.GetUfsInfoPRequest\032&.alluxio.grpc" +
-      ".file.GetUfsInfoPResponseB\'\n\014alluxio.grp" +
-      "cB\025FileSystemMasterProtoP\001"
+      "erCommonPOptions\022\021\n\trecursive\030\002 \001(\010\"\262\001\n\016" +
+      "SetAclPRequest\022\014\n\004path\030\001 \001(\t\022/\n\006action\030\002" +
+      " \001(\0162\037.alluxio.grpc.file.SetAclAction\022-\n" +
+      "\007entries\030\003 \003(\0132\034.alluxio.grpc.file.PAclE" +
+      "ntry\0222\n\007options\030\004 \001(\0132!.alluxio.grpc.fil" +
+      "e.SetAclPOptions\"#\n!ScheduleAsyncPersist" +
+      "encePResponse\"\211\001\n ScheduleAsyncPersisten" +
+      "cePOptions\022H\n\rcommonOptions\030\001 \001(\01321.allu" +
+      "xio.grpc.file.FileSystemMasterCommonPOpt" +
+      "ions\022\033\n\023persistenceWaitTime\030\002 \001(\003\"v\n Sch" +
+      "eduleAsyncPersistencePRequest\022\014\n\004path\030\001 " +
+      "\001(\t\022D\n\007options\030\002 \001(\01323.alluxio.grpc.file" +
+      ".ScheduleAsyncPersistencePOptions\"\024\n\022Sta" +
+      "rtSyncPResponse\"]\n\021StartSyncPOptions\022H\n\r" +
+      "commonOptions\030\001 \001(\01321.alluxio.grpc.file." +
+      "FileSystemMasterCommonPOptions\"X\n\021StartS" +
+      "yncPRequest\022\014\n\004path\030\001 \001(\t\0225\n\007options\030\002 \001" +
+      "(\0132$.alluxio.grpc.file.StartSyncPOptions" +
+      "\"\023\n\021StopSyncPResponse\"\\\n\020StopSyncPOption" +
+      "s\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.grpc." +
+      "file.FileSystemMasterCommonPOptions\"V\n\020S" +
+      "topSyncPRequest\022\014\n\004path\030\001 \001(\t\0224\n\007options" +
+      "\030\002 \001(\0132#.alluxio.grpc.file.StopSyncPOpti" +
+      "ons\"\022\n\020UnmountPResponse\"[\n\017UnmountPOptio" +
+      "ns\022H\n\rcommonOptions\030\001 \001(\01321.alluxio.grpc" +
+      ".file.FileSystemMasterCommonPOptions\"[\n\017" +
+      "UnmountPRequest\022\023\n\013alluxioPath\030\001 \001(\t\0223\n\007" +
+      "options\030\002 \001(\0132\".alluxio.grpc.file.Unmoun" +
+      "tPOptions\"L\n\007UfsInfo\022\013\n\003uri\030\001 \001(\t\0224\n\npro" +
+      "perties\030\002 \001(\0132 .alluxio.grpc.file.MountP" +
+      "Options\"]\n\023UpdateMountPRequest\022\023\n\013alluxi" +
+      "oPath\030\001 \001(\t\0221\n\007options\030\003 \001(\0132 .alluxio.g" +
+      "rpc.file.MountPOptions\"\026\n\024UpdateMountPRe" +
+      "sponse\"\030\n\026UpdateUfsModePResponse\"E\n\025Upda" +
+      "teUfsModePOptions\022,\n\007ufsMode\030\001 \001(\0162\033.all" +
+      "uxio.grpc.file.UfsPMode\"c\n\025UpdateUfsMode" +
+      "PRequest\022\017\n\007ufsPath\030\001 \001(\t\0229\n\007options\030\002 \001" +
+      "(\0132(.alluxio.grpc.file.UpdateUfsModePOpt" +
+      "ions\"U\n\034FileSystemHeartbeatPResponse\0225\n\007" +
+      "command\030\001 \001(\0132$.alluxio.grpc.file.FileSy" +
+      "stemCommand\"@\n\033FileSystemHeartbeatPOptio" +
+      "ns\022!\n\031persistedFileFingerprints\030\001 \003(\t\"\210\001" +
+      "\n\033FileSystemHeartbeatPRequest\022\020\n\010workerI" +
+      "d\030\001 \001(\003\022\026\n\016persistedFiles\030\002 \003(\003\022?\n\007optio" +
+      "ns\030\003 \001(\0132..alluxio.grpc.file.FileSystemH" +
+      "eartbeatPOptions\"E\n\024GetFileInfoPResponse" +
+      "\022-\n\010fileInfo\030\001 \001(\0132\033.alluxio.grpc.file.F" +
+      "ileInfo\"\025\n\023GetFileInfoPOptions\"^\n\023GetFil" +
+      "eInfoPRequest\022\016\n\006fileId\030\001 \001(\003\0227\n\007options" +
+      "\030\002 \001(\0132&.alluxio.grpc.file.GetFileInfoPO" +
+      "ptions\"2\n\031GetPinnedFileIdsPResponse\022\025\n\rp" +
+      "innedFileIds\030\001 \003(\003\"\032\n\030GetPinnedFileIdsPO" +
+      "ptions\"X\n\030GetPinnedFileIdsPRequest\022<\n\007op" +
+      "tions\030\001 \001(\0132+.alluxio.grpc.file.GetPinne" +
+      "dFileIdsPOptions\"B\n\023GetUfsInfoPResponse\022" +
+      "+\n\007ufsInfo\030\001 \001(\0132\032.alluxio.grpc.file.Ufs" +
+      "Info\"\024\n\022GetUfsInfoPOptions\"]\n\022GetUfsInfo" +
+      "PRequest\022\017\n\007mountId\030\001 \001(\003\0226\n\007options\030\002 \001" +
+      "(\0132%.alluxio.grpc.file.GetUfsInfoPOption" +
+      "s*h\n\nWritePType\022\016\n\nMUST_CACHE\020\001\022\r\n\tTRY_C" +
+      "ACHE\020\002\022\021\n\rCACHE_THROUGH\020\003\022\013\n\007THROUGH\020\004\022\021" +
+      "\n\rASYNC_THROUGH\020\005\022\010\n\004NONE\020\006*7\n\tReadPType" +
+      "\022\014\n\010NO_CACHE\020\001\022\t\n\005CACHE\020\002\022\021\n\rCACHE_PROMO" +
+      "TE\020\003*4\n\021LoadMetadataPType\022\t\n\005NEVER\020\000\022\010\n\004" +
+      "ONCE\020\001\022\n\n\006ALWAYS\020\002*N\n\017SyncPointStatus\022\030\n" +
+      "\024Not_Initially_Synced\020\000\022\013\n\007Syncing\020\001\022\024\n\020" +
+      "Initially_Synced\020\002*_\n\rPAclEntryType\022\t\n\005O" +
+      "wner\020\000\022\r\n\tNamedUser\020\001\022\017\n\013OwningGroup\020\002\022\016" +
+      "\n\nNamedGroup\020\003\022\010\n\004Mask\020\004\022\t\n\005Other\020\005*.\n\nP" +
+      "AclAction\022\010\n\004Read\020\000\022\t\n\005Write\020\001\022\013\n\007Execut" +
+      "e\020\002*W\n\014SetAclAction\022\013\n\007REPLACE\020\000\022\n\n\006MODI" +
+      "FY\020\001\022\n\n\006REMOVE\020\002\022\016\n\nREMOVE_ALL\020\003\022\022\n\016REMO" +
+      "VE_DEFAULT\020\004*8\n\010UfsPMode\022\r\n\tNO_ACCESS\020\001\022" +
+      "\r\n\tREAD_ONLY\020\002\022\016\n\nREAD_WRITE\020\0032\342\020\n\035FileS" +
+      "ystemMasterClientService\022m\n\020CheckConsist" +
+      "ency\022+.alluxio.grpc.file.CheckConsistenc" +
+      "yPRequest\032,.alluxio.grpc.file.CheckConsi" +
+      "stencyPResponse\022a\n\014CompleteFile\022\'.alluxi" +
+      "o.grpc.file.CompleteFilePRequest\032(.allux" +
+      "io.grpc.file.CompleteFilePResponse\022j\n\017Cr" +
+      "eateDirectory\022*.alluxio.grpc.file.Create" +
+      "DirectoryPRequest\032+.alluxio.grpc.file.Cr" +
+      "eateDirectoryPResponse\022[\n\nCreateFile\022%.a" +
+      "lluxio.grpc.file.CreateFilePRequest\032&.al" +
+      "luxio.grpc.file.CreateFilePResponse\022I\n\004F" +
+      "ree\022\037.alluxio.grpc.file.FreePRequest\032 .a" +
+      "lluxio.grpc.file.FreePResponse\022^\n\013GetFil" +
+      "ePath\022&.alluxio.grpc.file.GetFilePathPRe" +
+      "quest\032\'.alluxio.grpc.file.GetFilePathPRe" +
+      "sponse\022d\n\rGetMountTable\022(.alluxio.grpc.f" +
+      "ile.GetMountTablePRequest\032).alluxio.grpc" +
+      ".file.GetMountTablePResponse\022j\n\017GetSyncP" +
+      "athList\022*.alluxio.grpc.file.GetSyncPathL" +
+      "istPRequest\032+.alluxio.grpc.file.GetSyncP" +
+      "athListPResponse\022y\n\024GetNewBlockIdForFile" +
+      "\022/.alluxio.grpc.file.GetNewBlockIdForFil" +
+      "ePRequest\0320.alluxio.grpc.file.GetNewBloc" +
+      "kIdForFilePResponse\022X\n\tGetStatus\022$.allux" +
+      "io.grpc.file.GetStatusPRequest\032%.alluxio" +
+      ".grpc.file.GetStatusPResponse\022]\n\nListSta" +
+      "tus\022%.alluxio.grpc.file.ListStatusPReque" +
+      "st\032&.alluxio.grpc.file.ListStatusPRespon" +
+      "se0\001\022L\n\005Mount\022 .alluxio.grpc.file.MountP" +
+      "Request\032!.alluxio.grpc.file.MountPRespon" +
+      "se\022O\n\006Remove\022!.alluxio.grpc.file.DeleteP" +
+      "Request\032\".alluxio.grpc.file.DeletePRespo" +
+      "nse\022O\n\006Rename\022!.alluxio.grpc.file.Rename" +
+      "PRequest\032\".alluxio.grpc.file.RenamePResp" +
+      "onse\022\205\001\n\030ScheduleAsyncPersistence\0223.allu" +
+      "xio.grpc.file.ScheduleAsyncPersistencePR" +
+      "equest\0324.alluxio.grpc.file.ScheduleAsync" +
+      "PersistencePResponse\022O\n\006SetAcl\022!.alluxio" +
+      ".grpc.file.SetAclPRequest\032\".alluxio.grpc" +
+      ".file.SetAclPResponse\022a\n\014SetAttribute\022\'." +
+      "alluxio.grpc.file.SetAttributePRequest\032(" +
+      ".alluxio.grpc.file.SetAttributePResponse" +
+      "\022X\n\tStartSync\022$.alluxio.grpc.file.StartS" +
+      "yncPRequest\032%.alluxio.grpc.file.StartSyn" +
+      "cPResponse\022U\n\010StopSync\022#.alluxio.grpc.fi" +
+      "le.StopSyncPRequest\032$.alluxio.grpc.file." +
+      "StopSyncPResponse\022R\n\007Unmount\022\".alluxio.g" +
+      "rpc.file.UnmountPRequest\032#.alluxio.grpc." +
+      "file.UnmountPResponse\022^\n\013UpdateMount\022&.a" +
+      "lluxio.grpc.file.UpdateMountPRequest\032\'.a" +
+      "lluxio.grpc.file.UpdateMountPResponse\022d\n" +
+      "\rUpdateUfsMode\022(.alluxio.grpc.file.Updat" +
+      "eUfsModePRequest\032).alluxio.grpc.file.Upd" +
+      "ateUfsModePResponse2\303\003\n\035FileSystemMaster" +
+      "WorkerService\022v\n\023FileSystemHeartbeat\022..a" +
+      "lluxio.grpc.file.FileSystemHeartbeatPReq" +
+      "uest\032/.alluxio.grpc.file.FileSystemHeart" +
+      "beatPResponse\022^\n\013GetFileInfo\022&.alluxio.g" +
+      "rpc.file.GetFileInfoPRequest\032\'.alluxio.g" +
+      "rpc.file.GetFileInfoPResponse\022m\n\020GetPinn" +
+      "edFileIds\022+.alluxio.grpc.file.GetPinnedF" +
+      "ileIdsPRequest\032,.alluxio.grpc.file.GetPi" +
+      "nnedFileIdsPResponse\022[\n\nGetUfsInfo\022%.all" +
+      "uxio.grpc.file.GetUfsInfoPRequest\032&.allu" +
+      "xio.grpc.file.GetUfsInfoPResponse2\331\001\n\032Fi" +
+      "leSystemMasterJobService\022^\n\013GetFileInfo\022" +
+      "&.alluxio.grpc.file.GetFileInfoPRequest\032" +
+      "\'.alluxio.grpc.file.GetFileInfoPResponse" +
+      "\022[\n\nGetUfsInfo\022%.alluxio.grpc.file.GetUf" +
+      "sInfoPRequest\032&.alluxio.grpc.file.GetUfs" +
+      "InfoPResponseB\'\n\014alluxio.grpcB\025FileSyste" +
+      "mMasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -868,7 +870,7 @@ public final class FileSystemMasterProto {
     internal_static_alluxio_grpc_file_OpenFilePOptions_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_file_OpenFilePOptions_descriptor,
-        new java.lang.String[] { "ReadType", "MaxUfsReadConcurrency", "CommonOptions", });
+        new java.lang.String[] { "ReadType", "MaxUfsReadConcurrency", "CommonOptions", "UpdateLastAccessTime", });
     internal_static_alluxio_grpc_file_CreateDirectoryPResponse_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_alluxio_grpc_file_CreateDirectoryPResponse_fieldAccessorTable = new
@@ -970,7 +972,7 @@ public final class FileSystemMasterProto {
     internal_static_alluxio_grpc_file_GetStatusPOptions_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_file_GetStatusPOptions_descriptor,
-        new java.lang.String[] { "LoadMetadataType", "CommonOptions", "AccessMode", });
+        new java.lang.String[] { "LoadMetadataType", "CommonOptions", "AccessMode", "UpdateTimestamps", });
     internal_static_alluxio_grpc_file_GetStatusPRequest_descriptor =
       getDescriptor().getMessageTypes().get(25);
     internal_static_alluxio_grpc_file_GetStatusPRequest_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/GetStatusPOptions.java
+++ b/core/transport/src/main/java/alluxio/grpc/GetStatusPOptions.java
@@ -18,6 +18,7 @@ private static final long serialVersionUID = 0L;
   private GetStatusPOptions() {
     loadMetadataType_ = 0;
     accessMode_ = 1;
+    updateTimestamps_ = true;
   }
 
   @java.lang.Override
@@ -84,6 +85,11 @@ private static final long serialVersionUID = 0L;
               bitField0_ |= 0x00000004;
               accessMode_ = rawValue;
             }
+            break;
+          }
+          case 32: {
+            bitField0_ |= 0x00000008;
+            updateTimestamps_ = input.readBool();
             break;
           }
         }
@@ -164,6 +170,21 @@ private static final long serialVersionUID = 0L;
     return result == null ? alluxio.grpc.Bits.NONE : result;
   }
 
+  public static final int UPDATETIMESTAMPS_FIELD_NUMBER = 4;
+  private boolean updateTimestamps_;
+  /**
+   * <code>optional bool updateTimestamps = 4 [default = true];</code>
+   */
+  public boolean hasUpdateTimestamps() {
+    return ((bitField0_ & 0x00000008) == 0x00000008);
+  }
+  /**
+   * <code>optional bool updateTimestamps = 4 [default = true];</code>
+   */
+  public boolean getUpdateTimestamps() {
+    return updateTimestamps_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -185,6 +206,9 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) == 0x00000004)) {
       output.writeEnum(3, accessMode_);
     }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      output.writeBool(4, updateTimestamps_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -204,6 +228,10 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) == 0x00000004)) {
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(3, accessMode_);
+    }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(4, updateTimestamps_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -234,6 +262,11 @@ private static final long serialVersionUID = 0L;
     if (hasAccessMode()) {
       result = result && accessMode_ == other.accessMode_;
     }
+    result = result && (hasUpdateTimestamps() == other.hasUpdateTimestamps());
+    if (hasUpdateTimestamps()) {
+      result = result && (getUpdateTimestamps()
+          == other.getUpdateTimestamps());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -256,6 +289,11 @@ private static final long serialVersionUID = 0L;
     if (hasAccessMode()) {
       hash = (37 * hash) + ACCESSMODE_FIELD_NUMBER;
       hash = (53 * hash) + accessMode_;
+    }
+    if (hasUpdateTimestamps()) {
+      hash = (37 * hash) + UPDATETIMESTAMPS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getUpdateTimestamps());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -397,6 +435,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000002);
       accessMode_ = 1;
       bitField0_ = (bitField0_ & ~0x00000004);
+      updateTimestamps_ = true;
+      bitField0_ = (bitField0_ & ~0x00000008);
       return this;
     }
 
@@ -437,6 +477,10 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000004;
       }
       result.accessMode_ = accessMode_;
+      if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        to_bitField0_ |= 0x00000008;
+      }
+      result.updateTimestamps_ = updateTimestamps_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -487,6 +531,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasAccessMode()) {
         setAccessMode(other.getAccessMode());
+      }
+      if (other.hasUpdateTimestamps()) {
+        setUpdateTimestamps(other.getUpdateTimestamps());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -702,6 +749,38 @@ private static final long serialVersionUID = 0L;
     public Builder clearAccessMode() {
       bitField0_ = (bitField0_ & ~0x00000004);
       accessMode_ = 1;
+      onChanged();
+      return this;
+    }
+
+    private boolean updateTimestamps_ = true;
+    /**
+     * <code>optional bool updateTimestamps = 4 [default = true];</code>
+     */
+    public boolean hasUpdateTimestamps() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bool updateTimestamps = 4 [default = true];</code>
+     */
+    public boolean getUpdateTimestamps() {
+      return updateTimestamps_;
+    }
+    /**
+     * <code>optional bool updateTimestamps = 4 [default = true];</code>
+     */
+    public Builder setUpdateTimestamps(boolean value) {
+      bitField0_ |= 0x00000008;
+      updateTimestamps_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional bool updateTimestamps = 4 [default = true];</code>
+     */
+    public Builder clearUpdateTimestamps() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      updateTimestamps_ = true;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/GetStatusPOptionsOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/GetStatusPOptionsOrBuilder.java
@@ -37,4 +37,13 @@ public interface GetStatusPOptionsOrBuilder extends
    * <code>optional .alluxio.grpc.Bits accessMode = 3;</code>
    */
   alluxio.grpc.Bits getAccessMode();
+
+  /**
+   * <code>optional bool updateTimestamps = 4 [default = true];</code>
+   */
+  boolean hasUpdateTimestamps();
+  /**
+   * <code>optional bool updateTimestamps = 4 [default = true];</code>
+   */
+  boolean getUpdateTimestamps();
 }

--- a/core/transport/src/main/java/alluxio/grpc/OpenFilePOptions.java
+++ b/core/transport/src/main/java/alluxio/grpc/OpenFilePOptions.java
@@ -18,6 +18,7 @@ private static final long serialVersionUID = 0L;
   private OpenFilePOptions() {
     readType_ = 1;
     maxUfsReadConcurrency_ = 0;
+    updateLastAccessTime_ = true;
   }
 
   @java.lang.Override
@@ -78,6 +79,11 @@ private static final long serialVersionUID = 0L;
               commonOptions_ = subBuilder.buildPartial();
             }
             bitField0_ |= 0x00000004;
+            break;
+          }
+          case 32: {
+            bitField0_ |= 0x00000008;
+            updateLastAccessTime_ = input.readBool();
             break;
           }
         }
@@ -157,6 +163,21 @@ private static final long serialVersionUID = 0L;
     return commonOptions_ == null ? alluxio.grpc.FileSystemMasterCommonPOptions.getDefaultInstance() : commonOptions_;
   }
 
+  public static final int UPDATELASTACCESSTIME_FIELD_NUMBER = 4;
+  private boolean updateLastAccessTime_;
+  /**
+   * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+   */
+  public boolean hasUpdateLastAccessTime() {
+    return ((bitField0_ & 0x00000008) == 0x00000008);
+  }
+  /**
+   * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+   */
+  public boolean getUpdateLastAccessTime() {
+    return updateLastAccessTime_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -178,6 +199,9 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) == 0x00000004)) {
       output.writeMessage(3, getCommonOptions());
     }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      output.writeBool(4, updateLastAccessTime_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -197,6 +221,10 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) == 0x00000004)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, getCommonOptions());
+    }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(4, updateLastAccessTime_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -228,6 +256,11 @@ private static final long serialVersionUID = 0L;
       result = result && getCommonOptions()
           .equals(other.getCommonOptions());
     }
+    result = result && (hasUpdateLastAccessTime() == other.hasUpdateLastAccessTime());
+    if (hasUpdateLastAccessTime()) {
+      result = result && (getUpdateLastAccessTime()
+          == other.getUpdateLastAccessTime());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -250,6 +283,11 @@ private static final long serialVersionUID = 0L;
     if (hasCommonOptions()) {
       hash = (37 * hash) + COMMONOPTIONS_FIELD_NUMBER;
       hash = (53 * hash) + getCommonOptions().hashCode();
+    }
+    if (hasUpdateLastAccessTime()) {
+      hash = (37 * hash) + UPDATELASTACCESSTIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getUpdateLastAccessTime());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -391,6 +429,8 @@ private static final long serialVersionUID = 0L;
         commonOptionsBuilder_.clear();
       }
       bitField0_ = (bitField0_ & ~0x00000004);
+      updateLastAccessTime_ = true;
+      bitField0_ = (bitField0_ & ~0x00000008);
       return this;
     }
 
@@ -431,6 +471,10 @@ private static final long serialVersionUID = 0L;
       } else {
         result.commonOptions_ = commonOptionsBuilder_.build();
       }
+      if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        to_bitField0_ |= 0x00000008;
+      }
+      result.updateLastAccessTime_ = updateLastAccessTime_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -481,6 +525,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasCommonOptions()) {
         mergeCommonOptions(other.getCommonOptions());
+      }
+      if (other.hasUpdateLastAccessTime()) {
+        setUpdateLastAccessTime(other.getUpdateLastAccessTime());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -694,6 +741,38 @@ private static final long serialVersionUID = 0L;
         commonOptions_ = null;
       }
       return commonOptionsBuilder_;
+    }
+
+    private boolean updateLastAccessTime_ = true;
+    /**
+     * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+     */
+    public boolean hasUpdateLastAccessTime() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+     */
+    public boolean getUpdateLastAccessTime() {
+      return updateLastAccessTime_;
+    }
+    /**
+     * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+     */
+    public Builder setUpdateLastAccessTime(boolean value) {
+      bitField0_ |= 0x00000008;
+      updateLastAccessTime_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+     */
+    public Builder clearUpdateLastAccessTime() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      updateLastAccessTime_ = true;
+      onChanged();
+      return this;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/OpenFilePOptionsOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/OpenFilePOptionsOrBuilder.java
@@ -37,4 +37,13 @@ public interface OpenFilePOptionsOrBuilder extends
    * <code>optional .alluxio.grpc.file.FileSystemMasterCommonPOptions commonOptions = 3;</code>
    */
   alluxio.grpc.FileSystemMasterCommonPOptionsOrBuilder getCommonOptionsOrBuilder();
+
+  /**
+   * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+   */
+  boolean hasUpdateLastAccessTime();
+  /**
+   * <code>optional bool updateLastAccessTime = 4 [default = true];</code>
+   */
+  boolean getUpdateLastAccessTime();
 }

--- a/core/transport/src/main/java/alluxio/proto/journal/File.java
+++ b/core/transport/src/main/java/alluxio/proto/journal/File.java
@@ -8060,7 +8060,7 @@ public final class File {
   }
   /**
    * <pre>
-   * next available id: 18
+   * next available id: 20
    * </pre>
    *
    * Protobuf type {@code alluxio.proto.journal.UpdateInodeEntry}
@@ -9248,7 +9248,7 @@ public final class File {
     }
     /**
      * <pre>
-     * next available id: 18
+     * next available id: 20
      * </pre>
      *
      * Protobuf type {@code alluxio.proto.journal.UpdateInodeEntry}

--- a/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
@@ -129,8 +129,10 @@ public final class PersistDefinition
       }
       long bytesWritten;
       try (Closer closer = Closer.create()) {
-        OpenFilePOptions options =
-            OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build();
+        OpenFilePOptions options = OpenFilePOptions.newBuilder()
+            .setReadType(ReadPType.NO_CACHE)
+            .setUpdateLastAccessTime(false)
+            .build();
         FileInStream in = closer.register(context.getFileSystem().openFile(uri, options));
         AlluxioURI dstPath = new AlluxioURI(ufsPath);
         // Create ancestor directories from top to the bottom. We cannot use recursive create

--- a/tests/src/test/java/alluxio/job/JobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/JobIntegrationTest.java
@@ -52,6 +52,7 @@ public abstract class JobIntegrationTest extends BaseIntegrationTest {
         .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
         .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES))
         .setProperty(PropertyKey.USER_NETWORK_READER_CHUNK_SIZE_BYTES, "64KB")
+        .setProperty(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0")
         .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_CAPACITY_BYTES);
     return resource.build();
   }

--- a/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
@@ -15,7 +15,6 @@ import static alluxio.job.wire.Status.COMPLETED;
 import static alluxio.job.wire.Status.FAILED;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemMasterClient;
@@ -38,10 +37,7 @@ import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.Closeable;
 
 /**
  * Integration tests for {@link PersistDefinition}.


### PR DESCRIPTION
Persist job uses `FileSystem.open` for reading file content from worker, which causes the access time to be updated. This change add an option to open file API to allow internal clients to indicate that access time should not be updated.