### PR TITLE
Support custom options provider for FileSystem implementations

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -30,7 +30,6 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.WorkerMetrics;
 import alluxio.resource.CloseableResource;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -176,8 +175,8 @@ public class FileOutStream extends AbstractOutStream {
       if (!mCanceled && mUnderStorageType.isAsyncPersist()
           && mOptions.getPersistenceWaitTime() != Constants.NO_AUTO_PERSIST) {
         optionsBuilder.setAsyncPersistOptions(
-            FileSystemOptions.scheduleAsyncPersistDefaults(mContext.getPathConf(mUri)).toBuilder()
-                .setCommonOptions(mOptions.getCommonOptions())
+            mContext.getOptionsProvider().scheduleAsyncPersistDefaults(mContext.getPathConf(mUri))
+                .toBuilder().setCommonOptions(mOptions.getCommonOptions())
                 .setPersistenceWaitTime(mOptions.getPersistenceWaitTime()));
       }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -43,6 +43,7 @@ import alluxio.security.authorization.AclEntry;
 import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.FileSystemOptionsProvider;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.SyncPointInfo;
@@ -244,6 +245,11 @@ public interface FileSystem extends Closeable {
    * @return whether or not this FileSystem has been closed
    */
   boolean isClosed();
+
+  /**
+   * @return Options provider associated with the file system implementation
+   */
+  FileSystemOptionsProvider getOptionsProvider();
 
   /**
    * Convenience method for {@link #createDirectory(AlluxioURI, CreateDirectoryPOptions)} with

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -30,6 +30,8 @@ import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
 import alluxio.security.authentication.AuthenticationUserUtils;
+import alluxio.util.DefaultFileSystemOptionsProvider;
+import alluxio.util.FileSystemOptionsProvider;
 import alluxio.util.IdUtils;
 import alluxio.util.network.NettyUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -144,6 +146,8 @@ public final class FileSystemContext implements Closeable {
    */
   private volatile FileSystemContextReinitializer mReinitializer;
 
+  private FileSystemOptionsProvider mOptionsProvider;
+
   /**
    * Creates a {@link FileSystemContext} with a null subject.
    *
@@ -230,6 +234,11 @@ public final class FileSystemContext implements Closeable {
     mMetricsEnabled = getClusterConf().getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED);
     if (mMetricsEnabled) {
       MetricsHeartbeatContext.addHeartbeat(getClientContext(), masterInquireClient);
+    }
+    mOptionsProvider = ctx.getOptionsProvider();
+    if (mOptionsProvider == null) {
+      // Use default options provider.
+      mOptionsProvider = new DefaultFileSystemOptionsProvider();
     }
   }
 
@@ -356,6 +365,13 @@ public final class FileSystemContext implements Closeable {
    */
   public ClientContext getClientContext() {
     return mMasterClientContext;
+  }
+
+  /**
+   * @return file system options provider
+   */
+  public synchronized FileSystemOptionsProvider getOptionsProvider() {
+    return mOptionsProvider;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -184,15 +184,6 @@ public interface FileSystemMasterClient extends Client {
    *
    * @param src the path to rename
    * @param dst new file path
-   * @throws NotFoundException if the path does not exist
-   */
-  void rename(AlluxioURI src, AlluxioURI dst) throws AlluxioStatusException;
-
-  /**
-   * Renames a file or a directory.
-   *
-   * @param src the path to rename
-   * @param dst new file path
    * @param options rename options
    * @throws NotFoundException if the path does not exist
    */

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -59,7 +59,6 @@ import alluxio.grpc.UpdateUfsModePOptions;
 import alluxio.grpc.UpdateUfsModePRequest;
 import alluxio.master.MasterClientContext;
 import alluxio.security.authorization.AclEntry;
-import alluxio.util.FileSystemOptions;
 import alluxio.wire.SyncPointInfo;
 
 import java.util.ArrayList;
@@ -243,12 +242,6 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
             .setAlluxioPath(alluxioPath.toString())
             .setOptions(options).build()),
         "UpdateMount");
-  }
-
-  @Override
-  public void rename(final AlluxioURI src, final AlluxioURI dst)
-      throws AlluxioStatusException {
-    rename(src, dst, FileSystemOptions.renameDefaults(mContext.getClusterConf()));
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -19,7 +19,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.master.block.BlockId;
 import alluxio.proto.dataserver.Protocol;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.DefaultFileSystemOptionsProvider;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
 
@@ -50,7 +50,8 @@ public final class InStreamOptions {
    * @param alluxioConf Alluxio configuration
    */
   public InStreamOptions(URIStatus status, AlluxioConfiguration alluxioConf) {
-    this(status, FileSystemOptions.openFileDefaults(alluxioConf), alluxioConf);
+    // TODO(ggezer) Remove dependency on DefaultFileSystemOptionsProvider.
+    this(status, new DefaultFileSystemOptionsProvider().openFileDefaults(alluxioConf), alluxioConf);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -24,7 +24,7 @@ import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.DefaultFileSystemOptionsProvider;
 import alluxio.util.IdUtils;
 import alluxio.util.ModeUtils;
 
@@ -122,7 +122,8 @@ public final class OutStreamOptions {
   }
 
   private OutStreamOptions(ClientContext context, AlluxioConfiguration alluxioConf) {
-    mCommonOptions = FileSystemOptions.commonDefaults(alluxioConf);
+    // TODO(ggezer) Remove dependency on DefaultFileSystemOptionsProvider.
+    mCommonOptions = new DefaultFileSystemOptionsProvider().commonDefaults(alluxioConf);
     mBlockSizeBytes = alluxioConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
     mLocationPolicy = BlockLocationPolicy.Factory.create(
         alluxioConf.get(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY),

--- a/core/client/fs/src/main/java/alluxio/util/DefaultFileSystemOptionsProvider.java
+++ b/core/client/fs/src/main/java/alluxio/util/DefaultFileSystemOptionsProvider.java
@@ -38,27 +38,23 @@ import alluxio.grpc.WritePType;
 import alluxio.security.authorization.Mode;
 
 /**
- * This class contains static methods which can be passed Alluxio configuration objects that
+ * This class contains methods which can be passed Alluxio configuration objects that
  * will populate the gRPC options objects with the proper values based on the given configuration.
+ *
+ * It is used as base options provider at client and master for base file system operations.
  */
-public class FileSystemOptions {
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static ScheduleAsyncPersistencePOptions scheduleAsyncPersistenceDefaults(
-      AlluxioConfiguration conf) {
+public class DefaultFileSystemOptionsProvider implements FileSystemOptionsProvider {
+  @Override
+  public ScheduleAsyncPersistencePOptions scheduleAsyncPersistenceDefaults(
+          AlluxioConfiguration conf) {
     return ScheduleAsyncPersistencePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setPersistenceWaitTime(0)
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static CreateDirectoryPOptions createDirectoryDefaults(AlluxioConfiguration conf) {
+  @Override
+  public CreateDirectoryPOptions createDirectoryDefaults(AlluxioConfiguration conf) {
     return CreateDirectoryPOptions.newBuilder()
         .setAllowExists(false)
         .setCommonOptions(commonDefaults(conf))
@@ -69,21 +65,15 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static CheckConsistencyPOptions checkConsistencyDefaults(AlluxioConfiguration conf) {
+  @Override
+  public CheckConsistencyPOptions checkConsistencyDefaults(AlluxioConfiguration conf) {
     return CheckConsistencyPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static CreateFilePOptions createFileDefaults(AlluxioConfiguration conf) {
+  @Override
+  public CreateFilePOptions createFileDefaults(AlluxioConfiguration conf) {
     return CreateFilePOptions.newBuilder()
         .setBlockSizeBytes(conf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT))
         .setCommonOptions(commonDefaults(conf))
@@ -99,11 +89,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static DeletePOptions deleteDefaults(AlluxioConfiguration conf) {
+  @Override
+  public DeletePOptions deleteDefaults(AlluxioConfiguration conf) {
     return DeletePOptions.newBuilder()
         .setAlluxioOnly(false)
         .setCommonOptions(commonDefaults(conf))
@@ -112,11 +99,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static ExistsPOptions existsDefaults(AlluxioConfiguration conf) {
+  @Override
+  public ExistsPOptions existsDefaults(AlluxioConfiguration conf) {
     return ExistsPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setLoadMetadataType(conf.getEnum(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
@@ -124,12 +108,9 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static FileSystemMasterCommonPOptions commonDefaults(
-      AlluxioConfiguration conf) {
+  @Override
+  public FileSystemMasterCommonPOptions commonDefaults(
+          AlluxioConfiguration conf) {
     return FileSystemMasterCommonPOptions.newBuilder()
         .setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
         .setTtl(conf.getMs(PropertyKey.USER_FILE_CREATE_TTL))
@@ -137,11 +118,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static FreePOptions freeDefaults(AlluxioConfiguration conf) {
+  @Override
+  public FreePOptions freeDefaults(AlluxioConfiguration conf) {
     return FreePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setForced(false)
@@ -149,11 +127,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static GetStatusPOptions getStatusDefaults(AlluxioConfiguration conf) {
+  @Override
+  public GetStatusPOptions getStatusDefaults(AlluxioConfiguration conf) {
     return GetStatusPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setLoadMetadataType(conf.getEnum(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
@@ -161,11 +136,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static ListStatusPOptions listStatusDefaults(AlluxioConfiguration conf) {
+  @Override
+  public ListStatusPOptions listStatusDefaults(AlluxioConfiguration conf) {
     return ListStatusPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setLoadMetadataType(conf.getEnum(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
@@ -173,11 +145,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static LoadMetadataPOptions loadMetadataDefaults(AlluxioConfiguration conf) {
+  @Override
+  public LoadMetadataPOptions loadMetadataDefaults(AlluxioConfiguration conf) {
     return LoadMetadataPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setRecursive(false)
@@ -186,11 +155,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static MountPOptions mountDefaults(AlluxioConfiguration conf) {
+  @Override
+  public MountPOptions mountDefaults(AlluxioConfiguration conf) {
     return MountPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setReadOnly(false)
@@ -198,11 +164,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static OpenFilePOptions openFileDefaults(AlluxioConfiguration conf) {
+  @Override
+  public OpenFilePOptions openFileDefaults(AlluxioConfiguration conf) {
     return OpenFilePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setMaxUfsReadConcurrency(conf.getInt(PropertyKey.USER_UFS_BLOCK_READ_CONCURRENCY_MAX))
@@ -211,57 +174,40 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static RenamePOptions renameDefaults(AlluxioConfiguration conf) {
+  @Override
+  public RenamePOptions renameDefaults(AlluxioConfiguration conf) {
     return RenamePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setPersist(conf.getBoolean(PropertyKey.USER_FILE_PERSIST_ON_RENAME))
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static ScheduleAsyncPersistencePOptions scheduleAsyncPersistDefaults(
-      AlluxioConfiguration conf) {
+  @Override
+  public ScheduleAsyncPersistencePOptions scheduleAsyncPersistDefaults(
+          AlluxioConfiguration conf) {
     return ScheduleAsyncPersistencePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static SetAclPOptions setAclDefaults(AlluxioConfiguration conf) {
+  @Override
+  public SetAclPOptions setAclDefaults(AlluxioConfiguration conf) {
     return SetAclPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setRecursive(false)
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static SetAttributePOptions setAttributeDefaults(AlluxioConfiguration conf) {
+  @Override
+  public SetAttributePOptions setAttributeDefaults(AlluxioConfiguration conf) {
     return SetAttributePOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .setRecursive(false)
         .build();
   }
 
-  /**
-   * Defaults for the SetAttribute RPC which should only be used on the client side.
-   *
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static SetAttributePOptions setAttributeClientDefaults(AlluxioConfiguration conf) {
+  @Override
+  public SetAttributePOptions setAttributeClientDefaults(AlluxioConfiguration conf) {
     // Specifically set and override *only* the metadata sync interval
     // Setting other attributes by default will make the server think the user is intentionally
     // setting the values. Most fields withinSetAttributePOptions are set by inclusion
@@ -272,11 +218,8 @@ public class FileSystemOptions {
         .build();
   }
 
-  /**
-   * @param conf Alluxio configuration
-   * @return options based on the configuration
-   */
-  public static UnmountPOptions unmountDefaults(AlluxioConfiguration conf) {
+  @Override
+  public UnmountPOptions unmountDefaults(AlluxioConfiguration conf) {
     return UnmountPOptions.newBuilder()
         .setCommonOptions(commonDefaults(conf))
         .build();

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -42,7 +42,6 @@ import alluxio.grpc.OpenLocalBlockRequest;
 import alluxio.grpc.OpenLocalBlockResponse;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.DummyCloseableResource;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
@@ -315,8 +314,7 @@ public final class AlluxioBlockStoreTest {
     URIStatus dummyStatus =
         new URIStatus(new FileInfo().setPersisted(true).setBlockIds(Collections.singletonList(0L)));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf),
-            sConf);
+        new InStreamOptions(dummyStatus, sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mMasterClient.getWorkerInfoList()).thenReturn(Collections.emptyList());
 
@@ -330,7 +328,7 @@ public final class AlluxioBlockStoreTest {
     URIStatus dummyStatus = new URIStatus(
         new FileInfo().setPersisted(false).setBlockIds(Collections.singletonList(0L)));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
+        new InStreamOptions(dummyStatus, sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mMasterClient.getWorkerInfoList()).thenReturn(Collections.emptyList());
 
@@ -469,7 +467,7 @@ public final class AlluxioBlockStoreTest {
         .getArgumentAt(0, GetWorkerOptions.class).getBlockWorkerInfos().iterator().next()
         .getNetAddress());
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
+        new InStreamOptions(dummyStatus, sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
     when(mMasterClient.getWorkerInfoList()).thenReturn(Arrays.stream(workers)
@@ -507,7 +505,7 @@ public final class AlluxioBlockStoreTest {
         .getArgumentAt(0, GetWorkerOptions.class).getBlockWorkerInfos().iterator().next()
         .getNetAddress());
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
+        new InStreamOptions(dummyStatus, sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
     when(mMasterClient.getWorkerInfoList()).thenReturn(Arrays.stream(workers)

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -43,7 +43,8 @@ import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.UnmountPOptions;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.DefaultFileSystemOptionsProvider;
+import alluxio.util.FileSystemOptionsProvider;
 import alluxio.wire.FileInfo;
 
 import org.junit.After;
@@ -76,6 +77,7 @@ public final class BaseFileSystemTest {
 
   private FileSystem mFileSystem;
   private FileSystemContext mFileContext;
+  private FileSystemOptionsProvider mOptionsProvider;
   private ClientContext mClientContext;
   private FileSystemMasterClient mFileSystemMasterClient;
 
@@ -91,6 +93,7 @@ public final class BaseFileSystemTest {
   @Before
   public void before() {
     mClientContext = ClientContext.create(mConf);
+    mOptionsProvider = new DefaultFileSystemOptionsProvider();
     mFileContext = PowerMockito.mock(FileSystemContext.class);
     mFileSystemMasterClient = PowerMockito.mock(FileSystemMasterClient.class);
     when(mFileContext.acquireMasterClientResource()).thenReturn(
@@ -103,6 +106,7 @@ public final class BaseFileSystemTest {
     when(mFileContext.getClientContext()).thenReturn(mClientContext);
     when(mFileContext.getClusterConf()).thenReturn(mConf);
     when(mFileContext.getPathConf(any())).thenReturn(mConf);
+    when(mFileContext.getOptionsProvider()).thenReturn(mOptionsProvider);
     mFileSystem = new DummyAlluxioFileSystem(mFileContext);
   }
 
@@ -129,7 +133,7 @@ public final class BaseFileSystemTest {
     when(mFileSystemMasterClient.createFile(any(AlluxioURI.class), any(CreateFilePOptions.class)))
         .thenReturn(status);
     FileOutStream out = mFileSystem.createFile(file, CreateFilePOptions.getDefaultInstance());
-    verify(mFileSystemMasterClient).createFile(file, FileSystemOptions.createFileDefaults(mConf)
+    verify(mFileSystemMasterClient).createFile(file, mOptionsProvider.createFileDefaults(mConf)
             .toBuilder().mergeFrom(CreateFilePOptions.getDefaultInstance()).build());
     assertEquals(out.mUri, file);
 
@@ -162,7 +166,7 @@ public final class BaseFileSystemTest {
     DeletePOptions deleteOptions = DeletePOptions.newBuilder().setRecursive(true).build();
     mFileSystem.delete(file, deleteOptions);
     verify(mFileSystemMasterClient).delete(file,
-        FileSystemOptions.deleteDefaults(mConf).toBuilder().mergeFrom(deleteOptions).build());
+        mOptionsProvider.deleteDefaults(mConf).toBuilder().mergeFrom(deleteOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
   }
@@ -175,7 +179,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     DeletePOptions deleteOptions = DeletePOptions.newBuilder().setRecursive(true).build();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).delete(file,
-        FileSystemOptions.deleteDefaults(mConf)
+        mOptionsProvider.deleteDefaults(mConf)
             .toBuilder().mergeFrom(deleteOptions).build());
     try {
       mFileSystem.delete(file, deleteOptions);
@@ -195,7 +199,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     FreePOptions freeOptions = FreePOptions.newBuilder().setRecursive(true).build();
     mFileSystem.free(file, freeOptions);
-    verify(mFileSystemMasterClient).free(file, FileSystemOptions.freeDefaults(mConf)
+    verify(mFileSystemMasterClient).free(file, mOptionsProvider.freeDefaults(mConf)
         .toBuilder().mergeFrom(freeOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -209,7 +213,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     FreePOptions freeOptions = FreePOptions.newBuilder().setRecursive(true).build();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).free(file,
-        FileSystemOptions.freeDefaults(mConf).toBuilder().mergeFrom(freeOptions).build());
+        mOptionsProvider.freeDefaults(mConf).toBuilder().mergeFrom(freeOptions).build());
     try {
       mFileSystem.free(file, freeOptions);
       fail(SHOULD_HAVE_PROPAGATED_MESSAGE);
@@ -228,10 +232,10 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     URIStatus status = new URIStatus(new FileInfo());
     GetStatusPOptions getStatusOptions = GetStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    when(mFileSystemMasterClient.getStatus(file, mOptionsProvider.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build())).thenReturn(status);
     assertSame(status, mFileSystem.getStatus(file, getStatusOptions));
-    verify(mFileSystemMasterClient).getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    verify(mFileSystemMasterClient).getStatus(file, mOptionsProvider.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -244,7 +248,7 @@ public final class BaseFileSystemTest {
   public void getStatusException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     GetStatusPOptions getStatusOptions = GetStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    when(mFileSystemMasterClient.getStatus(file, mOptionsProvider.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build())).thenThrow(EXCEPTION);
     try {
       mFileSystem.getStatus(file, getStatusOptions);
@@ -265,10 +269,10 @@ public final class BaseFileSystemTest {
     List<URIStatus> infos = new ArrayList<>();
     infos.add(new URIStatus(new FileInfo()));
     ListStatusPOptions listStatusOptions = ListStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    when(mFileSystemMasterClient.listStatus(file, mOptionsProvider.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(listStatusOptions).build())).thenReturn(infos);
     assertSame(infos, mFileSystem.listStatus(file, listStatusOptions));
-    verify(mFileSystemMasterClient).listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    verify(mFileSystemMasterClient).listStatus(file, mOptionsProvider.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(listStatusOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -280,7 +284,7 @@ public final class BaseFileSystemTest {
   @Test
   public void listStatusException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    when(mFileSystemMasterClient.listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    when(mFileSystemMasterClient.listStatus(file, mOptionsProvider.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(ListStatusPOptions.getDefaultInstance()).build()))
         .thenThrow(EXCEPTION);
     try {
@@ -336,11 +340,11 @@ public final class BaseFileSystemTest {
     AlluxioURI dir = new AlluxioURI("/dir");
     CreateDirectoryPOptions createDirectoryOptions = CreateDirectoryPOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        mOptionsProvider.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
     mFileSystem.createDirectory(dir, createDirectoryOptions);
     verify(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        mOptionsProvider.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -354,7 +358,7 @@ public final class BaseFileSystemTest {
     AlluxioURI dir = new AlluxioURI("/dir");
     CreateDirectoryPOptions createDirectoryOptions = CreateDirectoryPOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        mOptionsProvider.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
     try {
       mFileSystem.createDirectory(dir, createDirectoryOptions);
@@ -375,10 +379,10 @@ public final class BaseFileSystemTest {
     AlluxioURI ufsPath = new AlluxioURI("/u");
     MountPOptions mountOptions = MountPOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).mount(alluxioPath, ufsPath,
-        FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+        mOptionsProvider.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
     mFileSystem.mount(alluxioPath, ufsPath, mountOptions);
     verify(mFileSystemMasterClient).mount(alluxioPath, ufsPath,
-        FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+        mOptionsProvider.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
   }
@@ -393,7 +397,7 @@ public final class BaseFileSystemTest {
     MountPOptions mountOptions = MountPOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient)
         .mount(alluxioPath, ufsPath,
-            FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+            mOptionsProvider.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
     try {
       mFileSystem.mount(alluxioPath, ufsPath, mountOptions);
       fail(SHOULD_HAVE_PROPAGATED_MESSAGE);
@@ -450,10 +454,10 @@ public final class BaseFileSystemTest {
     AlluxioURI dst = new AlluxioURI("/file2");
     RenamePOptions renameOptions = RenamePOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
+        mOptionsProvider.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
     mFileSystem.rename(src, dst, renameOptions);
     verify(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
+        mOptionsProvider.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
   }
 
   /**
@@ -465,7 +469,7 @@ public final class BaseFileSystemTest {
     AlluxioURI dst = new AlluxioURI("/file2");
     RenamePOptions renameOptions = RenamePOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf)
+        mOptionsProvider.renameDefaults(mConf)
         .toBuilder().mergeFrom(renameOptions).build());
     try {
       mFileSystem.rename(src, dst, renameOptions);
@@ -482,7 +486,7 @@ public final class BaseFileSystemTest {
   public void setAttribute() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        mOptionsProvider.setAttributeClientDefaults(mFileContext.getPathConf(file));
     mFileSystem.setAttribute(file, setAttributeOptions);
     verify(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
   }
@@ -494,7 +498,7 @@ public final class BaseFileSystemTest {
   public void setAttributeSyncMetadataInterval() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions opt =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        mOptionsProvider.setAttributeClientDefaults(mFileContext.getPathConf(file));
     // Check that metadata sync interval from configuration is used when options are omitted
     mFileSystem.setAttribute(file);
     verify(mFileSystemMasterClient).setAttribute(file, opt);
@@ -507,7 +511,7 @@ public final class BaseFileSystemTest {
   public void setStateException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        mOptionsProvider.setAttributeClientDefaults(mFileContext.getPathConf(file));
     doThrow(EXCEPTION).when(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
     try {
       mFileSystem.setAttribute(file, setAttributeOptions);
@@ -626,7 +630,7 @@ public final class BaseFileSystemTest {
   }
 
   private GetStatusPOptions getOpenOptions(GetStatusPOptions getStatusOptions) {
-    return FileSystemOptions.getStatusDefaults(mConf)
+    return mOptionsProvider.getStatusDefaults(mConf)
         .toBuilder().setAccessMode(Bits.READ).setUpdateTimestamps(true)
         .mergeFrom(getStatusOptions).build();
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -55,6 +55,7 @@ import alluxio.grpc.WritePType;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.DummyCloseableResource;
 import alluxio.security.GroupMappingServiceTestUtils;
+import alluxio.util.DefaultFileSystemOptionsProvider;
 import alluxio.util.io.BufferUtils;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -123,6 +124,8 @@ public class FileOutStreamTest {
     when(mFileSystemContext.getClientContext()).thenReturn(mClientContext);
     when(mFileSystemContext.getClusterConf()).thenReturn(sConf);
     when(mFileSystemContext.getPathConf(any(AlluxioURI.class))).thenReturn(sConf);
+    when(mFileSystemContext.getOptionsProvider())
+        .thenReturn(new DefaultFileSystemOptionsProvider());
     mBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     mFileSystemMasterClient = PowerMockito.mock(FileSystemMasterClient.class);
 

--- a/core/client/fs/src/test/java/alluxio/util/DefaultFileSystemOptionsProviderTest.java
+++ b/core/client/fs/src/test/java/alluxio/util/DefaultFileSystemOptionsProviderTest.java
@@ -26,18 +26,23 @@ import alluxio.grpc.SetAclPOptions;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FileSystemOptionsTest {
+/**
+ * Tests for the {@link DefaultFileSystemOptionsProvider}.
+ */
+public class DefaultFileSystemOptionsProviderTest {
 
   private InstancedConfiguration mConf;
+  private FileSystemOptionsProvider mOptionsProvider;
 
   @Before
   public void before() throws Exception {
     mConf = ConfigurationTestUtils.defaults();
+    mOptionsProvider = new DefaultFileSystemOptionsProvider();
   }
 
   @Test
   public void loadMetadataOptionsDefaults() {
-    LoadMetadataPOptions options = FileSystemOptions.loadMetadataDefaults(mConf);
+    LoadMetadataPOptions options = mOptionsProvider.loadMetadataDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getRecursive());
     assertFalse(options.getCreateAncestors());
@@ -46,7 +51,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void deleteOptionsDefaults() {
-    DeletePOptions options = FileSystemOptions.deleteDefaults(mConf);
+    DeletePOptions options = mOptionsProvider.deleteDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getRecursive());
     assertFalse(options.getAlluxioOnly());
@@ -55,7 +60,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void mountOptionsDefaults() {
-    MountPOptions options = FileSystemOptions.mountDefaults(mConf);
+    MountPOptions options = mOptionsProvider.mountDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getShared());
     assertFalse(options.getReadOnly());
@@ -64,7 +69,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void setAclOptionsDefaults() {
-    SetAclPOptions options = FileSystemOptions.setAclDefaults(mConf);
+    SetAclPOptions options = mOptionsProvider.setAclDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getRecursive());
   }

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -18,6 +18,7 @@ import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.GetConfigurationPResponse;
 import alluxio.security.user.UserState;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.FileSystemOptionsProvider;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public class ClientContext {
   private volatile UserState mUserState;
   private volatile String mPathConfHash;
   private volatile boolean mIsPathConfLoaded = false;
+  private volatile FileSystemOptionsProvider mOptionsProvider;
 
   /**
    * A client context with information about the subject and configuration of the client.
@@ -86,6 +88,7 @@ public class ClientContext {
     mUserState = ctx.getUserState();
     mClusterConfHash = ctx.getClusterConfHash();
     mPathConfHash = ctx.getPathConfHash();
+    mOptionsProvider = ctx.getOptionsProvider();
   }
 
   private ClientContext(@Nullable Subject subject, @Nullable AlluxioConfiguration alluxioConf) {
@@ -103,6 +106,17 @@ public class ClientContext {
     }
     mPathConf = PathConfiguration.create(new HashMap<>());
     mUserState = UserState.Factory.create(mClusterConf, subject);
+  }
+
+  /**
+   * Updates client context with given options provider.
+   *
+   * @param optionsProvider the options provider
+   * @return the updated ClientContext instance
+   */
+  public ClientContext withOptionsProvider(FileSystemOptionsProvider optionsProvider) {
+    mOptionsProvider = optionsProvider;
+    return this;
   }
 
   /**
@@ -191,5 +205,12 @@ public class ClientContext {
    */
   public UserState getUserState() {
     return mUserState;
+  }
+
+  /**
+   * @return the FileSystemOptionsProvider for this context
+   */
+  public FileSystemOptionsProvider getOptionsProvider() {
+    return mOptionsProvider;
   }
 }

--- a/core/common/src/main/java/alluxio/util/FileSystemOptionsProvider.java
+++ b/core/common/src/main/java/alluxio/util/FileSystemOptionsProvider.java
@@ -1,0 +1,153 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.grpc.CheckConsistencyPOptions;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.ExistsPOptions;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
+import alluxio.grpc.FreePOptions;
+import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
+import alluxio.grpc.MountPOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
+import alluxio.grpc.SetAclPOptions;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.grpc.UnmountPOptions;
+
+/**
+ * This interface defines default options for file system operations that are
+ * common to client and master.
+ */
+public interface FileSystemOptionsProvider {
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  ScheduleAsyncPersistencePOptions scheduleAsyncPersistenceDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  CreateDirectoryPOptions createDirectoryDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  CheckConsistencyPOptions checkConsistencyDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  CreateFilePOptions createFileDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  DeletePOptions deleteDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  ExistsPOptions existsDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  FileSystemMasterCommonPOptions commonDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  FreePOptions freeDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  GetStatusPOptions getStatusDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  ListStatusPOptions listStatusDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  LoadMetadataPOptions loadMetadataDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  MountPOptions mountDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  OpenFilePOptions openFileDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  RenamePOptions renameDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  ScheduleAsyncPersistencePOptions scheduleAsyncPersistDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  SetAclPOptions setAclDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  SetAttributePOptions setAttributeDefaults(AlluxioConfiguration conf);
+
+  /**
+   * Defaults for the SetAttribute RPC which should only be used on the client side.
+   *
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  SetAttributePOptions setAttributeClientDefaults(AlluxioConfiguration conf);
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  UnmountPOptions unmountDefaults(AlluxioConfiguration conf);
+}

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMasterOptionsProvider.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMasterOptionsProvider.java
@@ -11,20 +11,20 @@
 
 package alluxio.master.file;
 
+import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CompleteFilePOptions;
-
-import org.junit.Assert;
-import org.junit.Test;
+import alluxio.util.DefaultFileSystemOptionsProvider;
 
 /**
- * Tests for the {@link alluxio.master.file.FileSystemMasterOptions}.
+ * Default implementation for {@link alluxio.util.FileSystemOptionsProvider} and
+ * {@link FileSystemMasterOptionsProvider}.
  */
-public class FileSystemMasterOptionsTest {
+public class DefaultFileSystemMasterOptionsProvider extends DefaultFileSystemOptionsProvider
+    implements FileSystemMasterOptionsProvider {
 
-  @Test
-  public void completeFileDefaultsTest() {
-    CompleteFilePOptions options = FileSystemMasterOptions.completeFileDefaults();
-    Assert.assertNotNull(options);
-    Assert.assertEquals(0, options.getUfsLength());
+  @Override
+  public CompleteFilePOptions completeFileDefaults() {
+    return CompleteFilePOptions.newBuilder()
+        .setCommonOptions(commonDefaults(ServerConfiguration.global())).setUfsLength(0).build();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptionsProvider.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptionsProvider.java
@@ -11,25 +11,16 @@
 
 package alluxio.master.file;
 
-import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CompleteFilePOptions;
-import alluxio.util.FileSystemOptions;
-
-import javax.annotation.concurrent.ThreadSafe;
+import alluxio.util.FileSystemOptionsProvider;
 
 /**
- * The file system class to set default options for master.
+ * This interface defines default options for master-only file system operations.
  */
-@ThreadSafe
-public final class FileSystemMasterOptions {
+public interface FileSystemMasterOptionsProvider extends FileSystemOptionsProvider {
 
   /**
    * @return Master side defaults for {@link CompleteFilePOptions}
    */
-  public static CompleteFilePOptions completeFileDefaults() {
-    return CompleteFilePOptions.newBuilder()
-        .setCommonOptions(FileSystemOptions.commonDefaults(ServerConfiguration.global()))
-        .setUfsLength(0)
-        .build();
-  }
+  CompleteFilePOptions completeFileDefaults();
 }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CheckConsistencyPOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -48,7 +47,7 @@ public class CheckConsistencyContext extends OperationContext<CheckConsistencyPO
    */
   public static CheckConsistencyContext mergeFrom(CheckConsistencyPOptions.Builder optionsBuilder) {
     CheckConsistencyPOptions masterOptions =
-        FileSystemOptions.checkConsistencyDefaults(ServerConfiguration.global());
+        getOptionsProvider().checkConsistencyDefaults(ServerConfiguration.global());
     CheckConsistencyPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -58,8 +57,8 @@ public class CheckConsistencyContext extends OperationContext<CheckConsistencyPO
    * @return the instance of {@link CheckConsistencyContext} with default values for master
    */
   public static CheckConsistencyContext defaults() {
-    return create(FileSystemOptions
-        .checkConsistencyDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().checkConsistencyDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CompleteFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CompleteFileContext.java
@@ -12,7 +12,6 @@
 package alluxio.master.file.contexts;
 
 import alluxio.grpc.CompleteFilePOptions;
-import alluxio.master.file.FileSystemMasterOptions;
 import alluxio.underfs.UfsStatus;
 
 import com.google.common.base.MoreObjects;
@@ -51,7 +50,7 @@ public class CompleteFileContext extends OperationContext<CompleteFilePOptions.B
    * @return the instance of {@link CompleteFileContext} with default values for master
    */
   public static CompleteFileContext mergeFrom(CompleteFilePOptions.Builder optionsBuilder) {
-    CompleteFilePOptions masterOptions = FileSystemMasterOptions.completeFileDefaults();
+    CompleteFilePOptions masterOptions = getOptionsProvider().completeFileDefaults();
     CompleteFilePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -61,7 +60,7 @@ public class CompleteFileContext extends OperationContext<CompleteFilePOptions.B
    * @return the instance of {@link CompleteFileContext} with default values for master
    */
   public static CompleteFileContext defaults() {
-    return create(FileSystemMasterOptions.completeFileDefaults().toBuilder());
+    return create(getOptionsProvider().completeFileDefaults().toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
@@ -15,7 +15,6 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.security.authorization.AclEntry;
 import alluxio.underfs.UfsStatus;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -59,7 +58,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext mergeFrom(CreateDirectoryPOptions.Builder optionsBuilder) {
     CreateDirectoryPOptions masterOptions =
-        FileSystemOptions.createDirectoryDefaults(ServerConfiguration.global());
+        getOptionsProvider().createDirectoryDefaults(ServerConfiguration.global());
     CreateDirectoryPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -69,8 +68,8 @@ public class CreateDirectoryContext
    * @return the instance of {@link CreateDirectoryContext} with default values for master
    */
   public static CreateDirectoryContext defaults() {
-    return create(FileSystemOptions
-        .createDirectoryDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().createDirectoryDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   protected CreateDirectoryContext getThis() {

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateFilePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -51,7 +50,7 @@ public class CreateFileContext
    */
   public static CreateFileContext mergeFrom(CreateFilePOptions.Builder optionsBuilder) {
     CreateFilePOptions masterOptions =
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global());
+        getOptionsProvider().createFileDefaults(ServerConfiguration.global());
     CreateFilePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return new CreateFileContext(mergedOptionsBuilder);
@@ -61,7 +60,8 @@ public class CreateFileContext
    * @return the instance of {@link CreateFileContext} with default values for master
    */
   public static CreateFileContext defaults() {
-    return create(FileSystemOptions.createFileDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().createFileDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   protected CreateFileContext getThis() {

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.DeletePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +45,8 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder> {
    * @return the instance of {@link DeleteContext} with default values for master
    */
   public static DeleteContext mergeFrom(DeletePOptions.Builder optionsBuilder) {
-    DeletePOptions masterOptions = FileSystemOptions.deleteDefaults(ServerConfiguration.global());
+    DeletePOptions masterOptions =
+        getOptionsProvider().deleteDefaults(ServerConfiguration.global());
     DeletePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder> {
    * @return the instance of {@link DeleteContext} with default values for master
    */
   public static DeleteContext defaults() {
-    return create(FileSystemOptions.deleteDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().deleteDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.FreePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +45,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder> {
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext mergeFrom(FreePOptions.Builder optionsBuilder) {
-    FreePOptions masterOptions = FileSystemOptions.freeDefaults(ServerConfiguration.global());
+    FreePOptions masterOptions = getOptionsProvider().freeDefaults(ServerConfiguration.global());
     FreePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +55,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder> {
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext defaults() {
-    return create(FileSystemOptions.freeDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().freeDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.GetStatusPOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +45,7 @@ public class GetStatusContext extends OperationContext<GetStatusPOptions.Builder
    */
   public static GetStatusContext mergeFrom(GetStatusPOptions.Builder optionsBuilder) {
     GetStatusPOptions masterOptions =
-        FileSystemOptions.getStatusDefaults(ServerConfiguration.global());
+        getOptionsProvider().getStatusDefaults(ServerConfiguration.global());
     GetStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +55,7 @@ public class GetStatusContext extends OperationContext<GetStatusPOptions.Builder
    * @return the instance of {@link GetStatusContext} with default values for master
    */
   public static GetStatusContext defaults() {
-    return create(FileSystemOptions.getStatusDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().getStatusDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.ListStatusPOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -47,7 +46,7 @@ public class ListStatusContext extends OperationContext<ListStatusPOptions.Build
    */
   public static ListStatusContext mergeFrom(ListStatusPOptions.Builder optionsBuilder) {
     ListStatusPOptions masterOptions =
-        FileSystemOptions.listStatusDefaults(ServerConfiguration.global());
+        getOptionsProvider().listStatusDefaults(ServerConfiguration.global());
     ListStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -57,7 +56,8 @@ public class ListStatusContext extends OperationContext<ListStatusPOptions.Build
    * @return the instance of {@link ListStatusContext} with default values for master
    */
   public static ListStatusContext defaults() {
-    return create(FileSystemOptions.listStatusDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().listStatusDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
@@ -14,7 +14,6 @@ package alluxio.master.file.contexts;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.underfs.UfsStatus;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -52,7 +51,7 @@ public class LoadMetadataContext extends OperationContext<LoadMetadataPOptions.B
    */
   public static LoadMetadataContext mergeFrom(LoadMetadataPOptions.Builder optionsBuilder) {
     LoadMetadataPOptions masterOptions =
-        FileSystemOptions.loadMetadataDefaults(ServerConfiguration.global());
+        getOptionsProvider().loadMetadataDefaults(ServerConfiguration.global());
     LoadMetadataPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -62,8 +61,8 @@ public class LoadMetadataContext extends OperationContext<LoadMetadataPOptions.B
    * @return the instance of {@link LoadMetadataContext} with default values for master
    */
   public static LoadMetadataContext defaults() {
-    return create(FileSystemOptions
-        .loadMetadataDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().loadMetadataDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.MountPOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +45,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder> {
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext mergeFrom(MountPOptions.Builder optionsBuilder) {
-    MountPOptions masterOptions = FileSystemOptions.mountDefaults(ServerConfiguration.global());
+    MountPOptions masterOptions = getOptionsProvider().mountDefaults(ServerConfiguration.global());
     MountPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +55,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder> {
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext defaults() {
-    return create(FileSystemOptions.mountDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().mountDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/OperationContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/OperationContext.java
@@ -11,6 +11,9 @@
 
 package alluxio.master.file.contexts;
 
+import alluxio.master.file.FileSystemMasterOptionsProvider;
+import alluxio.master.file.DefaultFileSystemMasterOptionsProvider;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -22,6 +25,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class OperationContext<T extends com.google.protobuf.GeneratedMessageV3.Builder<?>> {
   // Proto message that is being wrapped
   private T mOptionsBuilder;
+
+  // Static options provider for use by all contexts.
+  private static FileSystemMasterOptionsProvider sOptionsProvider;
+  // Initializer for the options provider.
+  static {
+    sOptionsProvider = new DefaultFileSystemMasterOptionsProvider();
+  }
 
   /**
    * Creates an instance with given proto message.
@@ -37,5 +47,12 @@ public class OperationContext<T extends com.google.protobuf.GeneratedMessageV3.B
    */
   public T getOptions() {
     return mOptionsBuilder;
+  }
+
+  /**
+   * @return file system options provider for master
+   */
+  protected static FileSystemMasterOptionsProvider getOptionsProvider() {
+    return sOptionsProvider;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.RenamePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -51,7 +50,8 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder> {
    * @return the instance of {@link RenameContext} with default values for master
    */
   public static RenameContext mergeFrom(RenamePOptions.Builder optionsBuilder) {
-    RenamePOptions masterOptions = FileSystemOptions.renameDefaults(ServerConfiguration.global());
+    RenamePOptions masterOptions =
+        getOptionsProvider().renameDefaults(ServerConfiguration.global());
     RenamePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -61,7 +61,7 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder> {
    * @return the instance of {@link RenameContext} with default values for master
    */
   public static RenameContext defaults() {
-    return create(FileSystemOptions.renameDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().renameDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.ScheduleAsyncPersistencePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -54,7 +53,7 @@ public class ScheduleAsyncPersistenceContext
   public static ScheduleAsyncPersistenceContext mergeFrom(
       ScheduleAsyncPersistencePOptions.Builder optionsBuilder) {
     ScheduleAsyncPersistencePOptions masterOptions =
-        FileSystemOptions.scheduleAsyncPersistenceDefaults(ServerConfiguration.global());
+        getOptionsProvider().scheduleAsyncPersistenceDefaults(ServerConfiguration.global());
     ScheduleAsyncPersistencePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -64,7 +63,7 @@ public class ScheduleAsyncPersistenceContext
    * @return the instance of {@link LoadMetadataContext} with default values for master
    */
   public static ScheduleAsyncPersistenceContext defaults() {
-    return create(FileSystemOptions
+    return create(getOptionsProvider()
         .scheduleAsyncPersistenceDefaults(ServerConfiguration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
@@ -13,7 +13,6 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.SetAclPOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +45,8 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder> {
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext mergeFrom(SetAclPOptions.Builder optionsBuilder) {
-    SetAclPOptions masterOptions = FileSystemOptions.setAclDefaults(ServerConfiguration.global());
+    SetAclPOptions masterOptions =
+        getOptionsProvider().setAclDefaults(ServerConfiguration.global());
     SetAclPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder> {
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext defaults() {
-    return create(FileSystemOptions.setAclDefaults(ServerConfiguration.global()).toBuilder());
+    return create(getOptionsProvider().setAclDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
@@ -14,7 +14,6 @@ package alluxio.master.file.contexts;
 import alluxio.Constants;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.SetAttributePOptions;
-import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
@@ -53,7 +52,7 @@ public class SetAttributeContext extends OperationContext<SetAttributePOptions.B
    */
   public static SetAttributeContext mergeFrom(SetAttributePOptions.Builder optionsBuilder) {
     SetAttributePOptions masterOptions =
-        FileSystemOptions.setAttributeDefaults(ServerConfiguration.global());
+        getOptionsProvider().setAttributeDefaults(ServerConfiguration.global());
     SetAttributePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -63,7 +62,8 @@ public class SetAttributeContext extends OperationContext<SetAttributePOptions.B
    * @return the instance of {@link SetAttributeContext} with default values for master
    */
   public static SetAttributeContext defaults() {
-    return create(FileSystemOptions.setAttributeDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        getOptionsProvider().setAttributeDefaults(ServerConfiguration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/DefaultFileSystemMasterOptionsProviderTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/DefaultFileSystemMasterOptionsProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import alluxio.grpc.CompleteFilePOptions;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link alluxio.master.file.DefaultFileSystemMasterOptionsProvider}.
+ */
+public class DefaultFileSystemMasterOptionsProviderTest {
+  private FileSystemMasterOptionsProvider mOptionsProvider;
+
+  @Before
+  public void before() throws Exception {
+    mOptionsProvider = new DefaultFileSystemMasterOptionsProvider();
+  }
+
+  @Test
+  public void completeFileDefaultsTest() {
+    CompleteFilePOptions options = mOptionsProvider.completeFileDefaults();
+    Assert.assertNotNull(options);
+    Assert.assertEquals(0, options.getUfsLength());
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -89,7 +89,6 @@ import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.Mode;
 import alluxio.security.user.TestUserState;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.IdUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
@@ -161,6 +160,7 @@ public final class FileSystemMasterTest {
   private BlockMaster mBlockMaster;
   private ExecutorService mExecutorService;
   private DefaultFileSystemMaster mFileSystemMaster;
+  private FileSystemMasterOptionsProvider mOptionsProvider;
   private ReadOnlyInodeStore mInodeStore;
   private MetricsMaster mMetricsMaster;
   private List<Metric> mMetrics;
@@ -1672,10 +1672,10 @@ public final class FileSystemMasterTest {
     long blockId = createFileWithSingleBlock(NESTED_FILE_URI);
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
-    mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
-            .commonDefaults(ServerConfiguration.global()).toBuilder().setTtl(0)
-            .setTtlAction(alluxio.grpc.TtlAction.FREE))));
+    mFileSystemMaster.setAttribute(NESTED_FILE_URI,
+        SetAttributeContext.mergeFrom(SetAttributePOptions.newBuilder()
+            .setCommonOptions(mOptionsProvider.commonDefaults(ServerConfiguration.global())
+                .toBuilder().setTtl(0).setTtlAction(alluxio.grpc.TtlAction.FREE))));
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of("MEM", (long) Constants.KB), ImmutableList.of(blockId),
         ImmutableMap.of(), ImmutableMap.of(), mMetrics);
@@ -1692,10 +1692,10 @@ public final class FileSystemMasterTest {
     long blockId = createFileWithSingleBlock(NESTED_FILE_URI);
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
-    mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
-            .commonDefaults(ServerConfiguration.global()).toBuilder().setTtl(0)
-            .setTtlAction(alluxio.grpc.TtlAction.FREE))));
+    mFileSystemMaster.setAttribute(NESTED_FILE_URI,
+        SetAttributeContext.mergeFrom(SetAttributePOptions.newBuilder()
+            .setCommonOptions(mOptionsProvider.commonDefaults(ServerConfiguration.global())
+                .toBuilder().setTtl(0).setTtlAction(alluxio.grpc.TtlAction.FREE))));
     // Simulate restart.
     stopServices();
     startServices();
@@ -1742,10 +1742,10 @@ public final class FileSystemMasterTest {
     long blockId = createFileWithSingleBlock(NESTED_FILE_URI);
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
-    mFileSystemMaster.setAttribute(NESTED_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
-            .commonDefaults(ServerConfiguration.global()).toBuilder().setTtl(0)
-            .setTtlAction(alluxio.grpc.TtlAction.FREE))));
+    mFileSystemMaster.setAttribute(NESTED_URI,
+        SetAttributeContext.mergeFrom(SetAttributePOptions.newBuilder()
+            .setCommonOptions(mOptionsProvider.commonDefaults(ServerConfiguration.global())
+                .toBuilder().setTtl(0).setTtlAction(alluxio.grpc.TtlAction.FREE))));
 
     // Simulate restart.
     stopServices();
@@ -2676,6 +2676,7 @@ public final class FileSystemMasterTest {
         ThreadFactoryUtils.build("DefaultFileSystemMasterTest-%d", true));
     mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster, masterContext,
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
+    mOptionsProvider = new DefaultFileSystemMasterOptionsProvider();
     mInodeStore = mFileSystemMaster.getInodeStore();
     mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
     mJournalSystem.start();

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -54,7 +54,8 @@ import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.security.authorization.Mode;
 import alluxio.security.group.GroupMappingService;
 import alluxio.security.user.TestUserState;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.DefaultFileSystemOptionsProvider;
+import alluxio.util.FileSystemOptionsProvider;
 import alluxio.util.SecurityUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.FileInfo;
@@ -112,6 +113,7 @@ public final class PermissionCheckTest {
   private MasterRegistry mRegistry;
   private MetricsMaster mMetricsMaster;
   private FileSystemMaster mFileSystemMaster;
+  private FileSystemOptionsProvider mOptionsProvider;
 
   @Rule
   public ConfigurationRule mConfiguration =
@@ -187,6 +189,7 @@ public final class PermissionCheckTest {
     mMetricsMaster = new MetricsMasterFactory().create(mRegistry, masterContext);
     new BlockMasterFactory().create(mRegistry, masterContext);
     mFileSystemMaster = new FileSystemMasterFactory().create(mRegistry, masterContext);
+    mOptionsProvider = new DefaultFileSystemOptionsProvider();
     mRegistry.start(true);
 
     createDirAndFileForTest();
@@ -699,9 +702,10 @@ public final class PermissionCheckTest {
 
       FileInfo fileInfo = mFileSystemMaster.getFileInfo(new AlluxioURI(path),
           GetStatusContext.defaults());
-      return FileSystemOptions.setAttributeDefaults(ServerConfiguration.global()).toBuilder()
-          .setPinned(fileInfo.isPinned()).setCommonOptions(FileSystemMasterCommonPOptions
-              .newBuilder().setTtl(fileInfo.getTtl()).build())
+      return mOptionsProvider.setAttributeDefaults(ServerConfiguration.global()).toBuilder()
+          .setPinned(fileInfo.isPinned())
+          .setCommonOptions(
+              FileSystemMasterCommonPOptions.newBuilder().setTtl(fileInfo.getTtl()).build())
           .setPersisted(fileInfo.isPersisted()).build();
     }
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
@@ -23,7 +23,6 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FileSystemOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -136,9 +135,8 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
    */
   private void runConsistencyCheck(AlluxioURI path, boolean repairConsistency, int repairThreads)
       throws AlluxioException, IOException {
-    List<AlluxioURI> inconsistentUris =
-        checkConsistency(path, FileSystemOptions.checkConsistencyDefaults(
-            mFsContext.getPathConf(path)));
+    List<AlluxioURI> inconsistentUris = checkConsistency(path,
+        mFsContext.getOptionsProvider().checkConsistencyDefaults(mFsContext.getPathConf(path)));
     if (inconsistentUris.isEmpty()) {
       System.out.println(path + " is consistent with the under storage system.");
       return;

--- a/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
+++ b/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
@@ -21,7 +21,6 @@ import alluxio.master.backcompat.TestOp;
 import alluxio.master.backcompat.Utils;
 import alluxio.multi.process.Clients;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.WaitForOptions;
 
 import java.util.Arrays;
@@ -38,10 +37,10 @@ public final class PersistFile implements TestOp {
     FileSystem fs = clients.getFileSystemClient();
     Utils.createFile(fs, PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+        fs.getOptionsProvider().scheduleAsyncPersistDefaults(ServerConfiguration.global()));
     Utils.createFile(fs, NESTED_PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(NESTED_PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+        fs.getOptionsProvider().scheduleAsyncPersistDefaults(ServerConfiguration.global()));
     CommonUtils.waitFor("file to be async persisted", () -> {
       try {
         return fs.getStatus(PATH).isPersisted() && fs.getStatus(NESTED_PATH).isPersisted();

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -42,7 +42,6 @@ import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.io.FileUtils;
 
 import com.google.common.collect.Sets;
@@ -561,9 +560,11 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     writeUfsFile(ufsPath(fileB), 1);
 
     // Should not exist, since no loading or syncing
-    assertFalse(mFileSystem.exists(new AlluxioURI(alluxioPath(fileA)), ExistsPOptions.newBuilder()
-        .setCommonOptions(FileSystemOptions.commonDefaults(mFileSystem.getConf()).toBuilder()
-            .setSyncIntervalMs(-1).build()).build()));
+    assertFalse(mFileSystem.exists(new AlluxioURI(alluxioPath(fileA)),
+        ExistsPOptions.newBuilder()
+            .setCommonOptions(
+                FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build())
+            .build()));
 
     try {
       mFileSystem.setAttribute(new AlluxioURI(alluxioPath("/dir1")),

--- a/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/persist/PersistIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.job.JobIntegrationTest;
 import alluxio.job.wire.JobInfo;
@@ -32,7 +33,6 @@ import alluxio.security.authorization.Mode;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 
@@ -132,7 +132,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(new AlluxioURI(TEST_URI),
-          FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+          ScheduleAsyncPersistencePOptions.getDefaultInstance());
     }
     CommonUtils.waitFor("persist timeout", () -> {
       try {
@@ -171,7 +171,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(path,
-          FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+          ScheduleAsyncPersistencePOptions.getDefaultInstance());
       Assert.fail("Should not be able to schedule persistence for incomplete file");
     } catch (Exception e) {
       // expected

--- a/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
@@ -25,9 +25,10 @@ import alluxio.security.user.TestUserState;
 import alluxio.security.user.UserState;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsProvider;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,6 +50,13 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
   private static final String SUPERGROUP = "supergroup";
   private static final String NONSUPER = "nonsuper";
   private static final String SUPERUSER = "alluxio";
+  private FileSystemOptionsProvider mOptionsProvider;
+
+  @Before
+  public void before() throws Exception {
+    // Get options provider from cluster.
+    mOptionsProvider = mLocalAlluxioClusterResource.get().getClient().getOptionsProvider();
+  }
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -144,10 +152,10 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
     masterClient.createFile(new AlluxioURI(filename),
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global()));
+        mOptionsProvider.createFileDefaults(ServerConfiguration.global()));
     Assert.assertNotNull(
         masterClient.getStatus(new AlluxioURI(filename),
-            FileSystemOptions.getStatusDefaults(ServerConfiguration.global())));
+            mOptionsProvider.getStatusDefaults(ServerConfiguration.global())));
     masterClient.disconnect();
     masterClient.close();
   }

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -20,6 +20,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.GetStatusPOptions;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.master.MasterClientContext;
@@ -29,7 +30,6 @@ import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.ufs.UfsJournal;
 import alluxio.master.journal.ufs.UfsJournalSnapshot;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
 import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.BlockHeartbeatReporter;
@@ -76,8 +76,7 @@ public final class IntegrationTestUtils {
             .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
       CommonUtils.waitFor(uri + " to be persisted", () -> {
         try {
-          return client.getStatus(uri,
-              FileSystemOptions.getStatusDefaults(ServerConfiguration.global())).isPersisted();
+          return client.getStatus(uri, GetStatusPOptions.getDefaultInstance()).isPersisted();
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }


### PR DESCRIPTION
Required for supporting transparent URI as each outgoing request should contain an auxiliary flag for master to decide whether to allow or deny the request for non-Alluxio scheme.