### PR TITLE
[DOCFIX] Add mkdir step to Alluxio building guide

### DIFF
--- a/docs/en/contributor/Building-Alluxio-From-Source.md
+++ b/docs/en/contributor/Building-Alluxio-From-Source.md
@@ -72,6 +72,8 @@ all the dependencies. Subsequent builds, however, will be much faster.
 Once Alluxio is built, you can validate and start it with:
 
 ```console
+$ # Alluxio uses ./underFSStorage for under file system storage by default
+$ mkdir ./underFSStorage 
 $ ./bin/alluxio validateEnv local
 $ ./bin/alluxio format
 $ ./bin/alluxio-start.sh local SudoMount


### PR DESCRIPTION
fixes #9251

For a user new to Alluxio and follows the Building-Alluxio-From-Source guide for the first time, the cloned repository doesn't have directory `./underFSStorage`. `bin/alluxio validateEnv local` will complain this directory doesn't exist and fail. 

I think it makes sense to add this step in the guide.