### PR TITLE
Fix NPE during RaftJournal shut down

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -503,7 +503,9 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void stopInternal() throws InterruptedException, IOException {
     LOG.info("Shutting down raft journal");
-    mRaftJournalWriter.close();
+    if (mRaftJournalWriter != null) {
+      mRaftJournalWriter.close();
+    }
     try {
       mServer.shutdown().get(ServerConfiguration
           .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This issue is encountered while authoring a new integration test for growing embedded journal cluster. Stopping a standby master was failing with NPE