### PR TITLE
Close journal system properly when stopping Alluxio processes

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -161,9 +161,9 @@ public class AlluxioMasterProcess extends MasterProcess {
     stopRejectingServers();
     if (isServing()) {
       stopServing();
-      mJournalSystem.stop();
     }
     closeMasters();
+    mJournalSystem.stop();
   }
 
   private void initFromBackup(AlluxioURI backup) throws IOException {

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -149,9 +149,9 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     stopRejectingServers();
     if (isServing()) {
       stopServing();
-      mJournalSystem.stop();
     }
     stopMaster();
+    mJournalSystem.stop();
   }
 
   protected void startMaster(boolean isLeader) {

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioJobCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioJobCluster.java
@@ -44,6 +44,8 @@ public final class LocalAlluxioJobCluster {
   private Thread mMasterThread;
   private Thread mWorkerThread;
 
+  private boolean mIsRunning = false;
+
   /**
    * Creates a new instance of {@link LocalAlluxioJobCluster}.
    */
@@ -63,6 +65,7 @@ public final class LocalAlluxioJobCluster {
     TestUtils.waitForReady(mMaster);
     startWorker();
     TestUtils.waitForReady(mWorker);
+    mIsRunning = true;
   }
 
   /**
@@ -71,9 +74,12 @@ public final class LocalAlluxioJobCluster {
    * @throws Exception when the operation fails
    */
   public void stop() throws Exception {
-    LOG.info("Stop Alluxio job service");
-    mWorker.stop();
-    mMaster.stop();
+    if (mIsRunning) {
+      LOG.info("Stop Alluxio job service");
+      mWorker.stop();
+      mMaster.stop();
+      mIsRunning = false;
+    }
   }
 
   /**


### PR DESCRIPTION
This issue is encountered while authoring a new integration test for growing embedded journal cluster. Restarting an in-process master showed that journal system was not being closed during stopping standby masters.