### PR TITLE
[DOCFIX] Add img links to Overview and Getting Started docs with HTML

### DIFF
--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -25,8 +25,10 @@ The optional sections will be labeled with **[Bonus]**.
 **Note**  This guide is designed to start an Alluxio system with minimal setup on a single machine.
 
 If you are trying to speedup SQL analytics, you can try the Presto Alluxio Getting Started tutorial:
-- [On laptop using docker](https://www.alluxio.io/alluxio-presto-sandbox-docker/)
-- [On Amazon AWS using AMI](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
+
+|  |  |
+| :---: | :---: |
+| [![Laptop with Docker](https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png)](https://www.alluxio.io/alluxio-presto-sandbox-docker/) | [![AWS with AMI](https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png)](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
 
 In addition, you can try more advanced testing with a cluster of Alluxio. 
 - Request [a sandbox cluster](https://www.alluxio.io/sandbox-request/) with Alluxio and Spark installed on AWS for free

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -26,9 +26,12 @@ The optional sections will be labeled with **[Bonus]**.
 
 If you are trying to speedup SQL analytics, you can try the Presto Alluxio Getting Started tutorial:
 
-|  |  |
-| :---: | :---: |
-| [![Laptop with Docker](https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png)](https://www.alluxio.io/alluxio-presto-sandbox-docker/) | [![AWS with AMI](https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png)](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
+<p align="center">
+<a href="https://www.alluxio.io/alluxio-presto-sandbox-docker/">
+ <img src="https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png" width="250" alt="Laptop with Docker"/></a>
+<a href="https://www.alluxio.io/alluxio-presto-sandbox-aws/">
+ <img src="https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png" width="250" alt="AWS with AMI"/></a>
+</p>
 
 In addition, you can try more advanced testing with a cluster of Alluxio. 
 - Request [a sandbox cluster](https://www.alluxio.io/sandbox-request/) with Alluxio and Spark installed on AWS for free

--- a/docs/en/Overview.md
+++ b/docs/en/Overview.md
@@ -107,9 +107,12 @@ which explains how to deploy Alluxio and run examples in a local environment.
 
 Also try our getting started tutorials for Presto & Alluxio via:
 
-|  |  |
-| :---: | :---: |
-| [![Laptop with Docker](https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png)](https://www.alluxio.io/alluxio-presto-sandbox-docker/) | [![AWS with AMI](https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png)](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
+<p align="center">
+<a href="https://www.alluxio.io/alluxio-presto-sandbox-docker/">
+ <img src="https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png" width="250" alt="Laptop with Docker"/></a>
+<a href="https://www.alluxio.io/alluxio-presto-sandbox-aws/">
+ <img src="https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png" width="250" alt="AWS with AMI"/></a>
+</p>
 
 In addition, you can try more advanced testing with a cluster of Alluxio. 
 - Request [a sandbox cluster](https://www.alluxio.io/sandbox-request/) with Alluxio and Spark installed on AWS for free

--- a/docs/en/Overview.md
+++ b/docs/en/Overview.md
@@ -106,8 +106,10 @@ To quickly get Alluxio up and running, take a look at our
 which explains how to deploy Alluxio and run examples in a local environment.
 
 Also try our getting started tutorials for Presto & Alluxio via:
-- [On laptop using docker](https://www.alluxio.io/alluxio-presto-sandbox-docker/)
-- [On Amazon AWS using AMI](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
+
+|  |  |
+| :---: | :---: |
+| [![Laptop with Docker](https://www.alluxio.io/app/uploads/2019/07/laptop-docker.png)](https://www.alluxio.io/alluxio-presto-sandbox-docker/) | [![AWS with AMI](https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png)](https://www.alluxio.io/alluxio-presto-sandbox-aws/)
 
 In addition, you can try more advanced testing with a cluster of Alluxio. 
 - Request [a sandbox cluster](https://www.alluxio.io/sandbox-request/) with Alluxio and Spark installed on AWS for free


### PR DESCRIPTION
Add HTML img links to Overview and Getting Started pages.

Images will look like: 

![Screen Shot 2019-08-07 at 1 17 31 PM](https://user-images.githubusercontent.com/3826800/62655433-ceb68d00-b916-11e9-966f-f412d95374cb.png)
