### PR TITLE
Implement ShimFileSystem

### DIFF
--- a/core/base/src/main/java/alluxio/Constants.java
+++ b/core/base/src/main/java/alluxio/Constants.java
@@ -57,6 +57,7 @@ public final class Constants {
 
   public static final long UNKNOWN_SIZE = -1;
 
+  public static final String SHIM_SCHEME = "alluxio-shim";
   public static final String SCHEME = "alluxio";
   public static final String HEADER = SCHEME + "://";
 

--- a/core/base/src/main/java/alluxio/Constants.java
+++ b/core/base/src/main/java/alluxio/Constants.java
@@ -57,7 +57,7 @@ public final class Constants {
 
   public static final long UNKNOWN_SIZE = -1;
 
-  public static final String SHIM_SCHEME = "alluxio-shim";
+  public static final String NO_SCHEME = "alluxio-noop";
   public static final String SCHEME = "alluxio";
   public static final String HEADER = SCHEME + "://";
 

--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -259,6 +259,7 @@ public enum ExceptionMessage {
       "Mount path {0} shadows an existing path {1} in the parent underlying filesystem"),
   MOUNT_READONLY("A write operation on {0} under a readonly mount point {1} is not allowed"),
   UFS_PATH_DOES_NOT_EXIST("Ufs path {0} does not exist"),
+  FOREIGN_URI_NOT_MOUNTED("Foreign URI: {0} is not found on Alluxio mounts."),
 
   // key-value
   KEY_VALUE_TOO_LARGE("Unable to put key-value pair: key {0} bytes, value {1} bytes"),

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -542,6 +542,10 @@ public class BaseFileSystem implements FileSystem {
    */
   private void checkUri(AlluxioURI uri) {
     Preconditions.checkNotNull(uri, "uri");
+    if (mFsContext.getDisableUriValidation()) {
+      return;
+    }
+
     if (uri.hasScheme()) {
       String warnMsg = "The URI scheme \"{}\" is ignored and not required in URIs passed to"
           + " the Alluxio Filesystem client.";

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -542,7 +542,7 @@ public class BaseFileSystem implements FileSystem {
    */
   private void checkUri(AlluxioURI uri) {
     Preconditions.checkNotNull(uri, "uri");
-    if (mFsContext.getDisableUriValidation()) {
+    if (!mFsContext.getUriValidationEnabled()) {
       return;
     }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -179,7 +179,6 @@ public final class FileSystemContext implements Closeable {
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
     ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf()));
-    ctx.mUriValidationEnabled = clientContext.getUriValidationEnabled();
     return ctx;
   }
 
@@ -235,6 +234,7 @@ public final class FileSystemContext implements Closeable {
     if (mMetricsEnabled) {
       MetricsHeartbeatContext.addHeartbeat(getClientContext(), masterInquireClient);
     }
+    mUriValidationEnabled = ctx.getUriValidationEnabled();
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -393,7 +393,7 @@ public final class FileSystemContext implements Closeable {
   /**
    * @return {@code true} if URI validation is enabled
    */
-  public boolean getUriValidationEnabled() {
+  public synchronized boolean getUriValidationEnabled() {
     return mUriValidationEnabled;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -144,6 +144,9 @@ public final class FileSystemContext implements Closeable {
    */
   private volatile FileSystemContextReinitializer mReinitializer;
 
+  /** Whether to disable URI scheme validation for file systems using this context.  */
+  private boolean mDisableUriValidation = false;
+
   /**
    * Creates a {@link FileSystemContext} with a null subject.
    *
@@ -176,6 +179,7 @@ public final class FileSystemContext implements Closeable {
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
     ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf()));
+    ctx.mDisableUriValidation = clientContext.getDisableSchemeValidation();
     return ctx;
   }
 
@@ -384,6 +388,13 @@ public final class FileSystemContext implements Closeable {
    */
   public synchronized InetSocketAddress getMasterAddress() throws UnavailableException {
     return mMasterClientContext.getMasterInquireClient().getPrimaryRpcAddress();
+  }
+
+  /**
+   * @return {@code true} if URI validation is disabled
+   */
+  public boolean getDisableUriValidation() {
+    return mDisableUriValidation;
   }
 
   private FileSystemMasterClient acquireMasterClient() {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -144,8 +144,8 @@ public final class FileSystemContext implements Closeable {
    */
   private volatile FileSystemContextReinitializer mReinitializer;
 
-  /** Whether to disable URI scheme validation for file systems using this context.  */
-  private boolean mDisableUriValidation = false;
+  /** Whether to do URI scheme validation for file systems using this context.  */
+  private boolean mUriValidationEnabled = true;
 
   /**
    * Creates a {@link FileSystemContext} with a null subject.
@@ -179,7 +179,7 @@ public final class FileSystemContext implements Closeable {
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
     ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf()));
-    ctx.mDisableUriValidation = clientContext.getDisableSchemeValidation();
+    ctx.mUriValidationEnabled = clientContext.getUriValidationEnabled();
     return ctx;
   }
 
@@ -391,10 +391,10 @@ public final class FileSystemContext implements Closeable {
   }
 
   /**
-   * @return {@code true} if URI validation is disabled
+   * @return {@code true} if URI validation is enabled
    */
-  public boolean getDisableUriValidation() {
-    return mDisableUriValidation;
+  public boolean getUriValidationEnabled() {
+    return mUriValidationEnabled;
   }
 
   private FileSystemMasterClient acquireMasterClient() {

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -114,7 +114,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       final CheckConsistencyPOptions options) throws AlluxioStatusException {
     return retryRPC(() -> {
       List<String> inconsistentPaths = mClient.checkConsistency(CheckConsistencyPRequest
-          .newBuilder().setPath(path.getPath()).setOptions(options).build())
+          .newBuilder().setPath(path.toString()).setOptions(options).build())
           .getInconsistentPathsList();
       List<AlluxioURI> inconsistentUris = new ArrayList<>(inconsistentPaths.size());
       for (String inconsistentPath : inconsistentPaths) {
@@ -129,7 +129,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       final CreateDirectoryPOptions options) throws AlluxioStatusException {
     retryRPC(
         () -> mClient.createDirectory(CreateDirectoryPRequest.newBuilder()
-            .setPath(path.getPath()).setOptions(options).build()),
+            .setPath(path.toString()).setOptions(options).build()),
         "CreateDirectory");
   }
 
@@ -138,7 +138,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       throws AlluxioStatusException {
     return retryRPC(
         () -> new URIStatus(GrpcUtils.fromProto(mClient.createFile(
-            CreateFilePRequest.newBuilder().setPath(path.getPath()).setOptions(options).build())
+            CreateFilePRequest.newBuilder().setPath(path.toString()).setOptions(options).build())
             .getFileInfo())), "CreateFile");
   }
 
@@ -146,20 +146,20 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   public void completeFile(final AlluxioURI path, final CompleteFilePOptions options)
       throws AlluxioStatusException {
     retryRPC(() -> mClient.completeFile(CompleteFilePRequest.newBuilder()
-        .setPath(path.getPath()).setOptions(options).build()), "CompleteFile");
+        .setPath(path.toString()).setOptions(options).build()), "CompleteFile");
   }
 
   @Override
   public void delete(final AlluxioURI path, final DeletePOptions options)
       throws AlluxioStatusException {
-    retryRPC(() -> mClient.remove(DeletePRequest.newBuilder().setPath(path.getPath())
+    retryRPC(() -> mClient.remove(DeletePRequest.newBuilder().setPath(path.toString())
         .setOptions(options).build()), "Delete");
   }
 
   @Override
   public void free(final AlluxioURI path, final FreePOptions options)
       throws AlluxioStatusException {
-    retryRPC(() -> mClient.free(FreePRequest.newBuilder().setPath(path.getPath())
+    retryRPC(() -> mClient.free(FreePRequest.newBuilder().setPath(path.toString())
         .setOptions(options).build()), "Free");
   }
 
@@ -173,7 +173,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   public URIStatus getStatus(final AlluxioURI path, final GetStatusPOptions options)
       throws AlluxioStatusException {
     return retryRPC(() -> new URIStatus(GrpcUtils
-        .fromProto(mClient.getStatus(GetStatusPRequest.newBuilder().setPath(path.getPath())
+        .fromProto(mClient.getStatus(GetStatusPRequest.newBuilder().setPath(path.toString())
             .setOptions(options).build()).getFileInfo())),
         "GetStatus");
   }
@@ -190,15 +190,14 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       throws AlluxioStatusException {
     return retryRPC(
         () -> mClient
-            .getNewBlockIdForFile(GetNewBlockIdForFilePRequest.newBuilder().setPath(path.getPath())
+            .getNewBlockIdForFile(GetNewBlockIdForFilePRequest.newBuilder().setPath(path.toString())
                 .setOptions(GetNewBlockIdForFilePOptions.newBuilder().build()).build())
             .getId(),
         "GetNewBlockIdForFile");
   }
 
   @Override
-  public Map<String, alluxio.wire.MountPointInfo> getMountTable()
-      throws AlluxioStatusException {
+  public Map<String, alluxio.wire.MountPointInfo> getMountTable() throws AlluxioStatusException {
     return retryRPC(() -> {
       Map<String, alluxio.wire.MountPointInfo> mountTableWire = new HashMap<>();
       for (Map.Entry<String, alluxio.grpc.MountPointInfo> entry : mClient
@@ -217,7 +216,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       List<URIStatus> result = new ArrayList<>();
       mClient
           .listStatus(
-              ListStatusPRequest.newBuilder().setPath(path.getPath()).setOptions(options).build())
+              ListStatusPRequest.newBuilder().setPath(path.toString()).setOptions(options).build())
           .forEachRemaining(
               (pListStatusResponse) -> result.addAll(pListStatusResponse.getFileInfosList().stream()
                   .map((pFileInfo) -> new URIStatus(GrpcUtils.fromProto(pFileInfo)))
@@ -254,15 +253,15 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   @Override
   public void rename(final AlluxioURI src, final AlluxioURI dst,
       final RenamePOptions options) throws AlluxioStatusException {
-    retryRPC(() -> mClient.rename(RenamePRequest.newBuilder().setPath(src.getPath())
-        .setDstPath(dst.getPath()).setOptions(options).build()), "Rename");
+    retryRPC(() -> mClient.rename(RenamePRequest.newBuilder().setPath(src.toString())
+        .setDstPath(dst.toString()).setOptions(options).build()), "Rename");
   }
 
   @Override
   public void setAcl(AlluxioURI path, SetAclAction action, List<AclEntry> entries,
       SetAclPOptions options) throws AlluxioStatusException {
     retryRPC(() -> mClient.setAcl(
-        SetAclPRequest.newBuilder().setPath(path.getPath()).setAction(action)
+        SetAclPRequest.newBuilder().setPath(path.toString()).setAction(action)
             .addAllEntries(entries.stream().map(GrpcUtils::toProto).collect(Collectors.toList()))
             .setOptions(options).build()),
         "SetAcl");
@@ -272,7 +271,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   public void setAttribute(final AlluxioURI path, final SetAttributePOptions options)
       throws AlluxioStatusException {
     retryRPC(() -> mClient.setAttribute(SetAttributePRequest.newBuilder()
-        .setPath(path.getPath()).setOptions(options).build()), "SetAttribute");
+        .setPath(path.toString()).setOptions(options).build()), "SetAttribute");
   }
 
   @Override
@@ -280,19 +279,19 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
       throws AlluxioStatusException {
     retryRPC(
         () -> mClient.scheduleAsyncPersistence(ScheduleAsyncPersistencePRequest.newBuilder()
-            .setPath(path.getPath()).setOptions(options).build()), "ScheduleAsyncPersist");
+            .setPath(path.toString()).setOptions(options).build()), "ScheduleAsyncPersist");
   }
 
   @Override
   public synchronized void startSync(final AlluxioURI path) throws AlluxioStatusException {
     retryRPC(
-        () -> mClient.startSync(StartSyncPRequest.newBuilder().setPath(path.getPath()).build()),
+        () -> mClient.startSync(StartSyncPRequest.newBuilder().setPath(path.toString()).build()),
         "StartSync");
   }
 
   @Override
   public synchronized void stopSync(final AlluxioURI path) throws AlluxioStatusException {
-    retryRPC(() -> mClient.stopSync(StopSyncPRequest.newBuilder().setPath(path.getPath()).build()),
+    retryRPC(() -> mClient.stopSync(StopSyncPRequest.newBuilder().setPath(path.toString()).build()),
         "StopSync");
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -319,7 +319,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
    * @param uri uri
    * @return transport path
    */
-  private String getTransportPath(AlluxioURI uri) {
+  private static String getTransportPath(AlluxioURI uri) {
     if (uri.hasScheme()) {
       return uri.toString();
     } else {

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -284,20 +284,23 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   @Override
   public synchronized void startSync(final AlluxioURI path) throws AlluxioStatusException {
     retryRPC(
-        () -> mClient.startSync(StartSyncPRequest.newBuilder().setPath(path.getPath()).build()),
+        () -> mClient
+            .startSync(StartSyncPRequest.newBuilder().setPath(getTransportPath(path)).build()),
         "StartSync");
   }
 
   @Override
   public synchronized void stopSync(final AlluxioURI path) throws AlluxioStatusException {
-    retryRPC(() -> mClient.stopSync(StopSyncPRequest.newBuilder().setPath(path.getPath()).build()),
+    retryRPC(
+        () -> mClient
+            .stopSync(StopSyncPRequest.newBuilder().setPath(getTransportPath(path)).build()),
         "StopSync");
   }
 
   @Override
   public void unmount(final AlluxioURI alluxioPath) throws AlluxioStatusException {
     retryRPC(() -> mClient
-        .unmount(UnmountPRequest.newBuilder().setAlluxioPath(alluxioPath.toString())
+        .unmount(UnmountPRequest.newBuilder().setAlluxioPath(getTransportPath(alluxioPath))
             .setOptions(UnmountPOptions.newBuilder().build()).build()),
         "Unmount");
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -313,8 +313,6 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
 
   /**
    * Gets the path that will be transported to master.
-   * Scheme-less URIs are assumed to be Alluxio paths,
-   * and getPath() is used to avoid string conversion.
    *
    * @param uri uri
    * @return transport path
@@ -323,6 +321,8 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
     if (uri.hasScheme()) {
       return uri.toString();
     } else {
+      // Scheme-less URIs are assumed to be Alluxio paths
+      // and getPath() is used to avoid string conversion.
       return uri.getPath();
     }
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -103,6 +103,7 @@ public final class BaseFileSystemTest {
     when(mFileContext.getClientContext()).thenReturn(mClientContext);
     when(mFileContext.getClusterConf()).thenReturn(mConf);
     when(mFileContext.getPathConf(any())).thenReturn(mConf);
+    when(mFileContext.getUriValidationEnabled()).thenReturn(true);
     mFileSystem = new DummyAlluxioFileSystem(mFileContext);
   }
 

--- a/core/client/hdfs/pom.xml
+++ b/core/client/hdfs/pom.xml
@@ -82,8 +82,9 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <excludes>
-                <!--In hadoop-1 profile, we skip build AlluxioFileSystem.java which requires hadoop-2 -->
+                <!--In hadoop-1 profile, we skip build delegate file systems which require hadoop-2 -->
                 <exclude>**/AlluxioFileSystem.java</exclude>
+                <exclude>**/AlluxioShimFileSystem.java</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -470,13 +470,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
     // HDFS doesn't allow the authority to be empty; it must be "/" instead.
     String authority = uri.getAuthority() == null ? "/" : uri.getAuthority();
-    // Use URI's scheme for shim mode.
-    String scheme = getScheme();
-    // Extract the scheme from URI if FS implementation is not bound to a scheme.
-    if (scheme.equals(Constants.NO_SCHEME)) {
-      scheme = uri.getScheme();
-    }
-    mAlluxioHeader = scheme + "://" + authority;
+    mAlluxioHeader = getFsScheme(uri) + "://" + authority;
     // Set the statistics member. Use mStatistics instead of the parent class's variable.
     mStatistics = statistics;
     mUri = URI.create(mAlluxioHeader);
@@ -753,6 +747,14 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @throws IllegalArgumentException
    */
   protected abstract void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException;
+
+  /**
+   * Used to get FS scheme.
+   *
+   * @param fsUri file system base URI
+   * @return file system scheme
+   */
+  protected abstract String getFsScheme(URI fsUri);
 
   /**
    * Used to convert hadoop path to Alluxio path.

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -509,8 +509,10 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
     // Create FileSystem for accessing Alluxio.
     // Disable URI validation for non-Alluxio schemes.
-    mFileSystem = FileSystem.Factory.create(ClientContext.create(subject, alluxioConf)
-        .setUriValidationEnabled(uri.getScheme().equals(Constants.SCHEME)));
+    boolean disableUriValidation =
+        (uri.getScheme() != null) ? uri.getScheme().equals(Constants.SCHEME) : true;
+    mFileSystem = FileSystem.Factory.create(
+        ClientContext.create(subject, alluxioConf).setUriValidationEnabled(disableUriValidation));
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -28,7 +28,6 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
-import alluxio.exception.PreconditionMessage;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -36,17 +35,14 @@ import alluxio.grpc.SetAttributePOptions;
 import alluxio.master.MasterInquireClient.Factory;
 import alluxio.security.CurrentUser;
 import alluxio.security.authorization.Mode;
-import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
 import alluxio.uri.SingleMasterAuthority;
-import alluxio.uri.UnknownAuthority;
 import alluxio.uri.ZookeeperAuthority;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
-import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.BlockLocation;
@@ -526,17 +522,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @throws IOException
    * @throws IllegalArgumentException
    */
-  protected void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException {
-    Preconditions.checkArgument(fsUri.getScheme().equals(getScheme()),
-        PreconditionMessage.URI_SCHEME_MISMATCH.toString(), fsUri.getScheme(), getScheme());
-
-    Authority auth = Authority.fromString(fsUri.getAuthority());
-    // Do not allow {@link UnknownAuthority} for alluxio:// scheme.
-    if (auth instanceof UnknownAuthority) {
-      throw new IOException(String.format("Authority \"%s\" is unknown. The client can not be "
-          + "configured with the authority from %s", auth, fsUri));
-    }
-  }
+  protected abstract void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException;
 
   /**
    * Merges the URI configuration with the Hadoop and Alluxio configuration, returning an

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -97,23 +97,29 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   private String mAlluxioHeader = null;
 
   /** Whether this fs should act like a shim for a foreign scheme. */
-  private boolean mIsShimFs = false;
+  private final boolean mIsShimFs;
 
   /**
    * Constructs a new {@link AbstractFileSystem} instance with specified a {@link FileSystem}
    * handler for tests.
    *
    * @param fileSystem handler to file system
+   * @param isShimFs whether to act as a shim
    */
   @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
-  AbstractFileSystem(FileSystem fileSystem) {
+  AbstractFileSystem(FileSystem fileSystem, boolean isShimFs) {
     mFileSystem = fileSystem;
+    mIsShimFs = isShimFs;
   }
 
   /**
    * Constructs a new {@link AbstractFileSystem} instance.
+   *
+   * @param isShimFs whether to act as a shim
    */
-  AbstractFileSystem() {}
+  AbstractFileSystem(boolean isShimFs) {
+    mIsShimFs = isShimFs;
+  }
 
   @Override
   public FSDataOutputStream append(Path path, int bufferSize, Progressable progress)
@@ -330,13 +336,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     } catch (AlluxioException e) {
       throw new IOException(e);
     }
-  }
-
-  /**
-   * @param isShimFs set shim mode for this fs
-   */
-  public void setShimFs(boolean isShimFs) {
-    mIsShimFs = isShimFs;
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -525,7 +525,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
         Factory.getConnectDetails(alluxioConf));
 
     mFileSystem = FileSystem.Factory
-        .create(ClientContext.create(subject, alluxioConf).setDisableUriValidation(mIsShimFs));
+        .create(ClientContext.create(subject, alluxioConf).setUriValidationEnabled(!mIsShimFs));
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -106,10 +106,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
   /**
    * Constructs a new {@link AbstractFileSystem} instance.
-   *
    */
-  AbstractFileSystem() {
-  }
+  AbstractFileSystem() {}
 
   @Override
   public FSDataOutputStream append(Path path, int bufferSize, Progressable progress)

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -116,7 +116,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     if (mStatistics != null) {
       mStatistics.incrementWriteOps(1);
     }
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     try {
       if (mFileSystem.exists(uri)) {
         throw new IOException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(uri));
@@ -160,7 +160,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       mStatistics.incrementWriteOps(1);
     }
 
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     CreateFilePOptions options = CreateFilePOptions.newBuilder().setBlockSizeBytes(blockSize)
         .setMode(new Mode(permission.toShort()).toProto()).setRecursive(true).build();
 
@@ -210,7 +210,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   public FSDataOutputStream createNonRecursive(Path path, FsPermission permission,
       boolean overwrite, int bufferSize, short replication, long blockSize, Progressable progress)
           throws IOException {
-    AlluxioURI parentUri = new AlluxioURI(getAlluxioPath(path.getParent()));
+    AlluxioURI parentUri = getAlluxioPath(path.getParent());
     ensureExists(parentUri);
     return create(path, permission, overwrite, bufferSize, replication, blockSize, progress);
   }
@@ -241,7 +241,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     if (mStatistics != null) {
       mStatistics.incrementWriteOps(1);
     }
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     DeletePOptions options = DeletePOptions.newBuilder().setRecursive(recursive).build();
     try {
       mFileSystem.delete(uri, options);
@@ -275,7 +275,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     }
 
     List<BlockLocation> blockLocations = new ArrayList<>();
-    AlluxioURI path = new AlluxioURI(getAlluxioPath(file.getPath()));
+    AlluxioURI path = getAlluxioPath(file.getPath());
     try {
       List<BlockLocationInfo> locations = mFileSystem.getBlockLocations(path);
       locations.forEach(location -> {
@@ -312,7 +312,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
 
   @Override
   public boolean setReplication(Path path, short replication) throws IOException {
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
 
     try {
       if (!mFileSystem.exists(uri) || mFileSystem.getStatus(uri).isFolder()) {
@@ -338,7 +338,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     if (mStatistics != null) {
       mStatistics.incrementReadOps(1);
     }
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     URIStatus fileStatus;
     try {
       fileStatus = mFileSystem.getStatus(uri);
@@ -351,17 +351,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     return new FileStatus(fileStatus.getLength(), fileStatus.isFolder(), getReplica(fileStatus),
         fileStatus.getBlockSizeBytes(), fileStatus.getLastModificationTimeMs(),
         fileStatus.getLastAccessTimeMs(), new FsPermission((short) fileStatus.getMode()),
-        fileStatus.getOwner(), fileStatus.getGroup(), getFsPath(fileStatus));
-  }
-
-  /**
-   * Used to get FS native path from Alluxio file status.
-   *
-   * @param fileStatus Alluxio file status
-   * @return FS native path
-   */
-  protected Path getFsPath(URIStatus fileStatus) {
-    return new Path(mAlluxioHeader + fileStatus.getPath());
+        fileStatus.getOwner(), fileStatus.getGroup(), getFsPath(mAlluxioHeader, fileStatus));
   }
 
   private int getReplica(URIStatus status) {
@@ -381,7 +371,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   public void setOwner(Path path, final String username, final String groupname)
       throws IOException {
     LOG.debug("setOwner({},{},{})", path, username, groupname);
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     SetAttributePOptions.Builder optionsBuilder = SetAttributePOptions.newBuilder();
     boolean ownerOrGroupChanged = false;
     if (username != null && !username.isEmpty()) {
@@ -410,7 +400,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   @Override
   public void setPermission(Path path, FsPermission permission) throws IOException {
     LOG.debug("setMode({},{})", path, permission.toString());
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     SetAttributePOptions options = SetAttributePOptions.newBuilder()
         .setMode(new Mode(permission.toShort()).toProto()).setRecursive(false).build();
     try {
@@ -514,15 +504,6 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     mFileSystem = FileSystem.Factory.create(
         ClientContext.create(subject, alluxioConf).setUriValidationEnabled(disableUriValidation));
   }
-
-  /**
-   * Validates given FS base URI for scheme and authority.
-   *
-   * @param fsUri FS Uri
-   * @throws IOException
-   * @throws IllegalArgumentException
-   */
-  protected abstract void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException;
 
   /**
    * Merges the URI configuration with the Hadoop and Alluxio configuration, returning an
@@ -632,12 +613,12 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       mStatistics.incrementReadOps(1);
     }
 
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     List<URIStatus> statuses;
     try {
       statuses = mFileSystem.listStatus(uri);
     } catch (FileDoesNotExistException e) {
-      throw new FileNotFoundException(getAlluxioPath(path));
+      throw new FileNotFoundException(getAlluxioPath(path).toString());
     } catch (AlluxioException e) {
       throw new IOException(e);
     }
@@ -649,7 +630,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       ret[k] = new FileStatus(status.getLength(), status.isFolder(), getReplica(status),
           status.getBlockSizeBytes(), status.getLastModificationTimeMs(),
           status.getLastAccessTimeMs(), new FsPermission((short) status.getMode()),
-          status.getOwner(), status.getGroup(), getFsPath(status));
+          status.getOwner(), status.getGroup(), getFsPath(mAlluxioHeader, status));
     }
     return ret;
   }
@@ -667,7 +648,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
     if (mStatistics != null) {
       mStatistics.incrementWriteOps(1);
     }
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     CreateDirectoryPOptions options = CreateDirectoryPOptions.newBuilder().setRecursive(true)
         .setAllowExists(true).setMode(new Mode(permission.toShort()).toProto()).build();
     try {
@@ -693,7 +674,7 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       mStatistics.incrementReadOps(1);
     }
 
-    AlluxioURI uri = new AlluxioURI(getAlluxioPath(path));
+    AlluxioURI uri = getAlluxioPath(path);
     return new FSDataInputStream(new HdfsFileInputStream(mFileSystem, uri, mStatistics));
   }
 
@@ -704,8 +685,8 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
       mStatistics.incrementWriteOps(1);
     }
 
-    AlluxioURI srcPath = new AlluxioURI(getAlluxioPath(src));
-    AlluxioURI dstPath = new AlluxioURI(getAlluxioPath(dst));
+    AlluxioURI srcPath = getAlluxioPath(src);
+    AlluxioURI dstPath = getAlluxioPath(dst);
     try {
       mFileSystem.rename(srcPath, dstPath);
     } catch (FileDoesNotExistException e) {
@@ -765,12 +746,28 @@ abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem {
   }
 
   /**
+   * Validates given FS base URI for scheme and authority.
+   *
+   * @param fsUri FS Uri
+   * @throws IOException
+   * @throws IllegalArgumentException
+   */
+  protected abstract void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException;
+
+  /**
    * Used to convert hadoop path to Alluxio path.
    *
    * @param path the input path
    * @return the Alluxio path
    */
-  protected String getAlluxioPath(Path path) {
-    return HadoopUtils.getPathWithoutScheme(path);
-  }
+  protected abstract AlluxioURI getAlluxioPath(Path path);
+
+  /**
+   * Used to get FS native path from Alluxio file status.
+   *
+   * @param fsUriHeader FS URI header -> "scheme://authority"
+   * @param fileStatus Alluxio file status
+   * @return FS native path
+   */
+  protected abstract Path getFsPath(String fsUriHeader, URIStatus fileStatus);
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioShimFileSystem.java
@@ -47,7 +47,7 @@ public class AlluxioShimFileSystem extends DelegateToFileSystem {
    */
   AlluxioShimFileSystem(final URI uri, final Configuration conf)
       throws IOException, URISyntaxException {
-    super(uri, new FileSystem(), conf, Constants.SCHEME, false);
+    super(uri, new ShimFileSystem(), conf, Constants.NO_SCHEME, false);
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioShimFileSystem.java
@@ -1,0 +1,57 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import alluxio.Constants;
+import alluxio.conf.PropertyKey;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.DelegateToFileSystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * The Alluxio implementation of Hadoop AbstractFileSystem. The implementation delegates to the
+ * existing Alluxio {@link alluxio.hadoop.ShimFileSystem} and is only necessary for use with Hadoop
+ * 2.x. Configuration example in Hadoop core-site.xml file:
+ *
+ * <pre>
+ * &lt;property&gt;
+ *    &lt;name>fs.AbstractFileSystem.***.impl&lt;/name&gt;
+ *    &lt;value>alluxio.hadoop.AlluxioShimFileSystem&lt;/value&gt;
+ * &lt;/property&gt;
+ * </pre>
+ *
+ * For a long term solution, we need to rewrite AlluxioShimFileSystem by extending Hadoop's
+ * {@link AbstractFileSystem} directly.
+ */
+public class AlluxioShimFileSystem extends DelegateToFileSystem {
+  /**
+   * This constructor has the signature needed by
+   * {@link AbstractFileSystem#createFileSystem(URI, Configuration)} in Hadoop 2.x.
+   *
+   * @param uri the uri for this Alluxio filesystem
+   * @param conf Hadoop configuration
+   * @throws URISyntaxException if <code>uri</code> has syntax error
+   */
+  AlluxioShimFileSystem(final URI uri, final Configuration conf)
+      throws IOException, URISyntaxException {
+    super(uri, new FileSystem(), conf, Constants.SCHEME, false);
+  }
+
+  @Override
+  public int getUriDefaultPort() {
+    return Integer.parseInt(PropertyKey.MASTER_RPC_PORT.getDefaultValue());
+  }
+}

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -64,6 +64,23 @@ public final class FileSystem extends AbstractFileSystem {
   }
 
   @Override
+  protected void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException {
+    Preconditions.checkArgument(fsUri.getScheme().equals(getScheme()),
+            PreconditionMessage.URI_SCHEME_MISMATCH.toString(), fsUri.getScheme(), getScheme());
+
+    Authority auth = Authority.fromString(fsUri.getAuthority());
+    if (auth instanceof UnknownAuthority) {
+      throw new IOException(String.format("Authority \"%s\" is unknown. The client can not be "
+              + "configured with the authority from %s", auth, fsUri));
+    }
+  }
+
+  @Override
+  protected String getFsScheme(URI fsUri) {
+    return getScheme();
+  }
+
+  @Override
   protected AlluxioURI getAlluxioPath(Path path) {
     return new AlluxioURI(HadoopUtils.getPathWithoutScheme(path));
   }
@@ -71,17 +88,5 @@ public final class FileSystem extends AbstractFileSystem {
   @Override
   protected Path getFsPath(String fsUriHeader, URIStatus fileStatus) {
     return new Path(fsUriHeader + fileStatus.getPath());
-  }
-
-  @Override
-  protected void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException {
-    Preconditions.checkArgument(fsUri.getScheme().equals(getScheme()),
-        PreconditionMessage.URI_SCHEME_MISMATCH.toString(), fsUri.getScheme(), getScheme());
-
-    Authority auth = Authority.fromString(fsUri.getAuthority());
-    if (auth instanceof UnknownAuthority) {
-      throw new IOException(String.format("Authority \"%s\" is unknown. The client can not be "
-          + "configured with the authority from %s", auth, fsUri));
-    }
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -30,7 +30,7 @@ public final class FileSystem extends AbstractFileSystem {
    * Constructs a new {@link FileSystem}.
    */
   public FileSystem() {
-    super();
+    super(false);
   }
 
   /**
@@ -40,7 +40,7 @@ public final class FileSystem extends AbstractFileSystem {
    * @param fileSystem handler to file system
    */
   public FileSystem(alluxio.client.file.FileSystem fileSystem) {
-    super(fileSystem);
+    super(fileSystem, false);
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -11,7 +11,9 @@
 
 package alluxio.hadoop;
 
+import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.annotation.PublicApi;
 import alluxio.exception.PreconditionMessage;
@@ -19,6 +21,7 @@ import alluxio.uri.Authority;
 import alluxio.uri.UnknownAuthority;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.Path;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
@@ -58,6 +61,16 @@ public final class FileSystem extends AbstractFileSystem {
   @Override
   protected boolean isZookeeperMode() {
     return mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
+  }
+
+  @Override
+  protected AlluxioURI getAlluxioPath(Path path) {
+    return new AlluxioURI(HadoopUtils.getPathWithoutScheme(path));
+  }
+
+  @Override
+  protected Path getFsPath(String fsUriHeader, URIStatus fileStatus) {
+    return new Path(fsUriHeader + fileStatus.getPath());
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -14,8 +14,15 @@ package alluxio.hadoop;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.annotation.PublicApi;
+import alluxio.exception.PreconditionMessage;
+import alluxio.uri.Authority;
+import alluxio.uri.UnknownAuthority;
+
+import com.google.common.base.Preconditions;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * An Alluxio client API compatible with Apache Hadoop {@link org.apache.hadoop.fs.FileSystem}
@@ -51,5 +58,17 @@ public final class FileSystem extends AbstractFileSystem {
   @Override
   protected boolean isZookeeperMode() {
     return mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
+  }
+
+  @Override
+  protected void validateFsUri(URI fsUri) throws IOException, IllegalArgumentException {
+    Preconditions.checkArgument(fsUri.getScheme().equals(getScheme()),
+        PreconditionMessage.URI_SCHEME_MISMATCH.toString(), fsUri.getScheme(), getScheme());
+
+    Authority auth = Authority.fromString(fsUri.getAuthority());
+    if (auth instanceof UnknownAuthority) {
+      throw new IOException(String.format("Authority \"%s\" is unknown. The client can not be "
+          + "configured with the authority from %s", auth, fsUri));
+    }
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -30,7 +30,7 @@ public final class FileSystem extends AbstractFileSystem {
    * Constructs a new {@link FileSystem}.
    */
   public FileSystem() {
-    super(false);
+    super();
   }
 
   /**
@@ -40,7 +40,7 @@ public final class FileSystem extends AbstractFileSystem {
    * @param fileSystem handler to file system
    */
   public FileSystem(alluxio.client.file.FileSystem fileSystem) {
-    super(fileSystem, false);
+    super(fileSystem);
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -13,9 +13,14 @@ package alluxio.hadoop;
 
 import alluxio.Constants;
 import alluxio.annotation.PublicApi;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 
+import org.apache.hadoop.fs.Path;
+
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * An Alluxio client API compatible with Apache Hadoop {@link org.apache.hadoop.fs.FileSystem}
@@ -32,7 +37,7 @@ public class ShimFileSystem extends AbstractFileSystem {
    * Constructs a new {@link ShimFileSystem}.
    */
   public ShimFileSystem() {
-    super(true);
+    super();
   }
 
   /**
@@ -42,7 +47,7 @@ public class ShimFileSystem extends AbstractFileSystem {
    * @param fileSystem handler to file system
    */
   public ShimFileSystem(alluxio.client.file.FileSystem fileSystem) {
-    super(fileSystem, true);
+    super(fileSystem);
   }
 
   @Override
@@ -57,11 +62,28 @@ public class ShimFileSystem extends AbstractFileSystem {
     // Below constant will basically hide ShimFileSystem from dynamic loading as
     // it maps to a bogus scheme.
     //
-    return Constants.SHIM_SCHEME;
+    return Constants.NO_SCHEME;
   }
 
   @Override
   protected boolean isZookeeperMode() {
     return mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
+  }
+
+  @Override
+  // Gets the full path to send to Alluxio.
+  protected String getAlluxioPath(Path path) {
+    return path.toString();
+  }
+
+  @Override
+  // Gets UFS path as native FS path.
+  protected Path getFsPath(URIStatus fileStatus) {
+    return new Path(fileStatus.getUfsPath());
+  }
+
+  @Override
+  protected void validateFsUri(URI fsUri) throws IOException {
+    // No validation for ShimFS.
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -1,0 +1,69 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import alluxio.Constants;
+import alluxio.annotation.PublicApi;
+import alluxio.conf.PropertyKey;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * An Alluxio client API compatible with Apache Hadoop {@link org.apache.hadoop.fs.FileSystem}
+ * interface. Any program working with Hadoop HDFS can work with Alluxio transparently. Note that
+ * the performance of using this API may not be as efficient as the performance of using the Alluxio
+ * native API defined in {@link alluxio.client.file.FileSystem}, which this API is built on top of.
+ *
+ * ShimFileSystem supports working with arbitrary schemes that are supported by Alluxio.
+ */
+@PublicApi
+@NotThreadSafe
+public class ShimFileSystem extends AbstractFileSystem {
+  /**
+   * Constructs a new {@link ShimFileSystem}.
+   */
+  public ShimFileSystem() {
+    super();
+    setShimFs(true);
+  }
+
+  /**
+   * Constructs a new {@link ShimFileSystem} instance with a specified
+   * {@link alluxio.client.file.FileSystem} handler for tests.
+   *
+   * @param fileSystem handler to file system
+   */
+  public ShimFileSystem(alluxio.client.file.FileSystem fileSystem) {
+    super(fileSystem);
+    setShimFs(true);
+  }
+
+  @Override
+  public String getScheme() {
+    //
+    // {@link #getScheme()} will be used in hadoop 2.x for dynamically loading
+    // filesystems based on scheme. This limits capability of ShimFileSystem
+    // as it's intended to be a forwarder for arbitrary schemes.
+    //
+    // Hadoop currently gives configuration priority over dynamic loading, so
+    // whatever scheme is configured for ShimFileSystem will be attached with a shim.
+    // Below constant will basically hide ShimFileSystem from dynamic loading as
+    // it maps to a bogus scheme.
+    //
+    return Constants.SHIM_SCHEME;
+  }
+
+  @Override
+  protected boolean isZookeeperMode() {
+    return mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
+  }
+}

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -71,7 +71,7 @@ public class ShimFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  // Gets the full path to send to Alluxio.
+  // Gets the full path to use when contacting Alluxio server.
   protected String getAlluxioPath(Path path) {
     return path.toString();
   }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -11,6 +11,7 @@
 
 package alluxio.hadoop;
 
+import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.file.URIStatus;
@@ -72,13 +73,13 @@ public class ShimFileSystem extends AbstractFileSystem {
 
   @Override
   // Gets the full path to use when contacting Alluxio server.
-  protected String getAlluxioPath(Path path) {
-    return path.toString();
+  protected AlluxioURI getAlluxioPath(Path path) {
+    return new AlluxioURI(path.toString());
   }
 
   @Override
   // Gets UFS path as native FS path.
-  protected Path getFsPath(URIStatus fileStatus) {
+  protected Path getFsPath(String fsUri, URIStatus fileStatus) {
     return new Path(fileStatus.getUfsPath());
   }
 

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -72,6 +72,18 @@ public class ShimFileSystem extends AbstractFileSystem {
   }
 
   @Override
+  protected void validateFsUri(URI fsUri) throws IOException {
+    // No validation for ShimFS.
+  }
+
+  @Override
+  protected String getFsScheme(URI fsUri) {
+    // ShimFS does not know its scheme until FS URI is supplied.
+    // Use base URI's scheme.
+    return fsUri.getScheme();
+  }
+
+  @Override
   // Gets the full path to use when contacting Alluxio server.
   protected AlluxioURI getAlluxioPath(Path path) {
     return new AlluxioURI(path.toString());
@@ -81,10 +93,5 @@ public class ShimFileSystem extends AbstractFileSystem {
   // Gets UFS path as native FS path.
   protected Path getFsPath(String fsUri, URIStatus fileStatus) {
     return new Path(fileStatus.getUfsPath());
-  }
-
-  @Override
-  protected void validateFsUri(URI fsUri) throws IOException {
-    // No validation for ShimFS.
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -84,14 +84,14 @@ public class ShimFileSystem extends AbstractFileSystem {
   }
 
   @Override
-  // Gets the full path to use when contacting Alluxio server.
   protected AlluxioURI getAlluxioPath(Path path) {
+    // Sends the full path to Alluxio for master side resolution.
     return new AlluxioURI(path.toString());
   }
-
+  
   @Override
-  // Gets UFS path as native FS path.
   protected Path getFsPath(String fsUri, URIStatus fileStatus) {
+    // ShimFS doesn't expose internal Alluxio path.
     return new Path(fileStatus.getUfsPath());
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -88,7 +88,7 @@ public class ShimFileSystem extends AbstractFileSystem {
     // Sends the full path to Alluxio for master side resolution.
     return new AlluxioURI(path.toString());
   }
-  
+
   @Override
   protected Path getFsPath(String fsUri, URIStatus fileStatus) {
     // ShimFS doesn't expose internal Alluxio path.

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/ShimFileSystem.java
@@ -32,8 +32,7 @@ public class ShimFileSystem extends AbstractFileSystem {
    * Constructs a new {@link ShimFileSystem}.
    */
   public ShimFileSystem() {
-    super();
-    setShimFs(true);
+    super(true);
   }
 
   /**
@@ -43,8 +42,7 @@ public class ShimFileSystem extends AbstractFileSystem {
    * @param fileSystem handler to file system
    */
   public ShimFileSystem(alluxio.client.file.FileSystem fileSystem) {
-    super(fileSystem);
-    setShimFs(true);
+    super(fileSystem, true);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -48,6 +48,7 @@ public class ClientContext {
   private volatile UserState mUserState;
   private volatile String mPathConfHash;
   private volatile boolean mIsPathConfLoaded = false;
+  private volatile boolean mDisableUriValidation = false;
 
   /**
    * A client context with information about the subject and configuration of the client.
@@ -149,6 +150,22 @@ public class ClientContext {
       throws AlluxioStatusException {
     loadConf(address, !mClusterConf.clusterDefaultsLoaded(), !mIsPathConfLoaded);
     mUserState = UserState.Factory.create(mClusterConf, mUserState.getSubject());
+  }
+
+  /**
+   * @param disableUriValidation whether to disable URI validation
+   * @return updated instance of ClientContext
+   */
+  public ClientContext setDisableUriValidation(boolean disableUriValidation) {
+    mDisableUriValidation = disableUriValidation;
+    return this;
+  }
+
+  /**
+   * @return {@code true} if URI scheme validation is disabled
+   */
+  public boolean getDisableSchemeValidation() {
+    return mDisableUriValidation;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -48,7 +48,7 @@ public class ClientContext {
   private volatile UserState mUserState;
   private volatile String mPathConfHash;
   private volatile boolean mIsPathConfLoaded = false;
-  private volatile boolean mDisableUriValidation = false;
+  private volatile boolean mUriValidationEnabled = true;
 
   /**
    * A client context with information about the subject and configuration of the client.
@@ -153,19 +153,19 @@ public class ClientContext {
   }
 
   /**
-   * @param disableUriValidation whether to disable URI validation
+   * @param uriValidationEnabled whether URI validation is enabled
    * @return updated instance of ClientContext
    */
-  public ClientContext setDisableUriValidation(boolean disableUriValidation) {
-    mDisableUriValidation = disableUriValidation;
+  public ClientContext setUriValidationEnabled(boolean uriValidationEnabled) {
+    mUriValidationEnabled = uriValidationEnabled;
     return this;
   }
 
   /**
-   * @return {@code true} if URI scheme validation is disabled
+   * @return {@code true} if URI validation is enabled
    */
-  public boolean getDisableSchemeValidation() {
-    return mDisableUriValidation;
+  public boolean getUriValidationEnabled() {
+    return mUriValidationEnabled;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1369,7 +1369,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       return uri;
     } else {
       // Reverse lookup mount table to find mount point that contains the path.
-      return mMountTable.translate(uriStr);
+      return mMountTable.reverseLookup(uriStr);
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1362,6 +1362,18 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   @Override
+  public AlluxioURI translateUri(String uriStr) throws InvalidPathException {
+    AlluxioURI uri = new AlluxioURI(uriStr);
+    // Scheme-less URIs are regarded as Alluxio URI.
+    if (uri.getScheme() == null || uri.getScheme().equals(Constants.SCHEME)) {
+      return uri;
+    } else {
+      // Reverse lookup mount table to find mount point that contains the path.
+      return mMountTable.translate(uri);
+    }
+  }
+
+  @Override
   public MountPointInfo getDisplayMountPointInfo(AlluxioURI path) throws InvalidPathException {
     if (!mMountTable.isMountPoint(path)) {
       throw new InvalidPathException(

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1369,7 +1369,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       return uri;
     } else {
       // Reverse lookup mount table to find mount point that contains the path.
-      return mMountTable.translate(uri);
+      return mMountTable.translate(uriStr);
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -222,7 +222,7 @@ public interface FileSystemMaster extends Master {
    *
    * @param uriStr uri
    * @return URI in Alluxio namespace
-   * @throws InvalidPathException
+   * @throws InvalidPathException if foreign URI not found in Alluxio
    */
   AlluxioURI translateUri(String uriStr) throws InvalidPathException;
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -217,6 +217,16 @@ public interface FileSystemMaster extends Master {
   Map<String, MountPointInfo>  getMountTable();
 
   /**
+   * Translates given URI to an Alluxio URI.
+   * If given URI does not contain a scheme, then it is regarded as Alluxio URI.
+   *
+   * @param uriStr uri
+   * @return URI in Alluxio namespace
+   * @throws InvalidPathException
+   */
+  AlluxioURI translateUri(String uriStr) throws InvalidPathException;
+
+  /**
    * Gets the mount point information of an Alluxio path for display purpose.
    *
    * @param path an Alluxio path which must be a mount point

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -219,6 +219,7 @@ public interface FileSystemMaster extends Master {
   /**
    * Translates given URI to an Alluxio URI.
    * If given URI does not contain a scheme, then it is regarded as Alluxio URI.
+   * For other cases it will go through a reverse lookup against mount table.
    *
    * @param uriStr uri
    * @return URI in Alluxio namespace

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -18,27 +18,22 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.CheckConsistencyPRequest;
 import alluxio.grpc.CheckConsistencyPResponse;
-import alluxio.grpc.CompleteFilePOptions;
 import alluxio.grpc.CompleteFilePRequest;
 import alluxio.grpc.CompleteFilePResponse;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateDirectoryPRequest;
 import alluxio.grpc.CreateDirectoryPResponse;
-import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.CreateFilePRequest;
 import alluxio.grpc.CreateFilePResponse;
-import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.DeletePRequest;
 import alluxio.grpc.DeletePResponse;
 import alluxio.grpc.FileSystemMasterClientServiceGrpc;
-import alluxio.grpc.FreePOptions;
 import alluxio.grpc.FreePRequest;
 import alluxio.grpc.FreePResponse;
 import alluxio.grpc.GetFilePathPRequest;
 import alluxio.grpc.GetFilePathPResponse;
 import alluxio.grpc.GetMountTablePRequest;
 import alluxio.grpc.GetMountTablePResponse;
-import alluxio.grpc.GetNewBlockIdForFilePOptions;
 import alluxio.grpc.GetNewBlockIdForFilePRequest;
 import alluxio.grpc.GetNewBlockIdForFilePResponse;
 import alluxio.grpc.GetStatusPOptions;
@@ -48,32 +43,24 @@ import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GetSyncPathListPResponse;
 import alluxio.grpc.ListStatusPRequest;
 import alluxio.grpc.ListStatusPResponse;
-import alluxio.grpc.MountPOptions;
 import alluxio.grpc.MountPRequest;
 import alluxio.grpc.MountPResponse;
-import alluxio.grpc.PAclEntry;
-import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.RenamePRequest;
 import alluxio.grpc.RenamePResponse;
-import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.ScheduleAsyncPersistencePRequest;
 import alluxio.grpc.ScheduleAsyncPersistencePResponse;
-import alluxio.grpc.SetAclPOptions;
 import alluxio.grpc.SetAclPRequest;
 import alluxio.grpc.SetAclPResponse;
-import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.SetAttributePRequest;
 import alluxio.grpc.SetAttributePResponse;
 import alluxio.grpc.StartSyncPRequest;
 import alluxio.grpc.StartSyncPResponse;
 import alluxio.grpc.StopSyncPRequest;
 import alluxio.grpc.StopSyncPResponse;
-import alluxio.grpc.UnmountPOptions;
 import alluxio.grpc.UnmountPRequest;
 import alluxio.grpc.UnmountPResponse;
 import alluxio.grpc.UpdateMountPRequest;
 import alluxio.grpc.UpdateMountPResponse;
-import alluxio.grpc.UpdateUfsModePOptions;
 import alluxio.grpc.UpdateUfsModePRequest;
 import alluxio.grpc.UpdateUfsModePResponse;
 import alluxio.master.file.contexts.CheckConsistencyContext;
@@ -92,7 +79,6 @@ import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.underfs.UfsMode;
 import alluxio.grpc.GrpcUtils;
 import alluxio.wire.MountPointInfo;
-import alluxio.grpc.SetAclAction;
 import alluxio.wire.SyncPointInfo;
 
 import com.google.common.base.Preconditions;
@@ -130,78 +116,70 @@ public final class FileSystemMasterClientServiceHandler
   @Override
   public void checkConsistency(CheckConsistencyPRequest request,
       StreamObserver<CheckConsistencyPResponse> responseObserver) {
-    String path = request.getPath();
     CheckConsistencyPOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CheckConsistencyPResponse>) () -> {
-      List<AlluxioURI> inconsistentUris =
-          mFileSystemMaster.checkConsistency(mFileSystemMaster.translateUri(path),
-              CheckConsistencyContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      List<AlluxioURI> inconsistentUris = mFileSystemMaster.checkConsistency(pathUri,
+          CheckConsistencyContext.create(options.toBuilder()));
       List<String> uris = new ArrayList<>(inconsistentUris.size());
       for (AlluxioURI uri : inconsistentUris) {
         uris.add(uri.getPath());
       }
       return CheckConsistencyPResponse.newBuilder().addAllInconsistentPaths(uris).build();
-    }, "CheckConsistency", "path=%s, options=%s", responseObserver, path, options);
+    }, "CheckConsistency", "request=%s", responseObserver, request);
   }
 
   @Override
   public void completeFile(CompleteFilePRequest request,
       StreamObserver<CompleteFilePResponse> responseObserver) {
-    String path = request.getPath();
-    CompleteFilePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CompleteFilePResponse>) () -> {
-      mFileSystemMaster.completeFile(mFileSystemMaster.translateUri(path),
-          CompleteFileContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.completeFile(pathUri,
+          CompleteFileContext.create(request.getOptions().toBuilder()));
       return CompleteFilePResponse.newBuilder().build();
-    }, "CompleteFile", "path=%s, options=%s", responseObserver, path, options);
+    }, "CompleteFile", "request=%s", responseObserver, request);
   }
 
   @Override
   public void createDirectory(CreateDirectoryPRequest request,
       StreamObserver<CreateDirectoryPResponse> responseObserver) {
-    String path = request.getPath();
     CreateDirectoryPOptions options = request.getOptions();
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<CreateDirectoryPResponse>) () -> {
-          mFileSystemMaster.createDirectory(mFileSystemMaster.translateUri(path),
-              CreateDirectoryContext.create(options.toBuilder()));
-          return CreateDirectoryPResponse.newBuilder().build();
-        }, "CreateDirectory", "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.createDirectory(pathUri,
+          CreateDirectoryContext.create(options.toBuilder()));
+      return CreateDirectoryPResponse.newBuilder().build();
+    }, "CreateDirectory", "request=%s", responseObserver, request);
   }
 
   @Override
   public void createFile(CreateFilePRequest request,
       StreamObserver<CreateFilePResponse> responseObserver) {
-    String path = request.getPath();
-    CreateFilePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<CreateFilePResponse>)
-        () -> CreateFilePResponse.newBuilder().setFileInfo(GrpcUtils.toProto(
-            mFileSystemMaster.createFile(mFileSystemMaster.translateUri(path),
-                CreateFileContext.create(options.toBuilder())))).build(),
-        "CreateFile", "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      return CreateFilePResponse.newBuilder().setFileInfo(GrpcUtils.toProto(mFileSystemMaster
+          .createFile(pathUri, CreateFileContext.create(request.getOptions().toBuilder()))))
+          .build();
+    }, "CreateFile", "request=%s", responseObserver, request);
   }
 
   @Override
   public void free(FreePRequest request, StreamObserver<FreePResponse> responseObserver) {
-    String path = request.getPath();
-    FreePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<FreePResponse>) () -> {
-      mFileSystemMaster.free(mFileSystemMaster.translateUri(path),
-          FreeContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.free(pathUri, FreeContext.create(request.getOptions().toBuilder()));
       return FreePResponse.newBuilder().build();
-    }, "Free", "path=%s, options=%s", responseObserver, path, options);
+    }, "Free", "request=%s", responseObserver, request);
   }
 
   @Override
   public void getNewBlockIdForFile(GetNewBlockIdForFilePRequest request,
       StreamObserver<GetNewBlockIdForFilePResponse> responseObserver) {
-    String path = request.getPath();
-    GetNewBlockIdForFilePOptions options = request.getOptions();
-    RpcUtils.call(LOG,
-        () -> GetNewBlockIdForFilePResponse.newBuilder()
-            .setId(mFileSystemMaster.getNewBlockIdForFile(mFileSystemMaster.translateUri(path)))
-            .build(),
-        "GetNewBlockIdForFile", "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      return GetNewBlockIdForFilePResponse.newBuilder()
+          .setId(mFileSystemMaster.getNewBlockIdForFile(pathUri)).build();
+    }, "GetNewBlockIdForFile", "request=%s", responseObserver, request);
   }
 
   @Override
@@ -209,11 +187,9 @@ public final class FileSystemMasterClientServiceHandler
       StreamObserver<GetFilePathPResponse> responseObserver) {
     long fileId = request.getFileId();
     RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetFilePathPResponse>) () -> GetFilePathPResponse
-            .newBuilder()
-            .setPath(mFileSystemMaster.getPath(fileId).toString())
-            .build(),
-        "GetFilePath", true, "id=%s", responseObserver, fileId);
+        () -> GetFilePathPResponse.newBuilder()
+            .setPath(mFileSystemMaster.getPath(fileId).toString()).build(),
+        "GetFilePath", true, "request=%s", responseObserver, request);
   }
 
   @Override
@@ -221,14 +197,13 @@ public final class FileSystemMasterClientServiceHandler
       StreamObserver<GetStatusPResponse> responseObserver) {
     String path = request.getPath();
     GetStatusPOptions options = request.getOptions();
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetStatusPResponse>) () -> GetStatusPResponse
-            .newBuilder()
-            .setFileInfo(GrpcUtils
-                .toProto(mFileSystemMaster.getFileInfo(mFileSystemMaster.translateUri(path),
-                    GetStatusContext.create(options.toBuilder()))))
-            .build(),
-        "GetStatus", true, "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      return GetStatusPResponse.newBuilder()
+          .setFileInfo(GrpcUtils.toProto(
+              mFileSystemMaster.getFileInfo(pathUri, GetStatusContext.create(options.toBuilder()))))
+          .build();
+    }, "GetStatus", true, "request=%s", responseObserver, request);
   }
 
   @Override
@@ -238,10 +213,11 @@ public final class FileSystemMasterClientServiceHandler
     // Receive {@link alluxio.wire.FileInfo} items from master.
     List<alluxio.wire.FileInfo> fileInfoList;
     try {
-      fileInfoList = RpcUtils.callAndReturn(LOG,
-          () -> mFileSystemMaster.listStatus(mFileSystemMaster.translateUri(request.getPath()),
-              ListStatusContext.create(request.getOptions().toBuilder())),
-          "ListStatus", false, "request: %s", request);
+      fileInfoList = RpcUtils.callAndReturn(LOG, () -> {
+        AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+        return mFileSystemMaster.listStatus(pathUri,
+            ListStatusContext.create(request.getOptions().toBuilder()));
+      }, "ListStatus", false, "request: %s", request);
     } catch (StatusException se) {
       responseObserver.onError(se);
       return;
@@ -300,47 +276,41 @@ public final class FileSystemMasterClientServiceHandler
 
   @Override
   public void mount(MountPRequest request, StreamObserver<MountPResponse> responseObserver) {
-    String alluxioPath = request.getAlluxioPath();
-    String ufsPath = request.getUfsPath();
-    MountPOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<MountPResponse>) () -> {
-      mFileSystemMaster.mount(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath),
-          MountContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.mount(new AlluxioURI(request.getAlluxioPath()),
+          new AlluxioURI(request.getUfsPath()),
+          MountContext.create(request.getOptions().toBuilder()));
       return MountPResponse.newBuilder().build();
-    }, "Mount", "alluxioPath=%s, ufsPath=%s, options=%s", responseObserver, alluxioPath, ufsPath,
-        options);
+    }, "Mount", "request=%s", responseObserver, request);
   }
 
   @Override
   public void updateMount(UpdateMountPRequest request,
       StreamObserver<UpdateMountPResponse> responseObserver) {
-    String alluxioPath = request.getAlluxioPath();
-    MountPOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<UpdateMountPResponse>) () -> {
-      mFileSystemMaster.updateMount(new AlluxioURI(alluxioPath),
-              MountContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.updateMount(new AlluxioURI(request.getAlluxioPath()),
+          MountContext.create(request.getOptions().toBuilder()));
       return UpdateMountPResponse.newBuilder().build();
-    }, "UpdateMount", "alluxioPath=%s, options=%s", responseObserver, alluxioPath,
-        options);
+    }, "UpdateMount", "request=%s", responseObserver, request);
   }
 
   @Override
   public void getMountTable(GetMountTablePRequest request,
       StreamObserver<GetMountTablePResponse> responseObserver) {
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetMountTablePResponse>) () -> {
+    RpcUtils.call(LOG, () -> {
       Map<String, MountPointInfo> mountTableWire = mFileSystemMaster.getMountTable();
       Map<String, alluxio.grpc.MountPointInfo> mountTableProto = new HashMap<>();
       for (Map.Entry<String, MountPointInfo> entry : mountTableWire.entrySet()) {
         mountTableProto.put(entry.getKey(), GrpcUtils.toProto(entry.getValue()));
       }
       return GetMountTablePResponse.newBuilder().putAllMountPoints(mountTableProto).build();
-    }, "GetMountTable", "", responseObserver);
+    }, "GetMountTable", "request=%s", responseObserver, request);
   }
 
   @Override
   public void getSyncPathList(GetSyncPathListPRequest request,
       StreamObserver<GetSyncPathListPResponse> responseObserver) {
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetSyncPathListPResponse>) () -> {
+    RpcUtils.call(LOG, () -> {
       List<SyncPointInfo> pathList = mFileSystemMaster.getSyncPathList();
       List<alluxio.grpc.SyncPointInfo> syncPointInfoList =
           pathList.stream().map(SyncPointInfo::toProto).collect(Collectors.toList());
@@ -350,58 +320,50 @@ public final class FileSystemMasterClientServiceHandler
 
   @Override
   public void remove(DeletePRequest request, StreamObserver<DeletePResponse> responseObserver) {
-    String path = request.getPath();
-    DeletePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<DeletePResponse>) () -> {
-      mFileSystemMaster.delete(mFileSystemMaster.translateUri(path),
-          DeleteContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.delete(pathUri, DeleteContext.create(request.getOptions().toBuilder()));
       return DeletePResponse.newBuilder().build();
-    }, "Remove", "path=%s, options=%s", responseObserver, path, options);
+    }, "Remove", "request=%s", responseObserver, request);
   }
 
   @Override
   public void rename(RenamePRequest request, StreamObserver<RenamePResponse> responseObserver) {
-    String srcPath = request.getPath();
-    String dstPath = request.getDstPath();
-    RenamePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<RenamePResponse>) () -> {
-      mFileSystemMaster.rename(mFileSystemMaster.translateUri(srcPath),
-          mFileSystemMaster.translateUri(dstPath), RenameContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI srcPathUri = mFileSystemMaster.translateUri(request.getPath());
+      AlluxioURI dstPathUri = mFileSystemMaster.translateUri(request.getDstPath());
+      mFileSystemMaster.rename(srcPathUri, dstPathUri,
+          RenameContext.create(request.getOptions().toBuilder()));
       return RenamePResponse.newBuilder().build();
-    }, "Rename", "srcPath=%s, dstPath=%s, options=%s", responseObserver, srcPath, dstPath, options);
+    }, "Rename", "request=%s", responseObserver, request);
   }
 
   @Override
   public void scheduleAsyncPersistence(ScheduleAsyncPersistencePRequest request,
       StreamObserver<ScheduleAsyncPersistencePResponse> responseObserver) {
-    String path = request.getPath();
-    ScheduleAsyncPersistencePOptions options = request.getOptions();
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<ScheduleAsyncPersistencePResponse>) () -> {
-          mFileSystemMaster.scheduleAsyncPersistence(mFileSystemMaster.translateUri(path),
-              ScheduleAsyncPersistenceContext.create(options.toBuilder()));
-          return ScheduleAsyncPersistencePResponse.newBuilder().build();
-        }, "ScheduleAsyncPersist", "path=%s, options=%s", responseObserver, path, options);
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.scheduleAsyncPersistence(new AlluxioURI(request.getPath()),
+          ScheduleAsyncPersistenceContext.create(request.getOptions().toBuilder()));
+      return ScheduleAsyncPersistencePResponse.newBuilder().build();
+    }, "ScheduleAsyncPersist", "request=%s", responseObserver, request);
   }
 
   @Override
   public void setAttribute(SetAttributePRequest request,
       StreamObserver<SetAttributePResponse> responseObserver) {
-    String path = request.getPath();
-    SetAttributePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<SetAttributePResponse>) () -> {
-      mFileSystemMaster.setAttribute(mFileSystemMaster.translateUri(path),
-          SetAttributeContext.create(options.toBuilder()));
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.setAttribute(pathUri,
+          SetAttributeContext.create(request.getOptions().toBuilder()));
       return SetAttributePResponse.newBuilder().build();
-    }, "SetAttribute", "path=%s, options=%s", responseObserver, path, options);
+    }, "SetAttribute", "request=%s", responseObserver, request);
   }
 
   @Override
   public void startSync(StartSyncPRequest request,
       StreamObserver<StartSyncPResponse> responseObserver) {
-    String path = request.getPath();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<StartSyncPResponse>) () -> {
-      mFileSystemMaster.startSync(mFileSystemMaster.translateUri(path));
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.startSync(new AlluxioURI(request.getPath()));
       return StartSyncPResponse.newBuilder().build();
     }, "startSync", "request=%s", responseObserver, request);
   }
@@ -409,31 +371,26 @@ public final class FileSystemMasterClientServiceHandler
   @Override
   public void stopSync(StopSyncPRequest request,
       StreamObserver<StopSyncPResponse> responseObserver) {
-    String path = request.getPath();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<StopSyncPResponse>) () -> {
-      mFileSystemMaster.stopSync(mFileSystemMaster.translateUri(path));
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.stopSync(new AlluxioURI(request.getPath()));
       return StopSyncPResponse.newBuilder().build();
     }, "stopSync", "request=%s", responseObserver, request);
   }
 
   @Override
   public void unmount(UnmountPRequest request, StreamObserver<UnmountPResponse> responseObserver) {
-    String alluxioPath = request.getAlluxioPath();
-    UnmountPOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<UnmountPResponse>) () -> {
-      mFileSystemMaster.unmount(new AlluxioURI(alluxioPath));
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.unmount(new AlluxioURI(request.getAlluxioPath()));
       return UnmountPResponse.newBuilder().build();
-    }, "Unmount", "alluxioPath=%s, options=%s", responseObserver, alluxioPath, options);
+    }, "Unmount", "request=%s", responseObserver, request);
   }
 
   @Override
   public void updateUfsMode(UpdateUfsModePRequest request,
       StreamObserver<UpdateUfsModePResponse> responseObserver) {
-    String ufsPath = request.getUfsPath();
-    UpdateUfsModePOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<UpdateUfsModePResponse>) () -> {
+    RpcUtils.call(LOG, () -> {
       UfsMode ufsMode;
-      switch (options.getUfsMode()) {
+      switch (request.getOptions().getUfsMode()) {
         case NO_ACCESS:
           ufsMode = UfsMode.NO_ACCESS;
           break;
@@ -444,24 +401,19 @@ public final class FileSystemMasterClientServiceHandler
           ufsMode = UfsMode.READ_WRITE;
           break;
       }
-      mFileSystemMaster.updateUfsMode(new AlluxioURI(ufsPath), ufsMode);
+      mFileSystemMaster.updateUfsMode(new AlluxioURI(request.getUfsPath()), ufsMode);
       return UpdateUfsModePResponse.newBuilder().build();
-    }, "UpdateUfsMode", "ufsPath=%s, options=%s", responseObserver, ufsPath, options);
+    }, "UpdateUfsMode", "request=%s", responseObserver, request);
   }
 
   @Override
-  public void setAcl(SetAclPRequest request,
-                     StreamObserver<SetAclPResponse> responseObserver) {
-    String alluxioPath = request.getPath();
-    SetAclAction aclAction = request.getAction();
-    List<PAclEntry> aclList = request.getEntriesList();
-    SetAclPOptions options = request.getOptions();
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<SetAclPResponse>) () -> {
-      mFileSystemMaster.setAcl(mFileSystemMaster.translateUri(alluxioPath), aclAction,
-          aclList.stream().map(GrpcUtils::fromProto).collect(Collectors.toList()),
-          SetAclContext.create(options.toBuilder()));
+  public void setAcl(SetAclPRequest request, StreamObserver<SetAclPResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> {
+      AlluxioURI pathUri = mFileSystemMaster.translateUri(request.getPath());
+      mFileSystemMaster.setAcl(pathUri, request.getAction(),
+          request.getEntriesList().stream().map(GrpcUtils::fromProto).collect(Collectors.toList()),
+          SetAclContext.create(request.getOptions().toBuilder()));
       return SetAclPResponse.newBuilder().build();
-    }, "setAcl", "alluxioPath=%s, setAclAction=%s, aclEntries=%s, options=%s", responseObserver,
-        alluxioPath, aclAction.name(), aclList, options);
+    }, "setAcl", "request=%s", responseObserver, request);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -404,7 +404,7 @@ public final class MountTable implements DelegatingJournaled {
       }
       // No mount found for given path.
       throw new InvalidPathException(
-          String.format("Foreign URI: %s is not found on Alluxio mounts.", foreignUriStr));
+          String.format(ExceptionMessage.FOREIGN_URI_NOT_MOUNTED.getMessage(foreignUriStr)));
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -388,9 +388,9 @@ public final class MountTable implements DelegatingJournaled {
    * @return Alluxio URI for given foreign path
    * @throws InvalidPathException
    */
-  public AlluxioURI translate(String foreignUriStr) throws InvalidPathException {
+  public AlluxioURI reverseLookup(String foreignUriStr) throws InvalidPathException {
     try (LockResource r = new LockResource(mReadLock)) {
-      LOG.debug("Translating foreign URI {}", foreignUriStr);
+      LOG.debug("Doing a reverse-lookup on foreign URI {}", foreignUriStr);
       // Enumerate existing mount points to find a mount point that owns
       // given uri.
       for (Map.Entry<String, MountInfo> mountEntry : mState.getMountTable().entrySet()) {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -395,7 +395,7 @@ public final class MountTableTest {
    * Tests {@link MountTable#translate(String)}.
    */
   @Test
-  public void translate() throws Exception {
+  public void translateKnownUri() throws Exception {
     String mountPath = "/mnt/foo";
     String ufsPath = "ufs-1://authority/root";
     addMount(mountPath, ufsPath, 2);
@@ -404,10 +404,16 @@ public final class MountTableTest {
     String testFileUfsPath = PathUtils.concatPath(ufsPath, testFile);
     String testFileAlluxioPath = PathUtils.concatPath(mountPath, testFile);
     Assert.assertEquals(testFileAlluxioPath, mMountTable.translate(testFileUfsPath).getPath());
+  }
 
+  /**
+   * Tests {@link MountTable#translate(String)}.
+   */
+  @Test
+  public void translateUnknownUri() throws Exception {
     // Test unknown translation.
     String unmountedUfsPath = "ufs-unknown://authority/root";
-    testFileUfsPath = PathUtils.concatPath(unmountedUfsPath, testFile);
+    String testFileUfsPath = PathUtils.concatPath(unmountedUfsPath, PathUtils.uniqPath());
     boolean translateFailed = false;
     try {
       mMountTable.translate(testFileUfsPath);
@@ -422,7 +428,7 @@ public final class MountTableTest {
 
   private void addMount(String alluxio, String ufs, long id) throws Exception {
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI(alluxio), new AlluxioURI(ufs), id,
-        MountContext.defaults().getOptions().build());
+            MountContext.defaults().getOptions().build());
   }
 
   private boolean deleteMount(String path) {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -392,38 +392,38 @@ public final class MountTableTest {
   }
 
   /**
-   * Tests {@link MountTable#translate(String)}.
+   * Tests {@link MountTable#reverseLookup(String)}.
    */
   @Test
-  public void translateKnownUri() throws Exception {
+  public void reverseLookupKnownUri() throws Exception {
     String mountPath = "/mnt/foo";
     String ufsPath = "ufs-1://authority/root";
     addMount(mountPath, ufsPath, 2);
-    // Test successful translation.
+    // Test successful reverse-lookup.
     String testFile = PathUtils.uniqPath();
     String testFileUfsPath = PathUtils.concatPath(ufsPath, testFile);
     String testFileAlluxioPath = PathUtils.concatPath(mountPath, testFile);
-    Assert.assertEquals(testFileAlluxioPath, mMountTable.translate(testFileUfsPath).getPath());
+    Assert.assertEquals(testFileAlluxioPath, mMountTable.reverseLookup(testFileUfsPath).getPath());
   }
 
   /**
-   * Tests {@link MountTable#translate(String)}.
+   * Tests {@link MountTable#reverseLookup(String)}.
    */
   @Test
-  public void translateUnknownUri() throws Exception {
-    // Test unknown translation.
+  public void reverseLookupUnknownUri() throws Exception {
+    // Test unknown reverse-lookup.
     String unmountedUfsPath = "ufs-unknown://authority/root";
     String testFileUfsPath = PathUtils.concatPath(unmountedUfsPath, PathUtils.uniqPath());
-    boolean translateFailed = false;
+    boolean lookupFailed = false;
     try {
-      mMountTable.translate(testFileUfsPath);
+      mMountTable.reverseLookup(testFileUfsPath);
     } catch (InvalidPathException e) {
       // Exception expected
       Assert.assertEquals(ExceptionMessage.FOREIGN_URI_NOT_MOUNTED.getMessage(testFileUfsPath),
           e.getMessage());
-      translateFailed = true;
+      lookupFailed = true;
     }
-    Assert.assertTrue(translateFailed);
+    Assert.assertTrue(lookupFailed);
   }
 
   private void addMount(String alluxio, String ufs, long id) throws Exception {

--- a/tests/src/test/java/alluxio/client/fs/ShimFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ShimFileSystemIntegrationTest.java
@@ -62,7 +62,7 @@ public class ShimFileSystemIntegrationTest {
     // Create a BaseFileSystem that has URI validation disabled.
     // Hadoop fs implementation, {@link ShimFileSystem} will also set this flag.
     mShimFileSystem = FileSystem.Factory.create(FileSystemContext
-        .create(ClientContext.create(ServerConfiguration.global()).setDisableUriValidation(true)));
+        .create(ClientContext.create(ServerConfiguration.global()).setUriValidationEnabled(false)));
     // Mount fs-ufs for testing.
     mFileSystem.mount(new AlluxioURI(SHIM_MOUNT_PATH),
         new AlluxioURI(mTempFolder.getRoot().toURI().toString()));

--- a/tests/src/test/java/alluxio/client/fs/ShimFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ShimFileSystemIntegrationTest.java
@@ -1,0 +1,229 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fs;
+
+import alluxio.AlluxioURI;
+import alluxio.ClientContext;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.InvalidPathException;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.io.FileUtils;
+import alluxio.util.io.PathUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+public class ShimFileSystemIntegrationTest {
+  private static final String SHIM_MOUNT_PATH = "/shim-mount";
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder().build();
+
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+
+  @Rule
+  public TemporaryFolder mTempFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
+
+  private FileSystem mFileSystem = null;
+  private FileSystem mShimFileSystem = null;
+
+  @Before
+  public void before() throws Exception {
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+    // Create a BaseFileSystem that has URI validation disabled.
+    // Hadoop fs implementation, {@link ShimFileSystem} will also set this flag.
+    mShimFileSystem = FileSystem.Factory.create(FileSystemContext
+        .create(ClientContext.create(ServerConfiguration.global()).setDisableUriValidation(true)));
+    // Mount fs-ufs for testing.
+    mFileSystem.mount(new AlluxioURI(SHIM_MOUNT_PATH),
+        new AlluxioURI(mTempFolder.getRoot().toURI().toString()));
+  }
+
+  @Test
+  public void createFile() throws Exception {
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    // Create a foreign URI.
+    AlluxioURI foreignUri = new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    mShimFileSystem.createFile(foreignUri,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).setRecursive(true).build())
+        .close();
+
+    URIStatus status = mShimFileSystem.getStatus(foreignUri);
+    Assert.assertNotNull(status);
+
+    // Verify file exists via shim.
+    Assert.assertTrue(mShimFileSystem.exists(foreignUri));
+    // Verify file exists on Alluxio path.
+    Assert.assertNotNull(mFileSystem.getStatus(new AlluxioURI(status.getPath())));
+    // Verify file is persisted to ufs. (As instructed by WritePType.THROUGH).
+    Assert.assertTrue(FileUtils.exists(new AlluxioURI(status.getUfsPath()).getPath()));
+  }
+
+  @Test
+  public void createDirectory() throws Exception {
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    // Create a foreign URI.
+    AlluxioURI foreignUri = new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    mShimFileSystem.createDirectory(foreignUri, CreateDirectoryPOptions.newBuilder()
+        .setWriteType(WritePType.THROUGH).setRecursive(true).build());
+
+    URIStatus status = mShimFileSystem.getStatus(foreignUri);
+    Assert.assertNotNull(status);
+
+    // Verify the dir exists.
+    Assert.assertTrue(mShimFileSystem.exists(foreignUri));
+    // Verify the dir exists on Alluxio path.
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI(status.getPath())));
+    // Verify the dir is persisted to ufs. (As instructed by WritePType.THROUGH).
+    Assert.assertTrue(FileUtils.exists(new AlluxioURI(status.getUfsPath()).getPath()));
+  }
+
+  @Test
+  public void deleteFile() throws Exception {
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    // Create a foreign URI.
+    AlluxioURI foreignUri = new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    mShimFileSystem.createFile(foreignUri,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).setRecursive(true).build())
+        .close();
+
+    // Verify file created.
+    URIStatus status = mShimFileSystem.getStatus(foreignUri);
+
+    // Delete the file with foreign URI via shim-fs
+    mShimFileSystem.delete(foreignUri, DeletePOptions.newBuilder().setAlluxioOnly(false).build());
+
+    // Verify file is deleted.
+    Assert.assertFalse(mShimFileSystem.exists(foreignUri));
+    Assert.assertFalse(mFileSystem.exists(new AlluxioURI(status.getPath())));
+    Assert.assertFalse(FileUtils.exists(new AlluxioURI(status.getUfsPath()).getPath()));
+  }
+
+  @Test
+  public void listFiles() throws Exception {
+    int testFileCount = 10;
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    for (int i = 0; i < testFileCount; i++) {
+      // Create a foreign URI.
+      AlluxioURI foreignUri =
+          new AlluxioURI(PathUtils.concatPath(foreignRoot, Integer.toString(i)));
+      // Create the file with foreign URI via shim-fs.
+      mShimFileSystem.createFile(foreignUri, CreateFilePOptions.newBuilder()
+          .setWriteType(WritePType.THROUGH).setRecursive(true).build()).close();
+    }
+
+    // List files via shim-fs.
+    List<URIStatus> shimStatusList = mShimFileSystem.listStatus(new AlluxioURI(foreignRoot),
+        ListStatusPOptions.newBuilder().setRecursive(true).build());
+    Assert.assertEquals(testFileCount, shimStatusList.size());
+    // List files via Alluxio-fs.
+    // Get foreign root status to get Alluxio path.
+    URIStatus dirStatus = mShimFileSystem.getStatus(new AlluxioURI(foreignRoot));
+    List<URIStatus> statusList = mFileSystem.listStatus(new AlluxioURI(dirStatus.getPath()));
+    Assert.assertEquals(testFileCount, statusList.size());
+  }
+
+  @Test
+  public void renameFile() throws Exception {
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    // Create a foreign URI.
+    AlluxioURI foreignUriSrc =
+        new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+    AlluxioURI foreignUriDst =
+        new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    mShimFileSystem.createFile(foreignUriSrc,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).setRecursive(true).build())
+        .close();
+    URIStatus srcStatus = mShimFileSystem.getStatus(foreignUriSrc);
+
+    // Rename the file with foreign URIs via shim-fs.
+    mShimFileSystem.rename(foreignUriSrc, foreignUriDst);
+    URIStatus dstStatus = mShimFileSystem.getStatus(foreignUriDst);
+
+    // Verify the file is moved to destination.
+    Assert.assertTrue(mShimFileSystem.exists(foreignUriDst));
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI(dstStatus.getPath())));
+    Assert.assertTrue(FileUtils.exists(new AlluxioURI(dstStatus.getUfsPath()).getPath()));
+    // Verify the source is gone.
+    Assert.assertFalse(mShimFileSystem.exists(foreignUriSrc));
+    Assert.assertFalse(mFileSystem.exists(new AlluxioURI(srcStatus.getPath())));
+    Assert.assertFalse(FileUtils.exists(new AlluxioURI(srcStatus.getUfsPath()).getPath()));
+  }
+
+  @Test
+  public void setAttribute() throws Exception {
+    // File root to be mounted folder's local path.
+    String foreignRoot = mTempFolder.getRoot().toURI().toString();
+    // Create a foreign URI.
+    AlluxioURI foreignUri = new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    mShimFileSystem.createFile(foreignUri,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).setRecursive(true).build())
+        .close();
+
+    // Change file attributes via shim-fs.
+    mShimFileSystem.setAttribute(foreignUri,
+        SetAttributePOptions.newBuilder().setPinned(true).build());
+
+    // Verify attribute change took place.
+    Assert.assertTrue(mShimFileSystem.getStatus(foreignUri).isPinned());
+  }
+
+  @Test
+  public void mountNotExist() throws Exception {
+    // Bogus foreign root.
+    String foreignRoot = "file:///bogus";
+    // Create a foreign URI.
+    AlluxioURI foreignUri = new AlluxioURI(PathUtils.concatPath(foreignRoot, PathUtils.uniqPath()));
+
+    // Create the file with foreign URI via shim-fs.
+    // This should fail as the foreign root is not mounted on Alluxio.
+    mException.expect(InvalidPathException.class);
+    mShimFileSystem.createFile(foreignUri,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).setRecursive(true).build())
+        .close();
+  }
+}


### PR DESCRIPTION
`ShimFileSystem` is an alternative to existing `AlluxioFileSystem` where foreign URIs are supported on client side. URIs that are sent to master as-is need to be translated to internal Alluxio URIs. This is done by a reverse lookup on master mount table. For `ShimFileSystem` to work properly, the file system that it has been attached to must be mounted on Alluxio.

Closes https://github.com/Alluxio/alluxio/issues/9231