### PR TITLE
Add more debugging to activeSync startSync and stopSync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3757,7 +3757,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       try {
         mSyncManager.startSyncPostJournal(uri);
       } catch (Throwable e) {
-        LOG.warn("Start sync failed because {}", ExceptionUtils.getStackTrace(e));
+        LOG.warn("Start sync failed on {}", uri, e);
         // revert state;
         RemoveSyncPointEntry removeSyncPoint =
             File.RemoveSyncPointEntry.newBuilder()
@@ -3809,7 +3809,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
         long mountId = resolution.getMountId();
         mSyncManager.stopSyncPostJournal(lockedInodePath.getUri());
       } catch (Throwable e) {
-        LOG.warn("Stop sync failed because {}", ExceptionUtils.getStackTrace(e));
+        LOG.warn("Stop sync failed on {}", uri, e);
         // revert state;
         AddSyncPointEntry addSyncPoint =
             File.AddSyncPointEntry.newBuilder()

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -185,7 +185,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -185,6 +185,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -3756,6 +3757,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       try {
         mSyncManager.startSyncPostJournal(uri);
       } catch (Throwable e) {
+        LOG.info("Start sync failed because {}", ExceptionUtils.getStackTrace(e));
         // revert state;
         RemoveSyncPointEntry removeSyncPoint =
             File.RemoveSyncPointEntry.newBuilder()
@@ -3807,6 +3809,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
         long mountId = resolution.getMountId();
         mSyncManager.stopSyncPostJournal(lockedInodePath.getUri());
       } catch (Throwable e) {
+        LOG.info("Stop sync failed because {}", ExceptionUtils.getStackTrace(e));
         // revert state;
         AddSyncPointEntry addSyncPoint =
             File.AddSyncPointEntry.newBuilder()

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3757,7 +3757,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       try {
         mSyncManager.startSyncPostJournal(uri);
       } catch (Throwable e) {
-        LOG.info("Start sync failed because {}", ExceptionUtils.getStackTrace(e));
+        LOG.warn("Start sync failed because {}", ExceptionUtils.getStackTrace(e));
         // revert state;
         RemoveSyncPointEntry removeSyncPoint =
             File.RemoveSyncPointEntry.newBuilder()
@@ -3809,7 +3809,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
         long mountId = resolution.getMountId();
         mSyncManager.stopSyncPostJournal(lockedInodePath.getUri());
       } catch (Throwable e) {
-        LOG.info("Stop sync failed because {}", ExceptionUtils.getStackTrace(e));
+        LOG.warn("Stop sync failed because {}", ExceptionUtils.getStackTrace(e));
         // revert state;
         AddSyncPointEntry addSyncPoint =
             File.AddSyncPointEntry.newBuilder()


### PR DESCRIPTION
Currently when a user's request to startSync and stopSync fails, very little information is printed because the exception printing happens after a fatal error. Adding this to help with debugging in the future.