### PR TITLE
Ensure tags are copied when overriding metrics

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileOutStream.java
@@ -26,8 +26,8 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CompleteFilePOptions;
+import alluxio.metrics.ClientMetrics;
 import alluxio.metrics.MetricsSystem;
-import alluxio.metrics.WorkerMetrics;
 import alluxio.resource.CloseableResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.FileSystemOptions;
@@ -315,7 +315,7 @@ public class FileOutStream extends AbstractOutStream {
   @ThreadSafe
   private static final class Metrics {
     private static final Counter BYTES_WRITTEN_UFS =
-        MetricsSystem.counter(WorkerMetrics.BYTES_WRITTEN_UFS);
+        MetricsSystem.counter(ClientMetrics.BYTES_WRITTEN_UFS);
 
     private Metrics() {} // prevent instantiation
   }

--- a/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
@@ -18,6 +18,7 @@ public final class ClientMetrics {
   /** Total number of bytes short-circuit read from local storage. */
   public static final String BYTES_READ_LOCAL = "BytesReadLocal";
   public static final String BYTES_READ_LOCAL_THROUGHPUT = "BytesReadLocalThroughput";
+  public static final String BYTES_WRITTEN_UFS = "BytesWrittenUfs";
 
   private ClientMetrics() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -420,11 +420,14 @@ public final class MetricsSystem {
   }
 
   /**
-   * Resets all the counters to 0 for testing.
+   * Resets all counters to 0 and unregisters gauges for testing.
    */
-  public static void resetAllCounters() {
+  public static void resetCountersAndGauges() {
     for (Map.Entry<String, Counter> entry : METRIC_REGISTRY.getCounters().entrySet()) {
       entry.getValue().dec(entry.getValue().getCount());
+    }
+    for (String gauge : METRIC_REGISTRY.getGauges().keySet()) {
+      METRIC_REGISTRY.remove(gauge);
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -147,6 +148,9 @@ public class MetricsStore {
         double oldVal = oldMetric == null ? 0.0 : oldMetric.getValue();
         Metric newMetric = new Metric(metric.getInstanceType(), metric.getHostname(),
             metric.getMetricType(), metric.getName(), oldVal + metric.getValue());
+        for (Map.Entry<String, String> tag : metric.getTags().entrySet()) {
+          newMetric.addTag(tag.getKey(), tag.getValue());
+        }
         metricSet.removeByField(FULL_NAME_INDEX, metric.getFullMetricName());
         newMetrics.add(newMetric);
       } else {

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
@@ -66,4 +66,18 @@ public class MetricsStoreTest {
         Metric.from("client.192_1_1_1:B.metric1", 15, MetricType.GAUGE)),
         mMetricStore.getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType.CLIENT, "metric1"));
   }
+
+  @Test
+  public void putTaggedMetrics() {
+    String name = "test";
+    Metric metric1 =
+        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.COUNTER, name, 1.0);
+    metric1.addTag("Tag", "1");
+    Metric metric2 =
+        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.COUNTER, name, 2.0);
+    metric2.addTag("Tag", "2");
+    mMetricStore.putWorkerMetrics("host", Lists.newArrayList(metric1, metric2));
+    assertEquals(mMetricStore.getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType.WORKER,
+        name), Sets.newHashSet(metric1, metric2));
+  }
 }

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -98,7 +98,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
     mStartCluster = startCluster;
     mNumWorkers = numWorkers;
     mConfiguration.putAll(configuration);
-    MetricsSystem.resetAllCounters();
+    MetricsSystem.resetCountersAndGauges();
   }
 
   /**


### PR DESCRIPTION
Fixes #9442

We need to consider tags in the uniqueness of our metrics, otherwise we
may incorrectly override metrics (usually to 0) leading to inaccurate
numbers.

Cherry-pick of existing commit.

orig-commit-author: calvinjia \<jia.calvin@gmail.com\>

pr-link: Alluxio/alluxio#9652
change-id: cid-5a2543e95ca1f4e6fcd218dd4be52f424418111f