### PR TITLE
Improve sync cache to consider recursive sync of ancestors

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3336,7 +3336,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
                     .mergeFrom(LoadMetadataPOptions.newBuilder().setCreateAncestors(true)
                         .setLoadDescendantType(GrpcUtils.toProto(syncDescendantType))));
 
-            mUfsSyncPathCache.notifySyncedPath(inodePath.getUri().getPath());
+            mUfsSyncPathCache.notifySyncedPath(inodePath.getUri().getPath(), syncDescendantType);
           } catch (Exception e) {
             // This may be expected. For example, when creating a new file, the UFS file is not
             // expected to exist.
@@ -3354,7 +3354,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
             } catch (Exception e) {
               LOG.debug("Failed to load metadata for mount point: {}", mountPointUri, e);
             }
-            mUfsSyncPathCache.notifySyncedPath(mountPoint);
+            mUfsSyncPathCache.notifySyncedPath(mountPoint, syncDescendantType);
           }
         }
       } catch (InvalidPathException e) {
@@ -3369,7 +3369,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     }
 
     if (pathsToLoad.isEmpty()) {
-      mUfsSyncPathCache.notifySyncedPath(inodePath.getUri().getPath());
+      mUfsSyncPathCache.notifySyncedPath(inodePath.getUri().getPath(), syncDescendantType);
     }
     return true;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -11,14 +11,19 @@
 
 package alluxio.master.file.meta;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.InvalidPathException;
+import alluxio.file.options.DescendantType;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -33,7 +38,7 @@ public final class UfsSyncPathCache {
       ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
 
   /** Cache of paths which have been synced. */
-  private final Cache<String, Long> mCache;
+  private final Cache<String, SyncTime> mCache;
 
   /**
    * Creates a new instance of {@link UfsSyncPathCache}.
@@ -46,9 +51,18 @@ public final class UfsSyncPathCache {
    * Notifies the cache that the path was synced.
    *
    * @param path the path that was synced
+   * @param descendantType the descendant type that the path was synced with
    */
-  public void notifySyncedPath(String path) {
-    mCache.put(path, System.currentTimeMillis());
+  public void notifySyncedPath(String path, DescendantType descendantType) {
+    long syncTimeMs = System.currentTimeMillis();
+    mCache.asMap().compute(path, (key, oldSyncTime) -> {
+      if (oldSyncTime != null) {
+        // update the existing sync time
+        oldSyncTime.updateSync(syncTimeMs, descendantType);
+        return oldSyncTime;
+      }
+      return new SyncTime(syncTimeMs, descendantType);
+    });
   }
 
   /**
@@ -65,11 +79,87 @@ public final class UfsSyncPathCache {
       // Always sync.
       return true;
     }
-    Long lastSync = mCache.getIfPresent(path);
-    if (lastSync == null) {
-      // No info about the last sync, so trigger a sync.
+
+    // check the last sync information for the path itself.
+    SyncTime lastSync = mCache.getIfPresent(path);
+    if (!shouldSyncInternal(lastSync, intervalMs, false)) {
+      // Sync is not necessary for this path.
+      return false;
+    }
+
+    // sync should be done on this path, but check all ancestors to determine if a recursive sync
+    // had been performed (to avoid a sync again).
+    String currPath = path;
+    while (!currPath.equals(AlluxioURI.SEPARATOR)) {
+      try {
+        currPath = PathUtils.getParent(currPath);
+        lastSync = mCache.getIfPresent(currPath);
+        if (!shouldSyncInternal(lastSync, intervalMs, true)) {
+          // Sync is not necessary because an ancestor was already recursively synced
+          return false;
+        }
+      } catch (InvalidPathException e) {
+        // this is not expected, but the sync should be triggered just in case.
+        LOG.debug("Failed to get parent of ({}), for checking sync for ({})", currPath, path);
+        return true;
+      }
+    }
+
+    // trigger a sync, because a sync on the path (or an ancestor) was performed recently
+    return true;
+  }
+
+  /**
+   * Determines if the sync should be performed.
+   *
+   * @param syncTime the {@link SyncTime} to examine
+   * @param intervalMs the sync interval, in ms
+   * @param checkRecursive checks the recursive sync time if true, checks the standard sync time
+   *                       otherwise
+   * @return true if the sync should be performed
+   */
+  private boolean shouldSyncInternal(@Nullable SyncTime syncTime, long intervalMs,
+      boolean checkRecursive) {
+    if (syncTime == null) {
       return true;
     }
-    return (System.currentTimeMillis() - lastSync) >= intervalMs;
+    long lastSyncMs = syncTime.getLastSyncMs();
+    if (checkRecursive) {
+      lastSyncMs = syncTime.getLastRecursiveSyncMs();
+    }
+    if (lastSyncMs == SyncTime.UNSYNCED) {
+      // was not synced ever, so should sync
+      return true;
+    }
+    return (System.currentTimeMillis() - lastSyncMs) >= intervalMs;
+  }
+
+  private static class SyncTime {
+    static final long UNSYNCED = -1;
+    /** the last time (in ms) that a sync was performed. */
+    private long mLastSyncMs;
+    /** the last time (in ms) that a recursive sync was performed. */
+    private long mLastRecursiveSyncMs;
+
+    SyncTime(long syncMs, DescendantType descendantType) {
+      mLastSyncMs = UNSYNCED;
+      mLastRecursiveSyncMs = UNSYNCED;
+      updateSync(syncMs, descendantType);
+    }
+
+    void updateSync(long syncMs, DescendantType descendantType) {
+      mLastSyncMs = syncMs;
+      if (descendantType == DescendantType.ALL) {
+        mLastRecursiveSyncMs = syncMs;
+      }
+    }
+
+    long getLastSyncMs() {
+      return mLastSyncMs;
+    }
+
+    long getLastRecursiveSyncMs() {
+      return mLastRecursiveSyncMs;
+    }
   }
 }


### PR DESCRIPTION
fixes #9545

This enables the ufs sync cache to inspect the ancestors of the path.
This allows the sync to be skipped if an ancestor was recently sync
recursively. This will potentially increase the time to check if sync
should be performed, since the path's parents have to be computed.

pr-link: Alluxio/alluxio#9668
change-id: cid-bd0cfe062c02c919585f5506bbe970d553dcc526