### PR TITLE
Allow getBlockInfo command to handle errors

### DIFF
--- a/shell/src/main/java/alluxio/cli/fsadmin/command/GetBlockInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/GetBlockInfoCommand.java
@@ -70,11 +70,29 @@ public class GetBlockInfoCommand extends AbstractFsAdminCommand {
       throw new InvalidArgumentException(arg + " is not a valid block id.");
     }
 
-    BlockInfo info = mBlockClient.getBlockInfo(blockId);
+    BlockInfo info = null;
+    try {
+      info = mBlockClient.getBlockInfo(blockId);
+    } catch (Exception e) {
+      // ignore
+    }
     long fileId = BlockId.getFileId(blockId);
-    String path = mFsClient.getFilePath(fileId);
-    System.out.println(info);
-    System.out.printf("This block belongs to file {id=%s, path=%s}%n", fileId, path);
+    String path = null;
+    try {
+      path = mFsClient.getFilePath(fileId);
+    } catch (Exception e) {
+      // ignore
+    }
+    if (info != null) {
+      System.out.println(info);
+    } else {
+      System.out.println("BlockMeta is not available for blockId: " + blockId);
+    }
+    if (path != null) {
+      System.out.printf("This block belongs to file {id=%s, path=%s}%n", fileId, path);
+    } else {
+      System.out.printf("This block belongs to file {id=%s}%n", fileId);
+    }
     return 0;
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
@@ -43,9 +43,12 @@ public final class GetBlockInfoCommandIntegrationTest extends AbstractFsAdminShe
   public void blockMetaNotFound() {
     long invalidId = 1421312312L;
     int ret = mFsAdminShell.run("getBlockInfo", String.valueOf(invalidId));
-    Assert.assertEquals(-1, ret);
+    // invalid block id should still continue to return useful information
+    Assert.assertEquals(0, ret);
     Assert.assertThat(mOutput.toString(),
-        containsString(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(invalidId)));
+        containsString("BlockMeta is not available for blockId"));
+    Assert.assertThat(mOutput.toString(),
+        containsString("This block belongs to file"));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/GetBlockInfoCommandIntegrationTest.java
@@ -18,7 +18,6 @@ import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.exception.AlluxioException;
-import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.WritePType;
 import alluxio.master.block.BlockId;
 


### PR DESCRIPTION
The getBlockInfo command may hit errors when contacting the block master or file system master. However, the command may still be able to print out useful information, even if some of the RPCs fail. Therefore, the RPC exceptions should be handled and ignored and print out any available information.