### PR TITLE
Propagate thread-local AuthenticatedClientUser to gRPC executors

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -36,20 +36,20 @@ final class GrpcExecutors {
   private static final long THREAD_STOP_MS = Constants.SECOND_MS * 10;
   private static final int THREADS_MIN = 4;
 
-  public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-      new ThreadPoolExecutor(THREADS_MIN,
+  public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR =
+      new ImpersonateThreadPoolExecutor(new ThreadPoolExecutor(THREADS_MIN,
           ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
           ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true)));
 
-  public static final ExecutorService BLOCK_READER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-      new ThreadPoolExecutor(THREADS_MIN,
+  public static final ExecutorService BLOCK_READER_EXECUTOR =
+      new ImpersonateThreadPoolExecutor(new ThreadPoolExecutor(THREADS_MIN,
           ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
           ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true)));
 
-  public static final ExecutorService BLOCK_WRITER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-      new ThreadPoolExecutor(THREADS_MIN,
+  public static final ExecutorService BLOCK_WRITER_EXECUTOR =
+      new ImpersonateThreadPoolExecutor(new ThreadPoolExecutor(THREADS_MIN,
           ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
           ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true)));

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -37,22 +37,22 @@ final class GrpcExecutors {
   private static final int THREADS_MIN = 4;
 
   public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-          new ThreadPoolExecutor(THREADS_MIN,
-                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
-                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
-                  ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true)));
+      new ThreadPoolExecutor(THREADS_MIN,
+          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
+          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
+          ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true)));
 
   public static final ExecutorService BLOCK_READER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-          new ThreadPoolExecutor(THREADS_MIN,
-                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
-                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-                  ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true)));
+      new ThreadPoolExecutor(THREADS_MIN,
+          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
+          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
+          ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true)));
 
   public static final ExecutorService BLOCK_WRITER_EXECUTOR = new ImpersonateThreadPoolExecutor(
-          new ThreadPoolExecutor(THREADS_MIN,
-                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
-                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-                  ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true)));
+      new ThreadPoolExecutor(THREADS_MIN,
+          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
+          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
+          ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true)));
 
   /**
    * Private constructor.

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -14,8 +14,12 @@ package alluxio.worker.grpc;
 import alluxio.conf.ServerConfiguration;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
+import alluxio.security.User;
+import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.ThreadFactoryUtils;
 
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
@@ -32,26 +36,79 @@ final class GrpcExecutors {
   private static final long THREAD_STOP_MS = Constants.SECOND_MS * 10;
   private static final int THREADS_MIN = 4;
 
-  public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
-          ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true));
+  public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR = new ImpersonateThreadPoolExecutor(
+          new ThreadPoolExecutor(THREADS_MIN,
+                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
+                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
+                  ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true)));
 
-  public static final ExecutorService BLOCK_READER_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true));
+  public static final ExecutorService BLOCK_READER_EXECUTOR = new ImpersonateThreadPoolExecutor(
+          new ThreadPoolExecutor(THREADS_MIN,
+                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
+                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
+                  ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true)));
 
-  public static final ExecutorService BLOCK_WRITER_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true));
+  public static final ExecutorService BLOCK_WRITER_EXECUTOR = new ImpersonateThreadPoolExecutor(
+          new ThreadPoolExecutor(THREADS_MIN,
+                  ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
+                  THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
+                  ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true)));
 
   /**
    * Private constructor.
    */
   private GrpcExecutors() {}
+
+  /**
+   * This executor passes impersonation information to the real worker thread.
+   * The proxy user is tracked by {@link AuthenticatedClientUser#sUserThreadLocal}.
+   * This executor delegates operations to the underlying executor while setting the ThreadLocal context
+   * for execution.
+   * */
+  private static class ImpersonateThreadPoolExecutor extends AbstractExecutorService {
+    private final ExecutorService mDelegate;
+
+    public ImpersonateThreadPoolExecutor(ExecutorService service) {
+      mDelegate = service;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      // If there's no impersonation, proxyUser is just null
+      User proxyUser = AuthenticatedClientUser.getOrNull();
+      mDelegate.execute(() -> {
+        try {
+          AuthenticatedClientUser.set(proxyUser);
+          command.run();
+        } finally {
+          AuthenticatedClientUser.remove();
+        }
+      });
+    }
+
+    @Override
+    public void shutdown() {
+      mDelegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return mDelegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return mDelegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return mDelegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      return mDelegate.awaitTermination(timeout, unit);
+    }
+  }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -62,8 +62,8 @@ final class GrpcExecutors {
   /**
    * This executor passes impersonation information to the real worker thread.
    * The proxy user is tracked by {@link AuthenticatedClientUser#sUserThreadLocal}.
-   * This executor delegates operations to the underlying executor while setting the ThreadLocal context
-   * for execution.
+   * This executor delegates operations to the underlying executor while setting the
+   * ThreadLocal context for execution.
    * */
   private static class ImpersonateThreadPoolExecutor extends AbstractExecutorService {
     private final ExecutorService mDelegate;

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/AbstractWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/AbstractWriteHandlerTest.java
@@ -166,11 +166,6 @@ public abstract class AbstractWriteHandlerTest {
     mWriteHandler.onError(new IOException("test exception"));
   }
 
-  @Test
-  public void impersonationInfoPropagated() {
-
-  }
-
   /**
    * Checks the file content matches expectation (file length and file checksum).
    *

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/AbstractWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/AbstractWriteHandlerTest.java
@@ -166,6 +166,11 @@ public abstract class AbstractWriteHandlerTest {
     mWriteHandler.onError(new IOException("test exception"));
   }
 
+  @Test
+  public void impersonationInfoPropagated() {
+
+  }
+
   /**
    * Checks the file content matches expectation (file length and file checksum).
    *

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.worker.grpc;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 
@@ -19,8 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
-
-import static org.junit.Assert.assertEquals;
 
 public class GrpcExecutorsTest {
   private static final String IMPERSONATION_PROXY_USER_NAME = "foo";

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
@@ -1,0 +1,67 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.grpc;
+
+import alluxio.security.User;
+import alluxio.security.authentication.AuthenticatedClientUser;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertEquals;
+
+public class GrpcExecutorsTest {
+  private static final String IMPERSONATION_PROXY_USER_NAME = "foo";
+
+  @Before
+  public void before() {
+    AuthenticatedClientUser.remove();
+  }
+
+  @After
+  public void after() {
+    AuthenticatedClientUser.remove();
+  }
+
+  private void validateImpersonationInfo(ExecutorService executor) {
+    final User contextProxyUser = AuthenticatedClientUser.getOrNull();
+    executor.execute(() -> {
+      User workerProxyUser = AuthenticatedClientUser.getOrNull();
+      assertEquals(contextProxyUser, workerProxyUser);
+    });
+
+    AuthenticatedClientUser.set(IMPERSONATION_PROXY_USER_NAME);
+    User newContextProxyUser = AuthenticatedClientUser.getOrNull();
+    executor.execute(() -> {
+      User workerProxyUser = AuthenticatedClientUser.getOrNull();
+      assertEquals(newContextProxyUser, workerProxyUser);
+    });
+  }
+
+  @Test
+  public void impersonationPassedToBlockReader() {
+    validateImpersonationInfo(GrpcExecutors.BLOCK_READER_EXECUTOR);
+  }
+
+  @Test
+  public void impersonationPassedToBlockWriter() {
+    validateImpersonationInfo(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+  }
+
+  @Test
+  public void impersonationPassedToAsyncCacheManager() {
+    validateImpersonationInfo(GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR);
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
@@ -35,7 +35,7 @@ public class GrpcExecutorsTest {
     AuthenticatedClientUser.remove();
   }
 
-  private void validateImpersonationInfo(ExecutorService executor) {
+  private void validateAuthenticatedClientUser(ExecutorService executor) {
     final User contextProxyUser = AuthenticatedClientUser.getOrNull();
     executor.execute(() -> {
       User workerProxyUser = AuthenticatedClientUser.getOrNull();
@@ -52,16 +52,16 @@ public class GrpcExecutorsTest {
 
   @Test
   public void impersonationPassedToBlockReader() {
-    validateImpersonationInfo(GrpcExecutors.BLOCK_READER_EXECUTOR);
+    validateAuthenticatedClientUser(GrpcExecutors.BLOCK_READER_EXECUTOR);
   }
 
   @Test
   public void impersonationPassedToBlockWriter() {
-    validateImpersonationInfo(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+    validateAuthenticatedClientUser(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
   }
 
   @Test
   public void impersonationPassedToAsyncCacheManager() {
-    validateImpersonationInfo(GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR);
+    validateAuthenticatedClientUser(GrpcExecutors.ASYNC_CACHE_MANAGER_EXECUTOR);
   }
 }


### PR DESCRIPTION
The proxy user information for impersonation is stored in the ThreadLocal object in AuthenticatedClientUser class. The thread pools in GrpcExecutors are not given this proxy user ThreadLocal when read/write tasks are submitted to them. We have to write a wrapper for ExecutorService that sets and unsets the ThreadLocal correctly.