### PR TITLE
Restore interrupted flag in DynamicResourcePool

### DIFF
--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -342,6 +342,8 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
             throw new TimeoutException("Acquire resource times out.");
           }
         } catch (InterruptedException e) {
+          // TODO(calvin): Propagate the interrupted exception instead of converting to IOException
+          Thread.currentThread().interrupt();
           throw new IOException("Thread interrupted while acquiring client from pool: " + this);
         }
       }


### PR DESCRIPTION
Follow up to #9584

Restoring the interrupted state can be helpful to callers if they catch
IOException and check the interrupted flag (ie. a retry handler).
We can reset the interrupted flag because we break out of the while loop
afterward.

Cherry-pick of existing commit.
orig-commit-author: Calvin Jia \<jia.calvin@gmail.com\>

pr-link: Alluxio/alluxio#9680
change-id: cid-ba835b158fb735fa5e31b97e098ba38bc9b44330