### PR TITLE
Prevent excessive flushing while applying a backup

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1012,6 +1012,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_BACKUP_ENTRY_BUFFER_COUNT =
+      new Builder(Name.MASTER_BACKUP_ENTRY_BUFFER_COUNT)
+          .setDefaultValue("10000")
+          .setDescription("How many journal entries to buffer during a back-up.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_BIND_HOST =
       new Builder(Name.MASTER_BIND_HOST)
           .setDefaultValue("0.0.0.0")
@@ -3363,6 +3370,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.audit.logging.queue.capacity";
     public static final String MASTER_BACKUP_DIRECTORY =
         "alluxio.master.backup.directory";
+    public static final String MASTER_BACKUP_ENTRY_BUFFER_COUNT =
+        "alluxio.master.backup.entry.buffer.count";
     public static final String MASTER_BIND_HOST = "alluxio.master.bind.host";
     public static final String MASTER_CLIENT_SOCKET_CLEANUP_INTERVAL =
         "alluxio.master.client.socket.cleanup.interval";

--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1012,10 +1012,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_BACKUP_ENTRY_BUFFER_COUNT =
-      new Builder(Name.MASTER_BACKUP_ENTRY_BUFFER_COUNT)
+  public static final PropertyKey MASTER_BACKUP_ENTRY_BATCH_SIZE =
+      new Builder(Name.MASTER_BACKUP_ENTRY_BATCH_SIZE)
           .setDefaultValue("10000")
-          .setDescription("How many journal entries to buffer during a back-up.")
+          .setDescription("How many journal entries to batch while applying a backup.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
@@ -3370,8 +3370,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.audit.logging.queue.capacity";
     public static final String MASTER_BACKUP_DIRECTORY =
         "alluxio.master.backup.directory";
-    public static final String MASTER_BACKUP_ENTRY_BUFFER_COUNT =
-        "alluxio.master.backup.entry.buffer.count";
+    public static final String MASTER_BACKUP_ENTRY_BATCH_SIZE =
+        "alluxio.master.backup.entry.batch.size";
     public static final String MASTER_BIND_HOST = "alluxio.master.bind.host";
     public static final String MASTER_CLIENT_SOCKET_CLEANUP_INTERVAL =
         "alluxio.master.client.socket.cleanup.interval";

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -11,6 +11,8 @@
 
 package alluxio.master;
 
+import alluxio.Configuration;
+import alluxio.PropertyKey;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.JournalEntryAssociation;
 import alluxio.master.journal.JournalEntryStreamReader;
@@ -25,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -86,15 +90,48 @@ public class BackupManager {
     try (GzipCompressorInputStream gzIn = new GzipCompressorInputStream(is);
          JournalEntryStreamReader reader = new JournalEntryStreamReader(gzIn)) {
       List<Master> masters = mRegistry.getServers();
-      JournalEntry entry;
       Map<String, Master> mastersByName = Maps.uniqueIndex(masters, Master::getName);
-      while ((entry = reader.readEntry()) != null) {
-        String masterName = JournalEntryAssociation.getMasterForEntry(entry);
-        Master master = mastersByName.get(masterName);
-        master.processJournalEntry(entry);
-        try (JournalContext jc = master.createJournalContext()) {
-          jc.append(entry);
-          count++;
+      // Create buffer to avoid flushing per-entry.
+      int bufferLimit = Configuration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT);
+      List<JournalEntry> entryBuffer = new ArrayList<>(bufferLimit);
+      // Apply entries from input stream.
+      JournalEntry entry;
+      while (true) {
+        // Read next entry.
+        entry = reader.readEntry();
+        // Buffer next entry.
+        if (entry != null) {
+          entryBuffer.add(entry);
+        }
+        // Process the buffer if it is full or the input stream has no more entries.
+        if (entry == null || entryBuffer.size() >= bufferLimit) {
+          // Used to keep track of journal contexts per master.
+          Map<String, JournalContext> contextMap = new HashMap<>();
+          // Process each buffered entry.
+          for (JournalEntry bufferedEntry : entryBuffer) {
+            String masterName = JournalEntryAssociation.getMasterForEntry(bufferedEntry);
+            Master master = mastersByName.get(masterName);
+            // Apply entry to master.
+            master.processJournalEntry(bufferedEntry);
+            // Create journal context if master is seens the first time.
+            if (!contextMap.containsKey(masterName)) {
+              contextMap.put(masterName, master.createJournalContext());
+            }
+            // Apply entry to journal.
+            contextMap.get(masterName).append(bufferedEntry);
+            // entry is processed.
+            count++;
+          }
+          // Close journal context.
+          for (JournalContext context : contextMap.values()) {
+            context.close();
+          }
+          // Clear the buffer.
+          entryBuffer.clear();
+        }
+        // Quit applying when stream has no more entries.
+        if (entry == null) {
+          break;
         }
       }
     }

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -92,7 +92,7 @@ public class BackupManager {
       List<Master> masters = mRegistry.getServers();
       Map<String, Master> mastersByName = Maps.uniqueIndex(masters, Master::getName);
       // Create buffer to avoid flushing per-entry.
-      int bufferLimit = Configuration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT);
+      int bufferLimit = Configuration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BATCH_SIZE);
       List<JournalEntry> entryBuffer = new ArrayList<>(bufferLimit);
       // Apply entries from input stream.
       JournalEntry entry;


### PR DESCRIPTION
Use a buffer to batch more entries at a time to apply and journal, while applying a backup.