### PR TITLE
Handle interruptions on various heart beats

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -53,10 +53,14 @@ final class InodeTtlChecker implements HeartbeatExecutor {
   }
 
   @Override
-  public void heartbeat() {
+  public void heartbeat() throws InterruptedException {
     Set<TtlBucket> expiredBuckets = mTtlBuckets.getExpiredBuckets(System.currentTimeMillis());
     for (TtlBucket bucket : expiredBuckets) {
       for (Inode inode : bucket.getInodes()) {
+        // Throw if interrupted.
+        if (Thread.interrupted()) {
+          throw new InterruptedException("InodeTtlChecker interrupted.");
+        }
         AlluxioURI path = null;
         try (LockedInodePath inodePath = mInodeTree
             .lockFullInodePath(inode.getId(), InodeTree.LockMode.READ)) {

--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -41,8 +41,12 @@ final class LostFileDetector implements HeartbeatExecutor {
   }
 
   @Override
-  public void heartbeat() {
+  public void heartbeat() throws InterruptedException {
     for (long fileId : mFileSystemMaster.getLostFiles()) {
+      // Throw if interrupted.
+      if (Thread.interrupted()) {
+        throw new InterruptedException("LostFileDetector interrupted.");
+      }
       // update the state
       try (LockedInodePath inodePath = mInodeTree
           .lockFullInodePath(fileId, InodeTree.LockMode.WRITE)) {


### PR DESCRIPTION
`HeartbeatExecutor#heaertbeat` should throw `InterruptedException` by contract. This PR enforces it for several implementations.

Fixes https://github.com/Alluxio/alluxio/issues/9658