### PR TITLE
Increase the default metadata space

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -270,6 +270,12 @@ start_master() {
       ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
     fi
 
+    # use a default Xmx value for the master
+    contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize"
+    if [[ $? -eq 0 ]]; then
+      ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=128M "
+    fi
+
     echo "Starting master @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
     (nohup "${JAVA}" -cp ${CLASSPATH} \
      ${ALLUXIO_MASTER_JAVA_OPTS} \

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -273,7 +273,7 @@ start_master() {
     # use a default Xmx value for the master
     contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize"
     if [[ $? -eq 0 ]]; then
-      ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=128M "
+      ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
     fi
 
     echo "Starting master @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -270,7 +270,7 @@ start_master() {
       ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
     fi
 
-    # use a default Xmx value for the master
+    # use a default MetaspaceSize value for the master
     contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize"
     if [[ $? -eq 0 ]]; then
       ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "


### PR DESCRIPTION
Loading UFS extensions can exceed the default metadata space and causes full GC during server start up, this can be problematic if Alluxio master uses a lot of heap space, for example due to large amount of files.

This change increases the default metadata space to reduce such chance. User can override it with larger numbers as needed.