### PR TITLE
Improve ufs journal parsing efficiency

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
@@ -76,9 +76,7 @@ public class JournalEntryStreamReader implements Closeable {
           totalBytesRead);
       return null;
     }
-
-    JournalEntry entry = JournalEntry.parseFrom(new ByteArrayInputStream(mBuffer, 0, size));
-    return entry;
+    return JournalEntry.parser().parseFrom(mBuffer, 0, size);
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
@@ -17,7 +17,6 @@ import alluxio.util.proto.ProtoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
@@ -38,7 +38,7 @@ public final class UfsJournalFileParser implements JournalFileParser {
 
   private final UnderFileSystem mUfs;
   /** Buffer used to read from the file. */
-  private final byte[] mBuffer = new byte[1024];
+  private byte[] mBuffer = new byte[1024];
 
   /** The input stream to read from the journal file. */
   private InputStream mInputStream;
@@ -79,12 +79,14 @@ public final class UfsJournalFileParser implements JournalFileParser {
       LOG.warn("Journal entry was truncated in the size portion.");
       return null;
     }
-    byte[] buffer = size <= mBuffer.length ? mBuffer : new byte[size];
+    if (size > mBuffer.length) {
+      mBuffer = new byte[size];
+    }
     // Total bytes read so far for journal entry.
     int totalBytesRead = 0;
     while (totalBytesRead < size) {
       // Bytes read in last read request.
-      int latestBytesRead = mInputStream.read(buffer, totalBytesRead, size - totalBytesRead);
+      int latestBytesRead = mInputStream.read(mBuffer, totalBytesRead, size - totalBytesRead);
       if (latestBytesRead < 0) {
         break;
       }
@@ -96,6 +98,6 @@ public final class UfsJournalFileParser implements JournalFileParser {
       return null;
     }
 
-    return Journal.JournalEntry.parseFrom(new ByteArrayInputStream(buffer, 0, size));
+    return Journal.JournalEntry.parser().parseFrom(mBuffer, 0, size);
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;


### PR DESCRIPTION
Fixes #9698 

In the journal entry stream reader we keep a buffer to reuse for reading entries. Because this buffer might not be fully utilized, we cannot use protobuf's default `parseFrom(byte[])` and instead wrap the valid portion of the buffer in a ByteArrayStream. However this causes additional buffer allocations. We can instead use the lower level parser API to parse a slice of the existing buffer.

This does not affect the embedded journal implementation because we allocate a fresh buffer for each entry (exact size). Also I did not apply this optimization for the v0 journals as those are no longer in use aside for migrations.

The overall performance improvement is about 75% for a 10MB edit log file stored on local disk, this also reduces the number of new objects allocated which can reduce GC pressure.