### PR TITLE
Run k8s as root by default

### DIFF
--- a/integration/kubernetes/alluxio-master.yaml.template
+++ b/integration/kubernetes/alluxio-master.yaml.template
@@ -54,6 +54,10 @@ spec:
       labels:
         app: alluxio-master
     spec:
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
       containers:
         - name: alluxio-master
           image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -103,3 +107,4 @@ spec:
         - name: alluxio-journal
           persistentVolumeClaim:
             claimName: alluxio-pv-claim
+

--- a/integration/kubernetes/alluxio-worker.yaml.template
+++ b/integration/kubernetes/alluxio-worker.yaml.template
@@ -27,6 +27,10 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
       containers:
         - name: alluxio-worker
           image: alluxio/alluxio:2.1.0-SNAPSHOT

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -52,6 +52,10 @@ spec:
       labels:
         app: alluxio-master
     spec:
+      securityContext:
+        runAsUser: {{ .Values.user }}
+        runAsGroup: {{ .Values.group }}
+        fsGroup: {{ .Values.fsGroup }}
       containers:
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
@@ -25,6 +25,10 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      securityContext:
+        runAsUser: {{ .Values.user }}
+        runAsGroup: {{ .Values.group }}
+        fsGroup: {{ .Values.fsGroup }}
       containers:
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/integration/kubernetes/helm/alluxio/values.yaml
+++ b/integration/kubernetes/helm/alluxio/values.yaml
@@ -13,6 +13,10 @@ image: alluxio/alluxio
 imageTag: "2.1.0-SNAPSHOT"
 imagePullPolicy: IfNotPresent
 
+user: 0
+group: 0
+fsGroup: 0
+
 resources:
   master:
     replicaCount: 1


### PR DESCRIPTION
After https://github.com/Alluxio/alluxio/pull/9363 is merged, we now run the docker containers with user `alluxio` by default. `hostPath` volumes in the default k8s specs are owned by `root` and the `alluxio` user does not have access to write the journal to that location.

This PR allows choosing the user to run the Alluxio service on k8s in the helm chart and replaces the generated template files.