### PR TITLE
Improve ufs journal parsing efficiency

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
@@ -17,7 +17,6 @@ import alluxio.util.proto.ProtoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -76,9 +75,7 @@ public class JournalEntryStreamReader implements Closeable {
           totalBytesRead);
       return null;
     }
-
-    JournalEntry entry = JournalEntry.parseFrom(new ByteArrayInputStream(mBuffer, 0, size));
-    return entry;
+    return JournalEntry.parser().parseFrom(mBuffer, 0, size);
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryStreamReader.java
@@ -75,7 +75,7 @@ public class JournalEntryStreamReader implements Closeable {
           totalBytesRead);
       return null;
     }
-    return JournalEntry.parser().parseFrom(mBuffer, 0, size);
+    return JournalEntry.PARSER.parseFrom(mBuffer, 0, size);
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
@@ -94,6 +94,6 @@ public final class UfsJournalFileParser implements JournalFileParser {
       return null;
     }
 
-    return Journal.JournalEntry.parser().parseFrom(mBuffer, 0, size);
+    return Journal.JournalEntry.PARSER.parseFrom(mBuffer, 0, size);
   }
 }


### PR DESCRIPTION
Fixes #9698

In the journal entry stream reader we keep a buffer to reuse for reading
entries. Because this buffer might not be fully utilized, we cannot use
protobuf's default `parseFrom(byte[])` and instead wrap the valid
portion of the buffer in a ByteArrayStream. However this causes
additional buffer allocations. We can instead use the lower level parser
API to parse a slice of the existing buffer.

This does not affect the embedded journal implementation because we
allocate a fresh buffer for each entry (exact size). Also I did not
apply this optimization for the v0 journals as those are no longer in
use aside for migrations.

The overall performance improvement is about 75% for a 10MB edit log
file stored on local disk, this also reduces the number of new objects
allocated which can reduce GC pressure.

Cherry-pick of existing commit.

pr-link: Alluxio/alluxio#9699
change-id: cid-5f1fdc9eb2cb39637dfb5518b0144839ab231827