### PR TITLE
Use Concurrent Mark Sweep garbage collector for master by default

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -276,6 +276,11 @@ start_master() {
       ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
     fi
 
+    # use a CMS garbage collector for the master
+    if ! [[ "${ALLUXIO_MASTER_JAVA_OPTS}" =~ (UseConcMarkSweepGC|UseSerialGC|UseG1GC|UseParallelGC|UseParallelOldGC|UseParNewGC) ]]; then
+      ALLUXIO_MASTER_JAVA_OPTS+=" -XX:+UseConcMarkSweepGC "
+    fi
+
     echo "Starting master @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
     (nohup "${JAVA}" -cp ${CLASSPATH} \
      ${ALLUXIO_MASTER_JAVA_OPTS} \

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -120,6 +120,10 @@ launch_master() {
   if [[ $? -eq 0 ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
   fi
+  # use a CMS garbage collector for the master
+  if ! [[ "${ALLUXIO_MASTER_JAVA_OPTS}" =~ (UseConcMarkSweepGC|UseSerialGC|UseG1GC|UseParallelGC|UseParallelOldGC|UseParNewGC) ]]; then
+    ALLUXIO_MASTER_JAVA_OPTS+=" -XX:+UseConcMarkSweepGC "
+  fi
 
   launch_process "${ALLUXIO_MASTER_JAVA_OPTS}" \
                  "alluxio.master.AlluxioMaster"


### PR DESCRIPTION
It is crucial to minimize full garbage collection pause in Alluxio master which could cause various issues including master fail over. This change switch to use Concurrent Mark Sweep garbage collector by default so it is less likely to enter a long full GC pause on master.