### PR TITLE
Improve parent dir check in UfsSyncPathCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -89,12 +89,14 @@ public final class UfsSyncPathCache {
 
     // sync should be done on this path, but check all ancestors to determine if a recursive sync
     // had been performed (to avoid a sync again).
+    int parentLevel = 0;
     String currPath = path;
     while (!currPath.equals(AlluxioURI.SEPARATOR)) {
       try {
         currPath = PathUtils.getParent(currPath);
+        parentLevel++;
         lastSync = mCache.getIfPresent(currPath);
-        if (!shouldSyncInternal(lastSync, intervalMs, true)) {
+        if (!shouldSyncInternal(lastSync, intervalMs, parentLevel > 1)) {
           // Sync is not necessary because an ancestor was already recursively synced
           return false;
         }


### PR DESCRIPTION
**Description**
Improving cache logic for https://github.com/Alluxio/alluxio/pull/9668. 
Please refer https://github.com/Alluxio/alluxio/pull/9715
#
If the dir is the last layer of directories, the result of "ls" is the same with "ls -R", but the descendantType of "ls" is "ONE" not "ALL", and the path cache will be not the same. 

**Improvement**
Add variable parentLevel for parent dir check and skip the mLastRecursiveSyncMs for direct parent.

