### PR TITLE
Improve parent dir check in UfsSyncPathCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -738,7 +738,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     Metrics.GET_FILE_INFO_OPS.inc();
     long opTimeMs = System.currentTimeMillis();
     LockingScheme lockingScheme =
-        createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ);
+        createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ, true);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern());
@@ -4574,12 +4574,18 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
   }
 
   private LockingScheme createLockingScheme(AlluxioURI path, FileSystemMasterCommonPOptions options,
-      LockPattern desiredLockMode) {
+      LockPattern desiredLockMode) throws InvalidPathException {
+    return createLockingScheme(path, options, desiredLockMode, false);
+  }
+
+  private LockingScheme createLockingScheme(AlluxioURI path, FileSystemMasterCommonPOptions options,
+      LockPattern desiredLockMode, boolean checkRecursive) throws InvalidPathException {
     // If client options didn't specify the interval, fallback to whatever the server has
     // configured to prevent unnecessary syncing due to the default value being 0
     long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
-        ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
-    boolean shouldSync = mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval);
+            ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+    boolean shouldSync =
+        mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval, checkRecursive);
     return new LockingScheme(path, desiredLockMode, shouldSync);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4583,7 +4583,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     // If client options didn't specify the interval, fallback to whatever the server has
     // configured to prevent unnecessary syncing due to the default value being 0
     long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
-            ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+        ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
     boolean shouldSync =
         mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval, checkRecursive);
     return new LockingScheme(path, desiredLockMode, shouldSync);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -86,8 +86,10 @@ public final class UfsSyncPathCache {
       return syncCheckRecursive(path, intervalMs);
     }
     SyncTime lastSync = mCache.getIfPresent(path);
-    return lastSync != null
-            && (System.currentTimeMillis() - lastSync.getLastSyncMs()) >= intervalMs;
+    if (lastSync == null) {
+      return true;
+    }
+    return (System.currentTimeMillis() - lastSync.getLastSyncMs()) >= intervalMs;
   }
 
   private boolean syncCheckRecursive(String path, long intervalMs) throws InvalidPathException {


### PR DESCRIPTION
**Description**
Improving cache logic for PR #9668 #9714 .

**Improvement**
Add SyncTimeLevel to record time for the immediate parent dir, the intermediate parent dir, and the cmd "ls" or "ls -R".
