### PR TITLE
Update launch-process contains function so the script does not exit

### DIFF
--- a/bin/launch-process
+++ b/bin/launch-process
@@ -120,7 +120,7 @@ launch_master() {
   fi
   # use a default MetaspaceSize value for the master
   res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize")"
-  if [[ $? -eq 0 ]]; then
+  if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
   fi
 
@@ -132,7 +132,7 @@ launch_master() {
 launch_secondary_master() {
   # use a default Xmx value for the master
   local res="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx")"
-  if [[ $? -eq 0 ]]; then
+  if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   launch_process "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" \
@@ -149,13 +149,13 @@ launch_job_master() {
 launch_worker() {
   # use a default Xmx value for the worker
   local res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx")"
-  if [[ $? -eq 0 ]]; then
+  if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Xmx4g "
   fi
 
   # use a default MaxDirectMemorySize value for the worker
   res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "XX:MaxDirectMemorySize")"
-  if [[ $? -eq 0 ]]; then
+  if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -XX:MaxDirectMemorySize=4g "
   fi
 
@@ -189,7 +189,7 @@ launch_logserver() {
 
 # Launch the desired process
 main() {
-  if [[ "$#" -gt "2" || "${#}" -eq "0" ]]; then
+  if [[ "${#}" -gt "2" || "${#}" -eq "0" ]]; then
     print_help 1
   fi
 

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -34,10 +34,16 @@ unless you know what you are doing.
     -h                Print this help text to stdout
 "
 
-# echos 1 if "$1" contains "$2", 0 otherwise.
+# prints "1" if "$1" contains "$2", "0" otherwise.
 #
 # Usage example: local result="$(contains "my string" "my")"
 #                + result="1"
+#
+# This function uses printf instead of echo because echo, by default, will add
+# a newline to its output. This would force the callers of the function to
+# strip newlines or force echo to not add newlines. Instead of using "-n" with
+# echo, printf is used as a safer and more portable alternative because the "-n"
+# argument is not in the UNIX standard.
 contains() {
   if [[ "$1" = *"$2"* ]]; then
     printf "1"

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -40,9 +40,9 @@ unless you know what you are doing.
 #                + result="1"
 contains() {
   if [[ "$1" = *"$2"* ]]; then
-    echo "1"
+    printf "1"
   fi
-  echo "0"
+  printf "0"
 }
 
 # Sets environment variables by sourcing ${ALLUXIO_HOME}/libexec/alluxio-config.sh

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -10,7 +10,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-set -e
+set -x
 
 BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
@@ -34,12 +34,15 @@ unless you know what you are doing.
     -h                Print this help text to stdout
 "
 
-# returns 1 if "$1" contains "$2", 0 otherwise.
+# echos 1 if "$1" contains "$2", 0 otherwise.
+#
+# Usage example: local result="$(contains "my string" "my")"
+#                + result="1"
 contains() {
   if [[ "$1" = *"$2"* ]]; then
-    return 1
+    echo "1"
   fi
-  return 0
+  echo "0"
 }
 
 # Sets environment variables by sourcing ${ALLUXIO_HOME}/libexec/alluxio-config.sh
@@ -111,12 +114,12 @@ launch_master() {
   fi
 
   # use a default Xmx value for the master
-  contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx"
-  if [[ $? -eq 0 ]]; then
+  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx")"
+  if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   # use a default MetaspaceSize value for the master
-  contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize"
+  res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "XX:MetaspaceSize")"
   if [[ $? -eq 0 ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
   fi
@@ -128,7 +131,7 @@ launch_master() {
 # Launch a secondary master process
 launch_secondary_master() {
   # use a default Xmx value for the master
-  contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx"
+  local res="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx")"
   if [[ $? -eq 0 ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
@@ -145,13 +148,13 @@ launch_job_master() {
 # Launch a worker process
 launch_worker() {
   # use a default Xmx value for the worker
-  contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx"
+  local res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx")"
   if [[ $? -eq 0 ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Xmx4g "
   fi
 
   # use a default MaxDirectMemorySize value for the worker
-  contains "${ALLUXIO_WORKER_JAVA_OPTS}" "XX:MaxDirectMemorySize"
+  res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "XX:MaxDirectMemorySize")"
   if [[ $? -eq 0 ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -XX:MaxDirectMemorySize=4g "
   fi

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -10,7 +10,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-set -x
+set -e
 
 BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 


### PR DESCRIPTION
The launch-process script uses the `set -e` flag which tells bash to exit
if a command returns non-zero; In the case when the "contains"
function returned "1", (meaning that arg 1 contains arg 2 somewhere within
it), the script would exit.

This means that any users which set values through alluxio-env.sh could
possibly have their processes fail to start if setting things like Xmx
and MetaspaceSize that are checked in either the master or workers.

To remediate this issue the contains function was modified to
instead, echo "1" or "0". Callers then simply have to call the
function in a subshell and use the result in their conditional
checks. This approach offers a better and more consistent usage
with the rest of our scripts.

Fixes #9740 