### PR TITLE
Perform copycat connection building in a dedicated thread pool

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClientConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClientConnection.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * {@link CopycatGrpcConnection} implementation for client.
@@ -34,12 +35,13 @@ public class CopycatGrpcClientConnection extends CopycatGrpcConnection {
    * Note: {@link #setTargetObserver} should be called explicitly before using the connection.
    *
    * @param context copycat thread context
+   * @param executor transport executor
    * @param channel underlying gRPC channel
    * @param requestTimeoutMs timeout in milliseconds for requests
    */
-  public CopycatGrpcClientConnection(ThreadContext context, GrpcChannel channel,
-      long requestTimeoutMs) {
-    super(ConnectionOwner.CLIENT, context, requestTimeoutMs);
+  public CopycatGrpcClientConnection(ThreadContext context, ExecutorService executor,
+      GrpcChannel channel, long requestTimeoutMs) {
+    super(ConnectionOwner.CLIENT, context, executor, requestTimeoutMs);
     mChannel = channel;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcConnection.java
@@ -100,7 +100,7 @@ public abstract class CopycatGrpcConnection
    * @param requestTimeoutMs timeout in milliseconds for requests
    */
   public CopycatGrpcConnection(ConnectionOwner connectionOwner, ThreadContext context,
-                               long requestTimeoutMs) {
+      long requestTimeoutMs) {
     mConnectionOwner = connectionOwner;
     mContext = context;
     mRequestTimeoutMs = requestTimeoutMs;
@@ -154,8 +154,8 @@ public abstract class CopycatGrpcConnection
 
       // Create a contextual future for the request.
       CopycatGrpcConnection.ContextualFuture<U> future =
-              new CopycatGrpcConnection.ContextualFuture<>(System.currentTimeMillis(),
-                      ThreadContext.currentContextOrThrow());
+          new CopycatGrpcConnection.ContextualFuture<>(System.currentTimeMillis(),
+              ThreadContext.currentContextOrThrow());
 
       // Don't allow request if connection is closed.
       if (mClosed) {
@@ -171,10 +171,10 @@ public abstract class CopycatGrpcConnection
       // Serialize the request and send it over to target.
       try {
         mTargetObserver.onNext(CopycatMessage.newBuilder()
-                .setRequestHeader(CopycatRequestHeader.newBuilder().setRequestId(requestId))
-                .setMessage(UnsafeByteOperations
-                        .unsafeWrap(future.getContext().serializer().writeObject(request).array()))
-                .build());
+            .setRequestHeader(CopycatRequestHeader.newBuilder().setRequestId(requestId))
+            .setMessage(UnsafeByteOperations
+                .unsafeWrap(future.getContext().serializer().writeObject(request).array()))
+            .build());
       } catch (Exception e) {
         future.completeExceptionally(e);
         return future;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcConnection.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -90,6 +91,9 @@ public abstract class CopycatGrpcConnection
   /** Used to synchronize during connection shut down. */
   private final ReadWriteLock mStateLock;
 
+  /** Executor for connection. */
+  private final ExecutorService mExecutor;
+
   /**
    * Creates a connection object.
    *
@@ -97,12 +101,14 @@ public abstract class CopycatGrpcConnection
    *
    * @param connectionOwner owner of connection
    * @param context copycat thread context
+   * @param executor transport executor
    * @param requestTimeoutMs timeout in milliseconds for requests
    */
   public CopycatGrpcConnection(ConnectionOwner connectionOwner, ThreadContext context,
-      long requestTimeoutMs) {
+      ExecutorService executor, long requestTimeoutMs) {
     mConnectionOwner = connectionOwner;
     mContext = context;
+    mExecutor = executor;
     mRequestTimeoutMs = requestTimeoutMs;
 
     mStateLock = new ReentrantReadWriteLock();
@@ -391,7 +397,7 @@ public abstract class CopycatGrpcConnection
           listener.accept(this);
         }
       }
-    });
+    }, mExecutor);
   }
 
   /*

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcServerConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcServerConnection.java
@@ -13,6 +13,8 @@ package alluxio.master.journal.raft.transport;
 
 import io.atomix.catalyst.concurrent.ThreadContext;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * {@link CopycatGrpcConnection} implementation for server.
  */
@@ -23,9 +25,11 @@ public class CopycatGrpcServerConnection extends CopycatGrpcConnection {
    * Note: {@link #setTargetObserver} should be called explicitly before using the connection.
    *
    * @param context copycat thread context
+   * @param executor transport executor
    * @param requestTimeoutMs timeout in milliseconds for requests
    */
-  public CopycatGrpcServerConnection(ThreadContext context, long requestTimeoutMs) {
-    super(ConnectionOwner.SERVER, context, requestTimeoutMs);
+  public CopycatGrpcServerConnection(ThreadContext context, ExecutorService executor,
+      long requestTimeoutMs) {
+    super(ConnectionOwner.SERVER, context, executor, requestTimeoutMs);
   }
 }


### PR DESCRIPTION
Earlier, copycat catalyst `ThreadContext` was used to build connections for transport clients/servers. There are some cluster states that are managed by a single threaded `ThreadContext` and that could cause a node to loose contact with rest of cluster while a connection is being built. This PR offloads copycat connection building to a dedicated thread pool.