### PR TITLE
Remove ps -w option in ./bin/alluxio

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -80,7 +80,7 @@ function killAll {
 
   keyword=$1
   count=0
-  for pid in $(ps -Aww -o pid,command | grep -i "[j]ava" | grep ${keyword} | awk '{print $1}'); do
+  for pid in $(ps -A -o pid,command | grep -i "[j]ava" | grep ${keyword} | awk '{print $1}'); do
     kill -15 ${pid} > /dev/null 2>&1
     local maxWait=120
     local cnt=${maxWait}


### PR DESCRIPTION
The `-w` is apparently not supported as an argument to `ps` in the
shell of our Alluxio docker container - thus causing the script to fail.

-w is only needed to expand column width when printing to a TTY.
Because the output is not a TTY, the -w can be removed safely and
the behavior is preserved.

Fixes #9744