### PR TITLE
Update kubernetes configMap in built tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -202,7 +202,6 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/kubernetes/alluxio-journal-volume.yaml.template",
 		"integration/kubernetes/alluxio-master.yaml.template",
 		"integration/kubernetes/alluxio-worker.yaml.template",
-		"integration/kubernetes/conf/alluxio.properties.template",
 		"integration/mesos/bin/alluxio-env-mesos.sh",
 		"integration/mesos/bin/alluxio-mesos-start.sh",
 		"integration/mesos/bin/alluxio-master-mesos.sh",

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -197,6 +197,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/emr/alluxio-emr.sh",
 		"integration/emr/alluxio-emr.json",
 		"integration/fuse/bin/alluxio-fuse",
+		"integration/kubernetes/alluxio-configMap.yaml.template",
 		"integration/kubernetes/alluxio-fuse.yaml.template",
 		"integration/kubernetes/alluxio-fuse-client.yaml.template",
 		"integration/kubernetes/alluxio-journal-volume.yaml.template",


### PR DESCRIPTION
Replace kubernetes `conf/alluxio.properties` with `alluxio-configMap.yaml.template` in generated tarball. This reflects changes in https://github.com/Alluxio/alluxio/pull/9748.