### PR TITLE
Remove EMR scripts from tarball build

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -195,8 +195,6 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/docker/bin/alluxio-worker.sh",
 		"integration/docker/conf/alluxio-site.properties.template",
 		"integration/docker/conf/alluxio-env.sh.template",
-		"integration/emr/alluxio-emr.sh",
-		"integration/emr/alluxio-emr.json",
 		"integration/fuse/bin/alluxio-fuse",
 		"integration/kubernetes/alluxio-fuse.yaml.template",
 		"integration/kubernetes/alluxio-fuse-client.yaml.template",


### PR DESCRIPTION
The EMR scripts are removed, so they should not be included in the tarball build