### PR TITLE
Disable DNS cache at docker build instead of entrypoint

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -45,6 +45,9 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
       chmod -R g=u /opt/* /journal; \
     fi
 
+# disable JVM DNS cache
+RUN echo "networkaddress.cache.ttl=0" >> $JAVA_HOME/jre/lib/security/java.security
+
 USER ${ALLUXIO_UID}
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -77,12 +77,6 @@ function writeConf {
 
 writeConf
 
-function disableDNSCache {
-  echo "networkaddress.cache.ttl=0" >> $JAVA_HOME/jre/lib/security/java.security
-}
-
-disableDNSCache
-
 function formatMasterIfSpecified {
   if [[ -n ${options} && ${options} != ${NO_FORMAT} ]]; then
     printUsage


### PR DESCRIPTION
Fixes: https://github.com/Alluxio/alluxio/issues/9760

The entry disabling DNS cache should be written at image build time instead run time (entrypoint). When the image is run as a non-root user (such as `alluxio`), the user may not have the permission to write to the desired location.