### PR TITLE
Update k8s doc to use the configMap file

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -138,8 +138,12 @@ helm install --name alluxio -f config.yaml alluxio-local/alluxio --version {{sit
 ```
 #### Using `kubectl`
 
-Define environment variables in `alluxio.properties`. Copy the properties template at
-`integration/kubernetes/conf`, and modify or add any configuration properties as required.
+Copy the template.
+```console
+$ cp alluxio-configMap.yaml.template alluxio-configMap.yaml
+```
+
+Modify or add any configuration properties as required.
 The Alluxio under filesystem address MUST be modified. Any credentials MUST be modified.
 
 ```
@@ -150,9 +154,6 @@ ALLUXIO_JAVA_OPTS=-Dalluxio.master.mount.table.root.ufs=<under_storage_address>
 
 Note that when running Alluxio with host networking, the ports assigned to Alluxio services must
 not be occupied beforehand.
-```console
-$ cp alluxio-configMap.yaml.template alluxio-configMap.yaml
-```
 
 Create a ConfigMap.
 ```console


### PR DESCRIPTION
The way to create the configMap was updated previously and docs are stale.