### PR TITLE
Improve parent dir check for UfsSyncPathCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -738,7 +738,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     Metrics.GET_FILE_INFO_OPS.inc();
     long opTimeMs = System.currentTimeMillis();
     LockingScheme lockingScheme =
-        createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ);
+        createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ, false);
     try (RpcContext rpcContext = createRpcContext();
          LockedInodePath inodePath = mInodeTree
              .lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern());
@@ -4577,11 +4577,17 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
   private LockingScheme createLockingScheme(AlluxioURI path, FileSystemMasterCommonPOptions options,
       LockPattern desiredLockMode) {
+    return createLockingScheme(path, options, desiredLockMode, true);
+  }
+
+  private LockingScheme createLockingScheme(AlluxioURI path, FileSystemMasterCommonPOptions options,
+      LockPattern desiredLockMode, boolean directParentRecursive) {
     // If client options didn't specify the interval, fallback to whatever the server has
     // configured to prevent unnecessary syncing due to the default value being 0
     long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
         ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
-    boolean shouldSync = mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval);
+    boolean shouldSync =
+        mUfsSyncPathCache.shouldSyncPath(path.getPath(), syncInterval, directParentRecursive);
     return new LockingScheme(path, desiredLockMode, shouldSync);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -68,9 +68,10 @@ public final class UfsSyncPathCache {
   /**
    * @param path the path to check
    * @param intervalMs the sync interval, in ms
+   * @param directParentRecursive check the recursive time of direct parent or not
    * @return true if a sync should occur for the path and interval setting, false otherwise
    */
-  public boolean shouldSyncPath(String path, long intervalMs) {
+  public boolean shouldSyncPath(String path, long intervalMs, boolean directParentRecursive) {
     if (intervalMs < 0) {
       // Never sync.
       return false;
@@ -89,12 +90,14 @@ public final class UfsSyncPathCache {
 
     // sync should be done on this path, but check all ancestors to determine if a recursive sync
     // had been performed (to avoid a sync again).
+    int parentLevel = 0;
     String currPath = path;
     while (!currPath.equals(AlluxioURI.SEPARATOR)) {
       try {
         currPath = PathUtils.getParent(currPath);
+        parentLevel++;
         lastSync = mCache.getIfPresent(currPath);
-        if (!shouldSyncInternal(lastSync, intervalMs, true)) {
+        if (!shouldSyncInternal(lastSync, intervalMs, parentLevel > 1 || directParentRecursive)) {
           // Sync is not necessary because an ancestor was already recursively synced
           return false;
         }

--- a/docs/en/contributor/Building-Alluxio-From-Source.md
+++ b/docs/en/contributor/Building-Alluxio-From-Source.md
@@ -72,6 +72,8 @@ all the dependencies. Subsequent builds, however, will be much faster.
 Once Alluxio is built, you can validate and start it with:
 
 ```console
+$ # Alluxio uses ./underFSStorage for under file system storage by default
+$ mkdir ./underFSStorage 
 $ ./bin/alluxio validateEnv local
 $ ./bin/alluxio format
 $ ./bin/alluxio-start.sh local SudoMount


### PR DESCRIPTION
**Description**
Improving cache logic for PR #9668 #9714 . from #9715, transfer to #9773

**Improvement**
Add SyncTimeLevel to record time for the immediate parent dir, the intermediate parent dir, and the cmd "ls" or "ls -R".