### PR TITLE
Copy journal files when creating new masters in integration test

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -208,7 +208,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   private MasterRegistry createFileSystemMasterFromJournal() throws Exception {
-    return MasterTestUtils.createSnapshotLeaderFileSystemMasterFromJournal();
+    return MasterTestUtils.createLeaderFileSystemMasterFromJournalCopy();
   }
 
   // TODO(calvin): This test currently relies on the fact the HDFS client is a cached instance to

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -208,7 +208,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   private MasterRegistry createFileSystemMasterFromJournal() throws Exception {
-    return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    return MasterTestUtils.createSnapshotLeaderFileSystemMasterFromJournal();
   }
 
   // TODO(calvin): This test currently relies on the fact the HDFS client is a cached instance to

--- a/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
@@ -70,12 +70,12 @@ public class MasterTestUtils {
   }
 
   /**
-   * Creates a new leader {@link FileSystemMaster} from journal along with its dependencies, and
-   * returns the master registry containing that master.
+   * Creates a new leader {@link FileSystemMaster} from a copy of the journal along with its
+   * dependencies, and returns the master registry containing that master.
    *
    * @return a master registry containing the created {@link FileSystemMaster} master
    */
-  public static MasterRegistry createSnapshotLeaderFileSystemMasterFromJournal() throws Exception {
+  public static MasterRegistry createLeaderFileSystemMasterFromJournalCopy() throws Exception {
     String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     String tempDir = Files.createTempDir().getAbsolutePath();
     FileUtils.copyDirectory(new File(masterJournal), new File(tempDir));

--- a/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
@@ -77,7 +77,9 @@ public class MasterTestUtils {
    */
   public static MasterRegistry createLeaderFileSystemMasterFromJournalCopy() throws Exception {
     String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
-    String tempDir = Files.createTempDir().getAbsolutePath();
+    File tmpDirFile = Files.createTempDir();
+    tmpDirFile.deleteOnExit();
+    String tempDir = tmpDirFile.getAbsolutePath();
     FileUtils.copyDirectory(new File(masterJournal), new File(tempDir));
     return createFileSystemMasterFromJournal(true, null, tempDir);
   }

--- a/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
@@ -30,6 +30,11 @@ import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.security.user.ServerUserState;
 import alluxio.security.user.UserState;
 
+import com.google.common.io.Files;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+
 public class MasterTestUtils {
 
   /**
@@ -65,6 +70,19 @@ public class MasterTestUtils {
   }
 
   /**
+   * Creates a new leader {@link FileSystemMaster} from journal along with its dependencies, and
+   * returns the master registry containing that master.
+   *
+   * @return a master registry containing the created {@link FileSystemMaster} master
+   */
+  public static MasterRegistry createSnapshotLeaderFileSystemMasterFromJournal() throws Exception {
+    String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
+    String tempDir = Files.createTempDir().getAbsolutePath();
+    FileUtils.copyDirectory(new File(masterJournal), new File(tempDir));
+    return createFileSystemMasterFromJournal(true, null, tempDir);
+  }
+
+  /**
    * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and returns
    * the master registry containing that master.
    *
@@ -75,6 +93,21 @@ public class MasterTestUtils {
   private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader,
       UserState userState) throws Exception {
     String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
+    return createFileSystemMasterFromJournal(isLeader, userState, masterJournal);
+  }
+
+  /**
+   * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and returns
+   * the master registry containing that master.
+   *
+   * @param isLeader whether to start as a leader
+   * @param userState the user state for the server. if null, will use ServerUserState.global()
+   * @param journalFolder the folder of the master journal
+   * @return a master registry containing the created {@link FileSystemMaster} master
+   */
+  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader,
+      UserState userState, String journalFolder) throws Exception {
+    String masterJournal = journalFolder;
     MasterRegistry registry = new MasterRegistry();
     SafeModeManager safeModeManager = new TestSafeModeManager();
     long startTimeMs = System.currentTimeMillis();


### PR DESCRIPTION
Currently in some integration tests we create a master replica from journal directory to check journal status. This can cause problems if the original master is not stopped when the new master is created. This change solves the issue by copying the journal to a separate directory and creating the new master based on the copy.