### PR TITLE
Copy journal files when creating new masters in integration test

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -207,7 +207,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   private MasterRegistry createFileSystemMasterFromJournal() throws Exception {
-    return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
+    return MasterTestUtils.createLeaderFileSystemMasterFromJournalCopy();
   }
 
   // TODO(calvin): This test currently relies on the fact the HDFS client is a cached instance to


### PR DESCRIPTION
Cherry-picked `60f14a3` to `branch-2.0`

Currently in some integration tests we create a master replica from
journal directory to check journal status. This can cause problems if
the original master is not stopped when the new master is created. This
change solves the issue by copying the journal to a separate directory
and creating the new master based on the copy.

pr-link: Alluxio/alluxio#9778
change-id: cid-ea6e0d655899da607950833c6e0840ba4f3a73ec