### PR TITLE
Set networkaddress.cache.ttl=0 at docker fuse image build time

### DIFF
--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -52,6 +52,9 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
       chmod -R g=u /opt/* /journal; \
     fi
 
+# disable JVM DNS cache
+RUN echo "networkaddress.cache.ttl=0" >> $JAVA_HOME/jre/lib/security/java.security
+
 USER ${ALLUXIO_UID}
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fix #9780 