### PR TITLE
Fix Dockerfile for RocksDB

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -30,4 +30,7 @@ COPY entrypoint.sh /
 # disable JVM DNS cache
 RUN echo "networkaddress.cache.ttl=0" >> $JAVA_HOME/jre/lib/security/java.security
 
+# add the following for native libraries needed by rocksdb
+ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Add LD_LIBRARY_PATH to use native libraries for RockDB.

Pick up Dockerfile specific change from: https://github.com/Alluxio/alluxio/pull/9783