### PR TITLE
Avoid string conversion for alluxio schemes

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -321,7 +321,8 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
    * @return transport path
    */
   private static String getTransportPath(AlluxioURI uri) {
-    if (uri.hasScheme()) {
+    if (uri.hasScheme() && !uri.getScheme().equals(Constants.SCHEME)) {
+      // Return full URI for non-Alluxio path.
       return uri.toString();
     } else {
       // Scheme-less URIs are assumed to be Alluxio paths


### PR DESCRIPTION
Clients of Alluxio FS API might use URIs with `alluxio://` scheme. This is a small optimization to cut unnecessary scheme identifier coming from fs client, which will also eliminate cost of URI translation at master.