### PR TITLE
Add missing hashCode()/equals() for GrpcServerAddress

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
@@ -12,9 +12,11 @@
 package alluxio.grpc;
 
 import com.google.common.base.MoreObjects;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 
 /**
  * Defines an gRPC server endpoint.
@@ -59,6 +61,27 @@ public class GrpcServerAddress {
    */
   public SocketAddress getSocketAddress() {
     return mSocketAddress;
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(mHostName)
+        .append(mSocketAddress)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof GrpcServerAddress)) {
+      return false;
+    }
+    GrpcServerAddress otherAddress = (GrpcServerAddress) other;
+    return Objects.equals(mHostName, otherAddress.getHostName())
+        && Objects.equals(mSocketAddress, otherAddress.getSocketAddress());
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcManagedChannelPoolTest.java
@@ -58,11 +58,13 @@ public final class GrpcManagedChannelPoolTest {
     GrpcServer server1 = GrpcServerBuilder
         .forAddress(GrpcServerAddress.create("localhost", bindAddress), sConf, us).build().start();
 
-    GrpcServerAddress address =
+    GrpcServerAddress address1 =
+        GrpcServerAddress.create(new InetSocketAddress("localhost", server1.getBindPort()));
+    GrpcServerAddress address2 =
         GrpcServerAddress.create(new InetSocketAddress("localhost", server1.getBindPort()));
 
-    key1.setServerAddress(address);
-    key2.setServerAddress(address);
+    key1.setServerAddress(address1);
+    key2.setServerAddress(address2);
 
     ManagedChannel channel1 = GrpcManagedChannelPool.INSTANCE().acquireManagedChannel(key1,
         HEALTH_CHECK_TIMEOUT, SHUTDOWN_TIMEOUT);
@@ -182,7 +184,7 @@ public final class GrpcManagedChannelPoolTest {
     GrpcChannelKey key2 = GrpcChannelKey.create(sConf)
         .setPoolingStrategy(GrpcChannelKey.PoolingStrategy.DISABLED);
 
-    InetSocketAddress bindAddress =  new InetSocketAddress("0.0.0.0", 0);
+    InetSocketAddress bindAddress = new InetSocketAddress("0.0.0.0", 0);
 
     UserState us = UserState.Factory.create(sConf);
     GrpcServer server1 = GrpcServerBuilder


### PR DESCRIPTION
This will fix gRPC channel pooling that is broken due to recent refactoring.