### PR TITLE
Disallow foreign schemes on mounts that have nested mounts

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -260,6 +260,7 @@ public enum ExceptionMessage {
   MOUNT_READONLY("A write operation on {0} under a readonly mount point {1} is not allowed"),
   UFS_PATH_DOES_NOT_EXIST("Ufs path {0} does not exist"),
   FOREIGN_URI_NOT_MOUNTED("Foreign URI: {0} is not found on Alluxio mounts."),
+  FOREIGN_URI_IN_NESTED_PARENT("Foreign URI: {0} is in a mount that has nested mounts."),
 
   // key-value
   KEY_VALUE_TOO_LARGE("Unable to put key-value pair: key {0} bytes, value {1} bytes"),

--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -260,7 +260,6 @@ public enum ExceptionMessage {
   MOUNT_READONLY("A write operation on {0} under a readonly mount point {1} is not allowed"),
   UFS_PATH_DOES_NOT_EXIST("Ufs path {0} does not exist"),
   FOREIGN_URI_NOT_MOUNTED("Foreign URI: {0} is not found on Alluxio mounts."),
-  FOREIGN_URI_IN_NESTED_PARENT("Foreign URI: {0} is in a mount that has nested mounts."),
 
   // key-value
   KEY_VALUE_TOO_LARGE("Unable to put key-value pair: key {0} bytes, value {1} bytes"),

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1377,14 +1377,16 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       // nested mounts as translation on one mount should not give visibility to another.
       if (mMountTable.containsMountPoint(resolution.getMountInfo().getAlluxioUri(), false)) {
         throw new IllegalStateException(
-            String.format("Foreign URI: %s is in a mount that has nested mounts.", uriStr));
+            String.format(
+                "Foreign URI: %s is reverse resolved to a mount :%s which has nested mounts.",
+                uriStr, resolution.getMountInfo().getAlluxioUri()));
       }
       return resolution.getUri();
     }
 
     // Resolve unsuccessful
     if (!ServerConfiguration.getBoolean(PropertyKey.MASTER_SHIMFS_AUTO_MOUNT_ENABLED)) {
-      throw new InvalidPathException(String.format("Could not reverse resolve path: %s", uriStr));
+      throw new InvalidPathException(String.format("Could not reverse resolve ufs path: %s", uriStr));
     }
 
     // Attempt to auto-mount.

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1378,7 +1378,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
       if (mMountTable.containsMountPoint(resolution.getMountInfo().getAlluxioUri(), false)) {
         throw new IllegalStateException(
             String.format(
-                "Foreign URI: %s is reverse resolved to a mount :%s which has nested mounts.",
+                "Foreign URI: %s is reverse resolved to a mount: %s which has nested mounts.",
                 uriStr, resolution.getMountInfo().getAlluxioUri()));
       }
       return resolution.getUri();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1386,7 +1386,8 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
 
     // Resolve unsuccessful
     if (!ServerConfiguration.getBoolean(PropertyKey.MASTER_SHIMFS_AUTO_MOUNT_ENABLED)) {
-      throw new InvalidPathException(String.format("Could not reverse resolve ufs path: %s", uriStr));
+      throw new InvalidPathException(
+          String.format("Could not reverse resolve ufs path: %s", uriStr));
     }
 
     // Attempt to auto-mount.

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -79,7 +79,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
           // This returns a list of ufsUris that we need to sync.
           Set<AlluxioURI> ufsSyncPoints = syncInfo.getSyncPoints();
           for (AlluxioURI ufsUri : ufsSyncPoints) {
-            AlluxioURI alluxioUri = mMountTable.reverseResolve(ufsUri);
+            AlluxioURI alluxioUri = mMountTable.reverseResolve(ufsUri).getUri();
             if (alluxioUri != null) {
               if (syncInfo.isForceSync()) {
                 LOG.debug("force full sync {}", ufsUri.toString());
@@ -93,7 +93,8 @@ public class ActiveSyncer implements HeartbeatExecutor {
                 RetryUtils.retry("Incremental Sync", () -> {
                   mFileSystemMaster.activeSyncMetadata(alluxioUri,
                       syncInfo.getChangedFiles(ufsUri).stream().parallel()
-                          .map(mMountTable::reverseResolve).collect(Collectors.toSet()),
+                          .map((uri) -> mMountTable.reverseResolve(uri).getUri())
+                          .collect(Collectors.toSet()),
                       mSyncManager.getExecutor()
                   );
                 }, RetryUtils.defaultActiveSyncClientRetry(ServerConfiguration

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -389,7 +389,7 @@ public final class MountTable implements DelegatingJournaled {
    * @throws InvalidPathException
    */
   public AlluxioURI reverseLookup(String foreignUriStr) throws InvalidPathException {
-    // TODO(ggezer) Consider alternative mount table representations for optimizing this method.
+    // TODO(ggezer): Consider alternative mount table representations for optimizing this method.
     try (LockResource r = new LockResource(mReadLock)) {
       LOG.debug("Doing a reverse-lookup on foreign URI {}", foreignUriStr);
       // Enumerate existing mount points to find a mount point that owns

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -472,7 +472,7 @@ public final class MountTable implements DelegatingJournaled {
   }
 
   /**
-   * This class represents a Alluxio path after resolution.
+   * This class represents a Alluxio path after reverse resolution.
    */
   public final class ReverseResolution {
     private final MountInfo mMountInfo;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -265,13 +265,14 @@ public final class MountTable implements DelegatingJournaled {
    * @param containsSelf cause method to return true when given uri itself is a mount point
    * @return true if the given uri has a descendant which is a mount point [, or is a mount point]
    */
-  public boolean containsMountPoint(AlluxioURI uri, boolean containsSelf) throws InvalidPathException {
+  public boolean containsMountPoint(AlluxioURI uri, boolean containsSelf)
+      throws InvalidPathException {
     String path = uri.getPath();
 
     try (LockResource r = new LockResource(mReadLock)) {
       for (Map.Entry<String, MountInfo> entry : mState.getMountTable().entrySet()) {
         String mountPath = entry.getKey();
-        if(!containsSelf && mountPath.equals(path)) {
+        if (!containsSelf && mountPath.equals(path)) {
           continue;
         }
         if (PathUtils.hasPrefix(mountPath, path)) {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -426,6 +426,33 @@ public final class MountTableTest {
     Assert.assertTrue(lookupFailed);
   }
 
+  /**
+   * Tests {@link MountTable#reverseLookup(String)}.
+   */
+  @Test
+  public void reverseLookupNestedParent() throws Exception {
+    String mountPath1 = "/mnt/foo";
+    String mountPath2 = "/mnt/foo/bar";
+    String ufsPath1 = "ufs-1://authority1/root1";
+    String ufsPath2 = "ufs-2://authority2/root2";
+    addMount(mountPath1, ufsPath1, 2);
+    addMount(mountPath2, ufsPath2, 3);
+
+    // Test successful reverse-lookup.
+    String testFile = PathUtils.uniqPath();
+    String testFileUfsPath = PathUtils.concatPath(ufsPath1, testFile);
+    boolean lookupFailed = false;
+    try {
+      mMountTable.reverseLookup(testFileUfsPath);
+    } catch (IllegalStateException e) {
+      // Exception expected
+      Assert.assertEquals(ExceptionMessage.FOREIGN_URI_IN_NESTED_PARENT.getMessage(testFileUfsPath),
+          e.getMessage());
+      lookupFailed = true;
+    }
+    Assert.assertTrue(lookupFailed);
+  }
+
   private void addMount(String alluxio, String ufs, long id) throws Exception {
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI(alluxio), new AlluxioURI(ufs), id,
             MountContext.defaults().getOptions().build());

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -214,7 +214,7 @@ public final class MountTableTest {
     Assert.assertTrue(mMountTable.isMountPoint(new AlluxioURI("/mnt/bar")));
     Assert.assertTrue(mMountTable.isMountPoint(new AlluxioURI("/mnt/bar/baz")));
 
-    // Test containsMountPoint
+    // Test containsMountPoint()
     Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar"), false));
     Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar/baz"), false));
     Assert.assertFalse(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar/baz/bay"), false));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -113,18 +113,18 @@ public final class MountTableTest {
 
     // Test reverseResolve()
     Assert.assertEquals(new AlluxioURI("/mnt/foo"),
-        mMountTable.reverseResolve(new AlluxioURI("/foo")));
+        mMountTable.reverseResolve(new AlluxioURI("/foo")).getUri());
     Assert.assertEquals(new AlluxioURI("/mnt/foo/x"),
-        mMountTable.reverseResolve(new AlluxioURI("/foo/x")));
-    Assert.assertEquals(mMountTable.reverseResolve(new AlluxioURI("/bar")),
+        mMountTable.reverseResolve(new AlluxioURI("/foo/x")).getUri());
+    Assert.assertEquals(mMountTable.reverseResolve(new AlluxioURI("/bar")).getUri(),
         new AlluxioURI("/mnt/bar"));
-    Assert.assertEquals(mMountTable.reverseResolve(new AlluxioURI("/bar/y")),
+    Assert.assertEquals(mMountTable.reverseResolve(new AlluxioURI("/bar/y")).getUri(),
         new AlluxioURI("/mnt/bar/y"));
     // Test reverseResolve(), ufs path is not mounted
     Assert.assertEquals(new AlluxioURI("/foobar"),
-        mMountTable.reverseResolve(new AlluxioURI("s3a://bucket/foobar")));
+        mMountTable.reverseResolve(new AlluxioURI("s3a://bucket/foobar")).getUri());
     Assert.assertEquals(new AlluxioURI("/"),
-        mMountTable.reverseResolve(new AlluxioURI("s3a://bucket/")));
+        mMountTable.reverseResolve(new AlluxioURI("s3a://bucket/")).getUri());
     Assert.assertNull(mMountTable.reverseResolve(new AlluxioURI("/foobar")));
 
     // Test getMountPoint()
@@ -389,68 +389,6 @@ public final class MountTableTest {
     Assert.assertEquals(info1, mMountTable.getMountInfo(info1.getMountId()));
     Assert.assertEquals(info2, mMountTable.getMountInfo(info2.getMountId()));
     Assert.assertEquals(null, mMountTable.getMountInfo(4L));
-  }
-
-  /**
-   * Tests {@link MountTable#reverseLookup(String)}.
-   */
-  @Test
-  public void reverseLookupKnownUri() throws Exception {
-    String mountPath = "/mnt/foo";
-    String ufsPath = "ufs-1://authority/root";
-    addMount(mountPath, ufsPath, 2);
-    // Test successful reverse-lookup.
-    String testFile = PathUtils.uniqPath();
-    String testFileUfsPath = PathUtils.concatPath(ufsPath, testFile);
-    String testFileAlluxioPath = PathUtils.concatPath(mountPath, testFile);
-    Assert.assertEquals(testFileAlluxioPath, mMountTable.reverseLookup(testFileUfsPath).getPath());
-  }
-
-  /**
-   * Tests {@link MountTable#reverseLookup(String)}.
-   */
-  @Test
-  public void reverseLookupUnknownUri() throws Exception {
-    // Test unknown reverse-lookup.
-    String unmountedUfsPath = "ufs-unknown://authority/root";
-    String testFileUfsPath = PathUtils.concatPath(unmountedUfsPath, PathUtils.uniqPath());
-    boolean lookupFailed = false;
-    try {
-      mMountTable.reverseLookup(testFileUfsPath);
-    } catch (InvalidPathException e) {
-      // Exception expected
-      Assert.assertEquals(ExceptionMessage.FOREIGN_URI_NOT_MOUNTED.getMessage(testFileUfsPath),
-          e.getMessage());
-      lookupFailed = true;
-    }
-    Assert.assertTrue(lookupFailed);
-  }
-
-  /**
-   * Tests {@link MountTable#reverseLookup(String)}.
-   */
-  @Test
-  public void reverseLookupNestedParent() throws Exception {
-    String mountPath1 = "/mnt/foo";
-    String mountPath2 = "/mnt/foo/bar";
-    String ufsPath1 = "ufs-1://authority1/root1";
-    String ufsPath2 = "ufs-2://authority2/root2";
-    addMount(mountPath1, ufsPath1, 2);
-    addMount(mountPath2, ufsPath2, 3);
-
-    // Test successful reverse-lookup.
-    String testFile = PathUtils.uniqPath();
-    String testFileUfsPath = PathUtils.concatPath(ufsPath1, testFile);
-    boolean lookupFailed = false;
-    try {
-      mMountTable.reverseLookup(testFileUfsPath);
-    } catch (IllegalStateException e) {
-      // Exception expected
-      Assert.assertEquals(ExceptionMessage.FOREIGN_URI_IN_NESTED_PARENT.getMessage(testFileUfsPath),
-          e.getMessage());
-      lookupFailed = true;
-    }
-    Assert.assertTrue(lookupFailed);
   }
 
   private void addMount(String alluxio, String ufs, long id) throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -31,7 +31,6 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.local.LocalUnderFileSystemFactory;
 import alluxio.util.IdUtils;
-import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -214,6 +214,15 @@ public final class MountTableTest {
     Assert.assertTrue(mMountTable.isMountPoint(new AlluxioURI("/mnt/bar")));
     Assert.assertTrue(mMountTable.isMountPoint(new AlluxioURI("/mnt/bar/baz")));
 
+    // Test containsMountPoint
+    Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar"), false));
+    Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar/baz"), false));
+    Assert.assertFalse(mMountTable.containsMountPoint(new AlluxioURI("/mnt/bar/baz/bay"), false));
+    Assert.assertFalse(mMountTable.containsMountPoint(new AlluxioURI("/mnt/foo"), false));
+    Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/mnt/foo"), true));
+    Assert.assertTrue(mMountTable.containsMountPoint(new AlluxioURI("/"), true));
+    Assert.assertFalse(mMountTable.containsMountPoint(new AlluxioURI("/bogus"), true));
+
     // Test delete()
     Assert.assertFalse(deleteMount("/mnt/bar/baz"));
     Assert.assertTrue(deleteMount("/mnt/bar/baz/bay"));


### PR DESCRIPTION
Master should restrict foreign URI's access to its own mount only. To guarantee that this fix blocks foreign URI translation for mounts that have nested mounts.