### PR TITLE
Add property to skip breadcrumb creation on list for ObjectStore UFS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -665,8 +665,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
           .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
           .setDefaultValue(true)
-          .setDescription(("Set this to false to prevent Alluxio from creating breadcrumbs during" +
-              " read or list operations on object store UFS"))
+          .setDescription("Set this to false to prevent Alluxio from creating breadcrumbs during" +
+              " read or list operations on object store UFS")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -665,8 +665,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
           .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
           .setDefaultValue(true)
-          .setDescription("Set this to false to prevent Alluxio from creating zero byte objects " +
-              "for faster directory listing during read or list operations on object store UFS")
+          .setDescription("Set this to false to prevent Alluxio from creating zero byte objects "
+              + "during read or list operations on object store UFS. Leaving this on enables more"
+              + " efficient listing of prefixes.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -662,14 +662,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey UNDERFS_OBJECT_BREADCRUMBS_ENABLED =
-          new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
-                  .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
-                  .setDefaultValue(true)
-                  .setDescription(("Set this to false to prevent Alluxio from creating breadcrumbs"
-                          + "during read or list operations on object store UFS"))
-                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-                  .setScope(Scope.SERVER)
-                  .build();
+      new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
+          .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
+          .setDefaultValue(true)
+          .setDescription(("Set this to false to prevent Alluxio from creating breadcrumbs during" +
+              " read or list operations on object store UFS"))
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE =
       new Builder(Name.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE)
           .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -665,8 +665,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
           .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
           .setDefaultValue(true)
-          .setDescription("Set this to false to prevent Alluxio from creating breadcrumbs during"
-              + " read or list operations on object store UFS")
+          .setDescription("Set this to false to prevent Alluxio from creating zero byte objects " +
+              "for faster directory listing during read or list operations on object store UFS")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -661,6 +661,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OBJECT_BREADCRUMBS_ENABLED =
+          new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
+                  .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
+                  .setDefaultValue(true)
+                  .setDescription(("Set this to false to prevent Alluxio from creating breadcrumbs"
+                          + "during read or list operations on object store UFS"))
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.SERVER)
+                  .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE =
       new Builder(Name.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE)
           .setDefaultValue(String.format("${%s}", Name.USER_BLOCK_SIZE_BYTES_DEFAULT))
@@ -3737,6 +3746,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_WEB_PARENT_NAMES = "alluxio.underfs.web.parent.names";
     public static final String UNDERFS_WEB_TITLES = "alluxio.underfs.web.titles";
     public static final String UNDERFS_VERSION = "alluxio.underfs.version";
+    public static final String UNDERFS_OBJECT_BREADCRUMBS_ENABLED =
+            "alluxio.underfs.object.breadcrumbs.enabled";
     public static final String UNDERFS_OBJECT_STORE_SERVICE_THREADS =
         "alluxio.underfs.object.store.service.threads";
     public static final String UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -665,8 +665,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)
           .setAlias("alluxio.underfs.object.breadcrumbs.enabled")
           .setDefaultValue(true)
-          .setDescription("Set this to false to prevent Alluxio from creating breadcrumbs during" +
-              " read or list operations on object store UFS")
+          .setDescription("Set this to false to prevent Alluxio from creating breadcrumbs during"
+              + " read or list operations on object store UFS")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -940,7 +940,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // If the breadcrumb exists, this is a no-op
       if (!mUfsConf.isReadOnly()
-              && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
+          && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
         mkdirsInternal(dir);
       }
       return objs;
@@ -1046,7 +1046,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           if (!child.isEmpty() && !children.containsKey(child)) {
             // This directory has not been created through Alluxio.
             if (!mUfsConf.isReadOnly()
-                    && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
+                && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
               mkdirsInternal(commonPrefix);
             }
             // If both a file and a directory existed with the same name, the path will be

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -939,7 +939,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // If the breadcrumb exists, this is a no-op
-      if (!mUfsConf.isReadOnly() && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
+      if (!mUfsConf.isReadOnly()
+              && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
         mkdirsInternal(dir);
       }
       return objs;
@@ -1044,7 +1045,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           child = childNameIndex != -1 ? child.substring(0, childNameIndex) : child;
           if (!child.isEmpty() && !children.containsKey(child)) {
             // This directory has not been created through Alluxio.
-            if (!mUfsConf.isReadOnly() && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
+            if (!mUfsConf.isReadOnly()
+                    && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
               mkdirsInternal(commonPrefix);
             }
             // If both a file and a directory existed with the same name, the path will be

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -939,7 +939,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // If the breadcrumb exists, this is a no-op
-      if (!mUfsConf.isReadOnly()) {
+      if (!mUfsConf.isReadOnly() && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
         mkdirsInternal(dir);
       }
       return objs;
@@ -1044,7 +1044,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           child = childNameIndex != -1 ? child.substring(0, childNameIndex) : child;
           if (!child.isEmpty() && !children.containsKey(child)) {
             // This directory has not been created through Alluxio.
-            if (!mUfsConf.isReadOnly()) {
+            if (!mUfsConf.isReadOnly() && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_BREADCRUMBS_ENABLED)) {
               mkdirsInternal(commonPrefix);
             }
             // If both a file and a directory existed with the same name, the path will be


### PR DESCRIPTION
Setting "alluxio.underfs.object.breadcrumbs.enabled" to false will disable breadcrumb creation when doing a "list" operation.