### PR TITLE
Improve diagnosibility of error message for channel authentication

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -168,17 +168,17 @@ public class ChannelAuthenticator {
         // Intercept authenticated channel with channel-Id injector.
         mChannel = ClientInterceptors.intercept(mManagedChannel,
             new ChannelIdInjector(mChannelKey.getChannelId()));
-      } catch (IOException exc) {
+      } catch (IOException e) {
         Status.Code code = Status.Code.UNKNOWN;
-        if (exc instanceof AlluxioStatusException) {
-          code = ((AlluxioStatusException) exc).getStatusCode();
+        if (e instanceof AlluxioStatusException) {
+          code = ((AlluxioStatusException) e).getStatusCode();
         }
         String message = String.format(
             "Channel authentication failed with code:%s. ChannelKey: %s, AuthType: %s, Error: %s",
-            code.name(), mChannelKey.toStringShort(), mAuthType, exc.toString());
+            code.name(), mChannelKey.toStringShort(), mAuthType, e.toString());
         LOG.warn(message);
         throw AlluxioStatusException
-            .from(Status.fromCode(code).withDescription(message).withCause(exc));
+            .from(Status.fromCode(code).withDescription(message).withCause(e));
       }
     }
 

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -15,7 +15,6 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
-import alluxio.exception.status.UnknownException;
 import alluxio.grpc.ChannelAuthenticationScheme;
 import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcChannelKey;
@@ -30,11 +29,13 @@ import io.grpc.ClientInterceptors;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -167,17 +168,17 @@ public class ChannelAuthenticator {
         // Intercept authenticated channel with channel-Id injector.
         mChannel = ClientInterceptors.intercept(mManagedChannel,
             new ChannelIdInjector(mChannelKey.getChannelId()));
-      } catch (Exception exc) {
-        String message = String.format(
-            "Channel authentication failed. ChannelKey: %s, AuthType: %s, Target: %s, Error: %s",
-            mChannelKey, mAuthType, mManagedChannel.authority(), exc.toString());
-        LOG.warn(message);
+      } catch (IOException exc) {
+        Status.Code code = Status.Code.UNKNOWN;
         if (exc instanceof AlluxioStatusException) {
-          throw AlluxioStatusException.from(
-              ((AlluxioStatusException) exc).getStatus().withDescription(message).withCause(exc));
-        } else {
-          throw new UnknownException(message, exc);
+          code = ((AlluxioStatusException) exc).getStatusCode();
         }
+        String message = String.format(
+            "Channel authentication failed with code:%s. ChannelKey: %s, AuthType: %s, Error: %s",
+            code.name(), mChannelKey.toStringShort(), mAuthType, exc.toString());
+        LOG.warn(message);
+        throw AlluxioStatusException
+            .from(Status.fromCode(code).withDescription(message).withCause(exc));
       }
     }
 


### PR DESCRIPTION
For quicker diagnostics it is better for channel authentication failure message to contain underlying error code early in the message + some code improvements.