### PR TITLE
[SMALLFIX] Use static imports for standard test utilities (#547)

### DIFF
--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -15,8 +15,8 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
 import com.google.common.collect.Lists;
-import org.junit.Assert;
 import org.junit.Ignore;
+import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 
 import java.util.List;
@@ -42,7 +42,7 @@ public final class JvmPauseMonitorTest {
         break;
       }
     }
-    Assert.assertNotEquals(jvmPauseMonitor.getWarnTimeExceeded(), 0);
-    Assert.assertNotEquals(jvmPauseMonitor.getTotalExtraTime(), 0);
+    assertNotEquals(jvmPauseMonitor.getWarnTimeExceeded(), 0);
+    assertNotEquals(jvmPauseMonitor.getTotalExtraTime(), 0);
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assume.assumeTrue;
 import alluxio.Constants;
 
 import com.google.common.base.Optional;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
@@ -39,7 +38,7 @@ public final class ShellUtilsTest {
     String testString = "alluxio";
     // Execute echo for testing command execution.
     String result = ShellUtils.execCommand("bash", "-c", "echo " + testString);
-    Assert.assertEquals(testString + "\n", result);
+    assertEquals(testString + "\n", result);
   }
 
   /**
@@ -51,7 +50,7 @@ public final class ShellUtilsTest {
   public void execGetGroupCommand() throws Exception {
     String result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand("root"));
     // On Linux user "root" will be a part of the group "root". On OSX it will be a part of "admin".
-    Assert.assertTrue(result.contains("root") || result.contains("admin"));
+    assertTrue(result.contains("root") || result.contains("admin"));
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

* Fixed this [PR](https://github.com/Alluxio/new-contributor-tasks/issues/547)
* Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java

## Brief change log

*I use static imports rather than Non-static imports for standard test utilities in "/alluxio/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java"*