### PR TITLE
[SMALLFIX] Use static imports for test utilities in JvmPauseMonitorTest

### DIFF
--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -12,6 +12,7 @@
 package alluxio.util;
 
 import static org.junit.Assert.assertNotEquals;
+
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 

--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -11,12 +11,12 @@
 
 package alluxio.util;
 
+import static org.junit.Assert.assertNotEquals;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
 import com.google.common.collect.Lists;
 import org.junit.Ignore;
-import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 
 import java.util.List;

--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -15,8 +15,8 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
 import com.google.common.collect.Lists;
-import org.junit.Assert;
 import org.junit.Ignore;
+import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 
 import java.util.List;
@@ -42,7 +42,7 @@ public final class JvmPauseMonitorTest {
         break;
       }
     }
-    Assert.assertNotEquals(jvmPauseMonitor.getWarnTimeExceeded(), 0);
-    Assert.assertNotEquals(jvmPauseMonitor.getTotalExtraTime(), 0);
+    assertNotEquals(jvmPauseMonitor.getWarnTimeExceeded(), 0);
+    assertNotEquals(jvmPauseMonitor.getTotalExtraTime(), 0);
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Fixed this [PR](https://github.com/Alluxio/new-contributor-tasks/issues/547)
* Use static imports for standard test utilities in /alluxio/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java

## Brief change log

*I use static imports rather than Non-static imports for standard test utilities in "/alluxio/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java"*
