### PR TITLE
[SMALLFIX] Use static imports for asserts in FileLocationOptionsTest

### DIFF
--- a/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
@@ -11,9 +11,10 @@
 
 package alluxio.underfs.options;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.test.util.CommonUtils;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -32,7 +33,7 @@ public final class FileLocationOptionsTest {
   public void defaults() throws IOException {
     FileLocationOptions options = FileLocationOptions.defaults();
 
-    Assert.assertEquals(0, options.getOffset());
+    assertEquals(0, options.getOffset());
   }
 
   /**
@@ -45,7 +46,7 @@ public final class FileLocationOptionsTest {
     long[] offsets = {100, 110, 150, 200};
     for (long offset : offsets) {
       options.setOffset(offset);
-      Assert.assertEquals(offset, options.getOffset());
+      assertEquals(offset, options.getOffset());
     }
   }
 

--- a/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
@@ -11,9 +11,9 @@
 
 package alluxio.underfs.options;
 
-import alluxio.test.util.CommonUtils;
-
 import static org.junit.Assert.assertEquals;
+
+import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
@@ -13,13 +13,13 @@ package alluxio.underfs.options;
 
 import alluxio.test.util.CommonUtils;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the {@link FileLocationOptions} class.

--- a/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
@@ -11,8 +11,6 @@
 
 package alluxio.underfs.options;
 
-import static org.junit.Assert.assertEquals;
-
 import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
@@ -20,6 +18,8 @@ import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the {@link FileLocationOptions} class.


### PR DESCRIPTION
## What is the purpose of the change

* Fixed this [PR](https://github.com/Alluxio/new-contributor-tasks/issues/541)
* Use static imports for standard test utilities in  /alluxio/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java

## Brief change log

*I use static imports rather than Non-static imports for standard test utilities in "/alluxio/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java"*
