### PR TITLE
[SMALLFIX] Use static imports for asserts in UfsDirectoryStatusTest

### DIFF
--- a/core/common/src/test/java/alluxio/underfs/UfsDirectoryStatusTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UfsDirectoryStatusTest.java
@@ -11,7 +11,8 @@
 
 package alluxio.underfs;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 /**
@@ -26,12 +27,12 @@ public final class UfsDirectoryStatusTest {
     short mode = 077;
     UfsDirectoryStatus status = new UfsDirectoryStatus("name", "owner", "group", mode);
 
-    Assert.assertEquals("name", status.getName());
-    Assert.assertEquals(true, status.isDirectory());
-    Assert.assertEquals(false, status.isFile());
-    Assert.assertEquals("owner", status.getOwner());
-    Assert.assertEquals("group", status.getGroup());
-    Assert.assertEquals(mode, status.getMode());
+    assertEquals("name", status.getName());
+    assertEquals(true, status.isDirectory());
+    assertEquals(false, status.isFile());
+    assertEquals("owner", status.getOwner());
+    assertEquals("group", status.getGroup());
+    assertEquals(mode, status.getMode());
   }
 
   /**
@@ -43,6 +44,6 @@ public final class UfsDirectoryStatusTest {
     UfsDirectoryStatus statusToCopy =
         new UfsDirectoryStatus("name", "owner", "group", mode);
     UfsDirectoryStatus status = new UfsDirectoryStatus(statusToCopy);
-    Assert.assertEquals(statusToCopy, status);
+    assertEquals(statusToCopy, status);
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Fixed this [PR](https://github.com/Alluxio/new-contributor-tasks/issues/537)
* Use static imports for standard test utilities in  /alluxio/core/common/src/test/java/alluxio/underfs/UfsDirectoryStatusTest.java

## Brief change log

*I use static imports rather than Non-static imports for standard test utilities in "/alluxio/core/common/src/test/java/alluxio/underfs/UfsDirectoryStatusTest.java"*
