### PR TITLE
Fix leaking rejecting-servers when primacy is unstable

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterProcess.java
@@ -175,10 +175,14 @@ public abstract class MasterProcess implements Process {
   }
 
   protected void startRejectingServers() {
-    mRejectingRpcServer = new RejectingServer(mRpcBindAddress.getPort());
-    mRejectingRpcServer.start();
-    mRejectingWebServer = new RejectingServer(mWebBindAddress.getPort());
-    mRejectingWebServer.start();
+    if (mRejectingRpcServer == null) {
+      mRejectingRpcServer = new RejectingServer(mRpcBindAddress.getPort());
+      mRejectingRpcServer.start();
+    }
+    if (mRejectingWebServer == null) {
+      mRejectingWebServer = new RejectingServer(mWebBindAddress.getPort());
+      mRejectingWebServer.start();
+    }
   }
 
   protected void stopRejectingRpcServer() {


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/9845

If leadership is lost during transitioning, `startMasters(false)` ends up being called back-to-back. That will cause earlier rejecting-server to be leaked and block the port for later. Fix ensures we don't recreate over a created rejecting-server.