### PR TITLE
Improve copycat transport traces

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -131,6 +131,13 @@ public final class GrpcChannel extends Channel {
   }
 
   /**
+   * @return a short identifier for the channel
+   */
+  public String toStringShort() {
+    return mChannelKey.toStringShort();
+  }
+
+  /**
    * An interceptor that is used to track server calls and invalidate the channel status. Upon
    * receiving Unauthenticated or Unavailable code from the server it invalidates the channel by
    * marking it unhealthy for channel owner to be able to detect and re-authenticate or re-create

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClient.java
@@ -70,7 +70,7 @@ public class CopycatGrpcClient implements Client {
 
   @Override
   public CompletableFuture<Connection> connect(Address address) {
-    LOG.debug("Copycat transport client connecting to: {}", address);
+    LOG.debug("Creating a copycat client connection to: {}", address);
     final ThreadContext threadContext = ThreadContext.currentContextOrThrow();
     // Future for this connection.
     final CompletableFuture<Connection> connectionFuture = new CompletableFuture<>();
@@ -95,7 +95,7 @@ public class CopycatGrpcClient implements Client {
                 mConf.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS));
         clientConnection.setTargetObserver(messageClientStub.connect(clientConnection));
 
-        LOG.debug("Created copycat connection for target: {}", address);
+        LOG.debug("Created a copycat client connection: {}", clientConnection);
         mConnections.add(clientConnection);
         return clientConnection;
       } catch (Throwable e) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClientConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcClientConnection.java
@@ -41,7 +41,7 @@ public class CopycatGrpcClientConnection extends CopycatGrpcConnection {
    */
   public CopycatGrpcClientConnection(ThreadContext context, ExecutorService executor,
       GrpcChannel channel, long requestTimeoutMs) {
-    super(ConnectionOwner.CLIENT, context, executor, requestTimeoutMs);
+    super(ConnectionOwner.CLIENT, channel.toStringShort(), context, executor, requestTimeoutMs);
     mChannel = channel;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcServerConnection.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/transport/CopycatGrpcServerConnection.java
@@ -19,17 +19,19 @@ import java.util.concurrent.ExecutorService;
  * {@link CopycatGrpcConnection} implementation for server.
  */
 public class CopycatGrpcServerConnection extends CopycatGrpcConnection {
+
   /**
    * Creates a connection object for server.
    *
    * Note: {@link #setTargetObserver} should be called explicitly before using the connection.
    *
+   * @param transportId transport Id for this connection
    * @param context copycat thread context
    * @param executor transport executor
    * @param requestTimeoutMs timeout in milliseconds for requests
    */
-  public CopycatGrpcServerConnection(ThreadContext context, ExecutorService executor,
-      long requestTimeoutMs) {
-    super(ConnectionOwner.SERVER, context, executor, requestTimeoutMs);
+  public CopycatGrpcServerConnection(String transportId, ThreadContext context,
+      ExecutorService executor, long requestTimeoutMs) {
+    super(ConnectionOwner.SERVER, transportId, context, executor, requestTimeoutMs);
   }
 }

--- a/core/transport/src/grpc/copycat.proto
+++ b/core/transport/src/grpc/copycat.proto
@@ -11,7 +11,7 @@ message CopycatRequestHeader {
 }
 message CopycatResponseHeader {
     optional int64 requestId = 1;
-    optional bool failed = 2;
+    optional bool isThrowable = 2;
 }
 message CopycatMessage {
     optional CopycatRequestHeader requestHeader = 1;

--- a/core/transport/src/main/java/alluxio/grpc/CopycatProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/CopycatProto.java
@@ -40,16 +40,16 @@ public final class CopycatProto {
     java.lang.String[] descriptorData = {
       "\n\022grpc/copycat.proto\022\024alluxio.grpc.copyc" +
       "at\")\n\024CopycatRequestHeader\022\021\n\trequestId\030" +
-      "\001 \001(\003\":\n\025CopycatResponseHeader\022\021\n\treques" +
-      "tId\030\001 \001(\003\022\016\n\006failed\030\002 \001(\010\"\251\001\n\016CopycatMes" +
-      "sage\022A\n\rrequestHeader\030\001 \001(\0132*.alluxio.gr" +
-      "pc.copycat.CopycatRequestHeader\022C\n\016respo" +
-      "nseHeader\030\002 \001(\0132+.alluxio.grpc.copycat.C" +
-      "opycatResponseHeader\022\017\n\007message\030\003 \001(\0142q\n" +
-      "\024CopycatMessageServer\022Y\n\007connect\022$.allux" +
-      "io.grpc.copycat.CopycatMessage\032$.alluxio" +
-      ".grpc.copycat.CopycatMessage(\0010\001B\036\n\014allu" +
-      "xio.grpcB\014CopycatProtoP\001"
+      "\001 \001(\003\"?\n\025CopycatResponseHeader\022\021\n\treques" +
+      "tId\030\001 \001(\003\022\023\n\013isThrowable\030\002 \001(\010\"\251\001\n\016Copyc" +
+      "atMessage\022A\n\rrequestHeader\030\001 \001(\0132*.allux" +
+      "io.grpc.copycat.CopycatRequestHeader\022C\n\016" +
+      "responseHeader\030\002 \001(\0132+.alluxio.grpc.copy" +
+      "cat.CopycatResponseHeader\022\017\n\007message\030\003 \001" +
+      "(\0142q\n\024CopycatMessageServer\022Y\n\007connect\022$." +
+      "alluxio.grpc.copycat.CopycatMessage\032$.al" +
+      "luxio.grpc.copycat.CopycatMessage(\0010\001B\036\n" +
+      "\014alluxio.grpcB\014CopycatProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -74,7 +74,7 @@ public final class CopycatProto {
     internal_static_alluxio_grpc_copycat_CopycatResponseHeader_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_copycat_CopycatResponseHeader_descriptor,
-        new java.lang.String[] { "RequestId", "Failed", });
+        new java.lang.String[] { "RequestId", "IsThrowable", });
     internal_static_alluxio_grpc_copycat_CopycatMessage_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_alluxio_grpc_copycat_CopycatMessage_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/CopycatResponseHeader.java
+++ b/core/transport/src/main/java/alluxio/grpc/CopycatResponseHeader.java
@@ -17,7 +17,7 @@ private static final long serialVersionUID = 0L;
   }
   private CopycatResponseHeader() {
     requestId_ = 0L;
-    failed_ = false;
+    isThrowable_ = false;
   }
 
   @java.lang.Override
@@ -58,7 +58,7 @@ private static final long serialVersionUID = 0L;
           }
           case 16: {
             bitField0_ |= 0x00000002;
-            failed_ = input.readBool();
+            isThrowable_ = input.readBool();
             break;
           }
         }
@@ -101,19 +101,19 @@ private static final long serialVersionUID = 0L;
     return requestId_;
   }
 
-  public static final int FAILED_FIELD_NUMBER = 2;
-  private boolean failed_;
+  public static final int ISTHROWABLE_FIELD_NUMBER = 2;
+  private boolean isThrowable_;
   /**
-   * <code>optional bool failed = 2;</code>
+   * <code>optional bool isThrowable = 2;</code>
    */
-  public boolean hasFailed() {
+  public boolean hasIsThrowable() {
     return ((bitField0_ & 0x00000002) == 0x00000002);
   }
   /**
-   * <code>optional bool failed = 2;</code>
+   * <code>optional bool isThrowable = 2;</code>
    */
-  public boolean getFailed() {
-    return failed_;
+  public boolean getIsThrowable() {
+    return isThrowable_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
       output.writeInt64(1, requestId_);
     }
     if (((bitField0_ & 0x00000002) == 0x00000002)) {
-      output.writeBool(2, failed_);
+      output.writeBool(2, isThrowable_);
     }
     unknownFields.writeTo(output);
   }
@@ -148,7 +148,7 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000002) == 0x00000002)) {
       size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(2, failed_);
+        .computeBoolSize(2, isThrowable_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -171,10 +171,10 @@ private static final long serialVersionUID = 0L;
       result = result && (getRequestId()
           == other.getRequestId());
     }
-    result = result && (hasFailed() == other.hasFailed());
-    if (hasFailed()) {
-      result = result && (getFailed()
-          == other.getFailed());
+    result = result && (hasIsThrowable() == other.hasIsThrowable());
+    if (hasIsThrowable()) {
+      result = result && (getIsThrowable()
+          == other.getIsThrowable());
     }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
@@ -192,10 +192,10 @@ private static final long serialVersionUID = 0L;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getRequestId());
     }
-    if (hasFailed()) {
-      hash = (37 * hash) + FAILED_FIELD_NUMBER;
+    if (hasIsThrowable()) {
+      hash = (37 * hash) + ISTHROWABLE_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-          getFailed());
+          getIsThrowable());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -328,7 +328,7 @@ private static final long serialVersionUID = 0L;
       super.clear();
       requestId_ = 0L;
       bitField0_ = (bitField0_ & ~0x00000001);
-      failed_ = false;
+      isThrowable_ = false;
       bitField0_ = (bitField0_ & ~0x00000002);
       return this;
     }
@@ -361,7 +361,7 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
         to_bitField0_ |= 0x00000002;
       }
-      result.failed_ = failed_;
+      result.isThrowable_ = isThrowable_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -407,8 +407,8 @@ private static final long serialVersionUID = 0L;
       if (other.hasRequestId()) {
         setRequestId(other.getRequestId());
       }
-      if (other.hasFailed()) {
-        setFailed(other.getFailed());
+      if (other.hasIsThrowable()) {
+        setIsThrowable(other.getIsThrowable());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -470,34 +470,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean failed_ ;
+    private boolean isThrowable_ ;
     /**
-     * <code>optional bool failed = 2;</code>
+     * <code>optional bool isThrowable = 2;</code>
      */
-    public boolean hasFailed() {
+    public boolean hasIsThrowable() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional bool failed = 2;</code>
+     * <code>optional bool isThrowable = 2;</code>
      */
-    public boolean getFailed() {
-      return failed_;
+    public boolean getIsThrowable() {
+      return isThrowable_;
     }
     /**
-     * <code>optional bool failed = 2;</code>
+     * <code>optional bool isThrowable = 2;</code>
      */
-    public Builder setFailed(boolean value) {
+    public Builder setIsThrowable(boolean value) {
       bitField0_ |= 0x00000002;
-      failed_ = value;
+      isThrowable_ = value;
       onChanged();
       return this;
     }
     /**
-     * <code>optional bool failed = 2;</code>
+     * <code>optional bool isThrowable = 2;</code>
      */
-    public Builder clearFailed() {
+    public Builder clearIsThrowable() {
       bitField0_ = (bitField0_ & ~0x00000002);
-      failed_ = false;
+      isThrowable_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/CopycatResponseHeaderOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/CopycatResponseHeaderOrBuilder.java
@@ -17,11 +17,11 @@ public interface CopycatResponseHeaderOrBuilder extends
   long getRequestId();
 
   /**
-   * <code>optional bool failed = 2;</code>
+   * <code>optional bool isThrowable = 2;</code>
    */
-  boolean hasFailed();
+  boolean hasIsThrowable();
   /**
-   * <code>optional bool failed = 2;</code>
+   * <code>optional bool isThrowable = 2;</code>
    */
-  boolean getFailed();
+  boolean getIsThrowable();
 }


### PR DESCRIPTION
Without a transport level identifier, existing copycat transport traces were not sufficient in some cases to pinpoint source and destination of traffic. This PR makes necessary changes for that and does some improvements for tracing in overall.