### PR TITLE
Use more specific Iceberg dependencies

### DIFF
--- a/experimental/table/pom.xml
+++ b/experimental/table/pom.xml
@@ -32,7 +32,7 @@
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
-    <hive-metastore.verison>2.3.2</hive-metastore.verison>
+    <hive-metastore.verison>2.3.6</hive-metastore.verison>
     <iceberg.version>8c0f53bb</iceberg.version>
   </properties>
 
@@ -54,8 +54,13 @@
         <version>${iceberg.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.github.apache</groupId>
-        <artifactId>incubator-iceberg</artifactId>
+        <groupId>com.github.apache.incubator-iceberg</groupId>
+        <artifactId>iceberg-core</artifactId>
+        <version>${iceberg.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.apache.incubator-iceberg</groupId>
+        <artifactId>iceberg-parquet</artifactId>
         <version>${iceberg.version}</version>
       </dependency>
     </dependencies>

--- a/experimental/table/server/under/hive/pom.xml
+++ b/experimental/table/server/under/hive/pom.xml
@@ -36,8 +36,16 @@
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.apache</groupId>
-      <artifactId>incubator-iceberg</artifactId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <artifactId>iceberg-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <artifactId>iceberg-parquet</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Previously, the Hive UDB required all of iceberg's jars. This led to
some conflicts with older spark jars when developing integration
tests. By restricting the dependencies we get rid of conflicting
jars.

This change is a pre-requisite to full integration tests for the catalog
master. After this change we can use a local spark session to write out
parquet files which can then be consumed by an embedded HMS

Also, this PR increases the HMS version from 2.3.2 to 2.3.6