### PR TITLE
Close journal in tests

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -48,7 +48,6 @@ import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.MasterClientContext;
-import alluxio.master.MasterRegistry;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.contexts.CompleteFileContext;
@@ -66,6 +65,7 @@ import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.testutils.master.FsMasterResource;
 import alluxio.testutils.master.MasterTestUtils;
 import alluxio.underfs.UfsDirectoryStatus;
 import alluxio.underfs.UfsMode;
@@ -207,7 +207,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(0644, (short) fileInfo.getMode());
   }
 
-  private MasterRegistry createFileSystemMasterFromJournal() throws Exception {
+  private FsMasterResource createFileSystemMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournalCopy();
   }
 
@@ -222,14 +222,14 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
           new ConcurrentCreator(DEPTH, CONCURRENCY_DEPTH, ROOT_PATH);
       concurrentCreator.call();
 
-      MasterRegistry registry = createFileSystemMasterFromJournal();
-      FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-      for (FileInfo info : mFsMaster.listStatus(new AlluxioURI("/"),
-              ListStatusContext.defaults())) {
-        AlluxioURI path = new AlluxioURI(info.getPath());
-        Assert.assertEquals(mFsMaster.getFileId(path), fsMaster.getFileId(path));
+      try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+        FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+        for (FileInfo info : mFsMaster
+            .listStatus(new AlluxioURI("/"), ListStatusContext.defaults())) {
+          AlluxioURI path = new AlluxioURI(info.getPath());
+          Assert.assertEquals(mFsMaster.getFileId(path), fsMaster.getFileId(path));
+        }
       }
-      registry.stop();
       before();
     }
   }
@@ -792,7 +792,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
       // Stop Alluxio.
       mLocalAlluxioClusterResource.get().stopFS();
       // Create the master using the existing journal.
-      createFileSystemMasterFromJournal();
+      createFileSystemMasterFromJournal().close();
     } finally {
       threadPool.shutdownNow();
       threadPool.awaitTermination(SHUTDOWN_TIME_MS, TimeUnit.MILLISECONDS);
@@ -853,18 +853,19 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    MasterRegistry registry = createFileSystemMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    // List what is in Alluxio, without syncing. Should match the last state.
-    files = fsMaster.listStatus(root,
-        ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder()
-            .setLoadMetadataType(LoadMetadataPType.NEVER)
-            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1))));
-    Assert.assertEquals(2, files.size());
-    filenames = files.stream().map(FileInfo::getName).collect(Collectors.toSet());
-    Assert.assertTrue(filenames.contains("ufs_dir"));
-    Assert.assertTrue(filenames.contains("ufs_file"));
+      // List what is in Alluxio, without syncing. Should match the last state.
+      files = fsMaster.listStatus(root, ListStatusContext.mergeFrom(
+          ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)
+              .setCommonOptions(
+                  FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1))));
+      Assert.assertEquals(2, files.size());
+      filenames = files.stream().map(FileInfo::getName).collect(Collectors.toSet());
+      Assert.assertTrue(filenames.contains("ufs_dir"));
+      Assert.assertTrue(filenames.contains("ufs_file"));
+    }
   }
 
   @Test
@@ -908,17 +909,18 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    MasterRegistry registry = createFileSystemMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    // List what is in Alluxio, without syncing.
-    info = fsMaster.getFileInfo(dir,
-        GetStatusContext.mergeFrom(GetStatusPOptions.newBuilder()
-            .setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(
-                FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build())));
-    Assert.assertNotNull(info);
-    Assert.assertEquals("dir", info.getName());
-    Assert.assertEquals(mode, info.getMode());
+      // List what is in Alluxio, without syncing.
+      info = fsMaster.getFileInfo(dir, GetStatusContext.mergeFrom(
+          GetStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)
+              .setCommonOptions(
+                  FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build())));
+      Assert.assertNotNull(info);
+      Assert.assertEquals("dir", info.getName());
+      Assert.assertEquals(mode, info.getMode());
+    }
   }
 
   @Test
@@ -994,12 +996,14 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    MasterRegistry registry = MasterTestUtils.createLeaderFileSystemMasterFromJournal();
-    FileSystemMaster newFsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = MasterTestUtils
+        .createLeaderFileSystemMasterFromJournal()) {
+      FileSystemMaster newFsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    files = newFsMaster.listStatus(new AlluxioURI("/mnt/"),
-        ListStatusContext.defaults());
-    Assert.assertTrue(files.isEmpty());
+      files = newFsMaster.listStatus(new AlluxioURI("/mnt/"),
+          ListStatusContext.defaults());
+      Assert.assertTrue(files.isEmpty());
+    }
   }
 
   // TODO(gene): Journal format has changed, maybe add Version to the format and add this test back
@@ -1171,13 +1175,14 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    MasterRegistry registry = createFileSystemMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
-    // Create file should throw an Exception even after restart
-    mThrown.expect(AccessControlException.class);
-    fsMaster.createFile(alluxioFile, CreateFileContext.defaults().setPersisted(true));
+      AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
+      // Create file should throw an Exception even after restart
+      mThrown.expect(AccessControlException.class);
+      fsMaster.createFile(alluxioFile, CreateFileContext.defaults().setPersisted(true));
+    }
   }
 
   @Test
@@ -1419,19 +1424,21 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     long newAccessTime = mFsMaster.getFileInfo(parentId).getLastAccessTimeMs();
     // time is changed in master
     Assert.assertNotEquals(newAccessTime, oldAccessTime);
-    MasterRegistry registry = createFileSystemMasterFromJournal();
-    FileSystemMaster fsm = registry.get(FileSystemMaster.class);
-    long journaledAccessTime = fsm.getFileInfo(parentId).getLastAccessTimeMs();
-    // time is not flushed to journal
-    Assert.assertEquals(journaledAccessTime, oldAccessTime);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsm = masterResource.getRegistry().get(FileSystemMaster.class);
+      long journaledAccessTime = fsm.getFileInfo(parentId).getLastAccessTimeMs();
+      // time is not flushed to journal
+      Assert.assertEquals(journaledAccessTime, oldAccessTime);
+    }
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    registry = createFileSystemMasterFromJournal();
-    fsm = registry.get(FileSystemMaster.class);
-    long journaledAccessTimeAfterStop = fsm.getFileInfo(parentId).getLastAccessTimeMs();
-    // time is now flushed to journal
-    Assert.assertEquals(journaledAccessTimeAfterStop, newAccessTime);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsm = masterResource.getRegistry().get(FileSystemMaster.class);
+      long journaledAccessTimeAfterStop = fsm.getFileInfo(parentId).getLastAccessTimeMs();
+      // time is now flushed to journal
+      Assert.assertEquals(journaledAccessTimeAfterStop, newAccessTime);
+    }
   }
 
   /**
@@ -1450,19 +1457,21 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     long newAccessTime = mFsMaster.getFileInfo(parentId).getLastAccessTimeMs();
     // time is changed in master
     Assert.assertNotEquals(newAccessTime, oldAccessTime);
-    MasterRegistry registry = createFileSystemMasterFromJournal();
-    FileSystemMaster fsm = registry.get(FileSystemMaster.class);
-    long journaledAccessTime = fsm.getFileInfo(parentId).getLastAccessTimeMs();
-    // time is not flushed to journal
-    Assert.assertEquals(journaledAccessTime, oldAccessTime);
-    // delete the directory
-    mFsMaster.delete(parentPath, DeleteContext.defaults());
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsm = masterResource.getRegistry().get(FileSystemMaster.class);
+      long journaledAccessTime = fsm.getFileInfo(parentId).getLastAccessTimeMs();
+      // time is not flushed to journal
+      Assert.assertEquals(journaledAccessTime, oldAccessTime);
+      // delete the directory
+      mFsMaster.delete(parentPath, DeleteContext.defaults());
+    }
     // Stop Alluxio.
     mLocalAlluxioClusterResource.get().stopFS();
     // Create the master using the existing journal.
-    registry = createFileSystemMasterFromJournal();
-    fsm = registry.get(FileSystemMaster.class);
-    Assert.assertEquals(fsm.getFileId(parentPath), -1);
+    try (FsMasterResource masterResource = createFileSystemMasterFromJournal()) {
+      FileSystemMaster fsm = masterResource.getRegistry().get(FileSystemMaster.class);
+      Assert.assertEquals(fsm.getFileId(parentPath), -1);
+    }
   }
 
   /**

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -19,20 +19,20 @@ import static org.mockito.Mockito.spy;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
-import alluxio.conf.ServerConfiguration;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 import alluxio.SystemPropertyRule;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.master.LocalAlluxioCluster;
-import alluxio.master.MasterRegistry;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.PortCoordination;
 import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.master.FsMasterResource;
 import alluxio.testutils.master.MasterTestUtils;
 import alluxio.testutils.underfs.sleeping.SleepingUnderFileSystem;
 import alluxio.testutils.underfs.sleeping.SleepingUnderFileSystemFactory;
@@ -173,7 +173,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
     // Fail the creation of UFS
     doThrow(new RuntimeException()).when(factory).create(anyString(),
         any(UnderFileSystemConfiguration.class));
-    createFsMasterFromJournal();
+    createFsMasterFromJournal().close();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
     // Fail the creation of UFS
     doThrow(new RuntimeException()).when(factory).create(anyString(),
         any(UnderFileSystemConfiguration.class));
-    createFsMasterFromJournal();
+    createFsMasterFromJournal().close();
   }
 
   /**
@@ -235,7 +235,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   /**
    * Creates file system master from journal.
    */
-  private MasterRegistry createFsMasterFromJournal() throws Exception {
+  private FsMasterResource createFsMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
   }
 
@@ -312,12 +312,6 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
             } catch (IOException e) {
               break;
             }
-          } else if (mOpType == 1) {
-            // TODO(gene): Add this back when there is new RawTable client API.
-            // if (mFileSystem.createRawTable(new AlluxioURI(TEST_TABLE_DIR + mSuccessNum), 1) ==
-            // -1) {
-            // break;
-            // }
           }
           // The create operation may succeed at the master side but still returns false due to the
           // shutdown. So the mSuccessNum may be less than the actual success number.

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsJournalIntegrationTest.java
@@ -27,7 +27,6 @@ import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.LocalAlluxioCluster;
-import alluxio.master.MasterRegistry;
 import alluxio.master.NoopMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.contexts.GetStatusContext;
@@ -40,6 +39,7 @@ import alluxio.security.authorization.Mode;
 import alluxio.security.group.GroupMappingService;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.testutils.master.FsMasterResource;
 import alluxio.testutils.master.MasterTestUtils;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
@@ -109,25 +109,22 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void addBlockTestUtil(URIStatus status) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(1,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    long xyzId = fsMaster.getFileId(new AlluxioURI("/xyz"));
-    Assert.assertTrue(xyzId != IdUtils.INVALID_FILE_ID);
-    FileInfo fsMasterInfo = fsMaster.getFileInfo(xyzId);
-    Assert.assertEquals(0, fsMaster.getFileInfo(xyzId).getInMemoryPercentage());
-    Assert.assertEquals(status.getBlockIds(), fsMasterInfo.getBlockIds());
-    Assert.assertEquals(status.getBlockSizeBytes(), fsMasterInfo.getBlockSizeBytes());
-    Assert.assertEquals(status.getLength(), fsMasterInfo.getLength());
-    registry.close();
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(1, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      long xyzId = fsMaster.getFileId(new AlluxioURI("/xyz"));
+      Assert.assertTrue(xyzId != IdUtils.INVALID_FILE_ID);
+      FileInfo fsMasterInfo = fsMaster.getFileInfo(xyzId);
+      Assert.assertEquals(0, fsMaster.getFileInfo(xyzId).getInMemoryPercentage());
+      Assert.assertEquals(status.getBlockIds(), fsMasterInfo.getBlockIds());
+      Assert.assertEquals(status.getBlockSizeBytes(), fsMasterInfo.getBlockSizeBytes());
+      Assert.assertEquals(status.getLength(), fsMasterInfo.getLength());
+    }
   }
 
   /**
@@ -176,21 +173,18 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void loadMetadataTestUtil(URIStatus status) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(1,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/xyz")) != IdUtils.INVALID_FILE_ID);
-    FileInfo fsMasterInfo = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/xyz")));
-    Assert.assertEquals(status, new URIStatus(fsMasterInfo.setMountId(status.getMountId())));
-    registry.close();
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(1, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/xyz")) != IdUtils.INVALID_FILE_ID);
+      FileInfo fsMasterInfo = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/xyz")));
+      Assert.assertEquals(status, new URIStatus(fsMasterInfo.setMountId(status.getMountId())));
+    }
   }
 
   /**
@@ -253,40 +247,34 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void deleteTestUtil() throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(5,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    for (int i = 0; i < 5; i++) {
-      for (int j = 0; j < 5; j++) {
-        Assert.assertTrue(
-            fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(5, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      for (int i = 0; i < 5; i++) {
+        for (int j = 0; j < 5; j++) {
+          Assert.assertTrue(
+              fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
+        }
       }
     }
-    registry.close();
   }
 
   @Test
   public void emptyFileSystem() throws Exception {
     Assert.assertEquals(0, mFileSystem.listStatus(mRootUri).size());
     mLocalAlluxioCluster.stopFS();
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(0,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    registry.close();
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(0, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+    }
   }
 
   /**
@@ -309,23 +297,20 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void fileDirectoryTestUtil() throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(10,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    for (int i = 0; i < 10; i++) {
-      for (int j = 0; j < 10; j++) {
-        Assert.assertTrue(
-            fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(10, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++) {
+          Assert.assertTrue(
+              fsMaster.getFileId(new AlluxioURI("/i" + i + "/j" + j)) != IdUtils.INVALID_FILE_ID);
+        }
       }
     }
-    registry.close();
   }
 
   /**
@@ -344,21 +329,18 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void fileTestUtil(URIStatus status) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(1,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
-    Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(
-        status, new URIStatus(fsMaster.getFileInfo(fileId).setMountId(status.getMountId())));
-    registry.close();
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(1, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
+      Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(status,
+          new URIStatus(fsMaster.getFileInfo(fileId).setMountId(status.getMountId())));
+    }
   }
 
   /**
@@ -392,22 +374,21 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void pinTestUtil(URIStatus directory, URIStatus file0, URIStatus file1) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
-    FileInfo info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder")));
-    Assert.assertEquals(directory, new URIStatus(info.setMountId(directory.getMountId())));
-    Assert.assertTrue(info.isPinned());
+      FileInfo info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder")));
+      Assert.assertEquals(directory, new URIStatus(info.setMountId(directory.getMountId())));
+      Assert.assertTrue(info.isPinned());
 
-    info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder/file0")));
-    Assert.assertEquals(file0, new URIStatus(info.setMountId(file0.getMountId())));
-    Assert.assertFalse(info.isPinned());
+      info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder/file0")));
+      Assert.assertEquals(file0, new URIStatus(info.setMountId(file0.getMountId())));
+      Assert.assertFalse(info.isPinned());
 
-    info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder/file1")));
-    Assert.assertEquals(file1, new URIStatus(info.setMountId(file1.getMountId())));
-    Assert.assertTrue(info.isPinned());
-
-    registry.close();
+      info = fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI("/myFolder/file1")));
+      Assert.assertEquals(file1, new URIStatus(info.setMountId(file1.getMountId())));
+      Assert.assertTrue(info.isPinned());
+    }
   }
 
   /**
@@ -425,21 +406,18 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void directoryTestUtil(URIStatus status) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(1,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
-    Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(
-        status, new URIStatus(fsMaster.getFileInfo(fileId).setMountId(status.getMountId())));
-    registry.close();
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(1, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      long fileId = fsMaster.getFileId(new AlluxioURI("/xyz"));
+      Assert.assertTrue(fileId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(status,
+          new URIStatus(fsMaster.getFileInfo(fileId).setMountId(status.getMountId())));
+    }
   }
 
   /**
@@ -477,15 +455,14 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
 
   private void persistDirectoryLaterTestUtil(Map<String, URIStatus> directoryStatuses)
       throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    for (Map.Entry<String, URIStatus> directoryStatus : directoryStatuses.entrySet()) {
-      Assert.assertEquals(
-          directoryStatus.getValue(),
-          new URIStatus(fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI(directoryStatus
-              .getKey()))).setMountId(directoryStatus.getValue().getMountId())));
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      for (Map.Entry<String, URIStatus> directoryStatus : directoryStatuses.entrySet()) {
+        Assert.assertEquals(directoryStatus.getValue(), new URIStatus(
+            fsMaster.getFileInfo(fsMaster.getFileId(new AlluxioURI(directoryStatus.getKey())))
+                .setMountId(directoryStatus.getValue().getMountId())));
+      }
     }
-    registry.close();
   }
 
   /**
@@ -505,20 +482,17 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void manyFileTestUtil() throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(10,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    for (int k = 0; k < 10; k++) {
-      Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(10, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      for (int k = 0; k < 10; k++) {
+        Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
+      }
     }
-    registry.close();
   }
 
   /**
@@ -538,20 +512,17 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void multiEditLogTestUtil() throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(124,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    for (int k = 0; k < 124; k++) {
-      Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(124, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      for (int k = 0; k < 124; k++) {
+        Assert.assertTrue(fsMaster.getFileId(new AlluxioURI("/a" + k)) != IdUtils.INVALID_FILE_ID);
+      }
     }
-    registry.close();
   }
 
   /**
@@ -577,23 +548,20 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void renameTestUtil() throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    long rootId = fsMaster.getFileId(mRootUri);
-    Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
-    Assert.assertEquals(10,
-        fsMaster
-            .listStatus(mRootUri,
-                ListStatusContext.mergeFrom(
-                    ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
-            .size());
-    for (int i = 0; i < 10; i++) {
-      for (int j = 0; j < 10; j++) {
-        Assert.assertTrue(
-            fsMaster.getFileId(new AlluxioURI("/ii" + i + "/jj" + j)) != IdUtils.INVALID_FILE_ID);
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      long rootId = fsMaster.getFileId(mRootUri);
+      Assert.assertTrue(rootId != IdUtils.INVALID_FILE_ID);
+      Assert.assertEquals(10, fsMaster.listStatus(mRootUri, ListStatusContext
+          .mergeFrom(ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER)))
+          .size());
+      for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++) {
+          Assert.assertTrue(
+              fsMaster.getFileId(new AlluxioURI("/ii" + i + "/jj" + j)) != IdUtils.INVALID_FILE_ID);
+        }
       }
     }
-    registry.close();
   }
 
   @Test
@@ -623,15 +591,15 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   private void aclTestUtil(URIStatus status, String user) throws Exception {
-    MasterRegistry registry = createFsMasterFromJournal();
-    FileSystemMaster fsMaster = registry.get(FileSystemMaster.class);
-    AuthenticatedClientUser.set(user);
-    FileInfo info = fsMaster.getFileInfo(new AlluxioURI("/file"), GetStatusContext.defaults());
-    Assert.assertEquals(status, new URIStatus(info.setMountId(status.getMountId())));
-    registry.close();
+    try (FsMasterResource masterResource = createFsMasterFromJournal()) {
+      FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
+      AuthenticatedClientUser.set(user);
+      FileInfo info = fsMaster.getFileInfo(new AlluxioURI("/file"), GetStatusContext.defaults());
+      Assert.assertEquals(status, new URIStatus(info.setMountId(status.getMountId())));
+    }
   }
 
-  private MasterRegistry createFsMasterFromJournal() throws Exception {
+  private FsMasterResource createFsMasterFromJournal() throws Exception {
     return MasterTestUtils.createLeaderFileSystemMasterFromJournal();
   }
 

--- a/tests/src/test/java/alluxio/testutils/master/FsMasterResource.java
+++ b/tests/src/test/java/alluxio/testutils/master/FsMasterResource.java
@@ -1,0 +1,65 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.testutils.master;
+
+import alluxio.master.MasterRegistry;
+import alluxio.master.journal.JournalSystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * This class is a closeable resource that holds the master registry and the journal system. The
+ * close() must be called to stop the masters and journal.
+ */
+public class FsMasterResource implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(FsMasterResource.class);
+
+  private final MasterRegistry mRegistry;
+  private final JournalSystem mJournal;
+
+  /**
+   * @param registry the master registry
+   * @param journal the journal system
+   */
+  FsMasterResource(MasterRegistry registry, JournalSystem journal) {
+    mRegistry = registry;
+    mJournal = journal;
+  }
+
+  /**
+   * @return the master registry
+   */
+  public MasterRegistry getRegistry() {
+    return mRegistry;
+  }
+
+  /**
+   * @return the journal system
+   */
+  public JournalSystem getJournal() {
+    return mJournal;
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      mRegistry.close();
+      mJournal.stop();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
@@ -40,43 +40,43 @@ public class MasterTestUtils {
 
   /**
    * Creates a new leader {@link FileSystemMaster} from journal along with its dependencies, and
-   * returns the master registry containing that master.
+   * returns the master registry and the journal system.
    *
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  public static MasterRegistry createLeaderFileSystemMasterFromJournal() throws Exception {
+  public static FsMasterResource createLeaderFileSystemMasterFromJournal() throws Exception {
     return createFileSystemMasterFromJournal(true, null);
   }
 
   /**
    * Creates a new leader {@link FileSystemMaster} from journal along with its dependencies, and
-   * returns the master registry containing that master.
+   * returns the master registry and the journal system.
    *
    * @param userState the user state for the server
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  public static MasterRegistry createLeaderFileSystemMasterFromJournal(UserState userState)
+  public static FsMasterResource createLeaderFileSystemMasterFromJournal(UserState userState)
       throws Exception {
     return createFileSystemMasterFromJournal(true, userState);
   }
 
   /**
    * Creates a new standby {@link FileSystemMaster} from journal along with its dependencies, and
-   * returns the master registry containing that master.
+   * returns the master registry and the journal system.
    *
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  public static MasterRegistry createStandbyFileSystemMasterFromJournal() throws Exception {
+  public static FsMasterResource createStandbyFileSystemMasterFromJournal() throws Exception {
     return createFileSystemMasterFromJournal(false, null);
   }
 
   /**
    * Creates a new leader {@link FileSystemMaster} from a copy of the journal along with its
-   * dependencies, and returns the master registry containing that master.
+   * dependencies, and returns the master registry and the journal system.
    *
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  public static MasterRegistry createLeaderFileSystemMasterFromJournalCopy() throws Exception {
+  public static FsMasterResource createLeaderFileSystemMasterFromJournalCopy() throws Exception {
     String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     File tmpDirFile = Files.createTempDir();
     tmpDirFile.deleteOnExit();
@@ -87,13 +87,13 @@ public class MasterTestUtils {
 
   /**
    * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and returns
-   * the master registry containing that master.
+   * the master registry and the journal system.
    *
    * @param isLeader whether to start as a leader
    * @param userState the user state for the server. if null, will use ServerUserState.global()
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader,
+  private static FsMasterResource createFileSystemMasterFromJournal(boolean isLeader,
       UserState userState) throws Exception {
     String masterJournal = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     return createFileSystemMasterFromJournal(isLeader, userState, masterJournal);
@@ -101,14 +101,14 @@ public class MasterTestUtils {
 
   /**
    * Creates a new {@link FileSystemMaster} from journal along with its dependencies, and returns
-   * the master registry containing that master.
+   * the master registry and the journal system.
    *
    * @param isLeader whether to start as a leader
    * @param userState the user state for the server. if null, will use ServerUserState.global()
    * @param journalFolder the folder of the master journal
-   * @return a master registry containing the created {@link FileSystemMaster} master
+   * @return a resource that contains the master registry and the journal system
    */
-  private static MasterRegistry createFileSystemMasterFromJournal(boolean isLeader,
+  private static FsMasterResource createFileSystemMasterFromJournal(boolean isLeader,
       UserState userState, String journalFolder) throws Exception {
     String masterJournal = journalFolder;
     MasterRegistry registry = new MasterRegistry();
@@ -139,6 +139,6 @@ public class MasterTestUtils {
       journalSystem.gainPrimacy();
     }
     registry.start(isLeader);
-    return registry;
+    return new FsMasterResource(registry, journalSystem);
   }
 }


### PR DESCRIPTION
In some tests, the journal was not being closed when the master registry is closed. This caused some of the flaky checkpoint read failures.