### PR TITLE
Remove noisy log in BlockMaster

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -918,7 +918,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
       try (LockResource lr = lockBlock(removedBlockId)) {
         Optional<BlockMeta> block = mBlockStore.getBlock(removedBlockId);
         if (block.isPresent()) {
-          LOG.info("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
+          LOG.debug("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
           mBlockStore.removeLocation(removedBlockId, workerInfo.getId());
           if (mBlockStore.getLocations(removedBlockId).size() == 0) {
             mLostBlocks.add(removedBlockId);


### PR DESCRIPTION
This line is too noisy and provides little to no valuable information. Will only get worse if default block size is reduced.