### PR TITLE
Remove noisy log in BlockMaster

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -892,7 +892,7 @@ public final class DefaultBlockMaster extends AbstractMaster implements BlockMas
         continue;
       }
       synchronized (block) {
-        LOG.info("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
+        LOG.debug("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
         workerInfo.removeBlock(block.getBlockId());
         block.removeWorker(workerInfo.getId());
         if (block.getNumLocations() == 0) {


### PR DESCRIPTION
This line is too noisy and provides little to no valuable information.
Will only get worse if default block size is reduced.

pr-link: #9923
change-id: cid-f2fb1d66ddb5601422d35a0a6c34e72e0cd24bc7
