### PR TITLE
[WIP] Jobs are disappearing from the job master

### DIFF
--- a/job/common/src/main/java/alluxio/job/meta/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/meta/JobInfo.java
@@ -17,6 +17,7 @@ import alluxio.job.wire.TaskInfo;
 import alluxio.util.CommonUtils;
 
 import com.google.common.base.Function;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -64,7 +65,7 @@ public final class JobInfo implements Comparable<JobInfo> {
    */
   @Override
   public synchronized int compareTo(JobInfo other) {
-    return Long.compare(mLastStatusChangeMs, other.getLastStatusChangeMs());
+    return Long.compare(mLastStatusChangeMs, other.mLastStatusChangeMs);
   }
 
   /**
@@ -176,5 +177,24 @@ public final class JobInfo implements Comparable<JobInfo> {
    */
   public synchronized List<TaskInfo> getTaskInfoList() {
     return Lists.newArrayList(mTaskIdToInfo.values());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof JobInfo)) {
+      return false;
+    }
+
+    JobInfo other = (JobInfo) o;
+    return Objects.equal(mId, other.mId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mId);
   }
 }


### PR DESCRIPTION
Run the FileOutStreamAsyncWriteIntegrationTest#badSpaceReserverTest

The test will trigger many jobs to run in the job service. It also sets
the max limit to only 500 jobs, but a retention of 0 seconds, so new jobs
coming in can run so long as there are jobs that have finished.

The issue we're seeing is that when we have many new jobs come in
Some will get scheduled, finish their tasks, and then be put into the
mFinishedJobs map with the time they finished. However, after extensive
testing I still see ResourceExhaustedExceptions being thrown, and when
they are thrown the state of the mIdToJobCoodinator map contains many
(hundreds) of jobs which say completed.

Logging has been added for the time when each job id gets added to
mFinished, removed from mFinished, and also removed from
mJobIdToCoordinator.

Essentially all the logs have shown me is that there are a number
of jobs which are created, run, finishes its task, gets added to
mFinished, but never logs a removal from the map.

The exception is only thrown when the map is empty. It seems that
we're having some kind of "ghost removal".