### PR TITLE
Add git revision to ./bin/alluxio version

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -147,6 +147,40 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>create-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputDirectory>${project.build.directory}/generated/build-metadata</outputDirectory>
+          <outputName>build.properties</outputName>
+          <revisionPropertyName>git.revision</revisionPropertyName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <files>
+                <file>${project.build.directory}/generated/build-metadata/build.properties</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/core/common/src/main/java-templates/alluxio/ProjectConstants.java
+++ b/core/common/src/main/java-templates/alluxio/ProjectConstants.java
@@ -17,6 +17,8 @@ package alluxio;
 public final class ProjectConstants {
   /* Project version, specified in maven property. **/
   public static final String VERSION = "${project.version}";
+  /* The latest git revision of at the time of building**/
+  public static final String REVISION = "${git.revision}";
   /* Hadoop version, specified in maven property. **/
   public static final String HADOOP_VERSION = "${hadoop.version}";
   /* Whether update check is enabled. **/

--- a/pom.xml
+++ b/pom.xml
@@ -918,6 +918,11 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>1.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>1.4.0</version>
         </plugin>
@@ -925,6 +930,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
           <version>3.0.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>1.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/shell/src/main/java/alluxio/cli/Version.java
+++ b/shell/src/main/java/alluxio/cli/Version.java
@@ -14,7 +14,6 @@ package alluxio.cli;
 import alluxio.ProjectConstants;
 import alluxio.RuntimeConstants;
 
-import com.google.rpc.Help;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -22,8 +21,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-
-import java.io.PrintWriter;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -74,6 +71,9 @@ public final class Version {
     System.exit(1);
   }
 
+  /**
+   * Prints the usage of the version command.
+   */
   public static void printUsage(Options options) {
     new HelpFormatter().printHelp("version", options);
   }

--- a/shell/src/main/java/alluxio/cli/Version.java
+++ b/shell/src/main/java/alluxio/cli/Version.java
@@ -73,6 +73,8 @@ public final class Version {
 
   /**
    * Prints the usage of the version command.
+   *
+   * @param options the set of command line options to put in the help text
    */
   public static void printUsage(Options options) {
     new HelpFormatter().printHelp("version", options);

--- a/shell/src/main/java/alluxio/cli/Version.java
+++ b/shell/src/main/java/alluxio/cli/Version.java
@@ -11,7 +11,19 @@
 
 package alluxio.cli;
 
+import alluxio.ProjectConstants;
 import alluxio.RuntimeConstants;
+
+import com.google.rpc.Help;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.io.PrintWriter;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -21,6 +33,15 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class Version {
 
+  private static final Option REVISION_OPT = Option.builder("r")
+      .longOpt("revision")
+      .desc("Prints the git revision along with the Alluxio version. Optionally specify the "
+          + "revision length")
+      .optionalArg(true)
+      .argName("revision_length")
+      .hasArg(true)
+      .build();
+
   private Version() {} // prevent instantiation
 
   /**
@@ -29,6 +50,31 @@ public final class Version {
    * @param args the arguments
    */
   public static void main(String[] args) {
-    System.out.println(RuntimeConstants.VERSION);
+    CommandLineParser parser = new DefaultParser();
+    Options opts = new Options().addOption(REVISION_OPT);
+    try {
+      CommandLine cl = parser.parse(opts, args);
+      String revision = "";
+      if (cl.hasOption(REVISION_OPT.getOpt())) {
+        String r = cl.getOptionValue(REVISION_OPT.getOpt());
+        int revisionLen = r == null ? ProjectConstants.REVISION.length() :
+            Integer.parseInt(r);
+        revision = String.format("-%s", ProjectConstants.REVISION.substring(0,
+            Math.min(revisionLen, ProjectConstants.REVISION.length())));
+      }
+      System.out.println(String.format("%s%s", RuntimeConstants.VERSION, revision));
+      System.exit(0);
+    } catch (ParseException e) {
+      printUsage(opts);
+    } catch (NumberFormatException e) {
+      System.out.println(String.format("Couldn't parse <%s> as an integer",
+          REVISION_OPT.getValue()));
+      printUsage(opts);
+    }
+    System.exit(1);
+  }
+
+  public static void printUsage(Options options) {
+    new HelpFormatter().printHelp("version", options);
   }
 }


### PR DESCRIPTION
In light of preserving behavior, the command behaves the same as in
previous versions. This change adds the -r option which can be specified
optionally so that users can  see part or all of the revision output
appended to the end of the normal version string.

Added two new maven plugins to retrieve the git revision.

Closes #9930 