### PR TITLE
Remove dependency: commons-lang 2.x and commons-httpclient 3.x

### DIFF
--- a/core/base/pom.xml
+++ b/core/base/pom.xml
@@ -44,10 +44,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
     </dependency>

--- a/core/base/src/main/java/alluxio/AlluxioURI.java
+++ b/core/base/src/main/java/alluxio/AlluxioURI.java
@@ -20,7 +20,7 @@ import alluxio.uri.URI;
 import alluxio.util.URIUtils;
 import alluxio.util.io.PathUtils;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/base/src/main/java/alluxio/collections/PrefixList.java
+++ b/core/base/src/main/java/alluxio/collections/PrefixList.java
@@ -13,7 +13,7 @@ package alluxio.collections;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -16,8 +16,8 @@ import alluxio.exception.status.InvalidArgumentException;
 
 import com.google.common.io.Closer;
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
@@ -17,7 +17,7 @@ import alluxio.util.network.NetworkAddressUtils;
 
 import com.google.common.base.MoreObjects;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerAddress.java
@@ -12,7 +12,7 @@
 package alluxio.grpc;
 
 import com.google.common.base.MoreObjects;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/core/common/src/main/java/alluxio/metrics/sink/RegexMetricFilter.java
+++ b/core/common/src/main/java/alluxio/metrics/sink/RegexMetricFilter.java
@@ -13,7 +13,7 @@ package alluxio.metrics.sink;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Properties;
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -18,7 +18,7 @@ import alluxio.extensions.ExtensionFactoryRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.ServiceLoader;

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -31,7 +31,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.netty.channel.Channel;
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/common/src/main/java/alluxio/util/LogUtils.java
+++ b/core/common/src/main/java/alluxio/util/LogUtils.java
@@ -13,7 +13,7 @@ package alluxio.util;
 
 import alluxio.wire.LogInfo;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.impl.Jdk14Logger;

--- a/core/common/src/main/java/alluxio/wire/BackupStatus.java
+++ b/core/common/src/main/java/alluxio/wire/BackupStatus.java
@@ -18,7 +18,7 @@ import alluxio.grpc.BackupState;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
-import org.apache.commons.lang.SerializationUtils;
+import org.apache.commons.lang3.SerializationUtils;
 
 import java.util.UUID;
 

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -14,7 +14,7 @@ package alluxio;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,13 +37,13 @@ public final class ProcessUtils {
       System.exit(0);
     } catch (Throwable t) {
       LOG.error("Uncaught exception while running {}, stopping it and exiting. "
-          + "Exception \"{}\", Root Cause \"{}\"", process, t, ExceptionUtils.getRootCause(t), t);
+          + "Exception \"{}\", Root Cause \"{}\"", process, t, Throwables.getRootCause(t), t);
       try {
         process.stop();
       } catch (Throwable t2) {
         // continue to exit
         LOG.error("Uncaught exception while stopping {}, simply exiting. "
-            + "Exception \"{}\", Root Cause \"{}\"", process, t2, ExceptionUtils.getRootCause(t2),
+            + "Exception \"{}\", Root Cause \"{}\"", process, t2, Throwables.getRootCause(t2),
             t2);
       }
       System.exit(-1);
@@ -72,7 +72,7 @@ public final class ProcessUtils {
   public static void fatalError(Logger logger, Throwable t, String format, Object... args) {
     String message = String.format("Fatal error: " + format, args);
     if (t != null) {
-      message += "\n" + ExceptionUtils.getStackTrace(t);
+      message += "\n" + Throwables.getStackTraceAsString(t);
     }
     if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
       throw new RuntimeException(message);

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -27,7 +27,7 @@ import alluxio.util.StreamUtils;
 
 import com.esotericsoftware.kryo.io.OutputChunked;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,7 +178,7 @@ public final class JournalUtils {
       String format, Object... args) throws RuntimeException {
     String message = String.format("Journal replay error: " + format, args);
     if (t != null) {
-      message += "\n" + ExceptionUtils.getStackTrace(t);
+      message += "\n" + Throwables.getStackTraceAsString(t);
     }
     if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
       throw new RuntimeException(message);

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -26,7 +26,7 @@ import alluxio.util.interfaces.Scoped;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +129,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       try {
         startServing(" (gained leadership)", " (lost leadership)");
       } catch (Throwable t) {
-        Throwable root = ExceptionUtils.getRootCause(t);
+        Throwable root = Throwables.getRootCause(t);
         if ((root != null && (root instanceof InterruptedException)) || Thread.interrupted()) {
           return;
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -175,7 +175,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsMasterClientServiceHandler.java
@@ -22,9 +22,9 @@ import alluxio.grpc.MetricsMasterClientServiceGrpc;
 import alluxio.metrics.Metric;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import io.grpc.stub.StreamObserver;
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationCheckerTest.java
@@ -20,7 +20,7 @@ import alluxio.grpc.Scope;
 import alluxio.wire.Address;
 import alluxio.wire.ConfigCheckReport;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/checkconf/ServerConfigurationStoreTest.java
@@ -19,7 +19,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.ConfigProperty;
 import alluxio.wire.Address;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
@@ -104,8 +104,8 @@ public final class AlluxioProxyProcess implements ProxyProcess {
         }
         HttpClient client = HttpClientBuilder.create().build();
         HttpPost method = new HttpPost(String
-            .format("http://%s:%d%s/%s///%s", mWebServer.getBindHost(), mWebServer.getLocalPort(),
-                Constants.REST_API_PREFIX, PathsRestServiceHandler.SERVICE_PREFIX,
+            .format("http://%s:%d%s/%s/%s/%s", mWebServer.getBindHost(), mWebServer.getLocalPort(),
+                Constants.REST_API_PREFIX, PathsRestServiceHandler.SERVICE_PREFIX, "%2f",
                 PathsRestServiceHandler.EXISTS));
         try {
           HttpResponse response = client.execute(method);

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -25,8 +25,8 @@ import alluxio.worker.block.meta.TempBlockMeta;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
@@ -18,7 +18,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.util.ShellUtils;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
@@ -23,7 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -22,7 +22,7 @@ import alluxio.job.RunTaskContext;
 import alluxio.job.util.SerializationUtils;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +102,8 @@ public final class TaskExecutor implements Runnable {
 
   private void fail(Throwable t, JobConfig jobConfig, Serializable taskArgs) {
     if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
-      mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, ExceptionUtils.getStackTrace(t));
+      mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId,
+          Throwables.getStackTraceAsString(t));
     } else {
       mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, t.getMessage());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -266,19 +266,9 @@
         <version>1.13</version>
       </dependency>
       <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>3.1</version>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.7</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -521,7 +511,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.6</version>
+        <version>4.5.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -44,8 +44,8 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -33,7 +33,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
 import java.io.IOException;

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -34,7 +34,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
@@ -19,7 +19,7 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closer;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,7 +188,7 @@ public final class ConfigurationDocGenerator {
         } else {
           fileWriter = fileWriterMap.get("common");
         }
-        fileWriter.append(StringEscapeUtils.escapeHtml(keyValueStr));
+        fileWriter.append(StringEscapeUtils.escapeHtml4(keyValueStr));
       }
 
       LOG.info("YML files for description of Property Keys were created successfully.");

--- a/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
@@ -21,7 +21,7 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Objects;
 import com.google.common.io.Closer;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +102,7 @@ public final class MetricsDocGenerator {
               new FileWriterKey(metricTypeMap.get(components[0]), YML_SUFFIX));
           csvFileWriter.append(String.format("%s,%s%n", key, metricKey.getMetricType().toString()));
           ymlFileWriter.append(String.format("%s:%n  '%s'%n",
-              key, StringEscapeUtils.escapeHtml(metricKey.getDescription().replace("'", "''"))));
+              key, StringEscapeUtils.escapeHtml4(metricKey.getDescription().replace("'", "''"))));
         } else {
           throw new IOException(String
               .format("The metric key starts with invalid instance type %s", components[0]));

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -40,7 +40,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
@@ -24,7 +24,7 @@ import alluxio.wire.BackupStatus;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.UUID;

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -25,7 +25,7 @@ import alluxio.table.common.transform.TransformPlan;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/table/server/common/src/main/java/alluxio/table/common/transform/action/CompactAction.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/action/CompactAction.java
@@ -18,7 +18,7 @@ import alluxio.table.common.Layout;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Properties;
 

--- a/tests/src/test/java/alluxio/client/cli/fs/ConfigurationDocGeneratorTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/ConfigurationDocGeneratorTest.java
@@ -21,7 +21,7 @@ import alluxio.collections.Pair;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Joiner;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptionsTest.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptionsTest.java
@@ -13,7 +13,7 @@ package alluxio.client.rest;
 
 import alluxio.test.util.CommonUtils;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSInputStream.java
@@ -19,7 +19,7 @@ import com.qcloud.cos.exception.CosServiceException;
 import com.qcloud.cos.model.COSObject;
 import com.qcloud.cos.model.GetObjectRequest;
 import com.qcloud.cos.model.ObjectMetadata;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSInputStream.java
@@ -13,7 +13,7 @@ package alluxio.underfs.gcs;
 
 import alluxio.retry.RetryPolicy;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.impl.rest.httpclient.GoogleStorageService;
 import org.jets3t.service.model.GSObject;

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -26,7 +26,7 @@ import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.StorageObjectsChunk;
 import org.jets3t.service.acl.gs.GSAccessControlList;

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoClient.java
@@ -24,7 +24,7 @@ import com.qiniu.util.Auth;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 
 import java.io.File;
 import java.io.IOException;

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -17,7 +17,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
+++ b/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
@@ -28,7 +28,7 @@ import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.network.HttpUtils;
 
 import com.google.common.io.ByteStreams;
-import org.apache.commons.httpclient.Header;
+import org.apache.http.Header;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;


### PR DESCRIPTION
Remove the older versions of these libraries, since it is not a good practice to use different versions of commons-lang and httpclient in the same project.