### PR TITLE
Add explicit dependency on netty-native

### DIFF
--- a/experimental/table/client/pom.xml
+++ b/experimental/table/client/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
         <version>${netty.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient</artifactId>
         <version>${prometheus.version}</version>


### PR DESCRIPTION
Presto imports netty packages individually, so we exclude netty-all. We could also explicitly import each package, but the only one we need over what is provided is the native module for domain socket.