### PR TITLE
Fix bug for job info loss

### DIFF
--- a/job/common/src/main/java/alluxio/job/meta/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/meta/JobInfo.java
@@ -64,7 +64,7 @@ public final class JobInfo implements Comparable<JobInfo> {
    */
   @Override
   public synchronized int compareTo(JobInfo other) {
-    return Long.compare(mLastStatusChangeMs, other.getLastStatusChangeMs());
+    return Long.compare(mId, other.getId());
   }
 
   /**

--- a/job/common/src/test/java/alluxio/job/meta/JobInfoTest.java
+++ b/job/common/src/test/java/alluxio/job/meta/JobInfoTest.java
@@ -26,12 +26,12 @@ public final class JobInfoTest {
     JobConfig jobConfig = new TestJobConfig("unused");
     JobInfo a = new JobInfo(0L, jobConfig, null);
     CommonUtils.sleepMs(1);
-    JobInfo b = new JobInfo(0L, jobConfig, null);
+    JobInfo b = new JobInfo(1L, jobConfig, null);
     Assert.assertEquals(-1, a.compareTo(b));
     b.setStatus(Status.RUNNING);
     CommonUtils.sleepMs(1);
     a.setStatus(Status.RUNNING);
-    Assert.assertEquals(1, a.compareTo(b));
+    Assert.assertEquals(-1, a.compareTo(b));
     a.setStatus(Status.COMPLETED);
     CommonUtils.sleepMs(1);
     b.setStatus(Status.COMPLETED);


### PR DESCRIPTION
mFinishedJobs in JobMaster is a ConcurrentSkipListSet to store finished
JobInfo. JobInfo implements the compareTo() function to compare the
JobInfos by mLastStatusChangeMs. For two different JobInfos, if the
mLastStatusChangeMs in is the same, there is only one JobInfo stored in
mFinishedJobs after the JobInfos added and one is lost.

mId in JobInfo is unique and can be used to compare JobInfos.

Signed-off-by: liuhongtong <hongtongliu@126.com>