### PR TITLE
Shorten k8s port name for embedded journal

### DIFF
--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -103,7 +103,7 @@ spec:
           name: web
         {{- if $isEmbedded }}
         - containerPort: 19200
-          name: ej
+          name: embedded
         {{- end}}
         volumeMounts:
         {{- if $needJournalVolume }}

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -48,7 +48,7 @@ spec:
     name: web
   {{- if $isEmbedded }}
   - port: 19200
-    name: embedded-journal
+    name: ej
   {{- end}}
   clusterIP: None
   selector:
@@ -103,7 +103,7 @@ spec:
           name: web
         {{- if $isEmbedded }}
         - containerPort: 19200
-          name: embedded-journal
+          name: ej
         {{- end}}
         volumeMounts:
         {{- if $needJournalVolume }}

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -48,7 +48,7 @@ spec:
     name: web
   {{- if $isEmbedded }}
   - port: 19200
-    name: ej
+    name: embedded
   {{- end}}
   clusterIP: None
   selector:

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
@@ -76,7 +76,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: ej
+          name: embedded
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -174,7 +174,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: ej
+          name: embedded
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -272,7 +272,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: ej
+          name: embedded
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
@@ -25,7 +25,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: ej
+    name: embedded
   clusterIP: None
   selector:
     app: alluxio-master-0
@@ -123,7 +123,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: ej
+    name: embedded
   clusterIP: None
   selector:
     app: alluxio-master-1
@@ -221,7 +221,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: ej
+    name: embedded
   clusterIP: None
   selector:
     app: alluxio-master-2

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
@@ -25,7 +25,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: embedded-journal
+    name: ej
   clusterIP: None
   selector:
     app: alluxio-master-0
@@ -76,7 +76,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: embedded-journal
+          name: ej
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -123,7 +123,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: embedded-journal
+    name: ej
   clusterIP: None
   selector:
     app: alluxio-master-1
@@ -174,7 +174,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: embedded-journal
+          name: ej
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -221,7 +221,7 @@ spec:
   - port: 19999
     name: web
   - port: 19200
-    name: embedded-journal
+    name: ej
   clusterIP: None
   selector:
     app: alluxio-master-2
@@ -272,7 +272,7 @@ spec:
         - containerPort: 19999
           name: web
         - containerPort: 19200
-          name: embedded-journal
+          name: ej
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal


### PR DESCRIPTION
The port name for embedded journal was `embedded-journal`. K8s has a restriction for a port name to be shorter than 15 characters, so the Pod creation will fail. This changes the port name to be short enough to be accepted.