### PR TITLE
Enable Alluxio to run as non-root in Kubernetes cluster

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG ALLUXIO_GROUP=alluxio
 ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 
-RUN apk --no-cache --update add bash libc6-compat shadow && \
+RUN apk --no-cache --update add bash libc6-compat shadow sudo && \
     rm -rf /var/cache/apk/*
 
 ADD ${ALLUXIO_TARBALL} /opt/

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG ALLUXIO_GROUP=alluxio
 ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 
-RUN apk --no-cache --update add bash libc6-compat shadow sudo && \
+RUN apk --no-cache --update add bash libc6-compat shadow && \
     rm -rf /var/cache/apk/*
 
 ADD ${ALLUXIO_TARBALL} /opt/

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -10,6 +10,8 @@
 #
 
 {{ $root := . -}}
+{{- $isRoot := eq (int $root.Values.user) 0 }}
+{{- $ugi := printf "%v:%v" $root.Values.user $root.Values.group }}
 {{- $masterCount := int .Values.resources.masterCount }}
 {{- $isSingleMaster := eq $masterCount 1 }}
 {{- $isEmbedded := (eq .Values.journal.type "EMBEDDED") }}
@@ -17,7 +19,7 @@
 {{- $isUfsLocal := and (eq .Values.journal.type "UFS") (eq .Values.journal.ufsType "local") }}
 {{- $isSingleUfsLocal := and $isUfsLocal $isSingleMaster }}
 {{- $needJournalVolume := or $isEmbedded $isUfsLocal }}
-{{- if $isUfsLocal}}
+{{- if $isUfsLocal }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -30,7 +32,7 @@ spec:
     requests:
       storage: {{ .Values.volumes.master.journal.size | quote }}
 ---
-{{- end}}
+{{- end }}
 {{- range $i := until $masterCount }}
   {{- $masterName := printf "alluxio-master-%v" $i }}
   {{- $masterJavaOpts := printf " -Dalluxio.master.hostname=alluxio-master-%v " $i }}
@@ -70,9 +72,16 @@ spec:
         app: {{ $masterName }}
     spec:
       securityContext:
-        runAsUser: {{ $root.Values.user }}
-        runAsGroup: {{ $root.Values.group }}
         fsGroup: {{ $root.Values.fsGroup }}
+      {{- if and $isSingleUfsLocal (not $isRoot) }}
+      initContainers:
+      - name: journal-chown
+        image: busybox
+        command: ["/bin/chown","-R",{{ $ugi | quote }}, "/journal"]
+        volumeMounts:
+          - name: alluxio-journal
+            mountPath: /journal
+      {{- end}}
       containers:
       - name: alluxio-master
         image: {{ $root.Values.image }}:{{ $root.Values.imageTag }}
@@ -84,6 +93,9 @@ spec:
           requests:
             cpu: {{ $root.Values.resources.master.requests.cpu }}
             memory: {{ $root.Values.resources.master.requests.memory }}
+        securityContext:
+          runAsUser: {{ $root.Values.user }}
+          runAsGroup: {{ $root.Values.group }}
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         {{- if $isHaEmbedded }}
@@ -129,6 +141,9 @@ spec:
           requests:
             cpu: {{ $root.Values.resources.jobMaster.requests.cpu }}
             memory: {{ $root.Values.resources.jobMaster.requests.memory }}
+        securityContext:
+          runAsUser: {{ $root.Values.user }}
+          runAsGroup: {{ $root.Values.group }}
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         {{- if $isHaEmbedded }}

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -76,8 +76,10 @@ spec:
       {{- if and $isSingleUfsLocal (not $isRoot) }}
       initContainers:
       - name: journal-chown
-        image: busybox
-        command: ["/bin/chown","-R",{{ $ugi | quote }}, "/journal"]
+        securityContext:
+          runAsUser: 0
+        image: {{ $root.Values.image }}:{{ $root.Values.imageTag }}
+        command: ["/bin/chown","-R", {{ $ugi | quote }}, "/journal"]
         volumeMounts:
           - name: alluxio-journal
             mountPath: /journal

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
@@ -9,6 +9,8 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+{{ $isRoot := eq (int .Values.user) 0 }}
+{{- $ugi := printf "%v:%v" .Values.user .Values.group }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -26,9 +28,16 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        runAsUser: {{ .Values.user }}
-        runAsGroup: {{ .Values.group }}
         fsGroup: {{ .Values.fsGroup }}
+      {{- if not $isRoot }}
+      initContainers:
+        - name: socket-chown
+          image: busybox
+          command: ["/bin/chown","-R",{{ $ugi | quote }}, "/opt/domain"]
+          volumeMounts:
+          - name: alluxio-domain
+            mountPath: /opt/domain
+      {{- end }}
       containers:
       - name: alluxio-worker
         image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -40,6 +49,9 @@ spec:
           requests:
             cpu: {{ .Values.resources.worker.requests.cpu }}
             memory: {{ .Values.resources.worker.requests.memory }}
+        securityContext:
+          runAsUser: {{ .Values.user }}
+          runAsGroup: {{ .Values.group }}
         command: ["/entrypoint.sh"]
         args: ["worker-only", "--no-format"]
         env:
@@ -81,6 +93,9 @@ spec:
           requests:
             cpu: {{ .Values.resources.jobWorker.requests.cpu }}
             memory: {{ .Values.resources.jobWorker.requests.memory }}
+        securityContext:
+          runAsUser: {{ .Values.user }}
+          runAsGroup: {{ .Values.group }}
         command: ["/entrypoint.sh"]
         args: ["job-worker"]
         env:

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
@@ -32,8 +32,10 @@ spec:
       {{- if not $isRoot }}
       initContainers:
         - name: socket-chown
-          image: busybox
-          command: ["/bin/chown","-R",{{ $ugi | quote }}, "/opt/domain"]
+          securityContext:
+            runAsUser: 0
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          command: ["/bin/chown","-R", {{ $ugi | quote }}, "/opt/domain"]
           volumeMounts:
           - name: alluxio-domain
             mountPath: /opt/domain

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-worker.yaml
@@ -10,7 +10,7 @@
 #
 
 {{ $isRoot := eq (int .Values.user) 0 }}
-{{- $ugi := printf "%v:%v" .Values.user .Values.group }}
+{{- $ugi := printf "%v:%v" .Values.user .Values.group -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/integration/kubernetes/helm/alluxio/values.yaml
+++ b/integration/kubernetes/helm/alluxio/values.yaml
@@ -13,9 +13,9 @@ image: alluxio/alluxio
 imageTag: "2.1.0-SNAPSHOT"
 imagePullPolicy: IfNotPresent
 
-user: 0
-group: 0
-fsGroup: 0
+user: 1000
+group: 1000
+fsGroup: 1000
 
 resources:
   masterCount: 1 # For multiMaster mode increase this to >1

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
@@ -46,9 +46,7 @@ spec:
         app: alluxio-master-0
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: alluxio-master
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -60,6 +58,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         env:
@@ -90,6 +91,9 @@ spec:
           requests:
             cpu: 1
             memory: 1024M
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         env:
@@ -144,9 +148,7 @@ spec:
         app: alluxio-master-1
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: alluxio-master
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -158,6 +160,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         env:
@@ -188,6 +193,9 @@ spec:
           requests:
             cpu: 1
             memory: 1024M
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         env:
@@ -242,9 +250,7 @@ spec:
         app: alluxio-master-2
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: alluxio-master
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -256,6 +262,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         env:
@@ -286,6 +295,9 @@ spec:
           requests:
             cpu: 1
             memory: 1024M
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         env:

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
@@ -11,6 +11,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,9 +29,14 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
+      initContainers:
+        - name: socket-chown
+          image: busybox
+          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          volumeMounts:
+          - name: alluxio-domain
+            mountPath: /opt/domain
       containers:
       - name: alluxio-worker
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -42,6 +48,9 @@ spec:
           requests:
             cpu: 1
             memory: 2G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["worker-only", "--no-format"]
         env:
@@ -74,6 +83,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-worker"]
         env:

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
@@ -31,8 +31,10 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: socket-chown
-          image: busybox
-          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          securityContext:
+            runAsUser: 0
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
           volumeMounts:
           - name: alluxio-domain
             mountPath: /opt/domain

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-worker.yaml.template
@@ -11,7 +11,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-master.yaml.template
@@ -44,9 +44,7 @@ spec:
         app: alluxio-master-0
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: alluxio-master
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -58,6 +56,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         envFrom:
@@ -82,6 +83,9 @@ spec:
           requests:
             cpu: 1
             memory: 1024M
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         envFrom:

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
@@ -11,6 +11,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,9 +29,14 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
+      initContainers:
+        - name: socket-chown
+          image: busybox
+          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          volumeMounts:
+          - name: alluxio-domain
+            mountPath: /opt/domain
       containers:
       - name: alluxio-worker
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -42,6 +48,9 @@ spec:
           requests:
             cpu: 1
             memory: 2G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["worker-only", "--no-format"]
         env:
@@ -77,6 +86,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-worker"]
         env:

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
@@ -31,8 +31,10 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: socket-chown
-          image: busybox
-          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          securityContext:
+            runAsUser: 0
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
           volumeMounts:
           - name: alluxio-domain
             mountPath: /opt/domain

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-worker.yaml.template
@@ -11,7 +11,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
@@ -56,9 +56,14 @@ spec:
         app: alluxio-master-0
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
+      initContainers:
+      - name: journal-chown
+        image: busybox
+        command: ["/bin/chown","-R","1000:1000", "/journal"]
+        volumeMounts:
+          - name: alluxio-journal
+            mountPath: /journal
       containers:
       - name: alluxio-master
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -70,6 +75,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["master-only", "--no-format"]
         envFrom:
@@ -93,6 +101,9 @@ spec:
           requests:
             cpu: 1
             memory: 1024M
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-master"]
         envFrom:

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
@@ -59,8 +59,10 @@ spec:
         fsGroup: 1000
       initContainers:
       - name: journal-chown
-        image: busybox
-        command: ["/bin/chown","-R","1000:1000", "/journal"]
+        securityContext:
+          runAsUser: 0
+        image: alluxio/alluxio:2.1.0-SNAPSHOT
+        command: ["/bin/chown","-R", "1000:1000", "/journal"]
         volumeMounts:
           - name: alluxio-journal
             mountPath: /journal

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
@@ -11,6 +11,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,9 +29,14 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
+      initContainers:
+        - name: socket-chown
+          image: busybox
+          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          volumeMounts:
+          - name: alluxio-domain
+            mountPath: /opt/domain
       containers:
       - name: alluxio-worker
         image: alluxio/alluxio:2.1.0-SNAPSHOT
@@ -42,6 +48,9 @@ spec:
           requests:
             cpu: 1
             memory: 2G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["worker-only", "--no-format"]
         env:
@@ -74,6 +83,9 @@ spec:
           requests:
             cpu: 1
             memory: 1G
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["/entrypoint.sh"]
         args: ["job-worker"]
         env:

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
@@ -31,8 +31,10 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: socket-chown
-          image: busybox
-          command: ["/bin/chown","-R","1000:1000", "/opt/domain"]
+          securityContext:
+            runAsUser: 0
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
           volumeMounts:
           - name: alluxio-domain
             mountPath: /opt/domain

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-worker.yaml.template
@@ -11,7 +11,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
This change will enable Alluxio to run as non-root user in Kubernetes cluster. 

The UFS local journal directory and the domain socket directory will have to be `chown` to `alluxio:alluxio`. This is done by adding `initContainers` which are executed before the containers. The `securityContext` are split up and moved to each container to provider security configuration in finer granularity.

Ref: [Kubernetes security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)