### PR TITLE
Use better locking in JobInfo to avoid deadlocks

### DIFF
--- a/job/common/src/main/java/alluxio/job/meta/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/meta/JobInfo.java
@@ -19,10 +19,9 @@ import alluxio.util.CommonUtils;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -32,14 +31,14 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class JobInfo implements Comparable<JobInfo> {
-  private String mErrorMessage;
   private final long mId;
   private final JobConfig mJobConfig;
-  private volatile long mLastStatusChangeMs;
-  private String mResult;
+  private final ConcurrentHashMap<Integer, TaskInfo> mTaskIdToInfo;
+  private final Consumer<JobInfo> mStatusChangeCallback;
   private volatile Status mStatus;
-  private Consumer<JobInfo> mStatusChangeCallback;
-  private final Map<Integer, TaskInfo> mTaskIdToInfo;
+  private volatile long mLastStatusChangeMs;
+  private volatile String mErrorMessage;
+  private volatile String mResult;
 
   /**
    * Creates a new instance of {@link JobInfo}.
@@ -51,7 +50,7 @@ public final class JobInfo implements Comparable<JobInfo> {
   public JobInfo(long id, JobConfig jobConfig, Consumer<JobInfo> statusChangeCallback) {
     mId = id;
     mJobConfig = Preconditions.checkNotNull(jobConfig);
-    mTaskIdToInfo = Maps.newHashMap();
+    mTaskIdToInfo = new ConcurrentHashMap<>(4, 0.95f);
     mLastStatusChangeMs = CommonUtils.getCurrentMs();
     mErrorMessage = "";
     mStatus = Status.CREATED;
@@ -65,7 +64,7 @@ public final class JobInfo implements Comparable<JobInfo> {
    * equal, they are compared by jobId
    */
   @Override
-  public synchronized int compareTo(JobInfo other) {
+  public int compareTo(JobInfo other) {
     int res = Long.compare(mLastStatusChangeMs, other.mLastStatusChangeMs);
     if (res != 0) {
       return res;
@@ -79,44 +78,46 @@ public final class JobInfo implements Comparable<JobInfo> {
    *
    * @param taskId the task id
    */
-  public synchronized void addTask(int taskId) {
-    Preconditions.checkArgument(!mTaskIdToInfo.containsKey(taskId), "");
-    mTaskIdToInfo.put(taskId, new TaskInfo().setJobId(mId).setTaskId(taskId)
-        .setStatus(Status.CREATED).setErrorMessage("").setResult(null));
+  public void addTask(int taskId) {
+    TaskInfo oldValue = mTaskIdToInfo.putIfAbsent(taskId,
+        new TaskInfo().setJobId(mId).setTaskId(taskId).setStatus(Status.CREATED).setErrorMessage("")
+            .setResult(null));
+    Preconditions.checkState(oldValue == null,
+        String.format("JobId %d cannot add duplicate taskId %d", mId, taskId));
   }
 
   /**
    * @return the job id
    */
-  public synchronized long getId() {
+  public long getId() {
     return mId;
   }
 
   /**
    * @return the job configuration
    */
-  public synchronized JobConfig getJobConfig() {
+  public JobConfig getJobConfig() {
     return mJobConfig;
   }
 
   /**
    * @return the time when the job status was last changed (in milliseconds)
    */
-  public synchronized long getLastStatusChangeMs() {
+  public long getLastStatusChangeMs() {
     return mLastStatusChangeMs;
   }
 
   /**
    * @param errorMessage the error message
    */
-  public synchronized void setErrorMessage(String errorMessage) {
+  public void setErrorMessage(String errorMessage) {
     mErrorMessage = errorMessage == null ? "" : errorMessage;
   }
 
   /**
    * @return the error message
    */
-  public synchronized String getErrorMessage() {
+  public String getErrorMessage() {
     return mErrorMessage;
   }
 
@@ -124,7 +125,7 @@ public final class JobInfo implements Comparable<JobInfo> {
    * @param taskId the task ID to get the task info for
    * @return the task info, or null if the task ID doesn't exist
    */
-  public synchronized TaskInfo getTaskInfo(int taskId) {
+  public TaskInfo getTaskInfo(int taskId) {
     return mTaskIdToInfo.get(taskId);
   }
 
@@ -134,14 +135,14 @@ public final class JobInfo implements Comparable<JobInfo> {
    * @param taskId the task id
    * @param taskInfo the task information
    */
-  public synchronized void setTaskInfo(int taskId, TaskInfo taskInfo) {
+  public void setTaskInfo(int taskId, TaskInfo taskInfo) {
     mTaskIdToInfo.put(taskId, taskInfo);
   }
 
   /**
    * @return the list of task ids
    */
-  public synchronized List<Integer> getTaskIdList() {
+  public List<Integer> getTaskIdList() {
     return Lists.newArrayList(mTaskIdToInfo.keySet());
   }
 
@@ -154,6 +155,7 @@ public final class JobInfo implements Comparable<JobInfo> {
    * @param status the job status
    */
   public synchronized void setStatus(Status status) {
+    // this is synchronized to serialize all setStatus calls.
     if (mStatus.isFinished()) {
       return;
     }
@@ -168,28 +170,28 @@ public final class JobInfo implements Comparable<JobInfo> {
   /**
    * @return the status of the job
    */
-  public synchronized Status getStatus() {
+  public Status getStatus() {
     return mStatus;
   }
 
   /**
    * @param result the joined job result
    */
-  public synchronized void setResult(String result) {
+  public void setResult(String result) {
     mResult = result;
   }
 
   /**
    * @return the result of the job
    */
-  public synchronized String getResult() {
+  public String getResult() {
     return mResult;
   }
 
   /**
    * @return the list of task information
    */
-  public synchronized List<TaskInfo> getTaskInfoList() {
+  public List<TaskInfo> getTaskInfoList() {
     return Lists.newArrayList(mTaskIdToInfo.values());
   }
 

--- a/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
@@ -11,11 +11,11 @@
 
 package alluxio.master.job;
 
+import alluxio.exception.JobDoesNotExistException;
 import alluxio.job.JobConfig;
 import alluxio.job.JobDefinition;
 import alluxio.job.JobDefinitionRegistry;
 import alluxio.job.JobServerContext;
-import alluxio.exception.JobDoesNotExistException;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.meta.JobInfo;
 import alluxio.job.wire.Status;


### PR DESCRIPTION
JobInfo had unnecessary synchronized blocks which caused deadlocks. `final` variables do not need `synchronized` block, and converted some to concurrent data structures.

fixes #9970 
