### PR TITLE
Improve gRPC exception flow and trace readibility

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -14,6 +14,7 @@ package alluxio.grpc;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.ChannelAuthenticator;
 
@@ -236,6 +237,11 @@ public final class GrpcChannelBuilder {
       // Release the managed channel to the pool before throwing.
       GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey,
           mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SHUTDOWN_TIMEOUT));
+      if (exc instanceof UnavailableException) {
+        // Override exception from authentication layer.
+        throw new UnavailableException(
+            String.format("Target Unavailable. %s", mChannelKey.toStringShort()));
+      }
       throw exc;
     }
   }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -233,16 +233,16 @@ public final class GrpcChannelBuilder {
         return new GrpcChannel(mChannelKey, underlyingChannel,
             mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SHUTDOWN_TIMEOUT));
       }
-    } catch (Exception exc) {
+    } catch (Exception e) {
       // Release the managed channel to the pool before throwing.
       GrpcManagedChannelPool.INSTANCE().releaseManagedChannel(mChannelKey,
           mConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SHUTDOWN_TIMEOUT));
-      if (exc instanceof UnavailableException) {
+      if (e instanceof UnavailableException) {
         // Override exception from authentication layer.
         throw new UnavailableException(
-            String.format("Target Unavailable. %s", mChannelKey.toStringShort()));
+            String.format("Target Unavailable. %s", mChannelKey.toStringShort()), e.getCause());
       }
-      throw exc;
+      throw e;
     }
   }
 }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
@@ -280,6 +280,7 @@ public class GrpcChannelKey {
         .add("FlowControlWindow", getStringFromOptional(mFlowControlWindow))
         .add("MaxInboundMessageSize", getStringFromOptional(mMaxInboundMessageSize))
         .add("ChannelType", getStringFromOptional(mChannelType))
+        .omitNullValues()
         .toString();
   }
 
@@ -291,6 +292,7 @@ public class GrpcChannelKey {
         .add("ClientType", getStringFromOptional(mClientType))
         .add("ServerAddress", mServerAddress)
         .add("ChannelId", mChannelId)
+        .omitNullValues()
         .toString();
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelKey.java
@@ -272,14 +272,14 @@ public class GrpcChannelKey {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("ChannelId", mChannelId)
-        .add("ClientType", mClientType)
+        .add("ClientType", getStringFromOptional(mClientType))
         .add("ServerAddress", mServerAddress)
-        .add("KeepAliveTime", mKeepAliveTime)
-        .add("KeepAliveTimeout", mKeepAliveTimeout)
-        .add("FlowControlWindow", mFlowControlWindow)
-        .add("MaxInboundMessageSize", mMaxInboundMessageSize)
-        .add("ChannelType", mChannelType)
+        .add("ChannelId", mChannelId)
+        .add("KeepAliveTime", getStringFromOptional(mKeepAliveTime))
+        .add("KeepAliveTimeout", getStringFromOptional(mKeepAliveTimeout))
+        .add("FlowControlWindow", getStringFromOptional(mFlowControlWindow))
+        .add("MaxInboundMessageSize", getStringFromOptional(mMaxInboundMessageSize))
+        .add("ChannelType", getStringFromOptional(mChannelType))
         .toString();
   }
 
@@ -288,10 +288,24 @@ public class GrpcChannelKey {
    */
   public String toStringShort() {
     return MoreObjects.toStringHelper(this)
-        .add("ChannelId", mChannelId)
-        .add("ClientType", mClientType)
+        .add("ClientType", getStringFromOptional(mClientType))
         .add("ServerAddress", mServerAddress)
+        .add("ChannelId", mChannelId)
         .toString();
+  }
+
+  /**
+   * Used to get underlying string representation from {@link Optional} fields.
+   *
+   * @param field an optional field
+   * @return underlying string representation or {@code null} if field is not present
+   */
+  private String getStringFromOptional(Optional<?> field) {
+    if (field.isPresent()) {
+      return field.get().toString();
+    } else {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
- Rethrow `UnavailableException` coming form auth-layer to avoid confusion.
- Simplify channel traces by avoiding Optional field representation(`Optional["value"]`)