### PR TITLE
Adjust embedded journal properties

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1280,7 +1280,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription(
               "The election timeout for the embedded journal. When this period elapses without a "
                   + "master receiving any messages, the master will attempt to become the primary.")
-          .setDefaultValue("5s")
+          .setDefaultValue("10s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
@@ -1289,7 +1289,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               "The period between sending heartbeats from the embedded journal primary to "
                   + "followers. This should be less than half of the election timeout "
                   + "(alluxio.master.embedded.journal.election.timeout).")
-          .setDefaultValue("1s")
+          .setDefaultValue("3s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
@@ -1298,7 +1298,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "in a single heartbeat. Setting higher values might require increasing "
               + "election timeout due to increased network delay. Setting lower values "
               + "might stall knowledge propagation between the leader and followers.")
-          .setDefaultValue("32KB")
+          .setDefaultValue("512KB")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1281,7 +1281,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               "The election timeout for the embedded journal. When this period elapses without a "
                   + "master receiving any messages, the master will attempt to become the primary."
                   + "Election timeout will be waited initially when the cluster is forming. "
-                  + "So larger values for election timeout will cause longer star-up time.")
+                  + "So larger values for election timeout will cause longer star-up time. "
+                  + "Smaller values might introduce instability to leadership.")
           .setDefaultValue("10s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -1295,6 +1296,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   + "is driven by heart beats.")
           .setDefaultValue("3s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1292,8 +1292,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription(
               "The period between sending heartbeats from the embedded journal primary to "
                   + "followers. This should be less than half of the election timeout "
-                  + "(alluxio.master.embedded.journal.election.timeout), because the election "
-                  + "is driven by heart beats.")
+                  + String.format("{%s}", Name.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)
+                  + ", because the election is driven by heart beats.")
           .setDefaultValue("3s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1281,7 +1281,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               "The election timeout for the embedded journal. When this period elapses without a "
                   + "master receiving any messages, the master will attempt to become the primary."
                   + "Election timeout will be waited initially when the cluster is forming. "
-                  + "So larger values for election timeout will cause longer star-up time. "
+                  + "So larger values for election timeout will cause longer start-up time. "
                   + "Smaller values might introduce instability to leadership.")
           .setDefaultValue("10s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
@@ -1292,7 +1292,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription(
               "The period between sending heartbeats from the embedded journal primary to "
                   + "followers. This should be less than half of the election timeout "
-                  + "(alluxio.master.embedded.journal.election.timeout).Because the election "
+                  + "(alluxio.master.embedded.journal.election.timeout), because the election "
                   + "is driven by heart beats.")
           .setDefaultValue("3s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1279,16 +1279,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)
           .setDescription(
               "The election timeout for the embedded journal. When this period elapses without a "
-                  + "master receiving any messages, the master will attempt to become the primary.")
+                  + "master receiving any messages, the master will attempt to become the primary."
+                  + "Election timeout will be waited initially when the cluster is forming. "
+                  + "So larger values for election timeout will cause longer star-up time.")
           .setDefaultValue("10s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL)
           .setDescription(
               "The period between sending heartbeats from the embedded journal primary to "
                   + "followers. This should be less than half of the election timeout "
-                  + "(alluxio.master.embedded.journal.election.timeout).")
+                  + "(alluxio.master.embedded.journal.election.timeout).Because the election "
+                  + "is driven by heart beats.")
           .setDefaultValue("3s")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
@@ -1300,6 +1304,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "might stall knowledge propagation between the leader and followers.")
           .setDefaultValue("512KB")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_PORT)
@@ -1313,6 +1318,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "losing state in case of power loss or host failure. Use MEMORY for "
               + "optimal performance, but no state persistence across cluster restarts.")
           .setDefaultValue("DISK")
+          .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1281,6 +1281,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               "The election timeout for the embedded journal. When this period elapses without a "
                   + "master receiving any messages, the master will attempt to become the primary.")
           .setDefaultValue("5s")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL)
@@ -1289,6 +1290,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   + "followers. This should be less than half of the election timeout "
                   + "(alluxio.master.embedded.journal.election.timeout).")
           .setDefaultValue("1s")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE)
@@ -1297,6 +1299,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "election timeout due to increased network delay. Setting lower values "
               + "might stall knowledge propagation between the leader and followers.")
           .setDefaultValue("32KB")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_PORT)


### PR DESCRIPTION
`HEARTBEAT_INTERVAL` to `3sec`: Heartbeat controls the frequency of communication between copycat nodes. So a larger value would stall entire communication.

`ELECTION_TIMEOUT` to `10sec` : Leader election timeout is effective during cluster startup as well.  A larger value would have been a bad user experience.

`APPENDER_BATCH_SIZE` to `512KB` : 512KB of data at every heartbeat (3sec) would utilize network bandwith better than `32KB` every `1sec` as before.

