### PR TITLE
Replace the shaded hadoop version when generating tarballs

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -287,6 +287,8 @@ func generateTarball(hadoopClients []string) error {
 		return err
 	}
 
+	// Reset the shaded hadoop version if it's auto-resolved by the maven release plugin
+	replace("shaded/hadoop/pom.xml", "<version>2.2.0</version>", "<version>${ufs.hadoop.version}</version>")
 	// Update the assembly jar paths.
 	replace("libexec/alluxio-config.sh", "assembly/client/target/alluxio-assembly-client-${VERSION}-jar-with-dependencies.jar", "assembly/alluxio-client-${VERSION}.jar")
 	replace("libexec/alluxio-config.sh", "assembly/server/target/alluxio-assembly-server-${VERSION}-jar-with-dependencies.jar", "assembly/alluxio-server-${VERSION}.jar")


### PR DESCRIPTION
address https://github.com/Alluxio/alluxio/issues/9432

The version in shaded hadoop module pom file (`<version>${ufs.hadoop.version}</version> ` is resolved to its value (e.g. `2.2.0`) by the maven release plugin.  When generating tarball with other ufs versions (e.g. 2.7.3), the shaded hadoop module version should be 2.7.3 but remain to be 2.2.0. This is why we cannot generate tarball with tag v2.0.0 and v2.0.1. 

Instead of directly modify the last commit of the tag (which is hard and strange), this PR targets to make the generate tarball part works.
