### PR TITLE
Fix local file writer client memory leak by cleaning up mmapped files

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -169,7 +169,8 @@ public class GrpcBlockingStream<ReqT, ResT> {
   }
 
   /**
-   * Closes the outbound stream.
+   * Closes the outbound stream. If the stream is already closed then invoking this method has no
+   * effect.
    */
   public void close() {
     if (isOpen()) {
@@ -180,7 +181,8 @@ public class GrpcBlockingStream<ReqT, ResT> {
   }
 
   /**
-   * Cancels the stream.
+   * Cancels the stream. If the stream is already cancelled then invoking this method has no
+   * effect.
    */
   public void cancel() {
     if (isOpen()) {

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -134,11 +134,8 @@ public final class LocalFileDataWriter implements DataWriter {
 
   @Override
   public void cancel() throws IOException {
-    boolean cancelStream = !(mStream.isClosed() || mStream.isCanceled());
     try {
-      if (cancelStream) {
-        mStream.cancel();
-      }
+      mStream.cancel();
     } catch (Exception e) {
       throw mCloser.rethrow(e);
     } finally {
@@ -151,13 +148,10 @@ public final class LocalFileDataWriter implements DataWriter {
 
   @Override
   public void close() throws IOException {
-    boolean closeStream = !(mStream.isClosed() || mStream.isCanceled());
-    if (closeStream) {
-      mCloser.register(() -> {
-        mStream.close();
-        mStream.waitForComplete(mDataTimeoutMs);
-      });
-    }
+    mCloser.register(() -> {
+      mStream.close();
+      mStream.waitForComplete(mDataTimeoutMs);
+    });
     mCloser.close();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -29,7 +29,6 @@ import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -155,8 +154,8 @@ public final class LocalFileDataWriter implements DataWriter {
     boolean closeStream = !(mStream.isClosed() || mStream.isCanceled());
     if (closeStream) {
       mCloser.register(() -> {
-          mStream.close();
-          mStream.waitForComplete(mDataTimeoutMs);
+        mStream.close();
+        mStream.waitForComplete(mDataTimeoutMs);
       });
     }
     mCloser.close();

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -134,13 +134,8 @@ public final class LocalFileDataWriter implements DataWriter {
 
   @Override
   public void cancel() throws IOException {
-    try {
-      mStream.cancel();
-    } catch (Exception e) {
-      throw mCloser.rethrow(e);
-    } finally {
-      mCloser.close();
-    }
+    mCloser.register(() -> mStream.cancel());
+    mCloser.close();
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -154,12 +154,9 @@ public final class LocalFileDataWriter implements DataWriter {
   public void close() throws IOException {
     boolean closeStream = !(mStream.isClosed() || mStream.isCanceled());
     if (closeStream) {
-      mCloser.register(new Closeable() {
-        @Override
-        public void close() throws IOException {
+      mCloser.register(() -> {
           mStream.close();
           mStream.waitForComplete(mDataTimeoutMs);
-        }
       });
     }
     mCloser.close();

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -1,0 +1,125 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.stream;
+
+import static org.mockito.Mockito.mock;
+
+import alluxio.AlluxioTestDirectory;
+import alluxio.ClientContext;
+import alluxio.ConfigurationTestUtils;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.options.OutStreamOptions;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.grpc.CreateLocalBlockRequest;
+import alluxio.grpc.CreateLocalBlockResponse;
+import alluxio.util.IdUtils;
+import alluxio.util.io.PathUtils;
+import alluxio.wire.WorkerNetAddress;
+import alluxio.worker.block.io.LocalFileBlockWriter;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+/**
+ * Tests {@link LocalFileDataWriterTest}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileSystemContext.class, WorkerNetAddress.class, LocalFileDataWriter.class, GrpcBlockingStream.class})
+public class LocalFileDataWriterTest {
+  private static final long BLOCK_ID = 1L;
+
+  protected String mWorkDirectory;
+
+  private WorkerNetAddress mAddress;
+  private BlockWorkerClient mClient;
+  private ClientContext mClientContext;
+  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private FileSystemContext mContext;
+  private GrpcBlockingStream<CreateLocalBlockRequest, CreateLocalBlockResponse> mStream;
+
+  @Before
+  public void before() throws Exception {
+    mWorkDirectory =
+        AlluxioTestDirectory.createTemporaryDirectory("blocks").getAbsolutePath();
+
+    mClientContext = ClientContext.create(mConf);
+
+    mContext = PowerMockito.mock(FileSystemContext.class);
+    mAddress = mock(WorkerNetAddress.class);
+
+    mClient = mock(BlockWorkerClient.class);
+    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(mClient);
+    PowerMockito.when(mContext.getClientContext()).thenReturn(mClientContext);
+    PowerMockito.when(mContext.getClusterConf()).thenReturn(mConf);
+    PowerMockito.doNothing().when(mContext).releaseBlockWorkerClient(mAddress, mClient);
+
+    mStream = mock(GrpcBlockingStream.class);
+    PowerMockito.doNothing().when(mStream).send(Matchers.any(), Matchers.anyLong());
+    PowerMockito.when(mStream.receive(Matchers.anyLong()))
+        .thenReturn(CreateLocalBlockResponse.newBuilder()
+            .setPath(PathUtils.temporaryFileName(IdUtils.getRandomNonNegativeLong(),
+                PathUtils.concatPath(mWorkDirectory, BLOCK_ID)))
+            .build());
+    PowerMockito.when(mStream.isCanceled()).thenReturn(false);
+    PowerMockito.when(mStream.isClosed()).thenReturn(false);
+    PowerMockito.when(mStream.isOpen()).thenReturn(true);
+
+    PowerMockito.whenNew(GrpcBlockingStream.class).withAnyArguments().thenReturn(mStream);
+  }
+
+  @After
+  public void after() throws Exception {
+    mClient.close();
+  }
+
+  @Test
+  public void streamCancelled() throws Exception {
+    LocalFileDataWriter writer = LocalFileDataWriter.create(mContext, mAddress, BLOCK_ID,
+        OutStreamOptions.defaults(mClientContext));
+
+    // Cancel stream before cancelling the writer
+    PowerMockito.when(mStream.isCanceled()).thenReturn(true);
+    PowerMockito.when(mStream.isClosed()).thenReturn(true);
+    PowerMockito.when(mStream.isOpen()).thenReturn(true);
+
+    writer.cancel();
+
+    // Verify there are no open files
+    LocalFileBlockWriter blockWriter = Whitebox.getInternalState(writer, "mWriter");
+    Assert.assertTrue(Whitebox.getInternalState(blockWriter, "mClosed"));
+  }
+
+  @Test
+  public void streamClosed() throws Exception {
+    LocalFileDataWriter writer = LocalFileDataWriter.create(mContext, mAddress, BLOCK_ID,
+        OutStreamOptions.defaults(mClientContext));
+
+    // Close stream before closing the writer
+    PowerMockito.when(mStream.isCanceled()).thenReturn(true);
+    PowerMockito.when(mStream.isClosed()).thenReturn(true);
+    PowerMockito.when(mStream.isOpen()).thenReturn(true);
+
+    writer.close();
+
+    // Verify there are no open files
+    LocalFileBlockWriter blockWriter = Whitebox.getInternalState(writer, "mWriter");
+    Assert.assertTrue(Whitebox.getInternalState(blockWriter, "mClosed"));
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -41,7 +41,8 @@ import org.powermock.reflect.Whitebox;
  * Tests {@link LocalFileDataWriterTest}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FileSystemContext.class, WorkerNetAddress.class, LocalFileDataWriter.class, GrpcBlockingStream.class})
+@PrepareForTest({FileSystemContext.class, WorkerNetAddress.class, LocalFileDataWriter.class,
+    GrpcBlockingStream.class})
 public class LocalFileDataWriterTest {
   private static final long BLOCK_ID = 1L;
 


### PR DESCRIPTION
This PR addresses a memory leak in the Alluxio client for local file writes on the short-circuit data access path. The impact is most significant for long running processes, such as the job worker (with an embedded Alluxio client), as open files are not released until the JVM terminates and continue to occupy memory in the mean time.
    
In the issue reported, the worker and job worker run in the same container. Pinning a 2G file causes set replication = 1 and the replication checker creates a job for the job worker to load the file from the ufs. The job worker opens mmaped files for temporary blocks and does not cleanup temporary blocks correctly as reported by: 
```
bash-4.4# lsof +L1 | grep /dev/shm
...
166	/usr/lib/jvm/java-1.8-openjdk/jre/bin/java	/dev/shm/alluxioworker/.tmp_blocks/4/109d8b9683aba404-1000014 (deleted)
166	/usr/lib/jvm/java-1.8-openjdk/jre/bin/java	/dev/shm/alluxioworker/.tmp_blocks/917/1c977804f85aa395-1000017 (deleted)
```

When running `du` and based on the worker metadata, there is space available in `/dev/shm`. However when `df` is run, the job worker process occupies memory for unclosed files which have been deleted.

Fixes: https://github.com/Alluxio/alluxio/issues/9666