### PR TITLE
Add K8s Job dedicated for formatting master journal

### DIFF
--- a/integration/kubernetes/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/alluxio-format-master.yaml.template
@@ -1,0 +1,1 @@
+singleMaster-localJournal/alluxio-format-master.yaml.template

--- a/integration/kubernetes/helm-generate.sh
+++ b/integration/kubernetes/helm-generate.sh
@@ -42,12 +42,16 @@ function generatePodTemplatesWithConfig {
   helm template helm/alluxio/ -x templates/alluxio-master.yaml -f ./$dir/config.yaml > "$dir/alluxio-master.yaml.template"
   helm template helm/alluxio/ -x templates/alluxio-worker.yaml -f ./$dir/config.yaml > "$dir/alluxio-worker.yaml.template"
   helm template helm/alluxio/ -x templates/alluxio-configMap.yaml -f ./$dir/config.yaml > "$dir/alluxio-configMap.yaml.template"
-  helm template helm/alluxio/ -x templates/alluxio-format-master.yaml -f ./$dir/config.yaml > "$dir/alluxio-format-master.yaml.template"
 }
 
 function generateVolumeTemplatesWithConfig {
   echo "Generating persistent volume templates into $dir"
   helm template helm/alluxio/ -x templates/alluxio-journal-volume.yaml -f ./$dir/config.yaml > "$dir/alluxio-journal-volume.yaml.template"
+}
+
+function generateJobTemplatesWithConfig {
+  echo "Generating job templates into $dir"
+  helm template helm/alluxio/ -x templates/alluxio-format-master.yaml -f ./$dir/config.yaml > "$dir/alluxio-format-master.yaml.template"
 }
 
 function generateSingleUfsTemplates {
@@ -59,11 +63,13 @@ function generateSingleUfsTemplates {
       dir="singleMaster-localJournal"
       generateVolumeTemplatesWithConfig
       generatePodTemplatesWithConfig
+      generateJobTemplatesWithConfig
       ;;
     "hdfs")
       echo "Journal UFS $ufs"
       dir="singleMaster-hdfsJournal"
       generatePodTemplatesWithConfig
+      generateJobTemplatesWithConfig
       ;;
     *)
       echo "Unknown Journal UFS type $ufs"
@@ -75,6 +81,7 @@ function generateSingleUfsTemplates {
 function generateMultiEmbeddedTemplates {
   dir="multiMaster-embeddedJournal"
   generatePodTemplatesWithConfig
+  generateJobTemplatesWithConfig
 }
 
 function generateAllTemplates {

--- a/integration/kubernetes/helm-generate.sh
+++ b/integration/kubernetes/helm-generate.sh
@@ -42,6 +42,7 @@ function generatePodTemplatesWithConfig {
   helm template helm/alluxio/ -x templates/alluxio-master.yaml -f ./$dir/config.yaml > "$dir/alluxio-master.yaml.template"
   helm template helm/alluxio/ -x templates/alluxio-worker.yaml -f ./$dir/config.yaml > "$dir/alluxio-worker.yaml.template"
   helm template helm/alluxio/ -x templates/alluxio-configMap.yaml -f ./$dir/config.yaml > "$dir/alluxio-configMap.yaml.template"
+  helm template helm/alluxio/ -x templates/alluxio-format-master.yaml -f ./$dir/config.yaml > "$dir/alluxio-format-master.yaml.template"
 }
 
 function generateVolumeTemplatesWithConfig {

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: {{ .Values.resources.master.requests.cpu }}
               memory: {{ .Values.resources.master.requests.memory }}
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["format"]
+          args: ["formatMasters"]
           envFrom:
             - configMapRef:
                 name: {{ .Values.const.configName }}

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
@@ -1,0 +1,50 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master
+spec:
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["format"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          ports:
+            - containerPort: 19998
+              name: rpc
+            - containerPort: 19999
+              name: web
+            - containerPort: 19200
+              name: embedded
+          volumeMounts:
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-pv-claim

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
@@ -14,6 +14,7 @@ kind: Job
 metadata:
   name: alluxio-format-master
 spec:
+  activeDeadlineSeconds: 30
   ttlSecondsAfterFinished: 10
   template:
     spec:

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
@@ -14,36 +14,36 @@ kind: Job
 metadata:
   name: alluxio-format-master
 spec:
-  activeDeadlineSeconds: 30
-  ttlSecondsAfterFinished: 10
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
   template:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0-SNAPSHOT
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
             limits:
-              cpu: 1
-              memory: 1G
+              cpu: {{ .Values.resources.master.limits.cpu }}
+              memory: {{ .Values.resources.master.limits.memory }}
             requests:
-              cpu: 1
-              memory: 1G
+              cpu: {{ .Values.resources.master.requests.cpu }}
+              memory: {{ .Values.resources.master.requests.memory }}
           command: ["/opt/alluxio/bin/alluxio"]
           args: ["format"]
           envFrom:
             - configMapRef:
-                name: alluxio-config
+                name: {{ .Values.const.configName }}
           ports:
-            - containerPort: 19998
-              name: rpc
-            - containerPort: 19999
-              name: web
-            - containerPort: 19200
-              name: embedded
+          - containerPort: 19998
+            name: rpc
+          - containerPort: 19999
+            name: web
+          - containerPort: 19200
+            name: embedded
           volumeMounts:
-            - name: alluxio-journal
-              mountPath: /journal
+          - name: alluxio-journal
+            mountPath: {{ .Values.journal.folder }}
       restartPolicy: OnFailure
       volumes:
         - name: alluxio-journal

--- a/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-format-master.yaml
@@ -9,13 +9,21 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+{{- $masterCount := int .Values.resources.masterCount }}
+{{- $isSingleMaster := eq $masterCount 1 }}
+{{- $isEmbedded := (eq .Values.journal.type "EMBEDDED") }}
+{{- $isHaEmbedded := and $isEmbedded (gt $masterCount 1) }}
+{{- $isUfsLocal := and (eq .Values.journal.type "UFS") (eq .Values.journal.ufsType "local") }}
+{{- $isSingleUfsLocal := and $isUfsLocal $isSingleMaster }}
+{{- $needJournalVolume := or $isEmbedded $isUfsLocal }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: alluxio-format-master
 spec:
-  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
-  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  activeDeadlineSeconds: {{ .Values.journal.format.job.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.journal.format.job.ttlSecondsAfterFinished }}
   template:
     spec:
       containers:
@@ -34,18 +42,38 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.const.configName }}
-          ports:
-          - containerPort: 19998
-            name: rpc
-          - containerPort: 19999
-            name: web
-          - containerPort: 19200
-            name: embedded
           volumeMounts:
+          {{- if $needJournalVolume }}
           - name: alluxio-journal
             mountPath: {{ .Values.journal.folder }}
+          {{- end }}
+          {{- if .Values.secrets }}
+          {{- if .Values.secrets.master }}
+          {{- range $key, $val := .Values.secrets.master }}
+          - name: secret-{{ $key }}-volume
+            mountPath: /secrets/{{ $val }}
+            readOnly: true
+          {{- end }}
+          {{- end }}
+          {{- end }}
       restartPolicy: OnFailure
       volumes:
-        - name: alluxio-journal
-          persistentVolumeClaim:
-            claimName: alluxio-pv-claim
+      {{- if $isSingleUfsLocal }}
+      - name: alluxio-journal
+        persistentVolumeClaim:
+          claimName: alluxio-pv-claim
+      {{- end }}
+      {{- if $isHaEmbedded }}
+      - name: alluxio-journal
+        emptyDir: {}
+      {{- end}}
+      {{- if .Values.secrets }}
+      {{- if .Values.secrets.master }}
+      {{- range $key, $val := .Values.secrets.master }}
+      - name: secret-{{ $key }}-volume
+        secret:
+          secretName: {{ $key }}
+          defaultMode: 256
+      {{- end }}
+      {{- end }}
+      {{- end }}

--- a/integration/kubernetes/helm/alluxio/values.yaml
+++ b/integration/kubernetes/helm/alluxio/values.yaml
@@ -105,3 +105,8 @@ const:
 #       medium: ""
 #       size: 1Gi
 #       mountPath: /metastore
+
+# Configuration for Alluxio formatting Jobs
+job:
+  activeDeadlineSeconds: 30
+  ttlSecondsAfterFinished: 10

--- a/integration/kubernetes/helm/alluxio/values.yaml
+++ b/integration/kubernetes/helm/alluxio/values.yaml
@@ -82,6 +82,11 @@ journal:
   type: "UFS"
   ufsType: "local" # Ignored if type is "EMBEDDED"
   folder: "/journal"
+  # Configuration for journal formatting job
+  format:
+    job:
+      activeDeadlineSeconds: 30
+      ttlSecondsAfterFinished: 10
 
 const:
   configName: "alluxio-config"
@@ -105,8 +110,3 @@ const:
 #       medium: ""
 #       size: 1Gi
 #       mountPath: /metastore
-
-# Configuration for Alluxio formatting Jobs
-job:
-  activeDeadlineSeconds: 30
-  ttlSecondsAfterFinished: 10

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
@@ -32,7 +32,7 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["format"]
+          args: ["formatMasters"]
           envFrom:
             - configMapRef:
                 name: alluxio-config

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
@@ -1,0 +1,53 @@
+---
+# Source: alluxio/templates/alluxio-format-master.yaml
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master
+spec:
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["format"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          ports:
+            - containerPort: 19998
+              name: rpc
+            - containerPort: 19999
+              name: web
+            - containerPort: 19200
+              name: embedded
+          volumeMounts:
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-pv-claim
+

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
@@ -16,6 +16,7 @@ kind: Job
 metadata:
   name: alluxio-format-master
 spec:
+  activeDeadlineSeconds: 30
   ttlSecondsAfterFinished: 10
   template:
     spec:

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
@@ -37,15 +37,15 @@ spec:
             - configMapRef:
                 name: alluxio-config
           ports:
-            - containerPort: 19998
-              name: rpc
-            - containerPort: 19999
-              name: web
-            - containerPort: 19200
-              name: embedded
+          - containerPort: 19998
+            name: rpc
+          - containerPort: 19999
+            name: web
+          - containerPort: 19200
+            name: embedded
           volumeMounts:
-            - name: alluxio-journal
-              mountPath: /journal
+          - name: alluxio-journal
+            mountPath: /journal
       restartPolicy: OnFailure
       volumes:
         - name: alluxio-journal

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-format-master.yaml.template
@@ -36,19 +36,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: alluxio-config
-          ports:
-          - containerPort: 19998
-            name: rpc
-          - containerPort: 19999
-            name: web
-          - containerPort: 19200
-            name: embedded
           volumeMounts:
           - name: alluxio-journal
             mountPath: /journal
       restartPolicy: OnFailure
       volumes:
-        - name: alluxio-journal
-          persistentVolumeClaim:
-            claimName: alluxio-pv-claim
+      - name: alluxio-journal
+        emptyDir: {}
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
@@ -32,7 +32,7 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["format"]
+          args: ["formatMasters"]
           envFrom:
             - configMapRef:
                 name: alluxio-config

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
@@ -1,0 +1,53 @@
+---
+# Source: alluxio/templates/alluxio-format-master.yaml
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master
+spec:
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["format"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          ports:
+            - containerPort: 19998
+              name: rpc
+            - containerPort: 19999
+              name: web
+            - containerPort: 19200
+              name: embedded
+          volumeMounts:
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-pv-claim
+

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
@@ -16,6 +16,7 @@ kind: Job
 metadata:
   name: alluxio-format-master
 spec:
+  activeDeadlineSeconds: 30
   ttlSecondsAfterFinished: 10
   template:
     spec:

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
@@ -37,15 +37,15 @@ spec:
             - configMapRef:
                 name: alluxio-config
           ports:
-            - containerPort: 19998
-              name: rpc
-            - containerPort: 19999
-              name: web
-            - containerPort: 19200
-              name: embedded
+          - containerPort: 19998
+            name: rpc
+          - containerPort: 19999
+            name: web
+          - containerPort: 19200
+            name: embedded
           volumeMounts:
-            - name: alluxio-journal
-              mountPath: /journal
+          - name: alluxio-journal
+            mountPath: hdfs://{$hostname}:{$hostport}/journal
       restartPolicy: OnFailure
       volumes:
         - name: alluxio-journal

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-format-master.yaml.template
@@ -36,19 +36,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: alluxio-config
-          ports:
-          - containerPort: 19998
-            name: rpc
-          - containerPort: 19999
-            name: web
-          - containerPort: 19200
-            name: embedded
           volumeMounts:
-          - name: alluxio-journal
-            mountPath: hdfs://{$hostname}:{$hostport}/journal
+          - name: secret-alluxio-hdfs-config-volume
+            mountPath: /secrets/hdfsConfig
+            readOnly: true
       restartPolicy: OnFailure
       volumes:
-        - name: alluxio-journal
-          persistentVolumeClaim:
-            claimName: alluxio-pv-claim
+      - name: secret-alluxio-hdfs-config-volume
+        secret:
+          secretName: alluxio-hdfs-config
+          defaultMode: 256
 

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
@@ -32,7 +32,7 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["format"]
+          args: ["formatMasters"]
           envFrom:
             - configMapRef:
                 name: alluxio-config

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
@@ -1,0 +1,53 @@
+---
+# Source: alluxio/templates/alluxio-format-master.yaml
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master
+spec:
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.1.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["format"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          ports:
+            - containerPort: 19998
+              name: rpc
+            - containerPort: 19999
+              name: web
+            - containerPort: 19200
+              name: embedded
+          volumeMounts:
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-pv-claim
+

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
@@ -16,6 +16,7 @@ kind: Job
 metadata:
   name: alluxio-format-master
 spec:
+  activeDeadlineSeconds: 30
   ttlSecondsAfterFinished: 10
   template:
     spec:

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
@@ -37,15 +37,15 @@ spec:
             - configMapRef:
                 name: alluxio-config
           ports:
-            - containerPort: 19998
-              name: rpc
-            - containerPort: 19999
-              name: web
-            - containerPort: 19200
-              name: embedded
+          - containerPort: 19998
+            name: rpc
+          - containerPort: 19999
+            name: web
+          - containerPort: 19200
+            name: embedded
           volumeMounts:
-            - name: alluxio-journal
-              mountPath: /journal
+          - name: alluxio-journal
+            mountPath: /journal
       restartPolicy: OnFailure
       volumes:
         - name: alluxio-journal

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-format-master.yaml.template
@@ -36,19 +36,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: alluxio-config
-          ports:
-          - containerPort: 19998
-            name: rpc
-          - containerPort: 19999
-            name: web
-          - containerPort: 19200
-            name: embedded
           volumeMounts:
           - name: alluxio-journal
             mountPath: /journal
       restartPolicy: OnFailure
       volumes:
-        - name: alluxio-journal
-          persistentVolumeClaim:
-            claimName: alluxio-pv-claim
+      - name: alluxio-journal
+        persistentVolumeClaim:
+          claimName: alluxio-pv-claim
 


### PR DESCRIPTION
This changes adds a set of Helm YAML templates.

The YAML creates a K8s Job that formats the master log and dies after finishing. This provides a clean way for the user to format log without going into the Pods, especially helpful when the masters are not started or to clean up state without the need to start a master container.