### PR TITLE
Remove from persist jobs synchronously

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4192,8 +4192,6 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
           }
         }
         mPersistRequests.put(fileId, job.getTimer());
-      } finally {
-        mPersistJobs.remove(fileId);
       }
 
       // Cleanup possible staging UFS blocks files due to fast durable write fallback.
@@ -4276,6 +4274,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
               mPersistJobs.remove(fileId);
               break;
             case COMPLETED:
+              mPersistJobs.remove(fileId);
               mPersistCheckerPool.execute(() -> handleSuccess(job));
               break;
             default:


### PR DESCRIPTION
There is a case when `handleSuccess` is expensive (for example for object stores). This leads to a large number of `handleSuccess` calls being queued up, possibly conflicting with each other and consuming the threadpool / queue.

I validated it with S3, but unfortunately it is nontrivial to make a test for this case.

Fixes #9925