### PR TITLE
Improve distributedCp command to support write type parameter

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -17,6 +17,8 @@ import alluxio.annotation.PublicApi;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobGrpcClientUtils;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.migrate.MigrateConfig;
@@ -60,7 +62,9 @@ public final class DistributedCpCommand extends AbstractFileSystemCommand {
     Thread thread = CommonUtils.createProgressThread(2 * Constants.SECOND_MS, System.out);
     thread.start();
     try {
-      JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(), null, true,
+      AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
+      JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
           false), 3, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
For distributedCp command, make sure client write type configuration is passed to job service.