### PR TITLE
Remove left-over warning trace in ChannelAuthenticator

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -176,7 +176,6 @@ public class ChannelAuthenticator {
         String message = String.format(
             "Channel authentication failed with code:%s. ChannelKey: %s, AuthType: %s, Error: %s",
             code.name(), mChannelKey.toStringShort(), mAuthType, e.toString());
-        LOG.warn(message);
         throw AlluxioStatusException
             .from(Status.fromCode(code).withDescription(message).withCause(e));
       }


### PR DESCRIPTION
This trace should have been removed as part of https://github.com/Alluxio/alluxio/pull/9973