### PR TITLE
[DOCFIX] Require trailing slash when mounting whole s3 bucket

### DIFF
--- a/docs/en/ufs/S3.md
+++ b/docs/en/ufs/S3.md
@@ -45,6 +45,9 @@ Specify an **existing** S3 bucket and directory as the under storage system by m
 alluxio.master.mount.table.root.ufs=s3://S3_BUCKET/S3_DIRECTORY
 ```
 
+Note that if you want to mount the whole s3 bucket, add a trailing slash after the bucket name 
+(e.g. `s3://S3_BUCKET/`).
+
 Specify the AWS credentials for S3 access by setting aws.accessKeyId and aws.secretKey in
 `alluxio-site.properties`.
 


### PR DESCRIPTION
When backing up to root ufs with the following configuration
```
alluxio.master.mount.table.root.ufs=s3://bucket-name
```
The `fasdmin backup` command will fail because our Alluxio URI has problem processing uri with no path (without a trailing slash after authority).

This PR fixes the issue and allows s3://bucket-name as root ufs.
