### PR TITLE
Fix K8s Service label selector

### DIFF
--- a/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
+++ b/integration/kubernetes/helm/alluxio/templates/alluxio-master.yaml
@@ -54,7 +54,7 @@ spec:
   {{- end}}
   clusterIP: None
   selector:
-    app: {{ $masterName }}
+    name: {{ $masterName }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-master.yaml.template
@@ -28,7 +28,7 @@ spec:
     name: embedded
   clusterIP: None
   selector:
-    app: alluxio-master-0
+    name: alluxio-master-0
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -133,7 +133,7 @@ spec:
     name: embedded
   clusterIP: None
   selector:
-    app: alluxio-master-1
+    name: alluxio-master-1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -238,7 +238,7 @@ spec:
     name: embedded
   clusterIP: None
   selector:
-    app: alluxio-master-2
+    name: alluxio-master-2
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-master.yaml.template
@@ -26,7 +26,7 @@ spec:
     name: web
   clusterIP: None
   selector:
-    app: alluxio-master-0
+    name: alluxio-master-0
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-master.yaml.template
@@ -38,7 +38,7 @@ spec:
     name: web
   clusterIP: None
   selector:
-    app: alluxio-master-0
+    name: alluxio-master-0
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
This change fixes the selector used by K8s Services to find the correct master Pods. Without this change the Services are not able to find the correct master Pods so the master Pods cannot be talked to. 

This bug was introduced by the previous change to use `app: alluxio` for all resource and `name: {{$masterName}}` for the master Pods. Only the selector for StatefulSet was updated, and the selector for Service was missed.