### PR TITLE
Use ALLUXIO_CLIENT_JAVA_OPTS in k8s fuse yaml to not override configMap

### DIFF
--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -40,7 +40,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: ALLUXIO_JAVA_OPTS
+          - name: ALLUXIO_CLIENT_JAVA_OPTS
             value: " -Dalluxio.user.hostname=$(ALLUXIO_CLIENT_HOSTNAME) "
           securityContext:
             privileged: true


### PR DESCRIPTION
ALLUXIO_JAVA_OPTS is redundantly defined in the fuse container and the configMap which lead to configMap being ignored.