### PR TITLE
Support aliyun oss for multiple part download

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -766,7 +766,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   .setDefaultValue(false)
                   .setDescription("(Experimental) If true, using streaming download from OSS.")
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-                  .setScope(Scope.SERVER)
+                  .setScope(Scope.CLIENT)
                   .build();
   public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM =
           new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM)
@@ -775,14 +775,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                           + "communicating with OSS. These operations may be fairly concurrent and "
                           + "frequent but should not take much time to process.")
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-                  .setScope(Scope.SERVER)
+                  .setScope(Scope.CLIENT)
                   .build();
   public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE =
           new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE)
                   .setDefaultValue("2MB")
                   .setDescription("Default block size for OSS streaming download.")
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-                  .setScope(Scope.SERVER)
+                  .setScope(Scope.CLIENT)
                   .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       new Builder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -752,6 +752,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_REQUEST_TIMEOUT =
+          new Builder(Name.UNDERFS_OSS_REQUEST_TIMEOUT)
+                  .setDefaultValue("600sec")
+                  .setDescription("The timeout of getting object from OSS.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.SERVER)
+                  .build();
   public static final PropertyKey UNDERFS_OSS_SOCKET_TIMEOUT =
       new Builder(Name.UNDERFS_OSS_SOCKET_TIMEOUT)
           .setAlias("alluxio.underfs.oss.socket.timeout.ms")
@@ -3833,6 +3840,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
+    public static final String UNDERFS_OSS_REQUEST_TIMEOUT = "alluxio.underfs.oss.request.timeout";
     public static final String UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED = "alluxio.underfs.oss.streaming.download.enabled";
     public static final String UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM = "alluxio.underfs.oss.streaming.download.task.num";
     public static final String UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE = "alluxio.underfs.oss.streaming.download.partition.size";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -760,6 +760,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED =
+          new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED)
+                  .setAlias("alluxio.underfs.s3a.streaming.upload.enabled")
+                  .setDefaultValue(false)
+                  .setDescription("(Experimental) If true, using streaming download from OSS.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.SERVER)
+                  .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       new Builder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
           .setDefaultValue(20)
@@ -3809,6 +3817,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
+    public static final String UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED = "alluxio.underfs.oss.streaming.download.enabled";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -762,9 +762,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED =
           new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED)
-                  .setAlias("alluxio.underfs.s3a.streaming.upload.enabled")
+                  .setAlias("alluxio.underfs.oss.streaming.download.enabled")
                   .setDefaultValue(false)
                   .setDescription("(Experimental) If true, using streaming download from OSS.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.SERVER)
+                  .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM =
+          new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM)
+                  .setDefaultValue(5)
+                  .setDescription("The maximum number of threads to use for downloading operations when "
+                          + "communicating with OSS. These operations may be fairly concurrent and "
+                          + "frequent but should not take much time to process.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.SERVER)
+                  .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE =
+          new Builder(Name.UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE)
+                  .setDefaultValue("2MB")
+                  .setDescription("Default block size for OSS streaming download.")
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
                   .setScope(Scope.SERVER)
                   .build();
@@ -3818,6 +3834,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
     public static final String UNDERFS_OSS_STREAMING_DOWNLOAD_ENABLED = "alluxio.underfs.oss.streaming.download.enabled";
+    public static final String UNDERFS_OSS_STREAMING_DOWNLOADING_TASK_NUM = "alluxio.underfs.oss.streaming.download.task.num";
+    public static final String UNDERFS_OSS_STREAMING_DOWNLOADING_PARTITION_SIZE = "alluxio.underfs.oss.streaming.download.partition.size";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractReadHandler.java
@@ -362,9 +362,11 @@ abstract class AbstractReadHandler<T extends ReadRequestContext<?>>
             });
           }
         } catch (Exception e) {
-          LogUtils.warnWithException(LOG,
-              "Exception occurred while reading data for read request {}.", mContext.getRequest(),
-              e);
+//          LogUtils.warnWithException(LOG,
+//              "Exception occurred while reading data for read request {}.", mContext.getRequest(),
+//              e);
+          LOG.warn("Exception occurred while reading data for read request {}.", mContext.getRequest(),
+          e);
           setError(new Error(AlluxioStatusException.fromThrowable(e), true));
           continue;
         }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -87,8 +87,8 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
         try {
           reader.close();
         } catch (Exception e) {
-          LOG.warn("Failed to close block reader for block {} with error {}.",
-              context.getRequest().getId(), e.getMessage());
+          LOG.warn("Failed to close block reader for block {} with error.",
+              context.getRequest().getId(), e);
         }
       }
       if (!mWorker.unlockBlock(context.getRequest().getSessionId(), context.getRequest().getId())) {

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
       <dependency>
         <groupId>com.aliyun.oss</groupId>
         <artifactId>aliyun-sdk-oss</artifactId>
-        <version>2.0.7</version>
+        <version>3.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>

--- a/underfs/oss/pom.xml
+++ b/underfs/oss/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>com.aliyun.oss</groupId>
       <artifactId>aliyun-sdk-oss</artifactId>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -113,7 +113,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
       } catch (OSSException e) {
         LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
-        LOG.warn("IOException " + Throwables.getStackTraceAsString(e));
+        LOG.warn("OSSException " + Throwables.getStackTraceAsString(e));
         if (!e.getErrorCode().equals("NoSuchKey")) {
           throw new IOException(e);
         }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -97,6 +97,8 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
     // OSS returns entire object if we read past the end
     req.setRange(startPos, endPos < mContentLength ? endPos - 1 : mContentLength - 1);
     OSSException lastException = null;
+    LOG.info("Create stream for key {} in bucket {} from {} to {}",
+            mKey, mBucketName, startPos, endPos);
     while (mRetryPolicy.attempt()) {
       try {
         OSSObject ossObject = mOssClient.getObject(req);
@@ -114,4 +116,6 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
     // Failed after retrying key does not exist
     throw new IOException(lastException);
   }
+
+
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -14,12 +14,12 @@ package alluxio.underfs.oss;
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.MultiRangeObjectInputStream;
 
-import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSException;
 import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,6 +113,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
       } catch (OSSException e) {
         LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
             mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+        LOG.warn("IOException " + Throwables.getStackTraceAsString(e));
         if (!e.getErrorCode().equals("NoSuchKey")) {
           throw new IOException(e);
         }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -15,6 +15,7 @@ import alluxio.retry.RetryPolicy;
 import alluxio.underfs.MultiRangeObjectInputStream;
 
 import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSException;
 import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
@@ -43,7 +44,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
   private final String mKey;
 
   /** The OSS client for OSS operations. */
-  private final OSSClient mOssClient;
+  private final OSS mOssClient;
 
   /** The size of the object in bytes. */
   private final long mContentLength;
@@ -63,7 +64,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param retryPolicy retry policy in case the key does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
-  OSSInputStream(String bucketName, String key, OSSClient client, RetryPolicy retryPolicy,
+  OSSInputStream(String bucketName, String key, OSS client, RetryPolicy retryPolicy,
       long multiRangeChunkSize) throws IOException {
     this(bucketName, key, client, 0L, retryPolicy, multiRangeChunkSize);
   }
@@ -78,7 +79,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
    * @param retryPolicy retry policy in case the key does not exist
    * @param multiRangeChunkSize the chunk size to use on this stream
    */
-  OSSInputStream(String bucketName, String key, OSSClient client, long position,
+  OSSInputStream(String bucketName, String key, OSS client, long position,
       RetryPolicy retryPolicy, long multiRangeChunkSize) throws IOException {
     super(multiRangeChunkSize);
     mBucketName = bucketName;
@@ -97,7 +98,7 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
     // OSS returns entire object if we read past the end
     req.setRange(startPos, endPos < mContentLength ? endPos - 1 : mContentLength - 1);
     OSSException lastException = null;
-    LOG.info("Create stream for key {} in bucket {} from {} to {}",
+    LOG.debug("Create stream for key {} in bucket {} from {} to {}",
             mKey, mBucketName, startPos, endPos);
     while (mRetryPolicy.attempt()) {
       try {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSInputStream.java
@@ -127,5 +127,4 @@ public class OSSInputStream extends MultiRangeObjectInputStream {
     throw new IOException(lastException);
   }
 
-
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -169,6 +169,8 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
         File tmpFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(mTmpDirs), mKey));
         boolean created = tmpFile.getParentFile().mkdirs();
         LOG.debug("the tmp directory is created: "+ created);
+        // Set the download file
+        req.setDownloadFile(tmpFile.getAbsolutePath());
 
         OSSException lastException = null;
         LOG.debug("Create stream with partition for key {} in bucket {} from {} to {}",

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -232,4 +232,5 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
         // Failed after retrying key does not exist
         throw new IOException(lastException);
     }
+
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -169,7 +169,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
         File tmpFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(mTmpDirs), mKey));
         boolean created = tmpFile.getParentFile().mkdirs();
         LOG.debug("the tmp directory is created: "+ created);
-        // Set the download file
+        // Set the download file.
         req.setDownloadFile(tmpFile.getAbsolutePath());
 
         OSSException lastException = null;

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -1,0 +1,161 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.MultiRangeObjectInputStream;
+
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.DownloadFileRequest;
+import com.aliyun.oss.internal.OSSConstants;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A stream for reading a file from OSS. This input stream in multiple stream returns 0 when calling read with an empty
+ * buffer.
+ */
+@NotThreadSafe
+public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
+    private static final Logger LOG = LoggerFactory.getLogger(OSSLowLevelInputStream.class);
+
+    /** Bucket name of the Alluxio OSS bucket. */
+    private final String mBucketName;
+
+    /** Key of the file in OSS to read. */
+    private final String mKey;
+
+    /** The OSS client for OSS operations. */
+    private final OSSClient mOssClient;
+
+    /** The size of the object in bytes. */
+    private final long mContentLength;
+
+    /** The maximum allowed size of a partition. */
+    private final long mStreamingDownloadPartitionSize;
+
+    /** The task count for downloading parts */
+    private final int mTaskNum;
+
+    private final List<String> mTmpDirs;
+
+    /**
+     * Policy determining the retry behavior in case the key does not exist. The key may not exist
+     * because of eventual consistency.
+     */
+    private final RetryPolicy mRetryPolicy;
+
+    /**
+     * Creates a new instance of {@link MultiRangeObjectInputStream}.
+     *
+     * @param bucketName the name of the bucket
+     * @param key the key of the file
+     * @param client the client for OSS
+     * @param position the position to begin reading from
+     * @param retryPolicy retry policy in case the key does not exist
+     * @param multiRangeChunkSize the chunk size to use on this stream
+     * @param streamingDownloadPartitionSize the size in bytes for partitions of streaming downloads
+     * @param taskNum task count for downloading parts
+     * @param tmpDirs a list of temporary directories
+     */
+    OSSLowLevelInputStream(String bucketName, String key, OSSClient client, long position,
+                   RetryPolicy retryPolicy, long multiRangeChunkSize,
+                   long streamingDownloadPartitionSize, int taskNum, List<String> tmpDirs) throws IOException {
+        super(multiRangeChunkSize);
+        mBucketName = bucketName;
+        mKey = key;
+        mOssClient = client;
+        mPos = position;
+        ObjectMetadata meta = mOssClient.getObjectMetadata(mBucketName, key);
+        mContentLength = meta == null ? 0 : meta.getContentLength();
+        mRetryPolicy = retryPolicy;
+        mStreamingDownloadPartitionSize = streamingDownloadPartitionSize;
+        mTaskNum = taskNum;
+        mTmpDirs = tmpDirs;
+    }
+
+    @Override
+    protected InputStream createStream(long startPos, long endPos)
+            throws IOException {
+        DownloadFileRequest req = new DownloadFileRequest(mBucketName, mKey);
+        // Sets the concurrent task thread count 5. By default it's 1.
+        req.setTaskNum(mTaskNum);
+        // Sets the part size, by default it's 1K.
+        req.setPartSize(1024 * mStreamingDownloadPartitionSize);
+        // Enable checkpoint.
+        req.setEnableCheckpoint(true);
+
+        // Make the temp file
+        File tmpFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(mTmpDirs), mKey));
+        tmpFile.getParentFile().mkdirs();
+
+        OSSException lastException = null;
+        LOG.debug("Create stream for key {} in bucket {} from {} to {}",
+                mKey, mBucketName, startPos, endPos);
+        while (mRetryPolicy.attempt()) {
+            try {
+                mOssClient.downloadFile(req);
+                fis = new FileInputSteam(tmpFile);
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+                if (startPos > 0){
+                    fis.skip(startPos);
+                }
+
+                long length = endPos < mContentLength ? endPos - 1 : mContentLength - 1;
+                byte[] buffer = new byte[OSSConstants.DEFAULT_BUFFER_SIZE];
+                int bytesRead;
+                // all the bytes read from scratch
+                long bytesReadInAll = 0;
+                while ((bytesRead = fis.read(buf)) != -1 ) {
+                    bytesReadInAll += (long)bytesRead;
+                    if (bytesReadInAll > length) {
+                        // If the bytes read is more than the length (endPos - startPos), only read the length
+                        bytesRead = (int)(bytesReadInAll - length);
+                    }else if (bytesReadInAll == length){
+                        break;
+                    }
+                    bos.write(buffer, 0, bytesRead);
+                }
+
+                bos.flush();
+                //    byte[] bytes = bos.toByteArray();
+                return new BufferedInputStream(bos);
+            } catch (OSSException e) {
+                LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
+                        mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+                if (!e.getErrorCode().equals("NoSuchKey")) {
+                    throw new IOException(e);
+                }
+                // Key does not exist
+                lastException = e;
+            } finally {
+                // Delete the temporary downloaded file
+                if (!tmpFile.delete()) {
+                    LOG.error("Failed to delete temporary file @ {}", tmpFile.getPath());
+                }
+            }
+        }
+        // Failed after retrying key does not exist
+        throw new IOException(lastException);
+    }
+
+}

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -13,21 +13,19 @@ package alluxio.underfs.oss;
 
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.MultiRangeObjectInputStream;
-
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSException;
-import com.aliyun.oss.model.ObjectMetadata;
-import com.aliyun.oss.model.DownloadFileRequest;
 import com.aliyun.oss.internal.OSSConstants;
-
+import com.aliyun.oss.model.DownloadFileRequest;
+import com.aliyun.oss.model.ObjectMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * A stream for reading a file from OSS. This input stream in multiple stream returns 0 when calling read with an empty
@@ -80,6 +78,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                    RetryPolicy retryPolicy, long multiRangeChunkSize,
                    long streamingDownloadPartitionSize, int taskNum, List<String> tmpDirs) throws IOException {
         super(multiRangeChunkSize);
+        LOG.debug("Use OSSLowLevelInputStream.");
         mBucketName = bucketName;
         mKey = key;
         mOssClient = client;
@@ -99,7 +98,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
         // Sets the concurrent task thread count 5. By default it's 1.
         req.setTaskNum(mTaskNum);
         // Sets the part size, by default it's 1K.
-        req.setPartSize(1024 * mStreamingDownloadPartitionSize);
+        req.setPartSize(mStreamingDownloadPartitionSize);
         // Enable checkpoint.
         req.setEnableCheckpoint(true);
 

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -174,6 +174,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
 
         OSSException lastException = null;
         long start = 0;
+        long length;
         LOG.debug("Create stream with partition for key {} in bucket {} from {} to {}",
                 mKey, mBucketName, startPos, endPos);
         while (mRetryPolicy.attempt()) {
@@ -191,7 +192,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                     fis.skip(startPos);
                 }
 
-                long length = endPos - startPos < mContentLength ? endPos - startPos : mContentLength ;
+                length = endPos - startPos < mContentLength ? endPos - startPos : mContentLength ;
                 LOG.debug("The mContentLength is {}, endPos - startPos is {}, the length is {}",
                         mContentLength, endPos - startPos, length);
                 byte[] bytes = IOUtils.toByteArray(fis, length);
@@ -209,14 +210,10 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                         mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
                 throw new IOException(e);
             } finally {
+                LOG.debug("Calling createStreamWithPartition took: {} ms", (System.currentTimeMillis()-start));
                 // Delete the temporary downloaded file
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Calling createStreamWithPartition took: {} ms", (System.currentTimeMillis()-start));
-                    LOG.debug("Keep tmp file:", tmpFile.getAbsolutePath());
-                }else {
-                    if (!tmpFile.delete()) {
-                        LOG.error("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
-                    }
+                if (!tmpFile.delete()) {
+                    LOG.error("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
                 }
             }
         }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -217,8 +217,10 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                     fis.close();
                 }
                 // Delete the temporary downloaded file
-                if (!tmpFile.delete()) {
-                    LOG.warn("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
+                if (tmpFile.exists()) {
+                    if (!tmpFile.delete()) {
+                        LOG.warn("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
+                    }
                 }
             }
         }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -23,6 +23,7 @@ import com.aliyun.oss.model.DownloadFileRequest;
 import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,6 +133,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
             } catch (OSSException e) {
                 LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
                         mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+                LOG.warn("IOException " + Throwables.getStackTraceAsString(e));
                 if (!e.getErrorCode().equals("NoSuchKey")) {
                     throw new IOException(e);
                 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -209,6 +209,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
             } catch (Throwable e) {
                 LOG.warn("Attempt {} to open key {} in bucket {} failed with exception : {}",
                         mRetryPolicy.getAttemptCount(), mKey, mBucketName, e.toString());
+                LOG.warn("IOException " + Throwables.getStackTraceAsString(e));
                 throw new IOException(e);
             } finally {
                 LOG.debug("Calling createStreamWithPartition took: {} ms", (System.currentTimeMillis()-start));
@@ -217,7 +218,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                 }
                 // Delete the temporary downloaded file
                 if (!tmpFile.delete()) {
-                    LOG.error("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
+                    LOG.warn("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());
                 }
             }
         }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -176,6 +176,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
         OSSException lastException = null;
         long start = 0;
         long length;
+        FileInputStream fis = null;
         LOG.debug("Create stream with partition for key {} in bucket {} from {} to {}",
                 mKey, mBucketName, startPos, endPos);
         while (mRetryPolicy.attempt()) {
@@ -186,8 +187,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                 }
                 mOssClient.downloadFile(req);
                 LOG.debug("Calling OSS download file method took: {} ms", (System.currentTimeMillis()-start));
-                FileInputStream fis = new FileInputStream(tmpFile);
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                fis = new FileInputStream(tmpFile);
 
                 if (startPos > 0){
                     fis.skip(startPos);
@@ -212,6 +212,9 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
                 throw new IOException(e);
             } finally {
                 LOG.debug("Calling createStreamWithPartition took: {} ms", (System.currentTimeMillis()-start));
+                if (fis != null) {
+                    fis.close();
+                }
                 // Delete the temporary downloaded file
                 if (!tmpFile.delete()) {
                     LOG.error("Failed to delete temporary file @ {}", tmpFile.getAbsolutePath());

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelInputStream.java
@@ -157,6 +157,7 @@ public class OSSLowLevelInputStream extends MultiRangeObjectInputStream {
      */
     private InputStream createStreamWithPartition(long startPos, long endPos, int taskNum)
             throws IOException {
+        LOG.debug("the taskNum: {} and the partition size is {}", taskNum, mStreamingDownloadPartitionSize);
         DownloadFileRequest req = new DownloadFileRequest(mBucketName, mKey);
         // Sets the concurrent task thread count 5. By default it's 1.
         req.setTaskNum(taskNum);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSOutputStream.java
@@ -14,7 +14,7 @@ package alluxio.underfs.oss;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
-import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSS;
 import com.aliyun.oss.ServiceException;
 import com.aliyun.oss.model.ObjectMetadata;
 import com.google.common.base.Preconditions;
@@ -53,7 +53,7 @@ public final class OSSOutputStream extends OutputStream {
   /** The local file that will be uploaded when the stream is closed. */
   private final File mFile;
   /** The oss client for OSS operations. */
-  private final OSSClient mOssClient;
+  private final OSS mOssClient;
 
   /** The OutputStream to a local file where the file will be buffered until closed. */
   private OutputStream mLocalOutputStream;
@@ -71,7 +71,7 @@ public final class OSSOutputStream extends OutputStream {
    * @param client the client for OSS
    * @param tmpDirs a list of temporary directories
    */
-  public OSSOutputStream(String bucketName, String key, OSSClient client, List<String> tmpDirs)
+  public OSSOutputStream(String bucketName, String key, OSS client, List<String> tmpDirs)
       throws IOException {
     Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(),
         "Bucket name must not be null or empty.");

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -284,6 +284,13 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
         .setSocketTimeout((int) alluxioConf.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
     ossClientConf.setConnectionTTL(alluxioConf.getLong(PropertyKey.UNDERFS_OSS_CONNECT_TTL));
     ossClientConf.setMaxConnections(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
+    ossClientConf.setRequestTimeout((int) alluxioConf.getMs(PropertyKey.UNDERFS_OSS_REQUEST_TIMEOUT));
+    LOG.info("ossClientConf: connectionTimeout={}ms, socketTimeout={}ms, connectionTTL={}ms, maxConnections={}, requestTimeout={}ms",
+            ossClientConf.getConnectionTimeout(),
+            ossClientConf.getSocketTimeout(),
+            ossClientConf.getConnectionTTL(),
+            ossClientConf.getMaxConnections(),
+            ossClientConf.getRequestTimeout());
     return ossClientConf;
   }
 

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -277,7 +277,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    * @return the OSS {@link ClientBuilderConfiguration}
    */
   private static ClientBuilderConfiguration initializeOSSClientConfig(AlluxioConfiguration alluxioConf) {
-      ClientBuilderConfiguration ossClientConf = new ClientConfiguration();
+      ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
     ossClientConf
         .setConnectionTimeout((int) alluxioConf.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TIMEOUT));
     ossClientConf

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -25,7 +25,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.retry.CountingRetry;
 import alluxio.util.ConfigurationUtils;
 
-import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSS;
 import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
 
@@ -51,7 +51,7 @@ public class OSSInputStreamTest {
       new InstancedConfiguration(ConfigurationUtils.defaults());
 
   private OSSInputStream mOssInputStream;
-  private OSSClient mOssClient;
+  private OSS mOssClient;
   private InputStream[] mInputStreamSpy;
   private OSSObject[] mOssObject;
 
@@ -63,7 +63,7 @@ public class OSSInputStreamTest {
 
   @Before
   public void setUp() throws IOException {
-    mOssClient = mock(OSSClient.class);
+    mOssClient = mock(OSS.class);
 
     byte[] input = new byte[] {1, 2, 3};
     mOssObject = new OSSObject[input.length];

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -16,7 +16,7 @@ import alluxio.ConfigurationTestUtils;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
-import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSS;
 import com.aliyun.oss.ServiceException;
 import com.aliyun.oss.model.ListObjectsRequest;
 import org.junit.Assert;
@@ -33,7 +33,8 @@ import java.io.IOException;
 public class OSSUnderFileSystemTest {
 
   private OSSUnderFileSystem mOSSUnderFileSystem;
-  private OSSClient mClient;
+  private OSS mClient;
+  private boolean mStreamingDownloadEnabled;
 
   private static final String PATH = "path";
   private static final String SRC = "src";
@@ -45,11 +46,11 @@ public class OSSUnderFileSystemTest {
    * Set up.
    */
   @Before
-  public void before() throws InterruptedException, ServiceException {
-    mClient = Mockito.mock(OSSClient.class);
+  public void before() throws ServiceException {
+    mClient = Mockito.mock(OSS.class);
 
     mOSSUnderFileSystem = new OSSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()), mStreamingDownloadEnabled);
   }
 
   /**


### PR DESCRIPTION
1. Update aliyun_oss_sdk to 3.6.0
2. Support multi parts download to speed up
   a file's size is 136977679 can be complete  in
Single Part: 1982 ms
``` 
java -jar osscli-1.0-SNAPSHOT-jar-with-dependencies.jar imagenet-huabei5 images/train-00760-of-01024
Download the metadata: false
Getting Started with OSS SDK for Java

Downloading an object
Download time in ms = 1982
Content-Type: application/octet-stream
Size: 136977679
Dump to file:images/train-00760-of-01024
```
Multi part: 455 ms

```
java -cp osscli-1.0-SNAPSHOT-jar-with-dependencies.jar com.aliyun.osscli.DownloadOSSObject imagenet-huabei5 images/train-00760-of-01024 8 16
Use num: 8
Use part size: 16
Download time in ms = 455
D8F69CE8F96710BB6FB620B99D17E717-54
```

It can get 4 times speed up.