### PR TITLE
Add metrics to BackupManager for backup and restore of the journal

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MasterMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/MasterMetrics.java
@@ -15,6 +15,11 @@ package alluxio.metrics;
  * Metrics of Alluxio master.
  */
 public final class MasterMetrics {
+  // metrics for BackupManager
+  public static final String LAST_BACKUP_ENTRIES_COUNT = "LastBackupEntriesCount";
+  public static final String LAST_BACKUP_RESTORE_COUNT = "LastBackupRestoreCount";
+  public static final String BACKUP_ENTRIES_PROCESS_TIME = "BackupEntriesProcessTime";
+  public static final String BACKUP_RESTORE_PROCESS_TIME = "BackupRestoreProcessTime";
   // metrics names for FileSystemMaster
   public static final String DIRECTORIES_CREATED = "DirectoriesCreated";
   public static final String FILE_BLOCK_INFOS_GOT = "FileBlockInfosGot";

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -340,6 +340,11 @@ public class BackupManager {
     }
   }
 
+  /**
+   * Class that contains metrics for BackupManager.
+   * This class is public because the counter names are referenced in
+   * {@link alluxio.web.WebInterfaceAbstractMetricsServlet}.
+   */
   public static final class Metrics {
     private static final Timer BACKUP_ENTRIES_PROCESS_TIME
         = MetricsSystem.timer(MasterMetrics.BACKUP_ENTRIES_PROCESS_TIME);

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -16,9 +16,13 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.JournalEntryAssociation;
 import alluxio.master.journal.JournalEntryStreamReader;
+import alluxio.metrics.MasterMetrics;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.util.ThreadFactoryUtils;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import com.google.common.collect.Maps;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -105,6 +109,10 @@ public class BackupManager {
     // Whether buffering is still active.
     AtomicBoolean bufferingActive = new AtomicBoolean(true);
 
+    // Start the timer for backup metrics and reset the entry counter.
+    Metrics.LAST_BACKUP_ENTRIES_COUNT.dec(Metrics.LAST_BACKUP_ENTRIES_COUNT.getCount());
+    Timer.Context backup = Metrics.BACKUP_ENTRIES_PROCESS_TIME.time();
+
     // Submit master reader task.
     activeTasks.add(completionService.submit(() -> {
       try {
@@ -160,6 +168,10 @@ public class BackupManager {
     // Wait until backup tasks are completed.
     safeWaitTasks(activeTasks, completionService);
 
+    // Close timer and update entry count.
+    backup.close();
+    Metrics.LAST_BACKUP_ENTRIES_COUNT.inc(entryCount.get());
+
     // finish() instead of close() since close would close os, which is owned by the caller.
     zipStream.finish();
     LOG.info("Created backup with {} entries", entryCount.get());
@@ -201,6 +213,10 @@ public class BackupManager {
       traceExecutor.scheduleAtFixedRate(() -> {
         LOG.info("{} entries from backup applied so far...", appliedEntryCount.get());
       }, 30, 30, TimeUnit.SECONDS);
+
+      // Start the timer for backup metrics and reset restore entry count.
+      Metrics.LAST_BACKUP_RESTORE_COUNT.dec(Metrics.LAST_BACKUP_RESTORE_COUNT.getCount());
+      Timer.Context restore = Metrics.BACKUP_RESTORE_PROCESS_TIME.time();
 
       // Create backup reader task.
       activeTasks.add(completionService.submit(() -> {
@@ -276,10 +292,12 @@ public class BackupManager {
         }
       }));
 
-      // Wait until backup tasks are completed.
+      // Wait until backup tasks are completed and stop metrics timer.
       try {
         safeWaitTasks(activeTasks, completionService);
       } finally {
+        restore.close();
+        Metrics.LAST_BACKUP_RESTORE_COUNT.inc(appliedEntryCount.get());
         traceExecutor.shutdownNow();
       }
 
@@ -320,5 +338,19 @@ public class BackupManager {
         }
       }
     }
+  }
+
+  public static final class Metrics {
+    private static final Timer BACKUP_ENTRIES_PROCESS_TIME
+        = MetricsSystem.timer(MasterMetrics.BACKUP_ENTRIES_PROCESS_TIME);
+    private static final Timer BACKUP_RESTORE_PROCESS_TIME
+        = MetricsSystem.timer(MasterMetrics.BACKUP_RESTORE_PROCESS_TIME);
+    private static final Counter LAST_BACKUP_ENTRIES_COUNT
+        = MetricsSystem.counter(MasterMetrics.LAST_BACKUP_ENTRIES_COUNT);
+    private static final Counter LAST_BACKUP_RESTORE_COUNT
+        = MetricsSystem.counter(MasterMetrics.LAST_BACKUP_RESTORE_COUNT);
+
+    private Metrics() {
+    } // prevent instantiation
   }
 }


### PR DESCRIPTION
Adding metrics for backup and restore from backup to track number of entries and time taken for backup.