### PR TITLE
Add block size to information stored in UfsFileStatus

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -531,7 +531,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       ObjectPermissions permissions = getPermissions();
       return new UfsFileStatus(path, details.getContentHash(), details.getContentLength(),
           details.getLastModifiedTimeMs(), permissions.getOwner(), permissions.getGroup(),
-          permissions.getMode());
+          permissions.getMode(), mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
     } else {
       LOG.warn("Error fetching file status, assuming file {} does not exist", path);
       throw new FileNotFoundException(path);
@@ -553,7 +553,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       ObjectPermissions permissions = getPermissions();
       return new UfsFileStatus(path, details.getContentHash(), details.getContentLength(),
           details.getLastModifiedTimeMs(), permissions.getOwner(), permissions.getGroup(),
-          permissions.getMode());
+          permissions.getMode(), mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
     }
     return getDirectoryStatus(path);
   }
@@ -1012,7 +1012,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           children.put(child,
               new UfsFileStatus(child, status.getContentHash(), status.getContentLength(),
                   status.getLastModifiedTimeMs(), permissions.getOwner(), permissions.getGroup(),
-                  permissions.getMode()));
+                  permissions.getMode(),
+                  mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT)));
         }
       }
       // Handle case (2)

--- a/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
@@ -22,9 +22,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class UfsFileStatus extends UfsStatus {
   public static final String INVALID_CONTENT_HASH = "";
+  public static final long UNKNOWN_BLOCK_SIZE = -1;
 
   protected final String mContentHash;
   protected final long mContentLength;
+  protected final long mBlockSize;
 
   /**
    * Creates new instance of {@link UfsFileStatus}.
@@ -37,16 +39,63 @@ public class UfsFileStatus extends UfsStatus {
    * @param group of the file
    * @param mode of the file
    * @param xAttr extended attributes, if any
+   * @param blockSize blocksize, -1 if unknown
    */
   public UfsFileStatus(String name, String contentHash, long contentLength, long lastModifiedTimeMs,
-      String owner, String group, short mode, @Nullable Map<String, byte[]> xAttr) {
+      String owner, String group, short mode, @Nullable Map<String, byte[]> xAttr, long blockSize) {
     super(name, false, owner, group, mode, lastModifiedTimeMs, xAttr);
     mContentHash = contentHash;
     mContentLength = contentLength;
+    mBlockSize = blockSize;
+  }
+
+  /**
+   * Creates new instance of {@link UfsFileStatus} without any extended attributes.
+   *
+   * @param name relative path of file
+   * @param contentHash hash of the file contents
+   * @param contentLength in bytes
+   * @param lastModifiedTimeMs UTC time
+   * @param owner of the file
+   * @param group of the file
+   * @param mode of the file
+   * @param blockSize blocksize, -1 if unknown
+   */
+  public UfsFileStatus(String name, String contentHash, long contentLength, long lastModifiedTimeMs,
+      String owner, String group, short mode, long blockSize) {
+    super(name, false, owner, group, mode, lastModifiedTimeMs, /* xattrs */ null);
+    mContentHash = contentHash;
+    mContentLength = contentLength;
+    mBlockSize = blockSize;
+  }
+
+  /**
+   * Creates new instance of {@link UfsFileStatus}.
+   *
+   * @deprecated as of 2.1.0, use
+   * {@link #UfsFileStatus(String, String, long, long, String, String, short, Map, long)}
+   *
+   * @param name relative path of file
+   * @param contentHash hash of the file contents
+   * @param contentLength in bytes
+   * @param lastModifiedTimeMs UTC time
+   * @param owner of the file
+   * @param group of the file
+   * @param mode of the file
+   * @param xAttr extended attributes, if any
+   */
+  @Deprecated
+  public UfsFileStatus(String name, String contentHash, long contentLength, long lastModifiedTimeMs,
+      String owner, String group, short mode, @Nullable Map<String, byte[]> xAttr) {
+    this(name, contentHash, contentLength, lastModifiedTimeMs, owner, group, mode, xAttr,
+        UNKNOWN_BLOCK_SIZE);
   }
 
   /**
    * Creates a new instance of {@link UfsFileStatus} without any extended attributes.
+   *
+   * @deprecated as of 2.1.0, use
+   * {@link #UfsFileStatus(String, String, long, long, String, String, short, long)}.
    *
    * @param name relative path of file
    * @param contentHash hash of the file contents
@@ -56,9 +105,11 @@ public class UfsFileStatus extends UfsStatus {
    * @param group of the file
    * @param mode of the file
    */
+  @Deprecated
   public UfsFileStatus(String name, String contentHash, long contentLength, long lastModifiedTimeMs,
       String owner, String group, short mode) {
-    this(name, contentHash, contentLength, lastModifiedTimeMs, owner, group, mode, null);
+    this(name, contentHash, contentLength, lastModifiedTimeMs, owner, group, mode, null,
+        UNKNOWN_BLOCK_SIZE);
   }
 
   /**
@@ -70,6 +121,7 @@ public class UfsFileStatus extends UfsStatus {
     super(status);
     mContentHash = status.mContentHash;
     mContentLength = status.mContentLength;
+    mBlockSize = status.mBlockSize;
   }
 
   @Override
@@ -91,6 +143,13 @@ public class UfsFileStatus extends UfsStatus {
    */
   public long getContentLength() {
     return mContentLength;
+  }
+
+  /**
+   * @return the block size in bytes, -1 if unknown
+   */
+  public long getBlockSize() {
+    return mBlockSize;
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -329,9 +329,13 @@ public interface UnderFileSystem extends Closeable {
   /**
    * Gets the block size of a file in under file system, in bytes.
    *
+   * @deprecated block size should be returned as part of the {@link UfsFileStatus} from
+   * {@link #getFileStatus(String)} or {@link #getExistingFileStatus(String)}
+   *
    * @param path the file name
    * @return the block size in bytes
    */
+  @Deprecated
   long getBlockSizeByte(String path) throws IOException;
 
   /**

--- a/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
+++ b/core/common/src/test/java/alluxio/underfs/FingerprintTest.java
@@ -36,7 +36,7 @@ public final class FingerprintTest {
     UfsStatus status = new UfsFileStatus(CommonUtils.randomAlphaNumString(10),
         CommonUtils.randomAlphaNumString(10), mRandom.nextLong(), mRandom.nextLong(),
         CommonUtils.randomAlphaNumString(10), CommonUtils.randomAlphaNumString(10),
-        (short) mRandom.nextInt());
+        (short) mRandom.nextInt(), mRandom.nextLong());
     Fingerprint fp = Fingerprint.create(CommonUtils.randomAlphaNumString(10), status);
     String expected = fp.serialize();
     assertNotNull(expected);
@@ -47,7 +47,7 @@ public final class FingerprintTest {
   public void parseDirectoryFingerprint() {
     UfsStatus status = new UfsDirectoryStatus(CommonUtils.randomAlphaNumString(10),
         CommonUtils.randomAlphaNumString(10), CommonUtils.randomAlphaNumString(10),
-        (short) mRandom.nextInt());
+        (short) mRandom.nextInt(), mRandom.nextLong());
     Fingerprint fp = Fingerprint.create(CommonUtils.randomAlphaNumString(10), status);
     String expected = fp.serialize();
     assertNotNull(expected);
@@ -73,14 +73,15 @@ public final class FingerprintTest {
     String group = CommonUtils.randomAlphaNumString(10);
     short mode = (short) mRandom.nextInt();
     String ufsName = CommonUtils.randomAlphaNumString(10);
+    Long blockSize = mRandom.nextLong();
 
     UfsFileStatus status = new UfsFileStatus(name, contentHash, contentLength, lastModifiedTimeMs,
-        owner, group, mode);
+        owner, group, mode, blockSize);
     UfsFileStatus metadataChangedStatus = new UfsFileStatus(name, contentHash, contentLength,
         lastModifiedTimeMs, CommonUtils.randomAlphaNumString(10),
-        CommonUtils.randomAlphaNumString(10), mode);
+        CommonUtils.randomAlphaNumString(10), mode, blockSize);
     UfsFileStatus dataChangedStatus = new UfsFileStatus(name, contentHash2, contentLength,
-        lastModifiedTimeMs, owner, group, mode);
+        lastModifiedTimeMs, owner, group, mode, blockSize);
     Fingerprint fp = Fingerprint.create(ufsName, status);
     Fingerprint fpMetadataChanged = Fingerprint.create(ufsName, metadataChangedStatus);
     Fingerprint fpDataChanged = Fingerprint.create(ufsName, dataChangedStatus);
@@ -109,9 +110,10 @@ public final class FingerprintTest {
     String contentHash = CommonUtils.randomAlphaNumString(10);
     Long contentLength = mRandom.nextLong();
     Long lastModifiedTimeMs = mRandom.nextLong();
+    Long blockSize = mRandom.nextLong();
 
     UfsFileStatus fileStatus = new UfsFileStatus(name, contentHash, contentLength,
-        lastModifiedTimeMs, owner, group, mode);
+        lastModifiedTimeMs, owner, group, mode, blockSize);
     fp = Fingerprint.create(ufsName, fileStatus);
 
     assertEquals(owner, fp.getTag(Fingerprint.Tag.OWNER));
@@ -124,7 +126,7 @@ public final class FingerprintTest {
     UfsStatus status = new UfsFileStatus(CommonUtils.randomAlphaNumString(10),
         CommonUtils.randomAlphaNumString(10), mRandom.nextLong(), mRandom.nextLong(),
         CommonUtils.randomAlphaNumString(10), CommonUtils.randomAlphaNumString(10),
-        (short) mRandom.nextInt());
+        (short) mRandom.nextInt(), mRandom.nextLong());
     AccessControlList acl = AccessControlList.fromStringEntries(
         CommonUtils.randomAlphaNumString(10),
         CommonUtils.randomAlphaNumString(10),

--- a/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UfsFileStatusTest.java
@@ -33,9 +33,10 @@ public final class UfsFileStatusTest {
     long contentLength = random.nextLong();
     long lastModifiedTimeMs = random.nextLong();
     short mode = 077;
+    long blockSize = random.nextLong();
     UfsFileStatus status =
         new UfsFileStatus("name", contentHash, contentLength, lastModifiedTimeMs, "owner", "group",
-            mode);
+            mode, blockSize);
 
     assertEquals("name", status.getName());
     assertEquals(contentHash, status.getContentHash());
@@ -46,6 +47,7 @@ public final class UfsFileStatusTest {
     assertEquals("owner", status.getOwner());
     assertEquals("group", status.getGroup());
     assertEquals(mode, status.getMode());
+    assertEquals(blockSize, status.getBlockSize());
   }
 
   /**
@@ -58,9 +60,11 @@ public final class UfsFileStatusTest {
     long contentLength = random.nextLong();
     long lastModifiedTimeMs = random.nextLong();
     short mode = 077;
+    long blockSize = random.nextLong();
+
     UfsFileStatus statusToCopy =
         new UfsFileStatus("name", contentHash, contentLength, lastModifiedTimeMs, "owner", "group",
-            mode);
+            mode, blockSize);
     UfsFileStatus status = new UfsFileStatus(statusToCopy);
     assertEquals(statusToCopy, status);
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2467,11 +2467,13 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();
 
-      ufsBlockSizeByte = ufs.getBlockSizeByte(ufsUri.toString());
       if (context.getUfsStatus() == null) {
         context.setUfsStatus(ufs.getExistingFileStatus(ufsUri.toString()));
       }
       ufsLength = ((UfsFileStatus) context.getUfsStatus()).getContentLength();
+      long blockSize = ((UfsFileStatus) context.getUfsStatus()).getBlockSize();
+      ufsBlockSizeByte = blockSize != UfsFileStatus.UNKNOWN_BLOCK_SIZE
+          ? blockSize : ufs.getBlockSizeByte(ufsUri.toString());
 
       if (isAclEnabled()) {
         Pair<AccessControlList, DefaultAccessControlList> aclPair

--- a/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
@@ -128,7 +128,7 @@ public class DailyMetadataBackupTest {
       statuses[i] = new UfsFileStatus(generateBackupFileName(),
           CommonUtils.randomAlphaNumString(10), mRandom.nextLong(), mRandom.nextLong(),
           CommonUtils.randomAlphaNumString(10), CommonUtils.randomAlphaNumString(10),
-          (short) mRandom.nextInt());
+          (short) mRandom.nextInt(), mRandom.nextLong());
     }
     return statuses;
   }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -373,8 +373,8 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     FileStatus fs = hdfs.getFileStatus(tPath);
     String contentHash =
         UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
-    return new UfsFileStatus(path, contentHash, fs.getLen(),
-        fs.getModificationTime(), fs.getOwner(), fs.getGroup(), fs.getPermission().toShort());
+    return new UfsFileStatus(path, contentHash, fs.getLen(), fs.getModificationTime(),
+        fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(), fs.getBlockSize());
   }
 
   @Override
@@ -425,7 +425,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       String contentHash =
           UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
       return new UfsFileStatus(path, contentHash, fs.getLen(), fs.getModificationTime(),
-          fs.getOwner(), fs.getGroup(), fs.getPermission().toShort());
+          fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(), fs.getBlockSize());
     }
     // Return directory status.
     return new UfsDirectoryStatus(path, fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(),
@@ -461,7 +461,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
             .approximateContentHash(status.getLen(), status.getModificationTime());
         retStatus = new UfsFileStatus(status.getPath().getName(), contentHash, status.getLen(),
             status.getModificationTime(), status.getOwner(), status.getGroup(),
-            status.getPermission().toShort());
+            status.getPermission().toShort(), status.getBlockSize());
       } else {
         retStatus = new UfsDirectoryStatus(status.getPath().getName(), status.getOwner(),
             status.getGroup(), status.getPermission().toShort(), status.getModificationTime());

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -218,7 +218,8 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
           UnderFileSystemUtils.approximateContentHash(file.length(), file.lastModified());
       return new UfsFileStatus(path, contentHash, file.length(), file.lastModified(),
           attr.owner().getName(), attr.group().getName(),
-          FileUtils.translatePosixPermissionToMode(attr.permissions()));
+          FileUtils.translatePosixPermissionToMode(attr.permissions()),
+          mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
     } catch (FileSystemException e) {
       throw new FileNotFoundException(e.getMessage());
     }
@@ -253,7 +254,8 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
             UnderFileSystemUtils.approximateContentHash(file.length(), file.lastModified());
         return new UfsFileStatus(path, contentHash, file.length(), file.lastModified(),
             attr.owner().getName(), attr.group().getName(),
-            FileUtils.translatePosixPermissionToMode(attr.permissions()));
+            FileUtils.translatePosixPermissionToMode(attr.permissions()),
+            mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
       }
       // Return directory status.
       return new UfsDirectoryStatus(path, attr.owner().getName(), attr.group().getName(),
@@ -298,7 +300,8 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
           String contentHash =
               UnderFileSystemUtils.approximateContentHash(f.length(), f.lastModified());
           retStatus = new UfsFileStatus(f.getName(), contentHash, f.length(), f.lastModified(),
-              attr.owner().getName(), attr.group().getName(), mode);
+              attr.owner().getName(), attr.group().getName(), mode,
+              mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
         }
         rtn[i++] = retStatus;
       }

--- a/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
+++ b/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
@@ -176,7 +176,8 @@ public class WebUnderFileSystem extends ConsistentUnderFileSystem {
       // Return file status.
       String contentHash = UnderFileSystemUtils.approximateContentHash(contentLength, lastModified);
       return new UfsFileStatus(fileName == null ? path : fileName, contentHash, contentLength,
-          lastModified, "", "", (short) 288);
+          lastModified, "", "", (short) 288,
+          mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
     }
     // Return directory status.
     return new UfsDirectoryStatus(path == null ? path : fileName, "", "", (short) 800,


### PR DESCRIPTION
Adds block size info to the `UfsFileStatus`. This mainly helps HDFS whos implementation of `getBlockSizeBytes` has 2(!) rpc calls.

This change should be fully backward compatible, but older servers using newer ufs jars will not work (because the constructor of UfsFileStatus is different). 

@apc999 A separate question is if we should enforce usage of UFS jars which are on the same version of the server so we don't need to maintain legacy code.

Fixes #10035