### PR TITLE
Load Configuration from Meta Master for all clients

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -56,7 +56,7 @@ public abstract class AbstractClient implements Client {
 
   protected InetSocketAddress mAddress;
 
-  /** Address to load the cluster defaults */
+  /** Address to load configuration */
   protected InetSocketAddress mConfAddress;
 
   /** Underlying channel to the target service. */

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -56,6 +56,9 @@ public abstract class AbstractClient implements Client {
 
   protected InetSocketAddress mAddress;
 
+  /** Address to load the cluster defaults */
+  protected InetSocketAddress mConfAddress;
+
   /** Underlying channel to the target service. */
   protected GrpcChannel mChannel;
 
@@ -163,7 +166,7 @@ public abstract class AbstractClient implements Client {
       throws IOException {
     // Bootstrap once for clients
     if (!isConnected()) {
-      mContext.loadConfIfNotLoaded(mAddress);
+      mContext.loadConfIfNotLoaded(mConfAddress);
     }
   }
 
@@ -205,6 +208,7 @@ public abstract class AbstractClient implements Client {
       // failover).
       try {
         mAddress = getAddress();
+        mConfAddress = getConfAddress();
       } catch (UnavailableException e) {
         LOG.debug("Failed to determine {} rpc address ({}): {}",
             getServiceName(), retryPolicy.getAttemptCount(), e.toString());
@@ -290,6 +294,13 @@ public abstract class AbstractClient implements Client {
 
   @Override
   public synchronized InetSocketAddress getAddress() throws UnavailableException {
+    return mAddress;
+  }
+
+  public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
+    if (mConfAddress != null) {
+      return mConfAddress;
+    }
     return mAddress;
   }
 

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -56,7 +56,7 @@ public abstract class AbstractClient implements Client {
 
   protected InetSocketAddress mAddress;
 
-  /** Address to load configuration. */
+  /** Address to load configuration, which may differ from {@code mAddress}. */
   protected InetSocketAddress mConfAddress;
 
   /** Underlying channel to the target service. */

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -56,7 +56,7 @@ public abstract class AbstractClient implements Client {
 
   protected InetSocketAddress mAddress;
 
-  /** Address to load configuration */
+  /** Address to load configuration. */
   protected InetSocketAddress mConfAddress;
 
   /** Underlying channel to the target service. */
@@ -297,6 +297,7 @@ public abstract class AbstractClient implements Client {
     return mAddress;
   }
 
+  @Override
   public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
     if (mConfAddress != null) {
       return mConfAddress;

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -29,6 +29,9 @@ public abstract class AbstractMasterClient extends AbstractClient {
   /** Client for determining the master RPC address. */
   private final MasterInquireClient mMasterInquireClient;
 
+  /** Client for determining the RPC address for getting configuration */
+  private final MasterInquireClient mConfMasterInquireClient;
+
   /**
    * Creates a new master client base.
    *
@@ -37,6 +40,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
   public AbstractMasterClient(MasterClientContext clientConf) {
     super(clientConf, null);
     mMasterInquireClient = clientConf.getMasterInquireClient();
+    mConfMasterInquireClient = clientConf.getConfMasterInquireClient();
   }
 
   /**
@@ -50,10 +54,16 @@ public abstract class AbstractMasterClient extends AbstractClient {
       Supplier<RetryPolicy> retryPolicySupplier) {
     super(clientConf, address, retryPolicySupplier);
     mMasterInquireClient = clientConf.getMasterInquireClient();
+    mConfMasterInquireClient = clientConf.getConfMasterInquireClient();
   }
 
   @Override
   public synchronized InetSocketAddress getAddress() throws UnavailableException {
     return mMasterInquireClient.getPrimaryRpcAddress();
+  }
+
+  @Override
+  public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
+    return mConfMasterInquireClient.getPrimaryRpcAddress();
   }
 }

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -29,7 +29,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
   /** Client for determining the master RPC address. */
   private final MasterInquireClient mMasterInquireClient;
 
-  /** Client for determining the RPC address for getting configuration */
+  /** Client for determining the RPC address for getting configuration. */
   private final MasterInquireClient mConfMasterInquireClient;
 
   /**

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -30,7 +30,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
   private final MasterInquireClient mMasterInquireClient;
 
   /** Client for determining configuration RPC address,
-   * which may be different from target address */
+   * which may be different from target address. */
   private final MasterInquireClient mConfMasterInquireClient;
 
   /**

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -29,7 +29,8 @@ public abstract class AbstractMasterClient extends AbstractClient {
   /** Client for determining the master RPC address. */
   private final MasterInquireClient mMasterInquireClient;
 
-  /** Client for determining the RPC address for getting configuration. */
+  /** Client for determining configuration RPC address,
+   * which may be different from target address */
   private final MasterInquireClient mConfMasterInquireClient;
 
   /**

--- a/core/common/src/main/java/alluxio/Client.java
+++ b/core/common/src/main/java/alluxio/Client.java
@@ -34,10 +34,17 @@ public interface Client extends Closeable {
   void disconnect();
 
   /**
-   * @return the {@link InetSocketAddress} of the remote,
+   * @return the {@link InetSocketAddress} of the remote
    * @throws UnavailableException if the primary address cannot be determined
    */
   InetSocketAddress getAddress() throws UnavailableException;
+
+
+  /**
+   * @return the {@link InetSocketAddress} of the configuration remote
+   * @throws UnavailableException if the primary address cannot be determined
+   */
+  InetSocketAddress getConfAddress() throws UnavailableException;
 
   /**
    * Returns the connected status of the client.

--- a/core/common/src/main/java/alluxio/Client.java
+++ b/core/common/src/main/java/alluxio/Client.java
@@ -39,7 +39,6 @@ public interface Client extends Closeable {
    */
   InetSocketAddress getAddress() throws UnavailableException;
 
-
   /**
    * @return the {@link InetSocketAddress} of the configuration remote
    * @throws UnavailableException if the primary address cannot be determined

--- a/core/common/src/main/java/alluxio/master/MasterClientContext.java
+++ b/core/common/src/main/java/alluxio/master/MasterClientContext.java
@@ -42,4 +42,11 @@ public class MasterClientContext extends ClientContext {
   public MasterInquireClient getMasterInquireClient() {
     return mMasterInquireClient;
   }
+
+  /**
+   * @return the master inquire client for configuration
+   */
+  public MasterInquireClient getConfMasterInquireClient() {
+    return mMasterInquireClient;
+  }
 }

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -476,7 +476,7 @@ public final class ConfigurationUtils {
       throws AlluxioStatusException {
     GrpcChannel channel = null;
     try {
-      LOG.debug("Alluxio client (version {}) is trying to load configuration from meta master {}",
+      LOG.info("Alluxio client (version {}) is trying to load configuration from meta master {}",
           RuntimeConstants.VERSION, address);
       channel = GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), conf)
           .setClientType("ConfigurationUtils").disableAuthentication().build();

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -476,7 +476,7 @@ public final class ConfigurationUtils {
       throws AlluxioStatusException {
     GrpcChannel channel = null;
     try {
-      LOG.info("Alluxio client (version {}) is trying to load configuration from meta master {}",
+      LOG.debug("Alluxio client (version {}) is trying to load configuration from meta master {}",
           RuntimeConstants.VERSION, address);
       channel = GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), conf)
           .setClientType("ConfigurationUtils").disableAuthentication().build();

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -12,6 +12,7 @@
 package alluxio;
 
 import static alluxio.exception.ExceptionMessage.INCOMPATIBLE_VERSION;
+import static org.mockito.Matchers.any;
 
 import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.status.UnavailableException;
@@ -19,9 +20,13 @@ import alluxio.grpc.ServiceType;
 import alluxio.retry.CountingRetry;
 import alluxio.util.ConfigurationUtils;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -41,6 +46,10 @@ public final class AbstractClientTest {
     protected BaseTestClient() {
       super(ClientContext.create(new InstancedConfiguration(ConfigurationUtils.defaults())), null,
           () -> new CountingRetry(1));
+    }
+
+    protected BaseTestClient(ClientContext context) {
+      super(context, null, () -> new CountingRetry(1));
     }
 
     public BaseTestClient(long remoteServiceVersion) {
@@ -96,5 +105,41 @@ public final class AbstractClientTest {
     final AbstractClient client = new BaseTestClient(1);
     client.checkVersion(1);
     client.close();
+  }
+
+  @Test
+  public void confAddress() throws Exception {
+    ClientContext context = Mockito.mock(ClientContext.class);
+
+    InetSocketAddress baseAddress = new InetSocketAddress("0.0.0.0", 2000);
+    InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2001);
+    final alluxio.Client client = new BaseTestClient(context) {
+      @Override
+      public synchronized InetSocketAddress getAddress() {
+        return baseAddress;
+      }
+
+      @Override
+      public synchronized InetSocketAddress getConfAddress() {
+        return confAddress;
+      }
+    };
+
+
+    ArgumentCaptor<InetSocketAddress> argument = ArgumentCaptor.forClass(InetSocketAddress.class);
+
+    Mockito.doThrow(new RuntimeException("test"))
+            .when(context)
+            .loadConfIfNotLoaded(argument.capture());
+
+    try {
+      client.connect();
+      Assert.fail();
+    } catch (Exception e) {
+      // ignore any exceptions. It's expected.
+    }
+
+    Assert.assertEquals(confAddress, argument.getValue());
+
   }
 }

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -137,6 +137,5 @@ public final class AbstractClientTest {
     }
 
     Assert.assertEquals(confAddress, argument.getValue());
-
   }
 }

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -12,7 +12,6 @@
 package alluxio;
 
 import static alluxio.exception.ExceptionMessage.INCOMPATIBLE_VERSION;
-import static org.mockito.Matchers.any;
 
 import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.status.UnavailableException;
@@ -26,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -124,7 +122,6 @@ public final class AbstractClientTest {
         return confAddress;
       }
     };
-
 
     ArgumentCaptor<InetSocketAddress> argument = ArgumentCaptor.forClass(InetSocketAddress.class);
 

--- a/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
+++ b/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
@@ -66,13 +66,6 @@ public final class RetryHandlingJobMasterClient extends AbstractMasterClient
   }
 
   @Override
-  protected void beforeConnect()
-      throws IOException {
-    // Job master client does not load cluster-default configuration because only the master
-    // will use this client
-  }
-
-  @Override
   protected void afterConnect() throws IOException {
     mClient = JobMasterClientServiceGrpc.newBlockingStub(mChannel);
   }

--- a/job/client/src/main/java/alluxio/worker/job/JobMasterClientContext.java
+++ b/job/client/src/main/java/alluxio/worker/job/JobMasterClientContext.java
@@ -21,6 +21,8 @@ import alluxio.master.MasterInquireClient;
  */
 public class JobMasterClientContext extends MasterClientContext {
 
+  private MasterInquireClient mConfMasterInquireClient;
+
   /**
    * Create a builder for {@link JobMasterClientContext}.
    *
@@ -31,7 +33,14 @@ public class JobMasterClientContext extends MasterClientContext {
     return new JobMasterClientContextBuilder(context);
   }
 
-  protected JobMasterClientContext(ClientContext context, MasterInquireClient masterInquireClient) {
+  protected JobMasterClientContext(ClientContext context, MasterInquireClient masterInquireClient,
+                                   MasterInquireClient confMasterInquireClient) {
     super(context, masterInquireClient);
+    mConfMasterInquireClient = confMasterInquireClient;
+  }
+
+  @Override
+  public MasterInquireClient getConfMasterInquireClient() {
+    return mConfMasterInquireClient;
   }
 }

--- a/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
+++ b/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
@@ -21,6 +21,8 @@ import alluxio.master.MasterInquireClient;
  */
 public class JobMasterClientContextBuilder extends MasterClientContextBuilder {
 
+  private MasterInquireClient mConfMasterInquireClient;
+
   /**
    * Creates a builder with the given {@link AlluxioConfiguration}.
    *
@@ -42,6 +44,10 @@ public class JobMasterClientContextBuilder extends MasterClientContextBuilder {
       mMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(
           mContext.getClusterConf());
     }
-    return new JobMasterClientContext(mContext, mMasterInquireClient);
+    if (mConfMasterInquireClient == null) {
+      mConfMasterInquireClient = MasterInquireClient.Factory.create(
+              mContext.getClusterConf());
+    }
+    return new JobMasterClientContext(mContext, mMasterInquireClient, mConfMasterInquireClient);
   }
 }

--- a/job/client/src/main/java/alluxio/worker/job/RetryHandlingJobMasterClient.java
+++ b/job/client/src/main/java/alluxio/worker/job/RetryHandlingJobMasterClient.java
@@ -61,12 +61,6 @@ public final class RetryHandlingJobMasterClient extends AbstractMasterClient
   }
 
   @Override
-  protected void beforeConnect()
-      throws IOException {
-    // Job master client does not load cluster-default because job worker has loaded it on start
-  }
-
-  @Override
   protected void afterConnect() {
     mClient = JobMasterWorkerServiceGrpc.newBlockingStub(mChannel);
   }


### PR DESCRIPTION
The InetSocketAddress for configuration must always be the master.

While the address could be the master or the job master.

@calvinjia 