### PR TITLE
Optimize alluxio.resource.DynamicResourcePool

### DIFF
--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
@@ -197,7 +197,7 @@ public final class DynamicResourcePoolTest {
    * Tests the logic that the recently used resource is preferred.
    */
   @Test
-  public void acquireRentlyUsed() throws Exception {
+  public void acquireRecentlyUsed() throws Exception {
     ManualClock manualClock = new ManualClock();
     TestPool pool = new TestPool(DynamicResourcePool.Options.defaultOptions(), manualClock);
     List<Resource> resourceList = new ArrayList<>();


### PR DESCRIPTION
Optimize DynamicResourcePool by using ConcurrentLinkedDeque instead of (ArrayDeque + Lock)

JMH benchmark result shows about 4 times faster when simply calling acquire and release methods.

JMH test case:
https://gist.github.com/gengxin/4296a4c43b3cff9339df4b8100d5f1ee

Result before optimization:
> Benchmark                                              Mode  Cnt  Score   Error  Units
> DynamicResourcePoolBenchmark.acquireAndRelease         avgt   20  4.936 ± 0.429  us/op
> 
> ....[Thread state distributions]....................................................................
>  58.2%         RUNNABLE
>  22.5%         WAITING
>  19.3%         TIMED_WAITING

Result after optimization:
> Benchmark                                              Mode  Cnt  Score   Error  Units
> DynamicResourcePoolBenchmark.acquireAndRelease         avgt   20  1.378 ± 0.052  us/op
> 
> ....[Thread state distributions]....................................................................
>  77.2%         RUNNABLE
>  18.7%         TIMED_WAITING
>   4.2%         WAITING

Benchmark hardware:
Intel i5 (6 core)
