### PR TITLE
Improve error message when passing wrong args to CLI

### DIFF
--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -123,6 +123,8 @@ public abstract class AbstractShell implements Closeable {
       }
       cmdline = command.parseAndValidateArgs(args);
     } catch (InvalidArgumentException e) {
+      // It outputs a prompt message  when passing wrong args to CLI
+      System.out.println(e.getMessage());
       System.out.println("Usage: " + command.getUsage());
       System.out.println(command.getDescription());
       LOG.error("Invalid arguments for command {}:", command.getCommandName(), e);

--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -123,7 +123,7 @@ public abstract class AbstractShell implements Closeable {
       }
       cmdline = command.parseAndValidateArgs(args);
     } catch (InvalidArgumentException e) {
-      // It outputs a prompt message  when passing wrong args to CLI
+      // It outputs a prompt message when passing wrong args to CLI
       System.out.println(e.getMessage());
       System.out.println("Usage: " + command.getUsage());
       System.out.println(command.getDescription());


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10032


## Describe the bug

```
$ bin/alluxio fs mount --readOnly /input s3://apc999/emr/mid_input_alluxio_alluxio
Usage: mount [--readonly] [--shared] [--option <key=val>] <alluxioPath> <ufsURI>
Mounts a UFS path onto an Alluxio path.
```
The console output should say the `--readOnly` is unrecognized before showing the usage.
After fixed, the correct output is as follows:

```
$ bin/alluxio fs mount --readOnly  /mnt s3://alluxio-quick-start/data
Failed to parse args for mount: Unrecognized option: --readOnly
Usage: mount [--readonly] [--shared] [--option <key=val>] <alluxioPath> <ufsURI>
Mounts a UFS path onto an Alluxio path.
```

## What is the purpose of the change

* Improve error message when passing wrong args to CLI, Here you can find the  [issue](https://github.com/Alluxio/alluxio/issues/10032).

## Brief change log

* I modified the "alluxio/core/common/src/main/java/alluxio/cli/AbstractShell.java" file.
* This is a general solution.

## Verifying this change

*I have verified the changes by entering the wrong command on the client.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
