### PR TITLE
Update the output message for FreeCommand

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/FreeCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/FreeCommand.java
@@ -95,7 +95,7 @@ public final class FreeCommand extends AbstractFileSystemCommand {
     } catch (TimeoutException e) {
       throw new RuntimeException(e);
     }
-    System.out.println(path + " was successfully freed from memory.");
+    System.out.println(path + " was successfully freed from Alluxio space.");
   }
 
   @Override


### PR DESCRIPTION
Previous message of "xxx was successfully freed from memory" is not accurate. Change this to Alluxio space