### PR TITLE
Fix incorrect Helm chart file name upper/lower case

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -193,7 +193,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/docker/conf/alluxio-site.properties.template",
 		"integration/docker/conf/alluxio-env.sh.template",
 		"integration/fuse/bin/alluxio-fuse",
-		"integration/kubernetes/alluxio-configMap.yaml.template",
+		"integration/kubernetes/alluxio-configmap.yaml.template",
 		"integration/kubernetes/alluxio-fuse.yaml.template",
 		"integration/kubernetes/alluxio-fuse-client.yaml.template",
 		"integration/kubernetes/alluxio-master-journal-pv.yaml.template",

--- a/integration/kubernetes/alluxio-configMap.yaml.template
+++ b/integration/kubernetes/alluxio-configMap.yaml.template
@@ -1,1 +1,0 @@
-singleMaster-localJournal/alluxio-configMap.yaml.template

--- a/integration/kubernetes/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/alluxio-configmap.yaml.template
@@ -1,0 +1,1 @@
+singleMaster-localJournal/alluxio-configmap.yaml.template


### PR DESCRIPTION
This change fixes the incorrect upper/lower case in updated Helm chart files and `generate-tarball.go`. The file doesn't exist anymore so the tarball cannot be generated correctly.