### PR TITLE
Increase reliability of ZookeeperFailureIntegrationTest

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -96,7 +96,7 @@ public final class MultiProcessCluster {
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File(Constants.TEST_ARTIFACTS_DIR);
   private static final File TESTS_LOG = new File(Constants.TESTS_LOG);
-  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 5000;
+  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 10000;
 
   private final Map<PropertyKey, String> mProperties;
   private final Map<Integer, Map<PropertyKey, String>> mMasterProperties;


### PR DESCRIPTION
I will be running jenkins test 10 times to see if I still get ZookeeperFailureIntegrationTest failures.