### PR TITLE
Implement blacklist for persisting files

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1702,6 +1702,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
             + "persist) but does not affect CACHE_THROUGH writes. Users may want to specify "
             + "temporary files in the blacklist to avoid unnecessary I/O and errors. Some "
             + "examples are `.staging` and `.tmp`.")
+          .setScope(Scope.MASTER)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_REPLICATION_CHECK_INTERVAL_MS =
       new Builder(Name.MASTER_REPLICATION_CHECK_INTERVAL_MS)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1697,7 +1697,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_PERSISTENCE_BLACKLIST =
       new Builder(Name.MASTER_PERSISTENCE_BLACKLIST)
-          .setDescription("Patterns to blacklist persist, comma separated, string match, no regex.")
+          .setDescription("Patterns to blacklist persist, comma separated, string match, no regex."
+            + " This affects any async persist call (including ASYNC_THROUGH writes and CLI "
+            + "persist) but does not affect CACHE_THROUGH writes. Users may want to specify "
+            + "temporary files in the blacklist to avoid unnecessary I/O and errors. Some "
+            + "examples are `.staging` and `.tmp`.")
           .build();
   public static final PropertyKey MASTER_REPLICATION_CHECK_INTERVAL_MS =
       new Builder(Name.MASTER_REPLICATION_CHECK_INTERVAL_MS)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1697,7 +1697,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_PERSISTENCE_BLACKLIST =
       new Builder(Name.MASTER_PERSISTENCE_BLACKLIST)
-          .setDefaultValue("")
           .setDescription("Patterns to blacklist persist, comma separated, string match, no regex.")
           .build();
   public static final PropertyKey MASTER_REPLICATION_CHECK_INTERVAL_MS =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1695,6 +1695,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("How often the master schedules persistence jobs "
               + "for files written using ASYNC_THROUGH")
           .build();
+  public static final PropertyKey MASTER_PERSISTENCE_BLACKLIST =
+      new Builder(Name.MASTER_PERSISTENCE_BLACKLIST)
+          .setDefaultValue("")
+          .setDescription("Patterns to blacklist persist, comma separated, string match, no regex.")
+          .build();
   public static final PropertyKey MASTER_REPLICATION_CHECK_INTERVAL_MS =
       new Builder(Name.MASTER_REPLICATION_CHECK_INTERVAL_MS)
           .setDefaultValue("1min")
@@ -4015,6 +4020,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.persistence.max.interval";
     public static final String MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS =
         "alluxio.master.persistence.scheduler.interval";
+    public static final String MASTER_PERSISTENCE_BLACKLIST =
+        "alluxio.master.persistence.blacklist";
     public static final String MASTER_LOG_CONFIG_REPORT_HEARTBEAT_INTERVAL =
         "alluxio.master.log.config.report.heartbeat.interval";
     public static final String MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1985,16 +1985,15 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     }
   }
 
-  private static final List<String> PERSISTENCE_BLACKLIST =
-      ServerConfiguration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
-          ? ServerConfiguration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST, ",")
-          : Collections.emptyList();
-
   private boolean shouldPersistPath(String path) {
-    for (String pattern : PERSISTENCE_BLACKLIST) {
+    List<String> blacklist =
+        ServerConfiguration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
+            ? ServerConfiguration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST, ",")
+            : Collections.emptyList();
+    for (String pattern : blacklist) {
       if (path.contains(pattern)) {
         LOG.debug("Not persisting path {} because it is in {} {}", path,
-            PropertyKey.Name.MASTER_PERSISTENCE_BLACKLIST, PERSISTENCE_BLACKLIST);
+            PropertyKey.Name.MASTER_PERSISTENCE_BLACKLIST, blacklist);
         return false;
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2075,7 +2075,7 @@ public final class DefaultFileSystemMaster extends CoreMaster implements FileSys
     // frameworks that use rename as a commit operation.
     if (context.getPersist() && srcInode.isFile() && !srcInode.isPersisted()
         && shouldPersistPath(dstInodePath.toString())) {
-      LOG.debug("Schedule Async Persist on rename for File {}", srcInodePath.toString());
+      LOG.debug("Schedule Async Persist on rename for File {}", srcInodePath);
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(srcInode.getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
@@ -85,10 +85,6 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT,
       "MUST_CACHE", PropertyKey.Name.USER_FILE_PERSIST_ON_RENAME, "true"})
   public void persistOnRenameDirectory() throws Exception {
-    // Set the default write type to MUST_CACHE, so that directories are not persisted by default
-    ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
-    // Set the default behavior to be persist on rename
-    ServerConfiguration.set(PropertyKey.USER_FILE_PERSIST_ON_RENAME, "true");
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
     String toPersist = testDir + "/foo";
     String persisted = testDir + "/foo_persisted";
@@ -108,7 +104,6 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
     checkFilePersisted(new AlluxioURI(persisted + "/foobar1"), 10);
     checkFilePersisted(new AlluxioURI(persisted + "/foobar2"), 20);
-    ServerConfiguration.reset();
   }
 
   @Test
@@ -132,7 +127,6 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     }, WaitForOptions.defaults().setTimeoutMs(10000));
     assertFalse(mFileSystem.getStatus(new AlluxioURI(persisted + "/foobar2")).isPersisted());
     checkFilePersisted(new AlluxioURI(persisted + "/foobar1"), 10);
-    ServerConfiguration.reset();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
@@ -29,7 +29,9 @@ import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.util.CommonUtils;
 import alluxio.util.UnderFileSystemUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
@@ -76,6 +78,60 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
     checkFilePersisted(new AlluxioURI(testDir + "/foo/foobar2"), 20);
     checkFilePersisted(new AlluxioURI(testDir + "/bar/foobar3"), 30);
     checkFilePersisted(new AlluxioURI(testDir + "/foobar4"), 40);
+    ServerConfiguration.reset();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT,
+      "MUST_CACHE", PropertyKey.Name.USER_FILE_PERSIST_ON_RENAME, "true"})
+  public void persistOnRenameDirectory() throws Exception {
+    // Set the default write type to MUST_CACHE, so that directories are not persisted by default
+    ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    // Set the default behavior to be persist on rename
+    ServerConfiguration.set(PropertyKey.USER_FILE_PERSIST_ON_RENAME, "true");
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    String toPersist = testDir + "/foo";
+    String persisted = testDir + "/foo_persisted";
+    String doNotPersist = testDir + "/bar";
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(toPersist)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(doNotPersist)).isPersisted());
+    int ret = mFsShell.run("mv", toPersist, persisted);
+    Assert.assertEquals(0, ret);
+    CommonUtils.waitFor("Directory to be persisted", () -> {
+      try {
+        return mFileSystem.getStatus(new AlluxioURI(persisted)).isPersisted();
+      } catch (Exception e) {
+        return false;
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10000));
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir + "/bar")).isPersisted());
+    checkFilePersisted(new AlluxioURI(persisted + "/foobar1"), 10);
+    checkFilePersisted(new AlluxioURI(persisted + "/foobar2"), 20);
+    ServerConfiguration.reset();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT,
+      "MUST_CACHE", PropertyKey.Name.USER_FILE_PERSIST_ON_RENAME, "true",
+      PropertyKey.Name.MASTER_PERSISTENCE_BLACKLIST, "foobar2"})
+  public void persistOnRenameDirectoryBlacklist() throws Exception {
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+    String toPersist = testDir + "/foo";
+    String persisted = testDir + "/foo_persisted";
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(toPersist)).isPersisted());
+    int ret = mFsShell.run("mv", toPersist, persisted);
+    Assert.assertEquals(0, ret);
+    CommonUtils.waitFor("Directory to be persisted", () -> {
+      try {
+        return mFileSystem.getStatus(new AlluxioURI(persisted)).isPersisted();
+      } catch (Exception e) {
+        return false;
+      }
+    }, WaitForOptions.defaults().setTimeoutMs(10000));
+    assertFalse(mFileSystem.getStatus(new AlluxioURI(persisted + "/foobar2")).isPersisted());
+    checkFilePersisted(new AlluxioURI(persisted + "/foobar1"), 10);
     ServerConfiguration.reset();
   }
 


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/10043

Files containing strings in the blacklist will not be persisted. This can be useful for Alluxio to avoid persisting results too early for workloads like Hive or MapReduce as they typically create temp results first into temp directories, before the entire directory was renamed (as commit).