### PR TITLE
Update the option name in distributedLoad

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
@@ -55,7 +55,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
   private static final Option PARALLELISM_OPTION =
       Option.builder("p")
           .longOpt("parallelism")
-          .argName("# threads")
+          .argName("# concurrent operations")
           .numberOfArgs(1)
           .desc("Number of concurrent persist operations, default: " + DEFAULT_PARALLELISM)
           .required(false)


### PR DESCRIPTION
Consolidate the option name in `distributedLoad` and `persist` regarding parallelism. Using `--thread` is confusing as it is not indicating how many working threads on that machine but number of concurrent operations across an Alluxio cluster