### PR TITLE
Improve distributedCp and distributedMv and Persist

### DIFF
--- a/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/persist/PersistDefinition.java
@@ -12,6 +12,7 @@
 package alluxio.job.persist;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileInStream;
@@ -179,7 +180,7 @@ public final class PersistDefinition
         List<AclEntry> allAcls = Stream.concat(status.getDefaultAcl().getEntries().stream(),
             status.getAcl().getEntries().stream()).collect(Collectors.toList());
         ufs.setAclEntries(dstPath.toString(), allAcls);
-        bytesWritten = IOUtils.copyLarge(in, out);
+        bytesWritten = IOUtils.copyLarge(in, out, new byte[8 * Constants.MB]);
         incrementPersistedMetric(ufsClient.getUfsMountPointUri(), bytesWritten);
       }
       LOG.info("Persisted file {} with size {}", ufsPath, bytesWritten);

--- a/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/migrate/MigrateDefinitionRunTaskTest.java
@@ -29,6 +29,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.job.JobServerContext;
 import alluxio.job.RunTaskContext;
@@ -91,7 +92,8 @@ public final class MigrateDefinitionRunTaskTest {
     when(mMockFileSystemContext.getClusterConf()).thenReturn(conf);
     when(mMockFileSystemContext.getPathConf(any(AlluxioURI.class))).thenReturn(conf);
     mMockInStream = new MockFileInStream(mMockFileSystemContext, TEST_SOURCE_CONTENTS, conf);
-    when(mMockFileSystem.openFile(new AlluxioURI(TEST_SOURCE))).thenReturn(mMockInStream);
+    when(mMockFileSystem.openFile(eq(new AlluxioURI(TEST_SOURCE)),
+        any(OpenFilePOptions.class))).thenReturn(mMockInStream);
     mMockOutStream = new MockFileOutStream(mMockFileSystemContext);
     when(mMockFileSystem.createFile(eq(new AlluxioURI(TEST_DESTINATION)),
         any(CreateFilePOptions.class))).thenReturn(mMockOutStream);

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -536,11 +536,10 @@ public final class CpCommand extends AbstractFileSystemCommand {
    */
   private void copyFile(AlluxioURI srcPath, AlluxioURI dstPath)
       throws AlluxioException, IOException {
-    try (Closer closer = Closer.create()) {
-      FileInStream is = closer.register(mFileSystem.openFile(srcPath));
-      FileOutStream os = closer.register(mFileSystem.createFile(dstPath));
+    try (FileInStream is = mFileSystem.openFile(srcPath);
+         FileOutStream os = mFileSystem.createFile(dstPath)) {
       try {
-        IOUtils.copy(is, os);
+        IOUtils.copyLarge(is, os, new byte[8 * Constants.MB]);
       } catch (Exception e) {
         os.cancel();
         throw e;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
@@ -16,6 +16,8 @@ import alluxio.annotation.PublicApi;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobGrpcClientUtils;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.migrate.MigrateConfig;
@@ -62,7 +64,9 @@ public final class DistributedMvCommand extends AbstractFileSystemCommand {
     Thread thread = CommonUtils.createProgressThread(System.out);
     thread.start();
     try {
-      JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(), null, true,
+      AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
+      JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
           true), 3, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
- Set readtype to `NO_CACHE` to `distributedCp` and `distributedMv` (in migration definition)
- Increase buffersize to 8 MB (from 8KB or less) for these jobs
- Make `distributedMv` carry writetype