### PR TITLE
Propagate UserState to PollingMasterInquireClient

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -566,7 +566,8 @@ public class BaseFileSystem implements FileSystem {
        * user passes. If not, throw an exception letting the user know they don't match.
        */
       Authority configured =
-          MasterInquireClient.Factory.create(mFsContext.getClusterConf())
+          MasterInquireClient.Factory
+              .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
               .getConnectDetails().toAuthority();
       if (!configured.equals(uri.getAuthority())) {
         throw new IllegalArgumentException(

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -167,7 +167,8 @@ public final class FileSystemContext implements Closeable {
       @Nullable AlluxioConfiguration conf) {
     FileSystemContext context = new FileSystemContext();
     ClientContext ctx = ClientContext.create(subject, conf);
-    MasterInquireClient inquireClient = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient inquireClient =
+        MasterInquireClient.Factory.create(ctx.getClusterConf(), ctx.getSubject());
     context.init(ctx, inquireClient);
     return context;
   }
@@ -178,7 +179,8 @@ public final class FileSystemContext implements Closeable {
    */
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
-    ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf()));
+    ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf(),
+        clientContext.getSubject()));
     return ctx;
   }
 
@@ -336,7 +338,8 @@ public final class FileSystemContext implements Closeable {
             + "meta master (%s) during reinitialization", masterAddr), e);
       }
       closeContext();
-      initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf()));
+      initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf(),
+          getClientContext().getSubject()));
       mReinitializer.onSuccess();
     }
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -168,7 +168,7 @@ public final class FileSystemContext implements Closeable {
     FileSystemContext context = new FileSystemContext();
     ClientContext ctx = ClientContext.create(subject, conf);
     MasterInquireClient inquireClient =
-        MasterInquireClient.Factory.create(ctx.getClusterConf(), ctx.getSubject());
+        MasterInquireClient.Factory.create(ctx.getClusterConf(), ctx.getUserState());
     context.init(ctx, inquireClient);
     return context;
   }
@@ -180,7 +180,7 @@ public final class FileSystemContext implements Closeable {
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
     ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf(),
-        clientContext.getSubject()));
+        clientContext.getUserState()));
     return ctx;
   }
 
@@ -339,7 +339,7 @@ public final class FileSystemContext implements Closeable {
       }
       closeContext();
       initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf(),
-          getClientContext().getSubject()));
+          getClientContext().getUserState()));
       mReinitializer.onSuccess();
     }
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
@@ -44,7 +44,8 @@ public class BlockMasterClientPoolTest {
         .thenReturn(expectedClient);
     BlockMasterClient client;
     ClientContext clientContext = ClientContext.create(mConf);
-    MasterInquireClient masterInquireClient = MasterInquireClient.Factory.create(mConf);
+    MasterInquireClient masterInquireClient = MasterInquireClient.Factory
+        .create(mConf, clientContext.getUserState());
     MasterClientContext masterClientContext = MasterClientContext.newBuilder(clientContext)
         .setMasterInquireClient(masterInquireClient).build();
     try (BlockMasterClientPool pool = new BlockMasterClientPool(masterClientContext)) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
@@ -39,7 +39,8 @@ public class FileSystemMasterClientPoolTest {
         .thenReturn(expectedClient);
     FileSystemMasterClient client;
     ClientContext clientContext = ClientContext.create(conf);
-    MasterInquireClient masterInquireClient = MasterInquireClient.Factory.create(conf);
+    MasterInquireClient masterInquireClient = MasterInquireClient.Factory
+        .create(conf, clientContext.getUserState());
     MasterClientContext masterClientContext = MasterClientContext.newBuilder(clientContext)
         .setMasterInquireClient(masterInquireClient).build();
     try (FileSystemMasterClientPool pool = new FileSystemMasterClientPool(masterClientContext)) {

--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -43,7 +43,8 @@ public class MetricsHeartbeatContextTest {
   public void testExecutorInitialized() {
 
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
 
     // Add and delete a single context, make sure it is non null after adding, and then null after
     // removing
@@ -75,7 +76,8 @@ public class MetricsHeartbeatContextTest {
     assertTrue(map.isEmpty());
 
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);
     assertFalse(map.isEmpty());
 
@@ -89,7 +91,8 @@ public class MetricsHeartbeatContextTest {
     InstancedConfiguration conf = ConfigurationTestUtils.defaults();
     conf.set(PropertyKey.MASTER_RPC_ADDRESSES, "master1:19998,master2:19998,master3:19998");
     ClientContext haCtx = ClientContext.create(conf);
-    MetricsHeartbeatContext.addHeartbeat(haCtx, MasterInquireClient.Factory.create(conf));
+    MetricsHeartbeatContext.addHeartbeat(haCtx, MasterInquireClient.Factory
+        .create(conf, haCtx.getUserState()));
     assertEquals(2, map.size());
 
     MetricsHeartbeatContext.removeHeartbeat(ctx);
@@ -113,7 +116,8 @@ public class MetricsHeartbeatContextTest {
     ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
     when(future.cancel(any(Boolean.class))).thenReturn(true);
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);
     assertFalse(map.isEmpty());
     map.forEach((addr, heartbeat) -> {

--- a/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
+++ b/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
@@ -49,7 +49,8 @@ public class MasterClientContextBuilder {
    */
   public MasterClientContext build() {
     if (mMasterInquireClient == null) {
-      mMasterInquireClient = MasterInquireClient.Factory.create(mContext.getClusterConf());
+      mMasterInquireClient = MasterInquireClient.Factory.create(mContext.getClusterConf(),
+          mContext.getSubject());
     }
     return new MasterClientContext(mContext, mMasterInquireClient);
   }

--- a/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
+++ b/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
@@ -50,7 +50,7 @@ public class MasterClientContextBuilder {
   public MasterClientContext build() {
     if (mMasterInquireClient == null) {
       mMasterInquireClient = MasterInquireClient.Factory.create(mContext.getClusterConf(),
-          mContext.getSubject());
+          mContext.getUserState());
     }
     return new MasterClientContext(mContext, mMasterInquireClient);
   }

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
-import javax.security.auth.Subject;
 
 /**
  * PollingMasterInquireClient finds the address of the primary master by polling a list of master
@@ -57,13 +56,13 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   /**
    * @param masterAddresses the potential master addresses
    * @param alluxioConf Alluxio configuration
-   * @param subject user subject
+   * @param userState user state
    */
   public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
       AlluxioConfiguration alluxioConf,
-      Subject subject) {
+      UserState userState) {
     this(masterAddresses, () -> new ExponentialBackoffRetry(20, 2000, 30),
-        alluxioConf, subject);
+        alluxioConf, userState);
   }
 
   /**
@@ -84,16 +83,16 @@ public class PollingMasterInquireClient implements MasterInquireClient {
    * @param masterAddresses the potential master addresses
    * @param retryPolicySupplier the retry policy supplier
    * @param alluxioConf Alluxio configuration
-   * @param subject subject of the user
+   * @param userState user state
    */
   public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
       Supplier<RetryPolicy> retryPolicySupplier,
       AlluxioConfiguration alluxioConf,
-      Subject subject) {
+      UserState userState) {
     mConnectDetails = new MultiMasterConnectDetails(masterAddresses);
     mRetryPolicySupplier = retryPolicySupplier;
     mConfiguration = alluxioConf;
-    mUserState = UserState.Factory.create(mConfiguration, subject);
+    mUserState = userState;
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
+import javax.security.auth.Subject;
 
 /**
  * PollingMasterInquireClient finds the address of the primary master by polling a list of master
@@ -56,11 +57,13 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   /**
    * @param masterAddresses the potential master addresses
    * @param alluxioConf Alluxio configuration
+   * @param subject user subject
    */
   public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
-      AlluxioConfiguration alluxioConf) {
+      AlluxioConfiguration alluxioConf,
+      Subject subject) {
     this(masterAddresses, () -> new ExponentialBackoffRetry(20, 2000, 30),
-        alluxioConf);
+        alluxioConf, subject);
   }
 
   /**
@@ -75,6 +78,22 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     mRetryPolicySupplier = retryPolicySupplier;
     mConfiguration = alluxioConf;
     mUserState = UserState.Factory.create(mConfiguration);
+  }
+
+  /**
+   * @param masterAddresses the potential master addresses
+   * @param retryPolicySupplier the retry policy supplier
+   * @param alluxioConf Alluxio configuration
+   * @param subject subject of the user
+   */
+  public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
+      Supplier<RetryPolicy> retryPolicySupplier,
+      AlluxioConfiguration alluxioConf,
+      Subject subject) {
+    mConnectDetails = new MultiMasterConnectDetails(masterAddresses);
+    mRetryPolicySupplier = retryPolicySupplier;
+    mConfiguration = alluxioConf;
+    mUserState = UserState.Factory.create(mConfiguration, subject);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
@@ -54,7 +55,7 @@ public final class AlluxioWorker {
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.WORKER);
     MasterInquireClient masterInquireClient =
-        MasterInquireClient.Factory.create(ServerConfiguration.global());
+        MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
     try {
       RetryUtils.retry("load cluster default configuration with master", () -> {
         InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();

--- a/job/client/src/main/java/alluxio/client/job/JobContext.java
+++ b/job/client/src/main/java/alluxio/client/job/JobContext.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
+import javax.security.auth.Subject;
 
 /**
  * A shared context that isolates all operations within the same JVM. Usually, one user only needs
@@ -64,7 +65,8 @@ public final class JobContext implements Closeable  {
    * Initializes the context. Only called in the factory methods and reset.
    */
   private synchronized void init(AlluxioConfiguration alluxioConf) {
-    mJobMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(alluxioConf);
+    mJobMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(alluxioConf,
+        new Subject());
     mJobMasterClientPool =
         new JobMasterClientPool(JobMasterClientContext
             .newBuilder(ClientContext.create(alluxioConf)).build());

--- a/job/client/src/main/java/alluxio/client/job/JobContext.java
+++ b/job/client/src/main/java/alluxio/client/job/JobContext.java
@@ -16,6 +16,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
+import alluxio.security.user.UserState;
 import alluxio.worker.job.JobMasterClientContext;
 
 import java.io.Closeable;
@@ -24,7 +25,6 @@ import java.net.InetSocketAddress;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.security.auth.Subject;
 
 /**
  * A shared context that isolates all operations within the same JVM. Usually, one user only needs
@@ -48,11 +48,12 @@ public final class JobContext implements Closeable  {
    * Creates a job context.
    *
    * @param alluxioConf Alluxio configuration
+   * @param userState user state
    * @return the context
    */
-  public static JobContext create(AlluxioConfiguration alluxioConf) {
+  public static JobContext create(AlluxioConfiguration alluxioConf, UserState userState) {
     JobContext context = new JobContext();
-    context.init(alluxioConf);
+    context.init(alluxioConf, userState);
     return context;
   }
 
@@ -64,12 +65,12 @@ public final class JobContext implements Closeable  {
   /**
    * Initializes the context. Only called in the factory methods and reset.
    */
-  private synchronized void init(AlluxioConfiguration alluxioConf) {
-    mJobMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(alluxioConf,
-        new Subject());
+  private synchronized void init(AlluxioConfiguration alluxioConf, UserState userState) {
+    mJobMasterInquireClient = MasterInquireClient.Factory
+        .createForJobMaster(alluxioConf, userState);
     mJobMasterClientPool =
         new JobMasterClientPool(JobMasterClientContext
-            .newBuilder(ClientContext.create(alluxioConf)).build());
+            .newBuilder(ClientContext.create(userState.getSubject(), alluxioConf)).build());
   }
 
   /**

--- a/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
+++ b/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
@@ -42,7 +42,7 @@ public class JobMasterClientContextBuilder extends MasterClientContextBuilder {
   public JobMasterClientContext build() {
     if (mMasterInquireClient == null) {
       mMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(
-          mContext.getClusterConf());
+          mContext.getClusterConf(), mContext.getSubject());
     }
     if (mConfMasterInquireClient == null) {
       mConfMasterInquireClient = MasterInquireClient.Factory.create(

--- a/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
+++ b/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
@@ -42,11 +42,11 @@ public class JobMasterClientContextBuilder extends MasterClientContextBuilder {
   public JobMasterClientContext build() {
     if (mMasterInquireClient == null) {
       mMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(
-          mContext.getClusterConf(), mContext.getSubject());
+          mContext.getClusterConf(), mContext.getUserState());
     }
     if (mConfMasterInquireClient == null) {
       mConfMasterInquireClient = MasterInquireClient.Factory.create(
-              mContext.getClusterConf());
+              mContext.getClusterConf(), mContext.getUserState());
     }
     return new JobMasterClientContext(mContext, mMasterInquireClient, mConfMasterInquireClient);
   }

--- a/job/client/src/test/java/alluxio/client/job/JobContextTest.java
+++ b/job/client/src/test/java/alluxio/client/job/JobContextTest.java
@@ -17,6 +17,7 @@ import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.security.user.UserState;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
@@ -36,7 +37,8 @@ public final class JobContextTest {
 
   @Test
   public void getAddress() throws Exception {
-    try (JobContext context = JobContext.create(sConf)) {
+    UserState userState = UserState.Factory.create(sConf);
+    try (JobContext context = JobContext.create(sConf, userState)) {
       assertEquals("host2", context.getJobMasterAddress().getHostName());
     }
   }

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
@@ -61,7 +62,7 @@ public final class AlluxioJobWorker {
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.JOB_WORKER);
     MasterInquireClient masterInquireClient =
-        MasterInquireClient.Factory.create(ServerConfiguration.global());
+        MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
     try {
       RetryUtils.retry("load cluster default configuration with master", () -> {
         InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -41,7 +41,7 @@ import alluxio.master.ZkMasterInquireClient;
 import alluxio.master.journal.JournalType;
 import alluxio.multi.process.PortCoordination.ReservedPort;
 import alluxio.network.PortUtils;
-import alluxio.security.user.UserState;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
@@ -674,9 +674,8 @@ public final class MultiProcessCluster {
             addresses.add(
                 InetSocketAddress.createUnresolved(address.getHostname(), address.getRpcPort()));
           }
-          UserState userState = UserState.Factory.create(ServerConfiguration.global());
           return new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
-              userState);
+              ServerUserState.global());
         } else {
           return new SingleMasterInquireClient(InetSocketAddress.createUnresolved(
               mMasterAddresses.get(0).getHostname(), mMasterAddresses.get(0).getRpcPort()));

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -41,6 +41,7 @@ import alluxio.master.ZkMasterInquireClient;
 import alluxio.master.journal.JournalType;
 import alluxio.multi.process.PortCoordination.ReservedPort;
 import alluxio.network.PortUtils;
+import alluxio.security.user.UserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
@@ -71,7 +72,6 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.security.auth.Subject;
 
 /**
  * Class for starting, stopping, and interacting with an Alluxio cluster where each master and
@@ -674,8 +674,9 @@ public final class MultiProcessCluster {
             addresses.add(
                 InetSocketAddress.createUnresolved(address.getHostname(), address.getRpcPort()));
           }
+          UserState userState = UserState.Factory.create(ServerConfiguration.global());
           return new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
-              new Subject());
+              userState);
         } else {
           return new SingleMasterInquireClient(InetSocketAddress.createUnresolved(
               mMasterAddresses.get(0).getHostname(), mMasterAddresses.get(0).getRpcPort()));

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import javax.security.auth.Subject;
 
 /**
  * Class for starting, stopping, and interacting with an Alluxio cluster where each master and
@@ -673,7 +674,8 @@ public final class MultiProcessCluster {
             addresses.add(
                 InetSocketAddress.createUnresolved(address.getHostname(), address.getRpcPort()));
           }
-          return new PollingMasterInquireClient(addresses, ServerConfiguration.global());
+          return new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
+              new Subject());
         } else {
           return new SingleMasterInquireClient(InetSocketAddress.createUnresolved(
               mMasterAddresses.get(0).getHostname(), mMasterAddresses.get(0).getRpcPort()));

--- a/shell/src/main/java/alluxio/cli/fs/command/MasterInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MasterInfoCommand.java
@@ -53,7 +53,8 @@ public final class MasterInfoCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) {
     MasterInquireClient inquireClient =
-        MasterInquireClient.Factory.create(mFsContext.getClusterConf());
+        MasterInquireClient.Factory
+            .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState());
     try {
       InetSocketAddress leaderAddress = inquireClient.getPrimaryRpcAddress();
       System.out.println("Current leader master: " + leaderAddress.toString());

--- a/shell/src/main/java/alluxio/cli/job/command/LeaderCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/LeaderCommand.java
@@ -56,8 +56,9 @@ public final class LeaderCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) {
     try {
-      InetSocketAddress address =
-          JobContext.create(mFsContext.getClusterConf()).getJobMasterAddress();
+      InetSocketAddress address = JobContext
+          .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+          .getJobMasterAddress();
       System.out.println(address.getHostName());
     } catch (Exception e) {
       LOG.error("Failed to get the primary job master", e);

--- a/shell/src/main/java/alluxio/cli/job/command/ListCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/ListCommand.java
@@ -59,8 +59,9 @@ public final class ListCommand extends AbstractFileSystemCommand {
 
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
-    try (CloseableResource<JobMasterClient> client =
-        JobContext.create(mFsContext.getClusterConf()).acquireMasterClientResource()) {
+    try (CloseableResource<JobMasterClient> client = JobContext
+        .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+        .acquireMasterClientResource()) {
       List<Long> ids = client.get().list();
       for (long id : ids) {
         System.out.println(id);

--- a/shell/src/main/java/alluxio/cli/job/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/StatCommand.java
@@ -71,7 +71,7 @@ public final class StatCommand extends AbstractFileSystemCommand {
   public int run(CommandLine cl) throws AlluxioException, IOException {
     long id = Long.parseLong(cl.getArgs()[0]);
     try (CloseableResource<JobMasterClient> client =
-        JobContext.create(mFsContext.getClusterConf())
+        JobContext.create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
             .acquireMasterClientResource()) {
       JobInfo info = client.get().getStatus(id);
       System.out.print(formatOutput(cl, info));

--- a/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
+++ b/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
@@ -17,6 +17,7 @@ import alluxio.common.RpcPortHealthCheckClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.RetryPolicy;
+import alluxio.security.user.UserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.ShellUtils;
@@ -192,7 +193,8 @@ public class MasterHealthCheckClient implements HealthCheckClient {
 
     @Override
     public void run() {
-      MasterInquireClient client = MasterInquireClient.Factory.create(mConf);
+      UserState userState = UserState.Factory.create(mConf);
+      MasterInquireClient client = MasterInquireClient.Factory.create(mConf, userState);
       try {
         while (true) {
           List<InetSocketAddress> addresses = client.getMasterRpcAddresses();

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -260,9 +260,9 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
   public void queryStandby() throws Exception {
     List<InetSocketAddress> addresses = mMultiMasterLocalAlluxioCluster.getMasterAddresses();
     Collections.shuffle(addresses);
-    PollingMasterInquireClient inquireClient =
-        new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
-            FileSystemContext.create(ServerConfiguration.global()).getClientContext().getSubject());
+    PollingMasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
+        ServerConfiguration.global(),
+        FileSystemContext.create(ServerConfiguration.global()).getClientContext().getUserState());
     assertEquals(mMultiMasterLocalAlluxioCluster.getLocalAlluxioMaster().getAddress(),
         inquireClient.getPrimaryRpcAddress());
   }

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -35,6 +35,7 @@ import alluxio.hadoop.HadoopClientTestUtils;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.master.PollingMasterInquireClient;
 import alluxio.master.block.BlockMaster;
+import alluxio.security.user.ServerUserState;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.IntegrationTestUtils;
 import alluxio.util.CommonUtils;
@@ -261,8 +262,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     List<InetSocketAddress> addresses = mMultiMasterLocalAlluxioCluster.getMasterAddresses();
     Collections.shuffle(addresses);
     PollingMasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
-        ServerConfiguration.global(),
-        FileSystemContext.create(ServerConfiguration.global()).getClientContext().getUserState());
+        ServerConfiguration.global(), ServerUserState.global());
     assertEquals(mMultiMasterLocalAlluxioCluster.getLocalAlluxioMaster().getAddress(),
         inquireClient.getPrimaryRpcAddress());
   }

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -261,7 +261,8 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     List<InetSocketAddress> addresses = mMultiMasterLocalAlluxioCluster.getMasterAddresses();
     Collections.shuffle(addresses);
     PollingMasterInquireClient inquireClient =
-        new PollingMasterInquireClient(addresses, ServerConfiguration.global());
+        new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
+            FileSystemContext.create(ServerConfiguration.global()).getClientContext().getSubject());
     assertEquals(mMultiMasterLocalAlluxioCluster.getLocalAlluxioMaster().getAddress(),
         inquireClient.getPrimaryRpcAddress());
   }


### PR DESCRIPTION
Currently `PollingMasterInquireClient` uses a new `Subject` when querying master. If the call needs authentication using credentials from `Subject`, it will fail the request because the credentials are missing. This change add parameters to APIs to allow passing in the required `Subject`.

Manually tested with external `Subject` from Hadoop client.