### PR TITLE
Override EJ election timeout for single-master cluster

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1258,14 +1258,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT =
-      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT)
-          .setDescription(
-              "The election timeout to use for single master embedded journal cluster.")
-          .setDefaultValue("500ms")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL)
           .setDescription(
@@ -3997,8 +3989,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.addresses";
     public static final String MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT =
         "alluxio.master.embedded.journal.election.timeout";
-    public static final String MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT =
-        "alluxio.master.embedded.journal.single.master.election.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
         "alluxio.master.embedded.journal.appender.batch.size";
     public static final String MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1258,6 +1258,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT)
+          .setDescription(
+              "The election timeout to use for single master embedded journal cluster.")
+          .setDefaultValue("500ms")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL)
           .setDescription(
@@ -3989,6 +3997,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.addresses";
     public static final String MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT =
         "alluxio.master.embedded.journal.election.timeout";
+    public static final String MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT =
+        "alluxio.master.embedded.journal.single.master.election.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
         "alluxio.master.embedded.journal.appender.batch.size";
     public static final String MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -122,6 +122,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class RaftJournalSystem extends AbstractJournalSystem {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalSystem.class);
 
+  private static final long SINGLE_MASTER_ELECTION_TIMEOUT = 500;
+
   /// Lifecycle: constant from when the journal system is constructed.
 
   private final RaftJournalConfiguration mConf;
@@ -175,17 +177,7 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
    * @param conf raft journal configuration
    */
   private RaftJournalSystem(RaftJournalConfiguration conf) {
-    // Override election/heartbeat timeouts for single master cluster.
-    if (conf.getClusterAddresses().size() == 1) {
-      long electionTimeout = ServerConfiguration
-          .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_SINGLE_MASTER_ELECTION_TIMEOUT);
-      LOG.debug("Overriding election timeout to {} for single master cluster.", electionTimeout);
-      conf.setElectionTimeoutMs(electionTimeout);
-      // Use the highest heartbeat internal relative to election timeout.
-      conf.setHeartbeatIntervalMs(Math.max(1, (electionTimeout / 2) - 1));
-    }
-    conf.validate();
-    mConf = conf;
+    mConf = processRaftConfiguration(conf);
     mJournals = new ConcurrentHashMap<>();
     mSnapshotAllowed = new AtomicBoolean(true);
     mJournalStateLock = new ReentrantReadWriteLock(true);
@@ -202,6 +194,23 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
   public static RaftJournalSystem create(RaftJournalConfiguration conf) {
     RaftJournalSystem system = new RaftJournalSystem(conf);
     return system;
+  }
+
+  private RaftJournalConfiguration processRaftConfiguration(RaftJournalConfiguration conf) {
+    // Override election/heartbeat timeouts for single master cluster
+    // if election timeout is not set explicitly.
+    // This is to speed up single master cluster boot-up.
+    if (conf.getClusterAddresses().size() == 1
+        && !ServerConfiguration.isSet(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)) {
+      LOG.debug("Overriding election timeout to {} for single master cluster.",
+          SINGLE_MASTER_ELECTION_TIMEOUT);
+      conf.setElectionTimeoutMs(SINGLE_MASTER_ELECTION_TIMEOUT);
+      // Use the highest heartbeat internal relative to election timeout.
+      conf.setHeartbeatIntervalMs(Math.max(1, (SINGLE_MASTER_ELECTION_TIMEOUT / 2) - 1));
+    }
+    // Validate the conf.
+    conf.validate();
+    return conf;
   }
 
   private synchronized void initServer() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -203,11 +203,11 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
     // This is to speed up single master cluster boot-up.
     if (conf.getClusterAddresses().size() == 1
         && !ServerConfiguration.isSet(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)) {
-      LOG.debug("Overriding election timeout to {} for single master cluster.",
+      LOG.debug("Overriding election timeout to {}ms for single master cluster.",
           SINGLE_MASTER_ELECTION_TIMEOUT_MS);
       conf.setElectionTimeoutMs(SINGLE_MASTER_ELECTION_TIMEOUT_MS);
       // Use the highest heartbeat internal relative to election timeout.
-      conf.setHeartbeatIntervalMs(Math.max(1, (SINGLE_MASTER_ELECTION_TIMEOUT_MS / 2) - 1));
+      conf.setHeartbeatIntervalMs((SINGLE_MASTER_ELECTION_TIMEOUT_MS / 2) - 1);
     }
     // Validate the conf.
     conf.validate();

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -122,7 +122,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class RaftJournalSystem extends AbstractJournalSystem {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalSystem.class);
 
-  private static final long SINGLE_MASTER_ELECTION_TIMEOUT = 500;
+  // Election timeout to use in a single master cluster.
+  private static final long SINGLE_MASTER_ELECTION_TIMEOUT_MS = 500;
 
   /// Lifecycle: constant from when the journal system is constructed.
 
@@ -203,10 +204,10 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
     if (conf.getClusterAddresses().size() == 1
         && !ServerConfiguration.isSet(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)) {
       LOG.debug("Overriding election timeout to {} for single master cluster.",
-          SINGLE_MASTER_ELECTION_TIMEOUT);
-      conf.setElectionTimeoutMs(SINGLE_MASTER_ELECTION_TIMEOUT);
+          SINGLE_MASTER_ELECTION_TIMEOUT_MS);
+      conf.setElectionTimeoutMs(SINGLE_MASTER_ELECTION_TIMEOUT_MS);
       // Use the highest heartbeat internal relative to election timeout.
-      conf.setHeartbeatIntervalMs(Math.max(1, (SINGLE_MASTER_ELECTION_TIMEOUT / 2) - 1));
+      conf.setHeartbeatIntervalMs(Math.max(1, (SINGLE_MASTER_ELECTION_TIMEOUT_MS / 2) - 1));
     }
     // Validate the conf.
     conf.validate();

--- a/docs/en/deploy/Running-Alluxio-On-a-HA-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-HA-Cluster.md
@@ -354,6 +354,8 @@ Note: Adding to an already shut down cluster still requires adding only single m
 Note: When adding a master to a single master cluster, you should shut down and update configuration for the existing master.
 Then both masters could be started together.
 
+See [here]({{ '/en/operation/Journal.html' | relativize_url }}) for configuring embedded journal.
+
 ##### Removing a master
 Embedded journal cluster will take a notice when a member is not available anymore. Such masters will count
 against failure tolerance of the cluster based on the initial member count. In order to resize the cluster

--- a/docs/en/deploy/Running-Alluxio-On-a-HA-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-HA-Cluster.md
@@ -351,6 +351,9 @@ Below are the steps to add a new master to a live cluster:
 
 Note: Adding to an already shut down cluster still requires adding only single master at a time.
 
+Note: When adding a master to a single master cluster, you should shut down and update configuration for the existing master.
+Then both masters could be started together.
+
 ##### Removing a master
 Embedded journal cluster will take a notice when a member is not available anymore. Such masters will count
 against failure tolerance of the cluster based on the initial member count. In order to resize the cluster


### PR DESCRIPTION
EmbeddedJournal cluster will take 2 election timeouts to elect a leader even when it's a single master. This change is to override election timeouts to lower values in single master cluster.

Fixes https://github.com/Alluxio/alluxio/issues/10122