### PR TITLE
Add recently modified/failed jobs to the report

### DIFF
--- a/core/transport/src/grpc/job_master.proto
+++ b/core/transport/src/grpc/job_master.proto
@@ -41,8 +41,8 @@ message StatusSummary {
 
 message JobServiceSummary {
   repeated StatusSummary summaryPerStatus = 1;
-  repeated JobInfo lastActivities = 2;
-  repeated JobInfo lastFailures = 3;
+  repeated JobInfo recentActivities = 2;
+  repeated JobInfo recentFailures = 3;
 }
 
 message JobCommand {

--- a/core/transport/src/grpc/job_master.proto
+++ b/core/transport/src/grpc/job_master.proto
@@ -31,6 +31,7 @@ message JobInfo {
   repeated TaskInfo taskInfos = 3;
   optional Status status = 4;
   optional string result = 5;
+  optional int64 lastStatusChangeMs = 6;
 }
 
 message StatusSummary {
@@ -40,6 +41,8 @@ message StatusSummary {
 
 message JobServiceSummary {
   repeated StatusSummary summaryPerStatus = 1;
+  repeated JobInfo lastActivities = 2;
+  repeated JobInfo lastFailures = 3;
 }
 
 message JobCommand {

--- a/core/transport/src/main/java/alluxio/grpc/JobInfo.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobInfo.java
@@ -21,6 +21,7 @@ private static final long serialVersionUID = 0L;
     taskInfos_ = java.util.Collections.emptyList();
     status_ = 0;
     result_ = "";
+    lastStatusChangeMs_ = 0L;
   }
 
   @java.lang.Override
@@ -89,6 +90,11 @@ private static final long serialVersionUID = 0L;
             com.google.protobuf.ByteString bs = input.readBytes();
             bitField0_ |= 0x00000008;
             result_ = bs;
+            break;
+          }
+          case 48: {
+            bitField0_ |= 0x00000010;
+            lastStatusChangeMs_ = input.readInt64();
             break;
           }
         }
@@ -269,6 +275,21 @@ private static final long serialVersionUID = 0L;
     }
   }
 
+  public static final int LASTSTATUSCHANGEMS_FIELD_NUMBER = 6;
+  private long lastStatusChangeMs_;
+  /**
+   * <code>optional int64 lastStatusChangeMs = 6;</code>
+   */
+  public boolean hasLastStatusChangeMs() {
+    return ((bitField0_ & 0x00000010) == 0x00000010);
+  }
+  /**
+   * <code>optional int64 lastStatusChangeMs = 6;</code>
+   */
+  public long getLastStatusChangeMs() {
+    return lastStatusChangeMs_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -296,6 +317,9 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000008) == 0x00000008)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 5, result_);
     }
+    if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      output.writeInt64(6, lastStatusChangeMs_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -321,6 +345,10 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000008) == 0x00000008)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, result_);
+    }
+    if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(6, lastStatusChangeMs_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -359,6 +387,11 @@ private static final long serialVersionUID = 0L;
       result = result && getResult()
           .equals(other.getResult());
     }
+    result = result && (hasLastStatusChangeMs() == other.hasLastStatusChangeMs());
+    if (hasLastStatusChangeMs()) {
+      result = result && (getLastStatusChangeMs()
+          == other.getLastStatusChangeMs());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -390,6 +423,11 @@ private static final long serialVersionUID = 0L;
     if (hasResult()) {
       hash = (37 * hash) + RESULT_FIELD_NUMBER;
       hash = (53 * hash) + getResult().hashCode();
+    }
+    if (hasLastStatusChangeMs()) {
+      hash = (37 * hash) + LASTSTATUSCHANGEMS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getLastStatusChangeMs());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -535,6 +573,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000008);
       result_ = "";
       bitField0_ = (bitField0_ & ~0x00000010);
+      lastStatusChangeMs_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000020);
       return this;
     }
 
@@ -584,6 +624,10 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000008;
       }
       result.result_ = result_;
+      if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        to_bitField0_ |= 0x00000010;
+      }
+      result.lastStatusChangeMs_ = lastStatusChangeMs_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -667,6 +711,9 @@ private static final long serialVersionUID = 0L;
         bitField0_ |= 0x00000010;
         result_ = other.result_;
         onChanged();
+      }
+      if (other.hasLastStatusChangeMs()) {
+        setLastStatusChangeMs(other.getLastStatusChangeMs());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1152,6 +1199,38 @@ private static final long serialVersionUID = 0L;
   }
   bitField0_ |= 0x00000010;
       result_ = value;
+      onChanged();
+      return this;
+    }
+
+    private long lastStatusChangeMs_ ;
+    /**
+     * <code>optional int64 lastStatusChangeMs = 6;</code>
+     */
+    public boolean hasLastStatusChangeMs() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional int64 lastStatusChangeMs = 6;</code>
+     */
+    public long getLastStatusChangeMs() {
+      return lastStatusChangeMs_;
+    }
+    /**
+     * <code>optional int64 lastStatusChangeMs = 6;</code>
+     */
+    public Builder setLastStatusChangeMs(long value) {
+      bitField0_ |= 0x00000020;
+      lastStatusChangeMs_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 lastStatusChangeMs = 6;</code>
+     */
+    public Builder clearLastStatusChangeMs() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      lastStatusChangeMs_ = 0L;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/JobInfoOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobInfoOrBuilder.java
@@ -76,4 +76,13 @@ public interface JobInfoOrBuilder extends
    */
   com.google.protobuf.ByteString
       getResultBytes();
+
+  /**
+   * <code>optional int64 lastStatusChangeMs = 6;</code>
+   */
+  boolean hasLastStatusChangeMs();
+  /**
+   * <code>optional int64 lastStatusChangeMs = 6;</code>
+   */
+  long getLastStatusChangeMs();
 }

--- a/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
@@ -172,75 +172,79 @@ public final class JobMasterProto {
       "b\032\021grpc/common.proto\"y\n\010TaskInfo\022\r\n\005jobI" +
       "d\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\005\022(\n\006status\030\003 \001(\0162" +
       "\030.alluxio.grpc.job.Status\022\024\n\014errorMessag" +
-      "e\030\004 \001(\t\022\016\n\006result\030\005 \001(\014\"\224\001\n\007JobInfo\022\n\n\002i" +
+      "e\030\004 \001(\t\022\016\n\006result\030\005 \001(\014\"\260\001\n\007JobInfo\022\n\n\002i" +
       "d\030\001 \001(\003\022\024\n\014errorMessage\030\002 \001(\t\022-\n\ttaskInf" +
       "os\030\003 \003(\0132\032.alluxio.grpc.job.TaskInfo\022(\n\006" +
       "status\030\004 \001(\0162\030.alluxio.grpc.job.Status\022\016" +
-      "\n\006result\030\005 \001(\t\"H\n\rStatusSummary\022(\n\006statu" +
-      "s\030\001 \001(\0162\030.alluxio.grpc.job.Status\022\r\n\005cou" +
-      "nt\030\002 \001(\003\"N\n\021JobServiceSummary\0229\n\020summary" +
-      "PerStatus\030\001 \003(\0132\037.alluxio.grpc.job.Statu" +
-      "sSummary\"\302\001\n\nJobCommand\0228\n\016runTaskComman" +
-      "d\030\001 \001(\0132 .alluxio.grpc.job.RunTaskComman" +
-      "d\022>\n\021cancelTaskCommand\030\002 \001(\0132#.alluxio.g" +
-      "rpc.job.CancelTaskCommand\022:\n\017registerCom" +
-      "mand\030\003 \001(\0132!.alluxio.grpc.job.RegisterCo" +
-      "mmand\"T\n\016RunTaskCommand\022\r\n\005jobId\030\001 \001(\003\022\016" +
-      "\n\006taskId\030\002 \001(\005\022\021\n\tjobConfig\030\003 \001(\014\022\020\n\010tas" +
-      "kArgs\030\004 \001(\014\"\021\n\017RegisterCommand\"2\n\021Cancel" +
-      "TaskCommand\022\r\n\005jobId\030\001 \001(\003\022\016\n\006taskId\030\002 \001" +
-      "(\005\"\020\n\016CancelPOptions\"R\n\016CancelPRequest\022\r" +
-      "\n\005jobId\030\001 \001(\003\0221\n\007options\030\002 \001(\0132 .alluxio" +
-      ".grpc.job.CancelPOptions\"\021\n\017CancelPRespo" +
-      "nse\"\026\n\024GetJobStatusPOptions\"^\n\024GetJobSta" +
-      "tusPRequest\022\r\n\005jobId\030\001 \001(\003\0227\n\007options\030\002 " +
-      "\001(\0132&.alluxio.grpc.job.GetJobStatusPOpti" +
-      "ons\"C\n\025GetJobStatusPResponse\022*\n\007jobInfo\030" +
-      "\001 \001(\0132\031.alluxio.grpc.job.JobInfo\"\021\n\017List" +
-      "AllPOptions\"E\n\017ListAllPRequest\0222\n\007option" +
-      "s\030\001 \001(\0132!.alluxio.grpc.job.ListAllPOptio" +
-      "ns\"\"\n\020ListAllPResponse\022\016\n\006jobIds\030\001 \003(\003\"\r" +
-      "\n\013RunPOptions\"P\n\013RunPRequest\022\021\n\tjobConfi" +
-      "g\030\001 \001(\014\022.\n\007options\030\002 \001(\0132\035.alluxio.grpc." +
-      "job.RunPOptions\"\035\n\014RunPResponse\022\r\n\005jobId" +
-      "\030\001 \001(\003\"\036\n\034GetJobServiceSummaryPOptions\"_" +
-      "\n\034GetJobServiceSummaryPRequest\022?\n\007option" +
-      "s\030\001 \001(\0132..alluxio.grpc.job.GetJobService" +
-      "SummaryPOptions\"U\n\035GetJobServiceSummaryP" +
-      "Response\0224\n\007summary\030\001 \001(\0132#.alluxio.grpc" +
-      ".job.JobServiceSummary\"\026\n\024JobHeartbeatPO" +
-      "ptions\"\220\001\n\024JobHeartbeatPRequest\022\020\n\010worke" +
-      "rId\030\001 \001(\003\022-\n\ttaskInfos\030\002 \003(\0132\032.alluxio.g" +
-      "rpc.job.TaskInfo\0227\n\007options\030\003 \001(\0132&.allu" +
-      "xio.grpc.job.JobHeartbeatPOptions\"G\n\025Job" +
-      "HeartbeatPResponse\022.\n\010commands\030\001 \003(\0132\034.a" +
-      "lluxio.grpc.job.JobCommand\"\033\n\031RegisterJo" +
-      "bWorkerPOptions\"\223\001\n\031RegisterJobWorkerPRe" +
-      "quest\0228\n\020workerNetAddress\030\001 \001(\0132\036.alluxi" +
-      "o.grpc.WorkerNetAddress\022<\n\007options\030\002 \001(\013" +
-      "2+.alluxio.grpc.job.RegisterJobWorkerPOp" +
-      "tions\"(\n\032RegisterJobWorkerPResponse\022\n\n\002i" +
-      "d\030\001 \001(\003*X\n\006Status\022\013\n\007UNKNOWN\020\000\022\013\n\007CREATE" +
-      "D\020\001\022\014\n\010CANCELED\020\002\022\n\n\006FAILED\020\003\022\013\n\007RUNNING" +
-      "\020\004\022\r\n\tCOMPLETED\020\0052\331\003\n\026JobMasterClientSer" +
-      "vice\022M\n\006Cancel\022 .alluxio.grpc.job.Cancel" +
-      "PRequest\032!.alluxio.grpc.job.CancelPRespo" +
-      "nse\022_\n\014GetJobStatus\022&.alluxio.grpc.job.G" +
-      "etJobStatusPRequest\032\'.alluxio.grpc.job.G" +
-      "etJobStatusPResponse\022w\n\024GetJobServiceSum" +
-      "mary\022..alluxio.grpc.job.GetJobServiceSum" +
-      "maryPRequest\032/.alluxio.grpc.job.GetJobSe" +
-      "rviceSummaryPResponse\022P\n\007ListAll\022!.allux" +
-      "io.grpc.job.ListAllPRequest\032\".alluxio.gr" +
-      "pc.job.ListAllPResponse\022D\n\003Run\022\035.alluxio" +
-      ".grpc.job.RunPRequest\032\036.alluxio.grpc.job" +
-      ".RunPResponse2\346\001\n\026JobMasterWorkerService" +
-      "\022\\\n\tHeartbeat\022&.alluxio.grpc.job.JobHear" +
-      "tbeatPRequest\032\'.alluxio.grpc.job.JobHear" +
-      "tbeatPResponse\022n\n\021RegisterJobWorker\022+.al" +
-      "luxio.grpc.job.RegisterJobWorkerPRequest" +
-      "\032,.alluxio.grpc.job.RegisterJobWorkerPRe" +
-      "sponseB \n\014alluxio.grpcB\016JobMasterProtoP\001"
+      "\n\006result\030\005 \001(\t\022\032\n\022lastStatusChangeMs\030\006 \001" +
+      "(\003\"H\n\rStatusSummary\022(\n\006status\030\001 \001(\0162\030.al" +
+      "luxio.grpc.job.Status\022\r\n\005count\030\002 \001(\003\"\262\001\n" +
+      "\021JobServiceSummary\0229\n\020summaryPerStatus\030\001" +
+      " \003(\0132\037.alluxio.grpc.job.StatusSummary\0221\n" +
+      "\016lastActivities\030\002 \003(\0132\031.alluxio.grpc.job" +
+      ".JobInfo\022/\n\014lastFailures\030\003 \003(\0132\031.alluxio" +
+      ".grpc.job.JobInfo\"\302\001\n\nJobCommand\0228\n\016runT" +
+      "askCommand\030\001 \001(\0132 .alluxio.grpc.job.RunT" +
+      "askCommand\022>\n\021cancelTaskCommand\030\002 \001(\0132#." +
+      "alluxio.grpc.job.CancelTaskCommand\022:\n\017re" +
+      "gisterCommand\030\003 \001(\0132!.alluxio.grpc.job.R" +
+      "egisterCommand\"T\n\016RunTaskCommand\022\r\n\005jobI" +
+      "d\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\005\022\021\n\tjobConfig\030\003 \001" +
+      "(\014\022\020\n\010taskArgs\030\004 \001(\014\"\021\n\017RegisterCommand\"" +
+      "2\n\021CancelTaskCommand\022\r\n\005jobId\030\001 \001(\003\022\016\n\006t" +
+      "askId\030\002 \001(\005\"\020\n\016CancelPOptions\"R\n\016CancelP" +
+      "Request\022\r\n\005jobId\030\001 \001(\003\0221\n\007options\030\002 \001(\0132" +
+      " .alluxio.grpc.job.CancelPOptions\"\021\n\017Can" +
+      "celPResponse\"\026\n\024GetJobStatusPOptions\"^\n\024" +
+      "GetJobStatusPRequest\022\r\n\005jobId\030\001 \001(\003\0227\n\007o" +
+      "ptions\030\002 \001(\0132&.alluxio.grpc.job.GetJobSt" +
+      "atusPOptions\"C\n\025GetJobStatusPResponse\022*\n" +
+      "\007jobInfo\030\001 \001(\0132\031.alluxio.grpc.job.JobInf" +
+      "o\"\021\n\017ListAllPOptions\"E\n\017ListAllPRequest\022" +
+      "2\n\007options\030\001 \001(\0132!.alluxio.grpc.job.List" +
+      "AllPOptions\"\"\n\020ListAllPResponse\022\016\n\006jobId" +
+      "s\030\001 \003(\003\"\r\n\013RunPOptions\"P\n\013RunPRequest\022\021\n" +
+      "\tjobConfig\030\001 \001(\014\022.\n\007options\030\002 \001(\0132\035.allu" +
+      "xio.grpc.job.RunPOptions\"\035\n\014RunPResponse" +
+      "\022\r\n\005jobId\030\001 \001(\003\"\036\n\034GetJobServiceSummaryP" +
+      "Options\"_\n\034GetJobServiceSummaryPRequest\022" +
+      "?\n\007options\030\001 \001(\0132..alluxio.grpc.job.GetJ" +
+      "obServiceSummaryPOptions\"U\n\035GetJobServic" +
+      "eSummaryPResponse\0224\n\007summary\030\001 \001(\0132#.all" +
+      "uxio.grpc.job.JobServiceSummary\"\026\n\024JobHe" +
+      "artbeatPOptions\"\220\001\n\024JobHeartbeatPRequest" +
+      "\022\020\n\010workerId\030\001 \001(\003\022-\n\ttaskInfos\030\002 \003(\0132\032." +
+      "alluxio.grpc.job.TaskInfo\0227\n\007options\030\003 \001" +
+      "(\0132&.alluxio.grpc.job.JobHeartbeatPOptio" +
+      "ns\"G\n\025JobHeartbeatPResponse\022.\n\010commands\030" +
+      "\001 \003(\0132\034.alluxio.grpc.job.JobCommand\"\033\n\031R" +
+      "egisterJobWorkerPOptions\"\223\001\n\031RegisterJob" +
+      "WorkerPRequest\0228\n\020workerNetAddress\030\001 \001(\013" +
+      "2\036.alluxio.grpc.WorkerNetAddress\022<\n\007opti" +
+      "ons\030\002 \001(\0132+.alluxio.grpc.job.RegisterJob" +
+      "WorkerPOptions\"(\n\032RegisterJobWorkerPResp" +
+      "onse\022\n\n\002id\030\001 \001(\003*X\n\006Status\022\013\n\007UNKNOWN\020\000\022" +
+      "\013\n\007CREATED\020\001\022\014\n\010CANCELED\020\002\022\n\n\006FAILED\020\003\022\013" +
+      "\n\007RUNNING\020\004\022\r\n\tCOMPLETED\020\0052\331\003\n\026JobMaster" +
+      "ClientService\022M\n\006Cancel\022 .alluxio.grpc.j" +
+      "ob.CancelPRequest\032!.alluxio.grpc.job.Can" +
+      "celPResponse\022_\n\014GetJobStatus\022&.alluxio.g" +
+      "rpc.job.GetJobStatusPRequest\032\'.alluxio.g" +
+      "rpc.job.GetJobStatusPResponse\022w\n\024GetJobS" +
+      "erviceSummary\022..alluxio.grpc.job.GetJobS" +
+      "erviceSummaryPRequest\032/.alluxio.grpc.job" +
+      ".GetJobServiceSummaryPResponse\022P\n\007ListAl" +
+      "l\022!.alluxio.grpc.job.ListAllPRequest\032\".a" +
+      "lluxio.grpc.job.ListAllPResponse\022D\n\003Run\022" +
+      "\035.alluxio.grpc.job.RunPRequest\032\036.alluxio" +
+      ".grpc.job.RunPResponse2\346\001\n\026JobMasterWork" +
+      "erService\022\\\n\tHeartbeat\022&.alluxio.grpc.jo" +
+      "b.JobHeartbeatPRequest\032\'.alluxio.grpc.jo" +
+      "b.JobHeartbeatPResponse\022n\n\021RegisterJobWo" +
+      "rker\022+.alluxio.grpc.job.RegisterJobWorke" +
+      "rPRequest\032,.alluxio.grpc.job.RegisterJob" +
+      "WorkerPResponseB \n\014alluxio.grpcB\016JobMast" +
+      "erProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -266,7 +270,7 @@ public final class JobMasterProto {
     internal_static_alluxio_grpc_job_JobInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_job_JobInfo_descriptor,
-        new java.lang.String[] { "Id", "ErrorMessage", "TaskInfos", "Status", "Result", });
+        new java.lang.String[] { "Id", "ErrorMessage", "TaskInfos", "Status", "Result", "LastStatusChangeMs", });
     internal_static_alluxio_grpc_job_StatusSummary_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_alluxio_grpc_job_StatusSummary_fieldAccessorTable = new
@@ -278,7 +282,7 @@ public final class JobMasterProto {
     internal_static_alluxio_grpc_job_JobServiceSummary_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_job_JobServiceSummary_descriptor,
-        new java.lang.String[] { "SummaryPerStatus", });
+        new java.lang.String[] { "SummaryPerStatus", "LastActivities", "LastFailures", });
     internal_static_alluxio_grpc_job_JobCommand_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_grpc_job_JobCommand_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
@@ -178,73 +178,73 @@ public final class JobMasterProto {
       "status\030\004 \001(\0162\030.alluxio.grpc.job.Status\022\016" +
       "\n\006result\030\005 \001(\t\022\032\n\022lastStatusChangeMs\030\006 \001" +
       "(\003\"H\n\rStatusSummary\022(\n\006status\030\001 \001(\0162\030.al" +
-      "luxio.grpc.job.Status\022\r\n\005count\030\002 \001(\003\"\262\001\n" +
+      "luxio.grpc.job.Status\022\r\n\005count\030\002 \001(\003\"\266\001\n" +
       "\021JobServiceSummary\0229\n\020summaryPerStatus\030\001" +
-      " \003(\0132\037.alluxio.grpc.job.StatusSummary\0221\n" +
-      "\016lastActivities\030\002 \003(\0132\031.alluxio.grpc.job" +
-      ".JobInfo\022/\n\014lastFailures\030\003 \003(\0132\031.alluxio" +
-      ".grpc.job.JobInfo\"\302\001\n\nJobCommand\0228\n\016runT" +
-      "askCommand\030\001 \001(\0132 .alluxio.grpc.job.RunT" +
-      "askCommand\022>\n\021cancelTaskCommand\030\002 \001(\0132#." +
-      "alluxio.grpc.job.CancelTaskCommand\022:\n\017re" +
-      "gisterCommand\030\003 \001(\0132!.alluxio.grpc.job.R" +
-      "egisterCommand\"T\n\016RunTaskCommand\022\r\n\005jobI" +
-      "d\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\005\022\021\n\tjobConfig\030\003 \001" +
-      "(\014\022\020\n\010taskArgs\030\004 \001(\014\"\021\n\017RegisterCommand\"" +
-      "2\n\021CancelTaskCommand\022\r\n\005jobId\030\001 \001(\003\022\016\n\006t" +
-      "askId\030\002 \001(\005\"\020\n\016CancelPOptions\"R\n\016CancelP" +
-      "Request\022\r\n\005jobId\030\001 \001(\003\0221\n\007options\030\002 \001(\0132" +
-      " .alluxio.grpc.job.CancelPOptions\"\021\n\017Can" +
-      "celPResponse\"\026\n\024GetJobStatusPOptions\"^\n\024" +
-      "GetJobStatusPRequest\022\r\n\005jobId\030\001 \001(\003\0227\n\007o" +
-      "ptions\030\002 \001(\0132&.alluxio.grpc.job.GetJobSt" +
-      "atusPOptions\"C\n\025GetJobStatusPResponse\022*\n" +
-      "\007jobInfo\030\001 \001(\0132\031.alluxio.grpc.job.JobInf" +
-      "o\"\021\n\017ListAllPOptions\"E\n\017ListAllPRequest\022" +
-      "2\n\007options\030\001 \001(\0132!.alluxio.grpc.job.List" +
-      "AllPOptions\"\"\n\020ListAllPResponse\022\016\n\006jobId" +
-      "s\030\001 \003(\003\"\r\n\013RunPOptions\"P\n\013RunPRequest\022\021\n" +
-      "\tjobConfig\030\001 \001(\014\022.\n\007options\030\002 \001(\0132\035.allu" +
-      "xio.grpc.job.RunPOptions\"\035\n\014RunPResponse" +
-      "\022\r\n\005jobId\030\001 \001(\003\"\036\n\034GetJobServiceSummaryP" +
-      "Options\"_\n\034GetJobServiceSummaryPRequest\022" +
-      "?\n\007options\030\001 \001(\0132..alluxio.grpc.job.GetJ" +
-      "obServiceSummaryPOptions\"U\n\035GetJobServic" +
-      "eSummaryPResponse\0224\n\007summary\030\001 \001(\0132#.all" +
-      "uxio.grpc.job.JobServiceSummary\"\026\n\024JobHe" +
-      "artbeatPOptions\"\220\001\n\024JobHeartbeatPRequest" +
-      "\022\020\n\010workerId\030\001 \001(\003\022-\n\ttaskInfos\030\002 \003(\0132\032." +
-      "alluxio.grpc.job.TaskInfo\0227\n\007options\030\003 \001" +
-      "(\0132&.alluxio.grpc.job.JobHeartbeatPOptio" +
-      "ns\"G\n\025JobHeartbeatPResponse\022.\n\010commands\030" +
-      "\001 \003(\0132\034.alluxio.grpc.job.JobCommand\"\033\n\031R" +
-      "egisterJobWorkerPOptions\"\223\001\n\031RegisterJob" +
-      "WorkerPRequest\0228\n\020workerNetAddress\030\001 \001(\013" +
-      "2\036.alluxio.grpc.WorkerNetAddress\022<\n\007opti" +
-      "ons\030\002 \001(\0132+.alluxio.grpc.job.RegisterJob" +
-      "WorkerPOptions\"(\n\032RegisterJobWorkerPResp" +
-      "onse\022\n\n\002id\030\001 \001(\003*X\n\006Status\022\013\n\007UNKNOWN\020\000\022" +
-      "\013\n\007CREATED\020\001\022\014\n\010CANCELED\020\002\022\n\n\006FAILED\020\003\022\013" +
-      "\n\007RUNNING\020\004\022\r\n\tCOMPLETED\020\0052\331\003\n\026JobMaster" +
-      "ClientService\022M\n\006Cancel\022 .alluxio.grpc.j" +
-      "ob.CancelPRequest\032!.alluxio.grpc.job.Can" +
-      "celPResponse\022_\n\014GetJobStatus\022&.alluxio.g" +
-      "rpc.job.GetJobStatusPRequest\032\'.alluxio.g" +
-      "rpc.job.GetJobStatusPResponse\022w\n\024GetJobS" +
-      "erviceSummary\022..alluxio.grpc.job.GetJobS" +
-      "erviceSummaryPRequest\032/.alluxio.grpc.job" +
-      ".GetJobServiceSummaryPResponse\022P\n\007ListAl" +
-      "l\022!.alluxio.grpc.job.ListAllPRequest\032\".a" +
-      "lluxio.grpc.job.ListAllPResponse\022D\n\003Run\022" +
-      "\035.alluxio.grpc.job.RunPRequest\032\036.alluxio" +
-      ".grpc.job.RunPResponse2\346\001\n\026JobMasterWork" +
-      "erService\022\\\n\tHeartbeat\022&.alluxio.grpc.jo" +
-      "b.JobHeartbeatPRequest\032\'.alluxio.grpc.jo" +
-      "b.JobHeartbeatPResponse\022n\n\021RegisterJobWo" +
-      "rker\022+.alluxio.grpc.job.RegisterJobWorke" +
-      "rPRequest\032,.alluxio.grpc.job.RegisterJob" +
-      "WorkerPResponseB \n\014alluxio.grpcB\016JobMast" +
-      "erProtoP\001"
+      " \003(\0132\037.alluxio.grpc.job.StatusSummary\0223\n" +
+      "\020recentActivities\030\002 \003(\0132\031.alluxio.grpc.j" +
+      "ob.JobInfo\0221\n\016recentFailures\030\003 \003(\0132\031.all" +
+      "uxio.grpc.job.JobInfo\"\302\001\n\nJobCommand\0228\n\016" +
+      "runTaskCommand\030\001 \001(\0132 .alluxio.grpc.job." +
+      "RunTaskCommand\022>\n\021cancelTaskCommand\030\002 \001(" +
+      "\0132#.alluxio.grpc.job.CancelTaskCommand\022:" +
+      "\n\017registerCommand\030\003 \001(\0132!.alluxio.grpc.j" +
+      "ob.RegisterCommand\"T\n\016RunTaskCommand\022\r\n\005" +
+      "jobId\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\005\022\021\n\tjobConfig" +
+      "\030\003 \001(\014\022\020\n\010taskArgs\030\004 \001(\014\"\021\n\017RegisterComm" +
+      "and\"2\n\021CancelTaskCommand\022\r\n\005jobId\030\001 \001(\003\022" +
+      "\016\n\006taskId\030\002 \001(\005\"\020\n\016CancelPOptions\"R\n\016Can" +
+      "celPRequest\022\r\n\005jobId\030\001 \001(\003\0221\n\007options\030\002 " +
+      "\001(\0132 .alluxio.grpc.job.CancelPOptions\"\021\n" +
+      "\017CancelPResponse\"\026\n\024GetJobStatusPOptions" +
+      "\"^\n\024GetJobStatusPRequest\022\r\n\005jobId\030\001 \001(\003\022" +
+      "7\n\007options\030\002 \001(\0132&.alluxio.grpc.job.GetJ" +
+      "obStatusPOptions\"C\n\025GetJobStatusPRespons" +
+      "e\022*\n\007jobInfo\030\001 \001(\0132\031.alluxio.grpc.job.Jo" +
+      "bInfo\"\021\n\017ListAllPOptions\"E\n\017ListAllPRequ" +
+      "est\0222\n\007options\030\001 \001(\0132!.alluxio.grpc.job." +
+      "ListAllPOptions\"\"\n\020ListAllPResponse\022\016\n\006j" +
+      "obIds\030\001 \003(\003\"\r\n\013RunPOptions\"P\n\013RunPReques" +
+      "t\022\021\n\tjobConfig\030\001 \001(\014\022.\n\007options\030\002 \001(\0132\035." +
+      "alluxio.grpc.job.RunPOptions\"\035\n\014RunPResp" +
+      "onse\022\r\n\005jobId\030\001 \001(\003\"\036\n\034GetJobServiceSumm" +
+      "aryPOptions\"_\n\034GetJobServiceSummaryPRequ" +
+      "est\022?\n\007options\030\001 \001(\0132..alluxio.grpc.job." +
+      "GetJobServiceSummaryPOptions\"U\n\035GetJobSe" +
+      "rviceSummaryPResponse\0224\n\007summary\030\001 \001(\0132#" +
+      ".alluxio.grpc.job.JobServiceSummary\"\026\n\024J" +
+      "obHeartbeatPOptions\"\220\001\n\024JobHeartbeatPReq" +
+      "uest\022\020\n\010workerId\030\001 \001(\003\022-\n\ttaskInfos\030\002 \003(" +
+      "\0132\032.alluxio.grpc.job.TaskInfo\0227\n\007options" +
+      "\030\003 \001(\0132&.alluxio.grpc.job.JobHeartbeatPO" +
+      "ptions\"G\n\025JobHeartbeatPResponse\022.\n\010comma" +
+      "nds\030\001 \003(\0132\034.alluxio.grpc.job.JobCommand\"" +
+      "\033\n\031RegisterJobWorkerPOptions\"\223\001\n\031Registe" +
+      "rJobWorkerPRequest\0228\n\020workerNetAddress\030\001" +
+      " \001(\0132\036.alluxio.grpc.WorkerNetAddress\022<\n\007" +
+      "options\030\002 \001(\0132+.alluxio.grpc.job.Registe" +
+      "rJobWorkerPOptions\"(\n\032RegisterJobWorkerP" +
+      "Response\022\n\n\002id\030\001 \001(\003*X\n\006Status\022\013\n\007UNKNOW" +
+      "N\020\000\022\013\n\007CREATED\020\001\022\014\n\010CANCELED\020\002\022\n\n\006FAILED" +
+      "\020\003\022\013\n\007RUNNING\020\004\022\r\n\tCOMPLETED\020\0052\331\003\n\026JobMa" +
+      "sterClientService\022M\n\006Cancel\022 .alluxio.gr" +
+      "pc.job.CancelPRequest\032!.alluxio.grpc.job" +
+      ".CancelPResponse\022_\n\014GetJobStatus\022&.allux" +
+      "io.grpc.job.GetJobStatusPRequest\032\'.allux" +
+      "io.grpc.job.GetJobStatusPResponse\022w\n\024Get" +
+      "JobServiceSummary\022..alluxio.grpc.job.Get" +
+      "JobServiceSummaryPRequest\032/.alluxio.grpc" +
+      ".job.GetJobServiceSummaryPResponse\022P\n\007Li" +
+      "stAll\022!.alluxio.grpc.job.ListAllPRequest" +
+      "\032\".alluxio.grpc.job.ListAllPResponse\022D\n\003" +
+      "Run\022\035.alluxio.grpc.job.RunPRequest\032\036.all" +
+      "uxio.grpc.job.RunPResponse2\346\001\n\026JobMaster" +
+      "WorkerService\022\\\n\tHeartbeat\022&.alluxio.grp" +
+      "c.job.JobHeartbeatPRequest\032\'.alluxio.grp" +
+      "c.job.JobHeartbeatPResponse\022n\n\021RegisterJ" +
+      "obWorker\022+.alluxio.grpc.job.RegisterJobW" +
+      "orkerPRequest\032,.alluxio.grpc.job.Registe" +
+      "rJobWorkerPResponseB \n\014alluxio.grpcB\016Job" +
+      "MasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -282,7 +282,7 @@ public final class JobMasterProto {
     internal_static_alluxio_grpc_job_JobServiceSummary_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_job_JobServiceSummary_descriptor,
-        new java.lang.String[] { "SummaryPerStatus", "LastActivities", "LastFailures", });
+        new java.lang.String[] { "SummaryPerStatus", "RecentActivities", "RecentFailures", });
     internal_static_alluxio_grpc_job_JobCommand_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_grpc_job_JobCommand_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/JobServiceSummary.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobServiceSummary.java
@@ -17,8 +17,8 @@ private static final long serialVersionUID = 0L;
   }
   private JobServiceSummary() {
     summaryPerStatus_ = java.util.Collections.emptyList();
-    lastActivities_ = java.util.Collections.emptyList();
-    lastFailures_ = java.util.Collections.emptyList();
+    recentActivities_ = java.util.Collections.emptyList();
+    recentFailures_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
@@ -63,19 +63,19 @@ private static final long serialVersionUID = 0L;
           }
           case 18: {
             if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-              lastActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
+              recentActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
               mutable_bitField0_ |= 0x00000002;
             }
-            lastActivities_.add(
+            recentActivities_.add(
                 input.readMessage(alluxio.grpc.JobInfo.PARSER, extensionRegistry));
             break;
           }
           case 26: {
             if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-              lastFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
+              recentFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
               mutable_bitField0_ |= 0x00000004;
             }
-            lastFailures_.add(
+            recentFailures_.add(
                 input.readMessage(alluxio.grpc.JobInfo.PARSER, extensionRegistry));
             break;
           }
@@ -91,10 +91,10 @@ private static final long serialVersionUID = 0L;
         summaryPerStatus_ = java.util.Collections.unmodifiableList(summaryPerStatus_);
       }
       if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-        lastActivities_ = java.util.Collections.unmodifiableList(lastActivities_);
+        recentActivities_ = java.util.Collections.unmodifiableList(recentActivities_);
       }
       if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-        lastFailures_ = java.util.Collections.unmodifiableList(lastFailures_);
+        recentFailures_ = java.util.Collections.unmodifiableList(recentFailures_);
       }
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
@@ -147,74 +147,74 @@ private static final long serialVersionUID = 0L;
     return summaryPerStatus_.get(index);
   }
 
-  public static final int LASTACTIVITIES_FIELD_NUMBER = 2;
-  private java.util.List<alluxio.grpc.JobInfo> lastActivities_;
+  public static final int RECENTACTIVITIES_FIELD_NUMBER = 2;
+  private java.util.List<alluxio.grpc.JobInfo> recentActivities_;
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  public java.util.List<alluxio.grpc.JobInfo> getLastActivitiesList() {
-    return lastActivities_;
+  public java.util.List<alluxio.grpc.JobInfo> getRecentActivitiesList() {
+    return recentActivities_;
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
   public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-      getLastActivitiesOrBuilderList() {
-    return lastActivities_;
+      getRecentActivitiesOrBuilderList() {
+    return recentActivities_;
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  public int getLastActivitiesCount() {
-    return lastActivities_.size();
+  public int getRecentActivitiesCount() {
+    return recentActivities_.size();
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  public alluxio.grpc.JobInfo getLastActivities(int index) {
-    return lastActivities_.get(index);
+  public alluxio.grpc.JobInfo getRecentActivities(int index) {
+    return recentActivities_.get(index);
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  public alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+  public alluxio.grpc.JobInfoOrBuilder getRecentActivitiesOrBuilder(
       int index) {
-    return lastActivities_.get(index);
+    return recentActivities_.get(index);
   }
 
-  public static final int LASTFAILURES_FIELD_NUMBER = 3;
-  private java.util.List<alluxio.grpc.JobInfo> lastFailures_;
+  public static final int RECENTFAILURES_FIELD_NUMBER = 3;
+  private java.util.List<alluxio.grpc.JobInfo> recentFailures_;
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  public java.util.List<alluxio.grpc.JobInfo> getLastFailuresList() {
-    return lastFailures_;
+  public java.util.List<alluxio.grpc.JobInfo> getRecentFailuresList() {
+    return recentFailures_;
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
   public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-      getLastFailuresOrBuilderList() {
-    return lastFailures_;
+      getRecentFailuresOrBuilderList() {
+    return recentFailures_;
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  public int getLastFailuresCount() {
-    return lastFailures_.size();
+  public int getRecentFailuresCount() {
+    return recentFailures_.size();
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  public alluxio.grpc.JobInfo getLastFailures(int index) {
-    return lastFailures_.get(index);
+  public alluxio.grpc.JobInfo getRecentFailures(int index) {
+    return recentFailures_.get(index);
   }
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  public alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+  public alluxio.grpc.JobInfoOrBuilder getRecentFailuresOrBuilder(
       int index) {
-    return lastFailures_.get(index);
+    return recentFailures_.get(index);
   }
 
   private byte memoizedIsInitialized = -1;
@@ -232,11 +232,11 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < summaryPerStatus_.size(); i++) {
       output.writeMessage(1, summaryPerStatus_.get(i));
     }
-    for (int i = 0; i < lastActivities_.size(); i++) {
-      output.writeMessage(2, lastActivities_.get(i));
+    for (int i = 0; i < recentActivities_.size(); i++) {
+      output.writeMessage(2, recentActivities_.get(i));
     }
-    for (int i = 0; i < lastFailures_.size(); i++) {
-      output.writeMessage(3, lastFailures_.get(i));
+    for (int i = 0; i < recentFailures_.size(); i++) {
+      output.writeMessage(3, recentFailures_.get(i));
     }
     unknownFields.writeTo(output);
   }
@@ -250,13 +250,13 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, summaryPerStatus_.get(i));
     }
-    for (int i = 0; i < lastActivities_.size(); i++) {
+    for (int i = 0; i < recentActivities_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, lastActivities_.get(i));
+        .computeMessageSize(2, recentActivities_.get(i));
     }
-    for (int i = 0; i < lastFailures_.size(); i++) {
+    for (int i = 0; i < recentFailures_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, lastFailures_.get(i));
+        .computeMessageSize(3, recentFailures_.get(i));
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -276,10 +276,10 @@ private static final long serialVersionUID = 0L;
     boolean result = true;
     result = result && getSummaryPerStatusList()
         .equals(other.getSummaryPerStatusList());
-    result = result && getLastActivitiesList()
-        .equals(other.getLastActivitiesList());
-    result = result && getLastFailuresList()
-        .equals(other.getLastFailuresList());
+    result = result && getRecentActivitiesList()
+        .equals(other.getRecentActivitiesList());
+    result = result && getRecentFailuresList()
+        .equals(other.getRecentFailuresList());
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -295,13 +295,13 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + SUMMARYPERSTATUS_FIELD_NUMBER;
       hash = (53 * hash) + getSummaryPerStatusList().hashCode();
     }
-    if (getLastActivitiesCount() > 0) {
-      hash = (37 * hash) + LASTACTIVITIES_FIELD_NUMBER;
-      hash = (53 * hash) + getLastActivitiesList().hashCode();
+    if (getRecentActivitiesCount() > 0) {
+      hash = (37 * hash) + RECENTACTIVITIES_FIELD_NUMBER;
+      hash = (53 * hash) + getRecentActivitiesList().hashCode();
     }
-    if (getLastFailuresCount() > 0) {
-      hash = (37 * hash) + LASTFAILURES_FIELD_NUMBER;
-      hash = (53 * hash) + getLastFailuresList().hashCode();
+    if (getRecentFailuresCount() > 0) {
+      hash = (37 * hash) + RECENTFAILURES_FIELD_NUMBER;
+      hash = (53 * hash) + getRecentFailuresList().hashCode();
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -429,8 +429,8 @@ private static final long serialVersionUID = 0L;
       if (com.google.protobuf.GeneratedMessageV3
               .alwaysUseFieldBuilders) {
         getSummaryPerStatusFieldBuilder();
-        getLastActivitiesFieldBuilder();
-        getLastFailuresFieldBuilder();
+        getRecentActivitiesFieldBuilder();
+        getRecentFailuresFieldBuilder();
       }
     }
     public Builder clear() {
@@ -441,17 +441,17 @@ private static final long serialVersionUID = 0L;
       } else {
         summaryPerStatusBuilder_.clear();
       }
-      if (lastActivitiesBuilder_ == null) {
-        lastActivities_ = java.util.Collections.emptyList();
+      if (recentActivitiesBuilder_ == null) {
+        recentActivities_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000002);
       } else {
-        lastActivitiesBuilder_.clear();
+        recentActivitiesBuilder_.clear();
       }
-      if (lastFailuresBuilder_ == null) {
-        lastFailures_ = java.util.Collections.emptyList();
+      if (recentFailuresBuilder_ == null) {
+        recentFailures_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000004);
       } else {
-        lastFailuresBuilder_.clear();
+        recentFailuresBuilder_.clear();
       }
       return this;
     }
@@ -485,23 +485,23 @@ private static final long serialVersionUID = 0L;
       } else {
         result.summaryPerStatus_ = summaryPerStatusBuilder_.build();
       }
-      if (lastActivitiesBuilder_ == null) {
+      if (recentActivitiesBuilder_ == null) {
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          lastActivities_ = java.util.Collections.unmodifiableList(lastActivities_);
+          recentActivities_ = java.util.Collections.unmodifiableList(recentActivities_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
-        result.lastActivities_ = lastActivities_;
+        result.recentActivities_ = recentActivities_;
       } else {
-        result.lastActivities_ = lastActivitiesBuilder_.build();
+        result.recentActivities_ = recentActivitiesBuilder_.build();
       }
-      if (lastFailuresBuilder_ == null) {
+      if (recentFailuresBuilder_ == null) {
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
-          lastFailures_ = java.util.Collections.unmodifiableList(lastFailures_);
+          recentFailures_ = java.util.Collections.unmodifiableList(recentFailures_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
-        result.lastFailures_ = lastFailures_;
+        result.recentFailures_ = recentFailures_;
       } else {
-        result.lastFailures_ = lastFailuresBuilder_.build();
+        result.recentFailures_ = recentFailuresBuilder_.build();
       }
       onBuilt();
       return result;
@@ -570,55 +570,55 @@ private static final long serialVersionUID = 0L;
           }
         }
       }
-      if (lastActivitiesBuilder_ == null) {
-        if (!other.lastActivities_.isEmpty()) {
-          if (lastActivities_.isEmpty()) {
-            lastActivities_ = other.lastActivities_;
+      if (recentActivitiesBuilder_ == null) {
+        if (!other.recentActivities_.isEmpty()) {
+          if (recentActivities_.isEmpty()) {
+            recentActivities_ = other.recentActivities_;
             bitField0_ = (bitField0_ & ~0x00000002);
           } else {
-            ensureLastActivitiesIsMutable();
-            lastActivities_.addAll(other.lastActivities_);
+            ensureRecentActivitiesIsMutable();
+            recentActivities_.addAll(other.recentActivities_);
           }
           onChanged();
         }
       } else {
-        if (!other.lastActivities_.isEmpty()) {
-          if (lastActivitiesBuilder_.isEmpty()) {
-            lastActivitiesBuilder_.dispose();
-            lastActivitiesBuilder_ = null;
-            lastActivities_ = other.lastActivities_;
+        if (!other.recentActivities_.isEmpty()) {
+          if (recentActivitiesBuilder_.isEmpty()) {
+            recentActivitiesBuilder_.dispose();
+            recentActivitiesBuilder_ = null;
+            recentActivities_ = other.recentActivities_;
             bitField0_ = (bitField0_ & ~0x00000002);
-            lastActivitiesBuilder_ = 
+            recentActivitiesBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getLastActivitiesFieldBuilder() : null;
+                 getRecentActivitiesFieldBuilder() : null;
           } else {
-            lastActivitiesBuilder_.addAllMessages(other.lastActivities_);
+            recentActivitiesBuilder_.addAllMessages(other.recentActivities_);
           }
         }
       }
-      if (lastFailuresBuilder_ == null) {
-        if (!other.lastFailures_.isEmpty()) {
-          if (lastFailures_.isEmpty()) {
-            lastFailures_ = other.lastFailures_;
+      if (recentFailuresBuilder_ == null) {
+        if (!other.recentFailures_.isEmpty()) {
+          if (recentFailures_.isEmpty()) {
+            recentFailures_ = other.recentFailures_;
             bitField0_ = (bitField0_ & ~0x00000004);
           } else {
-            ensureLastFailuresIsMutable();
-            lastFailures_.addAll(other.lastFailures_);
+            ensureRecentFailuresIsMutable();
+            recentFailures_.addAll(other.recentFailures_);
           }
           onChanged();
         }
       } else {
-        if (!other.lastFailures_.isEmpty()) {
-          if (lastFailuresBuilder_.isEmpty()) {
-            lastFailuresBuilder_.dispose();
-            lastFailuresBuilder_ = null;
-            lastFailures_ = other.lastFailures_;
+        if (!other.recentFailures_.isEmpty()) {
+          if (recentFailuresBuilder_.isEmpty()) {
+            recentFailuresBuilder_.dispose();
+            recentFailuresBuilder_ = null;
+            recentFailures_ = other.recentFailures_;
             bitField0_ = (bitField0_ & ~0x00000004);
-            lastFailuresBuilder_ = 
+            recentFailuresBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getLastFailuresFieldBuilder() : null;
+                 getRecentFailuresFieldBuilder() : null;
           } else {
-            lastFailuresBuilder_.addAllMessages(other.lastFailures_);
+            recentFailuresBuilder_.addAllMessages(other.recentFailures_);
           }
         }
       }
@@ -890,484 +890,484 @@ private static final long serialVersionUID = 0L;
       return summaryPerStatusBuilder_;
     }
 
-    private java.util.List<alluxio.grpc.JobInfo> lastActivities_ =
+    private java.util.List<alluxio.grpc.JobInfo> recentActivities_ =
       java.util.Collections.emptyList();
-    private void ensureLastActivitiesIsMutable() {
+    private void ensureRecentActivitiesIsMutable() {
       if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-        lastActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(lastActivities_);
+        recentActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(recentActivities_);
         bitField0_ |= 0x00000002;
        }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> lastActivitiesBuilder_;
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> recentActivitiesBuilder_;
 
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public java.util.List<alluxio.grpc.JobInfo> getLastActivitiesList() {
-      if (lastActivitiesBuilder_ == null) {
-        return java.util.Collections.unmodifiableList(lastActivities_);
+    public java.util.List<alluxio.grpc.JobInfo> getRecentActivitiesList() {
+      if (recentActivitiesBuilder_ == null) {
+        return java.util.Collections.unmodifiableList(recentActivities_);
       } else {
-        return lastActivitiesBuilder_.getMessageList();
+        return recentActivitiesBuilder_.getMessageList();
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public int getLastActivitiesCount() {
-      if (lastActivitiesBuilder_ == null) {
-        return lastActivities_.size();
+    public int getRecentActivitiesCount() {
+      if (recentActivitiesBuilder_ == null) {
+        return recentActivities_.size();
       } else {
-        return lastActivitiesBuilder_.getCount();
+        return recentActivitiesBuilder_.getCount();
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public alluxio.grpc.JobInfo getLastActivities(int index) {
-      if (lastActivitiesBuilder_ == null) {
-        return lastActivities_.get(index);
+    public alluxio.grpc.JobInfo getRecentActivities(int index) {
+      if (recentActivitiesBuilder_ == null) {
+        return recentActivities_.get(index);
       } else {
-        return lastActivitiesBuilder_.getMessage(index);
+        return recentActivitiesBuilder_.getMessage(index);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder setLastActivities(
+    public Builder setRecentActivities(
         int index, alluxio.grpc.JobInfo value) {
-      if (lastActivitiesBuilder_ == null) {
+      if (recentActivitiesBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastActivitiesIsMutable();
-        lastActivities_.set(index, value);
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.set(index, value);
         onChanged();
       } else {
-        lastActivitiesBuilder_.setMessage(index, value);
+        recentActivitiesBuilder_.setMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder setLastActivities(
+    public Builder setRecentActivities(
         int index, alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastActivitiesBuilder_ == null) {
-        ensureLastActivitiesIsMutable();
-        lastActivities_.set(index, builderForValue.build());
+      if (recentActivitiesBuilder_ == null) {
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.set(index, builderForValue.build());
         onChanged();
       } else {
-        lastActivitiesBuilder_.setMessage(index, builderForValue.build());
+        recentActivitiesBuilder_.setMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder addLastActivities(alluxio.grpc.JobInfo value) {
-      if (lastActivitiesBuilder_ == null) {
+    public Builder addRecentActivities(alluxio.grpc.JobInfo value) {
+      if (recentActivitiesBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastActivitiesIsMutable();
-        lastActivities_.add(value);
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.add(value);
         onChanged();
       } else {
-        lastActivitiesBuilder_.addMessage(value);
+        recentActivitiesBuilder_.addMessage(value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder addLastActivities(
+    public Builder addRecentActivities(
         int index, alluxio.grpc.JobInfo value) {
-      if (lastActivitiesBuilder_ == null) {
+      if (recentActivitiesBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastActivitiesIsMutable();
-        lastActivities_.add(index, value);
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.add(index, value);
         onChanged();
       } else {
-        lastActivitiesBuilder_.addMessage(index, value);
+        recentActivitiesBuilder_.addMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder addLastActivities(
+    public Builder addRecentActivities(
         alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastActivitiesBuilder_ == null) {
-        ensureLastActivitiesIsMutable();
-        lastActivities_.add(builderForValue.build());
+      if (recentActivitiesBuilder_ == null) {
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.add(builderForValue.build());
         onChanged();
       } else {
-        lastActivitiesBuilder_.addMessage(builderForValue.build());
+        recentActivitiesBuilder_.addMessage(builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder addLastActivities(
+    public Builder addRecentActivities(
         int index, alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastActivitiesBuilder_ == null) {
-        ensureLastActivitiesIsMutable();
-        lastActivities_.add(index, builderForValue.build());
+      if (recentActivitiesBuilder_ == null) {
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.add(index, builderForValue.build());
         onChanged();
       } else {
-        lastActivitiesBuilder_.addMessage(index, builderForValue.build());
+        recentActivitiesBuilder_.addMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder addAllLastActivities(
+    public Builder addAllRecentActivities(
         java.lang.Iterable<? extends alluxio.grpc.JobInfo> values) {
-      if (lastActivitiesBuilder_ == null) {
-        ensureLastActivitiesIsMutable();
+      if (recentActivitiesBuilder_ == null) {
+        ensureRecentActivitiesIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, lastActivities_);
+            values, recentActivities_);
         onChanged();
       } else {
-        lastActivitiesBuilder_.addAllMessages(values);
+        recentActivitiesBuilder_.addAllMessages(values);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder clearLastActivities() {
-      if (lastActivitiesBuilder_ == null) {
-        lastActivities_ = java.util.Collections.emptyList();
+    public Builder clearRecentActivities() {
+      if (recentActivitiesBuilder_ == null) {
+        recentActivities_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
       } else {
-        lastActivitiesBuilder_.clear();
+        recentActivitiesBuilder_.clear();
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public Builder removeLastActivities(int index) {
-      if (lastActivitiesBuilder_ == null) {
-        ensureLastActivitiesIsMutable();
-        lastActivities_.remove(index);
+    public Builder removeRecentActivities(int index) {
+      if (recentActivitiesBuilder_ == null) {
+        ensureRecentActivitiesIsMutable();
+        recentActivities_.remove(index);
         onChanged();
       } else {
-        lastActivitiesBuilder_.remove(index);
+        recentActivitiesBuilder_.remove(index);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public alluxio.grpc.JobInfo.Builder getLastActivitiesBuilder(
+    public alluxio.grpc.JobInfo.Builder getRecentActivitiesBuilder(
         int index) {
-      return getLastActivitiesFieldBuilder().getBuilder(index);
+      return getRecentActivitiesFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+    public alluxio.grpc.JobInfoOrBuilder getRecentActivitiesOrBuilder(
         int index) {
-      if (lastActivitiesBuilder_ == null) {
-        return lastActivities_.get(index);  } else {
-        return lastActivitiesBuilder_.getMessageOrBuilder(index);
+      if (recentActivitiesBuilder_ == null) {
+        return recentActivities_.get(index);  } else {
+        return recentActivitiesBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
     public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-         getLastActivitiesOrBuilderList() {
-      if (lastActivitiesBuilder_ != null) {
-        return lastActivitiesBuilder_.getMessageOrBuilderList();
+         getRecentActivitiesOrBuilderList() {
+      if (recentActivitiesBuilder_ != null) {
+        return recentActivitiesBuilder_.getMessageOrBuilderList();
       } else {
-        return java.util.Collections.unmodifiableList(lastActivities_);
+        return java.util.Collections.unmodifiableList(recentActivities_);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public alluxio.grpc.JobInfo.Builder addLastActivitiesBuilder() {
-      return getLastActivitiesFieldBuilder().addBuilder(
+    public alluxio.grpc.JobInfo.Builder addRecentActivitiesBuilder() {
+      return getRecentActivitiesFieldBuilder().addBuilder(
           alluxio.grpc.JobInfo.getDefaultInstance());
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
-    public alluxio.grpc.JobInfo.Builder addLastActivitiesBuilder(
+    public alluxio.grpc.JobInfo.Builder addRecentActivitiesBuilder(
         int index) {
-      return getLastActivitiesFieldBuilder().addBuilder(
+      return getRecentActivitiesFieldBuilder().addBuilder(
           index, alluxio.grpc.JobInfo.getDefaultInstance());
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
      */
     public java.util.List<alluxio.grpc.JobInfo.Builder> 
-         getLastActivitiesBuilderList() {
-      return getLastActivitiesFieldBuilder().getBuilderList();
+         getRecentActivitiesBuilderList() {
+      return getRecentActivitiesFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
         alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> 
-        getLastActivitiesFieldBuilder() {
-      if (lastActivitiesBuilder_ == null) {
-        lastActivitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+        getRecentActivitiesFieldBuilder() {
+      if (recentActivitiesBuilder_ == null) {
+        recentActivitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder>(
-                lastActivities_,
+                recentActivities_,
                 ((bitField0_ & 0x00000002) == 0x00000002),
                 getParentForChildren(),
                 isClean());
-        lastActivities_ = null;
+        recentActivities_ = null;
       }
-      return lastActivitiesBuilder_;
+      return recentActivitiesBuilder_;
     }
 
-    private java.util.List<alluxio.grpc.JobInfo> lastFailures_ =
+    private java.util.List<alluxio.grpc.JobInfo> recentFailures_ =
       java.util.Collections.emptyList();
-    private void ensureLastFailuresIsMutable() {
+    private void ensureRecentFailuresIsMutable() {
       if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-        lastFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(lastFailures_);
+        recentFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(recentFailures_);
         bitField0_ |= 0x00000004;
        }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> lastFailuresBuilder_;
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> recentFailuresBuilder_;
 
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public java.util.List<alluxio.grpc.JobInfo> getLastFailuresList() {
-      if (lastFailuresBuilder_ == null) {
-        return java.util.Collections.unmodifiableList(lastFailures_);
+    public java.util.List<alluxio.grpc.JobInfo> getRecentFailuresList() {
+      if (recentFailuresBuilder_ == null) {
+        return java.util.Collections.unmodifiableList(recentFailures_);
       } else {
-        return lastFailuresBuilder_.getMessageList();
+        return recentFailuresBuilder_.getMessageList();
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public int getLastFailuresCount() {
-      if (lastFailuresBuilder_ == null) {
-        return lastFailures_.size();
+    public int getRecentFailuresCount() {
+      if (recentFailuresBuilder_ == null) {
+        return recentFailures_.size();
       } else {
-        return lastFailuresBuilder_.getCount();
+        return recentFailuresBuilder_.getCount();
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public alluxio.grpc.JobInfo getLastFailures(int index) {
-      if (lastFailuresBuilder_ == null) {
-        return lastFailures_.get(index);
+    public alluxio.grpc.JobInfo getRecentFailures(int index) {
+      if (recentFailuresBuilder_ == null) {
+        return recentFailures_.get(index);
       } else {
-        return lastFailuresBuilder_.getMessage(index);
+        return recentFailuresBuilder_.getMessage(index);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder setLastFailures(
+    public Builder setRecentFailures(
         int index, alluxio.grpc.JobInfo value) {
-      if (lastFailuresBuilder_ == null) {
+      if (recentFailuresBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastFailuresIsMutable();
-        lastFailures_.set(index, value);
+        ensureRecentFailuresIsMutable();
+        recentFailures_.set(index, value);
         onChanged();
       } else {
-        lastFailuresBuilder_.setMessage(index, value);
+        recentFailuresBuilder_.setMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder setLastFailures(
+    public Builder setRecentFailures(
         int index, alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastFailuresBuilder_ == null) {
-        ensureLastFailuresIsMutable();
-        lastFailures_.set(index, builderForValue.build());
+      if (recentFailuresBuilder_ == null) {
+        ensureRecentFailuresIsMutable();
+        recentFailures_.set(index, builderForValue.build());
         onChanged();
       } else {
-        lastFailuresBuilder_.setMessage(index, builderForValue.build());
+        recentFailuresBuilder_.setMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder addLastFailures(alluxio.grpc.JobInfo value) {
-      if (lastFailuresBuilder_ == null) {
+    public Builder addRecentFailures(alluxio.grpc.JobInfo value) {
+      if (recentFailuresBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastFailuresIsMutable();
-        lastFailures_.add(value);
+        ensureRecentFailuresIsMutable();
+        recentFailures_.add(value);
         onChanged();
       } else {
-        lastFailuresBuilder_.addMessage(value);
+        recentFailuresBuilder_.addMessage(value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder addLastFailures(
+    public Builder addRecentFailures(
         int index, alluxio.grpc.JobInfo value) {
-      if (lastFailuresBuilder_ == null) {
+      if (recentFailuresBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
         }
-        ensureLastFailuresIsMutable();
-        lastFailures_.add(index, value);
+        ensureRecentFailuresIsMutable();
+        recentFailures_.add(index, value);
         onChanged();
       } else {
-        lastFailuresBuilder_.addMessage(index, value);
+        recentFailuresBuilder_.addMessage(index, value);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder addLastFailures(
+    public Builder addRecentFailures(
         alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastFailuresBuilder_ == null) {
-        ensureLastFailuresIsMutable();
-        lastFailures_.add(builderForValue.build());
+      if (recentFailuresBuilder_ == null) {
+        ensureRecentFailuresIsMutable();
+        recentFailures_.add(builderForValue.build());
         onChanged();
       } else {
-        lastFailuresBuilder_.addMessage(builderForValue.build());
+        recentFailuresBuilder_.addMessage(builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder addLastFailures(
+    public Builder addRecentFailures(
         int index, alluxio.grpc.JobInfo.Builder builderForValue) {
-      if (lastFailuresBuilder_ == null) {
-        ensureLastFailuresIsMutable();
-        lastFailures_.add(index, builderForValue.build());
+      if (recentFailuresBuilder_ == null) {
+        ensureRecentFailuresIsMutable();
+        recentFailures_.add(index, builderForValue.build());
         onChanged();
       } else {
-        lastFailuresBuilder_.addMessage(index, builderForValue.build());
+        recentFailuresBuilder_.addMessage(index, builderForValue.build());
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder addAllLastFailures(
+    public Builder addAllRecentFailures(
         java.lang.Iterable<? extends alluxio.grpc.JobInfo> values) {
-      if (lastFailuresBuilder_ == null) {
-        ensureLastFailuresIsMutable();
+      if (recentFailuresBuilder_ == null) {
+        ensureRecentFailuresIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, lastFailures_);
+            values, recentFailures_);
         onChanged();
       } else {
-        lastFailuresBuilder_.addAllMessages(values);
+        recentFailuresBuilder_.addAllMessages(values);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder clearLastFailures() {
-      if (lastFailuresBuilder_ == null) {
-        lastFailures_ = java.util.Collections.emptyList();
+    public Builder clearRecentFailures() {
+      if (recentFailuresBuilder_ == null) {
+        recentFailures_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000004);
         onChanged();
       } else {
-        lastFailuresBuilder_.clear();
+        recentFailuresBuilder_.clear();
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public Builder removeLastFailures(int index) {
-      if (lastFailuresBuilder_ == null) {
-        ensureLastFailuresIsMutable();
-        lastFailures_.remove(index);
+    public Builder removeRecentFailures(int index) {
+      if (recentFailuresBuilder_ == null) {
+        ensureRecentFailuresIsMutable();
+        recentFailures_.remove(index);
         onChanged();
       } else {
-        lastFailuresBuilder_.remove(index);
+        recentFailuresBuilder_.remove(index);
       }
       return this;
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public alluxio.grpc.JobInfo.Builder getLastFailuresBuilder(
+    public alluxio.grpc.JobInfo.Builder getRecentFailuresBuilder(
         int index) {
-      return getLastFailuresFieldBuilder().getBuilder(index);
+      return getRecentFailuresFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+    public alluxio.grpc.JobInfoOrBuilder getRecentFailuresOrBuilder(
         int index) {
-      if (lastFailuresBuilder_ == null) {
-        return lastFailures_.get(index);  } else {
-        return lastFailuresBuilder_.getMessageOrBuilder(index);
+      if (recentFailuresBuilder_ == null) {
+        return recentFailures_.get(index);  } else {
+        return recentFailuresBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
     public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-         getLastFailuresOrBuilderList() {
-      if (lastFailuresBuilder_ != null) {
-        return lastFailuresBuilder_.getMessageOrBuilderList();
+         getRecentFailuresOrBuilderList() {
+      if (recentFailuresBuilder_ != null) {
+        return recentFailuresBuilder_.getMessageOrBuilderList();
       } else {
-        return java.util.Collections.unmodifiableList(lastFailures_);
+        return java.util.Collections.unmodifiableList(recentFailures_);
       }
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public alluxio.grpc.JobInfo.Builder addLastFailuresBuilder() {
-      return getLastFailuresFieldBuilder().addBuilder(
+    public alluxio.grpc.JobInfo.Builder addRecentFailuresBuilder() {
+      return getRecentFailuresFieldBuilder().addBuilder(
           alluxio.grpc.JobInfo.getDefaultInstance());
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
-    public alluxio.grpc.JobInfo.Builder addLastFailuresBuilder(
+    public alluxio.grpc.JobInfo.Builder addRecentFailuresBuilder(
         int index) {
-      return getLastFailuresFieldBuilder().addBuilder(
+      return getRecentFailuresFieldBuilder().addBuilder(
           index, alluxio.grpc.JobInfo.getDefaultInstance());
     }
     /**
-     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
      */
     public java.util.List<alluxio.grpc.JobInfo.Builder> 
-         getLastFailuresBuilderList() {
-      return getLastFailuresFieldBuilder().getBuilderList();
+         getRecentFailuresBuilderList() {
+      return getRecentFailuresFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
         alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> 
-        getLastFailuresFieldBuilder() {
-      if (lastFailuresBuilder_ == null) {
-        lastFailuresBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+        getRecentFailuresFieldBuilder() {
+      if (recentFailuresBuilder_ == null) {
+        recentFailuresBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder>(
-                lastFailures_,
+                recentFailures_,
                 ((bitField0_ & 0x00000004) == 0x00000004),
                 getParentForChildren(),
                 isClean());
-        lastFailures_ = null;
+        recentFailures_ = null;
       }
-      return lastFailuresBuilder_;
+      return recentFailuresBuilder_;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/JobServiceSummary.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobServiceSummary.java
@@ -17,6 +17,8 @@ private static final long serialVersionUID = 0L;
   }
   private JobServiceSummary() {
     summaryPerStatus_ = java.util.Collections.emptyList();
+    lastActivities_ = java.util.Collections.emptyList();
+    lastFailures_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
@@ -59,6 +61,24 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(alluxio.grpc.StatusSummary.PARSER, extensionRegistry));
             break;
           }
+          case 18: {
+            if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              lastActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
+              mutable_bitField0_ |= 0x00000002;
+            }
+            lastActivities_.add(
+                input.readMessage(alluxio.grpc.JobInfo.PARSER, extensionRegistry));
+            break;
+          }
+          case 26: {
+            if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+              lastFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>();
+              mutable_bitField0_ |= 0x00000004;
+            }
+            lastFailures_.add(
+                input.readMessage(alluxio.grpc.JobInfo.PARSER, extensionRegistry));
+            break;
+          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -69,6 +89,12 @@ private static final long serialVersionUID = 0L;
     } finally {
       if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
         summaryPerStatus_ = java.util.Collections.unmodifiableList(summaryPerStatus_);
+      }
+      if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        lastActivities_ = java.util.Collections.unmodifiableList(lastActivities_);
+      }
+      if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+        lastFailures_ = java.util.Collections.unmodifiableList(lastFailures_);
       }
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
@@ -121,6 +147,76 @@ private static final long serialVersionUID = 0L;
     return summaryPerStatus_.get(index);
   }
 
+  public static final int LASTACTIVITIES_FIELD_NUMBER = 2;
+  private java.util.List<alluxio.grpc.JobInfo> lastActivities_;
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  public java.util.List<alluxio.grpc.JobInfo> getLastActivitiesList() {
+    return lastActivities_;
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+      getLastActivitiesOrBuilderList() {
+    return lastActivities_;
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  public int getLastActivitiesCount() {
+    return lastActivities_.size();
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  public alluxio.grpc.JobInfo getLastActivities(int index) {
+    return lastActivities_.get(index);
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  public alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+      int index) {
+    return lastActivities_.get(index);
+  }
+
+  public static final int LASTFAILURES_FIELD_NUMBER = 3;
+  private java.util.List<alluxio.grpc.JobInfo> lastFailures_;
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  public java.util.List<alluxio.grpc.JobInfo> getLastFailuresList() {
+    return lastFailures_;
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+      getLastFailuresOrBuilderList() {
+    return lastFailures_;
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  public int getLastFailuresCount() {
+    return lastFailures_.size();
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  public alluxio.grpc.JobInfo getLastFailures(int index) {
+    return lastFailures_.get(index);
+  }
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  public alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+      int index) {
+    return lastFailures_.get(index);
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -136,6 +232,12 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < summaryPerStatus_.size(); i++) {
       output.writeMessage(1, summaryPerStatus_.get(i));
     }
+    for (int i = 0; i < lastActivities_.size(); i++) {
+      output.writeMessage(2, lastActivities_.get(i));
+    }
+    for (int i = 0; i < lastFailures_.size(); i++) {
+      output.writeMessage(3, lastFailures_.get(i));
+    }
     unknownFields.writeTo(output);
   }
 
@@ -147,6 +249,14 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < summaryPerStatus_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, summaryPerStatus_.get(i));
+    }
+    for (int i = 0; i < lastActivities_.size(); i++) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(2, lastActivities_.get(i));
+    }
+    for (int i = 0; i < lastFailures_.size(); i++) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(3, lastFailures_.get(i));
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -166,6 +276,10 @@ private static final long serialVersionUID = 0L;
     boolean result = true;
     result = result && getSummaryPerStatusList()
         .equals(other.getSummaryPerStatusList());
+    result = result && getLastActivitiesList()
+        .equals(other.getLastActivitiesList());
+    result = result && getLastFailuresList()
+        .equals(other.getLastFailuresList());
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -180,6 +294,14 @@ private static final long serialVersionUID = 0L;
     if (getSummaryPerStatusCount() > 0) {
       hash = (37 * hash) + SUMMARYPERSTATUS_FIELD_NUMBER;
       hash = (53 * hash) + getSummaryPerStatusList().hashCode();
+    }
+    if (getLastActivitiesCount() > 0) {
+      hash = (37 * hash) + LASTACTIVITIES_FIELD_NUMBER;
+      hash = (53 * hash) + getLastActivitiesList().hashCode();
+    }
+    if (getLastFailuresCount() > 0) {
+      hash = (37 * hash) + LASTFAILURES_FIELD_NUMBER;
+      hash = (53 * hash) + getLastFailuresList().hashCode();
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -307,6 +429,8 @@ private static final long serialVersionUID = 0L;
       if (com.google.protobuf.GeneratedMessageV3
               .alwaysUseFieldBuilders) {
         getSummaryPerStatusFieldBuilder();
+        getLastActivitiesFieldBuilder();
+        getLastFailuresFieldBuilder();
       }
     }
     public Builder clear() {
@@ -316,6 +440,18 @@ private static final long serialVersionUID = 0L;
         bitField0_ = (bitField0_ & ~0x00000001);
       } else {
         summaryPerStatusBuilder_.clear();
+      }
+      if (lastActivitiesBuilder_ == null) {
+        lastActivities_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);
+      } else {
+        lastActivitiesBuilder_.clear();
+      }
+      if (lastFailuresBuilder_ == null) {
+        lastFailures_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+      } else {
+        lastFailuresBuilder_.clear();
       }
       return this;
     }
@@ -348,6 +484,24 @@ private static final long serialVersionUID = 0L;
         result.summaryPerStatus_ = summaryPerStatus_;
       } else {
         result.summaryPerStatus_ = summaryPerStatusBuilder_.build();
+      }
+      if (lastActivitiesBuilder_ == null) {
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          lastActivities_ = java.util.Collections.unmodifiableList(lastActivities_);
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.lastActivities_ = lastActivities_;
+      } else {
+        result.lastActivities_ = lastActivitiesBuilder_.build();
+      }
+      if (lastFailuresBuilder_ == null) {
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          lastFailures_ = java.util.Collections.unmodifiableList(lastFailures_);
+          bitField0_ = (bitField0_ & ~0x00000004);
+        }
+        result.lastFailures_ = lastFailures_;
+      } else {
+        result.lastFailures_ = lastFailuresBuilder_.build();
       }
       onBuilt();
       return result;
@@ -413,6 +567,58 @@ private static final long serialVersionUID = 0L;
                  getSummaryPerStatusFieldBuilder() : null;
           } else {
             summaryPerStatusBuilder_.addAllMessages(other.summaryPerStatus_);
+          }
+        }
+      }
+      if (lastActivitiesBuilder_ == null) {
+        if (!other.lastActivities_.isEmpty()) {
+          if (lastActivities_.isEmpty()) {
+            lastActivities_ = other.lastActivities_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureLastActivitiesIsMutable();
+            lastActivities_.addAll(other.lastActivities_);
+          }
+          onChanged();
+        }
+      } else {
+        if (!other.lastActivities_.isEmpty()) {
+          if (lastActivitiesBuilder_.isEmpty()) {
+            lastActivitiesBuilder_.dispose();
+            lastActivitiesBuilder_ = null;
+            lastActivities_ = other.lastActivities_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+            lastActivitiesBuilder_ = 
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                 getLastActivitiesFieldBuilder() : null;
+          } else {
+            lastActivitiesBuilder_.addAllMessages(other.lastActivities_);
+          }
+        }
+      }
+      if (lastFailuresBuilder_ == null) {
+        if (!other.lastFailures_.isEmpty()) {
+          if (lastFailures_.isEmpty()) {
+            lastFailures_ = other.lastFailures_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+          } else {
+            ensureLastFailuresIsMutable();
+            lastFailures_.addAll(other.lastFailures_);
+          }
+          onChanged();
+        }
+      } else {
+        if (!other.lastFailures_.isEmpty()) {
+          if (lastFailuresBuilder_.isEmpty()) {
+            lastFailuresBuilder_.dispose();
+            lastFailuresBuilder_ = null;
+            lastFailures_ = other.lastFailures_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+            lastFailuresBuilder_ = 
+              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                 getLastFailuresFieldBuilder() : null;
+          } else {
+            lastFailuresBuilder_.addAllMessages(other.lastFailures_);
           }
         }
       }
@@ -682,6 +888,486 @@ private static final long serialVersionUID = 0L;
         summaryPerStatus_ = null;
       }
       return summaryPerStatusBuilder_;
+    }
+
+    private java.util.List<alluxio.grpc.JobInfo> lastActivities_ =
+      java.util.Collections.emptyList();
+    private void ensureLastActivitiesIsMutable() {
+      if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        lastActivities_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(lastActivities_);
+        bitField0_ |= 0x00000002;
+       }
+    }
+
+    private com.google.protobuf.RepeatedFieldBuilderV3<
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> lastActivitiesBuilder_;
+
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public java.util.List<alluxio.grpc.JobInfo> getLastActivitiesList() {
+      if (lastActivitiesBuilder_ == null) {
+        return java.util.Collections.unmodifiableList(lastActivities_);
+      } else {
+        return lastActivitiesBuilder_.getMessageList();
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public int getLastActivitiesCount() {
+      if (lastActivitiesBuilder_ == null) {
+        return lastActivities_.size();
+      } else {
+        return lastActivitiesBuilder_.getCount();
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public alluxio.grpc.JobInfo getLastActivities(int index) {
+      if (lastActivitiesBuilder_ == null) {
+        return lastActivities_.get(index);
+      } else {
+        return lastActivitiesBuilder_.getMessage(index);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder setLastActivities(
+        int index, alluxio.grpc.JobInfo value) {
+      if (lastActivitiesBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastActivitiesIsMutable();
+        lastActivities_.set(index, value);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.setMessage(index, value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder setLastActivities(
+        int index, alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastActivitiesBuilder_ == null) {
+        ensureLastActivitiesIsMutable();
+        lastActivities_.set(index, builderForValue.build());
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.setMessage(index, builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder addLastActivities(alluxio.grpc.JobInfo value) {
+      if (lastActivitiesBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastActivitiesIsMutable();
+        lastActivities_.add(value);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.addMessage(value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder addLastActivities(
+        int index, alluxio.grpc.JobInfo value) {
+      if (lastActivitiesBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastActivitiesIsMutable();
+        lastActivities_.add(index, value);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.addMessage(index, value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder addLastActivities(
+        alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastActivitiesBuilder_ == null) {
+        ensureLastActivitiesIsMutable();
+        lastActivities_.add(builderForValue.build());
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.addMessage(builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder addLastActivities(
+        int index, alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastActivitiesBuilder_ == null) {
+        ensureLastActivitiesIsMutable();
+        lastActivities_.add(index, builderForValue.build());
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.addMessage(index, builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder addAllLastActivities(
+        java.lang.Iterable<? extends alluxio.grpc.JobInfo> values) {
+      if (lastActivitiesBuilder_ == null) {
+        ensureLastActivitiesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, lastActivities_);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.addAllMessages(values);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder clearLastActivities() {
+      if (lastActivitiesBuilder_ == null) {
+        lastActivities_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.clear();
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public Builder removeLastActivities(int index) {
+      if (lastActivitiesBuilder_ == null) {
+        ensureLastActivitiesIsMutable();
+        lastActivities_.remove(index);
+        onChanged();
+      } else {
+        lastActivitiesBuilder_.remove(index);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder getLastActivitiesBuilder(
+        int index) {
+      return getLastActivitiesFieldBuilder().getBuilder(index);
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+        int index) {
+      if (lastActivitiesBuilder_ == null) {
+        return lastActivities_.get(index);  } else {
+        return lastActivitiesBuilder_.getMessageOrBuilder(index);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+         getLastActivitiesOrBuilderList() {
+      if (lastActivitiesBuilder_ != null) {
+        return lastActivitiesBuilder_.getMessageOrBuilderList();
+      } else {
+        return java.util.Collections.unmodifiableList(lastActivities_);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder addLastActivitiesBuilder() {
+      return getLastActivitiesFieldBuilder().addBuilder(
+          alluxio.grpc.JobInfo.getDefaultInstance());
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder addLastActivitiesBuilder(
+        int index) {
+      return getLastActivitiesFieldBuilder().addBuilder(
+          index, alluxio.grpc.JobInfo.getDefaultInstance());
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+     */
+    public java.util.List<alluxio.grpc.JobInfo.Builder> 
+         getLastActivitiesBuilderList() {
+      return getLastActivitiesFieldBuilder().getBuilderList();
+    }
+    private com.google.protobuf.RepeatedFieldBuilderV3<
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> 
+        getLastActivitiesFieldBuilder() {
+      if (lastActivitiesBuilder_ == null) {
+        lastActivitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+            alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder>(
+                lastActivities_,
+                ((bitField0_ & 0x00000002) == 0x00000002),
+                getParentForChildren(),
+                isClean());
+        lastActivities_ = null;
+      }
+      return lastActivitiesBuilder_;
+    }
+
+    private java.util.List<alluxio.grpc.JobInfo> lastFailures_ =
+      java.util.Collections.emptyList();
+    private void ensureLastFailuresIsMutable() {
+      if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        lastFailures_ = new java.util.ArrayList<alluxio.grpc.JobInfo>(lastFailures_);
+        bitField0_ |= 0x00000004;
+       }
+    }
+
+    private com.google.protobuf.RepeatedFieldBuilderV3<
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> lastFailuresBuilder_;
+
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public java.util.List<alluxio.grpc.JobInfo> getLastFailuresList() {
+      if (lastFailuresBuilder_ == null) {
+        return java.util.Collections.unmodifiableList(lastFailures_);
+      } else {
+        return lastFailuresBuilder_.getMessageList();
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public int getLastFailuresCount() {
+      if (lastFailuresBuilder_ == null) {
+        return lastFailures_.size();
+      } else {
+        return lastFailuresBuilder_.getCount();
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public alluxio.grpc.JobInfo getLastFailures(int index) {
+      if (lastFailuresBuilder_ == null) {
+        return lastFailures_.get(index);
+      } else {
+        return lastFailuresBuilder_.getMessage(index);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder setLastFailures(
+        int index, alluxio.grpc.JobInfo value) {
+      if (lastFailuresBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastFailuresIsMutable();
+        lastFailures_.set(index, value);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.setMessage(index, value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder setLastFailures(
+        int index, alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastFailuresBuilder_ == null) {
+        ensureLastFailuresIsMutable();
+        lastFailures_.set(index, builderForValue.build());
+        onChanged();
+      } else {
+        lastFailuresBuilder_.setMessage(index, builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder addLastFailures(alluxio.grpc.JobInfo value) {
+      if (lastFailuresBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastFailuresIsMutable();
+        lastFailures_.add(value);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.addMessage(value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder addLastFailures(
+        int index, alluxio.grpc.JobInfo value) {
+      if (lastFailuresBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureLastFailuresIsMutable();
+        lastFailures_.add(index, value);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.addMessage(index, value);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder addLastFailures(
+        alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastFailuresBuilder_ == null) {
+        ensureLastFailuresIsMutable();
+        lastFailures_.add(builderForValue.build());
+        onChanged();
+      } else {
+        lastFailuresBuilder_.addMessage(builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder addLastFailures(
+        int index, alluxio.grpc.JobInfo.Builder builderForValue) {
+      if (lastFailuresBuilder_ == null) {
+        ensureLastFailuresIsMutable();
+        lastFailures_.add(index, builderForValue.build());
+        onChanged();
+      } else {
+        lastFailuresBuilder_.addMessage(index, builderForValue.build());
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder addAllLastFailures(
+        java.lang.Iterable<? extends alluxio.grpc.JobInfo> values) {
+      if (lastFailuresBuilder_ == null) {
+        ensureLastFailuresIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, lastFailures_);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.addAllMessages(values);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder clearLastFailures() {
+      if (lastFailuresBuilder_ == null) {
+        lastFailures_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.clear();
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public Builder removeLastFailures(int index) {
+      if (lastFailuresBuilder_ == null) {
+        ensureLastFailuresIsMutable();
+        lastFailures_.remove(index);
+        onChanged();
+      } else {
+        lastFailuresBuilder_.remove(index);
+      }
+      return this;
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder getLastFailuresBuilder(
+        int index) {
+      return getLastFailuresFieldBuilder().getBuilder(index);
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+        int index) {
+      if (lastFailuresBuilder_ == null) {
+        return lastFailures_.get(index);  } else {
+        return lastFailuresBuilder_.getMessageOrBuilder(index);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+         getLastFailuresOrBuilderList() {
+      if (lastFailuresBuilder_ != null) {
+        return lastFailuresBuilder_.getMessageOrBuilderList();
+      } else {
+        return java.util.Collections.unmodifiableList(lastFailures_);
+      }
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder addLastFailuresBuilder() {
+      return getLastFailuresFieldBuilder().addBuilder(
+          alluxio.grpc.JobInfo.getDefaultInstance());
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public alluxio.grpc.JobInfo.Builder addLastFailuresBuilder(
+        int index) {
+      return getLastFailuresFieldBuilder().addBuilder(
+          index, alluxio.grpc.JobInfo.getDefaultInstance());
+    }
+    /**
+     * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+     */
+    public java.util.List<alluxio.grpc.JobInfo.Builder> 
+         getLastFailuresBuilderList() {
+      return getLastFailuresFieldBuilder().getBuilderList();
+    }
+    private com.google.protobuf.RepeatedFieldBuilderV3<
+        alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder> 
+        getLastFailuresFieldBuilder() {
+      if (lastFailuresBuilder_ == null) {
+        lastFailuresBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+            alluxio.grpc.JobInfo, alluxio.grpc.JobInfo.Builder, alluxio.grpc.JobInfoOrBuilder>(
+                lastFailures_,
+                ((bitField0_ & 0x00000004) == 0x00000004),
+                getParentForChildren(),
+                isClean());
+        lastFailures_ = null;
+      }
+      return lastFailuresBuilder_;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/JobServiceSummaryOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobServiceSummaryOrBuilder.java
@@ -32,50 +32,50 @@ public interface JobServiceSummaryOrBuilder extends
       int index);
 
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
   java.util.List<alluxio.grpc.JobInfo> 
-      getLastActivitiesList();
+      getRecentActivitiesList();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  alluxio.grpc.JobInfo getLastActivities(int index);
+  alluxio.grpc.JobInfo getRecentActivities(int index);
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  int getLastActivitiesCount();
+  int getRecentActivitiesCount();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
   java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-      getLastActivitiesOrBuilderList();
+      getRecentActivitiesOrBuilderList();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentActivities = 2;</code>
    */
-  alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+  alluxio.grpc.JobInfoOrBuilder getRecentActivitiesOrBuilder(
       int index);
 
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
   java.util.List<alluxio.grpc.JobInfo> 
-      getLastFailuresList();
+      getRecentFailuresList();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  alluxio.grpc.JobInfo getLastFailures(int index);
+  alluxio.grpc.JobInfo getRecentFailures(int index);
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  int getLastFailuresCount();
+  int getRecentFailuresCount();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
   java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
-      getLastFailuresOrBuilderList();
+      getRecentFailuresOrBuilderList();
   /**
-   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   * <code>repeated .alluxio.grpc.job.JobInfo recentFailures = 3;</code>
    */
-  alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+  alluxio.grpc.JobInfoOrBuilder getRecentFailuresOrBuilder(
       int index);
 }

--- a/core/transport/src/main/java/alluxio/grpc/JobServiceSummaryOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobServiceSummaryOrBuilder.java
@@ -30,4 +30,52 @@ public interface JobServiceSummaryOrBuilder extends
    */
   alluxio.grpc.StatusSummaryOrBuilder getSummaryPerStatusOrBuilder(
       int index);
+
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  java.util.List<alluxio.grpc.JobInfo> 
+      getLastActivitiesList();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  alluxio.grpc.JobInfo getLastActivities(int index);
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  int getLastActivitiesCount();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+      getLastActivitiesOrBuilderList();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastActivities = 2;</code>
+   */
+  alluxio.grpc.JobInfoOrBuilder getLastActivitiesOrBuilder(
+      int index);
+
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  java.util.List<alluxio.grpc.JobInfo> 
+      getLastFailuresList();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  alluxio.grpc.JobInfo getLastFailures(int index);
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  int getLastFailuresCount();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  java.util.List<? extends alluxio.grpc.JobInfoOrBuilder> 
+      getLastFailuresOrBuilderList();
+  /**
+   * <code>repeated .alluxio.grpc.job.JobInfo lastFailures = 3;</code>
+   */
+  alluxio.grpc.JobInfoOrBuilder getLastFailuresOrBuilder(
+      int index);
 }

--- a/job/common/src/main/java/alluxio/job/wire/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobInfo.java
@@ -35,6 +35,8 @@ public final class JobInfo {
   private List<TaskInfo> mTaskInfoList;
   private Status mStatus;
   private String mResult;
+  private long mLastStatusChangeMs;
+
 
   /**
    * Default constructor.
@@ -53,6 +55,7 @@ public final class JobInfo {
     mTaskInfoList = Lists.newArrayList();
     mStatus = Status.valueOf(jobInfo.getStatus().name());
     mResult = jobInfo.getResult();
+    mLastStatusChangeMs = jobInfo.getLastStatusChangeMs();
     for (TaskInfo taskInfo : jobInfo.getTaskInfoList()) {
       mTaskInfoList.add(taskInfo);
     }
@@ -73,6 +76,7 @@ public final class JobInfo {
     }
     mStatus = Status.valueOf(jobInfo.getStatus().name());
     mResult = jobInfo.getResult();
+    mLastStatusChangeMs = jobInfo.getLastStatusChangeMs();
   }
 
   /**
@@ -162,6 +166,18 @@ public final class JobInfo {
   public String getErrorMessage() {
     return mErrorMessage;
   }
+
+  /**
+   * @param lastStatusChangeMs the time when status last changed in milliseconds
+   */
+  public void setLastStatusChangeMs(long lastStatusChangeMs) {
+    mLastStatusChangeMs = lastStatusChangeMs;
+  }
+
+  /**
+   * @return the time when status last changed in milliseconds
+   */
+  public long getLastStatusChangeMs() { return mLastStatusChangeMs; }
 
   /**
    * @return proto representation of the job info

--- a/job/common/src/main/java/alluxio/job/wire/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobInfo.java
@@ -215,12 +215,14 @@ public final class JobInfo {
         && Objects.equal(mErrorMessage, that.mErrorMessage)
         && Objects.equal(mTaskInfoList, that.mTaskInfoList)
         && Objects.equal(mStatus, that.mStatus)
-        && Objects.equal(mResult, that.mResult);
+        && Objects.equal(mResult, that.mResult)
+        && Objects.equal(mLastStatusChangeMs, that.mLastStatusChangeMs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mJobId, mJobConfig, mErrorMessage, mTaskInfoList, mStatus, mResult);
+    return Objects.hashCode(mJobId, mJobConfig, mErrorMessage, mTaskInfoList, mStatus, mResult,
+        mLastStatusChangeMs);
   }
 
   @Override
@@ -232,6 +234,7 @@ public final class JobInfo {
         .add("taskInfoList", mTaskInfoList)
         .add("status", mStatus)
         .add("result", mResult)
+        .add("lastStatusChangeMs", mLastStatusChangeMs)
         .toString();
   }
 }

--- a/job/common/src/main/java/alluxio/job/wire/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobInfo.java
@@ -37,7 +37,6 @@ public final class JobInfo {
   private String mResult;
   private long mLastStatusChangeMs;
 
-
   /**
    * Default constructor.
    */
@@ -177,7 +176,9 @@ public final class JobInfo {
   /**
    * @return the time when status last changed in milliseconds
    */
-  public long getLastStatusChangeMs() { return mLastStatusChangeMs; }
+  public long getLastStatusChangeMs() {
+    return mLastStatusChangeMs;
+  }
 
   /**
    * @return proto representation of the job info

--- a/job/common/src/main/java/alluxio/job/wire/JobInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobInfo.java
@@ -194,6 +194,7 @@ public final class JobInfo {
     if (mResult != null) {
       jobInfoBuilder.setResult(mResult);
     }
+    jobInfoBuilder.setLastStatusChangeMs(mLastStatusChangeMs);
     return jobInfoBuilder.build();
   }
 

--- a/job/common/src/main/java/alluxio/job/wire/JobServiceSummary.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobServiceSummary.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 public final class JobServiceSummary {
   private final List<StatusSummary> mSummaryPerStatus;
 
-  private List<JobInfo> mLastActivities;
-  private List<JobInfo> mLastFailures;
+  private final List<JobInfo> mLastActivities;
+  private final List<JobInfo> mLastFailures;
 
   /**
    * Constructs a new instance of {@link JobServiceSummary} from a
@@ -56,10 +56,18 @@ public final class JobServiceSummary {
    *
    * @param jobServiceSummary the proto object
    */
-  public JobServiceSummary(alluxio.grpc.JobServiceSummary jobServiceSummary) {
+  public JobServiceSummary(alluxio.grpc.JobServiceSummary jobServiceSummary) throws IOException {
     mSummaryPerStatus = new ArrayList<>();
     for (alluxio.grpc.StatusSummary statusSummary : jobServiceSummary.getSummaryPerStatusList()) {
       mSummaryPerStatus.add(new StatusSummary(statusSummary));
+    }
+    mLastActivities = new ArrayList<>();
+    for (alluxio.grpc.JobInfo lastActivity : jobServiceSummary.getLastActivitiesList()) {
+      mLastActivities.add(new JobInfo(lastActivity));
+    }
+    mLastFailures = new ArrayList<>();
+    for (alluxio.grpc.JobInfo lastFailure : jobServiceSummary.getLastFailuresList()) {
+      mLastFailures.add(new JobInfo(lastFailure));
     }
   }
 

--- a/job/common/src/main/java/alluxio/job/wire/JobServiceSummary.java
+++ b/job/common/src/main/java/alluxio/job/wire/JobServiceSummary.java
@@ -16,7 +16,13 @@ import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**

--- a/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
+++ b/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
@@ -79,36 +79,36 @@ public class JobServiceSummaryTest {
   }
 
   @Test
-  public void testRecentFailures() {
-    Collection<JobInfo> lastFailures = mSummary.getRecentFailures();
+  public void testRecentActivities() {
+    Collection<JobInfo> recentActivities = mSummary.getRecentActivities();
 
-    Assert.assertEquals("Unexpected length of last failures", 3, lastFailures.size());
+    Assert.assertEquals("Unexpected length of recent activities", 6, recentActivities.size());
 
-    JobInfo[] lastFailuresArray = new JobInfo[3];
+    JobInfo[] recentActvitiesArray = new JobInfo[6];
 
-    lastFailures.toArray(lastFailuresArray);
+    recentActivities.toArray(recentActvitiesArray);
 
-    Assert.assertEquals(1, lastFailuresArray[0].getJobId());
-    Assert.assertEquals(6, lastFailuresArray[1].getJobId());
-    Assert.assertEquals(5, lastFailuresArray[2].getJobId());
-    Assert.assertEquals(3, lastFailuresArray[3].getJobId());
-    Assert.assertEquals(2, lastFailuresArray[4].getJobId());
-    Assert.assertEquals(4, lastFailuresArray[5].getJobId());
+    Assert.assertEquals(1, recentActvitiesArray[0].getJobId());
+    Assert.assertEquals(6, recentActvitiesArray[1].getJobId());
+    Assert.assertEquals(5, recentActvitiesArray[2].getJobId());
+    Assert.assertEquals(3, recentActvitiesArray[3].getJobId());
+    Assert.assertEquals(2, recentActvitiesArray[4].getJobId());
+    Assert.assertEquals(4, recentActvitiesArray[5].getJobId());
   }
 
   @Test
-  public void testRecentActivities() {
-    Collection<JobInfo> lastFailures = mSummary.getRecentActivities();
+  public void testRecentFailures() {
+    Collection<JobInfo> recentFailures = mSummary.getRecentFailures();
 
-    Assert.assertEquals("Unexpected length of last activities", 6, lastFailures.size());
+    Assert.assertEquals("Unexpected length of last activities", 3, recentFailures.size());
 
-    JobInfo[] lastFailuresArray = new JobInfo[6];
+    JobInfo[] recentFailuresArray = new JobInfo[3];
 
-    lastFailures.toArray(lastFailuresArray);
+    recentFailures.toArray(recentFailuresArray);
 
-    Assert.assertEquals(1, lastFailuresArray[0].getJobId());
-    Assert.assertEquals(6, lastFailuresArray[1].getJobId());
-    Assert.assertEquals(4, lastFailuresArray[2].getJobId());
+    Assert.assertEquals(1, recentFailuresArray[0].getJobId());
+    Assert.assertEquals(6, recentFailuresArray[1].getJobId());
+    Assert.assertEquals(4, recentFailuresArray[2].getJobId());
   }
 
   private JobInfo createJobInfo(int id, Status status, long lastStatusChangeMs) {

--- a/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
+++ b/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
@@ -79,27 +79,44 @@ public class JobServiceSummaryTest {
   }
 
   @Test
-  public void testRecent() {
+  public void testRecentFailures() {
     Collection<JobInfo> lastFailures = mSummary.getRecentFailures();
 
     Assert.assertEquals("Unexpected length of last failures", 3, lastFailures.size());
 
-    JobInfo[] lastFailuresArray = (JobInfo[]) lastFailures.toArray();
+    JobInfo[] lastFailuresArray = new JobInfo[3];
+
+    lastFailures.toArray(lastFailuresArray);
+
+    Assert.assertEquals(1, lastFailuresArray[0].getJobId());
+    Assert.assertEquals(6, lastFailuresArray[1].getJobId());
+    Assert.assertEquals(5, lastFailuresArray[2].getJobId());
+    Assert.assertEquals(3, lastFailuresArray[3].getJobId());
+    Assert.assertEquals(2, lastFailuresArray[4].getJobId());
+    Assert.assertEquals(4, lastFailuresArray[5].getJobId());
+  }
+
+  @Test
+  public void testRecentActivities() {
+    Collection<JobInfo> lastFailures = mSummary.getRecentActivities();
+
+    Assert.assertEquals("Unexpected length of last activities", 6, lastFailures.size());
+
+    JobInfo[] lastFailuresArray = new JobInfo[6];
+
+    lastFailures.toArray(lastFailuresArray);
 
     Assert.assertEquals(1, lastFailuresArray[0].getJobId());
     Assert.assertEquals(6, lastFailuresArray[1].getJobId());
     Assert.assertEquals(4, lastFailuresArray[2].getJobId());
   }
 
-  private JobInfo createJobInfo(int id, Status status, Long lastStatusChangeMs) {
+  private JobInfo createJobInfo(int id, Status status, long lastStatusChangeMs) {
     JobInfo jobInfo = new JobInfo();
 
     jobInfo.setJobId(id);
     jobInfo.setStatus(status);
 
-    if (lastStatusChangeMs == null) {
-      lastStatusChangeMs = System.currentTimeMillis();
-    }
     jobInfo.setLastStatusChangeMs(lastStatusChangeMs);
 
     return jobInfo;

--- a/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
+++ b/job/common/src/test/java/alluxio/job/wire/JobServiceSummaryTest.java
@@ -13,6 +13,7 @@ package alluxio.job.wire;
 
 import com.google.common.collect.Maps;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,20 +25,27 @@ import java.util.Map;
  * Tests the wire format of {@link JobServiceSummary}.
  */
 public class JobServiceSummaryTest {
+
+  JobServiceSummary mSummary;
+
+  @Before
+  public void before() {
+    List<JobInfo> jobInfos = new ArrayList<>();
+
+    jobInfos.add(createJobInfo(1, Status.FAILED, 10003L));
+    jobInfos.add(createJobInfo(2, Status.COMPLETED, 9998L));
+    jobInfos.add(createJobInfo(3, Status.COMPLETED, 9999L));
+    jobInfos.add(createJobInfo(4, Status.FAILED, 9997L));
+    jobInfos.add(createJobInfo(5, Status.RUNNING, 10000L));
+    jobInfos.add(createJobInfo(6, Status.FAILED, 10002L));
+
+    mSummary = new JobServiceSummary(jobInfos);
+  }
+
   @Test
   public void testJobServiceSummaryBuilder() {
 
-    List<JobInfo> jobInfos = new ArrayList<>();
-
-    jobInfos.add(createJobInfo(Status.CANCELED));
-    jobInfos.add(createJobInfo(Status.COMPLETED));
-    jobInfos.add(createJobInfo(Status.COMPLETED));
-    jobInfos.add(createJobInfo(Status.CANCELED));
-    jobInfos.add(createJobInfo(Status.RUNNING));
-
-    JobServiceSummary summary = new JobServiceSummary(jobInfos);
-
-    Collection<StatusSummary> summaryPerStatus = summary.getSummaryPerStatus();
+    Collection<StatusSummary> summaryPerStatus = mSummary.getSummaryPerStatus();
 
     Assert.assertEquals("Unexpected length of summaryPerStatus",
             Status.values().length, summaryPerStatus.size());
@@ -58,8 +66,8 @@ public class JobServiceSummaryTest {
         case COMPLETED:
           Assert.assertEquals("COMPLETED count unexpected", 2L, count);
           break;
-        case CANCELED:
-          Assert.assertEquals("CANCELED count unexpected", 2L, count);
+        case FAILED:
+          Assert.assertEquals("FAILED count unexpected", 3L, count);
           break;
         case RUNNING:
           Assert.assertEquals("RUNNING count unexpected", 1L, count);
@@ -70,9 +78,30 @@ public class JobServiceSummaryTest {
     }
   }
 
-  private JobInfo createJobInfo(Status status) {
+  @Test
+  public void testRecent() {
+    Collection<JobInfo> lastFailures = mSummary.getRecentFailures();
+
+    Assert.assertEquals("Unexpected length of last failures", 3, lastFailures.size());
+
+    JobInfo[] lastFailuresArray = (JobInfo[]) lastFailures.toArray();
+
+    Assert.assertEquals(1, lastFailuresArray[0].getJobId());
+    Assert.assertEquals(6, lastFailuresArray[1].getJobId());
+    Assert.assertEquals(4, lastFailuresArray[2].getJobId());
+  }
+
+  private JobInfo createJobInfo(int id, Status status, Long lastStatusChangeMs) {
     JobInfo jobInfo = new JobInfo();
+
+    jobInfo.setJobId(id);
     jobInfo.setStatus(status);
+
+    if (lastStatusChangeMs == null) {
+      lastStatusChangeMs = System.currentTimeMillis();
+    }
+    jobInfo.setLastStatusChangeMs(lastStatusChangeMs);
+
     return jobInfo;
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/ReportCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/ReportCommand.java
@@ -164,7 +164,7 @@ public final class ReportCommand extends AbstractFsAdminCommand {
         break;
       case JOBSERVICE:
         JobServiceMetricsCommand jobmetricsCommand = new JobServiceMetricsCommand(
-            mJobMasterClient, mPrintStream
+            mJobMasterClient, mPrintStream, mConf.get(PropertyKey.USER_DATE_FORMAT_PATTERN),
         );
         jobmetricsCommand.run();
         break;

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/ReportCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/ReportCommand.java
@@ -164,8 +164,7 @@ public final class ReportCommand extends AbstractFsAdminCommand {
         break;
       case JOBSERVICE:
         JobServiceMetricsCommand jobmetricsCommand = new JobServiceMetricsCommand(
-            mJobMasterClient, mPrintStream, mConf.get(PropertyKey.USER_DATE_FORMAT_PATTERN),
-        );
+            mJobMasterClient, mPrintStream, mConf.get(PropertyKey.USER_DATE_FORMAT_PATTERN));
         jobmetricsCommand.run();
         break;
       default:

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -61,7 +61,7 @@ public class JobServiceMetricsCommand {
     }
 
     mPrintStream.println();
-    mPrintStream.println("Last 10 Activities:");
+    mPrintStream.println("10 Most Recently Modified Jobs:");
 
     List<JobInfo> lastActivities = jobServiceSummary.getRecentActivities();
 
@@ -73,7 +73,7 @@ public class JobServiceMetricsCommand {
     }
 
     mPrintStream.println();
-    mPrintStream.println("Last 10 Failures:");
+    mPrintStream.println("10 Most Recently Failed Jobs:");
 
     List<JobInfo> lastFailures = jobServiceSummary.getRecentFailures();
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -15,6 +15,7 @@ import alluxio.client.job.JobMasterClient;
 import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.JobServiceSummary;
 import alluxio.job.wire.StatusSummary;
+import alluxio.util.CommonUtils;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -27,16 +28,20 @@ public class JobServiceMetricsCommand {
 
   private final JobMasterClient mJobMasterClient;
   private final PrintStream mPrintStream;
+  private final String mDateFormatPattern;
 
   /**
    * Creates a new instance of {@link JobServiceMetricsCommand}.
    *
    * @param JobMasterClient client to connect to job master client
    * @param printStream stream to print job services metrics information to
+   * @param dateFormatPattern the pattern to follow when printing the date
    */
-  public JobServiceMetricsCommand(JobMasterClient JobMasterClient, PrintStream printStream) {
+  public JobServiceMetricsCommand(JobMasterClient JobMasterClient, PrintStream printStream,
+      String dateFormatPattern) {
     mJobMasterClient = JobMasterClient;
     mPrintStream = printStream;
+    mDateFormatPattern = dateFormatPattern;
   }
 
   /**
@@ -54,17 +59,17 @@ public class JobServiceMetricsCommand {
       mPrintStream.println(String.format("Count: %s", statusSummary.getCount()));
     }
 
-
     mPrintStream.println();
     mPrintStream.println("Last 10 Activities:");
 
     Collection<JobInfo> lastActivities = jobServiceSummary.getLastActivities();
 
     for (JobInfo lastActivity : lastActivities) {
+      mPrintStream.print(String.format("Timestamp: %-30s",
+        CommonUtils.convertMsToDate(lastActivity.getLastStatusChangeMs(), mDateFormatPattern)));
       mPrintStream.print(String.format("Job Id: %-20s", lastActivity.getJobId()));
       mPrintStream.println(String.format("Status: %s", lastActivity.getStatus()));
     }
-
 
     mPrintStream.println();
     mPrintStream.println("Last 10 Failures:");
@@ -72,6 +77,8 @@ public class JobServiceMetricsCommand {
     Collection<JobInfo> lastFailures = jobServiceSummary.getLastFailures();
 
     for (JobInfo lastFailure : lastFailures) {
+      mPrintStream.print(String.format("Timestamp: %-30s",
+        CommonUtils.convertMsToDate(lastFailure.getLastStatusChangeMs(), mDateFormatPattern)));
       mPrintStream.print(String.format("Job Id: %-20s", lastFailure.getJobId()));
       mPrintStream.println(String.format("Status: %s", lastFailure.getStatus()));
     }

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -12,6 +12,7 @@
 package alluxio.cli.fsadmin.report;
 
 import alluxio.client.job.JobMasterClient;
+import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.JobServiceSummary;
 import alluxio.job.wire.StatusSummary;
 
@@ -52,6 +53,29 @@ public class JobServiceMetricsCommand {
       mPrintStream.print(String.format("Status: %-10s", statusSummary.getStatus()));
       mPrintStream.println(String.format("Count: %s", statusSummary.getCount()));
     }
+
+
+    mPrintStream.println();
+    mPrintStream.println("Last 10 Activities:");
+
+    Collection<JobInfo> lastActivities = jobServiceSummary.getLastActivities();
+
+    for (JobInfo lastActivity : lastActivities) {
+      mPrintStream.print(String.format("Job Id: %-20s", lastActivity.getJobId()));
+      mPrintStream.println(String.format("Status: %s", lastActivity.getStatus()));
+    }
+
+
+    mPrintStream.println();
+    mPrintStream.println("Last 10 Failures:");
+
+    Collection<JobInfo> lastFailures = jobServiceSummary.getLastFailures();
+
+    for (JobInfo lastFailure : lastFailures) {
+      mPrintStream.print(String.format("Job Id: %-20s", lastFailure.getJobId()));
+      mPrintStream.println(String.format("Status: %s", lastFailure.getStatus()));
+    }
+
     return 0;
   }
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -66,7 +66,7 @@ public class JobServiceMetricsCommand {
 
     for (JobInfo lastActivity : lastActivities) {
       mPrintStream.print(String.format("Timestamp: %-30s",
-        CommonUtils.convertMsToDate(lastActivity.getLastStatusChangeMs(), mDateFormatPattern)));
+          CommonUtils.convertMsToDate(lastActivity.getLastStatusChangeMs(), mDateFormatPattern)));
       mPrintStream.print(String.format("Job Id: %-20s", lastActivity.getJobId()));
       mPrintStream.println(String.format("Status: %s", lastActivity.getStatus()));
     }
@@ -78,7 +78,7 @@ public class JobServiceMetricsCommand {
 
     for (JobInfo lastFailure : lastFailures) {
       mPrintStream.print(String.format("Timestamp: %-30s",
-        CommonUtils.convertMsToDate(lastFailure.getLastStatusChangeMs(), mDateFormatPattern)));
+          CommonUtils.convertMsToDate(lastFailure.getLastStatusChangeMs(), mDateFormatPattern)));
       mPrintStream.print(String.format("Job Id: %-20s", lastFailure.getJobId()));
       mPrintStream.println(String.format("Status: %s", lastFailure.getStatus()));
     }

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -20,6 +20,7 @@ import alluxio.util.CommonUtils;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Prints job service metric information.
@@ -62,7 +63,7 @@ public class JobServiceMetricsCommand {
     mPrintStream.println();
     mPrintStream.println("Last 10 Activities:");
 
-    Collection<JobInfo> lastActivities = jobServiceSummary.getLastActivities();
+    List<JobInfo> lastActivities = jobServiceSummary.getRecentActivities();
 
     for (JobInfo lastActivity : lastActivities) {
       mPrintStream.print(String.format("Timestamp: %-30s",
@@ -74,7 +75,7 @@ public class JobServiceMetricsCommand {
     mPrintStream.println();
     mPrintStream.println("Last 10 Failures:");
 
-    Collection<JobInfo> lastFailures = jobServiceSummary.getLastFailures();
+    List<JobInfo> lastFailures = jobServiceSummary.getRecentFailures();
 
     for (JobInfo lastFailure : lastFailures) {
       mPrintStream.print(String.format("Timestamp: %-30s",

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -28,6 +28,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public class JobServiceMetricsCommandTest {
 
@@ -51,7 +52,7 @@ public class JobServiceMetricsCommandTest {
   @Test
   public void testBasic() throws IOException {
 
-    Collection<JobInfo> jobInfos = new ArrayList<>();
+    List<JobInfo> jobInfos = new ArrayList<>();
 
     jobInfos.add(createJobInfoWithStatus(Status.RUNNING));
     jobInfos.add(createJobInfoWithStatus(Status.CANCELED));

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -28,7 +28,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +55,6 @@ public class JobServiceMetricsCommandTest {
 
     List<JobInfo> jobInfos = new ArrayList<>();
 
-
     jobInfos.add(createJobInfo(1, Status.RUNNING, "2019-10-17 12:00:00"));
     jobInfos.add(createJobInfo(2, Status.FAILED, "2019-10-17 12:30:15"));
 
@@ -69,25 +67,24 @@ public class JobServiceMetricsCommandTest {
 
     String[] lineByLine = output.split("\n");
 
-
     Assert.assertEquals("Status: CREATED   Count: 0", lineByLine[0]);
     Assert.assertEquals("Status: CANCELED  Count: 0", lineByLine[1]);
     Assert.assertEquals("Status: FAILED    Count: 1", lineByLine[2]);
     Assert.assertEquals("Status: RUNNING   Count: 1", lineByLine[3]);
     Assert.assertEquals("Status: COMPLETED Count: 0", lineByLine[4]);
 
-    Assert.assertEquals("Last 10 Activities:", lineByLine[6]);
+    Assert.assertEquals("10 Most Recently Modified Jobs:", lineByLine[6]);
     Assert.assertEquals(
-      "Timestamp: 01-17-2019 12:30:15:000       Job Id: 2                   Status: FAILED",
-      lineByLine[7]);
+        "Timestamp: 01-17-2019 12:30:15:000       Job Id: 2                   Status: FAILED",
+        lineByLine[7]);
     Assert.assertEquals(
-      "Timestamp: 01-17-2019 12:00:00:000       Job Id: 1                   Status: RUNNING",
-      lineByLine[8]);
+        "Timestamp: 01-17-2019 12:00:00:000       Job Id: 1                   Status: RUNNING",
+        lineByLine[8]);
 
-    Assert.assertEquals("Last 10 Failures:", lineByLine[10]);
+    Assert.assertEquals("10 Most Recently Failed Jobs:", lineByLine[10]);
     Assert.assertEquals(
-      "Timestamp: 01-17-2019 12:30:15:000       Job Id: 2                   Status: FAILED",
-      lineByLine[11]);
+        "Timestamp: 01-17-2019 12:30:15:000       Job Id: 2                   Status: FAILED",
+        lineByLine[11]);
   }
 
   private JobInfo createJobInfo(int id, Status status, String datetime) throws ParseException {

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class JobServiceMetricsCommandTest {

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -59,7 +59,7 @@ public class JobServiceMetricsCommandTest {
     Mockito.when(mJobMasterClient.getJobServiceSummary())
             .thenReturn(new JobServiceSummary(jobInfos));
 
-    new JobServiceMetricsCommand(mJobMasterClient, mPrintStream).run();
+    new JobServiceMetricsCommand(mJobMasterClient, mPrintStream, "MM-dd-yyyy HH:mm:ss:SSS").run();
 
     String output = new String(mOutputStream.toByteArray(), StandardCharsets.UTF_8);
 


### PR DESCRIPTION
Don't need this in 2.1.0 so it can wait

Examples:

![example_01](https://user-images.githubusercontent.com/379257/67052862-66451280-f0f4-11e9-8e45-86c2e1485143.png)
![example_02](https://user-images.githubusercontent.com/379257/67052864-680ed600-f0f4-11e9-9520-a22bd7e507cf.png)


