### PR TITLE
[DOCFIX] Add vi/vim support in Fuse docs

### DIFF
--- a/docs/en/api/POSIX-API.md
+++ b/docs/en/api/POSIX-API.md
@@ -173,7 +173,8 @@ characteristics, please be aware that:
 
 * Files can be written only once, only sequentially, and never be modified. That means overriding a
   file is not allowed, and an explicit combination of delete and then create is needed. For example,
-  `cp` command will fail when the destination file exists.
+  `cp` command will fail when the destination file exists. `vi` and `vim` commands will succeed because the 
+  underlying system do create, delete, and rename operation combinations.
 * Alluxio does not have hard-link and soft-link concepts, so the commands like `ln` are not supported,
   neither the hardlinks number is displayed in `ll` output.
 * The user and group are mapped to the Unix user and group only when Alluxio POSIX API is configured to use


### PR DESCRIPTION
Modify the doc to document it support vi/vim.

Other than vi/vim, other operations which do the append, modify or override still not work.
Cp when destination file exist will file.
Append to a file will fail.
Sed to replace content in a file will fail.

Vi/Vim may just be sepcial case that it internally do create a new file, delete old file, rename the new file to old name operation combinations.