### PR TITLE
Fix K8s container runAsGroup typo

### DIFF
--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -44,7 +44,7 @@ spec:
       nodeSelector:
       securityContext:
         runAsUser: 1000
-        runAsGroup: 10000
+        runAsGroup: 1000
         fsGroup: 1000
       affinity:
         podAffinity:

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -28,7 +28,7 @@ tieredstore:
 
 # set the uid, gid and fsGroup
 user: 1000
-group: 10000
+group: 1000
 fsGroup: 1000
 
 # The domain hostPath for uuid mode in short Circuit

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -52,7 +52,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
-        command: ["/bin/chown","-R", "1000:10000", "/journal"]
+        command: ["/bin/chown","-R", "1000:1000", "/journal"]
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -62,7 +62,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -95,7 +95,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -164,7 +164,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
-        command: ["/bin/chown","-R", "1000:10000", "/journal"]
+        command: ["/bin/chown","-R", "1000:1000", "/journal"]
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -174,7 +174,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -207,7 +207,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -276,7 +276,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
-        command: ["/bin/chown","-R", "1000:10000", "/journal"]
+        command: ["/bin/chown","-R", "1000:1000", "/journal"]
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -286,7 +286,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -319,7 +319,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -46,7 +46,7 @@ spec:
         securityContext:
           runAsUser: 0
         image: alluxio/alluxio:2.1.0-SNAPSHOT
-        command: ["/bin/chown","-R", "1000:10000", "/opt/domain"]
+        command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -79,7 +79,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -46,7 +46,7 @@ spec:
         securityContext:
           runAsUser: 0
         image: alluxio/alluxio:2.1.0-SNAPSHOT
-        command: ["/bin/chown","-R", "1000:10000", "/opt/domain"]
+        command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -52,7 +52,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
-        command: ["/bin/chown","-R", "1000:10000", "/journal"]
+        command: ["/bin/chown","-R", "1000:1000", "/journal"]
         volumeMounts:
         - name: alluxio-journal
           mountPath: /journal
@@ -62,7 +62,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -88,7 +88,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
-            runAsGroup: 10000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -46,7 +46,7 @@ spec:
         securityContext:
           runAsUser: 0
         image: alluxio/alluxio:2.1.0-SNAPSHOT
-        command: ["/bin/chown","-R", "1000:10000", "/opt/domain"]
+        command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain


### PR DESCRIPTION
The securityContext for K8s containers has a typo in `runAsGroup` field that runs in GID 10000 instead of 1000. Group `alluxio` has GID 1000. This change fixed the GID to the correct one for user `alluxio`.