### PR TITLE
Make client throw NotFoundException when service is not found

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ServiceNotFoundException.java
+++ b/core/base/src/main/java/alluxio/exception/ServiceNotFoundException.java
@@ -1,0 +1,64 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Exception used when the service is not provided by the server.
+ *
+ */
+@ThreadSafe
+public final class ServiceNotFoundException extends AlluxioException {
+  private static final long serialVersionUID = 6180404970709548L;
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public ServiceNotFoundException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause
+   */
+  public ServiceNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message and multiple parameters.
+   *
+   * @param message the exception message
+   * @param params the parameters
+   */
+  public ServiceNotFoundException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message, the cause and multiple
+   * parameters.
+   *
+   * @param message the exception message
+   * @param cause the cause
+   * @param params the parameters
+   */
+  public ServiceNotFoundException(ExceptionMessage message, Throwable cause, Object... params) {
+    this(message.getMessage(params), cause);
+  }
+}

--- a/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
+++ b/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
@@ -47,7 +47,9 @@ public final class ServiceVersionClientServiceHandler
 
     ServiceType serviceType = request.getServiceType();
     if (serviceType != ServiceType.UNKNOWN_SERVICE && !mServices.contains(serviceType)) {
-      responseObserver.onError(Status.NOT_FOUND.asException());
+      responseObserver.onError(Status.NOT_FOUND
+          .withDescription(String.format("Service %s is not found.", serviceType.name()))
+          .asException());
       return;
     }
 

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -78,7 +78,7 @@ public final class AbstractClientTest {
     }
   }
 
-  private static class TestSerivceNotFoundClient extends BaseTestClient {
+  private static class TestServiceNotFoundClient extends BaseTestClient {
     protected long getRemoteServiceVersion() throws AlluxioStatusException {
       throw new NotFoundException("Service not found");
     }
@@ -160,7 +160,7 @@ public final class AbstractClientTest {
   @Test
   public void serviceNotFound() throws Exception {
     mExpectedException.expect(NotFoundException.class);
-    final AbstractClient client = new TestSerivceNotFoundClient();
+    final AbstractClient client = new TestServiceNotFoundClient();
     client.checkVersion(0);
     client.close();
   }

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -14,6 +14,8 @@ package alluxio;
 import static alluxio.exception.ExceptionMessage.INCOMPATIBLE_VERSION;
 
 import alluxio.conf.InstancedConfiguration;
+import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.CountingRetry;
@@ -71,8 +73,24 @@ public final class AbstractClientTest {
     }
 
     @Override
-    protected long getRemoteServiceVersion() {
+    protected long getRemoteServiceVersion() throws AlluxioStatusException {
       return mRemoteServiceVersion;
+    }
+  }
+
+  private static class TestSerivceNotFoundClient extends BaseTestClient {
+    protected long getRemoteServiceVersion() throws AlluxioStatusException {
+      throw new NotFoundException("Service not found");
+    }
+
+    @Override
+    protected void afterConnect() throws IOException {
+      return;
+    }
+
+    @Override
+    protected void beforeConnect() throws IOException {
+      return;
     }
   }
 
@@ -137,5 +155,13 @@ public final class AbstractClientTest {
     }
 
     Assert.assertEquals(confAddress, argument.getValue());
+  }
+
+  @Test
+  public void serviceNotFound() throws Exception {
+    mExpectedException.expect(NotFoundException.class);
+    final AbstractClient client = new TestSerivceNotFoundClient();
+    client.checkVersion(0);
+    client.close();
   }
 }


### PR DESCRIPTION
Currently if a service is not found on server, the client will throw `UnavailableException` which is confusing and causing unnecessary retries. This change makes it throw `NotFoundException` which is what the server is actually throwing. To differentiate it from other `NotFoundException` such as file not found, a `ServiceNotFoundException` is included as cause.