### PR TITLE
Skip caching data into Alluxio during transformation

### DIFF
--- a/job/server/src/main/java/alluxio/job/transform/format/ReadWriterUtils.java
+++ b/job/server/src/main/java/alluxio/job/transform/format/ReadWriterUtils.java
@@ -1,0 +1,48 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.job.transform.format;
+
+import alluxio.client.ReadType;
+import alluxio.client.WriteType;
+import alluxio.conf.PropertyKey;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Utilities for implementing {@link TableReader} and {@link TableWriter}.
+ */
+public final class ReadWriterUtils {
+  private static final String ALLUXIO_HADOOP_FILESYSTEM_DISABLE_CACHE =
+      "fs.alluxio.impl.disable.cache";
+
+  /**
+   * @return a new Hadoop conf with alluxio read type set to no cache
+   */
+  public static Configuration readNoCacheConf() {
+    Configuration conf = new Configuration();
+    conf.setEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(), ReadType.NO_CACHE);
+    // The cached filesystem might not be configured with the above read type.
+    conf.setBoolean(ALLUXIO_HADOOP_FILESYSTEM_DISABLE_CACHE, true);
+    return conf;
+  }
+
+  /**
+   * @return a new Hadoop conf with alluxio write type set to through
+   */
+  public static Configuration writeThroughConf() {
+    Configuration conf = new Configuration();
+    conf.setEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT.getName(), WriteType.THROUGH);
+    // The cached filesystem might not be configured with the above write type.
+    conf.setBoolean(ALLUXIO_HADOOP_FILESYSTEM_DISABLE_CACHE, true);
+    return conf;
+  }
+}

--- a/job/server/src/main/java/alluxio/job/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/transform/format/csv/CsvReader.java
@@ -13,6 +13,7 @@ package alluxio.job.transform.format.csv;
 
 import alluxio.job.transform.format.Format;
 import alluxio.job.transform.format.TableReader;
+import alluxio.job.transform.format.ReadWriterUtils;
 import alluxio.job.transform.format.TableRow;
 import alluxio.job.transform.format.TableSchema;
 
@@ -71,7 +72,7 @@ public final class CsvReader implements TableReader {
         .hasHeader()
         .build();
     Path inputPath = new Path(scheme, "", input);
-    Configuration conf = new Configuration();
+    Configuration conf = ReadWriterUtils.readNoCacheConf();
     FileSystem fs = inputPath.getFileSystem(conf);
     Schema schema;
     try (InputStream inputStream = open(fs, inputPath)) {

--- a/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetReader.java
+++ b/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetReader.java
@@ -12,6 +12,7 @@
 package alluxio.job.transform.format.parquet;
 
 import alluxio.job.transform.format.TableReader;
+import alluxio.job.transform.format.ReadWriterUtils;
 import alluxio.job.transform.format.TableRow;
 import alluxio.job.transform.format.TableSchema;
 
@@ -57,7 +58,7 @@ public final class ParquetReader implements TableReader {
   // TODO(cc): lazily open input streams
   public static ParquetReader create(String scheme, String input) throws IOException {
     Path inputPath = new Path(scheme, "", input);
-    Configuration conf = new Configuration();
+    Configuration conf = ReadWriterUtils.readNoCacheConf();
     InputFile inputFile = HadoopInputFile.fromPath(inputPath, conf);
     org.apache.parquet.hadoop.ParquetReader<Record> reader =
         AvroParquetReader.<Record>builder(inputFile)

--- a/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetWriter.java
@@ -39,8 +39,6 @@ public final class ParquetWriter implements TableWriter {
   private static final int MAX_IN_MEMORY_RECORDS = 10000;
   private static final int ROW_GROUP_SIZE =
       org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
-  private static final String ALLUXIO_HADOOP_FILESYSTEM_DISABLE_CACHE =
-      "fs.alluxio.impl.disable.cache";
 
   private final org.apache.parquet.hadoop.ParquetWriter<Record> mWriter;
   private long mRecordSize; // bytes

--- a/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/transform/format/parquet/ParquetWriter.java
@@ -11,8 +11,7 @@
 
 package alluxio.job.transform.format.parquet;
 
-import alluxio.client.WriteType;
-import alluxio.conf.PropertyKey;
+import alluxio.job.transform.format.ReadWriterUtils;
 import alluxio.job.transform.format.TableRow;
 import alluxio.job.transform.format.TableSchema;
 import alluxio.job.transform.format.TableWriter;
@@ -62,10 +61,7 @@ public final class ParquetWriter implements TableWriter {
    */
   public static ParquetWriter create(TableSchema schema, String scheme, String output)
       throws IOException {
-    Configuration conf = new Configuration();
-    conf.setEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT.getName(), WriteType.THROUGH);
-    // The cached filesystem might not be configured with the above write type.
-    conf.setBoolean(ALLUXIO_HADOOP_FILESYSTEM_DISABLE_CACHE, true);
+    Configuration conf = ReadWriterUtils.writeThroughConf();
     ParquetSchema parquetSchema = schema.toParquet();
     return new ParquetWriter(AvroParquetWriter.<Record>builder(
         HadoopOutputFile.fromPath(new Path(scheme, "", output), conf))


### PR DESCRIPTION
For transformation jobs on structured table, the output should not be written to Alluxio memory space, which might evict other active dataset, instead, write directly through to the under storage. Also, when reading the source files, it should be read with NO_CACHE so that the big tables are not cached into Alluxio.