### PR TITLE
Fix K8s worker start arguments

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -270,9 +270,9 @@ spec:
         - name: {{ .alias | lower }}
           emptyDir:
             medium: "Memory"
-                  {{- if .quota }} 
+                  {{- if .quota }}
             sizeLimit: {{ .quota }}
-                  {{- end}} 
+                  {{- end}}
                 {{- end}}
               {{- end}}
             {{- end}} 

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -136,7 +136,7 @@ domainHostPath: "/tmp/alluxio-domain"
 
 worker:
   args:
-    - worker
+    - worker-only
     - --no-format
   # Properties for the worker component
   properties:

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -128,6 +128,6 @@ spec:
             type: DirectoryOrCreate
         - name: mem
           emptyDir:
-            medium: "Memory" 
+            medium: "Memory"
             sizeLimit: 1G
 

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -63,7 +63,7 @@ spec:
               memory: 2G
           command: ["/entrypoint.sh"]
           args:
-            - worker
+            - worker-only
             - --no-format
           env:
           - name: ALLUXIO_WORKER_HOSTNAME
@@ -128,6 +128,6 @@ spec:
             type: DirectoryOrCreate
         - name: mem
           emptyDir:
-            medium: "Memory"
+            medium: "Memory" 
             sizeLimit: 1G
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -138,6 +138,6 @@ spec:
             defaultMode: 256
         - name: mem
           emptyDir:
-            medium: "Memory" 
+            medium: "Memory"
             sizeLimit: 1G
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -63,7 +63,7 @@ spec:
               memory: 2G
           command: ["/entrypoint.sh"]
           args:
-            - worker
+            - worker-only
             - --no-format
           env:
           - name: ALLUXIO_WORKER_HOSTNAME
@@ -138,6 +138,6 @@ spec:
             defaultMode: 256
         - name: mem
           emptyDir:
-            medium: "Memory"
+            medium: "Memory" 
             sizeLimit: 1G
 

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -128,6 +128,6 @@ spec:
             type: DirectoryOrCreate
         - name: mem
           emptyDir:
-            medium: "Memory" 
+            medium: "Memory"
             sizeLimit: 1G
 

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -63,7 +63,7 @@ spec:
               memory: 2G
           command: ["/entrypoint.sh"]
           args:
-            - worker
+            - worker-only
             - --no-format
           env:
           - name: ALLUXIO_WORKER_HOSTNAME
@@ -128,6 +128,6 @@ spec:
             type: DirectoryOrCreate
         - name: mem
           emptyDir:
-            medium: "Memory"
+            medium: "Memory" 
             sizeLimit: 1G
 


### PR DESCRIPTION
This change corrects start arguments for Alluxio worker containers, from `worker` to `worker-only`. Since we have worker and job-worker 2 separate processes, if we start worker with `worker` argument the ports will be occupied and the job-worker will not be able to start.