### PR TITLE
Improve error message on failed mount

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2661,7 +2661,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
       // Check that the ufsPath exists and is a directory
       if (!ufs.isDirectory(ufsPath.toString())) {
         throw new IOException(
-            ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(ufsPath.getPath()));
+            ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(ufsPath.toString()));
       }
       if (UnderFileSystemUtils.isWeb(ufs)) {
         mountOption.setReadOnly(true);


### PR DESCRIPTION
Before this patch
```console
$ bin/alluxio fs mount --readonly /reason s3://apc999/presto-tutorial/reason/
Ufs path /presto-tutorial/reason does not exist
```
After this patch:
```console
$ bin/alluxio fs mount --readonly /reason s3://apc999/presto-tutorial/reason/
Ufs path s3://apc999/presto-tutorial/reason does not exist
```