### PR TITLE
Fix close order for FSContext resources

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -266,6 +266,8 @@ public final class FileSystemContext implements Closeable {
       for (BlockWorkerClientPool pool : mBlockWorkerClientPool.values()) {
         pool.close();
       }
+      // Close worker group after block master clients in order to allow
+      // clean termination for open streams.
       mWorkerGroup.shutdownGracefully(1L, 10L, TimeUnit.SECONDS);
       mBlockWorkerClientPool.clear();
       mLocalWorkerInitialized = false;

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -259,7 +259,6 @@ public final class FileSystemContext implements Closeable {
       // developers should first mark their resources as closed prior to any exceptions being
       // thrown.
       mClosed.set(true);
-      mWorkerGroup.shutdownGracefully(1L, 10L, TimeUnit.SECONDS);
       mFileSystemMasterClientPool.close();
       mFileSystemMasterClientPool = null;
       mBlockMasterClientPool.close();
@@ -267,6 +266,7 @@ public final class FileSystemContext implements Closeable {
       for (BlockWorkerClientPool pool : mBlockWorkerClientPool.values()) {
         pool.close();
       }
+      mWorkerGroup.shutdownGracefully(1L, 10L, TimeUnit.SECONDS);
       mBlockWorkerClientPool.clear();
       mLocalWorkerInitialized = false;
       mLocalWorker = null;


### PR DESCRIPTION
Netty event loop manages propagating of stream control messages. Alluxio's authentication streams are bound to life-time of logical channels and it's unexpected for a stream to loose its loop while still alive.