### PR TITLE
Exclude logging from client jar and make then runtime dependencies

### DIFF
--- a/core/client/runtime/pom.xml
+++ b/core/client/runtime/pom.xml
@@ -41,6 +41,29 @@
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Runtime logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Move log4j to optional, since it is mainly used in test-->
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Internal dependencies -->
     <!-- This should include all Alluxio client implementations -->
@@ -88,6 +111,16 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <artifactSet>
+                <excludes>
+                  <!-- Leave slf4j unshaded so downstream users can configure logging -->
+                  <exclude>org.slf4j:*</exclude>
+                  <!-- Leave commons-logging unshaded so downstream users can configure logging -->
+                  <exclude>commons-logging:commons-logging</exclude>
+                  <!-- Leave log4j unshaded so downstream users can configure logging -->
+                  <exclude>log4j:log4j</exclude>
+                </excludes>
+              </artifactSet>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <relocations>
                 <!-- Relocate the native netty libraries to be prefixed with our shade prefix -->


### PR DESCRIPTION
fixes #10224
Exclude loggings from Alluxio client jar since it may conflict with application logging dependencies and affect performance.
Those loggings become runtime dependencies.