### PR TITLE
Fix ObjectUnderFileSystem isRoot to check stripped path

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -880,7 +880,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   /**
-   * Checks if the path is the root.
+   * Checks if the path is the root. This method supports full path (e.g. s3://bucket_name/dir)
+   * and stripped path (e.g. /dir).
    *
    * @param path ufs path including scheme and bucket
    * @return true if the path is the root, false otherwise

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -886,8 +886,9 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @return true if the path is the root, false otherwise
    */
   protected boolean isRoot(String path) {
-    return PathUtils.normalizePath(path, PATH_SEPARATOR).equals(
-        PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR));
+    String normalizePath = PathUtils.normalizePath(path, PATH_SEPARATOR);
+    return normalizePath.equals(PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR))
+        || normalizePath.equals(PATH_SEPARATOR);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -887,8 +887,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    */
   protected boolean isRoot(String path) {
     String normalizePath = PathUtils.normalizePath(path, PATH_SEPARATOR);
-    return normalizePath.equals(PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR))
-        || normalizePath.equals(PATH_SEPARATOR);
+    return normalizePath.equals(PATH_SEPARATOR)
+        || normalizePath.equals(PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR));
   }
 
   /**


### PR DESCRIPTION
https://github.com/Alluxio/alluxio/issues/10264

In most of the ObjectUnderFileSystem operations, we will strip prefix if exist. Prefix here refers to the specific object UFS root key (s3://bucket_name for example). 

However, in our ObjectUnderFileSystem.isRoot check, we still check if the stripped path ("/" for example) equals to the full root key (s3://bucket_name).

This fix consider the isRoot case for both stripped path and original full url.