### PR TITLE
Fix UFS RPC metrics aggregation

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -965,7 +965,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
 
   private String getUfsTag() {
     AlluxioURI uri = new AlluxioURI(mPath);
-    uri = new AlluxioURI(uri.getScheme(), uri.getAuthority(), uri.getRootPath());
+    uri = new AlluxioURI(uri.getScheme(), uri.getAuthority(), uri.getPath());
     return MetricsSystem.escape(uri);
   }
 


### PR DESCRIPTION
Originally, the metrics are aggregated on UFS paths. But in scenario where two paths in the same UFS are mounted to different Alluxio mount points, since there is only one UFS client for the mount points, all metrics are aggregated to the first mount point even when operations are on the second mount point, which is confusing.
This PR aggregates UFS RPC metrics per UFS, instead of per UFS path.

fixes #9628