### PR TITLE
Add hive udb to libs in generate tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -245,6 +245,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		fmt.Sprintf("lib/alluxio-underfs-s3a-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-underfs-swift-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-underfs-wasb-%v.jar", version),
+		fmt.Sprintf("lib/alluxio-table-server-underdb-hive-%v.jar", version),
 		"libexec/alluxio-config.sh",
 		"LICENSE",
 	}


### PR DESCRIPTION
Includes the hive udb library in generated tarballs.