### PR TITLE
Make Compact transformation idempotent

### DIFF
--- a/job/server/src/main/java/alluxio/job/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/transform/CompactDefinition.java
@@ -126,7 +126,11 @@ public final class CompactDefinition
       } catch (Throwable t) {
         closer.close();
         closed = true;
-        context.getFileSystem().delete(output); // output is the compacted file
+        try {
+          context.getFileSystem().delete(output); // output is the compacted file
+        } catch (Throwable e) {
+          t.addSuppressed(e);
+        }
         closer.rethrow(t);
       } finally {
         if (!closed) {


### PR DESCRIPTION
When a CompactTask fails, delete the output file, so when JobMaster retry the job, it might succeed, otherwise, during retry, it always throws FileAlreadyExistsException.