### PR TITLE
Ignore all tests that use MultiMasterLocalAlluxioCluster

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
@@ -25,6 +25,7 @@ import alluxio.testutils.IntegrationTestUtils;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -36,6 +37,7 @@ import java.io.PrintStream;
 /**
  * Tests that the job service is available to the shell when running in fault-tolerant mode.
  */
+@Ignore("Flaky test")
 public final class JobServiceFaultToleranceShellTest extends BaseIntegrationTest {
   private MultiMasterLocalAlluxioCluster mLocalAlluxioCluster;
   private LocalAlluxioJobCluster mLocalAlluxioJobCluster;

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
@@ -30,10 +30,12 @@ import alluxio.util.WaitForOptions;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+@Ignore("Flaky test")
 public class MultiMasterJournalTest extends BaseIntegrationTest {
   private MultiMasterLocalAlluxioCluster mCluster;
 


### PR DESCRIPTION
I wrote a small script to see how many times MultiMasterJournalTest failed in the last few builds


➜  ~ python flakeTest.py MultiMasterJournalTest 6605 6628 (23 builds, doesn't include 6628)
12
➜  ~ python flakeTest.py MultiMasterJournalTest 6620 6628 (8 builds)
5

Seems like it fails on about half the builds (though the build may succeed because of retries). Ignore the test.