### PR TITLE
Fix uri validation in client context reinit

### DIFF
--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -89,6 +89,7 @@ public class ClientContext {
     mUserState = ctx.getUserState();
     mClusterConfHash = ctx.getClusterConfHash();
     mPathConfHash = ctx.getPathConfHash();
+    mUriValidationEnabled = ctx.getUriValidationEnabled();
   }
 
   private ClientContext(@Nullable Subject subject, @Nullable AlluxioConfiguration alluxioConf) {


### PR DESCRIPTION
The UriValidationEnabled information in ClientContext should be remembered.