### PR TITLE
Update versions to 2.1.1-SNAPSHOT

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,17 +6,17 @@ kramdown:
 
 # For release candidates and release branches, this should match the pom.xml Alluxio version, e.g. "1.5.0" or "1.5.0-RC1"
 # For master branch, this should be the latest released version, e.g. "1.5.0"
-ALLUXIO_RELEASED_VERSION: 2.1.0
+ALLUXIO_RELEASED_VERSION: 2.1.1-SNAPSHOT
 # This should be the same as ALLUXIO_RELEASED_VERSION, except on master branch, where it should be "master"
-ALLUXIO_MASTER_VERSION_SHORT: 2.1.0
+ALLUXIO_MASTER_VERSION_SHORT: 2.1.1-SNAPSHOT
 # For release candidates and release branches, this should be the major Alluxio version, e.g. both 1.5.0 and 1.5.0-RC1 should use "1.5"
 # For master branch, this should be "master"
-ALLUXIO_MAJOR_VERSION: 2.1.0
+ALLUXIO_MAJOR_VERSION: 2.1
 # The version string must match the version string part of the client jar path
-ALLUXIO_VERSION_STRING: 2.1.0
+ALLUXIO_VERSION_STRING: 2.1.1-SNAPSHOT
 # We must inline the version string (e.g., "1.4.0-SNAPSHOT") rather than using the macro of Alluxio version.
 # Otherwise the macro name remains in the output.
-ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/client/alluxio-2.1.0-client.jar
+ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/client/alluxio-2.1.1-SNAPSHOT-client.jar
 # The version string must match the version of the K8s helm chart
 ALLUXIO_HELM_VERSION_STRING: 0.5.1
 

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -61,7 +61,7 @@ spec:
                 - alluxio-worker
       containers:
         - name: alluxio-fuse
-          image: alluxio/alluxio-fuse:2.1.0
+          image: alluxio/alluxio-fuse:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -10,7 +10,7 @@
 #
 
 name: alluxio
-apiVersion: 2.1.0
+apiVersion: 2.1.1-SNAPSHOT
 description: Open source data orchestration for analytics and machine learning in any cloud.
 version: 0.5.1
 home: https://www.alluxio.io/

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: alluxio
 
 # Docker Image
 image: alluxio/alluxio
-imageTag: 2.1.0
+imageTag: 2.1.1-SNAPSHOT
 imagePullPolicy: IfNotPresent
 
 # Security Context
@@ -187,7 +187,7 @@ jobWorker:
 
 fuse:
   image: alluxio/alluxio-fuse
-  imageTag: 2.1.0
+  imageTag: 2.1.1-SNAPSHOT
   imagePullPolicy: IfNotPresent
   # Properties for the jobWorker component
   properties:

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -48,7 +48,7 @@ spec:
         fsGroup: 1000
       initContainers:
       - name: journal-chown
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -58,7 +58,7 @@ spec:
           mountPath: /journal
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -93,7 +93,7 @@ spec:
             - name: alluxio-journal
               mountPath: /journal
         - name: alluxio-job-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -163,7 +163,7 @@ spec:
         fsGroup: 1000
       initContainers:
       - name: journal-chown
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -173,7 +173,7 @@ spec:
           mountPath: /journal
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -208,7 +208,7 @@ spec:
             - name: alluxio-journal
               mountPath: /journal
         - name: alluxio-job-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -278,7 +278,7 @@ spec:
         fsGroup: 1000
       initContainers:
       - name: journal-chown
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -288,7 +288,7 @@ spec:
           mountPath: /journal
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -323,7 +323,7 @@ spec:
             - name: alluxio-journal
               mountPath: /journal
         - name: alluxio-job-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -45,14 +45,14 @@ spec:
       - name: socket-chown
         securityContext:
           runAsUser: 0
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain
       containers:
         - name: alluxio-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -87,7 +87,7 @@ spec:
             - mountPath: /dev/shm
               name: mem
         - name: alluxio-job-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -48,7 +48,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -77,7 +77,7 @@ spec:
               mountPath: /secrets/hdfsConfig
               readOnly: true
         - name: alluxio-job-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -45,14 +45,14 @@ spec:
       - name: socket-chown
         securityContext:
           runAsUser: 0
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain
       containers:
         - name: alluxio-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -90,7 +90,7 @@ spec:
             - mountPath: /dev/shm
               name: mem
         - name: alluxio-job-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -48,7 +48,7 @@ spec:
         fsGroup: 1000
       initContainers:
       - name: journal-chown
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -58,7 +58,7 @@ spec:
           mountPath: /journal
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -86,7 +86,7 @@ spec:
             - name: alluxio-journal
               mountPath: /journal
         - name: alluxio-job-master
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -45,14 +45,14 @@ spec:
       - name: socket-chown
         securityContext:
           runAsUser: 0
-        image: alluxio/alluxio:2.1.0
+        image: alluxio/alluxio:2.1.1-SNAPSHOT
         command: ["/bin/chown","-R", "1000:1000", "/opt/domain"]
         volumeMounts:
         - name: alluxio-domain
           mountPath: /opt/domain
       containers:
         - name: alluxio-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -87,7 +87,7 @@ spec:
             - mountPath: /dev/shm
               name: mem
         - name: alluxio-job-worker
-          image: alluxio/alluxio:2.1.0
+          image: alluxio/alluxio:2.1.1-SNAPSHOT
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>alluxio-integration</artifactId>
     <groupId>org.alluxio</groupId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
   </parent>
   <name>Alluxio Integration - YARN</name>
   <artifactId>alluxio-integration-yarn</artifactId>

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -27,7 +27,7 @@ this="${config_bin}/${script}"
 
 # This will set the default installation for a tarball installation while os distributors can
 # set system installation locations.
-VERSION=2.1.0
+VERSION=2.1.1-SNAPSHOT
 ALLUXIO_HOME=$(dirname $(dirname "${this}"))
 ALLUXIO_ASSEMBLY_CLIENT_JAR="${ALLUXIO_HOME}/assembly/client/target/alluxio-assembly-client-${VERSION}-jar-with-dependencies.jar"
 ALLUXIO_ASSEMBLY_SERVER_JAR="${ALLUXIO_HOME}/assembly/server/target/alluxio-assembly-server-${VERSION}-jar-with-dependencies.jar"

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -329,7 +329,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>true</skipTests>
           <systemProperties>
             <property>
               <name>alluxio.hadoop.version</name>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -132,7 +132,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>


### PR DESCRIPTION
- Manually bumped versions (i.e. libexec, k8s)
- Removed skipTests from integration module
- Removed version from deploy plugin on webui/pom.xml
