### PR TITLE
Port changes from [#10384] to branch-2.1

### DIFF
--- a/integration/kubernetes/alluxio-fuse-client.yaml.template
+++ b/integration/kubernetes/alluxio-fuse-client.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-fuse-client
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse-client
@@ -25,7 +25,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.1
+      chart: alluxio-0.5.2
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse-client
@@ -33,7 +33,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse-client

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-fuse
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse
@@ -26,7 +26,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.1
+      chart: alluxio-0.5.2
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -32,3 +32,6 @@
 - Fix tiered store issue
 - Fix the issue of the user group of worker is not configurable
 
+0.5.2
+
+- Fix apiVersion key in Chart.yaml

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -10,9 +10,9 @@
 #
 
 name: alluxio
-apiVersion: 2.1.0
+apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.5.1
+version: 0.5.2
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -17,7 +17,7 @@ metadata:
   labels:
     name: alluxio-format-master
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -45,7 +45,7 @@ metadata:
   name: alluxio-master-1
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -72,7 +72,7 @@ metadata:
   name: alluxio-master-2
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-master-0
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -36,7 +36,7 @@ spec:
       labels:
         name: alluxio-master-0
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-master
@@ -134,7 +134,7 @@ metadata:
   labels:
     name: alluxio-master-1
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -151,7 +151,7 @@ spec:
       labels:
         name: alluxio-master-1
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-master
@@ -249,7 +249,7 @@ metadata:
   labels:
     name: alluxio-master-2
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -266,7 +266,7 @@ spec:
       labels:
         name: alluxio-master-2
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -17,7 +17,7 @@ metadata:
   labels:
     name: alluxio-format-master
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-master-0
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -36,7 +36,7 @@ spec:
       labels:
         name: alluxio-master-0
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -17,7 +17,7 @@ metadata:
   labels:
     name: alluxio-format-master
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-master-0
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -36,7 +36,7 @@ spec:
       labels:
         name: alluxio-master-0
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.1
+    chart: alluxio-0.5.2
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.1
+        chart: alluxio-0.5.2
         release: alluxio
         heritage: Tiller
         role: alluxio-worker


### PR DESCRIPTION
The original PR corrects `Chart.yaml` key `apiVersion` in Helm Chart.

pr-link: Alluxio/alluxio#10384
change-id: cid-cf15b0fd4caeee8b16cb68852f25ee55654fccd6