### PR TITLE
Fix race condition building extension properties

### DIFF
--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -149,7 +149,7 @@ public class AlluxioProperties {
         // This will register the key as a valid PropertyKey
         // TODO(adit): Do not add properties unrecognized by Ufs extensions when Configuration
         // is made dynamic
-        propertyKey = new PropertyKey.Builder(key).setIsBuiltIn(false).build();
+        propertyKey = PropertyKey.getOrBuildCustom(key);
       }
       put(propertyKey, value, source);
     }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4856,6 +4856,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     DEFAULT_ALIAS_MAP.remove(name);
   }
 
+  /**
+   * @param name name of the property
+   * @return the registered property key if found, or else create a new one and return
+   */
+  public static PropertyKey getOrBuildCustom(String name) {
+    return DEFAULT_KEYS_MAP.computeIfAbsent(name,
+        (key) -> new Builder(key).setIsBuiltIn(false).buildUnregistered());
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
There is a race condition when building multiple ufs configuration concurrently. Extension properties of the same name that are not built-in will be created as custom property but can throw due to duplication in the property registration.

Fixed by synchronizing registration of custom properties .