### PR TITLE
Do not trim stack traces for test failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,7 @@
             <systemPropertyVariables>
               <alluxio.test.mode>true</alluxio.test.mode>
             </systemPropertyVariables>
+            <trimStackTrace>false</trimStackTrace>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
         </plugin>


### PR DESCRIPTION
Here is a difference in example: 

I would have loved to find an example in between where everything below the Test file doesn't get trimmed but everything above does. But that doesn't seem to exist.

@ZacBlanco: What do you think?

------------------------------------------------

**Before Example**

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running alluxio.job.wire.TaskInfoTest
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.088 sec <<< FAILURE! - in alluxio.job.wire.TaskInfoTest
jsonTest(alluxio.job.wire.TaskInfoTest)  Time elapsed: 0.032 sec  <<< ERROR!
java.lang.NullPointerException
	at alluxio.job.wire.TaskInfoTest.jsonTest(TaskInfoTest.java:30)

jsonTest(alluxio.job.wire.TaskInfoTest)  Time elapsed: 0.001 sec  <<< ERROR!
java.lang.NullPointerException
	at alluxio.job.wire.TaskInfoTest.jsonTest(TaskInfoTest.java:30)


Results :

Tests in error:
alluxio.job.wire.TaskInfoTest.jsonTest(alluxio.job.wire.TaskInfoTest)
  Run 1: TaskInfoTest.jsonTest:30 » NullPointer
  Run 2: TaskInfoTest.jsonTest:30 » NullPointer

---------------------------------------------------------------------------

**After Example**

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running alluxio.job.wire.TaskInfoTest
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.09 sec <<< FAILURE! - in alluxio.job.wire.TaskInfoTest
jsonTest(alluxio.job.wire.TaskInfoTest)  Time elapsed: 0.034 sec  <<< ERROR!
java.lang.NullPointerException
	at alluxio.grpc.TaskInfo$Builder.setErrorMessage(TaskInfo.java:759)
	at alluxio.job.wire.TaskInfo.toProto(TaskInfo.java:155)
	at alluxio.job.wire.TaskInfoTest.jsonTest(TaskInfoTest.java:30)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)

jsonTest(alluxio.job.wire.TaskInfoTest)  Time elapsed: 0.001 sec  <<< ERROR!
java.lang.NullPointerException
	at alluxio.grpc.TaskInfo$Builder.setErrorMessage(TaskInfo.java:759)
	at alluxio.job.wire.TaskInfo.toProto(TaskInfo.java:155)
	at alluxio.job.wire.TaskInfoTest.jsonTest(TaskInfoTest.java:30)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeFailedMethod(JUnit4Provider.java:381)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:292)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)


Results :

Tests in error:
alluxio.job.wire.TaskInfoTest.jsonTest(alluxio.job.wire.TaskInfoTest)
  Run 1: TaskInfoTest.jsonTest:30 » NullPointer
  Run 2: TaskInfoTest.jsonTest:30 » NullPointer




