### PR TITLE
Fix NPE in UfsDirectoryStatus

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UfsDirectoryStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsDirectoryStatus.java
@@ -33,7 +33,7 @@ public class UfsDirectoryStatus extends UfsStatus {
    * @param xAttr extended attributes, if any
    */
   public UfsDirectoryStatus(String name, String owner, String group, short mode,
-      long lastModifiedTimeMs, @Nullable Map<String, byte[]> xAttr) {
+      Long lastModifiedTimeMs, @Nullable Map<String, byte[]> xAttr) {
     super(name, true, owner, group, mode, lastModifiedTimeMs, xAttr);
   }
 
@@ -47,7 +47,7 @@ public class UfsDirectoryStatus extends UfsStatus {
    * @param lastModifiedTimeMs of the directory
    */
   public UfsDirectoryStatus(String name, String owner, String group, short mode,
-      long lastModifiedTimeMs) {
+      Long lastModifiedTimeMs) {
     super(name, true, owner, group, mode, lastModifiedTimeMs, null);
   }
 


### PR DESCRIPTION
In some UFSes like S3, directories will have a null lastModifiedTimeMs indicating the timestamp is not available. We used `long` as constructor parameter type which will throw when null is passed in for a S3 directory.