### PR TITLE
Reduce the CPU usage of the alluxio master process

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -322,7 +322,7 @@ public abstract class Cache<K, V> implements Closeable {
     }
 
     private void evictToLowWaterMark() {
-      Instant evictionStart = Instant.now();
+      long evictionStart = System.nanoTime();
       int toEvict = mMap.size() - mLowWaterMark;
       int evictionCount = 0;
       while (evictionCount < toEvict) {
@@ -334,7 +334,7 @@ public abstract class Cache<K, V> implements Closeable {
       }
       if (evictionCount > 0) {
         LOG.debug("{}: Evicted {} entries in {}ms", mName, evictionCount,
-            Duration.between(evictionStart, Instant.now()).toMillis());
+            (System.nanoTime() - evictionStart) / Constants.MS_NANO);
       }
     }
 

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.lang.Thread.State;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
[`./profiler.sh -d 30 pid`](https://github.com/jvm-profiling-tools/async-profiler) => 
```
          ns  percent  samples  top
  ----------  -------  -------  ---
 15747991110   52.61%     1564  gettimeofday
 12484184818   41.70%     1238  [unknown]
   804458218    2.69%       80  alluxio.master.metastore.caching.Cache$EvictionThread.evictToLowWaterMark
   333278940    1.11%       33  os::javaTimeMillis()
   160014616    0.53%       16  alluxio.master.metastore.caching.Cache$EvictionThread.run
    65950919    0.22%        8  KlassScanClosure::do_klass(Klass*)
    40337398    0.13%        5  FastScanClosure::do_oop(oopDesc**)
    31711313    0.11%        3  __pthread_cond_timedwait
    22996059    0.08%        3  ClassLoaderData::oops_do(OopClosure*, KlassClosure*, bool)
    21247918    0.07%        1  __pthread_disable_asynccancel
    17538526    0.06%        2  frame::sender(RegisterMap*) const
    11612687    0.04%        1  jlong_disjoint_arraycopy
    11407171    0.04%        1  Unsafe_Park
    10902626    0.04%        1  io.netty.channel.epoll.EpollEventLoop.run
    10756523    0.04%        1  __pthread_getspecific
    10734461    0.04%        1  java.util.concurrent.locks.AbstractQueuedSynchronizer.hasQueuedPredecessors
    10585585    0.04%        1  java.util.stream.AbstractPipeline.wrapAndCopyInto
    10575251    0.04%        1  BlockOffsetArrayContigSpace::block_start_unsafe(void const*) const
    10503642    0.04%        1  java.lang.Thread.interrupted
    10491283    0.04%        1  /lib/x86_64-linux-gnu/libc-2.27.so
    10475662    0.03%        1  _init
    10455985    0.03%        1  Parker::park(bool, long)
    10425816    0.03%        1  java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos
    10031570    0.03%        1  OopMapSet::oops_do(frame const*, RegisterMap const*, OopClosure*)
     9999568    0.03%        1  AllocTracer::send_allocation_in_new_tlab_event(KlassHandle, unsigned long, unsigned long)
     9999125    0.03%        1  InstanceKlass::allocate_instance(Thread*)
     9019689    0.03%        1  CollectedHeap::oop_extra_words()
     8368977    0.03%        1  SafepointSynchronize::do_cleanup_tasks()
     8065174    0.03%        1  ContiguousSpace::block_size(HeapWord const*) const
     7797838    0.03%        1  InstanceKlass::oop_oop_iterate_nv(oopDesc*, FastScanClosure*)
     7751152    0.03%        1  mprotect
     6361080    0.02%        1  SymbolPropertyTable::oops_do(OopClosure*)

```