### PR TITLE
Set port reuse for web server

### DIFF
--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -72,6 +72,7 @@ public abstract class WebServer {
     mServerConnector = new ServerConnector(mServer);
     mServerConnector.setPort(mAddress.getPort());
     mServerConnector.setHost(mAddress.getAddress().getHostAddress());
+    mServerConnector.setReuseAddress(true);
 
     mServer.addConnector(mServerConnector);
 
@@ -79,7 +80,9 @@ public abstract class WebServer {
     try {
       mServerConnector.open();
     } catch (IOException e) {
-      throw new RuntimeException(String.format("Failed to listen on address %s", mAddress), e);
+      throw new RuntimeException(
+          String.format("Failed to listen on address %s for web server %s", mAddress, mServiceName),
+          e);
     }
 
     System.setProperty("org.apache.jasper.compiler.disablejsr199", "false");


### PR DESCRIPTION
This helps with the flakiness for testing, since we set the port reuse option for other server sockets. In unittests, a server socket is created, the port is retrieved ("reserved"), then the socket is closed, and then the actual server is started with that port. Port reuse is important for the actual server to start with that same port.