### PR TITLE
Increase block heartbeat interval from worker from 1s to 10s

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1526,7 +1526,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_INTERVAL_MS =
       new Builder(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)
           .setAlias(new String[]{"alluxio.worker.block.heartbeat.interval.ms"})
-          .setDefaultValue("1sec")
+          .setDefaultValue("10sec")
           .setDescription("The interval between block workers' heartbeats.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)


### PR DESCRIPTION
This change will reduce the load on the Alluxio Master when running a
large number of workers. However, it will also impact the ability of the
Alluxio Master to provide the most up-to-date block locations of a block
in a cluster with a high eviction rate.

pr-link: Alluxio/alluxio#10436
change-id: cid-31e4c88d414594902d2f93a464cb4a7d8168cd7f