### PR TITLE
Clean up block master service handler

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
@@ -64,8 +64,9 @@ public final class BlockMasterClientServiceHandler
       StreamObserver<GetBlockInfoPResponse> responseObserver) {
     long blockId = request.getBlockId();
     GetBlockInfoPOptions options = request.getOptions();
-    RpcUtils.call(LOG, () -> GetBlockInfoPResponse.newBuilder()
-        .setBlockInfo(GrpcUtils.toProto(mBlockMaster.getBlockInfo(blockId))).build(),
+    RpcUtils.call(LOG,
+        () -> GetBlockInfoPResponse.newBuilder()
+            .setBlockInfo(GrpcUtils.toProto(mBlockMaster.getBlockInfo(blockId))).build(),
         "GetBlockInfo", "blockId=%s, options=%s", responseObserver, blockId, options);
   }
 
@@ -111,8 +112,9 @@ public final class BlockMasterClientServiceHandler
   public void getCapacityBytes(GetCapacityBytesPOptions options,
       StreamObserver<GetCapacityBytesPResponse> responseObserver) {
     RpcUtils.call(LOG,
-        () -> GetCapacityBytesPResponse.newBuilder().setBytes(mBlockMaster.getCapacityBytes())
-            .build(), "getCapacityBytes", "options=%s", responseObserver, options);
+        () -> GetCapacityBytesPResponse.newBuilder()
+            .setBytes(mBlockMaster.getCapacityBytes()).build(),
+        "getCapacityBytes", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -126,25 +128,28 @@ public final class BlockMasterClientServiceHandler
   @Override
   public void getWorkerInfoList(GetWorkerInfoListPOptions options,
       StreamObserver<GetWorkerInfoListPResponse> responseObserver) {
-    RpcUtils.call(LOG, () -> GetWorkerInfoListPResponse.newBuilder().addAllWorkerInfos(
-        mBlockMaster.getWorkerInfoList().stream().map(GrpcUtils::toProto)
-            .collect(Collectors.toList())).build(), "getWorkerInfoList", "options=%s",
-        responseObserver, options);
+    RpcUtils.call(LOG,
+        () -> GetWorkerInfoListPResponse.newBuilder()
+            .addAllWorkerInfos(mBlockMaster.getWorkerInfoList().stream().map(GrpcUtils::toProto)
+            .collect(Collectors.toList())).build(),
+        "getWorkerInfoList", "options=%s", responseObserver, options);
   }
 
   @Override
   public void getWorkerReport(GetWorkerReportPOptions options,
       StreamObserver<GetWorkerInfoListPResponse> responseObserver) {
-    RpcUtils.call(LOG, () -> GetWorkerInfoListPResponse.newBuilder().addAllWorkerInfos(
-        mBlockMaster.getWorkerReport(new GetWorkerReportOptions(options)).stream()
-            .map(GrpcUtils::toProto).collect(Collectors.toList())).build(), "getWorkerReport",
-        "options=%s", responseObserver, options);
+    RpcUtils.call(LOG,
+        () -> GetWorkerInfoListPResponse.newBuilder()
+            .addAllWorkerInfos(mBlockMaster.getWorkerReport(new GetWorkerReportOptions(options))
+                .stream().map(GrpcUtils::toProto).collect(Collectors.toList())).build(),
+        "getWorkerReport", "options=%s", responseObserver, options);
   }
 
   @Override
   public void getWorkerLostStorage(GetWorkerLostStoragePOptions options,
       StreamObserver<GetWorkerLostStoragePResponse> responseObserver) {
-    RpcUtils.call(LOG, () -> GetWorkerLostStoragePResponse.newBuilder()
+    RpcUtils.call(LOG,
+        () -> GetWorkerLostStoragePResponse.newBuilder()
             .addAllWorkerLostStorageInfo(mBlockMaster.getWorkerLostStorage()).build(),
         "getWorkerLostStorage", "options=%s", responseObserver, options);
   }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
@@ -62,113 +62,90 @@ public final class BlockMasterClientServiceHandler
   @Override
   public void getBlockInfo(GetBlockInfoPRequest request,
       StreamObserver<GetBlockInfoPResponse> responseObserver) {
-
     long blockId = request.getBlockId();
     GetBlockInfoPOptions options = request.getOptions();
-
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetBlockInfoPResponse>) () -> {
-
-      return GetBlockInfoPResponse.newBuilder()
-          .setBlockInfo(GrpcUtils.toProto(mBlockMaster.getBlockInfo(blockId))).build();
-    }, "CreateFile", "blockId=%s, options=%s", responseObserver, blockId, options);
+    RpcUtils.call(LOG, () -> GetBlockInfoPResponse.newBuilder()
+        .setBlockInfo(GrpcUtils.toProto(mBlockMaster.getBlockInfo(blockId))).build(),
+        "GetBlockInfo", "blockId=%s, options=%s", responseObserver, blockId, options);
   }
 
   @Override
   public void getBlockMasterInfo(GetBlockMasterInfoPOptions options,
       StreamObserver<GetBlockMasterInfoPResponse> responseObserver) {
-
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetBlockMasterInfoPResponse>) () -> {
-
-          BlockMasterInfo.Builder infoBuilder = BlockMasterInfo.newBuilder();
-          for (BlockMasterInfoField field : (options.getFiltersCount() != 0)
-              ? options.getFiltersList()
-              : Arrays.asList(BlockMasterInfoField.values())) {
-            switch (field) {
-              case CAPACITY_BYTES:
-                infoBuilder.setCapacityBytes(mBlockMaster.getCapacityBytes());
-                break;
-              case CAPACITY_BYTES_ON_TIERS:
-                infoBuilder.putAllCapacityBytesOnTiers(mBlockMaster.getTotalBytesOnTiers());
-                break;
-              case FREE_BYTES:
-                infoBuilder
-                    .setFreeBytes(mBlockMaster.getCapacityBytes() - mBlockMaster.getUsedBytes());
-                break;
-              case LIVE_WORKER_NUM:
-                infoBuilder.setLiveWorkerNum(mBlockMaster.getWorkerCount());
-                break;
-              case LOST_WORKER_NUM:
-                infoBuilder.setLostWorkerNum(mBlockMaster.getLostWorkerCount());
-                break;
-              case USED_BYTES:
-                infoBuilder.setUsedBytes(mBlockMaster.getUsedBytes());
-                break;
-              case USED_BYTES_ON_TIERS:
-                infoBuilder.putAllUsedBytesOnTiers(mBlockMaster.getUsedBytesOnTiers());
-                break;
-              default:
-                LOG.warn("Unrecognized block master info field: " + field);
-            }
-          }
-
-          return GetBlockMasterInfoPResponse.newBuilder().setBlockMasterInfo(infoBuilder).build();
-        }, "getBlockMasterInfo", "Options=%s", responseObserver, options);
+    RpcUtils.call(LOG, () -> {
+      BlockMasterInfo.Builder infoBuilder = BlockMasterInfo.newBuilder();
+      for (BlockMasterInfoField field : (options.getFiltersCount() != 0)
+          ? options.getFiltersList()
+          : Arrays.asList(BlockMasterInfoField.values())) {
+        switch (field) {
+          case CAPACITY_BYTES:
+            infoBuilder.setCapacityBytes(mBlockMaster.getCapacityBytes());
+            break;
+          case CAPACITY_BYTES_ON_TIERS:
+            infoBuilder.putAllCapacityBytesOnTiers(mBlockMaster.getTotalBytesOnTiers());
+            break;
+          case FREE_BYTES:
+            infoBuilder.setFreeBytes(mBlockMaster.getCapacityBytes() - mBlockMaster.getUsedBytes());
+            break;
+          case LIVE_WORKER_NUM:
+            infoBuilder.setLiveWorkerNum(mBlockMaster.getWorkerCount());
+            break;
+          case LOST_WORKER_NUM:
+            infoBuilder.setLostWorkerNum(mBlockMaster.getLostWorkerCount());
+            break;
+          case USED_BYTES:
+            infoBuilder.setUsedBytes(mBlockMaster.getUsedBytes());
+            break;
+          case USED_BYTES_ON_TIERS:
+            infoBuilder.putAllUsedBytesOnTiers(mBlockMaster.getUsedBytesOnTiers());
+            break;
+          default:
+            LOG.warn("Unrecognized block master info field: " + field);
+        }
+      }
+      return GetBlockMasterInfoPResponse.newBuilder().setBlockMasterInfo(infoBuilder).build();
+    }, "getBlockMasterInfo", "options=%s", responseObserver, options);
   }
 
   @Override
   public void getCapacityBytes(GetCapacityBytesPOptions options,
       StreamObserver<GetCapacityBytesPResponse> responseObserver) {
     RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetCapacityBytesPResponse>) () -> {
-
-          return GetCapacityBytesPResponse.newBuilder().setBytes(mBlockMaster.getCapacityBytes())
-              .build();
-        }, "getCapacityBytes", "options=%s", responseObserver, options);
+        () -> GetCapacityBytesPResponse.newBuilder().setBytes(mBlockMaster.getCapacityBytes())
+            .build(), "getCapacityBytes", "options=%s", responseObserver, options);
   }
 
   @Override
   public void getUsedBytes(GetUsedBytesPOptions options,
       StreamObserver<GetUsedBytesPResponse> responseObserver) {
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetUsedBytesPResponse>) () -> {
-
-      return GetUsedBytesPResponse.newBuilder().setBytes(mBlockMaster.getUsedBytes()).build();
-    }, "getUsedBytes", "options=%s", responseObserver, options);
+    RpcUtils.call(LOG,
+        () -> GetUsedBytesPResponse.newBuilder().setBytes(mBlockMaster.getUsedBytes()).build(),
+        "getUsedBytes", "options=%s", responseObserver, options);
   }
 
   @Override
   public void getWorkerInfoList(GetWorkerInfoListPOptions options,
       StreamObserver<GetWorkerInfoListPResponse> responseObserver) {
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetWorkerInfoListPResponse>) () -> {
-
-          return GetWorkerInfoListPResponse.newBuilder().addAllWorkerInfos(mBlockMaster
-              .getWorkerInfoList().stream().map(GrpcUtils::toProto).collect(Collectors.toList()))
-              .build();
-        }, "getWorkerInfoList", "options=%s", responseObserver, options);
+    RpcUtils.call(LOG, () -> GetWorkerInfoListPResponse.newBuilder().addAllWorkerInfos(
+        mBlockMaster.getWorkerInfoList().stream().map(GrpcUtils::toProto)
+            .collect(Collectors.toList())).build(), "getWorkerInfoList", "options=%s",
+        responseObserver, options);
   }
 
   @Override
   public void getWorkerReport(GetWorkerReportPOptions options,
       StreamObserver<GetWorkerInfoListPResponse> responseObserver) {
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetWorkerInfoListPResponse>) () -> {
-
-          return GetWorkerInfoListPResponse.newBuilder()
-              .addAllWorkerInfos(
-                  mBlockMaster.getWorkerReport(new GetWorkerReportOptions(options)).stream()
-                      .map(GrpcUtils::toProto).collect(Collectors.toList()))
-              .build();
-        }, "getWorkerInfoList", "options=%s", responseObserver, options);
+    RpcUtils.call(LOG, () -> GetWorkerInfoListPResponse.newBuilder().addAllWorkerInfos(
+        mBlockMaster.getWorkerReport(new GetWorkerReportOptions(options)).stream()
+            .map(GrpcUtils::toProto).collect(Collectors.toList())).build(), "getWorkerReport",
+        "options=%s", responseObserver, options);
   }
 
   @Override
   public void getWorkerLostStorage(GetWorkerLostStoragePOptions options,
       StreamObserver<GetWorkerLostStoragePResponse> responseObserver) {
-    RpcUtils.call(LOG,
-        (RpcUtils.RpcCallableThrowsIOException<GetWorkerLostStoragePResponse>) () ->
-            GetWorkerLostStoragePResponse.newBuilder()
-                .addAllWorkerLostStorageInfo(mBlockMaster.getWorkerLostStorage()).build(),
+    RpcUtils.call(LOG, () -> GetWorkerLostStoragePResponse.newBuilder()
+            .addAllWorkerLostStorageInfo(mBlockMaster.getWorkerLostStorage()).build(),
         "getWorkerLostStorage", "options=%s", responseObserver, options);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
@@ -105,7 +105,7 @@ public final class BlockMasterClientServiceHandler
         }
       }
       return GetBlockMasterInfoPResponse.newBuilder().setBlockMasterInfo(infoBuilder).build();
-    }, "getBlockMasterInfo", "options=%s", responseObserver, options);
+    }, "GetBlockMasterInfo", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -114,7 +114,7 @@ public final class BlockMasterClientServiceHandler
     RpcUtils.call(LOG,
         () -> GetCapacityBytesPResponse.newBuilder()
             .setBytes(mBlockMaster.getCapacityBytes()).build(),
-        "getCapacityBytes", "options=%s", responseObserver, options);
+        "GetCapacityBytes", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -122,7 +122,7 @@ public final class BlockMasterClientServiceHandler
       StreamObserver<GetUsedBytesPResponse> responseObserver) {
     RpcUtils.call(LOG,
         () -> GetUsedBytesPResponse.newBuilder().setBytes(mBlockMaster.getUsedBytes()).build(),
-        "getUsedBytes", "options=%s", responseObserver, options);
+        "GetUsedBytes", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -132,7 +132,7 @@ public final class BlockMasterClientServiceHandler
         () -> GetWorkerInfoListPResponse.newBuilder()
             .addAllWorkerInfos(mBlockMaster.getWorkerInfoList().stream().map(GrpcUtils::toProto)
             .collect(Collectors.toList())).build(),
-        "getWorkerInfoList", "options=%s", responseObserver, options);
+        "GetWorkerInfoList", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -142,7 +142,7 @@ public final class BlockMasterClientServiceHandler
         () -> GetWorkerInfoListPResponse.newBuilder()
             .addAllWorkerInfos(mBlockMaster.getWorkerReport(new GetWorkerReportOptions(options))
                 .stream().map(GrpcUtils::toProto).collect(Collectors.toList())).build(),
-        "getWorkerReport", "options=%s", responseObserver, options);
+        "GetWorkerReport", "options=%s", responseObserver, options);
   }
 
   @Override
@@ -151,6 +151,6 @@ public final class BlockMasterClientServiceHandler
     RpcUtils.call(LOG,
         () -> GetWorkerLostStoragePResponse.newBuilder()
             .addAllWorkerLostStorageInfo(mBlockMaster.getWorkerLostStorage()).build(),
-        "getWorkerLostStorage", "options=%s", responseObserver, options);
+        "GetWorkerLostStorage", "options=%s", responseObserver, options);
   }
 }


### PR DESCRIPTION
Removes some unnecessary typing and also fixes the name of some methods so we collect the correct metrics.