### PR TITLE
Improve and speed up S3 rest test

### DIFF
--- a/tests/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -34,6 +34,7 @@ public abstract class RestApiTest extends BaseIntegrationTest {
   public LocalAlluxioClusterResource mResource = new LocalAlluxioClusterResource.Builder()
       .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
       .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
       .build();
 
   protected String getEndpoint(String suffix) {

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -58,6 +58,11 @@ import javax.ws.rs.core.Response;
  * Test cases for {@link S3RestServiceHandler}.
  */
 public final class S3ClientRestApiTest extends RestApiTest {
+  private static final int DATA_SIZE = 16 * Constants.KB;
+  // cannot be too large, since all block streams are open until file is closed, and may run out of
+  // block worker clients.
+  private static final int LARGE_DATA_SIZE = 256 * Constants.KB;
+
   private static final GetStatusContext GET_STATUS_CONTEXT = GetStatusContext.defaults();
   private static final Map<String, String> NO_PARAMS = new HashMap<>();
   private static final XmlMapper XML_MAPPER = new XmlMapper();
@@ -269,7 +274,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
   @Test
   public void putSmallObject() throws Exception {
-    final String bucketName = "bucket";
+    final String bucketName = "small-object-bucket";
     createBucketRestCall(bucketName);
 
     final String objectName = "object";
@@ -278,11 +283,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
   @Test
   public void putLargeObject() throws Exception {
-    final String bucketName = "bucket";
+    final String bucketName = "large-object-bucket";
     createBucketRestCall(bucketName);
 
     final String objectName = "object";
-    final byte[] object = CommonUtils.randomAlphaNumString(Constants.MB).getBytes();
+    final byte[] object = CommonUtils.randomAlphaNumString(LARGE_DATA_SIZE).getBytes();
     putObjectTest(bucketName, objectName, object, null, null);
   }
 
@@ -584,7 +589,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
   @Test
   public void getLargeObject() throws Exception {
-    getObjectTest(CommonUtils.randomAlphaNumString(Constants.MB).getBytes());
+    getObjectTest(CommonUtils.randomAlphaNumString(LARGE_DATA_SIZE).getBytes());
   }
 
   @Test
@@ -748,7 +753,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         XML_MAPPER.readValue(result, InitiateMultipartUploadResult.class);
 
     final long uploadId = Long.parseLong(multipartUploadResult.getUploadId());
-    final byte[] object = CommonUtils.randomAlphaNumString(Constants.MB).getBytes();
+    final byte[] object = CommonUtils.randomAlphaNumString(DATA_SIZE).getBytes();
     putObjectTest(bucketName, objectName, object, uploadId, 1);
   }
 
@@ -764,7 +769,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         XML_MAPPER.readValue(result, InitiateMultipartUploadResult.class);
 
     final long uploadId = Long.parseLong(multipartUploadResult.getUploadId());
-    final byte[] object = CommonUtils.randomAlphaNumString(Constants.MB).getBytes();
+    final byte[] object = CommonUtils.randomAlphaNumString(DATA_SIZE).getBytes();
     try {
       putObjectTest(bucketName, objectName, object, uploadId + 1, 1);
     } catch (AssertionError e) {
@@ -781,7 +786,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     try {
       final String objectName = "object";
-      final byte[] object = CommonUtils.randomAlphaNumString(Constants.MB).getBytes();
+      final byte[] object = CommonUtils.randomAlphaNumString(DATA_SIZE).getBytes();
       putObjectTest(bucketName, objectName, object, 1L, 1);
     } catch (AssertionError e) {
       // Expected because there is no such upload ID.
@@ -814,8 +819,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
     Assert.assertEquals(0, listPartsResult.getParts().size());
 
     // Upload 2 parts.
-    String object1 = CommonUtils.randomAlphaNumString(Constants.MB);
-    String object2 = CommonUtils.randomAlphaNumString(Constants.MB);
+    String object1 = CommonUtils.randomAlphaNumString(DATA_SIZE);
+    String object2 = CommonUtils.randomAlphaNumString(DATA_SIZE);
     createObject(objectKey, object1.getBytes(), uploadId, 1);
     createObject(objectKey, object2.getBytes(), uploadId, 2);
 
@@ -904,8 +909,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
     final long uploadId = Long.parseLong(multipartUploadResult.getUploadId());
 
     // Upload parts.
-    String object1 = CommonUtils.randomAlphaNumString(Constants.MB);
-    String object2 = CommonUtils.randomAlphaNumString(Constants.MB);
+    String object1 = CommonUtils.randomAlphaNumString(DATA_SIZE);
+    String object2 = CommonUtils.randomAlphaNumString(DATA_SIZE);
     createObject(objectKey, object1.getBytes(), uploadId, 1);
     createObject(objectKey, object2.getBytes(), uploadId, 2);
 


### PR DESCRIPTION
Speed up the test by avoiding worker out of space exceptions. Decreasing the `USER_FILE_BUFFER_BYTES` then caused issues with too many open block worker connections, so had to reduce the file sizes too, to avoid that resource pool issue.