### PR TITLE
Port #10353 to branch 2.1: Improve error message for Failed Block Reads

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
@@ -13,6 +13,8 @@ package alluxio.worker.grpc;
 
 import alluxio.proto.dataserver.Protocol;
 
+import com.google.common.base.MoreObjects;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -60,5 +62,18 @@ public final class BlockReadRequest extends ReadRequest {
    */
   public boolean isPersisted() {
     return mOpenUfsBlockOptions != null && mOpenUfsBlockOptions.hasUfsPath();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("chunkSize", getChunkSize())
+        .add("end", getEnd())
+        .add("id", getId())
+        .add("openUfsBlockOptions", mOpenUfsBlockOptions)
+        .add("promote", mPromote)
+        .add("sessionId", getSessionId())
+        .add("start", getStart())
+        .toString();
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/JobCoordinator.java
@@ -104,7 +104,7 @@ public final class JobCoordinator {
 
   private synchronized void start() throws JobDoesNotExistException {
     // get the job definition
-    LOG.info("Starting job {}", mJobInfo.getJobConfig());
+    LOG.info("Starting job Id={} Config={}", mJobInfo.getId(), mJobInfo.getJobConfig());
     JobDefinition<JobConfig, ?, ?> definition =
         JobDefinitionRegistry.INSTANCE.getJobDefinition(mJobInfo.getJobConfig());
     SelectExecutorsContext context =


### PR DESCRIPTION
Confusing error message on failed reads are observed. This PR improves
or corrects the following items:
- Throw the right exception on failed `openBlock(context, response);`,
rather than always complaining missing fallback blocks
- Implement `toString` for `BlockReadRequest`, otherwise `request
alluxio.worker.grpc.BlockReadRequest@1becc9d9` is not very helpful.
- Add Job Id in Job master logs so we can correlate Job master logs and
master logs much easier by the job Id

Before

```
On Worker:
2019-10-29 14:48:40,984 DEBUG AbstractReadHandler - Exception occurred
while reading data for read request
alluxio.worker.grpc.BlockReadRequest@1becc9d9.
java.io.FileNotFoundException:
/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/.alluxio_ufs_blocks.alluxio.0x1D91AC0E01AB0165.tmp/1325400064
(No such file or directory)

On Master:
2019-10-29 14:48:42,718 WARN DefaultFileSystemMaster - The persist job
(id=1572385668302) for file /cache/part-00083 (id=1426063359) failed:
Task execution failed:
/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/.alluxio_ufs_blocks.alluxio.0x1D91AC0E01AB0165.tmp/1409286144
(No such file or directory) (GrpcDataReader{request=block_id: 1409286144

on Job Master
2019-10-29 17:11:49,804 INFO job.JobCoordinator
(JobCoordinator.java:start) - Starting job
PersistConfig{filePath=/cache/part-00053, mountId=1, overwrite=false,
ufsPath=/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/cache/part-00053.alluxio.0x0000016E1A0118AA.tmp}
```

After

```
On Worker:
2019-10-29 17:11:50,517 WARN AbstractReadHandler - Exception occurred
while reading data for read request BlockReadRequest{chunkSize=1048576,
end=33554479, id=939524096, openUfsBlockOptions=offset_in_file: 0
block_size: 33554479
maxUfsReadConcurrency: 2147483647
mountId: 1
no_cache: true
block_in_ufs_tier: true
, promote=false, sessionId=1117586808638664750, start=0}.: Failed to
open block id=939524096

On Master
2019-10-29 17:11:51,771 WARN DefaultFileSystemMaster - The persist job
(id=1572389450770) for file /cache/part-00056 (id=973078527) failed:
Task execution failed: Failed to open block id=956301312
(GrpcDataReader{request=block_id: 956301312

On Job Master
2019-10-29 17:11:49,804 INFO job.JobCoordinator
(JobCoordinator.java:start) - Starting job Id=1572389450769
Config=PersistConfig{filePath=/cache/part-00053, mountId=1,
overwrite=false,
ufsPath=/Users/binfan/Dropbox/Work/alluxio/alluxio/underFSStorage/cache/part-00053.alluxio.0x0000016E1A0118AA.tmp}
```

pr-link: Alluxio/alluxio#10353
change-id: cid-6426db0936fc5df0b6d2c416715b66ea12035daa