### PR TITLE
Use different session IDs for async cache requests

### DIFF
--- a/core/server/worker/src/main/java/alluxio/Sessions.java
+++ b/core/server/worker/src/main/java/alluxio/Sessions.java
@@ -33,12 +33,10 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class Sessions {
   private static final Logger LOG = LoggerFactory.getLogger(Sessions.class);
 
-  public static final int DATASERVER_SESSION_ID = -1;
-  public static final int CHECKPOINT_SESSION_ID = -2;
   public static final int MIGRATE_DATA_SESSION_ID = -3;
   public static final int MASTER_COMMAND_SESSION_ID = -4;
-  public static final int ACCESS_BLOCK_SESSION_ID = -5;
-  public static final int ASYNC_CACHE_SESSION_ID = -7;
+  public static final int ASYNC_CACHE_WORKER_SESSION_ID = -7;
+  public static final int ASYNC_CACHE_UFS_SESSION_ID = -8;
 
   // internal session id base should be smaller than all predefined session ids
   public static final long INTERNAL_SESSION_ID_BASE = -8;

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -91,8 +91,12 @@ public class AsyncCacheRequestManager {
       mAsyncCacheExecutor.submit(() -> {
         boolean result = false;
         try {
+          boolean isSourceLocal = mLocalWorkerHostname.equals(request.getSourceHost());
+          long sessionId = isSourceLocal ? Sessions.ASYNC_CACHE_UFS_SESSION_ID
+              : Sessions.ASYNC_CACHE_WORKER_SESSION_ID;
           // Check if the block has already been cached on this worker
-          long lockId = mBlockWorker.lockBlockNoException(Sessions.ASYNC_CACHE_SESSION_ID, blockId);
+          long lockId =
+              mBlockWorker.lockBlockNoException(sessionId, blockId);
           if (lockId != BlockLockManager.INVALID_LOCK_ID) {
             try {
               mBlockWorker.unlockBlock(lockId);
@@ -103,7 +107,6 @@ public class AsyncCacheRequestManager {
             return;
           }
           Protocol.OpenUfsBlockOptions openUfsBlockOptions = request.getOpenUfsBlockOptions();
-          boolean isSourceLocal = mLocalWorkerHostname.equals(request.getSourceHost());
           // Depends on the request, cache the target block from different sources
           if (isSourceLocal) {
             ASYNC_CACHE_UFS_BLOCKS.inc();
@@ -150,7 +153,7 @@ public class AsyncCacheRequestManager {
     // Check if the block has been requested in UFS block store
     try {
       if (!mBlockWorker
-          .openUfsBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId, openUfsBlockOptions)) {
+          .openUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, openUfsBlockOptions)) {
         LOG.warn("Failed to async cache block {} from UFS on opening the block", blockId);
         return false;
       }
@@ -159,7 +162,7 @@ public class AsyncCacheRequestManager {
       return true;
     }
     try (BlockReader reader = mBlockWorker
-        .readUfsBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId, 0)) {
+        .readUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, 0)) {
       // Read the entire block, caching to block store will be handled internally in UFS block store
       // Note that, we read from UFS with a smaller buffer to avoid high pressure on heap
       // memory when concurrent async requests are received and thus trigger GC.
@@ -175,7 +178,7 @@ public class AsyncCacheRequestManager {
       return false;
     } finally {
       try {
-        mBlockWorker.closeUfsBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId);
+        mBlockWorker.closeUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId);
       } catch (AlluxioException | IOException ee) {
         LOG.warn("Failed to close UFS block {}: {}", blockId, ee);
         return false;
@@ -196,7 +199,7 @@ public class AsyncCacheRequestManager {
   private boolean cacheBlockFromRemoteWorker(long blockId, long blockSize,
       InetSocketAddress sourceAddress, Protocol.OpenUfsBlockOptions openUfsBlockOptions) {
     try {
-      mBlockWorker.createBlockRemote(Sessions.ASYNC_CACHE_SESSION_ID, blockId,
+      mBlockWorker.createBlockRemote(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId,
           mStorageTierAssoc.getAlias(0), "", blockSize);
     } catch (BlockAlreadyExistsException e) {
       // It is already cached
@@ -210,15 +213,15 @@ public class AsyncCacheRequestManager {
     try (BlockReader reader =
         new RemoteBlockReader(mFsContext, blockId, blockSize, sourceAddress, openUfsBlockOptions);
         BlockWriter writer =
-            mBlockWorker.getTempBlockWriterRemote(Sessions.ASYNC_CACHE_SESSION_ID, blockId)) {
+            mBlockWorker.getTempBlockWriterRemote(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId)) {
       BufferUtils.fastCopy(reader.getChannel(), writer.getChannel());
-      mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId, false);
+      mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId, false);
       return true;
     } catch (AlluxioException | IOException e) {
       LOG.warn("Failed to async cache block {} from remote worker ({}) on copying the block: {}",
           blockId, sourceAddress, e.getMessage());
       try {
-        mBlockWorker.abortBlock(Sessions.ASYNC_CACHE_SESSION_ID, blockId);
+        mBlockWorker.abortBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId);
       } catch (AlluxioException | IOException ee) {
         LOG.warn("Failed to abort block {}: {}", blockId, ee.getMessage());
       }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -212,8 +212,8 @@ public class AsyncCacheRequestManager {
     }
     try (BlockReader reader =
         new RemoteBlockReader(mFsContext, blockId, blockSize, sourceAddress, openUfsBlockOptions);
-        BlockWriter writer =
-            mBlockWorker.getTempBlockWriterRemote(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId)) {
+         BlockWriter writer = mBlockWorker
+             .getTempBlockWriterRemote(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId)) {
       BufferUtils.fastCopy(reader.getChannel(), writer.getChannel());
       mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId, false);
       return true;


### PR DESCRIPTION
- Differentiate `ASYNC_CACHE_WORKER_SESSION_ID` with `ASYNC_CACHE_UFS_SESSION_ID`: the former session is caching from a remote worker and the latter session is caching from UFS
- The goal of this PR is to enable more advanced allocator which can leverage the information: caching from UFS or caching for remote worker to make subtle decisions.