### PR TITLE
Reuse LocalAlluxioCluster to speedup REST tests

### DIFF
--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -14,14 +14,18 @@ package alluxio.client.rest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.WritePType;
 import alluxio.master.file.FileSystemMaster;
+import alluxio.master.file.contexts.GetStatusContext;
 import alluxio.master.meta.AlluxioMasterRestServiceHandler;
 import alluxio.metrics.MetricsSystem;
+import alluxio.security.authentication.AuthType;
+import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.testutils.underfs.UnderFileSystemTestUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
@@ -36,7 +40,10 @@ import alluxio.wire.WorkerInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.util.HashMap;
 import java.util.List;
@@ -50,18 +57,25 @@ import javax.ws.rs.HttpMethod;
 public final class AlluxioMasterRestApiTest extends RestApiTest {
   private FileSystemMaster mFileSystemMaster;
 
+  // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to
+  // fix the test setup in SIMPLE mode.
+  @ClassRule
+  public static LocalAlluxioClusterResource sResource = new LocalAlluxioClusterResource.Builder()
+      .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
+      .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
+      .build();
+
+  @Rule
+  public TestRule mResetRule = sResource.getResetResource();
+
   @Before
   public void before() {
-    mFileSystemMaster = mResource.get().getLocalAlluxioMaster().getMasterProcess()
+    mFileSystemMaster = sResource.get().getLocalAlluxioMaster().getMasterProcess()
         .getMaster(FileSystemMaster.class);
-    mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getLocalAlluxioMaster().getMasterProcess().getWebAddress().getPort();
+    mHostname = sResource.get().getHostname();
+    mPort = sResource.get().getLocalAlluxioMaster().getMasterProcess().getWebAddress().getPort();
     mServicePrefix = AlluxioMasterRestServiceHandler.SERVICE_PREFIX;
-  }
-
-  @After
-  public void after() {
-    ServerConfiguration.reset();
   }
 
   private AlluxioMasterInfo getInfo(Map<String, String> params) throws Exception {
@@ -122,14 +136,16 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getMetricsInfo() throws Exception {
-    assertEquals(Long.valueOf(0),
-        getInfo(NO_PARAMS).getMetrics().get(MetricsSystem.getMetricName("CompleteFileOps")));
+    long start = getInfo(NO_PARAMS).getMetrics().get(MetricsSystem.getMetricName("FileInfosGot"));
+    mFileSystemMaster.getFileInfo(new AlluxioURI("/"), GetStatusContext.defaults());
+    assertEquals(Long.valueOf(start + 1),
+        getInfo(NO_PARAMS).getMetrics().get(MetricsSystem.getMetricName("FileInfosGot")));
   }
 
   @Test
   public void getUfsMetrics() throws Exception {
     int len = 100;
-    FileSystemTestUtils.createByteFile(mResource.get().getClient(), "/f1", WritePType.THROUGH, len);
+    FileSystemTestUtils.createByteFile(sResource.get().getClient(), "/f1", WritePType.THROUGH, len);
     CommonUtils.waitFor("Metrics to be updated correctly", () -> {
       try {
         return FormatUtils.getSizeFromBytes(len).equals(getMetrics(NO_PARAMS)
@@ -139,7 +155,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
       }
     }, WaitForOptions.defaults().setTimeoutMs(2000));
 
-    FileSystemTestUtils.createByteFile(mResource.get().getClient(), "/f2", WritePType.THROUGH, len);
+    FileSystemTestUtils.createByteFile(sResource.get().getClient(), "/f2", WritePType.THROUGH, len);
     CommonUtils.waitFor("Metrics to be updated correctly", () -> {
       try {
         return FormatUtils.getSizeFromBytes(2 * len).equals(getMetrics(NO_PARAMS)

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -38,7 +38,6 @@ import alluxio.wire.MountPointInfo;
 import alluxio.wire.WorkerInfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
@@ -11,10 +11,12 @@
 
 package alluxio.client.rest;
 
-import alluxio.conf.ServerConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.metrics.MetricsSystem;
+import alluxio.security.authentication.AuthType;
+import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.AlluxioWorkerInfo;
 import alluxio.wire.Capacity;
@@ -23,7 +25,10 @@ import alluxio.worker.AlluxioWorkerRestServiceHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.HttpMethod;
 
@@ -32,10 +37,22 @@ import javax.ws.rs.HttpMethod;
  */
 public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
+  // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to
+  // fix the test setup in SIMPLE mode.
+  @ClassRule
+  public static LocalAlluxioClusterResource sResource = new LocalAlluxioClusterResource.Builder()
+      .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
+      .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
+      .build();
+
+  @Rule
+  public TestRule mResetRule = sResource.getResetResource();
+
   @Before
   public void before() {
-    mHostname = mResource.get().getHostname();
-    mPort = mResource.get().getWorkerProcess().getWebLocalPort();
+    mHostname = sResource.get().getHostname();
+    mPort = sResource.get().getWorkerProcess().getWebLocalPort();
     mServicePrefix = AlluxioWorkerRestServiceHandler.SERVICE_PREFIX;
   }
 

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -153,6 +153,6 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
         Throwables.propagate(e);
       }
       return null;
-    }, WaitForOptions.defaults().setInterval(10).setTimeoutMs(10 * Constants.SECOND_MS));
+    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
   }
 }

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -12,7 +12,7 @@
 package alluxio.client.rest;
 
 import alluxio.Constants;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.job.JobConfig;
 import alluxio.job.ServiceConstants;
 import alluxio.job.SleepJobConfig;
@@ -20,6 +20,8 @@ import alluxio.job.wire.Status;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.master.job.JobMaster;
 import alluxio.master.job.JobMasterClientRestServiceHandler;
+import alluxio.security.authentication.AuthType;
+import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
@@ -31,7 +33,10 @@ import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,6 +54,19 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
   private LocalAlluxioJobCluster mJobCluster;
   private JobMaster mJobMaster;
 
+  // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to
+  // fix the test setup in SIMPLE mode.
+  @ClassRule
+  public static LocalAlluxioClusterResource sResource = new LocalAlluxioClusterResource.Builder()
+      .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
+      .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
+      .setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "10ms")
+      .build();
+
+  @Rule
+  public TestRule mResetRule = sResource.getResetResource();
+
   @Before
   public void before() throws Exception {
     mJobCluster = new LocalAlluxioJobCluster();
@@ -62,7 +80,6 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
   @After
   public void after() throws Exception {
     mJobCluster.stop();
-    ServerConfiguration.reset();
   }
 
   @Test
@@ -79,7 +96,7 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
 
   @Test
   public void run() throws Exception {
-    final long jobId = startJob(new SleepJobConfig(Constants.SECOND_MS));
+    final long jobId = startJob(new SleepJobConfig(200));
     Assert.assertEquals(1, mJobMaster.list().size());
     waitForStatus(jobId, Status.COMPLETED);
   }
@@ -89,7 +106,7 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     long jobId = startJob(new SleepJobConfig(10 * Constants.SECOND_MS));
     // Sleep to make sure the run request and the cancel request are separated by a job worker
     // heartbeat. If not, job service will not handle that case correctly.
-    CommonUtils.sleepMs(Constants.SECOND_MS);
+    CommonUtils.sleepMs(30);
     Map<String, String> params = Maps.newHashMap();
     params.put("jobId", Long.toString(jobId));
     new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.CANCEL),
@@ -136,6 +153,6 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
         Throwables.propagate(e);
       }
       return null;
-    }, WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
+    }, WaitForOptions.defaults().setInterval(10).setTimeoutMs(10 * Constants.SECOND_MS));
   }
 }

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -11,13 +11,17 @@
 
 package alluxio.client.rest;
 
+import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.AlluxioJobMasterRestServiceHandler;
 import alluxio.master.LocalAlluxioJobCluster;
+import alluxio.security.authentication.AuthType;
+import alluxio.testutils.LocalAlluxioClusterResource;
 
 import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Map;
@@ -30,6 +34,15 @@ import javax.ws.rs.HttpMethod;
 public final class JobMasterRestApiTest extends RestApiTest {
   private static final Map<String, String> NO_PARAMS = Maps.newHashMap();
   private LocalAlluxioJobCluster mJobCluster;
+
+  // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to
+  // fix the test setup in SIMPLE mode.
+  @Rule
+  public LocalAlluxioClusterResource mResource = new LocalAlluxioClusterResource.Builder()
+      .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
+      .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
+      .build();
 
   @Before
   public void before() throws Exception {

--- a/tests/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -11,12 +11,7 @@
 
 package alluxio.client.rest;
 
-import alluxio.conf.PropertyKey;
-import alluxio.security.authentication.AuthType;
 import alluxio.testutils.BaseIntegrationTest;
-import alluxio.testutils.LocalAlluxioClusterResource;
-
-import org.junit.Rule;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,15 +22,6 @@ public abstract class RestApiTest extends BaseIntegrationTest {
   protected String mHostname;
   protected int mPort;
   protected String mServicePrefix;
-
-  // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to
-  // fix the test setup in SIMPLE mode.
-  @Rule
-  public LocalAlluxioClusterResource mResource = new LocalAlluxioClusterResource.Builder()
-      .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
-      .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
-      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
-      .build();
 
   protected String getEndpoint(String suffix) {
     return mServicePrefix + "/" + suffix;


### PR DESCRIPTION
This speeds up the REST tests, by reusing the LocalAlluxioCluster throughout each test class. This avoids tearing down and recreating the cluster between each individual test case. Minor modifications were required to be able to re-use an existing LocalAlluxioCluster between tests.