### PR TITLE
Optimize FileOutStream integration tests

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -202,7 +202,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
    * @param source the source of the the properties (e.g., system property, default and etc)
    */
   public void set(@Nonnull PropertyKey key, @Nonnull Object value, @Nonnull Source source) {
-    Preconditions.checkArgument(key != null && value != null && !value.equals(""),
+    Preconditions.checkArgument(key != null && value != null,
         String.format("The key value pair (%s, %s) cannot be null", key, value));
     Preconditions.checkArgument(!value.equals(""),
         String.format("The key \"%s\" cannot be have an empty string as a value. Use "

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -111,6 +113,13 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
    */
   public WorkerProcess getWorkerProcess() {
     return mWorkers.get(0);
+  }
+
+  /**
+   * @return a unmodifiable list of all the workers
+   */
+  public List<WorkerProcess> getWorkerProcesses() {
+    return Collections.unmodifiableList(mWorkers);
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
@@ -23,6 +23,8 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 
 /**
  * Abstract classes for all integration tests of {@link FileOutStream}.
@@ -38,6 +40,9 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       buildLocalAlluxioClusterResource();
+
+  @Rule
+  public TestRule mTestRule = sLocalAlluxioClusterResource.getResetResource();
 
   protected FileSystem mFileSystem = null;
 
@@ -67,11 +72,8 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
     }
   }
 
-  /**
-   * Override this method in a test in order to customize the {@link LocalAlluxioClusterResource}.
-   * @param resource an AlluxioClusterResource builder
-   */
-  protected static void customizeClusterResource(LocalAlluxioClusterResource.Builder resource) {
+  private static LocalAlluxioClusterResource buildLocalAlluxioClusterResource() {
+    LocalAlluxioClusterResource.Builder resource = new LocalAlluxioClusterResource.Builder();
     resource.setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
         .setProperty(PropertyKey.USER_FILE_REPLICATION_DURABLE, 1)
         .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
@@ -79,12 +81,8 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
         .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "10ms")
         .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "10ms")
         .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "10ms")
-        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES);
-  }
-
-  private static LocalAlluxioClusterResource buildLocalAlluxioClusterResource() {
-    LocalAlluxioClusterResource.Builder resource = new LocalAlluxioClusterResource.Builder();
-    customizeClusterResource(resource);
+        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
+    ;
     return resource.build();
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
+import org.junit.rules.RuleChain;
 
 /**
  * Abstract classes for all integration tests of {@link FileOutStream}.
@@ -36,12 +36,12 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   protected static final int BLOCK_SIZE_BYTES = 1024;
   protected static LocalAlluxioJobCluster sLocalAlluxioJobCluster;
 
-  @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       buildLocalAlluxioClusterResource();
 
   @ClassRule
-  public static TestRule sResetRule = sLocalAlluxioClusterResource.getResetResource();
+  public static RuleChain sRuleChain = RuleChain.outerRule(sLocalAlluxioClusterResource)
+      .around(sLocalAlluxioClusterResource.getResetResource());
 
   protected static FileSystem sFileSystem = null;
 

--- a/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
 
 /**
  * Abstract classes for all integration tests of {@link FileOutStream}.
@@ -36,21 +35,17 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   protected static final int BLOCK_SIZE_BYTES = 1024;
   protected static LocalAlluxioJobCluster sLocalAlluxioJobCluster;
 
+  @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       buildLocalAlluxioClusterResource();
 
-  @ClassRule
-  public static RuleChain sRuleChain = RuleChain.outerRule(sLocalAlluxioClusterResource)
-      .around(sLocalAlluxioClusterResource.getResetResource());
-
-  protected static FileSystem sFileSystem = null;
+  protected FileSystem mFileSystem = null;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     sLocalAlluxioJobCluster = new LocalAlluxioJobCluster();
     sLocalAlluxioJobCluster.setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "25ms");
     sLocalAlluxioJobCluster.start();
-    sFileSystem = sLocalAlluxioClusterResource.get().getClient();
   }
 
   @AfterClass
@@ -58,18 +53,17 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
     if (sLocalAlluxioJobCluster != null) {
       sLocalAlluxioJobCluster.stop();
     }
-    sFileSystem.close();
   }
 
   @Before
   public void before() throws Exception {
-    sFileSystem = sLocalAlluxioClusterResource.get().getClient();
+    mFileSystem = sLocalAlluxioClusterResource.get().getClient();
   }
 
   @After
   public void after() throws Exception {
-    if (sFileSystem != null) {
-      sFileSystem.close();
+    if (mFileSystem != null) {
+      mFileSystem.close();
     }
   }
 
@@ -80,11 +74,11 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   protected static void customizeClusterResource(LocalAlluxioClusterResource.Builder resource) {
     resource.setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
         .setProperty(PropertyKey.USER_FILE_REPLICATION_DURABLE, 1)
-        .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "100ms")
-        .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "100ms")
-        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "100ms")
-        .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "100ms")
-        .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "100ms")
+        .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
+        .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
+        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "10ms")
+        .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "10ms")
+        .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "10ms")
         .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES);
   }
 

--- a/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
@@ -83,6 +83,8 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
         .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "100ms")
         .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "100ms")
         .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "100ms")
+        .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "100ms")
+        .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "100ms")
         .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES);
   }
 

--- a/tests/src/test/java/alluxio/client/fs/AsyncWriteBlockCommitTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AsyncWriteBlockCommitTest.java
@@ -1,0 +1,96 @@
+package alluxio.client.fs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemUtils;
+import alluxio.conf.PropertyKey;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.master.LocalAlluxioJobCluster;
+import alluxio.testutils.IntegrationTestUtils;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.FormatUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class AsyncWriteBlockCommitTest {
+
+  private static final String TINY_WORKER_MEM = "512k";
+  private static final String TINY_BLOCK_SIZE = "16k";
+
+  protected LocalAlluxioJobCluster mLocalAlluxioJobCluster;
+
+  public static LocalAlluxioClusterResource buildLocalAlluxioClusterResource() {
+    LocalAlluxioClusterResource.Builder resource = new LocalAlluxioClusterResource.Builder()
+        .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "8k")
+        .setProperty(PropertyKey.USER_FILE_REPLICATION_DURABLE, 1)
+        .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "100ms")
+        .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "100ms")
+        .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "100ms")
+        .setProperty(PropertyKey.WORKER_MEMORY_SIZE, TINY_WORKER_MEM)
+        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, TINY_BLOCK_SIZE);
+    return resource.build();
+  }
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      buildLocalAlluxioClusterResource();
+
+  private static FileSystem sFileSystem;
+
+  @Before
+  public void before() throws Exception {
+    mLocalAlluxioJobCluster = new LocalAlluxioJobCluster();
+    mLocalAlluxioJobCluster.setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "25ms");
+    mLocalAlluxioJobCluster.start();
+    sFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @After
+  public void after() throws Exception {
+    if (mLocalAlluxioJobCluster != null) {
+      mLocalAlluxioJobCluster.stop();
+    }
+    sFileSystem.close();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_FILE_PERSISTENCE_INITIAL_WAIT_TIME, "-1",
+      PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT, "ASYNC_THROUGH",
+      PropertyKey.Name.WORKER_MEMORY_SIZE, TINY_WORKER_MEM,
+      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, TINY_BLOCK_SIZE,
+      PropertyKey.Name.USER_FILE_BUFFER_BYTES, TINY_BLOCK_SIZE,
+      PropertyKey.Name.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "10sec",
+      "alluxio.worker.tieredstore.level0.watermark.high.ratio", "0.5",
+      "alluxio.worker.tieredstore.level0.watermark.low.ratio", "0.25",
+      })
+  public void asyncWriteNoEvictBeforeBlockCommit() throws Exception {
+    long writeSize =
+        FormatUtils.parseSpaceSize(TINY_WORKER_MEM) - FormatUtils.parseSpaceSize(TINY_BLOCK_SIZE);
+    FileSystem fs = mLocalAlluxioClusterResource.get().getClient();
+    AlluxioURI p1 = new AlluxioURI("/p1");
+    FileOutStream fos = fs.createFile(p1, CreateFilePOptions.newBuilder()
+        .setWriteType(WritePType.ASYNC_THROUGH)
+        .setPersistenceWaitTime(-1).build());
+    byte[] arr = new byte[(int) writeSize];
+    Arrays.fill(arr, (byte) 0x7a);
+    fos.write(arr);
+    assertEquals(writeSize + FormatUtils.parseSpaceSize(TINY_BLOCK_SIZE),
+        IntegrationTestUtils.getClusterCapacity(mLocalAlluxioClusterResource.get()));
+    // subtract block size since the last block hasn't been committed yet
+    assertEquals(writeSize, IntegrationTestUtils.getUsedWorkerSpace(mLocalAlluxioClusterResource));
+    fos.close();
+    FileSystemUtils.persistAndWait(fs, p1, 0);
+    assertTrue(IntegrationTestUtils.getUsedWorkerSpace(mLocalAlluxioClusterResource) < writeSize);
+  }
+}

--- a/tests/src/test/java/alluxio/client/fs/AsyncWriteBlockCommitTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AsyncWriteBlockCommitTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.client.fs;
 
 import static org.junit.Assert.assertEquals;

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteIntegrationTest.java
@@ -174,7 +174,6 @@ public final class FileOutStreamAsyncWriteIntegrationTest extends BaseIntegratio
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     createTwoBytesFile(mFileSystem, filePath, 2000);
 
-    CommonUtils.sleepMs(500);
     IntegrationTestUtils
         .checkPersistStateAndWaitForPersist(sLocalAlluxioClusterResource, mFileSystem, filePath, 2);
   }

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -33,7 +33,6 @@ import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.block.BlockWorker;
 
-import org.datanucleus.util.PersistenceUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -60,7 +59,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   private AlluxioURI mUri;
 
   @ClassRule
-  public static ManuallyScheduleHeartbeat sMnauallySchedule =
+  public static ManuallyScheduleHeartbeat sManuallySchedule =
       new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_BLOCK_SYNC);
 
   @Override

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -77,10 +77,10 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
    * @return ths URIStatus of this file after creation
    */
   private URIStatus createAsyncFile() throws Exception {
-    FileOutStreamTestUtils.writeIncreasingByteArrayToFile(sFileSystem, mUri, LEN,
+    FileOutStreamTestUtils.writeIncreasingByteArrayToFile(mFileSystem, mUri, LEN,
         CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build());
-    return sFileSystem.getStatus(mUri);
+    return mFileSystem.getStatus(mUri);
   }
 
   @Test
@@ -94,10 +94,10 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
   }
 
   @Test
@@ -105,22 +105,22 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.pauseChecker(sLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
-    Assert.assertTrue(sFileSystem.exists(mUri));
+    Assert.assertTrue(mFileSystem.exists(mUri));
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
-    Assert.assertTrue(sFileSystem.exists(mUri));
+    Assert.assertTrue(mFileSystem.exists(mUri));
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    Assert.assertTrue(sFileSystem.exists(mUri));
+    Assert.assertTrue(mFileSystem.exists(mUri));
   }
 
   @Test
   public void deleteBeforeJobScheduled() throws Exception {
     PersistenceTestUtils.pauseScheduler(sLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
-    sFileSystem.delete(mUri);
+    mFileSystem.delete(mUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
 
@@ -135,7 +135,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseChecker(sLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
-    sFileSystem.delete(mUri);
+    mFileSystem.delete(mUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
 
@@ -149,7 +149,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   public void deleteAfterPersist() throws Exception {
     URIStatus status = createAsyncFile();
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    sFileSystem.delete(mUri);
+    mFileSystem.delete(mUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
   }
@@ -159,26 +159,26 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseScheduler(sLocalAlluxioClusterResource);
     createAsyncFile();
     try {
-      sFileSystem.free(mUri);
+      mFileSystem.free(mUri);
       Assert.fail("Expect free to fail before file is persisted");
     } catch (AlluxioException e) {
       // Expected
     }
     IntegrationTestUtils.waitForBlocksToBeFreed(
         sLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class));
-    URIStatus status = sFileSystem.getStatus(mUri);
+    URIStatus status = mFileSystem.getStatus(mUri);
     // free for non-persisted file is no-op
     Assert.assertEquals(100, status.getInMemoryPercentage());
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
     checkFileNotInUnderStorage(status.getUfsPath());
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     // free for non-persisted file is no-op
     Assert.assertEquals(100, status.getInMemoryPercentage());
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
   }
 
   @Test
@@ -187,22 +187,22 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
     try {
-      sFileSystem.free(mUri);
+      mFileSystem.free(mUri);
       Assert.fail("Expect free to fail before file is persisted");
     } catch (AlluxioException e) {
       // Expected
     }
     IntegrationTestUtils.waitForBlocksToBeFreed(
         sLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class));
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     // free for non-persisted file is no-op
     Assert.assertEquals(100, status.getInMemoryPercentage());
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
-    status = sFileSystem.getStatus(mUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
+    status = mFileSystem.getStatus(mUri);
     // free for non-persisted file is no-op
     Assert.assertEquals(100, status.getInMemoryPercentage());
   }
@@ -210,19 +210,16 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   @Test
   public void freeAfterFilePersisted() throws Exception {
     URIStatus status = createAsyncFile();
-    System.out.println(status);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    System.out.println("Finished waiting for persist");
-    sFileSystem.free(mUri);
-    System.out.println("Freed file");
+    mFileSystem.free(mUri);
     IntegrationTestUtils.waitForBlocksToBeFreed(
         sLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class),
         status.getBlockIds().toArray(new Long[status.getBlockIds().size()]));
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     // file persisted, free is no more a no-op
     Assert.assertEquals(0, status.getInMemoryPercentage());
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
   }
 
   @Test
@@ -238,7 +235,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    URIStatus statusAfter = sFileSystem.getStatus(mUri);
+    URIStatus statusAfter = mFileSystem.getStatus(mUri);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), statusAfter.getPersistenceState());
   }
 
@@ -247,16 +244,16 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.pauseChecker(sLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
   }
 
   @Test
@@ -264,17 +261,17 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseScheduler(sLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
-    checkFileNotInUnderStorage(sFileSystem.getStatus(newUri).getUfsPath());
+    checkFileNotInUnderStorage(mFileSystem.getStatus(newUri).getUfsPath());
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, newUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri, LEN);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
   }
@@ -285,17 +282,17 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
-    checkFileNotInUnderStorage(sFileSystem.getStatus(newUri).getUfsPath());
+    checkFileNotInUnderStorage(mFileSystem.getStatus(newUri).getUfsPath());
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, newUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri, LEN);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
   }
@@ -305,10 +302,10 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri, LEN);
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri, LEN);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(status.getUfsPath());
   }
@@ -319,19 +316,19 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
-    sFileSystem.setAttribute(mUri, TEST_OPTIONS);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
+    mFileSystem.setAttribute(mUri, TEST_OPTIONS);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
     checkFileNotInUnderStorage(status.getUfsPath());
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
-    status = sFileSystem.getStatus(mUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
+    status = mFileSystem.getStatus(mUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
@@ -348,19 +345,19 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
     String ufsPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
-    sFileSystem.setAttribute(mUri, TEST_OPTIONS);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
+    mFileSystem.setAttribute(mUri, TEST_OPTIONS);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
     checkFileNotInUnderStorage(status.getUfsPath());
-    status = sFileSystem.getStatus(mUri);
+    status = mFileSystem.getStatus(mUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
-    status = sFileSystem.getStatus(mUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
+    status = mFileSystem.getStatus(mUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
@@ -374,10 +371,10 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   public void setAttributeAfterFilePersisted() throws Exception {
     createAsyncFile();
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, mUri);
-    sFileSystem.setAttribute(mUri, TEST_OPTIONS);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, mUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, mUri, LEN);
-    URIStatus status = sFileSystem.getStatus(mUri);
+    mFileSystem.setAttribute(mUri, TEST_OPTIONS);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, mUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, mUri, LEN);
+    URIStatus status = mFileSystem.getStatus(mUri);
     String ufsPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
@@ -396,24 +393,24 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
     AlluxioURI newUri1 = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri1.getParent());
-    sFileSystem.rename(mUri, newUri1);
-    String ufsPath1 = sFileSystem.getStatus(newUri1).getUfsPath();
+    mFileSystem.createDirectory(newUri1.getParent());
+    mFileSystem.rename(mUri, newUri1);
+    String ufsPath1 = mFileSystem.getStatus(newUri1).getUfsPath();
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri1, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri1, LEN);
     checkFileNotInUnderStorage(ufsPath1);
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
     AlluxioURI newUri2 = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.rename(newUri1, newUri2);
-    String ufsPath2 = sFileSystem.getStatus(newUri2).getUfsPath();
+    mFileSystem.rename(newUri1, newUri2);
+    String ufsPath2 = mFileSystem.getStatus(newUri2).getUfsPath();
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
     checkFileNotInAlluxio(newUri1);
     checkFileNotInUnderStorage(ufsPath1);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri2, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri2, LEN);
     checkFileNotInUnderStorage(ufsPath2);
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
@@ -422,8 +419,8 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     checkFileNotInUnderStorage(ufsPath);
     checkFileNotInAlluxio(newUri1);
     checkFileNotInUnderStorage(ufsPath1);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri2, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri2, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri2, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri2, LEN);
   }
 
   @Test
@@ -433,18 +430,18 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    String newUfsPath = sFileSystem.getStatus(newUri).getUfsPath();
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    String newUfsPath = mFileSystem.getStatus(newUri).getUfsPath();
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInUnderStorage(newUfsPath);
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
     try {
-      sFileSystem.free(newUri);
+      mFileSystem.free(newUri);
       Assert.fail("Expect free to fail before file is persisted");
     } catch (AlluxioException e) {
       // Expected
@@ -453,19 +450,19 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
         sLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class));
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInUnderStorage(newUfsPath);
     // free for non-persisted file is no-op
-    Assert.assertEquals(100, sFileSystem.getStatus(newUri).getInMemoryPercentage());
+    Assert.assertEquals(100, mFileSystem.getStatus(newUri).getInMemoryPercentage());
 
     PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, newUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri, LEN);
     // free for non-persisted file is no-op
-    Assert.assertEquals(100, sFileSystem.getStatus(newUri).getInMemoryPercentage());
+    Assert.assertEquals(100, mFileSystem.getStatus(newUri).getInMemoryPercentage());
   }
 
   @Test
@@ -476,22 +473,22 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     String ufsPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    String newUfsPath = sFileSystem.getStatus(newUri).getUfsPath();
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    String newUfsPath = mFileSystem.getStatus(newUri).getUfsPath();
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInUnderStorage(newUfsPath);
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
-    sFileSystem.setAttribute(newUri, TEST_OPTIONS);
+    mFileSystem.setAttribute(newUri, TEST_OPTIONS);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInUnderStorage(newUfsPath);
-    status = sFileSystem.getStatus(newUri);
+    status = mFileSystem.getStatus(newUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
@@ -500,9 +497,9 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, newUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
-    FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, newUri, LEN);
-    status = sFileSystem.getStatus(newUri);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, newUri, LEN);
+    status = mFileSystem.getStatus(newUri);
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
@@ -519,17 +516,17 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createDirectory(newUri.getParent());
-    sFileSystem.rename(mUri, newUri);
-    String newUfsPath = sFileSystem.getStatus(newUri).getUfsPath();
+    mFileSystem.createDirectory(newUri.getParent());
+    mFileSystem.rename(mUri, newUri);
+    String newUfsPath = mFileSystem.getStatus(newUri).getUfsPath();
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
-    FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, newUri, LEN);
+    FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, newUri, LEN);
     checkFileNotInUnderStorage(newUfsPath);
 
     PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
     PersistenceTestUtils.waitForJobScheduled(sLocalAlluxioClusterResource, status.getFileId());
-    sFileSystem.delete(newUri);
+    mFileSystem.delete(newUri);
     checkFileNotInAlluxio(mUri);
     checkFileNotInUnderStorage(ufsPath);
     checkFileNotInAlluxio(mUri);
@@ -550,7 +547,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
    * @param filePath path of the tmp file
    */
   private void checkFileNotInAlluxio(AlluxioURI filePath) throws Exception {
-    Assert.assertFalse(sFileSystem.exists(filePath));
+    Assert.assertFalse(mFileSystem.exists(filePath));
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -23,7 +23,6 @@ import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.TtlAction;
 import alluxio.grpc.WritePType;
 import alluxio.heartbeat.HeartbeatContext;
-import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.security.authorization.Mode;
@@ -34,6 +33,7 @@ import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.block.BlockWorker;
 
+import org.datanucleus.util.PersistenceUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -60,7 +60,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   private AlluxioURI mUri;
 
   @ClassRule
-  public ManuallyScheduleHeartbeat mManuallySchedule =
+  public static ManuallyScheduleHeartbeat sMnauallySchedule =
       new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_BLOCK_SYNC);
 
   @Override
@@ -68,6 +68,8 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
   public void before() throws Exception {
     super.before();
     mUri = new AlluxioURI(PathUtils.uniqPath());
+    PersistenceTestUtils.resumeScheduler(sLocalAlluxioClusterResource);
+    PersistenceTestUtils.resumeChecker(sLocalAlluxioClusterResource);
   }
 
   /**
@@ -448,9 +450,6 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     } catch (AlluxioException e) {
       // Expected
     }
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
     IntegrationTestUtils.waitForBlocksToBeFreed(
         sLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class));
     checkFileNotInAlluxio(mUri);

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
@@ -68,12 +68,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      FileOutStreamTestUtils.writeIncreasingBytesToFile(sFileSystem, filePath, len, op);
+      FileOutStreamTestUtils.writeIncreasingBytesToFile(mFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, len);
       }
     }
   }
@@ -89,12 +89,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      FileOutStreamTestUtils.writeIncreasingByteArrayToFile(sFileSystem, filePath, len, op);
+      FileOutStreamTestUtils.writeIncreasingByteArrayToFile(mFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, len);
       }
     }
   }
@@ -110,12 +110,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      FileOutStreamTestUtils.writeTwoIncreasingByteArraysToFile(sFileSystem, filePath, len, op);
+      FileOutStreamTestUtils.writeTwoIncreasingByteArraysToFile(mFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, len);
       }
     }
   }
@@ -132,37 +132,37 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     final int length = 2;
     CreateFilePOptions op = CreateFilePOptions.newBuilder().setWriteType(mWriteType.toProto())
         .setRecursive(true).build();
-    try (FileOutStream os = sFileSystem.createFile(filePath, op)) {
+    try (FileOutStream os = mFileSystem.createFile(filePath, op)) {
       os.write((byte) 0);
       os.write((byte) 1);
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length);
+      FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, length);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length);
+      FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, length);
     }
   }
 
   /**
-   * Tests writing to a file for longer than {@link PropertyKey#WORKER_BLOCK_HEARTBEAT_INTERVAL_MS}
+   * Tests writing to a file for longer than {@link PropertyKey#MASTER_WORKER_HEARTBEAT_INTERVAL}
    * to make sure the sessionId doesn't change. Tracks [ALLUXIO-171].
    */
   @Test
   public void longWrite() throws Exception {
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     final int length = 2;
-    try (FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       os.write((byte) 0);
-      Thread.sleep(ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
+      Thread.sleep(ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2);
       os.write((byte) 1);
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length);
+      FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, length);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length);
+      FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, length);
     }
   }
 
@@ -176,7 +176,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     // A length greater than 0.5 * BUFFER_BYTES and less than BUFFER_BYTES.
     int length = (BUFFER_BYTES * 3) / 4;
-    try (FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       // Write something small, so it is written into the buffer, and not directly to the file.
       os.write((byte) 0);
@@ -184,10 +184,10 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.write(BufferUtils.getIncreasingByteArray(1, length));
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length + 1);
+      FileOutStreamTestUtils.checkFileInAlluxio(mFileSystem, filePath, length + 1);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length + 1);
+      FileOutStreamTestUtils.checkFileInUnderStorage(mFileSystem, filePath, length + 1);
     }
   }
 
@@ -203,7 +203,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     Map<WorkerInfo, Long> workerUsedBytes =
         workers.stream().collect(Collectors.toMap(identity(), WorkerInfo::getUsedBytes));
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
-    try (FileOutStream os = sFileSystem.createFile(path, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = mFileSystem.createFile(path, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       os.write(BufferUtils.getIncreasingByteArray(0, BLOCK_SIZE_BYTES * 3 + 1));
       os.cancel();

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
@@ -32,8 +32,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Integration tests for {@link alluxio.client.file.FileOutStream}, parameterized by the write

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
@@ -196,11 +196,6 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
    */
   @Test
   public void cancelWrite() throws Exception {
-    List<WorkerInfo> workers =
-        sLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
-            .getMaster(FileSystemMaster.class).getFileSystemMasterView().getWorkerInfoList();
-    Map<Long, Long> workerUsedBytes =
-        workers.stream().collect(Collectors.toMap(WorkerInfo::getId, WorkerInfo::getUsedBytes));
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
     try (FileOutStream os = mFileSystem.createFile(path, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
@@ -209,12 +204,11 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     }
     long gracePeriod = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL) * 2;
     CommonUtils.sleepMs(gracePeriod);
-    workers = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
-            .getMaster(FileSystemMaster.class).getFileSystemMasterView().getWorkerInfoList();
+    List<WorkerInfo> workers = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
+        .getMasterProcess().getMaster(FileSystemMaster.class).getFileSystemMasterView()
+        .getWorkerInfoList();
     for (WorkerInfo worker : workers) {
-      Long wub = workerUsedBytes.get(worker.getId());
-      Long ub = worker.getUsedBytes();
-      assertEquals(wub, ub);
+      assertEquals(0L, worker.getUsedBytes());
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
@@ -66,12 +66,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      writeIncreasingBytesToFile(filePath, len, op);
+      FileOutStreamTestUtils.writeIncreasingBytesToFile(sFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        checkFileInAlluxio(filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        checkFileInUnderStorage(filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
       }
     }
   }
@@ -87,12 +87,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      writeIncreasingByteArrayToFile(filePath, len, op);
+      FileOutStreamTestUtils.writeIncreasingByteArrayToFile(sFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        checkFileInAlluxio(filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        checkFileInUnderStorage(filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
       }
     }
   }
@@ -108,12 +108,12 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
           .setRecursive(true).build();
       AlluxioURI filePath =
           new AlluxioURI(PathUtils.concatPath(uniqPath, "file_" + len + "_" + mWriteType));
-      writeTwoIncreasingByteArraysToFile(filePath, len, op);
+      FileOutStreamTestUtils.writeTwoIncreasingByteArraysToFile(sFileSystem, filePath, len, op);
       if (mWriteType.getAlluxioStorageType().isStore()) {
-        checkFileInAlluxio(filePath, len);
+        FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, len);
       }
       if (mWriteType.getUnderStorageType().isSyncPersist()) {
-        checkFileInUnderStorage(filePath, len);
+        FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, len);
       }
     }
   }
@@ -131,15 +131,15 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     final int length = 2;
     CreateFilePOptions op = CreateFilePOptions.newBuilder().setWriteType(mWriteType.toProto())
         .setRecursive(true).build();
-    try (FileOutStream os = mFileSystem.createFile(filePath, op)) {
+    try (FileOutStream os = sFileSystem.createFile(filePath, op)) {
       os.write((byte) 0);
       os.write((byte) 1);
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      checkFileInAlluxio(filePath, length);
+      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      checkFileInUnderStorage(filePath, length);
+      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length);
     }
   }
 
@@ -151,17 +151,17 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
   public void longWrite() throws Exception {
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     final int length = 2;
-    try (FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       os.write((byte) 0);
       Thread.sleep(Constants.SECOND_MS * 2);
       os.write((byte) 1);
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      checkFileInAlluxio(filePath, length);
+      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      checkFileInUnderStorage(filePath, length);
+      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length);
     }
   }
 
@@ -175,7 +175,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
     // A length greater than 0.5 * BUFFER_BYTES and less than BUFFER_BYTES.
     int length = (BUFFER_BYTES * 3) / 4;
-    try (FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       // Write something small, so it is written into the buffer, and not directly to the file.
       os.write((byte) 0);
@@ -183,10 +183,10 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.write(BufferUtils.getIncreasingByteArray(1, length));
     }
     if (mWriteType.getAlluxioStorageType().isStore()) {
-      checkFileInAlluxio(filePath, length + 1);
+      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, length + 1);
     }
     if (mWriteType.getUnderStorageType().isSyncPersist()) {
-      checkFileInUnderStorage(filePath, length + 1);
+      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, length + 1);
     }
   }
 
@@ -199,7 +199,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
   @Test
   public void cancelWrite() throws Exception {
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
-    try (FileOutStream os = mFileSystem.createFile(path, CreateFilePOptions.newBuilder()
+    try (FileOutStream os = sFileSystem.createFile(path, CreateFilePOptions.newBuilder()
         .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
       os.write(BufferUtils.getIncreasingByteArray(0, BLOCK_SIZE_BYTES * 3 + 1));
       os.cancel();
@@ -207,7 +207,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     long gracePeriod = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL) * 2;
     CommonUtils.sleepMs(gracePeriod);
     List<WorkerInfo> workers =
-        mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
+        sLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
             .getMaster(FileSystemMaster.class).getFileSystemMasterView().getWorkerInfoList();
     for (WorkerInfo worker : workers) {
       Assert.assertEquals(0, worker.getUsedBytes());

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamTestUtils.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamTestUtils.java
@@ -1,0 +1,120 @@
+package alluxio.client.fs;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.ReadPType;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.util.io.BufferUtils;
+
+import org.junit.Assert;
+
+import java.io.InputStream;
+
+public class FileOutStreamTestUtils {
+
+  /**
+   * Helper to write an Alluxio file with stream of bytes of increasing byte value.
+   *
+   * @param fs the FileSystemClient to use
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   */
+  public static void writeIncreasingBytesToFile(FileSystem fs, AlluxioURI filePath, int fileLen,
+      CreateFilePOptions op)
+      throws Exception {
+    try (FileOutStream os = fs.createFile(filePath, op)) {
+      for (int k = 0; k < fileLen; k++) {
+        os.write((byte) k);
+      }
+    }
+  }
+
+  /**
+   * Helper to write an Alluxio file with one increasing byte array, using a single
+   * {@link FileOutStream#write(byte[], int, int)} invocation.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   */
+  public static void writeIncreasingByteArrayToFile(FileSystem fs, AlluxioURI filePath, int fileLen,
+      CreateFilePOptions op) throws Exception {
+    try (FileOutStream os = fs.createFile(filePath, op)) {
+      os.write(BufferUtils.getIncreasingByteArray(fileLen));
+    }
+  }
+
+  /**
+   * Helper to write an Alluxio file with one increasing byte array, but using two separate
+   * {@link FileOutStream#write(byte[], int, int)} invocations.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   * @param op options to create file
+   */
+  public static void writeTwoIncreasingByteArraysToFile(FileSystem fs, AlluxioURI filePath,
+      int fileLen,
+      CreateFilePOptions op) throws Exception {
+    try (FileOutStream os = fs.createFile(filePath, op)) {
+      int len1 = fileLen / 2;
+      int len2 = fileLen - len1;
+      os.write(BufferUtils.getIncreasingByteArray(0, len1), 0, len1);
+      os.write(BufferUtils.getIncreasingByteArray(len1, len2), 0, len2);
+    }
+  }
+
+  /**
+   * Checks the given file exists in Alluxio storage and expects its content to be an increasing
+   * array of the given length.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   */
+  public static void checkFileInAlluxio(FileSystem fs, AlluxioURI filePath, int fileLen)
+      throws Exception {
+    URIStatus status = fs.getStatus(filePath);
+    Assert.assertEquals(fileLen, status.getLength());
+    try (FileInStream is = fs.openFile(filePath,
+        OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build())) {
+      byte[] res = new byte[(int) status.getLength()];
+      Assert.assertEquals((int) status.getLength(), is.read(res));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(fileLen, res));
+    }
+  }
+
+  /**
+   * Checks the given file exists in under storage and expects its content to be an increasing
+   * array of the given length.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   */
+  public static void checkFileInUnderStorage(FileSystem fs, AlluxioURI filePath, int fileLen)
+      throws Exception {
+    URIStatus status = fs.getStatus(filePath);
+    String checkpointPath = status.getUfsPath();
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(checkpointPath,
+        ServerConfiguration.global());
+
+    try (InputStream is = ufs.open(checkpointPath)) {
+      byte[] res = new byte[(int) status.getLength()];
+      int totalBytesRead = 0;
+      while (true) {
+        int bytesRead = is.read(res, totalBytesRead, res.length - totalBytesRead);
+        if (bytesRead <= 0) {
+          break;
+        }
+        totalBytesRead += bytesRead;
+      }
+      Assert.assertEquals((int) status.getLength(), totalBytesRead);
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(fileLen, res));
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamTestUtils.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamTestUtils.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.client.fs;
 
 import alluxio.AlluxioURI;

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -46,7 +46,6 @@ public final class PersistMultipleMountsIntegrationTest
   private UnderFileSystem mMountedUfs;
 
   @Before
-  @Override
   public void before() throws Exception {
     super.before();
 
@@ -55,7 +54,7 @@ public final class PersistMultipleMountsIntegrationTest
     mUfs = UnderFileSystem.Factory.create(mUfsRoot, ServerConfiguration.global());
 
     mMountedUfsRoot = mTempFolder.getRoot().getAbsolutePath();
-    mFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
+    sFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
     mMountedUfs = UnderFileSystem.Factory.create(mMountedUfsRoot, ServerConfiguration.global());
   }
 
@@ -66,14 +65,14 @@ public final class PersistMultipleMountsIntegrationTest
 
     String path = PathUtils.uniqPath();
     AlluxioURI filePath = new AlluxioURI(path);
-    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = mFileSystem.getStatus(filePath);
+    URIStatus status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     Assert.assertTrue(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));
@@ -87,14 +86,14 @@ public final class PersistMultipleMountsIntegrationTest
 
     String path = PathUtils.uniqPath();
     AlluxioURI filePath = new AlluxioURI(MOUNT_PATH + path);
-    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = mFileSystem.getStatus(filePath);
+    URIStatus status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     Assert.assertFalse(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
 
 /**
  * Integration tests of file permission propagation for persist and async persist.
@@ -40,9 +39,6 @@ public final class PersistMultipleMountsIntegrationTest
 
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();
-
-  @Rule
-  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
 
   private String mUfsRoot;
   private UnderFileSystem mUfs;

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -23,7 +23,6 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.PathUtils;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -58,7 +58,7 @@ public final class PersistMultipleMountsIntegrationTest
     mUfs = UnderFileSystem.Factory.create(mUfsRoot, ServerConfiguration.global());
 
     mMountedUfsRoot = mTempFolder.getRoot().getAbsolutePath();
-    sFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
+    mFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
     mMountedUfs = UnderFileSystem.Factory.create(mMountedUfsRoot, ServerConfiguration.global());
   }
 
@@ -69,14 +69,14 @@ public final class PersistMultipleMountsIntegrationTest
 
     String path = PathUtils.uniqPath();
     AlluxioURI filePath = new AlluxioURI(path);
-    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = sFileSystem.getStatus(filePath);
+    URIStatus status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     Assert.assertTrue(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));
@@ -90,14 +90,14 @@ public final class PersistMultipleMountsIntegrationTest
 
     String path = PathUtils.uniqPath();
     AlluxioURI filePath = new AlluxioURI(MOUNT_PATH + path);
-    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = sFileSystem.getStatus(filePath);
+    URIStatus status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     Assert.assertFalse(mUfs.exists(PathUtils.concatPath(mUfsRoot, path)));

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -23,12 +23,14 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.PathUtils;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 /**
  * Integration tests of file permission propagation for persist and async persist.
@@ -39,6 +41,9 @@ public final class PersistMultipleMountsIntegrationTest
 
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();
+
+  @Rule
+  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
 
   private String mUfsRoot;
   private UnderFileSystem mUfs;

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -55,18 +55,18 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = sFileSystem.getStatus(filePath);
+    URIStatus status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
     Assert.assertEquals(fileMode,
@@ -81,7 +81,7 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
@@ -89,15 +89,15 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
 
     CommonUtils.sleepMs(1);
     // check the file is completed but not persisted
-    URIStatus status = sFileSystem.getStatus(filePath);
+    URIStatus status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
 
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-    status = sFileSystem.getStatus(filePath);
+    status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
@@ -113,19 +113,19 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build()).close();
 
     // check the file is completed but not persisted
-    URIStatus status = sFileSystem.getStatus(filePath);
+    URIStatus status = mFileSystem.getStatus(filePath);
     Assert.assertNotEquals(PersistenceState.PERSISTED, status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
 
     IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-    status = sFileSystem.getStatus(filePath);
+    status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -28,9 +28,7 @@ import alluxio.util.io.PathUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 
 /**
  * Integration tests of file permission propagation for persist and async persist.
@@ -38,9 +36,6 @@ import org.junit.rules.TestRule;
 public final class PersistPermissionIntegrationTest extends AbstractFileOutStreamIntegrationTest {
   private String mUfsRoot;
   private UnderFileSystem mUfs;
-
-  @Rule
-  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
 
   @Before
   public void before() throws Exception {

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -38,10 +38,7 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
   private UnderFileSystem mUfs;
 
   @Before
-  @Override
   public void before() throws Exception {
-    super.before();
-
     mUfsRoot = ServerConfiguration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     mUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
   }
@@ -52,18 +49,18 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.CACHE_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
     os.close();
 
     // Check the file is persisted
-    URIStatus status = mFileSystem.getStatus(filePath);
+    URIStatus status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
     Assert.assertEquals(fileMode,
@@ -78,7 +75,7 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    FileOutStream os = sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build());
     os.write((byte) 0);
     os.write((byte) 1);
@@ -86,15 +83,15 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
 
     CommonUtils.sleepMs(1);
     // check the file is completed but not persisted
-    URIStatus status = mFileSystem.getStatus(filePath);
+    URIStatus status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
 
-    IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+    IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-    status = mFileSystem.getStatus(filePath);
+    status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.
@@ -110,19 +107,19 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(mUfs) || UnderFileSystemUtils.isHdfs(mUfs));
 
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-    mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+    sFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
         .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build()).close();
 
     // check the file is completed but not persisted
-    URIStatus status = mFileSystem.getStatus(filePath);
+    URIStatus status = sFileSystem.getStatus(filePath);
     Assert.assertNotEquals(PersistenceState.PERSISTED, status.getPersistenceState());
     Assert.assertTrue(status.isCompleted());
     short fileMode = (short) status.getMode();
-    short parentMode = (short) mFileSystem.getStatus(filePath.getParent()).getMode();
+    short parentMode = (short) sFileSystem.getStatus(filePath.getParent()).getMode();
 
-    IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+    IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-    status = mFileSystem.getStatus(filePath);
+    status = sFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
     // Check the permission of the created file and parent dir are in-sync between Alluxio and UFS.

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -28,7 +28,9 @@ import alluxio.util.io.PathUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
  * Integration tests of file permission propagation for persist and async persist.
@@ -37,8 +39,12 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
   private String mUfsRoot;
   private UnderFileSystem mUfs;
 
+  @Rule
+  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
+
   @Before
   public void before() throws Exception {
+    super.before();
     mUfsRoot = ServerConfiguration.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     mUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
   }

--- a/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.client.fs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.client.file.FileSystem;
@@ -29,10 +32,7 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -57,7 +57,6 @@ public class UfsFallbackFileOutStreamIntegrationTest {
   private static final int WORKER_MEMORY_SIZE = 1500;
   private static final int BUFFER_BYTES = 100;
 
-
   @ClassRule
   public static ManuallyScheduleHeartbeat sManuallyScheduleEviction =
       new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_SPACE_RESERVER);
@@ -70,7 +69,8 @@ public class UfsFallbackFileOutStreamIntegrationTest {
           .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "100ms")
           .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "100ms")
           .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "100ms")
-          .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BUFFER_BYTES) // initial buffer for worker
+          // initial buffer for worker
+          .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BUFFER_BYTES)
           .setProperty(PropertyKey.USER_FILE_UFS_TIER_ENABLED, true)
           .setProperty(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_HIGH, "1.0")
           .setProperty(PropertyKey.WORKER_FREE_SPACE_TIMEOUT, "500ms")
@@ -135,20 +135,22 @@ public class UfsFallbackFileOutStreamIntegrationTest {
     }, ServerConfiguration.global()).toResource()) {
       try (FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global())) {
         AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-        CreateFilePOptions op =
-            CreateFilePOptions.newBuilder().setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();
+        CreateFilePOptions op = CreateFilePOptions.newBuilder()
+            .setWriteType(WritePType.ASYNC_THROUGH)
+            .setRecursive(true)
+            .build();
         FileOutStreamTestUtils.writeIncreasingBytesToFile(fs, filePath, mFileLength, op);
 
         CommonUtils.sleepMs(1);
         // check the file is completed but not persisted
         URIStatus status = fs.getStatus(filePath);
-        Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
-        Assert.assertTrue(status.isCompleted());
+        assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
+        assertTrue(status.isCompleted());
 
         IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
         status = fs.getStatus(filePath);
-        Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+        assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
         FileOutStreamTestUtils.checkFileInAlluxio(fs, filePath, mFileLength);
         FileOutStreamTestUtils.checkFileInUnderStorage(fs, filePath, mFileLength);
@@ -169,20 +171,22 @@ public class UfsFallbackFileOutStreamIntegrationTest {
 
       try (FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global())) {
         AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
-        CreateFilePOptions op =
-            CreateFilePOptions.newBuilder().setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();
+        CreateFilePOptions op = CreateFilePOptions.newBuilder()
+            .setWriteType(WritePType.ASYNC_THROUGH)
+            .setRecursive(true)
+            .build();
         FileOutStreamTestUtils.writeIncreasingBytesToFile(fs, filePath, mFileLength, op);
 
         CommonUtils.sleepMs(1);
         // check the file is completed but not persisted
         URIStatus status = fs.getStatus(filePath);
-        Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
-        Assert.assertTrue(status.isCompleted());
+        assertEquals(PersistenceState.TO_BE_PERSISTED.toString(), status.getPersistenceState());
+        assertTrue(status.isCompleted());
 
         IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
         status = fs.getStatus(filePath);
-        Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
+        assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
         FileOutStreamTestUtils.checkFileInAlluxio(fs, filePath, mFileLength);
         FileOutStreamTestUtils.checkFileInUnderStorage(fs, filePath, mFileLength);

--- a/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
@@ -38,7 +38,6 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -61,24 +60,21 @@ public class UfsFallbackFileOutStreamIntegrationTest {
   public static ManuallyScheduleHeartbeat sManuallyScheduleEviction =
       new ManuallyScheduleHeartbeat(HeartbeatContext.WORKER_SPACE_RESERVER);
 
+  @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_MEMORY_SIZE)
-          .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "100ms")
-          .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "100ms")
-          .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "100ms")
-          .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "100ms")
-          .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "100ms")
+          .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
+          .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
+          .setProperty(PropertyKey.WORKER_TIERED_STORE_RESERVER_INTERVAL_MS, "10ms")
+          .setProperty(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL, "10ms")
+          .setProperty(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "10ms")
           // initial buffer for worker
           .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BUFFER_BYTES)
           .setProperty(PropertyKey.USER_FILE_UFS_TIER_ENABLED, true)
           .setProperty(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_HIGH, "1.0")
-          .setProperty(PropertyKey.WORKER_FREE_SPACE_TIMEOUT, "500ms")
+          .setProperty(PropertyKey.WORKER_FREE_SPACE_TIMEOUT, "100ms")
       .build();
-
-  @ClassRule
-  public static RuleChain sRuleChain = RuleChain.outerRule(sLocalAlluxioClusterResource)
-      .around(sLocalAlluxioClusterResource.getResetResource());
 
   @Rule
   public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();

--- a/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsFallbackFileOutStreamIntegrationTest.java
@@ -53,8 +53,8 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
   protected static final int WORKER_MEMORY_SIZE = 1500;
   protected static final int BUFFER_BYTES = 100;
 
-  @Override
-  protected void customizeClusterResource(LocalAlluxioClusterResource.Builder resource) {
+//  @Override
+  protected static void customizeClusterResource(LocalAlluxioClusterResource.Builder resource) {
     resource.setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_MEMORY_SIZE)
         .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, BUFFER_BYTES) // initial buffer for worker
         .setProperty(PropertyKey.USER_FILE_UFS_TIER_ENABLED, true)
@@ -99,22 +99,22 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
       AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
       CreateFilePOptions op = CreateFilePOptions.newBuilder()
           .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();
-      writeIncreasingBytesToFile(fs, filePath, mFileLength, op);
+      FileOutStreamTestUtils.writeIncreasingBytesToFile(fs, filePath, mFileLength, op);
 
       CommonUtils.sleepMs(1);
       // check the file is completed but not persisted
-      URIStatus status = mFileSystem.getStatus(filePath);
+      URIStatus status = sFileSystem.getStatus(filePath);
       Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(),
           status.getPersistenceState());
       Assert.assertTrue(status.isCompleted());
 
-      IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+      IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-      status = mFileSystem.getStatus(filePath);
+      status = sFileSystem.getStatus(filePath);
       Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
-      checkFileInAlluxio(filePath, mFileLength);
-      checkFileInUnderStorage(filePath, mFileLength);
+      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, mFileLength);
+      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, mFileLength);
     }
   }
 
@@ -131,22 +131,22 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
       AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
       CreateFilePOptions op = CreateFilePOptions.newBuilder()
           .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();
-      writeIncreasingBytesToFile(filePath, mFileLength, op);
+      FileOutStreamTestUtils.writeIncreasingBytesToFile(sFileSystem, filePath, mFileLength, op);
 
       CommonUtils.sleepMs(1);
       // check the file is completed but not persisted
-      URIStatus status = mFileSystem.getStatus(filePath);
+      URIStatus status = sFileSystem.getStatus(filePath);
       Assert.assertEquals(PersistenceState.TO_BE_PERSISTED.toString(),
           status.getPersistenceState());
       Assert.assertTrue(status.isCompleted());
 
-      IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
+      IntegrationTestUtils.waitForPersist(sLocalAlluxioClusterResource, filePath);
 
-      status = mFileSystem.getStatus(filePath);
+      status = sFileSystem.getStatus(filePath);
       Assert.assertEquals(PersistenceState.PERSISTED.toString(), status.getPersistenceState());
 
-      checkFileInAlluxio(filePath, mFileLength);
-      checkFileInUnderStorage(filePath, mFileLength);
+      FileOutStreamTestUtils.checkFileInAlluxio(sFileSystem, filePath, mFileLength);
+      FileOutStreamTestUtils.checkFileInUnderStorage(sFileSystem, filePath, mFileLength);
     }
   }
 }

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -200,12 +200,11 @@ public final class IntegrationTestUtils {
       // Waiting for the blocks to be added into the heartbeat reportor, so that they will be
       // removed from master in the next heartbeat.
       CommonUtils.waitFor("blocks to be removed", () -> {
-
         Set<Long> blocks = bw.getBlockStore().getBlockStoreMetaFull()
             .getBlockListByStorageLocation().values().stream().flatMap(List::stream)
             .collect(Collectors.toSet());
         blocks.retainAll(Sets.newHashSet(blockIds));
-        return blocks.size() <= 0;
+        return blocks.isEmpty();
       }, WaitForOptions.defaults().setTimeoutMs(100 * Constants.SECOND_MS));
 
       // Execute 2nd heartbeat from worker.

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -18,6 +18,7 @@ import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemMasterClient;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.heartbeat.HeartbeatContext;
@@ -76,8 +77,9 @@ public final class IntegrationTestUtils {
             .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
       CommonUtils.waitFor(uri + " to be persisted", () -> {
         try {
-          return client.getStatus(uri,
-              FileSystemOptions.getStatusDefaults(ServerConfiguration.global())).isPersisted();
+          URIStatus stat = client.getStatus(uri,
+              FileSystemOptions.getStatusDefaults(ServerConfiguration.global()));
+          return stat.isPersisted();
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }
@@ -118,6 +120,7 @@ public final class IntegrationTestUtils {
     try {
       // Execute 1st heartbeat from worker.
       HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+//      Whitebox.getInternalState(bw, BlockMasterSync.class).heartbeat();
 
       // Waiting for the blocks to be added into the heartbeat reportor, so that they will be
       // removed from master in the next heartbeat.
@@ -129,6 +132,7 @@ public final class IntegrationTestUtils {
 
       // Execute 2nd heartbeat from worker.
       HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
+//      Whitebox.getInternalState(bw, BlockMasterSync.class).heartbeat();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -13,6 +13,7 @@ package alluxio.testutils;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedClientUserResource;
+import alluxio.conf.AlluxioProperties;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.DeletePOptions;
@@ -268,6 +269,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
       return new Statement() {
         @Override
         public void evaluate() throws Throwable {
+          AlluxioProperties props = ServerConfiguration.copyProperties();
           try {
             statement.evaluate();
           } finally {
@@ -284,6 +286,17 @@ public final class LocalAlluxioClusterResource implements TestRule {
             } else {
               resetCluster(fsm);
             }
+
+            // Reset any properties that have changed
+            ServerConfiguration.reset();
+            props.entrySet()
+                .forEach(e -> {
+                  if (e.getValue() == null || e.getValue().equals("")) {
+                    ServerConfiguration.unset(e.getKey());
+                  } else {
+                    ServerConfiguration.set(e.getKey(), e.getValue());
+                  }
+                });
           }
         }
       };

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -292,9 +292,9 @@ public final class LocalAlluxioClusterResource implements TestRule {
               resetFsm(fsm);
             }
 
-            BlockWorker blkWorker = mCluster.mLocalAlluxioCluster.getWorkerProcess()
-                .getWorker(BlockWorker.class);
-            resetBlockWorker(blkWorker);
+            mCluster.mLocalAlluxioCluster.getWorkerProcesses().stream()
+                .map(w -> w.getWorker(BlockWorker.class))
+            .forEach(blkWorker -> resetBlockWorker(blkWorker));
 
             // Reset any properties that have changed
             ServerConfiguration.reset();

--- a/tests/src/test/java/alluxio/testutils/PersistenceTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/PersistenceTestUtils.java
@@ -13,17 +13,17 @@ package alluxio.testutils;
 
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.PersistJob;
-import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.time.ExponentialTimer;
 import alluxio.util.CommonUtils;
 
 import org.powermock.reflect.Whitebox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class PersistenceTestUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(PersistenceTestUtils.class);
 
   /**
    * A simple wrapper around an inner map that delegates operations to the inner
@@ -98,7 +99,8 @@ public final class PersistenceTestUtils {
           Whitebox.getInternalState(nestedMaster, "mPersistRequests");
       Whitebox.setInternalState(nestedMaster, "mPersistRequests", persistRequests.getInnerMap());
     } catch (ClassCastException e) {
-      Whitebox.setInternalState(nestedMaster, "mPersistRequests", new ConcurrentHashMap<>());
+      // This will occur is resume is called without first being paused
+      LOG.warn("Call to resumeScheduler failed: ", e);
     }
   }
 
@@ -126,7 +128,8 @@ public final class PersistenceTestUtils {
           Whitebox.getInternalState(nestedMaster, "mPersistJobs");
       Whitebox.setInternalState(nestedMaster, "mPersistJobs", persistJobs.getInnerMap());
     } catch (ClassCastException e) {
-      Whitebox.setInternalState(nestedMaster, "mPersistJobs", new ConcurrentHashMap<>());
+      // This will occur is resume is called without first being paused
+      LOG.warn("Call to resumeChecker failed: ", e);
     }
   }
 

--- a/tests/src/test/java/alluxio/testutils/PersistenceTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/PersistenceTestUtils.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -92,9 +93,13 @@ public final class PersistenceTestUtils {
    */
   public static void resumeScheduler(LocalAlluxioClusterResource resource) {
     FileSystemMaster nestedMaster = getFileSystemMaster(resource);
-    BlackHoleMap<Long, ExponentialTimer> persistRequests =
-        Whitebox.getInternalState(nestedMaster, "mPersistRequests");
-    Whitebox.setInternalState(nestedMaster, "mPersistRequests", persistRequests.getInnerMap());
+    try {
+      BlackHoleMap<Long, ExponentialTimer> persistRequests =
+          Whitebox.getInternalState(nestedMaster, "mPersistRequests");
+      Whitebox.setInternalState(nestedMaster, "mPersistRequests", persistRequests.getInnerMap());
+    } catch (ClassCastException e) {
+      Whitebox.setInternalState(nestedMaster, "mPersistRequests", new ConcurrentHashMap<>());
+    }
   }
 
   /**
@@ -116,9 +121,13 @@ public final class PersistenceTestUtils {
    */
   public static void resumeChecker(LocalAlluxioClusterResource resource) {
     FileSystemMaster nestedMaster = getFileSystemMaster(resource);
-    BlackHoleMap<Long, PersistJob> persistJobs =
-        Whitebox.getInternalState(nestedMaster, "mPersistJobs");
-    Whitebox.setInternalState(nestedMaster, "mPersistJobs", persistJobs.getInnerMap());
+    try {
+      BlackHoleMap<Long, PersistJob> persistJobs =
+          Whitebox.getInternalState(nestedMaster, "mPersistJobs");
+      Whitebox.setInternalState(nestedMaster, "mPersistJobs", persistJobs.getInnerMap());
+    } catch (ClassCastException e) {
+      Whitebox.setInternalState(nestedMaster, "mPersistJobs", new ConcurrentHashMap<>());
+    }
   }
 
   /**


### PR DESCRIPTION
This improves and drops the times for a number of tests which
originally inherited from the AbstractFileOutStreamIntegrationTest
class.

Instead of starting a new cluster for each test, we re-use the same
cluster. Some tests needed more modifications to continue passing.

Depending on the number of tests per file, improvements in test
runtime ranged anywhere from 20%-1000%