### PR TITLE
Propagate UserState to PollingMasterInquireClient

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -562,7 +562,8 @@ public class BaseFileSystem implements FileSystem {
        * user passes. If not, throw an exception letting the user know they don't match.
        */
       Authority configured =
-          MasterInquireClient.Factory.create(mFsContext.getClusterConf())
+          MasterInquireClient.Factory
+              .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
               .getConnectDetails().toAuthority();
       if (!configured.equals(uri.getAuthority())) {
         throw new IllegalArgumentException(

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -164,7 +164,8 @@ public final class FileSystemContext implements Closeable {
       @Nullable AlluxioConfiguration conf) {
     FileSystemContext context = new FileSystemContext();
     ClientContext ctx = ClientContext.create(subject, conf);
-    MasterInquireClient inquireClient = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient inquireClient =
+        MasterInquireClient.Factory.create(ctx.getClusterConf(), ctx.getUserState());
     context.init(ctx, inquireClient);
     return context;
   }
@@ -175,7 +176,8 @@ public final class FileSystemContext implements Closeable {
    */
   public static FileSystemContext create(ClientContext clientContext) {
     FileSystemContext ctx = new FileSystemContext();
-    ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf()));
+    ctx.init(clientContext, MasterInquireClient.Factory.create(clientContext.getClusterConf(),
+        clientContext.getUserState()));
     return ctx;
   }
 
@@ -334,7 +336,8 @@ public final class FileSystemContext implements Closeable {
             + "meta master (%s) during reinitialization", masterAddr), e);
       }
       closeContext();
-      initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf()));
+      initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf(),
+          getClientContext().getUserState()));
       mReinitializer.onSuccess();
     }
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
@@ -44,7 +44,8 @@ public class BlockMasterClientPoolTest {
         .thenReturn(expectedClient);
     BlockMasterClient client;
     ClientContext clientContext = ClientContext.create(mConf);
-    MasterInquireClient masterInquireClient = MasterInquireClient.Factory.create(mConf);
+    MasterInquireClient masterInquireClient = MasterInquireClient.Factory
+        .create(mConf, clientContext.getUserState());
     MasterClientContext masterClientContext = MasterClientContext.newBuilder(clientContext)
         .setMasterInquireClient(masterInquireClient).build();
     try (BlockMasterClientPool pool = new BlockMasterClientPool(masterClientContext)) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
@@ -39,7 +39,8 @@ public class FileSystemMasterClientPoolTest {
         .thenReturn(expectedClient);
     FileSystemMasterClient client;
     ClientContext clientContext = ClientContext.create(conf);
-    MasterInquireClient masterInquireClient = MasterInquireClient.Factory.create(conf);
+    MasterInquireClient masterInquireClient = MasterInquireClient.Factory
+        .create(conf, clientContext.getUserState());
     MasterClientContext masterClientContext = MasterClientContext.newBuilder(clientContext)
         .setMasterInquireClient(masterInquireClient).build();
     try (FileSystemMasterClientPool pool = new FileSystemMasterClientPool(masterClientContext)) {

--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -43,7 +43,8 @@ public class MetricsHeartbeatContextTest {
   public void testExecutorInitialized() {
 
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
 
     // Add and delete a single context, make sure it is non null after adding, and then null after
     // removing
@@ -75,7 +76,8 @@ public class MetricsHeartbeatContextTest {
     assertTrue(map.isEmpty());
 
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);
     assertFalse(map.isEmpty());
 
@@ -89,7 +91,8 @@ public class MetricsHeartbeatContextTest {
     InstancedConfiguration conf = ConfigurationTestUtils.defaults();
     conf.set(PropertyKey.MASTER_RPC_ADDRESSES, "master1:19998,master2:19998,master3:19998");
     ClientContext haCtx = ClientContext.create(conf);
-    MetricsHeartbeatContext.addHeartbeat(haCtx, MasterInquireClient.Factory.create(conf));
+    MetricsHeartbeatContext.addHeartbeat(haCtx, MasterInquireClient.Factory
+        .create(conf, haCtx.getUserState()));
     assertEquals(2, map.size());
 
     MetricsHeartbeatContext.removeHeartbeat(ctx);
@@ -113,7 +116,8 @@ public class MetricsHeartbeatContextTest {
     ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
     when(future.cancel(any(Boolean.class))).thenReturn(true);
     ClientContext ctx = ClientContext.create();
-    MasterInquireClient client = MasterInquireClient.Factory.create(ctx.getClusterConf());
+    MasterInquireClient client = MasterInquireClient.Factory
+        .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);
     assertFalse(map.isEmpty());
     map.forEach((addr, heartbeat) -> {

--- a/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
+++ b/core/common/src/main/java/alluxio/master/MasterClientContextBuilder.java
@@ -49,7 +49,8 @@ public class MasterClientContextBuilder {
    */
   public MasterClientContext build() {
     if (mMasterInquireClient == null) {
-      mMasterInquireClient = MasterInquireClient.Factory.create(mContext.getClusterConf());
+      mMasterInquireClient = MasterInquireClient.Factory.create(mContext.getClusterConf(),
+          mContext.getUserState());
     }
     return new MasterClientContext(mContext, mMasterInquireClient);
   }

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -16,6 +16,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.SingleMasterInquireClient.SingleMasterConnectDetails;
 import alluxio.master.ZkMasterInquireClient.ZkMasterConnectDetails;
+import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -74,9 +75,10 @@ public interface MasterInquireClient {
   class Factory {
     /**
      * @param conf configuration for creating the master inquire client
+     * @param userState the user state for the client
      * @return a master inquire client
      */
-    public static MasterInquireClient create(AlluxioConfiguration conf) {
+    public static MasterInquireClient create(AlluxioConfiguration conf, UserState userState) {
       if (conf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
         return ZkMasterInquireClient.getClient(conf.get(PropertyKey.ZOOKEEPER_ADDRESS),
             conf.get(PropertyKey.ZOOKEEPER_ELECTION_PATH),
@@ -86,14 +88,20 @@ public interface MasterInquireClient {
       } else {
         List<InetSocketAddress> addresses = ConfigurationUtils.getMasterRpcAddresses(conf);
         if (addresses.size() > 1) {
-          return new PollingMasterInquireClient(addresses, conf);
+          return new PollingMasterInquireClient(addresses, conf, userState);
         } else {
           return new SingleMasterInquireClient(addresses.get(0));
         }
       }
     }
 
-    public static MasterInquireClient createForJobMaster(AlluxioConfiguration conf) {
+    /**
+     * @param conf configuration for creating the master inquire client
+     * @param userState the user state for the client
+     * @return a master inquire client
+     */
+    public static MasterInquireClient createForJobMaster(AlluxioConfiguration conf,
+        UserState userState) {
       if (conf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
         return ZkMasterInquireClient.getClient(conf.get(PropertyKey.ZOOKEEPER_ADDRESS),
             conf.get(PropertyKey.ZOOKEEPER_JOB_ELECTION_PATH),
@@ -103,7 +111,7 @@ public interface MasterInquireClient {
       } else {
         List<InetSocketAddress> addresses = ConfigurationUtils.getJobMasterRpcAddresses(conf);
         if (addresses.size() > 1) {
-          return new PollingMasterInquireClient(addresses, conf);
+          return new PollingMasterInquireClient(addresses, conf, userState);
         } else {
           return new SingleMasterInquireClient(addresses.get(0));
         }

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -56,11 +56,13 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   /**
    * @param masterAddresses the potential master addresses
    * @param alluxioConf Alluxio configuration
+   * @param userState user state
    */
   public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
-      AlluxioConfiguration alluxioConf) {
+      AlluxioConfiguration alluxioConf,
+      UserState userState) {
     this(masterAddresses, () -> new ExponentialBackoffRetry(20, 2000, 30),
-        alluxioConf);
+        alluxioConf, userState);
   }
 
   /**
@@ -75,6 +77,22 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     mRetryPolicySupplier = retryPolicySupplier;
     mConfiguration = alluxioConf;
     mUserState = UserState.Factory.create(mConfiguration);
+  }
+
+  /**
+   * @param masterAddresses the potential master addresses
+   * @param retryPolicySupplier the retry policy supplier
+   * @param alluxioConf Alluxio configuration
+   * @param userState user state
+   */
+  public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
+      Supplier<RetryPolicy> retryPolicySupplier,
+      AlluxioConfiguration alluxioConf,
+      UserState userState) {
+    mConnectDetails = new MultiMasterConnectDetails(masterAddresses);
+    mRetryPolicySupplier = retryPolicySupplier;
+    mConfiguration = alluxioConf;
+    mUserState = userState;
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
@@ -54,7 +55,7 @@ public final class AlluxioWorker {
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.WORKER);
     MasterInquireClient masterInquireClient =
-        MasterInquireClient.Factory.create(ServerConfiguration.global());
+        MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
     try {
       RetryUtils.retry("load cluster default configuration with master", () -> {
         InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();

--- a/job/client/src/main/java/alluxio/client/job/JobContext.java
+++ b/job/client/src/main/java/alluxio/client/job/JobContext.java
@@ -16,6 +16,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
+import alluxio.security.user.UserState;
 import alluxio.worker.job.JobMasterClientContext;
 
 import java.io.Closeable;
@@ -47,11 +48,12 @@ public final class JobContext implements Closeable  {
    * Creates a job context.
    *
    * @param alluxioConf Alluxio configuration
+   * @param userState user state
    * @return the context
    */
-  public static JobContext create(AlluxioConfiguration alluxioConf) {
+  public static JobContext create(AlluxioConfiguration alluxioConf, UserState userState) {
     JobContext context = new JobContext();
-    context.init(alluxioConf);
+    context.init(alluxioConf, userState);
     return context;
   }
 
@@ -63,11 +65,12 @@ public final class JobContext implements Closeable  {
   /**
    * Initializes the context. Only called in the factory methods and reset.
    */
-  private synchronized void init(AlluxioConfiguration alluxioConf) {
-    mJobMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(alluxioConf);
+  private synchronized void init(AlluxioConfiguration alluxioConf, UserState userState) {
+    mJobMasterInquireClient = MasterInquireClient.Factory
+        .createForJobMaster(alluxioConf, userState);
     mJobMasterClientPool =
         new JobMasterClientPool(JobMasterClientContext
-            .newBuilder(ClientContext.create(alluxioConf)).build());
+            .newBuilder(ClientContext.create(userState.getSubject(), alluxioConf)).build());
   }
 
   /**

--- a/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
+++ b/job/client/src/main/java/alluxio/worker/job/JobMasterClientContextBuilder.java
@@ -40,7 +40,7 @@ public class JobMasterClientContextBuilder extends MasterClientContextBuilder {
   public JobMasterClientContext build() {
     if (mMasterInquireClient == null) {
       mMasterInquireClient = MasterInquireClient.Factory.createForJobMaster(
-          mContext.getClusterConf());
+          mContext.getClusterConf(), mContext.getUserState());
     }
     return new JobMasterClientContext(mContext, mMasterInquireClient);
   }

--- a/job/client/src/test/java/alluxio/client/job/JobContextTest.java
+++ b/job/client/src/test/java/alluxio/client/job/JobContextTest.java
@@ -17,6 +17,7 @@ import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.security.user.UserState;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
@@ -36,7 +37,8 @@ public final class JobContextTest {
 
   @Test
   public void getAddress() throws Exception {
-    try (JobContext context = JobContext.create(sConf)) {
+    UserState userState = UserState.Factory.create(sConf);
+    try (JobContext context = JobContext.create(sConf, userState)) {
       assertEquals("host2", context.getJobMasterAddress().getHostName());
     }
   }

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.RuntimeConstants;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
@@ -61,7 +62,7 @@ public final class AlluxioJobWorker {
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.JOB_WORKER);
     MasterInquireClient masterInquireClient =
-        MasterInquireClient.Factory.create(ServerConfiguration.global());
+        MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
     try {
       RetryUtils.retry("load cluster default configuration with master", () -> {
         InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -39,6 +39,7 @@ import alluxio.master.ZkMasterInquireClient;
 import alluxio.master.journal.JournalType;
 import alluxio.multi.process.PortCoordination.ReservedPort;
 import alluxio.network.PortUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
@@ -643,7 +644,8 @@ public final class MultiProcessCluster {
           for (MasterNetAddress address : mMasterAddresses) {
             addresses.add(new InetSocketAddress(address.getHostname(), address.getRpcPort()));
           }
-          return new PollingMasterInquireClient(addresses, ServerConfiguration.global());
+          return new PollingMasterInquireClient(addresses, ServerConfiguration.global(),
+              ServerUserState.global());
         } else {
           return new SingleMasterInquireClient(new InetSocketAddress(
               mMasterAddresses.get(0).getHostname(), mMasterAddresses.get(0).getRpcPort()));

--- a/shell/src/main/java/alluxio/cli/fs/command/MasterInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MasterInfoCommand.java
@@ -51,7 +51,8 @@ public final class MasterInfoCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) {
     MasterInquireClient inquireClient =
-        MasterInquireClient.Factory.create(mFsContext.getClusterConf());
+        MasterInquireClient.Factory
+            .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState());
     try {
       InetSocketAddress leaderAddress = inquireClient.getPrimaryRpcAddress();
       System.out.println("Current leader master: " + leaderAddress.toString());

--- a/shell/src/main/java/alluxio/cli/job/command/LeaderCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/LeaderCommand.java
@@ -54,8 +54,9 @@ public final class LeaderCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) {
     try {
-      InetSocketAddress address =
-          JobContext.create(mFsContext.getClusterConf()).getJobMasterAddress();
+      InetSocketAddress address = JobContext
+          .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+          .getJobMasterAddress();
       System.out.println(address.getHostName());
     } catch (Exception e) {
       LOG.error("Failed to get the primary job master", e);

--- a/shell/src/main/java/alluxio/cli/job/command/ListCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/ListCommand.java
@@ -57,8 +57,9 @@ public final class ListCommand extends AbstractFileSystemCommand {
 
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
-    try (CloseableResource<JobMasterClient> client =
-        JobContext.create(mFsContext.getClusterConf()).acquireMasterClientResource()) {
+    try (CloseableResource<JobMasterClient> client = JobContext
+        .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+        .acquireMasterClientResource()) {
       List<Long> ids = client.get().list();
       for (long id : ids) {
         System.out.println(id);

--- a/shell/src/main/java/alluxio/cli/job/command/StatCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/StatCommand.java
@@ -69,7 +69,7 @@ public final class StatCommand extends AbstractFileSystemCommand {
   public int run(CommandLine cl) throws AlluxioException, IOException {
     long id = Long.parseLong(cl.getArgs()[0]);
     try (CloseableResource<JobMasterClient> client =
-        JobContext.create(mFsContext.getClusterConf())
+        JobContext.create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
             .acquireMasterClientResource()) {
       JobInfo info = client.get().getStatus(id);
       System.out.print(formatOutput(cl, info));

--- a/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
+++ b/shell/src/main/java/alluxio/master/MasterHealthCheckClient.java
@@ -17,6 +17,7 @@ import alluxio.common.RpcPortHealthCheckClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.RetryPolicy;
+import alluxio.security.user.UserState;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.ShellUtils;
@@ -192,7 +193,8 @@ public class MasterHealthCheckClient implements HealthCheckClient {
 
     @Override
     public void run() {
-      MasterInquireClient client = MasterInquireClient.Factory.create(mConf);
+      UserState userState = UserState.Factory.create(mConf);
+      MasterInquireClient client = MasterInquireClient.Factory.create(mConf, userState);
       try {
         while (true) {
           List<InetSocketAddress> addresses = client.getMasterRpcAddresses();

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -35,6 +35,7 @@ import alluxio.hadoop.HadoopClientTestUtils;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.master.PollingMasterInquireClient;
 import alluxio.master.block.BlockMaster;
+import alluxio.security.user.ServerUserState;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
@@ -253,8 +254,8 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
   public void queryStandby() throws Exception {
     List<InetSocketAddress> addresses = mMultiMasterLocalAlluxioCluster.getMasterAddresses();
     Collections.shuffle(addresses);
-    PollingMasterInquireClient inquireClient =
-        new PollingMasterInquireClient(addresses, ServerConfiguration.global());
+    PollingMasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
+        ServerConfiguration.global(), ServerUserState.global());
     assertEquals(mMultiMasterLocalAlluxioCluster.getLocalAlluxioMaster().getAddress(),
         inquireClient.getPrimaryRpcAddress());
   }


### PR DESCRIPTION
This is a manual back port of https://github.com/Alluxio/alluxio/pull/10128 to `branch-2.0`.
Currently PollingMasterInquireClient uses a new Subject when querying master. If the call needs authentication using credentials from Subject, it will fail the request because the credentials are missing. This change add parameters to APIs to allow passing in the required Subject.
