### PR TITLE
Improve reporting worker metrics concurrency [WIP]

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/Metric.java
+++ b/core/common/src/main/java/alluxio/metrics/Metric.java
@@ -12,8 +12,8 @@
 package alluxio.metrics;
 
 import alluxio.grpc.MetricType;
-
 import alluxio.resource.LockResource;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -138,9 +138,8 @@ public final class Metric implements Serializable {
     }
   }
 
-
   /**
-   * Add value to the existing value
+   * Add value to the existing metric value.
    *
    * @param value the value to add
    */
@@ -149,7 +148,6 @@ public final class Metric implements Serializable {
       mValue = mValue + value;
     }
   }
-
 
   /**
    * @return the instance id

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -21,7 +21,6 @@ import alluxio.metrics.MetricsSystem.InstanceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -94,7 +94,7 @@ public class MetricsMasterTest {
         Metric.from("worker.192_1_1_2.metricA", 3, MetricType.GAUGE));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics3);
     assertEquals(13L, getGauge("metricA"));
-    assertEquals(20L, getGauge("metricB"));
+    assertEquals(22L, getGauge("metricB"));
   }
 
   @Test


### PR DESCRIPTION
Reduce the synchronized on the whole `workerMetrics` when updating worker metrics through heartbeat.