### PR TITLE
Support session level connection management for leader election

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -536,7 +536,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY =
       new Builder(Name.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY)
-          .setDefaultValue("STANDARD")
+          .setDefaultValue("SESSION")
           .setDescription("Connection error policy defines how errors on zookeeper connections "
               + "to be treated in leader election. "
               + "STANDARD policy treats every connection event as failure."

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -534,6 +534,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY =
+      new Builder(Name.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY)
+          .setDefaultValue("STANDARD")
+          .setDescription("Connection error policy defines how errors on zookeeper connections "
+              + "to be treated in leader election. "
+              + "STANDARD policy treats every connection event as failure."
+              + "SESSION policy relies on zookeeper sessions for judging failures, "
+              + "helping leader to retain its status, as long as its session is protected.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
   /**
    * UFS related properties.
    */
@@ -3860,6 +3871,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String ZOOKEEPER_LEADER_PATH = "alluxio.zookeeper.leader.path";
     public static final String ZOOKEEPER_SESSION_TIMEOUT = "alluxio.zookeeper.session.timeout";
     public static final String ZOOKEEPER_AUTH_ENABLED = "alluxio.zookeeper.auth.enabled";
+    public static final String ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY =
+        "alluxio.zookeeper.leader.connection.error.policy";
     //
     // UFS related properties
     //

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
@@ -227,7 +227,7 @@ public final class PrimarySelectorClient extends AbstractPrimarySelector
     LOG.info("{} is now the leader.", mName);
     try {
       mLeaderZkSessionId = client.getZookeeperClient().getZooKeeper().getSessionId();
-      LOG.info("Taken leadership under session Id: {}", mLeaderZkSessionId);
+      LOG.info(String.format("Taken leadership under session Id: %x", mLeaderZkSessionId));
       waitForState(State.SECONDARY);
     } finally {
       LOG.warn("{} relinquishing leadership.", mName);

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -63,6 +63,8 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_DELEGATION_EMBEDDED = allocate(2, 1);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 1);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_SESSION = allocate(2, 1);
 
   public static final List<ReservedPort> CHECKPOINT = allocate(2, 0);
 

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -63,8 +63,8 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_DELEGATION_EMBEDDED = allocate(2, 1);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
-  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 1);
-  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_SESSION = allocate(2, 1);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_SESSION = allocate(2, 0);
 
   public static final List<ReservedPort> CHECKPOINT = allocate(2, 0);
 

--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -112,7 +112,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
     mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_CONNECTION_POLICY_STANDARD)
         .setClusterName("ZookeeperConnectionPolicy_Standard")
         .setNumMasters(2)
-        .setNumWorkers(1)
+        .setNumWorkers(0)
         .addProperty(PropertyKey.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY, "STANDARD")
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
         .build();
@@ -132,7 +132,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
     mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_CONNECTION_POLICY_SESSION)
         .setClusterName("ZookeeperConnectionPolicy_Session")
         .setNumMasters(2)
-        .setNumWorkers(1)
+        .setNumWorkers(0)
         .addProperty(PropertyKey.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY, "SESSION")
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
         .build();


### PR DESCRIPTION
Curator has 2 policies for managing zookeeper client state when connection errors happen.
- STANDARD; is finicky and treats leader state as dirty after any connection state change.
- SESSION; is for more stable leadership state as it leverages internal zookeeper session Ids.
Curator comes with STANDARD policy as default. 

This PR makes this setting configurable.