### PR TITLE
Remove extraneous client RPC to get block info from master

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -56,7 +56,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -180,7 +179,7 @@ public final class AlluxioBlockStore {
    * @param failedWorkers the map of workers address to most recent failure time
    * @return a stream which reads from the beginning of the block
    */
-  public BlockInStream getInStream(@Nonnull BlockInfo info, InStreamOptions options,
+  public BlockInStream getInStream(BlockInfo info, InStreamOptions options,
       Map<WorkerNetAddress, Long> failedWorkers) throws IOException {
     List<BlockLocation> locations = info.getLocations();
     List<BlockWorkerInfo> blockWorkerInfo = Collections.EMPTY_LIST;

--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -14,18 +14,18 @@ package alluxio.client.block;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
-import alluxio.client.block.util.BlockLocationUtils;
-import alluxio.collections.Pair;
-import alluxio.conf.PropertyKey;
 import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.block.stream.BlockInStream.BlockInStreamSource;
 import alluxio.client.block.stream.BlockOutStream;
+import alluxio.client.block.util.BlockLocationUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
+import alluxio.collections.Pair;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.ResourceExhaustedException;
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -168,6 +169,19 @@ public final class AlluxioBlockStore {
              mContext.acquireBlockMasterClientResource()) {
       info = masterClientResource.get().getBlockInfo(blockId);
     }
+    return getInStream(info, options, failedWorkers);
+  }
+
+  /**
+   * {@link #getInStream(long, InStreamOptions, Map)}.
+   *
+   * @param info the block info
+   * @param options the options associated with the read request
+   * @param failedWorkers the map of workers address to most recent failure time
+   * @return a stream which reads from the beginning of the block
+   */
+  public BlockInStream getInStream(@Nonnull BlockInfo info, InStreamOptions options,
+      Map<WorkerNetAddress, Long> failedWorkers) throws IOException {
     List<BlockLocation> locations = info.getLocations();
     List<BlockWorkerInfo> blockWorkerInfo = Collections.EMPTY_LIST;
     // Initial target workers to read the block given the block locations.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -332,9 +332,12 @@ public class FileInStream extends InputStream implements BoundedStream, Position
     }
     // Create stream
     boolean isBlockInfoOutdated = true;
+    // blockInfo is "outdated" when all the locations in that blockInfo are failed workers,
+    // if there is at least one location that is not a failed worker, then it's not outdated.
     for (BlockLocation location : blockInfo.getLocations()) {
       if (!mFailedWorkers.containsKey(location.getWorkerAddress())) {
         isBlockInfoOutdated = false;
+        break;
       }
     }
     if (isBlockInfoOutdated) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -326,11 +326,11 @@ public class FileInStream extends InputStream implements BoundedStream, Position
     long blockId = mStatus.getBlockIds().get(Math.toIntExact(mPosition / mBlockSize));
     BlockInfo blockInfo = mStatus.getBlockInfo(blockId);
     if (blockInfo == null) {
-      throw new IOException("Block " + blockId + " does not exist");
+      throw new IOException("No BlockInfo for block(id=" + blockId + ") of file"
+          + "(id=" + mStatus.getFileId() + ", path=" + mStatus.getPath() + ")");
     }
     // Create stream
-    mBlockInStream = mBlockStore.getInStream(blockInfo, mOptions,
-        mFailedWorkers);
+    mBlockInStream = mBlockStore.getInStream(blockInfo, mOptions, mFailedWorkers);
     // Set the stream to the correct position.
     long offset = mPosition % mBlockSize;
     mBlockInStream.seek(offset);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -29,6 +29,7 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.retry.CountingRetry;
 import alluxio.util.CommonUtils;
+import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
@@ -323,8 +324,13 @@ public class FileInStream extends InputStream implements BoundedStream, Position
     /* Create a new stream to read from mPosition. */
     // Calculate block id.
     long blockId = mStatus.getBlockIds().get(Math.toIntExact(mPosition / mBlockSize));
+    BlockInfo blockInfo = mStatus.getBlockInfo(blockId);
+    if (blockInfo == null) {
+      throw new IOException("Block " + blockId + " does not exist");
+    }
     // Create stream
-    mBlockInStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
+    mBlockInStream = mBlockStore.getInStream(blockInfo, mOptions,
+        mFailedWorkers);
     // Set the stream to the correct position.
     long offset = mPosition % mBlockSize;
     mBlockInStream.seek(offset);

--- a/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileInStreamTest.java
@@ -550,7 +550,7 @@ public final class FileInStreamTest {
    */
   @Test
   public void failGetInStream() throws IOException {
-    when(mBlockStore.getInStream(any(BlockInfo.class), any(InStreamOptions.class), any()))
+    when(mBlockStore.getInStream(anyLong(), any(InStreamOptions.class), any()))
         .thenThrow(new UnavailableException("test exception"));
     try {
       mTestStream.read();
@@ -643,7 +643,7 @@ public final class FileInStreamTest {
     TestBlockInStream workingStream = mInStreams.get(0);
     TestBlockInStream brokenStream = mock(TestBlockInStream.class);
     when(mBlockStore
-        .getInStream(eq(new BlockInfo().setBlockId(0)), any(InStreamOptions.class), any()))
+        .getInStream(eq(0L), any(InStreamOptions.class), any()))
         .thenReturn(brokenStream).thenReturn(workingStream);
     when(brokenStream.read()).thenThrow(new UnavailableException("test exception"));
     when(brokenStream.getPos()).thenReturn(offset);
@@ -662,7 +662,7 @@ public final class FileInStreamTest {
     TestBlockInStream workingStream = mInStreams.get(0);
     TestBlockInStream brokenStream = mock(TestBlockInStream.class);
     when(mBlockStore
-        .getInStream(eq(new BlockInfo().setBlockId(0)), any(InStreamOptions.class), any()))
+        .getInStream(eq(0L), any(InStreamOptions.class), any()))
         .thenReturn(brokenStream).thenReturn(workingStream);
     when(brokenStream.read(any(byte[].class), anyInt(), anyInt()))
         .thenThrow(new UnavailableException("test exception"));
@@ -707,7 +707,7 @@ public final class FileInStreamTest {
    */
   @Test
   public void blockInStreamOutOfSync() throws Exception {
-    when(mBlockStore.getInStream(any(BlockInfo.class), any(InStreamOptions.class), any()))
+    when(mBlockStore.getInStream(anyLong(), any(InStreamOptions.class), any()))
         .thenAnswer(new Answer<BlockInStream>() {
           @Override
           public BlockInStream answer(InvocationOnMock invocation) throws Throwable {

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -65,7 +65,8 @@ public class URIStatus {
    * @param blockId the block ID
    * @return the corresponding block info or null
    */
-  public @Nullable BlockInfo getBlockInfo(long blockId) {
+  @Nullable
+  public BlockInfo getBlockInfo(long blockId) {
     FileBlockInfo info = mInfo.getFileBlockInfo(blockId);
     return info == null ? null : info.getBlockInfo();
   }

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -64,7 +65,7 @@ public class URIStatus {
    * @param blockId the block ID
    * @return the corresponding block info or null
    */
-  public BlockInfo getBlockInfo(long blockId) {
+  public @Nullable BlockInfo getBlockInfo(long blockId) {
     FileBlockInfo info = mInfo.getFileBlockInfo(blockId);
     return info == null ? null : info.getBlockInfo();
   }

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -12,11 +12,12 @@
 package alluxio.client.file;
 
 import alluxio.annotation.PublicApi;
+import alluxio.grpc.TtlAction;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.DefaultAccessControlList;
+import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
-import alluxio.grpc.TtlAction;
 
 import com.google.common.base.Preconditions;
 
@@ -57,6 +58,15 @@ public class URIStatus {
    */
   public DefaultAccessControlList getDefaultAcl() {
     return mInfo.getDefaultAcl();
+  }
+
+  /**
+   * @param blockId the block ID
+   * @return the corresponding block info or null
+   */
+  public BlockInfo getBlockInfo(long blockId) {
+    FileBlockInfo info = mInfo.getFileBlockInfo(blockId);
+    return info == null ? null : info.getBlockInfo();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -65,6 +65,7 @@ public final class FileInfo implements Serializable {
   private String mPersistenceState = "";
   private boolean mMountPoint;
   private ArrayList<FileBlockInfo> mFileBlockInfoList = new ArrayList<>();
+  /* Index of mFileBlockInfoList. */
   private Map<Long, FileBlockInfo> mFileBlockInfoMap = new HashMap<>();
   private long mMountId;
   private int mReplicationMax;

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public final class FileInfo implements Serializable {
   private int mMode;
   private String mPersistenceState = "";
   private boolean mMountPoint;
-  private ArrayList<FileBlockInfo> mFileBlockInfos = new ArrayList<>();
+  private Map<Long, FileBlockInfo> mFileBlockInfos = new HashMap<>();
   private long mMountId;
   private int mReplicationMax;
   private int mReplicationMin;
@@ -251,7 +252,15 @@ public final class FileInfo implements Serializable {
    * @return the list of file block descriptors
    */
   public List<FileBlockInfo> getFileBlockInfos() {
-    return mFileBlockInfos;
+    return new ArrayList<>(mFileBlockInfos.values());
+  }
+
+  /**
+   * @param blockId the block ID
+   * @return the corresponding block info or null
+   */
+  public FileBlockInfo getFileBlockInfo(long blockId) {
+    return mFileBlockInfos.get(blockId);
   }
 
   /**
@@ -555,7 +564,9 @@ public final class FileInfo implements Serializable {
    * @return the file information
    */
   public FileInfo setFileBlockInfos(List<FileBlockInfo> fileBlockInfos) {
-    mFileBlockInfos = new ArrayList<>(fileBlockInfos);
+    for (FileBlockInfo info : fileBlockInfos) {
+      mFileBlockInfos.put(info.getBlockInfo().getBlockId(), info);
+    }
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 // TODO(jiri): Consolidate with URIStatus.
 public final class FileInfo implements Serializable {
-  private static final long serialVersionUID = 7119966306934831779L;
+  private static final long serialVersionUID = 3086599355791696602L;
 
   private long mFileId;
   private String mName = "";
@@ -64,7 +64,8 @@ public final class FileInfo implements Serializable {
   private int mMode;
   private String mPersistenceState = "";
   private boolean mMountPoint;
-  private Map<Long, FileBlockInfo> mFileBlockInfos = new HashMap<>();
+  private ArrayList<FileBlockInfo> mFileBlockInfoList = new ArrayList<>();
+  private Map<Long, FileBlockInfo> mFileBlockInfoMap = new HashMap<>();
   private long mMountId;
   private int mReplicationMax;
   private int mReplicationMin;
@@ -252,7 +253,7 @@ public final class FileInfo implements Serializable {
    * @return the list of file block descriptors
    */
   public List<FileBlockInfo> getFileBlockInfos() {
-    return new ArrayList<>(mFileBlockInfos.values());
+    return mFileBlockInfoList;
   }
 
   /**
@@ -260,7 +261,7 @@ public final class FileInfo implements Serializable {
    * @return the corresponding block info or null
    */
   public FileBlockInfo getFileBlockInfo(long blockId) {
-    return mFileBlockInfos.get(blockId);
+    return mFileBlockInfoMap.get(blockId);
   }
 
   /**
@@ -564,8 +565,9 @@ public final class FileInfo implements Serializable {
    * @return the file information
    */
   public FileInfo setFileBlockInfos(List<FileBlockInfo> fileBlockInfos) {
-    for (FileBlockInfo info : fileBlockInfos) {
-      mFileBlockInfos.put(info.getBlockInfo().getBlockId(), info);
+    mFileBlockInfoList = new ArrayList<>(fileBlockInfos);
+    for (FileBlockInfo info : mFileBlockInfoList) {
+      mFileBlockInfoMap.put(info.getBlockInfo().getBlockId(), info);
     }
     return this;
   }
@@ -662,7 +664,7 @@ public final class FileInfo implements Serializable {
         && mOwner.equals(that.mOwner) && mGroup.equals(that.mGroup) && mMode == that.mMode
         && mPersistenceState.equals(that.mPersistenceState) && mMountPoint == that.mMountPoint
         && mReplicationMax == that.mReplicationMax && mReplicationMin == that.mReplicationMin
-        && mFileBlockInfos.equals(that.mFileBlockInfos) && mTtlAction == that.mTtlAction
+        && mFileBlockInfoList.equals(that.mFileBlockInfoList) && mTtlAction == that.mTtlAction
         && mMountId == that.mMountId && mInAlluxioPercentage == that.mInAlluxioPercentage
         && mUfsFingerprint.equals(that.mUfsFingerprint)
         && Objects.equal(mAcl, that.mAcl)
@@ -675,7 +677,7 @@ public final class FileInfo implements Serializable {
     return Objects.hashCode(mFileId, mName, mPath, mUfsPath, mLength, mBlockSizeBytes,
         mCreationTimeMs, mCompleted, mFolder, mPinned, mCacheable, mPersisted, mBlockIds,
         mInMemoryPercentage, mLastModificationTimeMs, mLastAccessTimeMs, mTtl, mOwner, mGroup,
-        mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfos,
+        mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfoList,
         mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes);
   }
 
@@ -695,7 +697,7 @@ public final class FileInfo implements Serializable {
         .add("ttlAction", mTtlAction).add("owner", mOwner).add("group", mGroup).add("mode", mMode)
         .add("persistenceState", mPersistenceState).add("mountPoint", mMountPoint)
         .add("replicationMax", mReplicationMax).add("replicationMin", mReplicationMin)
-        .add("fileBlockInfos", mFileBlockInfos)
+        .add("fileBlockInfos", mFileBlockInfoList)
         .add("mountId", mMountId).add("inAlluxioPercentage", mInAlluxioPercentage)
         .add("ufsFingerprint", mUfsFingerprint)
         .add("acl", mAcl.toString())


### PR DESCRIPTION
In the FileInfo retrieved from master in openFile, there should be the latest block information, so there is no need to issue an RPC to get the block info again.