### PR TITLE
Process worker metrics asynchronously

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1461,6 +1461,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METRICS_SERVICE_THREADS =
+      new Builder(Name.MASTER_METRICS_SERVICE_THREADS)
+          .setDefaultValue(5)
+          .setDescription("The number of threads in executor pool for parallel processing "
+              + "metrics submitted by workers or clients")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METRICS_TIME_SERIES_INTERVAL =
       new Builder(Name.MASTER_METRICS_TIME_SERIES_INTERVAL)
           .setDefaultValue("5min")
@@ -4031,6 +4039,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.inode.inherit.owner.and.group";
     public static final String MASTER_PERSISTENCE_CHECKER_INTERVAL_MS =
         "alluxio.master.persistence.checker.interval";
+    public static final String MASTER_METRICS_SERVICE_THREADS =
+        "alluxio.master.metrics.service.threads";
     public static final String MASTER_METRICS_TIME_SERIES_INTERVAL =
         "alluxio.master.metrics.time.series.interval";
     public static final String MASTER_PERSISTENCE_INITIAL_INTERVAL_MS =

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -90,7 +90,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
             ServerConfiguration.global(), mMasterContext.getUserState());
     int numThreads = ServerConfiguration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS);
     mExecutorService = ExecutorServiceFactories.fixedThreadPool(
-        "alluxio-master-metrics-service", numThreads).create();
+        "alluxio-master-metrics-updater", numThreads).create();
   }
 
   @VisibleForTesting

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Default implementation of the metrics master.
@@ -57,6 +58,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
       new HashSet<>();
   private final MetricsStore mMetricsStore;
   private final HeartbeatThread mClusterMetricsUpdater;
+  private final ExecutorService mExecutorService;
 
   /**
    * Creates a new instance of {@link MetricsMaster}.
@@ -86,6 +88,9 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
             new ClusterMetricsUpdater(),
             ServerConfiguration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL),
             ServerConfiguration.global(), mMasterContext.getUserState());
+    int numThreads = ServerConfiguration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS);
+    mExecutorService = ExecutorServiceFactories.fixedThreadPool(
+        "alluxio-master-metrics-service", numThreads).create();
   }
 
   @VisibleForTesting
@@ -194,7 +199,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
 
   @Override
   public void clientHeartbeat(String clientId, String hostname, List<Metric> metrics) {
-    mMetricsStore.putClientMetrics(hostname, clientId, metrics);
+    submitMetrics(hostname, clientId, metrics);
   }
 
   @Override
@@ -204,7 +209,24 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
 
   @Override
   public void workerHeartbeat(String hostname, List<Metric> metrics) {
-    mMetricsStore.putWorkerMetrics(hostname, metrics);
+    submitMetrics(hostname, null, metrics);
+  }
+
+  /**
+   * Submits the worker or client metrics to executor service.
+   *
+   * @param clientId the client id, or null if submitting worker metrics
+   * @param hostname the worker or client hostname
+   * @param metrics worker or client metrics
+   */
+  private void submitMetrics(String hostname, String clientId, List<Metric> metrics) {
+    mExecutorService.submit(() -> {
+      if (clientId == null) {
+        mMetricsStore.putWorkerMetrics(hostname, metrics);
+      } else {
+        mMetricsStore.putClientMetrics(hostname, clientId, metrics);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10470
Previously we process worker metrics synchronously in the MasterWorkerInfo lock and also the WorkerMetrics lock. This will 
(1) Make each worker heartbeat takes longer. Worker heartbeat need to wait for the submitted metrics to be processed.
(2) Make worker heartbeats block each other. We can only process one worker metrics at a time.

Process worker metrics asynchronously will help unblock worker heartbeats.