### PR TITLE
Implement infra to close resources during gRPC server shutdown

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcServer.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServer.java
@@ -17,7 +17,10 @@ import alluxio.security.authentication.AuthenticationServer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.io.Closer;
 import io.grpc.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -27,8 +30,14 @@ import java.util.concurrent.TimeUnit;
  * {@link GrpcChannelBuilder}.
  */
 public final class GrpcServer {
+  private static final Logger LOG = LoggerFactory.getLogger(GrpcServer.class);
+
+  /** Internal server reference. */
   private Server mServer;
+  /** Authentication server for this server. */
   private AuthenticationServer mAuthServer;
+  /** Closer for closing resources during shutdown. */
+  private Closer mCloser;
 
   /** Set to TRUE when the server has been successfully started. **/
   private boolean mStarted = false;
@@ -39,12 +48,14 @@ public final class GrpcServer {
    *
    * @param server the wrapped server
    * @param authServer the authentication server
+   * @param closer resources to close before shutting down server
    * @param serverShutdownTimeoutMs server shutdown timeout in milliseconds
    */
-  public GrpcServer(Server server, AuthenticationServer authServer,
+  public GrpcServer(Server server, AuthenticationServer authServer, Closer closer,
       long serverShutdownTimeoutMs) {
     mServer = server;
     mAuthServer = authServer;
+    mCloser = closer;
     mServerShutdownTimeoutMs = serverShutdownTimeoutMs;
   }
 
@@ -83,18 +94,23 @@ public final class GrpcServer {
    * @throws InterruptedException
    */
   public boolean shutdown() {
+    // Stop accepting new connections.
     mServer.shutdown();
-    // Release authentication sessions if the server was authenticated.
-    if (mAuthServer != null) {
-      mAuthServer.close();
+    // Close resources that potentially owns active streams.
+    try {
+      mCloser.close();
+    } catch (IOException e) {
+      LOG.warn("Failed to close resources during shutdown.", e);
+      // Do nothing.
     }
+    // Force shutdown remaining calls.
+    mServer.shutdownNow();
+    // Wait until server terminates.
     try {
       return mServer.awaitTermination(mServerShutdownTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
       return false;
-    } finally {
-      mServer.shutdownNow();
     }
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcServer.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServer.java
@@ -100,7 +100,7 @@ public final class GrpcServer {
     try {
       mCloser.close();
     } catch (IOException e) {
-      LOG.warn("Failed to close resources during shutdown.", e);
+      LOG.error("Failed to close resources during shutdown.", e);
       // Do nothing.
     }
     // Force shutdown remaining calls.

--- a/core/common/src/main/java/alluxio/grpc/GrpcServer.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServer.java
@@ -48,7 +48,7 @@ public final class GrpcServer {
    *
    * @param server the wrapped server
    * @param authServer the authentication server
-   * @param closer resources to close before shutting down server
+   * @param closer resources to close during shutting down of this server
    * @param serverShutdownTimeoutMs server shutdown timeout in milliseconds
    */
   public GrpcServer(Server server, AuthenticationServer authServer, Closer closer,

--- a/core/common/src/main/java/alluxio/grpc/GrpcService.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcService.java
@@ -11,8 +11,11 @@
 
 package alluxio.grpc;
 
+import com.google.common.io.Closer;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
+
+import java.io.Closeable;
 
 /**
  * Utility class for wrapping gRPC service definition. It's internally used to specify whether the
@@ -23,6 +26,8 @@ public class GrpcService {
   private final ServerServiceDefinition mServiceDefinition;
   /** whether this service should be accessed with authentication. */
   private boolean mAuthenticated = true;
+  /** closer to be closed before owning server is shut down. */
+  private Closer mCloser = Closer.create();
 
   /**
    * Creates a new {@link GrpcService}.
@@ -50,6 +55,29 @@ public class GrpcService {
   public GrpcService disableAuthentication() {
     mAuthenticated = false;
     return this;
+  }
+
+  /**
+   * Add a new closeable resource to this service's closer.
+   *
+   * @param closeable the closeable resource
+   * @return the updated {@link GrpcService} instance
+   */
+  public GrpcService withCloseable(Closeable closeable) {
+    mCloser.register(closeable);
+    return this;
+  }
+
+  /**
+   * Gets the closer associated with this service.
+   *
+   * This is mostly used to close streams associated with service to not stall
+   * server's graceful shutdown.
+   *
+   * @return closer for the service
+   */
+  public Closer getCloser() {
+    return mCloser;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/grpc/GrpcService.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcService.java
@@ -60,6 +60,9 @@ public class GrpcService {
   /**
    * Add a new closeable resource to this service's closer.
    *
+   * Registered closer will be owned and closed by {@link GrpcServer} that hosts
+   * the service.
+   *
    * @param closeable the closeable resource
    * @return the updated {@link GrpcService} instance
    */

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticationServer.java
@@ -17,12 +17,14 @@ import alluxio.grpc.ChannelAuthenticationScheme;
 import io.grpc.BindableService;
 
 import javax.security.sasl.SaslException;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.UUID;
 
 /**
  * Interface for authentication server implementations.
  */
-public interface AuthenticationServer extends BindableService {
+public interface AuthenticationServer extends BindableService, Closeable {
   /**
    * Registers new user against given channel.
    *
@@ -62,5 +64,5 @@ public interface AuthenticationServer extends BindableService {
   /**
    * Closes the server, releases all authentication sessions.
    */
-  void close();
+  void close() throws IOException;
 }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -351,15 +351,13 @@ public class AlluxioMasterProcess extends MasterProcess {
       }
     }
     if (mRPCExecutor != null) {
-      mRPCExecutor.shutdown();
+      mRPCExecutor.shutdownNow();
       try {
         mRPCExecutor.awaitTermination(
             ServerConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT),
             TimeUnit.MILLISECONDS);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
-      } finally {
-        mRPCExecutor.shutdownNow();
       }
     }
     if (mJvmPauseMonitor != null) {

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -144,7 +144,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
                             ServerConfiguration.global())),
                         (conn) -> activateWorkerConnection(conn), mCatalystContext,
                         mExecutorService, mCatalystRequestTimeout),
-                    new ClientIpAddressInjector())));
+                    new ClientIpAddressInjector())).withCloseable(this));
     return services;
   }
 


### PR DESCRIPTION
Open gRPC streams prevents graceful server shutdown. This PR aims to provide infra for service implementations to provide closers to be invoked during server shutdown so they can close their active streams to allow for graceful shutdown.

There are currently 2 such services:
- Authentication service
- Backup leader service