### PR TITLE
Cleanup file after a failed cp command

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -27,6 +27,7 @@ import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.status.InvalidArgumentException;
+import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.security.authorization.Mode;
@@ -542,6 +543,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
         IOUtils.copyLarge(is, os, new byte[8 * Constants.MB]);
       } catch (Exception e) {
         os.cancel();
+        // clean up the incomplete file
+        mFileSystem.delete(dstPath, DeletePOptions.newBuilder().setUnchecked(true).build());
         throw e;
       }
       System.out.println(String.format(COPY_SUCCEED_MESSAGE, srcPath, dstPath));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -282,7 +282,31 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
     File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
     testFile.createNewFile();
-    mFsShell.run("mkdir", mLocalAlluxioCluster.getAlluxioHome());
+    FileOutputStream fos = new FileOutputStream(testFile);
+    byte[] toWrite = BufferUtils.getIncreasingByteArray(100);
+    fos.write(toWrite);
+    fos.close();
+
+    mFsShell.run("copyFromLocal", testFile.getPath(), "/");
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/testFile")));
+    mLocalAlluxioCluster.stopWorkers();
+    mFsShell.run("cp", "/testFile", "/testFile2");
+    Assert.assertFalse(mFileSystem.exists(new AlluxioURI("/testFile2")));
+  }
+
+  @Test
+  public void copyAfterWorkersNotAvailableMustCache() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    mFsShell = new FileSystemShell(conf);
+
+    File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
+    testFile.createNewFile();
+    FileOutputStream fos = new FileOutputStream(testFile);
+    byte[] toWrite = BufferUtils.getIncreasingByteArray(100);
+    fos.write(toWrite);
+    fos.close();
+
     mFsShell.run("copyFromLocal", testFile.getPath(), "/");
     Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/testFile")));
     mLocalAlluxioCluster.stopWorkers();


### PR DESCRIPTION
Sometimes, the cp command does not succeed (like when there are no available workers). However, the destination is created and not cleaned up. This PR deletes the destination file if the copy fails.