### PR TITLE
Improve concurrency for MetricsStore

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/Metric.java
+++ b/core/common/src/main/java/alluxio/metrics/Metric.java
@@ -40,12 +40,13 @@ public final class Metric implements Serializable {
   private final MetricsSystem.InstanceType mInstanceType;
   private final String mHostname;
   private final String mName;
-  private final Double mValue;
   private final MetricType mMetricType;
   private String mInstanceId;
   // TODO(yupeng): consider a dedicated data structure for tag, when more functionality are added to
   // tags in the future
   private final Map<String, String> mTags;
+
+  private Double mValue;
 
   /**
    * Constructs a {@link Metric} instance.
@@ -84,6 +85,33 @@ public final class Metric implements Serializable {
   }
 
   /**
+   * Add metric value delta to the existing value.
+   * This method should only be used by {@link alluxio.master.metrics.MetricsStore}
+   *
+   * @param value value to add
+   */
+  public void addValue(double value) {
+    mValue += value;
+  }
+
+  /**
+   * Set the metric value.
+   * This method should only be used by {@link alluxio.master.metrics.MetricsStore}
+   *
+   * @param value value to set
+   */
+  public void setValue(double value) {
+    mValue = value;
+  }
+
+  /**
+   * @return the metric value
+   */
+  public double getValue() {
+    return mValue;
+  }
+
+  /**
    * @return the instance type
    */
   public MetricsSystem.InstanceType getInstanceType() {
@@ -119,13 +147,6 @@ public final class Metric implements Serializable {
    */
   public String getName() {
     return mName;
-  }
-
-  /**
-   * @return the metric value
-   */
-  public double getValue() {
-    return mValue;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -26,7 +26,6 @@ import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
-import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.io.PathUtils;
 
@@ -79,7 +78,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
 
   /** The root key of an object fs. */
   protected final Supplier<String> mRootKeySupplier =
-      UnderFileSystemUtils.memoize(this::getRootKey);
+      CommonUtils.memoize(this::getRootKey);
 
   /**
    * Constructs an {@link ObjectUnderFileSystem}.

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -691,5 +691,31 @@ public final class CommonUtils {
     return output;
   }
 
+  /**
+   * Memoize implementation for java.util.function.supplier.
+   *
+   * @param original the original supplier
+   * @param <T> the object type
+   * @return the supplier with memorization
+   */
+  public static <T> Supplier<T> memoize(Supplier<T> original) {
+    return new Supplier<T>() {
+      Supplier<T> mDelegate = this::firstTime;
+      boolean mInitialized;
+      public T get() {
+        return mDelegate.get();
+      }
+
+      private synchronized T firstTime() {
+        if (!mInitialized) {
+          T value = original.get();
+          mDelegate = () -> value;
+          mInitialized = true;
+        }
+        return mDelegate.get();
+      }
+    };
+  }
+
   private CommonUtils() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
+++ b/core/common/src/main/java/alluxio/util/UnderFileSystemUtils.java
@@ -17,7 +17,6 @@ import alluxio.underfs.options.DeleteOptions;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.function.Supplier;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -144,32 +143,6 @@ public final class UnderFileSystemUtils {
    */
   public static String getBucketName(AlluxioURI uri) {
     return uri.getAuthority().toString();
-  }
-
-  /**
-   * Memoize implementation for java.util.function.supplier.
-   *
-   * @param original the original supplier
-   * @param <T> the object type
-   * @return the supplier with memorization
-   */
-  public static <T> Supplier<T> memoize(Supplier<T> original) {
-    return new Supplier<T>() {
-      Supplier<T> mDelegate = this::firstTime;
-      boolean mInitialized;
-      public T get() {
-        return mDelegate.get();
-      }
-
-      private synchronized T firstTime() {
-        if (!mInitialized) {
-          T value = original.get();
-          mDelegate = () -> value;
-          mInitialized = true;
-        }
-        return mDelegate.get();
-      }
-    };
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -188,6 +188,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
     if (isLeader) {
+      mMetricsStore.clear();
       getExecutorService().submit(mClusterMetricsUpdater);
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -136,7 +136,9 @@ public class MetricsStore {
       if (!metricSet.add(metric)) {
         Metric oldMetric = metricSet.getFirstByField(FULL_NAME_INDEX, metric.getFullMetricName());
         if (metric.getMetricType() == MetricType.COUNTER) {
-          oldMetric.addValue(metric.getValue());
+          if (metric.getValue() != 0L) {
+            oldMetric.addValue(metric.getValue());
+          }
         } else {
           oldMetric.setValue(metric.getValue());
         }

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -94,7 +94,7 @@ public class MetricsMasterTest {
         Metric.from("worker.192_1_1_2.metricA", 3, MetricType.GAUGE));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics3);
     assertEquals(13L, getGauge("metricA"));
-    assertEquals(20L, getGauge("metricB"));
+    assertEquals(22L, getGauge("metricB"));
   }
 
   @Test

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -69,7 +69,7 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
 
   /** The permissions associated with the bucket. Fetched once and assumed to be immutable. */
   private final Supplier<ObjectPermissions> mPermissions
-      = UnderFileSystemUtils.memoize(this::getPermissionsInternal);
+      = CommonUtils.memoize(this::getPermissionsInternal);
 
   static {
     try {

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -105,7 +105,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   /** The permissions associated with the bucket. Fetched once and assumed to be immutable. */
   private final Supplier<ObjectPermissions> mPermissions
-      = UnderFileSystemUtils.memoize(this::getPermissionsInternal);
+      = CommonUtils.memoize(this::getPermissionsInternal);
 
   static {
     byte[] dirByteHash = DigestUtils.md5(new byte[0]);


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10470
This PR aims to improve concurrency in MetricsStore when processing worker/client metrics.
It removes the synchronized lock on the metrics sets.
Atomically updates metric values instead of removing and constructing new objects.
This memoizes the Metrics.getFullMetricName(), since it is costly in time and allocations.

When Metric.getFullMetricName() runs normally, it bumps up the heartbeats can be processed per second from 1000-3000 heartbeats/second to 2000-5000 heartbeats/second.
When Metric.getFullMetricName() is unexpectedly slow, the performance improvement can be really big (when 100 worker heartbeats with 50 executor threads, before my change takes 11 min, after my change takes 18 second if getFullMetricName sleep for 15ms).