### PR TITLE
Change return type of selectExecutors for PlanDefinition

### DIFF
--- a/core/base/src/main/java/alluxio/collections/Pair.java
+++ b/core/base/src/main/java/alluxio/collections/Pair.java
@@ -11,6 +11,8 @@
 
 package alluxio.collections;
 
+import com.google.common.base.Objects;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -37,11 +39,19 @@ public class Pair<T1, T2> {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof Pair<?, ?>) {
-      return ((Pair<?, ?>) o).getFirst().equals(mFirst)
-          && ((Pair<?, ?>) o).getSecond().equals(mSecond);
+    if (o == null) {
+      return false;
     }
-    return false;
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Pair<?, ?>)) {
+      return false;
+    }
+    Pair that = (Pair) o;
+
+    return Objects.equal(mFirst, that.mFirst)
+        && Objects.equal(mSecond, that.mSecond);
   }
 
   /**
@@ -60,7 +70,7 @@ public class Pair<T1, T2> {
 
   @Override
   public int hashCode() {
-    return 31 * mFirst.hashCode() + mSecond.hashCode();
+    return Objects.hashCode(mFirst, mSecond);
   }
 
   /**

--- a/job/common/src/test/java/alluxio/job/SleepJobConfig.java
+++ b/job/common/src/test/java/alluxio/job/SleepJobConfig.java
@@ -13,6 +13,7 @@ package alluxio.job;
 
 import alluxio.job.plan.PlanConfig;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -37,7 +38,8 @@ public class SleepJobConfig implements PlanConfig {
     this(timeMs, 1);
   }
 
-  public SleepJobConfig(long timeMs, int tasksPerWorker) {
+  public SleepJobConfig(@JsonProperty("timeMs") long timeMs,
+                        @JsonProperty("tasksPerWorker") int tasksPerWorker) {
     mTimeMs = timeMs;
     mTasksPerWorker = tasksPerWorker;
   }

--- a/job/common/src/test/java/alluxio/job/SleepJobConfig.java
+++ b/job/common/src/test/java/alluxio/job/SleepJobConfig.java
@@ -13,7 +13,6 @@ package alluxio.job;
 
 import alluxio.job.plan.PlanConfig;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 

--- a/job/common/src/test/java/alluxio/job/SleepJobConfig.java
+++ b/job/common/src/test/java/alluxio/job/SleepJobConfig.java
@@ -29,12 +29,18 @@ public class SleepJobConfig implements PlanConfig {
   public static final String NAME = "Sleep";
 
   private final long mTimeMs;
+  private final int mTasksPerWorker;
 
   /**
    * @param timeMs the time to sleep for in milliseconds
    */
-  public SleepJobConfig(@JsonProperty("timeMs") long timeMs) {
+  public SleepJobConfig(long timeMs) {
+    this(timeMs, 1);
+  }
+
+  public SleepJobConfig(long timeMs, int tasksPerWorker) {
     mTimeMs = timeMs;
+    mTasksPerWorker = tasksPerWorker;
   }
 
   /**
@@ -42,6 +48,13 @@ public class SleepJobConfig implements PlanConfig {
    */
   public long getTimeMs() {
     return mTimeMs;
+  }
+
+  /**
+   * @return
+   */
+  public int getTasksPerWorker() {
+    return mTasksPerWorker;
   }
 
   @Override

--- a/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
@@ -45,11 +45,11 @@ public interface PlanDefinition<T extends JobConfig, P extends Serializable,
    * @param config the job configuration
    * @param jobWorkerInfoList the list of available workers' information
    * @param selectExecutorsContext the context containing information used to select executors
-   * @return a map of selected workers to the parameters to pass along
+   * @return a list of pairs of selected workers to the parameters to pass along
    * @throws Exception if any error occurs
    */
   List<Pair<WorkerInfo, P>> selectExecutors(T config, List<WorkerInfo> jobWorkerInfoList,
-    SelectExecutorsContext selectExecutorsContext) throws Exception;
+      SelectExecutorsContext selectExecutorsContext) throws Exception;
 
   /**
    * Runs the task in the executor.

--- a/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
@@ -20,6 +20,7 @@ import alluxio.wire.WorkerInfo;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A job definition. A definition has two important parts: (1) a
@@ -45,10 +46,10 @@ public interface PlanDefinition<T extends JobConfig, P extends Serializable,
    * @param config the job configuration
    * @param jobWorkerInfoList the list of available workers' information
    * @param selectExecutorsContext the context containing information used to select executors
-   * @return a list of pairs of selected workers to the parameters to pass along
+   * @return a set of pairs of selected workers to the parameters to pass along
    * @throws Exception if any error occurs
    */
-  List<Pair<WorkerInfo, P>> selectExecutors(T config, List<WorkerInfo> jobWorkerInfoList,
+  Set<Pair<WorkerInfo, P>> selectExecutors(T config, List<WorkerInfo> jobWorkerInfoList,
       SelectExecutorsContext selectExecutorsContext) throws Exception;
 
   /**

--- a/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/PlanDefinition.java
@@ -11,6 +11,7 @@
 
 package alluxio.job.plan;
 
+import alluxio.collections.Pair;
 import alluxio.job.JobConfig;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
@@ -47,8 +48,8 @@ public interface PlanDefinition<T extends JobConfig, P extends Serializable,
    * @return a map of selected workers to the parameters to pass along
    * @throws Exception if any error occurs
    */
-  Map<WorkerInfo, P> selectExecutors(T config, List<WorkerInfo> jobWorkerInfoList,
-      SelectExecutorsContext selectExecutorsContext) throws Exception;
+  List<Pair<WorkerInfo, P>> selectExecutors(T config, List<WorkerInfo> jobWorkerInfoList,
+    SelectExecutorsContext selectExecutorsContext) throws Exception;
 
   /**
    * Runs the task in the executor.

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -103,7 +103,7 @@ public final class LoadDefinition
 
     List<Pair<WorkerInfo, ArrayList<LoadTask>>> result = Lists.newArrayList();
     for (Map.Entry<WorkerInfo, Collection<LoadTask>> assignment : assignments.asMap().entrySet()) {
-      result.add(new Pair<>(assignment.getKey(), assignment.getValue()));
+      result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(assignment.getValue())));
     }
 
     return result;

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -30,6 +30,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -59,7 +61,7 @@ public final class LoadDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, ArrayList<LoadTask>>> selectExecutors(LoadConfig config,
+  public Set<Pair<WorkerInfo, ArrayList<LoadTask>>> selectExecutors(LoadConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     Map<String, WorkerInfo> jobWorkersByAddress = jobWorkerInfoList.stream()
@@ -101,7 +103,7 @@ public final class LoadDefinition
       }
     }
 
-    List<Pair<WorkerInfo, ArrayList<LoadTask>>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, ArrayList<LoadTask>>> result = Sets.newHashSet();
     for (Map.Entry<WorkerInfo, Collection<LoadTask>> assignment : assignments.asMap().entrySet()) {
       result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(assignment.getValue())));
     }

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -23,7 +23,6 @@ import alluxio.job.SelectExecutorsContext;
 import alluxio.job.plan.load.LoadDefinition.LoadTask;
 import alluxio.job.util.JobUtils;
 import alluxio.job.util.SerializableVoid;
-import alluxio.job.util.SerializationUtils;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerInfo;
 
@@ -104,7 +103,7 @@ public final class LoadDefinition
 
     List<Pair<WorkerInfo, ArrayList<LoadTask>>> result = Lists.newArrayList();
     for (Map.Entry<WorkerInfo, Collection<LoadTask>> assignment : assignments.asMap().entrySet()) {
-      result.add(new Pair(assignment.getKey(), assignment.getValue()));
+      result.add(new Pair<>(assignment.getKey(), assignment.getValue()));
     }
 
     return result;

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -39,6 +39,7 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.WorkerInfo;
 
+import com.beust.jcommander.internal.Sets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.ConcurrentMap;
 
@@ -156,14 +158,15 @@ public final class MigrateDefinition
    *
    * Assigns each worker to migrate whichever files it has the most blocks for.
    * If no worker has blocks for a file, a random worker is chosen.
+   * @return
    */
   @Override
-  public List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> selectExecutors(MigrateConfig config,
+  public Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> selectExecutors(MigrateConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context) throws Exception {
     AlluxioURI source = new AlluxioURI(config.getSource());
     AlluxioURI destination = new AlluxioURI(config.getDestination());
     if (source.equals(destination)) {
-      return Lists.newArrayList();
+      return Sets.newHashSet();
     }
     checkMigrateValid(config, context.getFileSystem());
     Preconditions.checkState(!jobWorkerInfoList.isEmpty(), "No workers are available");
@@ -191,7 +194,7 @@ public final class MigrateDefinition
       }
     }
 
-    List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> result = Sets.newHashSet();
 
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
       result.add(new Pair<>(assignment.getKey(), assignment.getValue()));

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -39,11 +39,11 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.WorkerInfo;
 
-import com.beust.jcommander.internal.Sets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -195,7 +194,7 @@ public final class MigrateDefinition
     List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> result = Lists.newArrayList();
 
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
-      result.add(new Pair(assignment.getKey(), assignment.getValue()));
+      result.add(new Pair<>(assignment.getKey(), assignment.getValue()));
     }
 
     return result;

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -36,7 +36,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.wire.WorkerInfo;
 
-import com.google.common.collect.Lists;
+import com.beust.jcommander.internal.Sets;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -67,7 +68,7 @@ public final class PersistDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(PersistConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(PersistConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     if (jobWorkerInfoList.isEmpty()) {
@@ -81,7 +82,7 @@ public final class PersistDefinition
         context.getFileSystem().getStatus(uri).getFileBlockInfos());
 
     // Map the best Alluxio worker to a job worker.
-    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> result = Sets.newHashSet();
     boolean found = false;
     if (workerWithMostBlocks != null) {
       for (WorkerInfo workerInfo : jobWorkerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -36,6 +36,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.wire.WorkerInfo;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
@@ -68,7 +69,7 @@ public final class PersistDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(PersistConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(PersistConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     if (jobWorkerInfoList.isEmpty()) {
@@ -82,20 +83,20 @@ public final class PersistDefinition
         context.getFileSystem().getStatus(uri).getFileBlockInfos());
 
     // Map the best Alluxio worker to a job worker.
-    Map<WorkerInfo, SerializableVoid> result = Maps.newHashMap();
+    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
     boolean found = false;
     if (workerWithMostBlocks != null) {
       for (WorkerInfo workerInfo : jobWorkerInfoList) {
         if (workerInfo.getAddress().getHost()
             .equals(workerWithMostBlocks.getNetAddress().getHost())) {
-          result.put(workerInfo, null);
+          result.add(new Pair(workerInfo, null));
           found = true;
           break;
         }
       }
     }
     if (!found) {
-      result.put(jobWorkerInfoList.get(new Random().nextInt(jobWorkerInfoList.size())), null);
+      result.add(new Pair(jobWorkerInfoList.get(new Random().nextInt(jobWorkerInfoList.size())), null));
     }
     return result;
   }

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -37,7 +37,6 @@ import alluxio.underfs.options.MkdirsOptions;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -46,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Stack;
 import java.util.stream.Collectors;
@@ -89,14 +87,15 @@ public final class PersistDefinition
       for (WorkerInfo workerInfo : jobWorkerInfoList) {
         if (workerInfo.getAddress().getHost()
             .equals(workerWithMostBlocks.getNetAddress().getHost())) {
-          result.add(new Pair(workerInfo, null));
+          result.add(new Pair<>(workerInfo, null));
           found = true;
           break;
         }
       }
     }
     if (!found) {
-      result.add(new Pair(jobWorkerInfoList.get(new Random().nextInt(jobWorkerInfoList.size())), null));
+      result.add(new Pair<>(
+          jobWorkerInfoList.get(new Random().nextInt(jobWorkerInfoList.size())), null));
     }
     return result;
   }

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -36,7 +36,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.wire.WorkerInfo;
 
-import com.beust.jcommander.internal.Sets;
+import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -31,14 +31,12 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -85,7 +83,7 @@ public final class EvictDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that have this block locally to evict
       if (hosts.contains(workerInfo.getAddress().getHost())) {
-        result.add(new Pair(workerInfo, null));
+        result.add(new Pair<>(workerInfo, null));
         if (result.size() >= numReplicas) {
           break;
         }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -30,7 +30,7 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ public final class EvictDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(EvictConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(EvictConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
@@ -77,7 +77,7 @@ public final class EvictDefinition
     for (BlockLocation blockLocation : blockInfo.getLocations()) {
       hosts.add(blockLocation.getWorkerAddress().getHost());
     }
-    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> result = Sets.newHashSet();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -11,6 +11,7 @@
 
 package alluxio.job.plan.replicate;
 
+import alluxio.collections.Pair;
 import alluxio.conf.ServerConfiguration;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
@@ -29,6 +30,7 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +64,7 @@ public final class EvictDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(EvictConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(EvictConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
@@ -77,13 +79,13 @@ public final class EvictDefinition
     for (BlockLocation blockLocation : blockInfo.getLocations()) {
       hosts.add(blockLocation.getWorkerAddress().getHost());
     }
-    Map<WorkerInfo, SerializableVoid> result = Maps.newHashMap();
+    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that have this block locally to evict
       if (hosts.contains(workerInfo.getAddress().getHost())) {
-        result.put(workerInfo, null);
+        result.add(new Pair(workerInfo, null));
         if (result.size() >= numReplicas) {
           break;
         }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -11,6 +11,7 @@
 
 package alluxio.job.plan.replicate;
 
+import alluxio.collections.Pair;
 import alluxio.conf.ServerConfiguration;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
@@ -27,6 +28,7 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,19 +60,19 @@ public final class MoveDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(MoveConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(MoveConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context) {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
 
     String workerHost = config.getWorkerHost();
 
-    Map<WorkerInfo, SerializableVoid> result = new HashMap<>();
+    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that have this block locally to move
       if (workerHost.equals(workerInfo.getAddress().getHost())) {
-        result.put(workerInfo, null);
+        result.add(new Pair(workerInfo, null));
         return result;
       }
     }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -33,9 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -72,7 +70,7 @@ public final class MoveDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that have this block locally to move
       if (workerHost.equals(workerInfo.getAddress().getHost())) {
-        result.add(new Pair(workerInfo, null));
+        result.add(new Pair<>(workerInfo, null));
         return result;
       }
     }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -28,12 +28,13 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -58,13 +59,13 @@ public final class MoveDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(MoveConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(MoveConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context) {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
 
     String workerHost = config.getWorkerHost();
 
-    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> result = Sets.newHashSet();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
@@ -23,7 +23,7 @@ import alluxio.wire.BlockLocation;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public final class ReplicateDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(ReplicateConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(ReplicateConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
@@ -72,7 +72,7 @@ public final class ReplicateDefinition
     for (BlockLocation blockLocation : blockInfo.getLocations()) {
       hosts.add(blockLocation.getWorkerAddress().getHost());
     }
-    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> result = Sets.newHashSet();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
@@ -24,14 +24,12 @@ import alluxio.wire.WorkerInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -80,7 +78,7 @@ public final class ReplicateDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that don't have this block locally to replicate
       if (!hosts.contains(workerInfo.getAddress().getHost())) {
-        result.add(new Pair(workerInfo, null));
+        result.add(new Pair<>(workerInfo, null));
         if (result.size() >= numReplicas) {
           break;
         }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/ReplicateDefinition.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.replicate;
 
 import alluxio.client.block.AlluxioBlockStore;
+import alluxio.collections.Pair;
 import alluxio.job.plan.AbstractVoidPlanDefinition;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
@@ -22,6 +23,7 @@ import alluxio.wire.BlockLocation;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +58,7 @@ public final class ReplicateDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(ReplicateConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(ReplicateConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context)
       throws Exception {
     Preconditions.checkArgument(!jobWorkerInfoList.isEmpty(), "No worker is available");
@@ -72,13 +74,13 @@ public final class ReplicateDefinition
     for (BlockLocation blockLocation : blockInfo.getLocations()) {
       hosts.add(blockLocation.getWorkerAddress().getHost());
     }
-    Map<WorkerInfo, SerializableVoid> result = Maps.newHashMap();
+    List<Pair<WorkerInfo, SerializableVoid>> result = Lists.newArrayList();
 
     Collections.shuffle(jobWorkerInfoList);
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       // Select job workers that don't have this block locally to replicate
       if (!hosts.contains(workerInfo.getAddress().getHost())) {
-        result.put(workerInfo, null);
+        result.add(new Pair(workerInfo, null));
         if (result.size() >= numReplicas) {
           break;
         }

--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -109,7 +109,7 @@ public final class CompactDefinition
 
     List<Pair<WorkerInfo, ArrayList<CompactTask>>> result = Lists.newArrayList();
     for (Map.Entry<WorkerInfo, ArrayList<CompactTask>> assignment : assignments.entrySet()) {
-      result.add(new Pair(assignment.getKey(), assignment.getValue()));
+      result.add(new Pair<>(assignment.getKey(), assignment.getValue()));
     }
 
     return result;

--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -28,6 +28,7 @@ import alluxio.wire.WorkerInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The job definition for compacting files representing a structured table under a directory.
@@ -69,7 +71,7 @@ public final class CompactDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, ArrayList<CompactTask>>> selectExecutors(CompactConfig config,
+  public Set<Pair<WorkerInfo, ArrayList<CompactTask>>> selectExecutors(CompactConfig config,
       List<WorkerInfo> jobWorkers, SelectExecutorsContext context) throws Exception {
     Preconditions.checkState(!jobWorkers.isEmpty(), "No job worker");
     AlluxioURI inputDir = new AlluxioURI(config.getInput());
@@ -107,7 +109,7 @@ public final class CompactDefinition
       }
     }
 
-    List<Pair<WorkerInfo, ArrayList<CompactTask>>> result = Lists.newArrayList();
+    Set<Pair<WorkerInfo, ArrayList<CompactTask>>> result = Sets.newHashSet();
     for (Map.Entry<WorkerInfo, ArrayList<CompactTask>> assignment : assignments.entrySet()) {
       result.add(new Pair<>(assignment.getKey(), assignment.getValue()));
     }

--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -13,6 +13,7 @@ package alluxio.job.plan.transform;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.URIStatus;
+import alluxio.collections.Pair;
 import alluxio.job.plan.AbstractVoidPlanDefinition;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
@@ -68,7 +69,7 @@ public final class CompactDefinition
   }
 
   @Override
-  public Map<WorkerInfo, ArrayList<CompactTask>> selectExecutors(CompactConfig config,
+  public List<Pair<WorkerInfo, ArrayList<CompactTask>>> selectExecutors(CompactConfig config,
       List<WorkerInfo> jobWorkers, SelectExecutorsContext context) throws Exception {
     Preconditions.checkState(!jobWorkers.isEmpty(), "No job worker");
     AlluxioURI inputDir = new AlluxioURI(config.getInput());
@@ -105,7 +106,13 @@ public final class CompactDefinition
         group = new ArrayList<>(groupSize);
       }
     }
-    return assignments;
+
+    List<Pair<WorkerInfo, ArrayList<CompactTask>>> result = Lists.newArrayList();
+    for (Map.Entry<WorkerInfo, ArrayList<CompactTask>> assignment : assignments.entrySet()) {
+      result.add(new Pair(assignment.getKey(), assignment.getValue()));
+    }
+
+    return result;
   }
 
   @Override

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -208,8 +208,8 @@ public final class PlanCoordinator {
       boolean statusChanged = false;
       for (Long taskId : taskIds) {
         TaskInfo taskInfo = mPlanInfo.getTaskInfo(taskId);
-        if (taskInfo.getStatus().isFinished()) {
-          return;
+        if (taskInfo == null || taskInfo.getStatus().isFinished()) {
+          continue;
         }
         if (!mPlanInfo.getStatus().isFinished()) {
           taskInfo.setStatus(Status.FAILED);

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -110,7 +111,7 @@ public final class PlanCoordinator {
         PlanDefinitionRegistry.INSTANCE.getJobDefinition(mPlanInfo.getJobConfig());
     SelectExecutorsContext context =
         new SelectExecutorsContext(mPlanInfo.getId(), mJobServerContext);
-    List<? extends Pair<WorkerInfo, ?>> taskAddressToArgs;
+    Set<? extends Pair<WorkerInfo, ?>> taskAddressToArgs;
     try {
       taskAddressToArgs =
           definition.selectExecutors(mPlanInfo.getJobConfig(), mWorkersInfoList, context);

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -200,6 +200,10 @@ public final class PlanCoordinator {
    */
   public void failTasksForWorker(long workerId) {
     synchronized (mPlanInfo) {
+      if (mPlanInfo.getStatus().isFinished()) {
+        return;
+      }
+
       List<Long> taskIds = mWorkerIdToTaskIds.get(workerId);
       if (taskIds == null) {
         return;
@@ -211,11 +215,9 @@ public final class PlanCoordinator {
         if (taskInfo == null || taskInfo.getStatus().isFinished()) {
           continue;
         }
-        if (!mPlanInfo.getStatus().isFinished()) {
-          taskInfo.setStatus(Status.FAILED);
-          taskInfo.setErrorMessage("Job worker was lost before the task could complete");
-          statusChanged = true;
-        }
+        taskInfo.setStatus(Status.FAILED);
+        taskInfo.setErrorMessage("Job worker was lost before the task could complete");
+        statusChanged = true;
       }
       if (statusChanged) {
         updateStatus();

--- a/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
@@ -19,9 +19,10 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * The definition for a job which sleeps for the specified number of milliseconds on each worker.
@@ -40,10 +41,10 @@ public final class SleepPlanDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(SleepJobConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(SleepJobConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
       throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> executors = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> executors = Sets.newHashSet();
     for (WorkerInfo jobWorker : jobWorkerInfoList) {
       for (int i = 0; i < config.getTasksPerWorker(); i++) {
         executors.add(new Pair<>(jobWorker, null));

--- a/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
@@ -18,11 +18,10 @@ import alluxio.job.SleepJobConfig;
 import alluxio.job.util.SerializableVoid;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
+
 import com.google.common.collect.Lists;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The definition for a job which sleeps for the specified number of milliseconds on each worker.
@@ -46,7 +45,7 @@ public final class SleepPlanDefinition
       throws Exception {
     List<Pair<WorkerInfo, SerializableVoid>> executors = Lists.newArrayList();
     for (WorkerInfo jobWorker : jobWorkerInfoList) {
-      executors.add(new Pair(jobWorker, null));
+      executors.add(new Pair<>(jobWorker, null));
     }
     return executors;
   }

--- a/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
@@ -45,7 +45,9 @@ public final class SleepPlanDefinition
       throws Exception {
     List<Pair<WorkerInfo, SerializableVoid>> executors = Lists.newArrayList();
     for (WorkerInfo jobWorker : jobWorkerInfoList) {
-      executors.add(new Pair<>(jobWorker, null));
+      for (int i = 0; i < config.getTasksPerWorker(); i++) {
+        executors.add(new Pair<>(jobWorker, null));
+      }
     }
     return executors;
   }

--- a/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
@@ -11,12 +11,14 @@
 
 package alluxio.job.plan;
 
+import alluxio.collections.Pair;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.SleepJobConfig;
 import alluxio.job.util.SerializableVoid;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
+import com.google.common.collect.Lists;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,12 +41,12 @@ public final class SleepPlanDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(SleepJobConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(SleepJobConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
       throws Exception {
-    Map<WorkerInfo, SerializableVoid> executors = new HashMap<>();
+    List<Pair<WorkerInfo, SerializableVoid>> executors = Lists.newArrayList();
     for (WorkerInfo jobWorker : jobWorkerInfoList) {
-      executors.put(jobWorker, null);
+      executors.add(new Pair(jobWorker, null));
     }
     return executors;
   }

--- a/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/SleepPlanDefinition.java
@@ -19,8 +19,8 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 
-import com.google.common.collect.Sets;
-
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -44,7 +44,8 @@ public final class SleepPlanDefinition
   public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(SleepJobConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
       throws Exception {
-    Set<Pair<WorkerInfo, SerializableVoid>> executors = Sets.newHashSet();
+    Set<Pair<WorkerInfo, SerializableVoid>> executors =
+        Collections.newSetFromMap(new IdentityHashMap<>());
     for (WorkerInfo jobWorker : jobWorkerInfoList) {
       for (int i = 0; i < config.getTasksPerWorker(); i++) {
         executors.add(new Pair<>(jobWorker, null));

--- a/job/server/src/test/java/alluxio/job/plan/TestPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/TestPlanDefinition.java
@@ -11,6 +11,7 @@
 
 package alluxio.job.plan;
 
+import alluxio.collections.Pair;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.TestPlanConfig;
@@ -18,7 +19,6 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.wire.WorkerInfo;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -46,7 +46,7 @@ public final class TestPlanDefinition
   }
 
   @Override
-  public Map<WorkerInfo, SerializableVoid> selectExecutors(TestPlanConfig config,
+  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(TestPlanConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
       throws Exception {
     return null;

--- a/job/server/src/test/java/alluxio/job/plan/TestPlanDefinition.java
+++ b/job/server/src/test/java/alluxio/job/plan/TestPlanDefinition.java
@@ -19,6 +19,7 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.wire.WorkerInfo;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -46,7 +47,7 @@ public final class TestPlanDefinition
   }
 
   @Override
-  public List<Pair<WorkerInfo, SerializableVoid>> selectExecutors(TestPlanConfig config,
+  public Set<Pair<WorkerInfo, SerializableVoid>> selectExecutors(TestPlanConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
       throws Exception {
     return null;

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -20,6 +20,7 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
+import alluxio.collections.Pair;
 import alluxio.conf.ServerConfiguration;
 import alluxio.job.JobServerContext;
 import alluxio.job.SelectExecutorsContext;
@@ -47,7 +48,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests {@link LoadDefinition}.
@@ -100,13 +100,14 @@ public class LoadDefinitionTest {
     int replication = 3;
     createFileWithNoLocations(TEST_URI, numBlocks);
     LoadConfig config = new LoadConfig(TEST_URI, replication);
-    Map<WorkerInfo, ArrayList<LoadTask>> assignments =
+    List<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
         new LoadDefinition().selectExecutors(config,
             JOB_WORKERS, new SelectExecutorsContext(1, mJobServerContext));
     // Check that we are loading the right number of blocks.
     int totalBlockLoads = 0;
-    for (List<LoadTask> blocks : assignments.values()) {
-      totalBlockLoads += blocks.size();
+
+    for (Pair<WorkerInfo, ArrayList<LoadTask>> assignment : assignments) {
+      totalBlockLoads += assignment.getSecond().size();
     }
     Assert.assertEquals(numBlocks * replication, totalBlockLoads);
   }
@@ -118,11 +119,11 @@ public class LoadDefinitionTest {
     Mockito.when(mMockBlockStore.getAllWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
-    Map<WorkerInfo, ArrayList<LoadTask>> assignments =
+    List<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
         new LoadDefinition().selectExecutors(config, JOB_WORKERS,
             new SelectExecutorsContext(1, mJobServerContext));
     Assert.assertEquals(1, assignments.size());
-    Assert.assertEquals(10, assignments.values().iterator().next().size());
+    Assert.assertEquals(10, assignments.get(0).getSecond().size());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -48,6 +48,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Tests {@link LoadDefinition}.
@@ -100,7 +101,7 @@ public class LoadDefinitionTest {
     int replication = 3;
     createFileWithNoLocations(TEST_URI, numBlocks);
     LoadConfig config = new LoadConfig(TEST_URI, replication);
-    List<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
+    Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
         new LoadDefinition().selectExecutors(config,
             JOB_WORKERS, new SelectExecutorsContext(1, mJobServerContext));
     // Check that we are loading the right number of blocks.
@@ -119,11 +120,11 @@ public class LoadDefinitionTest {
     Mockito.when(mMockBlockStore.getAllWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
-    List<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
+    Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
         new LoadDefinition().selectExecutors(config, JOB_WORKERS,
             new SelectExecutorsContext(1, mJobServerContext));
     Assert.assertEquals(1, assignments.size());
-    Assert.assertEquals(10, assignments.get(0).getSecond().size());
+    Assert.assertEquals(10, assignments.iterator().next().getSecond().size());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -36,11 +36,8 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -111,8 +107,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
   public void assignToLocalWorker() throws Exception {
     createFileWithBlocksOnWorkers("/src", 0);
     setPathToNotExist("/dst");
-    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0),
-        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(
+        JOB_WORKERS.get(0), Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 
@@ -120,8 +116,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
   public void assignToWorkerWithMostBlocks() throws Exception {
     createFileWithBlocksOnWorkers("/src", 3, 1, 1, 3, 1);
     setPathToNotExist("/dst");
-    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1),
-        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(
+        JOB_WORKERS.get(1), Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 
@@ -139,12 +135,13 @@ public final class MigrateDefinitionSelectExecutorsTest {
     setPathToNotExist("/dst");
 
     List<MigrateCommand> migrateCommandsWorker0 = Lists.newArrayList(
-        new MigrateCommand("/dir/src1", "/dst/src1"), new MigrateCommand("/dir/src3", "/dst/src3"));
+        new MigrateCommand("/dir/src1", "/dst/src1"),
+        new MigrateCommand("/dir/src3", "/dst/src3"));
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/dir/src2", "/dst/src2"));
     Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
-        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0), migrateCommandsWorker0), new Pair<>(JOB_WORKERS.get(2),
-                migrateCommandsWorker2));
+        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0), migrateCommandsWorker0), new Pair<>(
+            JOB_WORKERS.get(2), migrateCommandsWorker2));
     Assert.assertEquals(expected, assignMigrates("/dir", "/dst"));
   }
 
@@ -270,8 +267,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
     createFileWithBlocksOnWorkers("/src", 0);
     createFile("/dst");
 
-    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0),
-        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(
+        JOB_WORKERS.get(0), Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     // Set overwrite to true.
     Assert.assertEquals(expected, assignMigrates(new MigrateConfig("/src", "/dst", "THROUGH",
         true, false)));
@@ -297,8 +294,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/src/file1", "/dst/file1"));
     Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
-        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1), migrateCommandsWorker1), new Pair<>(JOB_WORKERS.get(2),
-                migrateCommandsWorker2));
+        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1), migrateCommandsWorker1), new Pair<>(
+            JOB_WORKERS.get(2), migrateCommandsWorker2));
     Assert.assertEquals(expected, assignMigrates(new MigrateConfig(
             "/src", "/dst", "THROUGH", true, false)));
   }

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -103,15 +104,15 @@ public final class MigrateDefinitionSelectExecutorsTest {
   @Test
   public void migrateToSelf() throws Exception {
     createDirectory("/src");
-    Assert.assertEquals(Maps.newHashMap(), assignMigrates("/src", "/src"));
+    Assert.assertEquals(ImmutableSet.of(), assignMigrates("/src", "/src"));
   }
 
   @Test
   public void assignToLocalWorker() throws Exception {
     createFileWithBlocksOnWorkers("/src", 0);
     setPathToNotExist("/dst");
-    Map<WorkerInfo, List<MigrateCommand>> expected = ImmutableMap.of(JOB_WORKERS.get(0),
-        Collections.singletonList(new MigrateCommand("/src", "/dst")));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0),
+        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 
@@ -119,8 +120,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
   public void assignToWorkerWithMostBlocks() throws Exception {
     createFileWithBlocksOnWorkers("/src", 3, 1, 1, 3, 1);
     setPathToNotExist("/dst");
-    Map<WorkerInfo, List<MigrateCommand>> expected = ImmutableMap.of(JOB_WORKERS.get(1),
-        Collections.singletonList(new MigrateCommand("/src", "/dst")));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1),
+        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 
@@ -141,9 +142,9 @@ public final class MigrateDefinitionSelectExecutorsTest {
         new MigrateCommand("/dir/src1", "/dst/src1"), new MigrateCommand("/dir/src3", "/dst/src3"));
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/dir/src2", "/dst/src2"));
-    ImmutableMap<WorkerInfo, List<MigrateCommand>> expected =
-        ImmutableMap.of(JOB_WORKERS.get(0), migrateCommandsWorker0, JOB_WORKERS.get(2),
-                migrateCommandsWorker2);
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
+        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0), migrateCommandsWorker0), new Pair<>(JOB_WORKERS.get(2),
+                migrateCommandsWorker2));
     Assert.assertEquals(expected, assignMigrates("/dir", "/dst"));
   }
 
@@ -269,8 +270,8 @@ public final class MigrateDefinitionSelectExecutorsTest {
     createFileWithBlocksOnWorkers("/src", 0);
     createFile("/dst");
 
-    Map<WorkerInfo, List<MigrateCommand>> expected = ImmutableMap.of(JOB_WORKERS.get(0),
-        Collections.singletonList(new MigrateCommand("/src", "/dst")));
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0),
+        Collections.singletonList(new MigrateCommand("/src", "/dst"))));
     // Set overwrite to true.
     Assert.assertEquals(expected, assignMigrates(new MigrateConfig("/src", "/dst", "THROUGH",
         true, false)));
@@ -295,9 +296,9 @@ public final class MigrateDefinitionSelectExecutorsTest {
                     "/dst/nested/moreNested/file3"));
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/src/file1", "/dst/file1"));
-    ImmutableMap<WorkerInfo, List<MigrateCommand>> expected =
-        ImmutableMap.of(JOB_WORKERS.get(1), migrateCommandsWorker1, JOB_WORKERS.get(2),
-                migrateCommandsWorker2);
+    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
+        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1), migrateCommandsWorker1), new Pair<>(JOB_WORKERS.get(2),
+                migrateCommandsWorker2));
     Assert.assertEquals(expected, assignMigrates(new MigrateConfig(
             "/src", "/dst", "THROUGH", true, false)));
   }

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -37,6 +37,7 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
@@ -53,6 +54,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Unit tests for
@@ -312,21 +314,21 @@ public final class MigrateDefinitionSelectExecutorsTest {
     createFileWithBlocksOnWorkers("/src", 0);
     setPathToNotExist("/dst");
 
-    List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignments =
+    Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignments =
         new MigrateDefinition().selectExecutors(
             new MigrateConfig("/src", "/dst", "THROUGH", true, false),
             ImmutableList.of(JOB_WORKER_3),
             new SelectExecutorsContext(1,
                 new JobServerContext(mMockFileSystem, mMockFileSystemContext, mMockUfsManager)));
 
-    Assert.assertEquals(ImmutableList.of(new Pair<>(JOB_WORKER_3,
+    Assert.assertEquals(ImmutableSet.of(new Pair<>(JOB_WORKER_3,
         new ArrayList<>(Arrays.asList(new MigrateCommand("/src", "/dst"))))), assignments);
   }
 
   /**
    * Runs selectExecutors for the migrate from source to destination.
    */
-  private List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(String source,
+  private Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(String source,
       String destination) throws Exception {
     return assignMigrates(new MigrateConfig(source, destination, "THROUGH", false, false));
   }
@@ -335,7 +337,7 @@ public final class MigrateDefinitionSelectExecutorsTest {
    * Runs selectExecutors for the migrate from source to destination with the given writeType and
    * overwrite value.
    */
-  private List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(MigrateConfig config)
+  private Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(MigrateConfig config)
       throws Exception {
     return new MigrateDefinition().selectExecutors(config,
         JOB_WORKERS, new SelectExecutorsContext(1,
@@ -354,7 +356,7 @@ public final class MigrateDefinitionSelectExecutorsTest {
    */
   private void assignMigratesFail(String source, String destination, String writeType,
       boolean overwrite) throws Exception {
-    List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignment =
+    Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignment =
         assignMigrates(new MigrateConfig(source, destination, writeType, overwrite, false));
     Assert.fail(
         "Selecting executors should have failed, but it succeeded with assignment " + assignment);

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -21,6 +21,7 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
+import alluxio.collections.Pair;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
@@ -311,21 +312,21 @@ public final class MigrateDefinitionSelectExecutorsTest {
     createFileWithBlocksOnWorkers("/src", 0);
     setPathToNotExist("/dst");
 
-    Map<WorkerInfo, ArrayList<MigrateCommand>> assignments =
+    List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignments =
         new MigrateDefinition().selectExecutors(
             new MigrateConfig("/src", "/dst", "THROUGH", true, false),
             ImmutableList.of(JOB_WORKER_3),
             new SelectExecutorsContext(1,
                 new JobServerContext(mMockFileSystem, mMockFileSystemContext, mMockUfsManager)));
 
-    Assert.assertEquals(ImmutableMap.of(JOB_WORKER_3,
-        new ArrayList<>(Arrays.asList(new MigrateCommand("/src", "/dst")))), assignments);
+    Assert.assertEquals(ImmutableList.of(new Pair<>(JOB_WORKER_3,
+        new ArrayList<>(Arrays.asList(new MigrateCommand("/src", "/dst"))))), assignments);
   }
 
   /**
    * Runs selectExecutors for the migrate from source to destination.
    */
-  private Map<WorkerInfo, ArrayList<MigrateCommand>> assignMigrates(String source,
+  private List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(String source,
       String destination) throws Exception {
     return assignMigrates(new MigrateConfig(source, destination, "THROUGH", false, false));
   }
@@ -334,7 +335,7 @@ public final class MigrateDefinitionSelectExecutorsTest {
    * Runs selectExecutors for the migrate from source to destination with the given writeType and
    * overwrite value.
    */
-  private Map<WorkerInfo, ArrayList<MigrateCommand>> assignMigrates(MigrateConfig config)
+  private List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignMigrates(MigrateConfig config)
       throws Exception {
     return new MigrateDefinition().selectExecutors(config,
         JOB_WORKERS, new SelectExecutorsContext(1,
@@ -353,7 +354,7 @@ public final class MigrateDefinitionSelectExecutorsTest {
    */
   private void assignMigratesFail(String source, String destination, String writeType,
       boolean overwrite) throws Exception {
-    Map<WorkerInfo, ArrayList<MigrateCommand>> assignment =
+    List<Pair<WorkerInfo, ArrayList<MigrateCommand>>> assignment =
         assignMigrates(new MigrateConfig(source, destination, writeType, overwrite, false));
     Assert.fail(
         "Selecting executors should have failed, but it succeeded with assignment " + assignment);

--- a/job/server/src/test/java/alluxio/job/plan/persist/PersistDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/persist/PersistDefinitionTest.java
@@ -40,7 +40,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Tests {@link PersistDefinition}.
@@ -82,11 +82,11 @@ public final class PersistDefinitionTest {
     testFileInfo.setFileBlockInfos(Lists.newArrayList(fileBlockInfo));
     Mockito.when(mMockFileSystem.getStatus(uri)).thenReturn(new URIStatus(testFileInfo));
 
-    List<Pair<WorkerInfo, SerializableVoid>> result =
+    Set<Pair<WorkerInfo, SerializableVoid>> result =
         new PersistDefinition().selectExecutors(config,
             Lists.newArrayList(workerInfo), new SelectExecutorsContext(1, mJobServerContext));
     Assert.assertEquals(1, result.size());
-    Assert.assertEquals(workerInfo, result.get(0).getFirst());
+    Assert.assertEquals(workerInfo, result.iterator().next().getFirst());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/plan/persist/PersistDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/persist/PersistDefinitionTest.java
@@ -18,6 +18,7 @@ import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
+import alluxio.collections.Pair;
 import alluxio.job.JobServerContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.SerializableVoid;
@@ -39,7 +40,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Tests {@link PersistDefinition}.
@@ -81,11 +82,11 @@ public final class PersistDefinitionTest {
     testFileInfo.setFileBlockInfos(Lists.newArrayList(fileBlockInfo));
     Mockito.when(mMockFileSystem.getStatus(uri)).thenReturn(new URIStatus(testFileInfo));
 
-    Map<WorkerInfo, SerializableVoid> result =
+    List<Pair<WorkerInfo, SerializableVoid>> result =
         new PersistDefinition().selectExecutors(config,
             Lists.newArrayList(workerInfo), new SelectExecutorsContext(1, mJobServerContext));
     Assert.assertEquals(1, result.size());
-    Assert.assertEquals(workerInfo, result.keySet().iterator().next());
+    Assert.assertEquals(workerInfo, result.get(0).getFirst());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
@@ -55,7 +55,7 @@ public final class EvictDefinitionTest {
   private static final WorkerInfo WORKER_INFO_1 = new WorkerInfo().setAddress(ADDRESS_1);
   private static final WorkerInfo WORKER_INFO_2 = new WorkerInfo().setAddress(ADDRESS_2);
   private static final WorkerInfo WORKER_INFO_3 = new WorkerInfo().setAddress(ADDRESS_3);
-  private static final Map<WorkerInfo, SerializableVoid> EMPTY = Maps.newHashMap();
+  private static final List<Pair<WorkerInfo, SerializableVoid>> EMPTY = Lists.newArrayList();
 
   private FileSystem mMockFileSystem;
   private FileSystemContext mMockFileSystemContext;
@@ -96,7 +96,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsNoBlockWorkerHasBlock() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result =
+    List<Pair<WorkerInfo, SerializableVoid>> result =
         selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
             Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     // Expect none as no worker has this copy
@@ -105,7 +105,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsNoJobWorkerHasBlock() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_2, WORKER_INFO_3));
     // Expect none as no worker that is available has this copy
@@ -114,7 +114,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneBlockWorkerHasBlock() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
@@ -125,7 +125,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsAnyOneWorkers() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(Lists
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(Lists
             .newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1),
                 new BlockLocation().setWorkerAddress(ADDRESS_2),
                 new BlockLocation().setWorkerAddress(ADDRESS_3)), 1,
@@ -137,7 +137,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsAllWorkers() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(Lists
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(Lists
             .newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1),
                 new BlockLocation().setWorkerAddress(ADDRESS_2),
                 new BlockLocation().setWorkerAddress(ADDRESS_3)), 3,
@@ -152,7 +152,7 @@ public final class EvictDefinitionTest {
 
   @Test
   public void selectExecutorsBothWorkers() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(Lists
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(Lists
             .newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1),
                 new BlockLocation().setWorkerAddress(ADDRESS_2)), 3,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));

--- a/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
@@ -132,7 +132,7 @@ public final class EvictDefinitionTest {
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     // Expect one worker from all workers having this block
     Assert.assertEquals(1, result.size());
-    Assert.assertEquals(null, result.values().iterator().next());
+    Assert.assertEquals(null, result.get(0).getSecond());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/EvictDefinitionTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
+import alluxio.collections.Pair;
 import alluxio.job.JobServerContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.SerializableVoid;
@@ -78,7 +79,7 @@ public final class EvictDefinitionTest {
    * @param workerInfoList a list of currently available job workers
    * @return the selection result
    */
-  private Map<WorkerInfo, SerializableVoid> selectExecutorsTestHelper(
+  private List<Pair<WorkerInfo, SerializableVoid>> selectExecutorsTestHelper(
       List<BlockLocation> blockLocations, int replicas, List<WorkerInfo> workerInfoList)
       throws Exception {
     BlockInfo blockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID);

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -178,7 +178,7 @@ public final class ReplicateDefinitionTest {
         selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
             Lists.newArrayList(WORKER_INFO_1));
     List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
-    expected.put(WORKER_INFO_1, null);
+    expected.add(new Pair<>(WORKER_INFO_1, null));
     // select the only worker
     assertEquals(expected, result);
   }
@@ -189,7 +189,7 @@ public final class ReplicateDefinitionTest {
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
     List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
-    expected.add(new Pair(WORKER_INFO_2, null));
+    expected.add(new Pair<>(WORKER_INFO_2, null));
     // select one worker left
     assertEquals(expected, result);
   }
@@ -200,8 +200,8 @@ public final class ReplicateDefinitionTest {
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
-    expected.add(new Pair(WORKER_INFO_2, null));
-    expected.add(new Pair(WORKER_INFO_3, null));
+    expected.add(new Pair<>(WORKER_INFO_2, null));
+    expected.add(new Pair<>(WORKER_INFO_3, null));
     // select both workers left
     assertEquals(expected, result);
   }
@@ -232,7 +232,7 @@ public final class ReplicateDefinitionTest {
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
     List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
-    expected.add(new Pair(WORKER_INFO_2, null));
+    expected.add(new Pair<>(WORKER_INFO_2, null));
     // select the only worker left though more copies are requested
     assertEquals(expected, result);
   }

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -57,7 +57,6 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +70,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests {@link ReplicateConfig}.
@@ -187,54 +185,54 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneWorkerValid() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
-    Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
-    expected.put(WORKER_INFO_2, null);
+    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    expected.add(new Pair(WORKER_INFO_2, null));
     // select one worker left
     assertEquals(expected, result);
   }
 
   @Test
   public void selectExecutorsTwoWorkersValid() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
-    Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
-    expected.put(WORKER_INFO_2, null);
-    expected.put(WORKER_INFO_3, null);
+    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    expected.add(new Pair(WORKER_INFO_2, null));
+    expected.add(new Pair(WORKER_INFO_3, null));
     // select both workers left
     assertEquals(expected, result);
   }
 
   @Test
   public void selectExecutorsOneOutOFTwoWorkersValid() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     // select one worker out of two
     assertEquals(1, result.size());
-    assertEquals(null, result.values().iterator().next());
+    assertEquals(null, result.get(0).getSecond());
   }
 
   @Test
   public void selectExecutorsNoWorkerValid() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1));
-    Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
+    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
     // select none as no choice left
     assertEquals(expected, result);
   }
 
   @Test
   public void selectExecutorsInsufficientWorkerValid() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result = selectExecutorsTestHelper(
+    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
-    Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
-    expected.put(WORKER_INFO_2, null);
+    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    expected.add(new Pair(WORKER_INFO_2, null));
     // select the only worker left though more copies are requested
     assertEquals(expected, result);
   }

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -37,6 +37,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
+import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.ExceptionMessage;
@@ -124,7 +125,7 @@ public final class ReplicateDefinitionTest {
    * @param workerInfoList a list of current available job workers
    * @return the selection result
    */
-  private Map<WorkerInfo, SerializableVoid> selectExecutorsTestHelper(
+  private List<Pair<WorkerInfo, SerializableVoid>> selectExecutorsTestHelper(
       List<BlockLocation> blockLocations, int numReplicas, List<WorkerInfo> workerInfoList)
       throws Exception {
     BlockInfo blockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID);
@@ -175,10 +176,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneWorkerAvailable() throws Exception {
-    Map<WorkerInfo, SerializableVoid> result =
+    List<Pair<WorkerInfo, SerializableVoid>> result =
         selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
             Lists.newArrayList(WORKER_INFO_1));
-    Map<WorkerInfo, SerializableVoid> expected = Maps.newHashMap();
+    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
     expected.put(WORKER_INFO_1, null);
     // select the only worker
     assertEquals(expected, result);

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -180,7 +180,7 @@ public final class ReplicateDefinitionTest {
     Set<Pair<WorkerInfo, SerializableVoid>> result =
         selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
             Lists.newArrayList(WORKER_INFO_1));
-    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_1, null));
     // select the only worker
     assertEquals(expected, result);
@@ -191,7 +191,7 @@ public final class ReplicateDefinitionTest {
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
-    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
     // select one worker left
     assertEquals(expected, result);
@@ -202,7 +202,7 @@ public final class ReplicateDefinitionTest {
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
-    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
     expected.add(new Pair<>(WORKER_INFO_3, null));
     // select both workers left

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -56,7 +56,9 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,6 +72,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Tests {@link ReplicateConfig}.
@@ -123,7 +126,7 @@ public final class ReplicateDefinitionTest {
    * @param workerInfoList a list of current available job workers
    * @return the selection result
    */
-  private List<Pair<WorkerInfo, SerializableVoid>> selectExecutorsTestHelper(
+  private Set<Pair<WorkerInfo, SerializableVoid>> selectExecutorsTestHelper(
       List<BlockLocation> blockLocations, int numReplicas, List<WorkerInfo> workerInfoList)
       throws Exception {
     BlockInfo blockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID);
@@ -174,10 +177,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneWorkerAvailable() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result =
+    Set<Pair<WorkerInfo, SerializableVoid>> result =
         selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
             Lists.newArrayList(WORKER_INFO_1));
-    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
     expected.add(new Pair<>(WORKER_INFO_1, null));
     // select the only worker
     assertEquals(expected, result);
@@ -185,10 +188,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneWorkerValid() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
+    Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
-    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
     expected.add(new Pair<>(WORKER_INFO_2, null));
     // select one worker left
     assertEquals(expected, result);
@@ -196,10 +199,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsTwoWorkersValid() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
+    Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
-    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
     expected.add(new Pair<>(WORKER_INFO_2, null));
     expected.add(new Pair<>(WORKER_INFO_3, null));
     // select both workers left
@@ -208,30 +211,30 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOneOutOFTwoWorkersValid() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
+    Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     // select one worker out of two
     assertEquals(1, result.size());
-    assertEquals(null, result.get(0).getSecond());
+    assertEquals(null, result.iterator().next().getSecond());
   }
 
   @Test
   public void selectExecutorsNoWorkerValid() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
+    Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
         Lists.newArrayList(WORKER_INFO_1));
-    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
     // select none as no choice left
     assertEquals(expected, result);
   }
 
   @Test
   public void selectExecutorsInsufficientWorkerValid() throws Exception {
-    List<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
+    Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
         Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
-    List<Pair<WorkerInfo, SerializableVoid>> expected = Lists.newArrayList();
+    Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
     // select the only worker left though more copies are requested
     assertEquals(expected, result);

--- a/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
+++ b/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
@@ -29,6 +29,7 @@ import alluxio.underfs.UfsManager;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,7 @@ import org.powermock.reflect.Whitebox;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Tests {@link PlanCoordinator}.
@@ -187,7 +189,7 @@ public final class PlanCoordinatorTest {
    * @param workerInfos the worker infos to return from the mocked selectExecutors method
    */
   private void mockSelectExecutors(WorkerInfo... workerInfos) throws Exception {
-    List<Pair<WorkerInfo, Serializable>> taskAddressToArgs = Lists.newArrayList();
+    Set<Pair<WorkerInfo, Serializable>> taskAddressToArgs = Sets.newHashSet();
     for (WorkerInfo workerInfo : workerInfos) {
       taskAddressToArgs.add(new Pair<>(workerInfo, null));
     }

--- a/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
+++ b/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
+import alluxio.collections.Pair;
 import alluxio.grpc.JobCommand;
 import alluxio.job.JobConfig;
 import alluxio.job.plan.PlanDefinition;
@@ -42,7 +43,6 @@ import org.powermock.reflect.Whitebox;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests {@link PlanCoordinator}.
@@ -188,9 +188,9 @@ public final class PlanCoordinatorTest {
    * @param workerInfos the worker infos to return from the mocked selectExecutors method
    */
   private void mockSelectExecutors(WorkerInfo... workerInfos) throws Exception {
-    Map<WorkerInfo, Serializable> taskAddressToArgs = Maps.newHashMap();
+    List<Pair<WorkerInfo, Serializable>> taskAddressToArgs = Maps.newHashMap();
     for (WorkerInfo workerInfo : workerInfos) {
-      taskAddressToArgs.put(workerInfo, null);
+      taskAddressToArgs.add(new Pair<>(workerInfo, null));
     }
     Mockito
         .when(mPlanDefinition.selectExecutors(Mockito.eq(mJobconfig),

--- a/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
+++ b/job/server/src/test/java/alluxio/master/job/plan/PlanCoordinatorTest.java
@@ -29,7 +29,6 @@ import alluxio.underfs.UfsManager;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -188,7 +187,7 @@ public final class PlanCoordinatorTest {
    * @param workerInfos the worker infos to return from the mocked selectExecutors method
    */
   private void mockSelectExecutors(WorkerInfo... workerInfos) throws Exception {
-    List<Pair<WorkerInfo, Serializable>> taskAddressToArgs = Maps.newHashMap();
+    List<Pair<WorkerInfo, Serializable>> taskAddressToArgs = Lists.newArrayList();
     for (WorkerInfo workerInfo : workerInfos) {
       taskAddressToArgs.add(new Pair<>(workerInfo, null));
     }

--- a/job/server/src/test/java/alluxio/master/job/plan/PlanTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/plan/PlanTrackerTest.java
@@ -64,7 +64,7 @@ public class PlanTrackerTest {
   }
 
   @Test
-  public void testAddJobIncreaesCount() throws Exception {
+  public void testAddJobIncreasesCount() throws Exception {
     assertEquals("tracker should be empty", 0, mTracker.coordinators().size());
     addJob(100);
     assertEquals("tracker should have one job", 1, mTracker.coordinators().size());

--- a/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
@@ -22,11 +22,12 @@ import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.SerializableVoid;
 import alluxio.wire.WorkerInfo;
 
-import com.google.common.collect.Lists;
+import com.beust.jcommander.internal.Sets;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Tests the cancellation of a job.
@@ -44,10 +45,10 @@ public final class CancelIntegrationTest extends JobIntegrationTest {
   public static class CancelTestDefinition
       extends AbstractVoidPlanDefinition<CancelTestConfig, Integer> {
     @Override
-    public List<Pair<WorkerInfo, Integer>> selectExecutors(CancelTestConfig config,
+    public Set<Pair<WorkerInfo, Integer>> selectExecutors(CancelTestConfig config,
         List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
         throws Exception {
-      List<Pair<WorkerInfo, Integer>> result = Lists.newArrayList();
+      Set<Pair<WorkerInfo, Integer>> result = Sets.newHashSet();
       for (WorkerInfo info : jobWorkerInfoList) {
         result.add(new Pair<>(info, 0));
       }

--- a/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.SerializableVoid;
 import alluxio.wire.WorkerInfo;
 
+import com.google.common.collect.Lists;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
@@ -48,9 +49,9 @@ public final class CancelIntegrationTest extends JobIntegrationTest {
     public List<Pair<WorkerInfo, Integer>> selectExecutors(CancelTestConfig config,
         List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
         throws Exception {
-      Map<WorkerInfo, Integer> result = new HashMap<>();
+      List<Pair<WorkerInfo, Integer>> result = Lists.newArrayList()
       for (WorkerInfo info : jobWorkerInfoList) {
-        result.put(info, 0);
+        result.add(new Pair<>(info, 0));
       }
       return result;
     }

--- a/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
@@ -26,9 +26,7 @@ import com.google.common.collect.Lists;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tests the cancellation of a job.
@@ -49,7 +47,7 @@ public final class CancelIntegrationTest extends JobIntegrationTest {
     public List<Pair<WorkerInfo, Integer>> selectExecutors(CancelTestConfig config,
         List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
         throws Exception {
-      List<Pair<WorkerInfo, Integer>> result = Lists.newArrayList()
+      List<Pair<WorkerInfo, Integer>> result = Lists.newArrayList();
       for (WorkerInfo info : jobWorkerInfoList) {
         result.add(new Pair<>(info, 0));
       }

--- a/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/cancel/CancelIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.job.cancel;
 
 import alluxio.Constants;
+import alluxio.collections.Pair;
 import alluxio.job.plan.AbstractVoidPlanDefinition;
 import alluxio.job.plan.PlanConfig;
 import alluxio.job.plan.PlanDefinitionRegistry;
@@ -44,7 +45,7 @@ public final class CancelIntegrationTest extends JobIntegrationTest {
   public static class CancelTestDefinition
       extends AbstractVoidPlanDefinition<CancelTestConfig, Integer> {
     @Override
-    public Map<WorkerInfo, Integer> selectExecutors(CancelTestConfig config,
+    public List<Pair<WorkerInfo, Integer>> selectExecutors(CancelTestConfig config,
         List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext selectExecutorsContext)
         throws Exception {
       Map<WorkerInfo, Integer> result = new HashMap<>();

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -23,6 +23,7 @@ import alluxio.job.SleepJobConfig;
 import alluxio.job.plan.SleepPlanDefinition;
 import alluxio.job.util.JobTestUtils;
 import alluxio.job.wire.JobWorkerHealth;
+import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.Status;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.master.job.JobMaster;
@@ -73,6 +74,19 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   @After
   public void after() throws Exception {
     mLocalAlluxioJobCluster.stop();
+  }
+
+  @Test
+  public void multipleTasksPerWorker() throws Exception {
+    long jobId = mJobMaster.run(new SleepJobConfig(1, 2));
+
+    JobInfo jobStatus = mJobMaster.getStatus(jobId);
+    assertEquals(2, jobStatus.getChildren().size());
+
+    JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.COMPLETED);
+
+    jobStatus = mJobMaster.getStatus(jobId);
+    assertEquals(2, jobStatus.getChildren().size());
   }
 
   @Test


### PR DESCRIPTION
From:

Map<WorkerInfo, Parameters> -> List<Pair<WorkerInfo, Parameters>>

This allows for each plans to submit more than one task perTaskWorker.


Other miscellaneous Change:

Pair's equal and hashcode was modified so that Pair accepts null as a valid input for First and/or Second.