### PR TITLE
Add worker host in TaskInfo from construction inside JobWorker

### DIFF
--- a/job/common/src/main/java/alluxio/job/plan/meta/PlanInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/meta/PlanInfo.java
@@ -81,7 +81,8 @@ public final class PlanInfo implements Comparable<PlanInfo> {
    * @param workerInfo the worker info
    */
   public void addTask(long taskId, WorkerInfo workerInfo) {
-    TaskInfo oldValue = mTaskIdToInfo.putIfAbsent(taskId, new TaskInfo(mId, taskId, workerInfo));
+    TaskInfo oldValue = mTaskIdToInfo.putIfAbsent(taskId,
+        new TaskInfo(mId, taskId, Status.CREATED, workerInfo.getAddress()));
     // the task is expected to not exist in the map.
     Preconditions.checkState(oldValue == null,
         String.format("JobId %d cannot add duplicate taskId %d", mId, taskId));

--- a/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
@@ -15,7 +15,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.JobType;
 import alluxio.job.util.SerializationUtils;
 import alluxio.util.CommonUtils;
-import alluxio.wire.WorkerInfo;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -53,34 +53,19 @@ public class TaskInfo implements JobInfo {
   public TaskInfo() {}
 
   /**
-   * Constructor for TaskInfo.
-   * @param jobId the job id
-   * @param taskId the task id
-   * @param workerInfo the worker info
-   */
-  public TaskInfo(long jobId, long taskId, WorkerInfo workerInfo) {
-    mJobId = jobId;
-    mTaskId = taskId;
-    mStatus = Status.CREATED;
-    mErrorMessage = "";
-    mResult = null;
-    mLastUpdated = CommonUtils.getCurrentMs();
-    mWorkerHost = workerInfo.getAddress().getHost();
-  }
-
-  /**
-   * Constructs a new TaskInfo from jobId, taskId, and Status.
+   * Constructs a new TaskInfo from jobId, taskId, Status, and workerAddress.
    * @param jobId the job id
    * @param taskId the task id
    * @param status the status
+   * @param workerAddress the worker address
    */
-  public TaskInfo(long jobId, long taskId, Status status) {
+  public TaskInfo(long jobId, long taskId, Status status, WorkerNetAddress workerAddress) {
     mJobId = jobId;
     mTaskId = taskId;
     mStatus = status;
     mErrorMessage = "";
     mResult = null;
-    mWorkerHost = "";
+    mWorkerHost = workerAddress.getHost();
   }
 
   /**

--- a/job/server/src/main/java/alluxio/worker/JobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/JobWorker.java
@@ -59,7 +59,7 @@ public final class JobWorker extends AbstractWorker {
   /** Client for job master communication. */
   private final JobMasterClient mJobMasterClient;
   /** The manager for the all the local task execution. */
-  private final TaskExecutorManager mTaskExecutorManager;
+  private TaskExecutorManager mTaskExecutorManager;
   /** The service that handles commands sent from master. */
   private Future<?> mCommandHandlingService;
 
@@ -74,8 +74,6 @@ public final class JobWorker extends AbstractWorker {
     mJobServerContext = new JobServerContext(filesystem, fsContext, ufsManager);
     mJobMasterClient = JobMasterClient.Factory.create(JobMasterClientContext
         .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
-    mTaskExecutorManager = new TaskExecutorManager(
-        ServerConfiguration.getInt(PropertyKey.JOB_WORKER_THREADPOOL_SIZE));
   }
 
   @Override
@@ -104,6 +102,9 @@ public final class JobWorker extends AbstractWorker {
       LOG.error("Failed to get a worker id from job master", e);
       throw Throwables.propagate(e);
     }
+
+    mTaskExecutorManager = new TaskExecutorManager(
+        ServerConfiguration.getInt(PropertyKey.JOB_WORKER_THREADPOOL_SIZE), address);
 
     mCommandHandlingService = getExecutorService().submit(
         new HeartbeatThread(HeartbeatContext.JOB_WORKER_COMMAND_HANDLING,

--- a/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
@@ -37,6 +37,7 @@ import alluxio.master.job.JobMaster;
 import alluxio.master.job.command.CommandManager;
 import alluxio.master.job.plan.PlanTracker;
 import alluxio.wire.WorkerInfo;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
@@ -95,7 +96,7 @@ public class WorkflowTrackerTest {
 
     verify(mMockJobMaster, never()).run(child2, 101);
 
-    TaskInfo task100 = new TaskInfo(100, 0, Status.COMPLETED);
+    TaskInfo task100 = new TaskInfo(100, 0, Status.COMPLETED, new WorkerNetAddress());
     ArrayList<TaskInfo> taskInfos = Lists.newArrayList(task100);
 
     PlanInfo plan100 = new PlanInfo(100, "test", Status.COMPLETED, 0, null);
@@ -106,7 +107,7 @@ public class WorkflowTrackerTest {
 
     assertEquals(Status.RUNNING, mWorkflowTracker.getStatus(0).getStatus());
 
-    TaskInfo task101 = new TaskInfo(101, 0, Status.COMPLETED);
+    TaskInfo task101 = new TaskInfo(101, 0, Status.COMPLETED, new WorkerNetAddress());
     taskInfos = Lists.newArrayList(task101);
     PlanInfo plan101 = new PlanInfo(101, "test", Status.COMPLETED, 0, null);
     when(mMockJobMaster.getStatus(101)).thenReturn(plan101);


### PR DESCRIPTION
@ZacBlanco: made a point that workerAddress is way more available from the CommandHandlingExecutor than I originally anticipated. So moving one more to being in constructor.


Other Miscellaneous Change: 

getAndClearTaskUpdates now returns a wire object and the GRPC protoization method happens during the worker's heartbeat instead.