### PR TITLE
Refine ufs.listStatus granularity for incremental sync

### DIFF
--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -150,9 +150,8 @@ public final class PathUtils {
         }
       }
     }
-    AlluxioURI lca = new AlluxioURI(AlluxioURI.SEPARATOR);
-    return new AlluxioURI(
-        PathUtils.concatPath(lca, matchedComponents.subList(0, matchedLen).toArray()));
+    return new AlluxioURI(PathUtils.concatPath(AlluxioURI.SEPARATOR,
+        matchedComponents.subList(0, matchedLen).toArray()));
   }
 
   /**

--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -20,6 +20,11 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FilenameUtils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -119,6 +124,35 @@ public final class PathUtils {
       return AlluxioURI.SEPARATOR;
     }
     return output.toString();
+  }
+
+  /**
+   * @param paths the set of paths
+   * @return the lowest common ancestor, or null if paths is null or empty
+   */
+  public static AlluxioURI findLowestCommonAncestor(Collection<AlluxioURI> paths) {
+    if (paths == null || paths.isEmpty()) {
+      return null;
+    }
+    List<String> matchedComponents = null;
+    int matchedLen = 0;
+    for (AlluxioURI path : paths) {
+      String[] pathComp = path.getPath().split(AlluxioURI.SEPARATOR);
+      if (matchedComponents == null) {
+        matchedComponents = new ArrayList<>(Arrays.asList(pathComp));
+        matchedLen = pathComp.length;
+      }
+
+      for (int i = 0; i < pathComp.length && i < matchedLen; ++i) {
+        if (!matchedComponents.get(i).equals(pathComp[i])) {
+          matchedLen = i;
+          break;
+        }
+      }
+    }
+    AlluxioURI lca = new AlluxioURI(AlluxioURI.SEPARATOR);
+    return new AlluxioURI(
+        PathUtils.concatPath(lca, matchedComponents.subList(0, matchedLen).toArray()));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -155,6 +155,17 @@ public final class PathUtilsTest {
     paths.add(new AlluxioURI("/a/b/d"));
     paths.add(new AlluxioURI("/a/b/e"));
     assertTrue("/a/b".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.clear();
+    String prefix = "/a/b/c";
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        for (int k = 0; k < 10; k++) {
+          paths.add(new AlluxioURI(String.format("%s/%d/%d/%d", prefix, i, j, k)));
+        }
+      }
+    }
+    assertTrue(prefix.equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -133,28 +133,28 @@ public final class PathUtilsTest {
     ArrayList<AlluxioURI> paths = new ArrayList<>();
 
     paths.add(new AlluxioURI("/"));
-    assertTrue("/".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.clear();
     paths.add(new AlluxioURI("/a"));
-    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/a", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.add(new AlluxioURI("/a/b"));
-    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/a", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.clear();
     paths.add(new AlluxioURI("/a/c"));
     paths.add(new AlluxioURI("/a/d/"));
-    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/a", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.add(new AlluxioURI("/b/a/"));
-    assertTrue("/".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.clear();
     paths.add(new AlluxioURI("/a/b/c"));
     paths.add(new AlluxioURI("/a/b/d"));
     paths.add(new AlluxioURI("/a/b/e"));
-    assertTrue("/a/b".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals("/a/b", PathUtils.findLowestCommonAncestor(paths).getPath());
 
     paths.clear();
     String prefix = "/a/b/c";
@@ -165,7 +165,7 @@ public final class PathUtilsTest {
         }
       }
     }
-    assertTrue(prefix.equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+    assertEquals(prefix, PathUtils.findLowestCommonAncestor(paths).getPath());
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
@@ -28,6 +29,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Tests for the {@link PathUtils} class.
@@ -117,6 +120,41 @@ public final class PathUtilsTest {
     // Header
     assertEquals(Constants.HEADER + "host:port/foo/bar",
         PathUtils.concatPath(Constants.HEADER + "host:port", "/foo", "bar"));
+  }
+
+  /**
+   * Tests the {@link PathUtils#findLowestCommonAncestor(Collection)} method.
+   */
+  @Test
+  public void findLowestCommonAncestor() {
+    assertNull(PathUtils.findLowestCommonAncestor(null));
+    assertNull(PathUtils.findLowestCommonAncestor(Collections.EMPTY_LIST));
+
+    ArrayList<AlluxioURI> paths = new ArrayList<>();
+
+    paths.add(new AlluxioURI("/"));
+    assertTrue("/".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.clear();
+    paths.add(new AlluxioURI("/a"));
+    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.add(new AlluxioURI("/a/b"));
+    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.clear();
+    paths.add(new AlluxioURI("/a/c"));
+    paths.add(new AlluxioURI("/a/d/"));
+    assertTrue("/a".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.add(new AlluxioURI("/b/a/"));
+    assertTrue("/".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
+
+    paths.clear();
+    paths.add(new AlluxioURI("/a/b/c"));
+    paths.add(new AlluxioURI("/a/b/d"));
+    paths.add(new AlluxioURI("/a/b/e"));
+    assertTrue("/a/b".equals(PathUtils.findLowestCommonAncestor(paths).getPath()));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3223,7 +3223,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
       }
       if (changedFiles == null) {
         LockingScheme lockingScheme = new LockingScheme(path, LockPattern.READ, true);
-        // TODO(adit): do we need to write lock entire sub-tree while full syncing
         try (LockedInodePath inodePath =
             mInodeTree.lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern())) {
           syncMetadataInternal(rpcContext, inodePath, lockingScheme, DescendantType.ALL,
@@ -3311,7 +3310,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
 
         listOptions.setRecursive(syncDescendantType == DescendantType.ALL);
         try {
-          long startTime = System.nanoTime();
           UfsStatus[] children = ufs.listStatus(ufsUri.toString(), listOptions);
           if (children != null) {
             for (UfsStatus childStatus : children) {
@@ -3319,7 +3317,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
                   childStatus);
             }
           }
-          LOG.info("AMDEBUG Time elapsed in ufs.listStatus {} (ns)", System.nanoTime() - startTime);
         } catch (Exception e) {
           LOG.debug("ListStatus failed as an preparation step for syncMetadata {}", path, e);
         }


### PR DESCRIPTION
For incremental sync on large directories, a ufs listing at the sync point can be an expensive operation. This PR attempts to address the issue by calculating the lowest common ancestor of the changed file list reported by the ufs. 