### PR TITLE
Fix potential NPE on worker start when local mount command fails

### DIFF
--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -110,7 +110,7 @@ public final class ShellUtils {
     // Now parse the rest
     matcher = Pattern.compile("(.*) on (.*) \\((.*)\\)").matcher(lineWithoutType);
     if (!matcher.matches()) {
-      LOG.debug("Unable to parse output of 'mount': {}", line);
+      LOG.warn("Unable to parse output of '{}': {}", MOUNT_COMMAND, line);
       return builder.build();
     }
     builder.setDeviceSpec(matcher.group(1));

--- a/core/common/src/main/java/alluxio/util/UnixMountInfo.java
+++ b/core/common/src/main/java/alluxio/util/UnixMountInfo.java
@@ -28,7 +28,7 @@ public final class UnixMountInfo {
     mDeviceSpec = Optional.fromNullable(deviceSpec);
     mMountPoint = Optional.fromNullable(mountPoint);
     mFsType = Optional.fromNullable(fsType);
-    mMountOptions = options;
+    mMountOptions = options == null ? new Options.Builder().build() : options;
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -96,6 +96,15 @@ public final class ShellUtilsTest {
   }
 
   @Test
+  public void parseMountInfoInvalidOutput() throws Exception {
+    UnixMountInfo info = ShellUtils.parseMountInfo("invalid output");
+    assertFalse(info.getDeviceSpec().isPresent());
+    assertFalse(info.getMountPoint().isPresent());
+    assertFalse(info.getFsType().isPresent());
+    assertFalse(info.getOptions().getSize().isPresent());
+  }
+
+  @Test
   public void getMountInfo() throws Exception {
     assumeTrue(OSUtils.isMacOS() || OSUtils.isLinux());
     List<UnixMountInfo> info = ShellUtils.getUnixMountInfo();


### PR DESCRIPTION
On the corner case when linux mount command returns invalid result during worker start-up, a NPE will be thrown [here](https://github.com/Alluxio/alluxio/blob/de0da9ccc26bb96f763ba78afc544c778023f646/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java#L148) as the `mMountOptions` will not be initialized. 

This PR will fix #10514