### PR TITLE
Add UnfinishedTasks to JobWorkerHealth

### DIFF
--- a/core/transport/src/grpc/job_master.proto
+++ b/core/transport/src/grpc/job_master.proto
@@ -65,6 +65,7 @@ message JobWorkerHealth {
   optional string hostname = 4;
   optional int32 taskPoolSize = 5;
   optional int32 numActiveTasks = 6;
+  optional int32 unfinishedTasks = 7;
 }
 
 message JobCommand {

--- a/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobMasterProto.java
@@ -211,85 +211,85 @@ public final class JobMasterProto {
       "\0132\031.alluxio.grpc.job.JobInfo\0221\n\016recentFa" +
       "ilures\030\003 \003(\0132\031.alluxio.grpc.job.JobInfo\022" +
       "1\n\016longestRunning\030\004 \003(\0132\031.alluxio.grpc.j" +
-      "ob.JobInfo\"\215\001\n\017JobWorkerHealth\022\020\n\010worker" +
+      "ob.JobInfo\"\246\001\n\017JobWorkerHealth\022\020\n\010worker" +
       "Id\030\001 \001(\003\022\023\n\013loadAverage\030\002 \003(\001\022\023\n\013lastUpd" +
       "ated\030\003 \001(\003\022\020\n\010hostname\030\004 \001(\t\022\024\n\014taskPool" +
-      "Size\030\005 \001(\005\022\026\n\016numActiveTasks\030\006 \001(\005\"\214\002\n\nJ" +
-      "obCommand\0228\n\016runTaskCommand\030\001 \001(\0132 .allu" +
-      "xio.grpc.job.RunTaskCommand\022>\n\021cancelTas" +
-      "kCommand\030\002 \001(\0132#.alluxio.grpc.job.Cancel" +
-      "TaskCommand\022:\n\017registerCommand\030\003 \001(\0132!.a" +
-      "lluxio.grpc.job.RegisterCommand\022H\n\026setTa" +
-      "skPoolSizeCommand\030\004 \001(\0132(.alluxio.grpc.j" +
-      "ob.SetTaskPoolSizeCommand\"T\n\016RunTaskComm" +
-      "and\022\r\n\005jobId\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\003\022\021\n\tjo" +
-      "bConfig\030\003 \001(\014\022\020\n\010taskArgs\030\004 \001(\014\"\021\n\017Regis" +
-      "terCommand\".\n\026SetTaskPoolSizeCommand\022\024\n\014" +
-      "taskPoolSize\030\001 \001(\005\"2\n\021CancelTaskCommand\022" +
-      "\r\n\005jobId\030\001 \001(\003\022\016\n\006taskId\030\002 \001(\003\"\020\n\016Cancel" +
-      "POptions\"R\n\016CancelPRequest\022\r\n\005jobId\030\001 \001(" +
-      "\003\0221\n\007options\030\002 \001(\0132 .alluxio.grpc.job.Ca" +
-      "ncelPOptions\"\021\n\017CancelPResponse\"\026\n\024GetJo" +
-      "bStatusPOptions\"^\n\024GetJobStatusPRequest\022" +
-      "\r\n\005jobId\030\001 \001(\003\0227\n\007options\030\002 \001(\0132&.alluxi" +
-      "o.grpc.job.GetJobStatusPOptions\"C\n\025GetJo" +
-      "bStatusPResponse\022*\n\007jobInfo\030\001 \001(\0132\031.allu" +
-      "xio.grpc.job.JobInfo\"\021\n\017ListAllPOptions\"" +
-      "E\n\017ListAllPRequest\0222\n\007options\030\001 \001(\0132!.al" +
-      "luxio.grpc.job.ListAllPOptions\"\"\n\020ListAl" +
-      "lPResponse\022\016\n\006jobIds\030\001 \003(\003\"\r\n\013RunPOption" +
-      "s\"P\n\013RunPRequest\022\021\n\tjobConfig\030\001 \001(\014\022.\n\007o" +
-      "ptions\030\002 \001(\0132\035.alluxio.grpc.job.RunPOpti" +
-      "ons\"\035\n\014RunPResponse\022\r\n\005jobId\030\001 \001(\003\"\036\n\034Ge" +
-      "tJobServiceSummaryPOptions\"_\n\034GetJobServ" +
-      "iceSummaryPRequest\022?\n\007options\030\001 \001(\0132..al" +
-      "luxio.grpc.job.GetJobServiceSummaryPOpti" +
-      "ons\"U\n\035GetJobServiceSummaryPResponse\0224\n\007" +
-      "summary\030\001 \001(\0132#.alluxio.grpc.job.JobServ" +
-      "iceSummary\"\034\n\032GetAllWorkerHealthPOptions" +
-      "\"[\n\032GetAllWorkerHealthPRequest\022=\n\007option" +
-      "s\030\001 \001(\0132,.alluxio.grpc.job.GetAllWorkerH" +
-      "ealthPOptions\"W\n\033GetAllWorkerHealthPResp" +
-      "onse\0228\n\rworkerHealths\030\001 \003(\0132!.alluxio.gr" +
-      "pc.job.JobWorkerHealth\"\026\n\024JobHeartbeatPO" +
-      "ptions\"\271\001\n\024JobHeartbeatPRequest\022:\n\017jobWo" +
-      "rkerHealth\030\001 \001(\0132!.alluxio.grpc.job.JobW" +
-      "orkerHealth\022,\n\ttaskInfos\030\002 \003(\0132\031.alluxio" +
-      ".grpc.job.JobInfo\0227\n\007options\030\003 \001(\0132&.all" +
-      "uxio.grpc.job.JobHeartbeatPOptions\"G\n\025Jo" +
-      "bHeartbeatPResponse\022.\n\010commands\030\001 \003(\0132\034." +
-      "alluxio.grpc.job.JobCommand\"\033\n\031RegisterJ" +
-      "obWorkerPOptions\"\223\001\n\031RegisterJobWorkerPR" +
-      "equest\0228\n\020workerNetAddress\030\001 \001(\0132\036.allux" +
-      "io.grpc.WorkerNetAddress\022<\n\007options\030\002 \001(" +
-      "\0132+.alluxio.grpc.job.RegisterJobWorkerPO" +
-      "ptions\"(\n\032RegisterJobWorkerPResponse\022\n\n\002" +
-      "id\030\001 \001(\003*X\n\006Status\022\013\n\007UNKNOWN\020\000\022\013\n\007CREAT" +
-      "ED\020\001\022\014\n\010CANCELED\020\002\022\n\n\006FAILED\020\003\022\013\n\007RUNNIN" +
-      "G\020\004\022\r\n\tCOMPLETED\020\005*+\n\007JobType\022\010\n\004PLAN\020\001\022" +
-      "\010\n\004TASK\020\002\022\014\n\010WORKFLOW\020\0032\314\004\n\026JobMasterCli" +
-      "entService\022M\n\006Cancel\022 .alluxio.grpc.job." +
-      "CancelPRequest\032!.alluxio.grpc.job.Cancel" +
-      "PResponse\022_\n\014GetJobStatus\022&.alluxio.grpc" +
-      ".job.GetJobStatusPRequest\032\'.alluxio.grpc" +
-      ".job.GetJobStatusPResponse\022w\n\024GetJobServ" +
-      "iceSummary\022..alluxio.grpc.job.GetJobServ" +
-      "iceSummaryPRequest\032/.alluxio.grpc.job.Ge" +
-      "tJobServiceSummaryPResponse\022P\n\007ListAll\022!" +
-      ".alluxio.grpc.job.ListAllPRequest\032\".allu" +
-      "xio.grpc.job.ListAllPResponse\022D\n\003Run\022\035.a" +
-      "lluxio.grpc.job.RunPRequest\032\036.alluxio.gr" +
-      "pc.job.RunPResponse\022q\n\022GetAllWorkerHealt" +
-      "h\022,.alluxio.grpc.job.GetAllWorkerHealthP" +
-      "Request\032-.alluxio.grpc.job.GetAllWorkerH" +
-      "ealthPResponse2\346\001\n\026JobMasterWorkerServic" +
-      "e\022\\\n\tHeartbeat\022&.alluxio.grpc.job.JobHea" +
-      "rtbeatPRequest\032\'.alluxio.grpc.job.JobHea" +
-      "rtbeatPResponse\022n\n\021RegisterJobWorker\022+.a" +
-      "lluxio.grpc.job.RegisterJobWorkerPReques" +
-      "t\032,.alluxio.grpc.job.RegisterJobWorkerPR" +
-      "esponseB \n\014alluxio.grpcB\016JobMasterProtoP" +
-      "\001"
+      "Size\030\005 \001(\005\022\026\n\016numActiveTasks\030\006 \001(\005\022\027\n\017un" +
+      "finishedTasks\030\007 \001(\005\"\214\002\n\nJobCommand\0228\n\016ru" +
+      "nTaskCommand\030\001 \001(\0132 .alluxio.grpc.job.Ru" +
+      "nTaskCommand\022>\n\021cancelTaskCommand\030\002 \001(\0132" +
+      "#.alluxio.grpc.job.CancelTaskCommand\022:\n\017" +
+      "registerCommand\030\003 \001(\0132!.alluxio.grpc.job" +
+      ".RegisterCommand\022H\n\026setTaskPoolSizeComma" +
+      "nd\030\004 \001(\0132(.alluxio.grpc.job.SetTaskPoolS" +
+      "izeCommand\"T\n\016RunTaskCommand\022\r\n\005jobId\030\001 " +
+      "\001(\003\022\016\n\006taskId\030\002 \001(\003\022\021\n\tjobConfig\030\003 \001(\014\022\020" +
+      "\n\010taskArgs\030\004 \001(\014\"\021\n\017RegisterCommand\".\n\026S" +
+      "etTaskPoolSizeCommand\022\024\n\014taskPoolSize\030\001 " +
+      "\001(\005\"2\n\021CancelTaskCommand\022\r\n\005jobId\030\001 \001(\003\022" +
+      "\016\n\006taskId\030\002 \001(\003\"\020\n\016CancelPOptions\"R\n\016Can" +
+      "celPRequest\022\r\n\005jobId\030\001 \001(\003\0221\n\007options\030\002 " +
+      "\001(\0132 .alluxio.grpc.job.CancelPOptions\"\021\n" +
+      "\017CancelPResponse\"\026\n\024GetJobStatusPOptions" +
+      "\"^\n\024GetJobStatusPRequest\022\r\n\005jobId\030\001 \001(\003\022" +
+      "7\n\007options\030\002 \001(\0132&.alluxio.grpc.job.GetJ" +
+      "obStatusPOptions\"C\n\025GetJobStatusPRespons" +
+      "e\022*\n\007jobInfo\030\001 \001(\0132\031.alluxio.grpc.job.Jo" +
+      "bInfo\"\021\n\017ListAllPOptions\"E\n\017ListAllPRequ" +
+      "est\0222\n\007options\030\001 \001(\0132!.alluxio.grpc.job." +
+      "ListAllPOptions\"\"\n\020ListAllPResponse\022\016\n\006j" +
+      "obIds\030\001 \003(\003\"\r\n\013RunPOptions\"P\n\013RunPReques" +
+      "t\022\021\n\tjobConfig\030\001 \001(\014\022.\n\007options\030\002 \001(\0132\035." +
+      "alluxio.grpc.job.RunPOptions\"\035\n\014RunPResp" +
+      "onse\022\r\n\005jobId\030\001 \001(\003\"\036\n\034GetJobServiceSumm" +
+      "aryPOptions\"_\n\034GetJobServiceSummaryPRequ" +
+      "est\022?\n\007options\030\001 \001(\0132..alluxio.grpc.job." +
+      "GetJobServiceSummaryPOptions\"U\n\035GetJobSe" +
+      "rviceSummaryPResponse\0224\n\007summary\030\001 \001(\0132#" +
+      ".alluxio.grpc.job.JobServiceSummary\"\034\n\032G" +
+      "etAllWorkerHealthPOptions\"[\n\032GetAllWorke" +
+      "rHealthPRequest\022=\n\007options\030\001 \001(\0132,.allux" +
+      "io.grpc.job.GetAllWorkerHealthPOptions\"W" +
+      "\n\033GetAllWorkerHealthPResponse\0228\n\rworkerH" +
+      "ealths\030\001 \003(\0132!.alluxio.grpc.job.JobWorke" +
+      "rHealth\"\026\n\024JobHeartbeatPOptions\"\271\001\n\024JobH" +
+      "eartbeatPRequest\022:\n\017jobWorkerHealth\030\001 \001(" +
+      "\0132!.alluxio.grpc.job.JobWorkerHealth\022,\n\t" +
+      "taskInfos\030\002 \003(\0132\031.alluxio.grpc.job.JobIn" +
+      "fo\0227\n\007options\030\003 \001(\0132&.alluxio.grpc.job.J" +
+      "obHeartbeatPOptions\"G\n\025JobHeartbeatPResp" +
+      "onse\022.\n\010commands\030\001 \003(\0132\034.alluxio.grpc.jo" +
+      "b.JobCommand\"\033\n\031RegisterJobWorkerPOption" +
+      "s\"\223\001\n\031RegisterJobWorkerPRequest\0228\n\020worke" +
+      "rNetAddress\030\001 \001(\0132\036.alluxio.grpc.WorkerN" +
+      "etAddress\022<\n\007options\030\002 \001(\0132+.alluxio.grp" +
+      "c.job.RegisterJobWorkerPOptions\"(\n\032Regis" +
+      "terJobWorkerPResponse\022\n\n\002id\030\001 \001(\003*X\n\006Sta" +
+      "tus\022\013\n\007UNKNOWN\020\000\022\013\n\007CREATED\020\001\022\014\n\010CANCELE" +
+      "D\020\002\022\n\n\006FAILED\020\003\022\013\n\007RUNNING\020\004\022\r\n\tCOMPLETE" +
+      "D\020\005*+\n\007JobType\022\010\n\004PLAN\020\001\022\010\n\004TASK\020\002\022\014\n\010WO" +
+      "RKFLOW\020\0032\314\004\n\026JobMasterClientService\022M\n\006C" +
+      "ancel\022 .alluxio.grpc.job.CancelPRequest\032" +
+      "!.alluxio.grpc.job.CancelPResponse\022_\n\014Ge" +
+      "tJobStatus\022&.alluxio.grpc.job.GetJobStat" +
+      "usPRequest\032\'.alluxio.grpc.job.GetJobStat" +
+      "usPResponse\022w\n\024GetJobServiceSummary\022..al" +
+      "luxio.grpc.job.GetJobServiceSummaryPRequ" +
+      "est\032/.alluxio.grpc.job.GetJobServiceSumm" +
+      "aryPResponse\022P\n\007ListAll\022!.alluxio.grpc.j" +
+      "ob.ListAllPRequest\032\".alluxio.grpc.job.Li" +
+      "stAllPResponse\022D\n\003Run\022\035.alluxio.grpc.job" +
+      ".RunPRequest\032\036.alluxio.grpc.job.RunPResp" +
+      "onse\022q\n\022GetAllWorkerHealth\022,.alluxio.grp" +
+      "c.job.GetAllWorkerHealthPRequest\032-.allux" +
+      "io.grpc.job.GetAllWorkerHealthPResponse2" +
+      "\346\001\n\026JobMasterWorkerService\022\\\n\tHeartbeat\022" +
+      "&.alluxio.grpc.job.JobHeartbeatPRequest\032" +
+      "\'.alluxio.grpc.job.JobHeartbeatPResponse" +
+      "\022n\n\021RegisterJobWorker\022+.alluxio.grpc.job" +
+      ".RegisterJobWorkerPRequest\032,.alluxio.grp" +
+      "c.job.RegisterJobWorkerPResponseB \n\014allu" +
+      "xio.grpcB\016JobMasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -333,7 +333,7 @@ public final class JobMasterProto {
     internal_static_alluxio_grpc_job_JobWorkerHealth_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_job_JobWorkerHealth_descriptor,
-        new java.lang.String[] { "WorkerId", "LoadAverage", "LastUpdated", "Hostname", "TaskPoolSize", "NumActiveTasks", });
+        new java.lang.String[] { "WorkerId", "LoadAverage", "LastUpdated", "Hostname", "TaskPoolSize", "NumActiveTasks", "UnfinishedTasks", });
     internal_static_alluxio_grpc_job_JobCommand_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_alluxio_grpc_job_JobCommand_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/JobWorkerHealth.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobWorkerHealth.java
@@ -22,6 +22,7 @@ private static final long serialVersionUID = 0L;
     hostname_ = "";
     taskPoolSize_ = 0;
     numActiveTasks_ = 0;
+    unfinishedTasks_ = 0;
   }
 
   @java.lang.Override
@@ -100,6 +101,11 @@ private static final long serialVersionUID = 0L;
           case 48: {
             bitField0_ |= 0x00000010;
             numActiveTasks_ = input.readInt32();
+            break;
+          }
+          case 56: {
+            bitField0_ |= 0x00000020;
+            unfinishedTasks_ = input.readInt32();
             break;
           }
         }
@@ -254,6 +260,21 @@ private static final long serialVersionUID = 0L;
     return numActiveTasks_;
   }
 
+  public static final int UNFINISHEDTASKS_FIELD_NUMBER = 7;
+  private int unfinishedTasks_;
+  /**
+   * <code>optional int32 unfinishedTasks = 7;</code>
+   */
+  public boolean hasUnfinishedTasks() {
+    return ((bitField0_ & 0x00000020) == 0x00000020);
+  }
+  /**
+   * <code>optional int32 unfinishedTasks = 7;</code>
+   */
+  public int getUnfinishedTasks() {
+    return unfinishedTasks_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -283,6 +304,9 @@ private static final long serialVersionUID = 0L;
     }
     if (((bitField0_ & 0x00000010) == 0x00000010)) {
       output.writeInt32(6, numActiveTasks_);
+    }
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      output.writeInt32(7, unfinishedTasks_);
     }
     unknownFields.writeTo(output);
   }
@@ -316,6 +340,10 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000010) == 0x00000010)) {
       size += com.google.protobuf.CodedOutputStream
         .computeInt32Size(6, numActiveTasks_);
+    }
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt32Size(7, unfinishedTasks_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -360,6 +388,11 @@ private static final long serialVersionUID = 0L;
       result = result && (getNumActiveTasks()
           == other.getNumActiveTasks());
     }
+    result = result && (hasUnfinishedTasks() == other.hasUnfinishedTasks());
+    if (hasUnfinishedTasks()) {
+      result = result && (getUnfinishedTasks()
+          == other.getUnfinishedTasks());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -396,6 +429,10 @@ private static final long serialVersionUID = 0L;
     if (hasNumActiveTasks()) {
       hash = (37 * hash) + NUMACTIVETASKS_FIELD_NUMBER;
       hash = (53 * hash) + getNumActiveTasks();
+    }
+    if (hasUnfinishedTasks()) {
+      hash = (37 * hash) + UNFINISHEDTASKS_FIELD_NUMBER;
+      hash = (53 * hash) + getUnfinishedTasks();
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -538,6 +575,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000010);
       numActiveTasks_ = 0;
       bitField0_ = (bitField0_ & ~0x00000020);
+      unfinishedTasks_ = 0;
+      bitField0_ = (bitField0_ & ~0x00000040);
       return this;
     }
 
@@ -587,6 +626,10 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000010;
       }
       result.numActiveTasks_ = numActiveTasks_;
+      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        to_bitField0_ |= 0x00000020;
+      }
+      result.unfinishedTasks_ = unfinishedTasks_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -655,6 +698,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasNumActiveTasks()) {
         setNumActiveTasks(other.getNumActiveTasks());
+      }
+      if (other.hasUnfinishedTasks()) {
+        setUnfinishedTasks(other.getUnfinishedTasks());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -950,6 +996,38 @@ private static final long serialVersionUID = 0L;
     public Builder clearNumActiveTasks() {
       bitField0_ = (bitField0_ & ~0x00000020);
       numActiveTasks_ = 0;
+      onChanged();
+      return this;
+    }
+
+    private int unfinishedTasks_ ;
+    /**
+     * <code>optional int32 unfinishedTasks = 7;</code>
+     */
+    public boolean hasUnfinishedTasks() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional int32 unfinishedTasks = 7;</code>
+     */
+    public int getUnfinishedTasks() {
+      return unfinishedTasks_;
+    }
+    /**
+     * <code>optional int32 unfinishedTasks = 7;</code>
+     */
+    public Builder setUnfinishedTasks(int value) {
+      bitField0_ |= 0x00000040;
+      unfinishedTasks_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int32 unfinishedTasks = 7;</code>
+     */
+    public Builder clearUnfinishedTasks() {
+      bitField0_ = (bitField0_ & ~0x00000040);
+      unfinishedTasks_ = 0;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/JobWorkerHealthOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/JobWorkerHealthOrBuilder.java
@@ -69,4 +69,13 @@ public interface JobWorkerHealthOrBuilder extends
    * <code>optional int32 numActiveTasks = 6;</code>
    */
   int getNumActiveTasks();
+
+  /**
+   * <code>optional int32 unfinishedTasks = 7;</code>
+   */
+  boolean hasUnfinishedTasks();
+  /**
+   * <code>optional int32 unfinishedTasks = 7;</code>
+   */
+  int getUnfinishedTasks();
 }

--- a/job/common/src/test/java/alluxio/job/wire/JobWorkerHealthTest.java
+++ b/job/common/src/test/java/alluxio/job/wire/JobWorkerHealthTest.java
@@ -13,13 +13,19 @@ package alluxio.job.wire;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Lists;
 import org.junit.Test;
 
 public class JobWorkerHealthTest {
 
   @Test
   public void testToProto() {
-    JobWorkerHealth host = new JobWorkerHealth(1L, new double[]{0.0, 0.0, 0.1}, 10, 1, "host");
+    JobWorkerHealth host = new JobWorkerHealth(1L,
+        Lists.newArrayList(0.0, 0.0, 0.1),
+        10,
+        1,
+        1,
+        "host");
 
     JobWorkerHealth other = new JobWorkerHealth(host.toProto());
 

--- a/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
@@ -86,7 +86,8 @@ public class CommandHandlingExecutor implements HeartbeatExecutor {
   public void heartbeat() {
     JobWorkerHealth jobWorkerHealth = new JobWorkerHealth(JobWorkerIdRegistry.getWorkerId(),
         mHealthReporter.getCpuLoadAverage(), mTaskExecutorManager.getTaskExecutorPoolSize(),
-        mTaskExecutorManager.getNumActiveTasks(), mWorkerNetAddress.getHost());
+        mTaskExecutorManager.getNumActiveTasks(), mTaskExecutorManager.unfinishedTasks(),
+        mWorkerNetAddress.getHost());
 
     List<TaskInfo> taskStatusList = mTaskExecutorManager.getAndClearTaskUpdates();
 

--- a/job/server/src/main/java/alluxio/worker/job/command/JobWorkerHealthReporter.java
+++ b/job/server/src/main/java/alluxio/worker/job/command/JobWorkerHealthReporter.java
@@ -12,20 +12,24 @@
 package alluxio.worker.job.command;
 
 import oshi.SystemInfo;
-import oshi.hardware.CentralProcessor;
+import oshi.hardware.HardwareAbstractionLayer;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 
 /**
  * The job worker health reporter.
  */
 public class JobWorkerHealthReporter {
 
-  CentralProcessor mProcessor;
+  HardwareAbstractionLayer mHardware;
 
   /**
    * Default constructor.
    */
   public JobWorkerHealthReporter() {
-    mProcessor = new SystemInfo().getHardware().getProcessor();
+    mHardware = new SystemInfo().getHardware();
   }
 
   /**
@@ -34,7 +38,8 @@ public class JobWorkerHealthReporter {
    *
    * @return the system load average of the worker
    */
-  public double[] getCpuLoadAverage() {
-    return mProcessor.getSystemLoadAverage(3);
+  public List<Double> getCpuLoadAverage() {
+    return DoubleStream.of(mHardware.getProcessor().getSystemLoadAverage(3)).boxed()
+        .collect(Collectors.toList());
   }
 }

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
@@ -102,6 +102,13 @@ public class TaskExecutorManager {
   }
 
   /**
+   * @return number of unfinished tasks
+   */
+  public int unfinishedTasks() {
+    return mUnfinishedTasks.size();
+  }
+
+  /**
    * Notifies the completion of the task.
    *
    * @param jobId the job id

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -59,6 +59,8 @@ public class JobServiceMetricsCommand {
     for (JobWorkerHealth workerHealth : allWorkerHealth) {
       mPrintStream.print(String.format("Worker: %-10s  ", workerHealth.getHostname()));
       mPrintStream.print(String.format("Task Pool Size: %-7s", workerHealth.getTaskPoolSize()));
+      mPrintStream.print(String.format("Unfinished Tasks: %-7s",
+          workerHealth.getUnfinishedTasks()));
       mPrintStream.println(String.format("Load Avg: %s",
           StringUtils.join(workerHealth.getLoadAverage(), ", ")));
     }

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -59,7 +59,7 @@ public class JobServiceMetricsCommandTest {
   public void testBasic() throws IOException, ParseException {
 
     JobWorkerHealth jobWorkerHealth = new JobWorkerHealth(
-        1, new double[]{1.2, 0.9, 0.7}, 10, 2, "testHost");
+        1, Lists.newArrayList(1.2, 0.9, 0.7), 10, 2, 2, "testHost");
 
     Mockito.when(mJobMasterClient.getAllWorkerHealth())
         .thenReturn(Lists.newArrayList(jobWorkerHealth));
@@ -79,7 +79,8 @@ public class JobServiceMetricsCommandTest {
     String[] lineByLine = output.split("\n");
 
     // Worker Health Section
-    assertEquals("Worker: testHost    Task Pool Size: 10     Load Avg: 1.2, 0.9, 0.7",
+    assertEquals("Worker: testHost    Task Pool Size: 10     Unfinished Tasks: 10"
+        + "     Load Avg: 1.2, 0.9, 0.7",
         lineByLine[0]);
     assertEquals("", lineByLine[1]);
 

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -79,8 +79,8 @@ public class JobServiceMetricsCommandTest {
     String[] lineByLine = output.split("\n");
 
     // Worker Health Section
-    assertEquals("Worker: testHost    Task Pool Size: 10     Unfinished Tasks: 10"
-        + "     Load Avg: 1.2, 0.9, 0.7",
+    assertEquals("Worker: testHost    Task Pool Size: 10     Unfinished Tasks: 2"
+        + "      Load Avg: 1.2, 0.9, 0.7",
         lineByLine[0]);
     assertEquals("", lineByLine[1]);
 


### PR DESCRIPTION
But only print UnfinishedTasks to jobservice report.

➜  alluxio git:(queue_length) ✗ ./bin/alluxio fsadmin report jobservice
Worker: 10.0.0.65   Unfinished Tasks: 1      Load Avg: 5.7861328125, 3.99169921875, 3.75390625

Status: CREATED   Count: 128
Status: CANCELED  Count: 0
Status: FAILED    Count: 0
Status: RUNNING   Count: 1
Status: COMPLETED Count: 1477


- Note here that unfinished task of a worker only contains jobs that are in "RUNNING" but not in "CREATED". 
- The Unfinished Tasks here is not very interesting because there is only one worker and not many running. 
