### PR TITLE
Support using alluxio default block size when UFS is hadoop-compatible object storage filesystem

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
+++ b/core/common/src/main/java/alluxio/underfs/UfsFileStatus.java
@@ -24,6 +24,9 @@ public class UfsFileStatus extends UfsStatus {
   public static final String INVALID_CONTENT_HASH = "";
   public static final long UNKNOWN_BLOCK_SIZE = -1;
 
+  // if block size equals to MAGIC_BLOCK_SIZE, use alluxio.user.block.size.bytes.default instread
+  public static final long MAGIC_BLOCK_SIZE = 1;
+
   protected final String mContentHash;
   protected final long mContentLength;
   protected final long mBlockSize;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2490,6 +2490,14 @@ public final class DefaultFileSystemMaster extends CoreMaster
       ufsBlockSizeByte = blockSize != UfsFileStatus.UNKNOWN_BLOCK_SIZE
           ? blockSize : ufs.getBlockSizeByte(ufsUri.toString());
 
+      // When UFS is using hadoop-compatible FileSystem for object storage, Block size is a fake number.
+      // In this case, it is better to use alluxio default block size.
+      // you can set ufs default block size configuration to UfsFileStatus.MAGIC_BLOCK_SIZE
+      // to use same block size with alluxio setting.
+      if (ufsBlockSizeByte == UfsFileStatus.MAGIC_BLOCK_SIZE) {
+        ufsBlockSizeByte = ServerConfiguration.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+      }
+
       if (isAclEnabled()) {
         Pair<AccessControlList, DefaultAccessControlList> aclPair
             = ufs.getAclPair(ufsUri.toString());


### PR DESCRIPTION
### Background
Alluxio has 2 ways to use object storage as UFS.

 - Alluxio native interface: `alluxio.underfs.ObjectUnderFileSystem`
 - Hadoop-compatible FileSystem interface: `org.apache.hadoop.fs.FileSystem`

About block size, in `ObjectUnderFileSystem`, it is default using alluxio default block size (*alluxio.user.block.size.bytes.default*). In hadoop filesystem case, it is depend on different FileSystem implementation. For example, `S3AFileSystem` take configuration 'fs.s3a.block.size' as blocksize.
So when i use hadoop filesystem to access S3, i need configure *fs.s3a.block.size* not exact *alluxio.user.block.size.bytes.default* . 

This patch allows user config block size by *alluxio.user.block.size.bytes.default* even using `S3AFileSystem` as UFS.

### Config

in S3A case, ```fs.s3a.block.size=1```, `1` is magic number block size. which hint Alluxio to use `alluxio.user.block.size.bytes.default` as default block size.