### PR TITLE
Support session level connection management for leader election

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -495,7 +495,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-
+  public static final PropertyKey ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY =
+      new Builder(Name.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY)
+          .setDefaultValue("SESSION")
+          .setDescription("Connection error policy defines how errors on zookeeper connections "
+              + "to be treated in leader election. "
+              + "STANDARD policy treats every connection event as failure."
+              + "SESSION policy relies on zookeeper sessions for judging failures, "
+              + "helping leader to retain its status, as long as its session is protected.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
   /**
    * UFS related properties.
    *
@@ -3270,6 +3280,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String ZOOKEEPER_LEADER_PATH = "alluxio.zookeeper.leader.path";
     public static final String ZOOKEEPER_SESSION_TIMEOUT = "alluxio.zookeeper.session.timeout";
     public static final String ZOOKEEPER_AUTH_ENABLED = "alluxio.zookeeper.auth.enabled";
+    public static final String ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY =
+        "alluxio.zookeeper.leader.connection.error.policy";
 
     //
     // UFS related properties

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -48,6 +48,8 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_RESTORE_SINGLE = allocate(1, 1);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(1, 1);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);
+  public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_SESSION = allocate(2, 0);
 
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
     int needed = numMasters * MultiProcessCluster.PORTS_PER_MASTER

--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -11,7 +11,9 @@
 
 package alluxio.server.ft;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
@@ -40,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Integration tests for Alluxio high availability when Zookeeper has failures.
@@ -114,6 +117,63 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
     mCluster.notifySuccess();
   }
 
+  @Test
+  public void zkConnectionPolicy_Standard() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_CONNECTION_POLICY_STANDARD)
+        .setClusterName("ZookeeperConnectionPolicy_Standard")
+        .setDeployMode(DeployMode.ZOOKEEPER_HA)
+        .setNumMasters(2)
+        .setNumWorkers(0)
+        .addProperty(PropertyKey.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY, "STANDARD")
+        .build();
+    mCluster.start();
+
+    int leaderIdx = getPrimaryMasterIndex();
+    mCluster.restartZk();
+    // Leader will step down under STANDARD connection error policy.
+    int leaderIdx2 = getPrimaryMasterIndex();
+    assertNotEquals(leaderIdx, leaderIdx2);
+
+    mCluster.notifySuccess();
+  }
+
+  @Test
+  public void zkConnectionPolicy_Session() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_CONNECTION_POLICY_SESSION)
+        .setClusterName("ZookeeperConnectionPolicy_Session")
+        .setDeployMode(DeployMode.ZOOKEEPER_HA)
+        .setNumMasters(2)
+        .setNumWorkers(0)
+        .addProperty(PropertyKey.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY, "SESSION")
+        .build();
+    mCluster.start();
+
+    int leaderIdx = getPrimaryMasterIndex();
+    mCluster.restartZk();
+    // Leader will retain its status under SESSION connection error policy.
+    int leaderIdx2 = getPrimaryMasterIndex();
+    assertEquals(leaderIdx, leaderIdx2);
+
+    mCluster.notifySuccess();
+  }
+
+  /**
+   * Used to get primary master index with retries for when zk server is down.
+   */
+  private int getPrimaryMasterIndex() throws Exception {
+    AtomicInteger primaryIndex = new AtomicInteger();
+    CommonUtils.waitFor("Getting primary master index", () -> {
+      try {
+        primaryIndex.set(mCluster.getPrimaryMasterIndex(30000));
+        return true;
+      } catch (Exception e) {
+        LOG.warn("Could not get primary master index.", e);
+        return false;
+      }
+    });
+
+    return primaryIndex.get();
+  }
   /*
    * This method uses a client with an explicit master address to ensure that the master has shut
    * down its rpc service.


### PR DESCRIPTION
Curator has 2 policies for managing zookeeper client state when
connection errors happen.
- STANDARD; is finicky and treats leader state as dirty after any
connection state change.
- SESSION; is for more stable leadership state as it leverages internal
zookeeper session Ids.
Curator comes with STANDARD policy as default.

This PR makes this setting configurable.

pr-link: Alluxio/alluxio#10483
change-id: cid-8aa2e2cffeed6deb0bb652bbbb22013c99f483b8