### PR TITLE
Remove synchronization on mOpenFiles in AlluxioFuseFileSystem

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -684,8 +684,8 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
     }
     try {
       mFileSystem.rename(oldUri, newUri);
-      if (mOpenFiles.contains(PATH_INDEX, oldPath)) {
-        OpenFileEntry oe = mOpenFiles.getFirstByField(PATH_INDEX, oldPath);
+      OpenFileEntry oe = mOpenFiles.getFirstByField(PATH_INDEX, oldPath);
+      if (oe != null) {
         oe.setPath(newPath);
       }
     } catch (FileDoesNotExistException e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -306,7 +306,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
           CreateFilePOptions.newBuilder()
               .setMode(new alluxio.security.authorization.Mode((short) mode).toProto())
               .build());
-      long fid = mNextOpenFileId.getAndAdd(1);
+      long fid = mNextOpenFileId.getAndIncrement();
       mOpenFiles.add(new OpenFileEntry(fid, path, null, os));
       fi.fh.set(fid);
       if (gid != GID || uid != UID) {
@@ -524,7 +524,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
       }
 
       FileInStream is = mFileSystem.openFile(uri);
-      long fid = mNextOpenFileId.getAndAdd(1);
+      long fid = mNextOpenFileId.getAndIncrement();
       mOpenFiles.add(new OpenFileEntry(fid, path, is, null));
       fi.fh.set(fid);
     } catch (FileDoesNotExistException | InvalidPathException e) {


### PR DESCRIPTION
Some code paths synchronize on mOpenFiles.
For one case, the synchronization can be replaced by an AtomicLong.
For other cases, removing the synchronization won't affect thread-safety.