### PR TITLE
Add CachingFileSystem

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -125,6 +125,7 @@ public enum ExceptionMessage {
   FAILED_RAFT_CONNECT("Failed to connect to raft cluster with addresses {0}: {1}"),
 
   // file
+  CANNOT_READ_INCOMPLETE_FILE("Cannot read from {0} because it is incomplete"),
   CANNOT_READ_DIRECTORY("Cannot read from {0} because it is a directory"),
   DELETE_FAILED_DIR_CHILDREN(
       "Cannot delete directory {0}. Failed to delete children: {1}"),

--- a/core/base/src/main/java/alluxio/exception/FileIncompleteException.java
+++ b/core/base/src/main/java/alluxio/exception/FileIncompleteException.java
@@ -1,0 +1,74 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+import alluxio.AlluxioURI;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The exception thrown when opening a file that hasn't completed.
+ */
+@ThreadSafe
+public class FileIncompleteException extends AlluxioException {
+  private static final long serialVersionUID = -4892636367696520754L;
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public FileIncompleteException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause
+   */
+  public FileIncompleteException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message and multiple parameters.
+   *
+   * @param message the exception message
+   * @param params the parameters
+   */
+  public FileIncompleteException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message, the cause and multiple
+   * parameters.
+   *
+   * @param message the exception message
+   * @param cause the cause
+   * @param params the parameters
+   */
+  public FileIncompleteException(ExceptionMessage message, Throwable cause, Object... params) {
+    this(message.getMessage(params), cause);
+  }
+
+  /**
+   * Constructs a new exception stating that the given file is incomplete.
+   *
+   * @param path the path to the incomplete file
+   */
+  public FileIncompleteException(AlluxioURI path) {
+    this(ExceptionMessage.CANNOT_READ_INCOMPLETE_FILE.getMessage(path));
+  }
+}

--- a/core/base/src/main/java/alluxio/exception/OpenDirectoryException.java
+++ b/core/base/src/main/java/alluxio/exception/OpenDirectoryException.java
@@ -1,0 +1,74 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+import alluxio.AlluxioURI;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The exception thrown when trying to call openFile on a directory.
+ */
+@ThreadSafe
+public class OpenDirectoryException extends AlluxioException {
+  private static final long serialVersionUID = 1101354870166829139L;
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public OpenDirectoryException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause
+   */
+  public OpenDirectoryException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message and multiple parameters.
+   *
+   * @param message the exception message
+   * @param params the parameters
+   */
+  public OpenDirectoryException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message, the cause and multiple
+   * parameters.
+   *
+   * @param message the exception message
+   * @param cause the cause
+   * @param params the parameters
+   */
+  public OpenDirectoryException(ExceptionMessage message, Throwable cause, Object... params) {
+    this(message.getMessage(params), cause);
+  }
+
+  /**
+   * Constructs a new exception stating that the given directory cannot be opened for reading.
+   *
+   * @param path the path to the directory
+   */
+  public OpenDirectoryException(AlluxioURI path) {
+    this(ExceptionMessage.CANNOT_READ_DIRECTORY.getMessage(path));
+  }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -456,6 +456,23 @@ public class BaseFileSystem implements FileSystem {
   }
 
   @Override
+  public FileInStream openFile(URIStatus status)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    return openFile(status, OpenFilePOptions.getDefaultInstance());
+  }
+
+  @Override
+  public FileInStream openFile(URIStatus status, OpenFilePOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    AlluxioURI path = new AlluxioURI(status.getPath());
+    AlluxioConfiguration conf = mFsContext.getPathConf(path);
+    OpenFilePOptions mergedOptions = FileSystemOptions.openFileDefaults(conf)
+        .toBuilder().mergeFrom(options).build();
+    InStreamOptions inStreamOptions = new InStreamOptions(status, mergedOptions, conf);
+    return new FileInStream(status, inStreamOptions, mFsContext);
+  }
+
+  @Override
   public void rename(AlluxioURI src, AlluxioURI dst)
       throws FileDoesNotExistException, IOException, AlluxioException {
     rename(src, dst, RenamePOptions.getDefaultInstance());

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -497,7 +497,7 @@ public class BaseFileSystem implements FileSystem {
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     AlluxioURI path = new AlluxioURI(status.getPath());
-    if (options.hasUpdateLastAccessTime()) {
+    if (options.getUpdateLastAccessTime()) {
       asyncUpdateFileAccessTime(path);
     }
     AlluxioConfiguration conf = mFsContext.getPathConf(path);

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -457,25 +457,6 @@ public class BaseFileSystem implements FileSystem {
     return openFile(path, OpenFilePOptions.getDefaultInstance());
   }
 
-  private void updateFileAccessTime(AlluxioURI path) throws IOException, AlluxioException {
-    AlluxioConfiguration conf = mFsContext.getPathConf(path);
-    GetStatusPOptions getStatusOptions = FileSystemOptions.getStatusDefaults(conf).toBuilder()
-        .setAccessMode(Bits.READ)
-        .setUpdateTimestamps(true)
-        .build();
-    getStatusThroughRPC(path, getStatusOptions);
-  }
-
-  private void asyncUpdateFileAccessTime(AlluxioURI path) {
-    mAccessTimeUpdater.submit(() -> {
-      try {
-        updateFileAccessTime(path);
-      } catch (IOException | AlluxioException e) {
-        LOG.error("Failed to update access time for file " + path, e);
-      }
-    });
-  }
-
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
@@ -640,6 +621,25 @@ public class BaseFileSystem implements FileSystem {
       client.unmount(path);
       LOG.debug("Unmounted {}, options: {}", path.getPath(), mergedOptions);
       return null;
+    });
+  }
+
+  private void updateFileAccessTime(AlluxioURI path) throws IOException, AlluxioException {
+    AlluxioConfiguration conf = mFsContext.getPathConf(path);
+    GetStatusPOptions getStatusOptions = FileSystemOptions.getStatusDefaults(conf).toBuilder()
+        .setAccessMode(Bits.READ)
+        .setUpdateTimestamps(true)
+        .build();
+    getStatusThroughRPC(path, getStatusOptions);
+  }
+
+  private void asyncUpdateFileAccessTime(AlluxioURI path) {
+    mAccessTimeUpdater.submit(() -> {
+      try {
+        updateFileAccessTime(path);
+      } catch (IOException | AlluxioException e) {
+        LOG.error("Failed to update access time for file " + path, e);
+      }
     });
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -124,7 +124,9 @@ public class BaseFileSystem implements FileSystem {
     mCachingEnabled = cachingEnabled;
     if (mFsContext.getClusterConf().getBoolean(PropertyKey.USER_METADATA_CACHE_ENABLED)) {
       int maxSize = mFsContext.getClusterConf().getInt(PropertyKey.USER_METADATA_CACHE_MAX_SIZE);
-      mMetadataCache = new MetadataCache(this, maxSize);
+      long expirationTimeMs = mFsContext.getClusterConf()
+          .getMs(PropertyKey.USER_METADATA_CACHE_EXPIRATION_TIME);
+      mMetadataCache = new MetadataCache(this, maxSize, expirationTimeMs);
     } else {
       mMetadataCache = null;
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
@@ -1,0 +1,125 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.grpc.Bits;
+import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.util.FileSystemOptions;
+import alluxio.util.ThreadUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * FileSystem implementation with the capability of caching metadata of paths.
+ */
+@ThreadSafe
+public class CachingFileSystem extends BaseFileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseFileSystem.class);
+  private static final int THREAD_KEEPALIVE_SECOND = 60;
+  private static final int THREAD_TERMINATION_TIMEOUT_MS = 10000;
+
+  private final MetadataCache mMetadataCache;
+  private final ExecutorService mAccessTimeUpdater;
+
+  /**
+   * @param context the fs context
+   * @param cachingEnabled enables caching
+   */
+  public CachingFileSystem(FileSystemContext context, boolean cachingEnabled) {
+    super(context, cachingEnabled);
+
+    int maxSize = mFsContext.getClusterConf().getInt(PropertyKey.USER_METADATA_CACHE_MAX_SIZE);
+    long expirationTimeMs = mFsContext.getClusterConf()
+        .getMs(PropertyKey.USER_METADATA_CACHE_EXPIRATION_TIME);
+    mMetadataCache = new MetadataCache(maxSize, expirationTimeMs);
+    int masterClientThreads = mFsContext.getClusterConf()
+        .getInt(PropertyKey.USER_FILE_MASTER_CLIENT_THREADS);
+    // At a time point, there are at most the same number of concurrent master clients that
+    // asynchronously update access time.
+    mAccessTimeUpdater = new ThreadPoolExecutor(0, masterClientThreads, THREAD_KEEPALIVE_SECOND,
+        TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @Override
+  public URIStatus getStatus(AlluxioURI path, GetStatusPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    checkUri(path);
+    URIStatus status = mMetadataCache.get(path);
+    if (status == null) {
+      status = super.getStatus(path, options);
+      mMetadataCache.put(path, status);
+    } else if (options.getUpdateTimestamps()) {
+      // Asynchronously send an RPC to master to update the access time.
+      // Otherwise, if we need to synchronously send RPC to master to do this,
+      // caching the status does not bring any benefit.
+      asyncUpdateFileAccessTime(path);
+    }
+    return status;
+  }
+
+  @Override
+  public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    checkUri(path);
+    List<URIStatus> statuses = super.listStatus(path, options);
+    for (URIStatus status : statuses) {
+      mMetadataCache.put(status.getPath(), status);
+    }
+    return statuses;
+  }
+
+  /**
+   * Asynchronously update file's last access time.
+   *
+   * @param path the path to the file
+   */
+  @VisibleForTesting
+  public void asyncUpdateFileAccessTime(AlluxioURI path) {
+    mAccessTimeUpdater.submit(() -> {
+      try {
+        AlluxioConfiguration conf = mFsContext.getPathConf(path);
+        GetStatusPOptions getStatusOptions = FileSystemOptions.getStatusDefaults(conf).toBuilder()
+            .setAccessMode(Bits.READ)
+            .setUpdateTimestamps(true)
+            .build();
+        super.getStatus(path, getStatusOptions);
+      } catch (IOException | AlluxioException e) {
+        LOG.error("Failed to update access time for file " + path, e);
+      }
+    });
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    if (!mClosed) {
+      ThreadUtils.shutdownAndAwaitTermination(mAccessTimeUpdater, THREAD_TERMINATION_TIMEOUT_MS);
+      super.close();
+    }
+  }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -479,6 +479,14 @@ public interface FileSystem extends Closeable {
   FileInStream openFile(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
+  /*
+   * @param status the file status
+   * @return a {@link FileInStream} for the given path
+   * @throws FileDoesNotExistException if the given file does not exist
+   */
+  FileInStream openFile(URIStatus status)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
   /**
    * Opens a file for reading.
    *
@@ -488,6 +496,15 @@ public interface FileSystem extends Closeable {
    * @throws FileDoesNotExistException if the given file does not exist
    */
   FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
+  /**
+   * @param status the file status
+   * @param options options to associate with this operation
+   * @return a {@link FileInStream} for the given path
+   * @throws FileDoesNotExistException if the given file does not exist
+   */
+  FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -479,14 +479,6 @@ public interface FileSystem extends Closeable {
   FileInStream openFile(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
-  /*
-   * @param status the file status
-   * @return a {@link FileInStream} for the given path
-   * @throws FileDoesNotExistException if the given file does not exist
-   */
-  FileInStream openFile(URIStatus status)
-      throws FileDoesNotExistException, IOException, AlluxioException;
-
   /**
    * Opens a file for reading.
    *
@@ -499,6 +491,18 @@ public interface FileSystem extends Closeable {
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**
+   * Convenience method for {@link #openFile(URIStatus, OpenFilePOptions)} with default options.
+   *
+   * @param status the file status
+   * @return a {@link FileInStream} for the given path
+   * @throws FileDoesNotExistException if the given file does not exist
+   */
+  FileInStream openFile(URIStatus status)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
+  /**
+   * Opens a file for reading.
+   *
    * @param status the file status
    * @param options options to associate with this operation
    * @return a {@link FileInStream} for the given path

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -1,0 +1,101 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.AlluxioURI;
+import alluxio.collections.ConcurrentHashSet;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ListStatusPOptions;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Cache for metadata of files.
+ */
+public final class MetadataCache {
+  private final BaseFileSystem mFs;
+  private final Cache<String, URIStatus> mCache;
+  private final ConcurrentHashSet<AlluxioURI> mLoadingDirectories = new ConcurrentHashSet<>();
+
+  /**
+   * @param fs the fs client
+   * @param maxSize the max size of the cache
+   */
+  public MetadataCache(BaseFileSystem fs, int maxSize) {
+    mFs = fs;
+    mCache = CacheBuilder.newBuilder().maximumSize(maxSize).build();
+  }
+
+  /**
+   * If file status is cached, return the cached status.
+   * Otherwise, issue an RPC to master to get the status, then the status is cached.
+   *
+   * @param file the file
+   * @param options the options
+   * @return the file status
+   */
+  public URIStatus getStatus(AlluxioURI file, GetStatusPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    try {
+      return mCache.get(file.getPath(), () -> {
+        AlluxioURI directory = file.getParent();
+        URIStatus fileStatus = null;
+        if (mLoadingDirectories.addIfAbsent(directory)) {
+          try {
+            List<URIStatus> statuses = mFs.listStatusThroughRPC(directory,
+                ListStatusPOptions.getDefaultInstance());
+            for (URIStatus status : statuses) {
+              if (status.getPath().equals(file.getPath())) {
+                fileStatus = status;
+              }
+              mCache.put(status.getPath(), status);
+            }
+          } finally {
+            mLoadingDirectories.remove(directory);
+          }
+        }
+        return fileStatus == null ? mFs.getStatusThroughRPC(file, options) : fileStatus;
+      });
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof FileDoesNotExistException) {
+        throw (FileDoesNotExistException) e.getCause();
+      }
+      if (e.getCause() instanceof AlluxioException) {
+        throw (AlluxioException) e.getCause();
+      }
+      throw new IOException(e.getCause());
+    }
+  }
+
+  /**
+   * Issues an RPC to master to list the status of the directory, and cache the results.
+   *
+   * @param directory the directory
+   * @param options the options
+   * @return the list of statuses
+   */
+  public List<URIStatus> listStatus(AlluxioURI directory, ListStatusPOptions options)
+      throws IOException, AlluxioException {
+    List<URIStatus> statuses = mFs.listStatusThroughRPC(directory, options);
+    for (URIStatus status : statuses) {
+      mCache.put(status.getPath(), status);
+    }
+    return statuses;
+  }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -23,6 +23,7 @@ import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Cache for metadata of files.
@@ -34,10 +35,14 @@ public final class MetadataCache {
   /**
    * @param fs the fs client
    * @param maxSize the max size of the cache
+   * @param expirationTimeMs the expiration time (in milliseconds) of the cached item
    */
-  public MetadataCache(BaseFileSystem fs, int maxSize) {
+  public MetadataCache(BaseFileSystem fs, int maxSize, long expirationTimeMs) {
     mFs = fs;
-    mCache = CacheBuilder.newBuilder().maximumSize(maxSize).build();
+    mCache = CacheBuilder.newBuilder()
+        .maximumSize(maxSize)
+        .expireAfterWrite(expirationTimeMs, TimeUnit.MILLISECONDS)
+        .build();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -412,7 +412,7 @@ public final class BaseFileSystemTest {
   @Test
   public void openFile() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    URIStatus status = new URIStatus(new FileInfo());
+    URIStatus status = new URIStatus(new FileInfo().setCompleted(true));
     GetStatusPOptions getStatusOptions = getOpenOptions(GetStatusPOptions.getDefaultInstance());
     when(mFileSystemMasterClient.getStatus(file, getStatusOptions))
         .thenReturn(status);

--- a/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
@@ -21,10 +21,12 @@ import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
+import alluxio.grpc.Bits;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.resource.CloseableResource;
+import alluxio.util.FileSystemOptions;
 import alluxio.wire.FileInfo;
 
 import org.junit.After;
@@ -108,6 +110,16 @@ public class CachingFileSystemTest {
     verifyGetStatusThroughRPC(FILE, 1);
     // File status has been cached, will try to asynchronously update the file's access time.
     mFs.openFile(FILE, OpenFilePOptions.getDefaultInstance());
+    verify(mFs, times(1)).asyncUpdateFileAccessTime(FILE);
+  }
+
+  @Test
+  public void updateAccessTimeOfCachedFile() throws Exception {
+    mFs.getStatus(FILE, GET_STATUS_OPTIONS);
+    mFs.getStatus(FILE, FileSystemOptions.getStatusDefaults(mConf).toBuilder()
+        .setAccessMode(Bits.READ)
+        .setUpdateTimestamps(true)
+        .build());
     verify(mFs, times(1)).asyncUpdateFileAccessTime(FILE);
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
@@ -1,0 +1,123 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import alluxio.AlluxioURI;
+import alluxio.ClientContext;
+import alluxio.ConfigurationTestUtils;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.resource.CloseableResource;
+import alluxio.wire.FileInfo;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileSystemContext.class, FileSystemMasterClient.class})
+public class CachingFileSystemTest {
+  private static final AlluxioURI DIR = new AlluxioURI("/dir");
+  private static final AlluxioURI FILE = new AlluxioURI("/dir/file");
+  private static final GetStatusPOptions GET_STATUS_OPTIONS =
+      GetStatusPOptions.getDefaultInstance();
+  private static final ListStatusPOptions LIST_STATUS_OPTIONS =
+      ListStatusPOptions.getDefaultInstance();
+  private static final URIStatus FILE_STATUS = new URIStatus(
+      new FileInfo().setPath(FILE.getPath()).setCompleted(true));
+
+  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private FileSystemContext mFileContext;
+  private ClientContext mClientContext;
+  private FileSystemMasterClient mFileSystemMasterClient;
+  private CachingFileSystem mFs;
+
+  @Before
+  public void before() throws Exception {
+    mClientContext = ClientContext.create(mConf);
+    mFileContext = PowerMockito.mock(FileSystemContext.class);
+    mFileSystemMasterClient = PowerMockito.mock(FileSystemMasterClient.class);
+    when(mFileContext.acquireMasterClientResource()).thenReturn(
+        new CloseableResource<FileSystemMasterClient>(mFileSystemMasterClient) {
+          @Override
+          public void close() {
+            // Noop.
+          }
+        });
+    when(mFileSystemMasterClient.listStatus(eq(DIR), any(ListStatusPOptions.class)))
+        .thenReturn(Arrays.asList(FILE_STATUS));
+    when(mFileSystemMasterClient.getStatus(eq(FILE), any(GetStatusPOptions.class)))
+        .thenReturn(FILE_STATUS);
+    when(mFileContext.getClientContext()).thenReturn(mClientContext);
+    when(mFileContext.getClusterConf()).thenReturn(mConf);
+    when(mFileContext.getPathConf(any())).thenReturn(mConf);
+    when(mFileContext.getUriValidationEnabled()).thenReturn(true);
+    mFs = Mockito.spy(new CachingFileSystem(mFileContext, false));
+  }
+
+  @After
+  public void after() {
+    mConf = ConfigurationTestUtils.defaults();
+  }
+
+  @Test
+  public void getStatus() throws Exception {
+    mFs.getStatus(FILE, GET_STATUS_OPTIONS);
+    verifyGetStatusThroughRPC(FILE, 1);
+    // The following getStatus gets from cache, so no RPC will be made.
+    mFs.getStatus(FILE, GET_STATUS_OPTIONS);
+    verifyGetStatusThroughRPC(FILE, 1);
+  }
+
+  @Test
+  public void listStatus() throws Exception {
+    mFs.listStatus(DIR, LIST_STATUS_OPTIONS);
+    verifyListStatusThroughRPC(DIR, 1);
+    // List status has cached the file status, so no RPC will be made.
+    mFs.getStatus(FILE, GET_STATUS_OPTIONS);
+    verifyGetStatusThroughRPC(FILE, 0);
+  }
+
+  @Test
+  public void openFile() throws Exception {
+    mFs.openFile(FILE, OpenFilePOptions.getDefaultInstance());
+    verifyGetStatusThroughRPC(FILE, 1);
+    // File status has been cached, will try to asynchronously update the file's access time.
+    mFs.openFile(FILE, OpenFilePOptions.getDefaultInstance());
+    verify(mFs, times(1)).asyncUpdateFileAccessTime(FILE);
+  }
+
+  private void verifyGetStatusThroughRPC(AlluxioURI path, int totalTimes) throws Exception {
+    verify(mFileSystemMasterClient, times(totalTimes))
+        .getStatus(eq(path), any(GetStatusPOptions.class));
+  }
+
+  private void verifyListStatusThroughRPC(AlluxioURI path, int totalTimes) throws Exception {
+    verify(mFileSystemMasterClient, times(totalTimes))
+        .listStatus(eq(path), any(ListStatusPOptions.class));
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCacheTest.java
@@ -1,0 +1,98 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import alluxio.AlluxioURI;
+import alluxio.wire.FileInfo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BaseFileSystem.class})
+public class MetadataCacheTest {
+  private static final AlluxioURI FILE = new AlluxioURI("/file");
+  private static final URIStatus FILE_STATUS =
+      new URIStatus(new FileInfo().setPath(FILE.getPath()));
+  private static final AlluxioURI DIR = new AlluxioURI("/dir");
+  private static final URIStatus DIR_STATUS =
+      new URIStatus(new FileInfo().setPath(DIR.getPath()));
+  private static final AlluxioURI DIR_FILE = new AlluxioURI("/dir/file");
+  private static final URIStatus DIR_FILE_STATUS =
+      new URIStatus(new FileInfo().setPath(DIR_FILE.getPath()));
+
+  private MetadataCache mCache;
+
+  @Test
+  public void putAndGet() {
+    mCache = new MetadataCache(100, Long.MAX_VALUE);
+    assertEquals(0, mCache.size());
+
+    mCache.put(FILE, FILE_STATUS);
+    assertEquals(1, mCache.size());
+    assertContain(FILE);
+
+    mCache.put(DIR, DIR_STATUS);
+    assertEquals(2, mCache.size());
+    assertContain(FILE);
+    assertContain(DIR);
+
+    mCache.put(DIR_FILE, DIR_FILE_STATUS);
+    assertEquals(3, mCache.size());
+    assertContain(FILE);
+    assertContain(DIR);
+    assertContain(DIR_FILE);
+  }
+
+  @Test
+  public void expire() throws Exception {
+    // after writing to cache, expire after 1ms.
+    mCache = new MetadataCache(100, 1);
+    assertEquals(0, mCache.size());
+
+    mCache.put(FILE, FILE_STATUS);
+
+    Thread.sleep(2);
+    // slept for 2ms, the cached item has expired.
+    assertNotContain(FILE);
+  }
+
+  @Test
+  public void evict() {
+    // cache capacity is 1, evict the first cached item when the second is written.
+    mCache = new MetadataCache(1, Long.MAX_VALUE);
+    assertEquals(0, mCache.size());
+
+    mCache.put(FILE, FILE_STATUS);
+    assertContain(FILE);
+
+    assertNotContain(DIR_FILE);
+    mCache.put(DIR_FILE, DIR_FILE_STATUS);
+    assertContain(DIR_FILE);
+    // FILE is evicted due to capacity limit.
+    assertNotContain(FILE);
+  }
+
+  private void assertContain(AlluxioURI path) {
+    assertNotNull(mCache.get(path));
+  }
+
+  private void assertNotContain(AlluxioURI path) {
+    assertNull(mCache.get(path));
+  }
+}

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3306,37 +3306,29 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_DIRECT_MEMORY_IO_ENABLED =
-      new Builder(Name.USER_DIRECT_MEMORY_IO_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("If this is enabled, when clients read from local worker, they read "
-              + "the block directly from the first directory of the first tier of that worker.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
-          .build();
   public static final PropertyKey USER_METADATA_CACHE_ENABLED =
       new Builder(Name.USER_METADATA_CACHE_ENABLED)
           .setDefaultValue(false)
-          .setDescription("If this is enabled, metadata of files will be cached. "
+          .setDescription("If this is enabled, metadata of paths will be cached. "
               + "The cached metadata will be evicted when it expires after "
-              + Name.USER_METADATA_CACHE_EXPIRATION_TIME + " or the cache size is over the limit. "
-              + "So this should only be enabled when the files and directories are immutable "
-              + "during the lifecycle of the client.")
+              + Name.USER_METADATA_CACHE_EXPIRATION_TIME
+              + " or the cache size is over the limit of "
+              + Name.USER_METADATA_CACHE_MAX_SIZE + ".")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_METADATA_CACHE_MAX_SIZE =
       new Builder(Name.USER_METADATA_CACHE_MAX_SIZE)
           .setDefaultValue(100000)
-          .setDescription("Maximum number of files to cache the metadata.")
+          .setDescription("Maximum number of paths with cached metadata.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_METADATA_CACHE_EXPIRATION_TIME =
       new Builder(Name.USER_METADATA_CACHE_EXPIRATION_TIME)
           .setDefaultValue("10min")
-          .setDescription("When the metadata for a file is cached, it will expire after this "
-              + "configured time period.")
+          .setDescription("Metadata will expire and be evicted after being cached for this time "
+              + "period.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
@@ -4465,8 +4457,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_SHORT_CIRCUIT_ENABLED = "alluxio.user.short.circuit.enabled";
     public static final String USER_WORKER_LIST_REFRESH_INTERVAL =
         "alluxio.user.worker.list.refresh.interval";
-    public static final String USER_DIRECT_MEMORY_IO_ENABLED =
-        "alluxio.user.direct.memory.io.enabled";
     public static final String USER_METADATA_CACHE_ENABLED =
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3318,7 +3318,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.USER_METADATA_CACHE_ENABLED)
           .setDefaultValue(false)
           .setDescription("If this is enabled, metadata of files will be cached. "
-              + "The cached metadata will be evicted only when the cache size is over the limit. "
+              + "The cached metadata will be evicted when it expires after "
+              + Name.USER_METADATA_CACHE_EXPIRATION_TIME + " or the cache size is over the limit. "
               + "So this should only be enabled when the files and directories are immutable "
               + "during the lifecycle of the client.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
@@ -3328,6 +3329,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.USER_METADATA_CACHE_MAX_SIZE)
           .setDefaultValue(100000)
           .setDescription("Maximum number of files to cache the metadata.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_METADATA_CACHE_EXPIRATION_TIME =
+      new Builder(Name.USER_METADATA_CACHE_EXPIRATION_TIME)
+          .setDefaultValue("10min")
+          .setDescription("When the metadata for a file is cached, it will expire after this "
+              + "configured time period.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
@@ -4462,6 +4471,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =
         "alluxio.user.metadata.cache.max.size";
+    public static final String USER_METADATA_CACHE_EXPIRATION_TIME =
+        "alluxio.user.metadata.cache.expiration.time";
 
     //
     // FUSE integration related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3306,6 +3306,31 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_DIRECT_MEMORY_IO_ENABLED =
+      new Builder(Name.USER_DIRECT_MEMORY_IO_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("If this is enabled, when clients read from local worker, they read "
+              + "the block directly from the first directory of the first tier of that worker.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_METADATA_CACHE_ENABLED =
+      new Builder(Name.USER_METADATA_CACHE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("If this is enabled, metadata of files will be cached. "
+              + "The cached metadata will be evicted only when the cache size is over the limit. "
+              + "So this should only be enabled when the files and directories are immutable "
+              + "during the lifecycle of the client.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_METADATA_CACHE_MAX_SIZE =
+      new Builder(Name.USER_METADATA_CACHE_MAX_SIZE)
+          .setDefaultValue(100000)
+          .setDescription("Maximum number of files to cache the metadata.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
 
   //
   // FUSE integration related properties
@@ -4431,6 +4456,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_SHORT_CIRCUIT_ENABLED = "alluxio.user.short.circuit.enabled";
     public static final String USER_WORKER_LIST_REFRESH_INTERVAL =
         "alluxio.user.worker.list.refresh.interval";
+    public static final String USER_DIRECT_MEMORY_IO_ENABLED =
+        "alluxio.user.direct.memory.io.enabled";
+    public static final String USER_METADATA_CACHE_ENABLED =
+        "alluxio.user.metadata.cache.enabled";
+    public static final String USER_METADATA_CACHE_MAX_SIZE =
+        "alluxio.user.metadata.cache.max.size";
 
     //
     // FUSE integration related properties

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -527,7 +527,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
         return ErrorCodes.EMFILE();
       }
 
-      FileInStream is = mFileSystem.openFile(uri);
+      FileInStream is = mFileSystem.openFile(status);
       synchronized (mOpenFiles) {
         mOpenFiles.add(new OpenFileEntry(mNextOpenFileId, path, is, null));
         fi.fh.set(mNextOpenFileId);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -25,6 +25,8 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.FileIncompleteException;
+import alluxio.exception.OpenDirectoryException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -505,35 +507,37 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
     // File creation flags are the last two bits of flags
     final int flags = fi.flags.get();
     LOG.trace("open({}, 0x{}) [Alluxio: {}]", path, Integer.toHexString(flags), uri);
-
+    if (mOpenFiles.size() >= MAX_OPEN_FILES) {
+      LOG.error("Cannot open {}: too many open files (MAX_OPEN_FILES: {})", path, MAX_OPEN_FILES);
+      return ErrorCodes.EMFILE();
+    }
+    FileInStream is;
     try {
-      final URIStatus status = mFileSystem.getStatus(uri);
-      if (status.isFolder()) {
-        LOG.error("Cannot open folder {}", path);
-        return -ErrorCodes.EISDIR();
+      try {
+        is = mFileSystem.openFile(uri);
+      } catch (FileIncompleteException e) {
+        if (waitForFileCompleted(uri)) {
+          is = mFileSystem.openFile(uri);
+        } else {
+          throw e;
+        }
       }
-
-      if (!status.isCompleted() && !waitForFileCompleted(uri)) {
-        LOG.error("Cannot open incomplete folder {}", path);
-        return -ErrorCodes.EFAULT();
-      }
-
-      if (mOpenFiles.size() >= MAX_OPEN_FILES) {
-        LOG.error("Cannot open {}: too many open files (MAX_OPEN_FILES: {})", path, MAX_OPEN_FILES);
-        return ErrorCodes.EMFILE();
-      }
-
-      FileInStream is = mFileSystem.openFile(status);
-      long fid = mNextOpenFileId.getAndIncrement();
-      mOpenFiles.add(new OpenFileEntry(fid, path, is, null));
-      fi.fh.set(fid);
+    } catch (OpenDirectoryException e) {
+      LOG.error("Cannot open folder {}", path);
+      return -ErrorCodes.EISDIR();
+    } catch (FileIncompleteException e) {
+      LOG.error("Cannot open incomplete file {}", path);
+      return -ErrorCodes.EFAULT();
     } catch (FileDoesNotExistException | InvalidPathException e) {
-      LOG.debug("Failed to open file {}, path does not exist or is invalid", path);
+      LOG.error("Failed to open file {}, path does not exist or is invalid", path);
       return -ErrorCodes.ENOENT();
     } catch (Throwable t) {
       LOG.error("Failed to open file {}", path, t);
       return AlluxioFuseUtils.getErrorCode(t);
     }
+    long fid = mNextOpenFileId.getAndIncrement();
+    mOpenFiles.add(new OpenFileEntry(fid, path, is, null));
+    fi.fh.set(fid);
 
     return 0;
   }


### PR DESCRIPTION
1. in fuse openFile, a getStatus RPC is issued, but openFile will also issue a getStatus RPC internally, this redundant RCP is reduced in this PR.
2. when getting status of a file, or listing status of a directory, cache the status results so that future getStatus and listStatus calls do not need to issue RPCs to master.

This PR introduces a new class `CachingFileSystem extends BaseFileSystem` to cache path metadata.