### PR TITLE
Fix UFS contract test options

### DIFF
--- a/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/examples/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -13,6 +13,7 @@ package alluxio.cli;
 
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.Source;
 import alluxio.examples.RelatedS3Operations;
 import alluxio.examples.S3ASpecificOperations;
 import alluxio.examples.UnderFileSystemCommonOperations;
@@ -33,7 +34,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Integration tests for Alluxio under filesystems. It describes the contract of Alluxio
@@ -56,13 +59,19 @@ public final class UnderFileSystemContractTest {
   private InstancedConfiguration mConf
       = new InstancedConfiguration(ConfigurationUtils.defaults());
 
+  private UnderFileSystemConfiguration mUfsConf;
+
   private UnderFileSystem mUfs;
 
   private UnderFileSystemContractTest() {}
 
   private void run() throws Exception {
-    UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find(mUfsPath,
-        UnderFileSystemConfiguration.defaults(mConf));
+    mUfsConf = UnderFileSystemConfiguration.defaults(mConf).createMountSpecificConf(
+        mConf.copyProperties().entrySet().stream()
+            .filter(entry -> mConf.getSource(entry.getKey()) == Source.SYSTEM_PROPERTY)
+            .filter(entry -> mConf.isSet(entry.getKey()) && !entry.getValue().isEmpty())
+            .collect(Collectors.toMap(entry -> entry.getKey().getName(), Map.Entry::getValue)));
+    UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find(mUfsPath, mUfsConf);
     // Check if the ufs path is valid
     if (factory == null || !factory.supportsPath(mUfsPath)) {
       System.out.printf("%s is not a valid path", mUfsPath);
@@ -75,8 +84,7 @@ public final class UnderFileSystemContractTest {
     // Increase the buffer time of journal writes to speed up tests
     mConf.set(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "1sec");
 
-    mUfs = UnderFileSystem.Factory.create(mUfsPath,
-        UnderFileSystemConfiguration.defaults(mConf));
+    mUfs = UnderFileSystem.Factory.create(mUfsPath, mUfsConf);
 
     runCommonOperations();
 
@@ -99,7 +107,7 @@ public final class UnderFileSystemContractTest {
     mConf.set(PropertyKey.UNDERFS_S3_INTERMEDIATE_UPLOAD_CLEAN_AGE, "0");
 
     mUfs = UnderFileSystem.Factory.create(mUfsPath,
-        UnderFileSystemConfiguration.defaults(mConf));
+        mUfsConf);
 
     String testDir = createTestDirectory();
     loadAndRunTests(new S3ASpecificOperations(testDir, mUfs, mConf), testDir);


### PR DESCRIPTION
Currently `UnderFileSystemContractTest` uses `-Dxxx=yyy` to pass UFS options. This does not work if the UFS uses `getMountSpecificConf` to retrieve the options. This fix added some logic to merge system properties passed through `-D` into the UFS configuration as mount specific properties.