### PR TITLE
Parallelize MigrateDefinition within a worker

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -203,8 +203,15 @@ public final class MigrateDefinition
 
       // split the list of MigrateCommands for a given worker into at most JOBS_PER_WORKER
       // equally sized lists
-      List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(),
-          Math.round(assignment.getValue().size() * 1.0f / JOBS_PER_WORKER + 0.5f));
+      ArrayList<MigrateCommand> migrateCommands = assignment.getValue();
+      ArrayList<ArrayList<MigrateCommand>> splittedCommands = Lists.newArrayList();
+
+      for (int i = 0; i < JOBS_PER_WORKER; i++) {
+        splittedCommands.add(Lists.newArrayList());
+      }
+      for (int i = 0; i < migrateCommands.size(); i++) {
+        splittedCommands.get(i % JOBS_PER_WORKER).add(migrateCommands.get(i));
+      }
 
       for (List<MigrateCommand> commands : splittedCommands) {
         if (!commands.isEmpty()) {

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -202,22 +202,11 @@ public final class MigrateDefinition
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
 
       // split the list of MigrateCommands for a given worker into JOBS_PER_WORKER.
+      List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(), JOBS_PER_WORKER);
 
-      ArrayList<MigrateCommand> migrateCommands = assignment.getValue();
-
-      ArrayList<ArrayList<MigrateCommand>> splittedCommands = Lists.newArrayList();
-
-      for (int i = 0; i < JOBS_PER_WORKER; i++) {
-        splittedCommands.add(Lists.newArrayList());
-      }
-
-      for (int i = 0; i < migrateCommands.size(); i++) {
-        splittedCommands.get(i % JOBS_PER_WORKER).add(migrateCommands.get(i));
-      }
-
-      for (ArrayList<MigrateCommand> commands : splittedCommands) {
+      for (List<MigrateCommand> commands : splittedCommands) {
         if (!commands.isEmpty()) {
-          result.add(new Pair<>(assignment.getKey(), commands));
+          result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(commands)));
         }
       }
     }

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -202,7 +202,8 @@ public final class MigrateDefinition
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
 
       // split the list of MigrateCommands for a given worker into JOBS_PER_WORKER.
-      List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(), JOBS_PER_WORKER);
+      List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(),
+          JOBS_PER_WORKER);
 
       for (List<MigrateCommand> commands : splittedCommands) {
         if (!commands.isEmpty()) {

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -201,7 +201,8 @@ public final class MigrateDefinition
 
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
 
-      // split the list of MigrateCommands for a given worker into at most equally sized JOBS_PER_WORKER lists
+      // split the list of MigrateCommands for a given worker into at most JOBS_PER_WORKER
+      // equally sized lists
       List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(),
           Math.round(assignment.getValue().size() * 1.0f / JOBS_PER_WORKER + 0.5f));
 

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -201,9 +201,9 @@ public final class MigrateDefinition
 
     for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
 
-      // split the list of MigrateCommands for a given worker into JOBS_PER_WORKER.
+      // split the list of MigrateCommands for a given worker into at most equally sized JOBS_PER_WORKER lists
       List<List<MigrateCommand>> splittedCommands = Lists.partition(assignment.getValue(),
-          JOBS_PER_WORKER);
+          Math.round(assignment.getValue().size() * 1.0f / JOBS_PER_WORKER + 0.5f));
 
       for (List<MigrateCommand> commands : splittedCommands) {
         if (!commands.isEmpty()) {

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -140,8 +140,10 @@ public final class MigrateDefinitionSelectExecutorsTest {
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/dir/src2", "/dst/src2"));
     Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
-        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(0), migrateCommandsWorker0), new Pair<>(
-            JOB_WORKERS.get(2), migrateCommandsWorker2));
+        ImmutableSet.of(
+            new Pair<>(JOB_WORKERS.get(0), ImmutableList.of(migrateCommandsWorker0.get(0))),
+            new Pair<>(JOB_WORKERS.get(0), ImmutableList.of(migrateCommandsWorker0.get(1))),
+            new Pair<>(JOB_WORKERS.get(2), ImmutableList.of(migrateCommandsWorker2.get(0))));
     Assert.assertEquals(expected, assignMigrates("/dir", "/dst"));
   }
 
@@ -294,8 +296,10 @@ public final class MigrateDefinitionSelectExecutorsTest {
     List<MigrateCommand> migrateCommandsWorker2 =
         Lists.newArrayList(new MigrateCommand("/src/file1", "/dst/file1"));
     Set<Pair<WorkerInfo, List<MigrateCommand>>> expected =
-        ImmutableSet.of(new Pair<>(JOB_WORKERS.get(1), migrateCommandsWorker1), new Pair<>(
-            JOB_WORKERS.get(2), migrateCommandsWorker2));
+        ImmutableSet.of(
+            new Pair<>(JOB_WORKERS.get(1), ImmutableList.of(migrateCommandsWorker1.get(0))),
+            new Pair<>(JOB_WORKERS.get(1), ImmutableList.of(migrateCommandsWorker1.get(1))),
+            new Pair<>(JOB_WORKERS.get(2), ImmutableList.of(migrateCommandsWorker2.get(0))));
     Assert.assertEquals(expected, assignMigrates(new MigrateConfig(
             "/src", "/dst", "THROUGH", true, false)));
   }


### PR DESCRIPTION
Using some of the API changes from before to make distributedCp and distributedMv faster (and take more resources).
The same logic can be applied to PersistCommand as well.

Test scenario: (r4.xlarge)
1. 4000 Files each with 100KB.
2. 2 Workers.
3. Deployed https://github.com/bradyoo/alluxio/pull/4/files for testing to see how different parallel factors impact this.
4. Async Through

Results:

The last parameter is the parallel factor: Which is not in this PR because this PR simply defaults that to 10 where as in this result, if you don't provide a parameter, it defaults to 1 (old behavior)

This is with alluxio.job.worker.threadpool.size set to 20. (Default is 10.)

$ time ./bin/alluxio fs distributedCp /async-write2/ /async-write20/
.................Copied /async-write2 to /async-write20

real	0m37.183s
user	0m3.613s
sys	0m0.238s

$ time ./bin/alluxio fs distributedCp /async-write2/ /async-write21/ 10
...Copied /async-write2 to /async-write21

real	0m9.066s
user	0m3.365s
sys	0m0.230s

$ time ./bin/alluxio fs distributedCp /async-write2/ /async-write22/ 2
..........Copied /async-write2 to /async-write22

real	0m23.179s
user	0m3.779s
sys	0m0.233s

$ time ./bin/alluxio fs distributedCp /async-write2/ /async-write23/
.................Copied /async-write2 to /async-write23

real	0m37.229s
user	0m3.647s
sys	0m0.251s

$ time ./bin/alluxio fs distributedCp /async-write2/ /async-write24/ 15
...Copied /async-write2 to /async-write24

real	0m8.059s
user	0m3.366s
sys	0m0.235s


