### PR TITLE
Use correct properties for csv lines to skip

### DIFF
--- a/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
@@ -29,22 +29,26 @@ public class PartitionInfo implements Serializable {
 
   private final String mSerdeClass;
   private final String mInputFormatClass;
-  private final HashMap<String, String> mProperties;
+  private final HashMap<String, String> mSerdeProperties;
+  private final HashMap<String, String> mTableProperties;
   private final ArrayList<FieldSchema> mFields;
 
   /**
    * @param serdeClass the full serde class name
    * @param inputFormatClass the full input format class name
-   * @param properties the properties
+   * @param serdeProperties the serde Properties
+   * @param tableProperties the table Properties
    * @param fields the fields
    */
   public PartitionInfo(@JsonProperty("serdeClass") String serdeClass,
       @JsonProperty("inputFormatClass") String inputFormatClass,
-      @JsonProperty("properties") HashMap<String, String> properties,
+      @JsonProperty("serdeProperties") HashMap<String, String> serdeProperties,
+      @JsonProperty("tableProperties") HashMap<String, String> tableProperties,
       @JsonProperty("fields") ArrayList<FieldSchema> fields) {
     mSerdeClass = serdeClass;
     mInputFormatClass = inputFormatClass;
-    mProperties = properties;
+    mSerdeProperties = serdeProperties;
+    mTableProperties = tableProperties;
     mFields = fields;
   }
 
@@ -59,7 +63,7 @@ public class PartitionInfo implements Serializable {
       return Format.PARQUET;
     } else if (mSerdeClass.equals(HiveConstants.CSV_SERDE_CLASS)
         || (mInputFormatClass.equals(HiveConstants.TEXT_INPUT_FORMAT_CLASS)
-        && mProperties.containsKey(HiveConstants.SERIALIZATION_FORMAT))) {
+        && mSerdeProperties.containsKey(HiveConstants.SERIALIZATION_FORMAT))) {
       if (filename.endsWith(Format.GZIP.getSuffix())) {
         return Format.GZIP_CSV;
       }
@@ -83,10 +87,17 @@ public class PartitionInfo implements Serializable {
   }
 
   /**
-   * @return the properties
+   * @return the serde properties
    */
-  public HashMap<String, String> getProperties() {
-    return mProperties;
+  public HashMap<String, String> getSerdeProperties() {
+    return mSerdeProperties;
+  }
+
+  /**
+   * @return the table properties
+   */
+  public HashMap<String, String> getTableProperties() {
+    return mTableProperties;
   }
 
   /**
@@ -110,13 +121,15 @@ public class PartitionInfo implements Serializable {
     PartitionInfo that = (PartitionInfo) obj;
     return mSerdeClass.equals(that.mSerdeClass)
         && mInputFormatClass.equals(that.mInputFormatClass)
-        && mProperties.equals(that.mProperties)
+        && mSerdeProperties.equals(that.mSerdeProperties)
+        && mTableProperties.equals(that.mTableProperties)
         && mFields.equals(that.mFields);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mSerdeClass, mInputFormatClass, mProperties, mFields);
+    return Objects.hashCode(mSerdeClass, mInputFormatClass, mSerdeProperties, mTableProperties,
+        mFields);
   }
 
   @Override
@@ -124,7 +137,8 @@ public class PartitionInfo implements Serializable {
     return MoreObjects.toStringHelper(this)
         .add("serdeClass", mSerdeClass)
         .add("inputFormatClass", mInputFormatClass)
-        .add("properties", mProperties)
+        .add("serdeProperties", mSerdeProperties)
+        .add("tableProperties", mTableProperties)
         .add("fields", mFields)
         .toString();
   }

--- a/job/common/src/test/java/alluxio/job/workflow/composite/CompositeConfigTest.java
+++ b/job/common/src/test/java/alluxio/job/workflow/composite/CompositeConfigTest.java
@@ -36,7 +36,7 @@ public final class CompositeConfigTest {
 
   static {
     PartitionInfo pInfo = new PartitionInfo("serde", "inputformat", new HashMap<>(),
-        new ArrayList<>());
+        new HashMap<>(), new ArrayList<>());
     ArrayList<JobConfig> jobs = new ArrayList<>();
     jobs.add(new CompositeConfig(new ArrayList<>(), true));
     jobs.add(new CompositeConfig(new ArrayList<>(), false));

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -84,7 +84,6 @@ public final class CsvReader implements TableReader {
       Map<String, String> serdeProperties) {
     CSVProperties.Builder propsBuilder = new CSVProperties.Builder();
     if (tableProperties.containsKey(HiveConstants.LINES_TO_SKIP)) {
-      // propsBuilder.hasHeader();
       propsBuilder.linesToSkip(Integer.parseInt(tableProperties.get(HiveConstants.LINES_TO_SKIP)));
     }
     if (serdeProperties.containsKey(HiveConstants.FIELD_DELIM)) {

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -61,7 +61,8 @@ public final class CsvReader implements TableReader {
       boolean isGzipped = pInfo.getFormat(inputPath.getName()).equals(Format.GZIP_CSV);
       InputStream input = open(mFs, inputPath, isGzipped);
 
-      CSVProperties props = buildProperties(pInfo.getProperties());
+      CSVProperties props = buildProperties(pInfo.getTableProperties(),
+          pInfo.getSerdeProperties());
 
       try {
         mReader = mCloser.register(new AvroCSVReader<>(input, props, mSchema.getReadSchema(),
@@ -79,14 +80,15 @@ public final class CsvReader implements TableReader {
     }
   }
 
-  private CSVProperties buildProperties(Map<String, String> properties) {
+  private CSVProperties buildProperties(Map<String, String> tableProperties,
+      Map<String, String> serdeProperties) {
     CSVProperties.Builder propsBuilder = new CSVProperties.Builder();
-    if (properties.containsKey(HiveConstants.LINES_TO_SKIP)) {
+    if (tableProperties.containsKey(HiveConstants.LINES_TO_SKIP)) {
       propsBuilder.hasHeader();
-      propsBuilder.linesToSkip(Integer.parseInt(properties.get(HiveConstants.LINES_TO_SKIP)));
+      propsBuilder.linesToSkip(Integer.parseInt(tableProperties.get(HiveConstants.LINES_TO_SKIP)));
     }
-    if (properties.containsKey(HiveConstants.FIELD_DELIM)) {
-      propsBuilder.delimiter(properties.get(HiveConstants.FIELD_DELIM));
+    if (serdeProperties.containsKey(HiveConstants.FIELD_DELIM)) {
+      propsBuilder.delimiter(serdeProperties.get(HiveConstants.FIELD_DELIM));
     }
     return propsBuilder.build();
   }

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -84,7 +84,7 @@ public final class CsvReader implements TableReader {
       Map<String, String> serdeProperties) {
     CSVProperties.Builder propsBuilder = new CSVProperties.Builder();
     if (tableProperties.containsKey(HiveConstants.LINES_TO_SKIP)) {
-      propsBuilder.hasHeader();
+      // propsBuilder.hasHeader();
       propsBuilder.linesToSkip(Integer.parseInt(tableProperties.get(HiveConstants.LINES_TO_SKIP)));
     }
     if (serdeProperties.containsKey(HiveConstants.FIELD_DELIM)) {

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -43,7 +43,8 @@ public final class ReadWriteTest extends BaseTransformTest {
   public TemporaryFolder mTempFolder = new TemporaryFolder();
 
   private PartitionInfo mPartitionInfo = new PartitionInfo(HiveConstants.PARQUET_SERDE_CLASS,
-      HiveConstants.PARQUET_INPUT_FORMAT_CLASS, new HashMap<>(), new ArrayList<>());
+      HiveConstants.PARQUET_INPUT_FORMAT_CLASS, new HashMap<>(), new HashMap<>(),
+      new ArrayList<>());
 
   private void createCsvFile(File file, boolean gzipped) throws IOException {
     OutputStream outputStream = new FileOutputStream(file);

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -113,6 +113,7 @@ public class HiveLayout implements Layout {
   private HiveLayout transformLayout(AlluxioURI transformedUri) {
     // TODO(cc): assumption here is the transformed data is in Parquet format.
     PartitionInfo info = mPartitionInfo.toBuilder()
+        .putAllParameters(mPartitionInfo.getParametersMap())
         .setStorage(mPartitionInfo.getStorage().toBuilder()
             .setStorageFormat(mPartitionInfo.getStorage().getStorageFormat().toBuilder()
                 .setSerde(HiveConstants.PARQUET_SERDE_CLASS)

--- a/table/server/common/src/main/java/alluxio/table/common/transform/action/TransformActionUtils.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/action/TransformActionUtils.java
@@ -48,6 +48,7 @@ public class TransformActionUtils {
 
     return new alluxio.job.plan.transform.PartitionInfo(serdeClass, inputFormat,
         new HashMap<>(partitionInfo.getStorage().getStorageFormat().getSerdelibParametersMap()),
+        new HashMap<>(partitionInfo.getParametersMap()),
         colList);
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -219,6 +219,7 @@ public class HiveDatabase implements UnderDatabase {
           .setTableName(tableName)
           .addAllDataCols(HiveUtils.toProto(table.getSd().getCols()))
           .setStorage(HiveUtils.toProto(table.getSd(), pathTranslator))
+          .putAllParameters(table.getParameters())
           // ignore partition name
           .build();
       Layout layout = Layout.newBuilder()

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
@@ -135,7 +135,8 @@ public class HiveTable implements UdbTable {
             .setDbName(mHiveDatabase.getUdbContext().getDbName()).setTableName(mName)
             .addAllDataCols(HiveUtils.toProto(mTable.getSd().getCols()))
             .setStorage(HiveUtils.toProto(mTable.getSd(), mPathTranslator))
-            .setPartitionName(mName);
+            .setPartitionName(mName)
+            .putAllParameters(mTable.getParameters());
         udbPartitions.add(new HivePartition(
             new HiveLayout(pib.build(), Collections.emptyList())));
         return udbPartitions;
@@ -156,7 +157,8 @@ public class HiveTable implements UdbTable {
             .setTableName(mName)
             .addAllDataCols(HiveUtils.toProto(partition.getSd().getCols()))
             .setStorage(HiveUtils.toProto(partition.getSd(), mPathTranslator))
-            .setPartitionName(partName);
+            .setPartitionName(partName)
+            .putAllParameters(partition.getParameters());
         if (partition.getValues() != null) {
           pib.addAllValues(partition.getValues());
         }

--- a/tests/src/test/java/alluxio/job/plan/transform/format/TableReaderIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/transform/format/TableReaderIntegrationTest.java
@@ -34,8 +34,8 @@ public class TableReaderIntegrationTest extends JobIntegrationTest {
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
-  private PartitionInfo mPartitionInfo = new PartitionInfo("serde", "inputformat", new HashMap<>(),
-      new ArrayList<>());
+  private PartitionInfo mPartitionInfo = new PartitionInfo("serde", "inputformat",
+      new HashMap<>(), new HashMap<>(), new ArrayList<>());
 
   @Test
   public void createReaderWithoutScheme() throws Exception {


### PR DESCRIPTION
Previously we were looking for lines to skip in the wrong properties. (serde properties) now look for it in table properties. 

Fixes #10557