### PR TITLE
Restore the hive client connection each time it is requested

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3782,7 +3782,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey TABLE_METASTORE_RETRY_TIMEOUT =
       new Builder(Name.TABLE_METASTORE_RETRY_TIMEOUT)
-          .setDescription("Retry period before Alluxio give up on connecting to metastore and exit.")
+          .setDescription("Retry period before Alluxio give up on connecting to"
+              + " metastore and exit.")
           .setDefaultValue("30 secs")
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3784,7 +3784,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.TABLE_METASTORE_RETRY_TIMEOUT)
           .setDescription("Retry period before Alluxio give up on connecting to"
               + " metastore and exit.")
-          .setDefaultValue("30 secs")
+          .setDefaultValue("30sec")
           .setScope(Scope.MASTER)
           .build();
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3780,6 +3780,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey TABLE_METASTORE_RETRY_TIMEOUT =
+      new Builder(Name.TABLE_METASTORE_RETRY_TIMEOUT)
+          .setDescription("Retry period before Alluxio give up on connecting to metastore and exit.")
+          .setDefaultValue("30 secs")
+          .setScope(Scope.MASTER)
+          .build();
 
   /**
    * @deprecated This key is used for testing. It is always deprecated.
@@ -4527,6 +4533,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.table.transform.manager.job.monitor.interval";
     public static final String TABLE_TRANSFORM_MANAGER_JOB_HISTORY_RETENTION_TIME =
         "alluxio.table.transform.manager.job.history.retention.time";
+    public static final String TABLE_METASTORE_RETRY_TIMEOUT =
+        "alluxio.table.metastore.retry.timeout";
 
     private Name() {} // prevent instantiation
   }

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -56,7 +56,7 @@ public final class RetryUtils {
    * @param policy the retry policy to use
    * @return T return a value
    */
-  public static <T> T retry(String action, RunnableFunctionThrowsException<T> f, RetryPolicy policy)
+  public static <T> T retryFunction(String action, RunnableFunctionThrowsException<T> f, RetryPolicy policy)
       throws CantRetryException {
     RetryException e = null;
     while (policy.attempt()) {

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -56,8 +56,8 @@ public final class RetryUtils {
    * @param policy the retry policy to use
    * @return T return a value
    */
-  public static <T> T retryFunction(String action, RunnableFunctionThrowsException<T> f, RetryPolicy policy)
-      throws CantRetryException {
+  public static <T> T retryFunction(String action, RunnableFunctionThrowsException<T> f,
+      RetryPolicy policy) throws CantRetryException {
     RetryException e = null;
     while (policy.attempt()) {
       try {

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -50,9 +50,11 @@ public final class RetryUtils {
    * Retries the given method until it doesn't throw an IO exception or the retry policy expires. If
    * the retry policy expires, the last exception generated will be rethrown.
    *
+   * @param <T> type of the return value
    * @param action a description of the action that fits the phrase "Failed to ${action}"
    * @param f the function to retry
    * @param policy the retry policy to use
+   * @return T return a value
    */
   public static <T> T retry(String action, RunnableFunctionThrowsException<T> f, RetryPolicy policy)
       throws CantRetryException {
@@ -137,34 +139,55 @@ public final class RetryUtils {
 
   /**
    * Interface for methods which return a result and may throw IOException.
+   * @param <T> type of the return value
    */
   @FunctionalInterface
   public interface RunnableFunctionThrowsException<T> {
     /**
      * Runs the runnable.
+     * @return T return an object of type T
      */
     T run() throws RetryException, CantRetryException;
   }
 
+  /**
+   * Exceptions that can be retried.
+   */
   public static class RetryException extends IOException {
-    public RetryException() {
-      super();
-    }
-    public RetryException(Throwable cause) {
-      super(cause);
-    }
+    /**
+     * Constructor for RetryException.
+     * @param msg error message
+     * @param cause cause of the error
+     */
     public RetryException(String msg, Throwable cause) {
       super(msg, cause);
     }
   }
 
+  /**
+   * Exceptions that can not be retried.
+   */
   public static class CantRetryException extends Exception {
+    /**
+     * Constructor for CantRetryException.
+     */
     public CantRetryException() {
       super();
     }
+
+    /**
+     * Constructor for CantRetryException.
+     * @param cause cause of the error
+     */
     public CantRetryException(Throwable cause) {
       super(cause);
     }
+
+    /**
+     * Constructor for CantRetryException.
+     * @param msg error message
+     * @param cause cause of the error
+     */
     public CantRetryException(String msg, Throwable cause) {
       super(msg, cause);
     }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -238,18 +238,8 @@ public class HiveDatabase implements UnderDatabase {
     }
   }
 
-  HiveMetaStoreClient getHive() throws IOException {
-    if (mHive != null) {
-      try {
-        mHive.reconnect();
-      } catch (MetaException e) {
-        throw new IOException(String
-            .format("Failed to reconnect client to hive metastore: %s. error: %s", mConnectionUri,
-                e.getMessage()), e);
-      }
-      return mHive;
-    }
-
+  private HiveMetaStoreClient newHiveClient() throws IOException {
+    HiveMetaStoreClient client;
     // Hive uses/saves the thread context class loader.
     ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
     try {
@@ -257,9 +247,9 @@ public class HiveDatabase implements UnderDatabase {
       Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
       HiveConf conf = new HiveConf();
       conf.set("hive.metastore.uris", mConnectionUri);
-      mHive = new HiveMetaStoreClient(conf);
-      mHive.getDatabase(mHiveDbName);
-      return mHive;
+      client = new HiveMetaStoreClient(conf);
+      client.getDatabase(mHiveDbName);
+      return client;
     } catch (NoSuchObjectException e) {
       throw new IOException(String
           .format("hive db name '%s' does not exist at metastore: %s", mHiveDbName, mConnectionUri),
@@ -272,5 +262,20 @@ public class HiveDatabase implements UnderDatabase {
     } finally {
       Thread.currentThread().setContextClassLoader(currentClassLoader);
     }
+  }
+
+  HiveMetaStoreClient getHive() throws IOException {
+    if (mHive != null) {
+      try {
+        mHive.getAllDatabases(); // test the connection
+      } catch (TException e) {
+        LOG.info("Hive metastore client disconnected, attempting to reconnect");
+        mHive = newHiveClient();
+      }
+      return mHive;
+    }
+
+    mHive = newHiveClient();
+    return mHive;
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -237,7 +237,7 @@ public class HiveDatabase implements UnderDatabase {
     }
   }
 
-  private MetaStoreClient getHive() {
+  MetaStoreClient getHive() {
     return mHive;
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -111,7 +111,7 @@ public class HiveDatabase implements UnderDatabase {
   public List<String> getTableNames() throws IOException {
     try {
       return getHive().getAllTables(mHiveDbName);
-    } catch (MetaException e) {
+    } catch (TException e) {
       throw new IOException("Failed to get hive tables: " + e.getMessage(), e);
     }
   }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -117,7 +117,7 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
   private <T> T retryCall(String action, SupplierThrowingException<T> supplier)
       throws TException, IOException {
     try {
-      return RetryUtils.retry(action, () -> {
+      return RetryUtils.retryFunction(action, () -> {
         try {
           return supplier.get();
         } catch (MetaException e) {

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -1,0 +1,113 @@
+package alluxio.table.under.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.InvalidInputException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A wrapper around HMS client that does caching and reconnection.
+ */
+public class HiveMetaStoreRetryClient implements MetaStoreClient {
+  private HiveMetaStoreClient mHive = null;
+  private String mConnectionUri;
+  private String mHiveDbName;
+
+  /**
+   * Constructor for the HiveMetaStoreRetryClient.
+   * @param connectionUri connection uri to the metastore
+   * @param hiveDbName the db name to access
+   */
+  public HiveMetaStoreRetryClient(String connectionUri, String hiveDbName) {
+    mConnectionUri = connectionUri;
+    mHiveDbName = hiveDbName;
+  }
+
+  private HiveMetaStoreClient getHive() throws IOException {
+    if (mHive != null) {
+      return mHive;
+    }
+
+    mHive = newHiveClient();
+    return mHive;
+  }
+
+  private HiveMetaStoreClient newHiveClient() throws IOException {
+    HiveMetaStoreClient client;
+    // Hive uses/saves the thread context class loader.
+    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // use the extension class loader
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      HiveConf conf = new HiveConf();
+      conf.set("hive.metastore.uris", mConnectionUri);
+      client = new HiveMetaStoreClient(conf);
+      client.getDatabase(mHiveDbName);
+      return client;
+    } catch (NoSuchObjectException e) {
+      throw new IOException(String
+          .format("hive db name '%s' does not exist at metastore: %s", mHiveDbName, mConnectionUri),
+          e);
+    } catch (NullPointerException | TException e) {
+      // HiveMetaStoreClient throws a NPE if the uri is not a uri for hive metastore
+      throw new IOException(String
+          .format("Failed to create client to hive metastore: %s. error: %s", mConnectionUri,
+              e.getMessage()), e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(currentClassLoader);
+    }
+  }
+
+  @Override
+  public List<String> getAllTables(String dbname) throws MetaException, IOException {
+    try {
+      return getHive().getAllTables(dbname);
+    } catch (TException e) {
+      mHive = newHiveClient();
+      return getHive().getAllTables(dbname);
+    }
+  }
+
+  @Override
+  public Table getTable(String dbname, String name) throws MetaException, TException,
+      NoSuchObjectException, IOException {
+    try {
+      return getHive().getTable(dbname, name);
+    } catch (TException e) {
+      mHive = newHiveClient();
+      return getHive().getTable(dbname, name);
+    }
+  }
+
+  @Override
+  public List<Partition> listPartitions(String dbName, String tblName, short maxParts)
+      throws NoSuchObjectException, MetaException, TException, IOException {
+    try {
+      return getHive().listPartitions(dbName, tblName, maxParts);
+    } catch (TException e) {
+      mHive = newHiveClient();
+      return getHive().listPartitions(dbName, tblName, maxParts);
+    }
+  }
+
+  @Override
+  public List<ColumnStatisticsObj> getTableColumnStatistics(String dbName, String tableName,
+      List<String> colNames) throws NoSuchObjectException, MetaException,
+      TException, InvalidInputException, InvalidObjectException, IOException {
+    try {
+      return getHive().getTableColumnStatistics(dbName, tableName, colNames);
+    } catch (TException e) {
+      mHive = newHiveClient();
+      return getHive().getTableColumnStatistics(dbName, tableName, colNames);
+    }
+  }
+}

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.table.under.hive;
 
 import org.apache.hadoop.hive.conf.HiveConf;

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -138,11 +138,12 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
         }
       }, mPolicy);
     } catch (RetryUtils.CantRetryException e) {
-      if (e.getCause() instanceof TException) {
+      Throwable exception = e.getCause();
+      if (exception instanceof TException) {
         // unwrap any Thrift Exceptions
-        throw (TException) e.getCause();
+        throw (TException) exception;
       } else {
-        throw new IOException(e.getCause());
+        throw new IOException(exception);
       }
     }
   }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -24,6 +24,7 @@ import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A wrapper around HMS client that does caching and reconnection.
@@ -119,6 +120,18 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
     } catch (TException e) {
       mHive = newHiveClient();
       return getHive().getTableColumnStatistics(dbName, tableName, colNames);
+    }
+  }
+
+  @Override
+  public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(
+      String dbName, String tableName, List<String> partNames, List<String> colNames)
+      throws NoSuchObjectException, MetaException, TException, IOException {
+    try {
+      return getHive().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
+    } catch (TException e) {
+      mHive = newHiveClient();
+      return getHive().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
     }
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -16,6 +16,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.resource.LockResource;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.RetryUtils;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -34,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * A wrapper around HMS client that does caching and reconnection.
@@ -56,7 +55,8 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
     mConnectionUri = connectionUri;
     mHiveDbName = hiveDbName;
     mLock = new ReentrantReadWriteLock();
-    mPolicy = RetryUtils.defaultClientRetry(ServerConfiguration.getDuration(PropertyKey.TABLE_METASTORE_RETRY_TIMEOUT),
+    mPolicy = RetryUtils.defaultClientRetry(
+        ServerConfiguration.getDuration(PropertyKey.TABLE_METASTORE_RETRY_TIMEOUT),
         Duration.ofMillis(100), Duration.ofSeconds(5));
   }
 
@@ -100,9 +100,12 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
     }
   }
 
+  /**
+   * Supplier throwing exception.
+   * @param <T> type of the return value
+   */
   @FunctionalInterface
   public interface SupplierThrowingException<T> {
-
     /**
      * Gets a result.
      *
@@ -143,6 +146,7 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
       }
     }
   }
+
   @Override
   public List<String> getAllTables(String dbname) throws TException, MetaException, IOException {
     return retryCall("getAllTables", () -> getHive().getAllTables(dbname));

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveMetaStoreRetryClient.java
@@ -11,6 +11,12 @@
 
 package alluxio.table.under.hive;
 
+import alluxio.conf.ServerConfiguration;
+import alluxio.resource.LockResource;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.ExponentialTimeBoundedRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -23,16 +29,23 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static alluxio.conf.PropertyKey.TABLE_METASTORE_RETRY_TIMEOUT;
 
 /**
  * A wrapper around HMS client that does caching and reconnection.
  */
 public class HiveMetaStoreRetryClient implements MetaStoreClient {
   private HiveMetaStoreClient mHive = null;
-  private String mConnectionUri;
-  private String mHiveDbName;
+  private final String mConnectionUri;
+  private final String mHiveDbName;
+  private final ReadWriteLock mLock;
+  private final RetryPolicy mPolicy;
 
   /**
    * Constructor for the HiveMetaStoreRetryClient.
@@ -42,29 +55,32 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
   public HiveMetaStoreRetryClient(String connectionUri, String hiveDbName) {
     mConnectionUri = connectionUri;
     mHiveDbName = hiveDbName;
+    mLock = new ReentrantReadWriteLock();
+    mPolicy = RetryUtils.defaultClientRetry(ServerConfiguration.getDuration(TABLE_METASTORE_RETRY_TIMEOUT),
+        Duration.ofMillis(100), Duration.ofSeconds(5));
   }
 
   private HiveMetaStoreClient getHive() throws IOException {
     if (mHive != null) {
       return mHive;
     }
-
-    mHive = newHiveClient();
+    newHiveClient();
     return mHive;
   }
 
-  private HiveMetaStoreClient newHiveClient() throws IOException {
+  private void newHiveClient() throws IOException {
     HiveMetaStoreClient client;
     // Hive uses/saves the thread context class loader.
     ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
-    try {
+    try (LockResource w = new LockResource(mLock.writeLock())) {
+
       // use the extension class loader
       Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
       HiveConf conf = new HiveConf();
       conf.set("hive.metastore.uris", mConnectionUri);
       client = new HiveMetaStoreClient(conf);
       client.getDatabase(mHiveDbName);
-      return client;
+      mHive = client;
     } catch (NoSuchObjectException e) {
       throw new IOException(String
           .format("hive db name '%s' does not exist at metastore: %s", mHiveDbName, mConnectionUri),
@@ -82,10 +98,16 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
   @Override
   public List<String> getAllTables(String dbname) throws MetaException, IOException {
     try {
-      return getHive().getAllTables(dbname);
-    } catch (TException e) {
-      mHive = newHiveClient();
-      return getHive().getAllTables(dbname);
+      return RetryUtils.retry("getAllTables", () -> {
+        try {
+          return getHive().getAllTables(dbname);
+        } catch (IOException | MetaException e) {
+          mHive = null;
+          throw new RetryUtils.RetryException("retry exception", e);
+        }
+      }, mPolicy);
+    } catch (RetryUtils.CantRetryException e) {
+      throw new IOException(e.getCause());
     }
   }
 
@@ -93,10 +115,23 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
   public Table getTable(String dbname, String name) throws MetaException, TException,
       NoSuchObjectException, IOException {
     try {
-      return getHive().getTable(dbname, name);
-    } catch (TException e) {
-      mHive = newHiveClient();
-      return getHive().getTable(dbname, name);
+      return RetryUtils.retry("getTable", () -> {
+        try {
+          return getHive().getTable(dbname, name);
+        } catch (NoSuchObjectException e) {
+          throw new RetryUtils.CantRetryException("Cannot retry", e);
+        } catch (IOException | TException e) {
+          mHive = null;
+          throw new RetryUtils.RetryException("Retry exception", e);
+        }
+      }, mPolicy);
+    } catch (RetryUtils.CantRetryException e) {
+      if (e.getCause() instanceof  NoSuchObjectException) {
+        // unwrap the NoSuchObjectException if it is the cause for unable to retry
+        throw (NoSuchObjectException)e.getCause();
+      } else {
+        throw new IOException(e.getCause());
+      }
     }
   }
 
@@ -104,10 +139,23 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
   public List<Partition> listPartitions(String dbName, String tblName, short maxParts)
       throws NoSuchObjectException, MetaException, TException, IOException {
     try {
-      return getHive().listPartitions(dbName, tblName, maxParts);
-    } catch (TException e) {
-      mHive = newHiveClient();
-      return getHive().listPartitions(dbName, tblName, maxParts);
+      return RetryUtils.retry("listPartitions", () -> {
+        try {
+          return getHive().listPartitions(dbName, tblName, maxParts);
+        } catch (NoSuchObjectException e) {
+          throw new RetryUtils.CantRetryException("Cannot retry", e);
+        } catch (IOException | TException e) {
+          mHive = null;
+          throw new RetryUtils.RetryException("Retry exception", e);
+        }
+      }, mPolicy);
+    } catch (RetryUtils.CantRetryException e) {
+      if (e.getCause() instanceof  NoSuchObjectException) {
+        // unwrap the NoSuchObjectException if it is the cause for unable to retry
+        throw (NoSuchObjectException)e.getCause();
+      } else {
+        throw new IOException(e.getCause());
+      }
     }
   }
 
@@ -116,10 +164,23 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
       List<String> colNames) throws NoSuchObjectException, MetaException,
       TException, InvalidInputException, InvalidObjectException, IOException {
     try {
-      return getHive().getTableColumnStatistics(dbName, tableName, colNames);
-    } catch (TException e) {
-      mHive = newHiveClient();
-      return getHive().getTableColumnStatistics(dbName, tableName, colNames);
+      return RetryUtils.retry("getTableColumnStatistics", () -> {
+        try {
+          return getHive().getTableColumnStatistics(dbName, tableName, colNames);
+        } catch (NoSuchObjectException|InvalidInputException|InvalidObjectException e) {
+          throw new RetryUtils.CantRetryException("Cannot retry", e);
+        } catch (IOException | TException e) {
+          mHive = null;
+          throw new RetryUtils.RetryException("Retry exception", e);
+        }
+      }, mPolicy);
+    } catch (RetryUtils.CantRetryException e) {
+      if (e.getCause() instanceof  NoSuchObjectException) {
+        // unwrap the NoSuchObjectException if it is the cause for unable to retry
+        throw (NoSuchObjectException)e.getCause();
+      } else {
+        throw new IOException(e.getCause());
+      }
     }
   }
 
@@ -128,10 +189,23 @@ public class HiveMetaStoreRetryClient implements MetaStoreClient {
       String dbName, String tableName, List<String> partNames, List<String> colNames)
       throws NoSuchObjectException, MetaException, TException, IOException {
     try {
-      return getHive().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
-    } catch (TException e) {
-      mHive = newHiveClient();
-      return getHive().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
+      return RetryUtils.retry("getPartitionColumnStatistics", () -> {
+        try {
+          return getHive().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
+        } catch (NoSuchObjectException|InvalidInputException|InvalidObjectException e) {
+          throw new RetryUtils.CantRetryException("Cannot retry", e);
+        } catch (IOException | TException e) {
+          mHive = null;
+          throw new RetryUtils.RetryException("Retry exception", e);
+        }
+      }, mPolicy);
+    } catch (RetryUtils.CantRetryException e) {
+      if (e.getCause() instanceof  NoSuchObjectException) {
+        // unwrap the NoSuchObjectException if it is the cause for unable to retry
+        throw (NoSuchObjectException)e.getCause();
+      } else {
+        throw new IOException(e.getCause());
+      }
     }
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
@@ -33,7 +33,8 @@ public interface MetaStoreClient {
    * @param dbname database name
    * @return a list of tables
    */
-  List<String> getAllTables(String dbname) throws MetaException, IOException, NoSuchObjectException, TException;
+  List<String> getAllTables(String dbname) throws MetaException, IOException,
+      NoSuchObjectException, TException;
 
   /**
    * Get a table object from the metastore.

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
@@ -33,7 +33,7 @@ public interface MetaStoreClient {
    * @param dbname database name
    * @return a list of tables
    */
-  List<String> getAllTables(String dbname) throws MetaException, IOException;
+  List<String> getAllTables(String dbname) throws MetaException, IOException, NoSuchObjectException, TException;
 
   /**
    * Get a table object from the metastore.

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
@@ -22,6 +22,7 @@ import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface for the metastore.
@@ -57,10 +58,22 @@ public interface MetaStoreClient {
    * Get a list of table column statistics.
    * @param dbName database name
    * @param tableName table name
-   * @param colNames column name
+   * @param colNames column names as a list
    * @return a list of table column statistics
    */
   List<ColumnStatisticsObj> getTableColumnStatistics(String dbName, String tableName,
       List<String> colNames) throws NoSuchObjectException, MetaException,
       TException, InvalidInputException, InvalidObjectException, IOException;
+
+  /**
+   * Get a map of partition column statistics.
+   * @param dbName database name
+   * @param tableName table name
+   * @param partNames partition names as a list
+   * @param colNames column names as a list
+   * @return a map mapping partition names to a list of column statistics objects
+   */
+  Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(
+      String dbName, String tableName, List<String> partNames, List<String> colNames)
+      throws NoSuchObjectException, MetaException, TException, IOException;
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.table.under.hive;
 
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/MetaStoreClient.java
@@ -1,0 +1,55 @@
+package alluxio.table.under.hive;
+
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.InvalidInputException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Interface for the metastore.
+ */
+public interface MetaStoreClient {
+  /**
+   * Get all tables from the metastore.
+   * @param dbname database name
+   * @return a list of tables
+   */
+  List<String> getAllTables(String dbname) throws MetaException, IOException;
+
+  /**
+   * Get a table object from the metastore.
+   * @param dbname database name
+   * @param name table name
+   * @return the table object
+   */
+  Table getTable(String dbname, String name) throws MetaException, TException,
+      NoSuchObjectException, IOException;
+
+  /**
+   * Get a list of partitions for a specific table.
+   * @param dbName database name
+   * @param tblName table name
+   * @param maxParts max number of partitions to return
+   * @return a list of partitions
+   */
+  List<Partition> listPartitions(String dbName, String tblName, short maxParts)
+      throws NoSuchObjectException, MetaException, TException, IOException;
+
+  /**
+   * Get a list of table column statistics.
+   * @param dbName database name
+   * @param tableName table name
+   * @param colNames column name
+   * @return a list of table column statistics
+   */
+  List<ColumnStatisticsObj> getTableColumnStatistics(String dbName, String tableName,
+      List<String> colNames) throws NoSuchObjectException, MetaException,
+      TException, InvalidInputException, InvalidObjectException, IOException;
+}


### PR DESCRIPTION
Slightly modified retry to support the following: 
- RetryException and CantRetryException
- When the function encounters RetryException, it retries. If it encounters CantRetryException, it unwraps the exception and throws it. 

- For concurrency protection, anytime we access it, we will grab a read lock, anytime we modify it we grab a write lock. 