### PR TITLE
Enable short circuit even domain socket is configured

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -110,11 +110,17 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     builder.setOpenUfsBlockOptions(options.getOpenUfsBlockOptions(blockId));
     AlluxioConfiguration alluxioConf = context.getClusterConf();
     boolean shortCircuit = alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED);
+    boolean shortCircuitPreferred =
+        alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_PREFERRED);
     boolean sourceSupportsDomainSocket = NettyUtils.isDomainSocketSupported(dataSource);
     boolean sourceIsLocal = dataSourceType == BlockInStreamSource.LOCAL;
 
-    // Short circuit
-    if (sourceIsLocal && shortCircuit && !sourceSupportsDomainSocket) {
+    // Short circuit is enabled when
+    // 1. data source is local node
+    // 2. alluxio.user.short.circuit.enabled is true
+    // 3. the worker's domain socket is not configuered
+    //      OR alluxio.user.short.circuit.preferred is true
+    if (sourceIsLocal && shortCircuit && (shortCircuitPreferred || !sourceSupportsDomainSocket)) {
       LOG.debug("Creating short circuit input stream for block {} @ {}", blockId, dataSource);
       try {
         return createLocalBlockInStream(context, dataSource, blockId, blockSize, options);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
@@ -57,9 +57,13 @@ public interface DataWriter extends Closeable, Cancelable {
     public static DataWriter create(FileSystemContext context, long blockId, long blockSize,
         WorkerNetAddress address, OutStreamOptions options) throws IOException {
       AlluxioConfiguration alluxioConf = context.getClusterConf();
-      if (CommonUtils.isLocalHost(address, alluxioConf) && alluxioConf
-          .getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED) && !NettyUtils
-          .isDomainSocketSupported(address)) {
+      boolean shortCircuit = alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED);
+      boolean shortCircuitPreferred =
+          alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_PREFERRED);
+
+      if (CommonUtils.isLocalHost(address, alluxioConf)
+          && shortCircuit
+          && (shortCircuitPreferred || !NettyUtils.isDomainSocketSupported(address))) {
         if (options.getWriteType() == WriteType.ASYNC_THROUGH
             && alluxioConf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED)) {
           LOG.info("Creating UFS-fallback short circuit output stream for block {} @ {}", blockId,

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3306,6 +3306,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_SHORT_CIRCUIT_PREFERRED =
+      new Builder(Name.USER_SHORT_CIRCUIT_PREFERRED)
+          .setDefaultValue(false)
+          .setDescription("When short circuit and domain socket both enabled, "
+              + "prefer to use short circuit.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_METADATA_CACHE_ENABLED =
       new Builder(Name.USER_METADATA_CACHE_ENABLED)
           .setDefaultValue(false)
@@ -4455,6 +4463,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_UFS_BLOCK_READ_CONCURRENCY_MAX =
         "alluxio.user.ufs.block.read.concurrency.max";
     public static final String USER_SHORT_CIRCUIT_ENABLED = "alluxio.user.short.circuit.enabled";
+    public static final String USER_SHORT_CIRCUIT_PREFERRED =
+        "alluxio.user.short.circuit.preferred";
     public static final String USER_WORKER_LIST_REFRESH_INTERVAL =
         "alluxio.user.worker.list.refresh.interval";
     public static final String USER_METADATA_CACHE_ENABLED =


### PR DESCRIPTION
### Background

I found short circuit has better performance than domain socket.
But when i enable short-circuit read/write, alluxio client prefer to use domain socket as default.

I want to use short-circuit read/write, even domain socket is ready in AlluxioWorker.

### Discussion

I use a new property `alluxio.user.short.circuit.preferred` to control the logic, which is backward compatible.

But i think it is better to use only `alluxio.user.short.circuit.enabled` to judge whether to enable short circuit.

