### PR TITLE
Improve error handling on creating Processes

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
@@ -47,7 +47,14 @@ public final class AlluxioProxy {
     }
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.PROXY);
-    ProxyProcess process = ProxyProcess.Factory.create();
+    ProxyProcess process;
+    try {
+      process = ProxyProcess.Factory.create();
+    } catch (Throwable t) {
+      ProcessUtils.fatalError(LOG, t, "Failed to create proxy process");
+      // fatalError will exit, so we shouldn't reach here.
+      throw t;
+    }
     ProcessUtils.run(process);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -67,7 +67,14 @@ public final class AlluxioWorker {
           "Failed to load cluster default configuration for worker. Please make sure that Alluxio "
               + "master is running: %s", e.toString());
     }
-    WorkerProcess process = WorkerProcess.Factory.create();
+    WorkerProcess process;
+    try {
+      process = WorkerProcess.Factory.create();
+    } catch (Throwable t) {
+      ProcessUtils.fatalError(LOG, t, "Failed to create worker process");
+      // fatalError will exit, so we shouldn't reach here.
+      throw t;
+    }
     ProcessUtils.run(process);
   }
 

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
@@ -75,7 +75,14 @@ public final class AlluxioJobWorker {
           "Failed to load cluster default configuration for job worker. Please make sure that "
               + "Alluxio master is running: %s", e.toString());
     }
-    JobWorkerProcess process = JobWorkerProcess.Factory.create();
+    JobWorkerProcess process;
+    try {
+      process = JobWorkerProcess.Factory.create();
+    } catch (Throwable t) {
+      ProcessUtils.fatalError(LOG, t, "Failed to create job worker process");
+      // fatalError will exit, so we shouldn't reach here.
+      throw t;
+    }
     ProcessUtils.run(process);
   }
 


### PR DESCRIPTION
It turns out that our process creation can be quite heavy and we may see `java.lang.ExceptionInInitializerError` on constructors. Adding error handling to match how we are doing with alluxio master and alluxio job master on other processes. 

Prior to this change, the reasons of a failed process (e.g., a worker) may not be in `worker.log` but in `worker.out` instead, as the `ExceptionInInitializerError` is treated as a JVM runtime exception not logged. After this patch, users can tell the errors easier by looking at `{worker,proxy,job_worker}.log` similar as how they can reason at `{master,job_master}.log`