### PR TITLE
Log errors instead of throwing exceptions for best-effort send

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -124,8 +124,9 @@ public class GrpcBlockingStream<ReqT, ResT> {
    */
   public void send(ReqT request) throws IOException {
     if (mClosed || mCanceled || mClosedFromRemote) {
-      throw new CancelledException(formatErrorMessage(
-          "Failed to send request %s: stream is already closed or canceled.", request));
+      LOG.debug("Failed to send request {}: stream is already closed or canceled. ({})",
+          request, mDescription);
+      return;
     }
     try (LockResource lr = new LockResource(mLock)) {
       checkError();

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -117,7 +117,8 @@ public class GrpcBlockingStream<ReqT, ResT> {
   }
 
   /**
-   * Sends a request. Will not wait for the stream to be ready.
+   * Sends a request. Will not wait for the stream to be ready. If the stream is closed or cancelled
+   * this method will return without an error.
    *
    * @param request the request
    * @throws IOException if any error occurs


### PR DESCRIPTION
The cost of formatting the error message and throwing the exception is nontrivial. Since this method does not ensure the channel is ready, we can simply log the failure (this is the previous behavior at the call site).