### PR TITLE
Include integration test results in code coverage

### DIFF
--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -33,5 +33,12 @@ mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dmaven.javadoc.sk
 
 if [ -n "${ALLUXIO_SONAR_ARGS}" ]
 then
+  # A separate step to run jacoco report, with all the generated coverage data. This requires the
+  # previous 'install' step to generate the jacoco exec data with the 'jacoco' profile.
+  #
+  # Must exclude some of the modules that fail to run verify again without a clean step. This is ok
+  # since these modules do not contain any source code to track for code coverage.
+  mvn -T 4C -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Dlicense.skip -PjacocoReport verify -pl '!webui,!shaded,!shaded/client,!shaded/hadoop'
+  # run sonar analysis
   mvn $(echo "${ALLUXIO_SONAR_ARGS}") sonar:sonar
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
     <netty.version>4.1.30.Final</netty.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop-openstack.version>2.6.0</hadoop-openstack.version>
+    <jacoco.version>0.8.5</jacoco.version>
     <java.version>1.8</java.version>
     <jersey.version>2.22</jersey.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
@@ -927,7 +928,8 @@
             <runOrder>alphabetical</runOrder>
             <systemPropertyVariables>
               <alluxio.test.mode>true</alluxio.test.mode>
-              <jacoco-agent.destfile>${project.basedir}/target/jacoco.exec</jacoco-agent.destfile>
+              <jacoco-agent.append>true</jacoco-agent.append>
+              <jacoco-agent.destfile>${build.path}/../target/jacoco-combined.exec</jacoco-agent.destfile>
             </systemPropertyVariables>
             <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
           </configuration>
@@ -1333,27 +1335,60 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.5</version>
+            <version>${jacoco.version}</version>
+            <configuration>
+              <!--
+                  Append all coverage data into a single .exec file, so the reports include
+                  integration test results. The report generation should happen in a separate,
+                  later stage, so the coverage data is complete with the results of all the tests
+                  in the project.
+               -->
+              <append>true</append>
+              <destFile>${build.path}/../target/jacoco-combined.exec</destFile>
+            </configuration>
             <executions>
               <execution>
                 <!-- offline instrumentation is required, for jacoco to work with powermock tests -->
-                <id>jacoco-instrument-classes</id>
+                <id>jacoco-unit-instrument-classes</id>
                 <goals>
                   <goal>instrument</goal>
                 </goals>
               </execution>
               <execution>
-                <id>jacoco-restore-instrumented-classes</id>
+                <!-- offline instrumentation is required, for jacoco to work with powermock tests -->
+                <id>jacoco-unit-restore-instrumented-classes</id>
                 <phase>test</phase>
                 <goals>
                   <goal>restore-instrumented-classes</goal>
                 </goals>
               </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacocoReport</id>
+      <!--
+          This profile depends on the generated coverage data from the jacoco profile (test phase).
+          This should be run as a separate step, since the generated coverage data should include
+          the results from all the tests in the project.
+       -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+            <executions>
               <execution>
-                <id>jacoco-report</id>
+                <id>jacoco-coverage-report</id>
                 <goals>
                   <goal>report</goal>
                 </goals>
+                <configuration>
+                  <dataFile>${build.path}/../target/jacoco-combined.exec</dataFile>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -320,6 +320,40 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+            <!-- integration tests shouldn't use PowerMock, so recommended prepare-agent goal can be used, instead of offline-instrumentation -->
+            <executions>
+              <execution>
+                <id>jacoco-unit-instrument-classes</id>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>jacoco-unit-restore-instrumented-classes</id>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>jacoco-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
Jacoco generates coverage data in .exec files, which are then used for the jacoco-report goal. However, integration tests are in a separate module from the source code they are testing. Therefore, all the coverage data is not included when reporting on the source code.

Therefore, to capture all the test coverage, the reporting has to be done in 2 steps:
- generate all coverage data (into the same data file)
- report the coverage data using the coverage data which includes all the tests

This is done with 2 separate profiles for the different steps:
- `jacoco` to generate the coverage data
- `jacocoReport` to generate the report using the coverage data