### PR TITLE
Remove unused io.grpc:grpc-netty dependency from alluxio-core-transport

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hello, I noticed that the direct dependency with compile scope `io.grpc:grpc-netty` is declared in the module `alluxio-core-transport`. However, this dependency is not used and, therefore, it can be removed safely to make the pom of this module clearer. 

This dependency also induces a set of transitive dependencies that are not used, as we can see from the dependency tree:

```
+- io.grpc:grpc-netty:jar:1.17.1:compile 
|  +- (io.grpc:grpc-core:jar:1.17.1:compile - omitted for duplicate)
|  +- io.netty:netty-codec-http2:jar:4.1.30.Final:compile
|  |  +- io.netty:netty-codec-http:jar:4.1.30.Final:compile
|  |  |  \- io.netty:netty-codec:jar:4.1.30.Final:compile
|  |  |     \- (io.netty:netty-transport:jar:4.1.30.Final:compile - omitted for duplicate)
|  |  \- io.netty:netty-handler:jar:4.1.30.Final:compile
|  |     +- io.netty:netty-buffer:jar:4.1.30.Final:compile
|  |     |  \- io.netty:netty-common:jar:4.1.30.Final:compile
|  |     +- (io.netty:netty-transport:jar:4.1.30.Final:compile - omitted for duplicate)
|  |     \- (io.netty:netty-codec:jar:4.1.30.Final:compile - omitted for duplicate)
```