### PR TITLE
Change default worker heartbeat back to 1s

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1526,7 +1526,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_WORKER_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_WORKER_HEARTBEAT_INTERVAL)
           .setDefaultValue("1sec")
-          .setDescription("The interval between Alluxio master and worker heartbeats.")
+          .setDescription("The interval between Alluxio master heartbeats to detect lost workers "
+              + "and files based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -2111,7 +2112,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)
           .setAlias("alluxio.worker.block.heartbeat.interval.ms")
           .setDefaultValue("1sec")
-          .setDescription("The interval between block workers' heartbeats.")
+          .setDescription("The interval between block workers' heartbeats to update "
+              + "block status, storage health and other workers' information to Alluxio Master.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1525,6 +1525,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
       new Builder(Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL)
+          .setAlias("alluxio.master.worker.heartbeat.interval")
           .setDefaultValue("10sec")
           .setDescription("The interval between Alluxio master detections to find lost workers "
               + "and files based on updates from Alluxio workers.")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1523,10 +1523,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_WORKER_HEARTBEAT_INTERVAL =
-      new Builder(Name.MASTER_WORKER_HEARTBEAT_INTERVAL)
-          .setDefaultValue("1sec")
-          .setDescription("The interval between Alluxio master heartbeats to detect lost workers "
+  public static final PropertyKey MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
+      new Builder(Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL)
+          .setDefaultValue("10sec")
+          .setDescription("The interval between Alluxio master detections to find lost workers "
               + "and files based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
@@ -4054,8 +4054,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_FORMAT_FILE_PREFIX = "alluxio.master.format.file.prefix";
     public static final String MASTER_STANDBY_HEARTBEAT_INTERVAL =
         "alluxio.master.standby.heartbeat.interval";
-    public static final String MASTER_WORKER_HEARTBEAT_INTERVAL =
-        "alluxio.master.worker.heartbeat.interval";
+    public static final String MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
+        "alluxio.master.lost.worker.file.detection.interval";
     public static final String MASTER_HEARTBEAT_TIMEOUT =
         "alluxio.master.heartbeat.timeout";
     public static final String MASTER_HOSTNAME = "alluxio.master.hostname";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1525,7 +1525,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_WORKER_HEARTBEAT_INTERVAL =
       new Builder(Name.MASTER_WORKER_HEARTBEAT_INTERVAL)
-          .setDefaultValue("10sec")
+          .setDefaultValue("1sec")
           .setDescription("The interval between Alluxio master and worker heartbeats.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
@@ -2110,7 +2110,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_INTERVAL_MS =
       new Builder(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)
           .setAlias("alluxio.worker.block.heartbeat.interval.ms")
-          .setDefaultValue("10sec")
+          .setDefaultValue("1sec")
           .setDescription("The interval between block workers' heartbeats.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)

--- a/core/common/src/main/java/alluxio/conf/RemovedKey.java
+++ b/core/common/src/main/java/alluxio/conf/RemovedKey.java
@@ -64,7 +64,7 @@ public final class RemovedKey {
       put("alluxio.master.connection.timeout", removedSince(V2_0_0));
       put("alluxio.master.file.async.persist.handler", removedSince(V2_0_0));
       put("alluxio.master.heartbeat.interval",
-          replacedSince(V2_0_0, PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL.getName()));
+          replacedSince(V2_0_0, PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL.getName()));
       put("alluxio.master.journal.formatter.class",
           "v2.0 removed the ability to specify the master journal formatter");
       put("alluxio.master.lineage.checkpoint.class", removedSince(V2_0_0));

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -347,7 +347,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     if (isLeader) {
       mLostWorkerDetectionService = getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_LOST_WORKER_DETECTION, new LostWorkerDetectionHeartbeatExecutor(),
-          (int) ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL),
+          (int) ServerConfiguration.getMs(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL),
           ServerConfiguration.global(), mMasterContext.getUserState()));
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -602,7 +602,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_LOST_FILES_DETECTION,
               new LostFileDetector(this, mInodeTree),
-              (int) ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL),
+              (int) ServerConfiguration.getMs(PropertyKey
+                  .MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL),
               ServerConfiguration.global(), mMasterContext.getUserState()));
       getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_REPLICATION_CHECK,

--- a/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileOutStreamIntegrationTest.java
@@ -195,7 +195,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
    * resources.
    */
   @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.MASTER_WORKER_HEARTBEAT_INTERVAL, "250ms"})
+      confParams = {PropertyKey.Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "250ms"})
   @Test
   public void cancelWrite() throws Exception {
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
@@ -204,7 +204,8 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.write(BufferUtils.getIncreasingByteArray(0, BLOCK_SIZE_BYTES * 3 + 1));
       os.cancel();
     }
-    long gracePeriod = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_HEARTBEAT_INTERVAL) * 2;
+    long gracePeriod = ServerConfiguration
+        .getMs(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL) * 2;
     CommonUtils.sleepMs(gracePeriod);
     List<WorkerInfo> workers =
         mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()


### PR DESCRIPTION
After the changes in https://github.com/Alluxio/alluxio/pull/10485 to make metrics processing async, worker heartheat has not related to the latency of metrics. 
Change default worker heartbeat back to 1s can improve RPC performance.