### PR TITLE
Optimize DistributedLoadCommand

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -120,9 +120,8 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         case FAILED:
           return false;
         default:
-          throw new IllegalStateException(String.format("Unexpected Status: %s", jobInfo.getStatus());
+          throw new IllegalStateException(String.format("Unexpected Status: %s", jobInfo.getStatus()));
       }
-
     }
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -116,6 +116,11 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
           return null;
         case CANCELED:
         case COMPLETED:
+          try {
+            mClient.close();
+          } catch (IOException e) {
+            // ignore IOException
+          }
           return true;
         case FAILED:
           return false;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -73,8 +73,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
           .desc("Maximum number of active outgoing jobs, default: " + DEFAULT_ACTIVE_JOBS)
           .build();
 
-  private final List<JobAttempt> mSubmittedJobAttempts;
-
   private class JobAttempt {
     private final JobConfig mJobConfig;
     private final RetryPolicy mRetryPolicy;
@@ -142,6 +140,9 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     }
   }
 
+  private final List<JobAttempt> mSubmittedJobAttempts;
+  private int mActiveJobs;
+
   /**
    * Constructs a new instance to load a file or directory in Alluxio space.
    *
@@ -172,6 +173,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);
     int replication = FileSystemShellUtils.getIntArg(cl, REPLICATION_OPTION, DEFAULT_REPLICATION);
+    mActiveJobs = FileSystemShellUtils.getIntArg(cl, ACTIVE_JOBS_OPTION, DEFAULT_ACTIVE_JOBS);
     distributedLoad(path, replication);
     return 0;
   }
@@ -229,7 +231,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
       System.out.println(filePath + " is already fully loaded in Alluxio");
       return;
     }
-    if (mSubmittedJobAttempts.size() >= DEFAULT_ACTIVE_JOBS) {
+    if (mSubmittedJobAttempts.size() >= mActiveJobs) {
       // Wait one job to complete.
       waitJob();
     }


### PR DESCRIPTION
Premise: Each job has an overhead of at least 1~2 seconds because of it takes at least JobWorker heartbeats (once for the work to go from JobMaster to JobWorker and once more for the JobWorker work completion to be reported backed to JobMaster) so it is important that when there are a lot of jobs to be done, that many jobs get submitted at the same time.

What was done:
- Remove creating threads per job (only 1 thread)
- Increase number of default outgoing jobs from 10 -> 1000 (also configurable)
- Client round robins all of the outgoing active jobs, handles retries, and when they succeed, remove from the list to be filled with new jobs.


Test Environment: 

- Local machine
- 12000 Files
- Approximately 450 bytes each
- Ran fs free followed by fs distributedLoad, checked that distributedLoad was actually loading files and timed the run

New Code: 59 seconds
Old Code: 43 minutes 33 seconds

This is about a 45x speedup.

Memory Usage: Both the old version and new version memory leaked (the new version memory leaked much faster because it executes much faster) but the addition of https://github.com/Alluxio/alluxio/pull/10606 fixed the issue.


