### PR TITLE
Change default worker heartbeat back to 1sec

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1124,7 +1124,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setAlias(new String[]{"alluxio.master.heartbeat.interval.ms",
               "alluxio.master.heartbeat.interval"})
           .setDefaultValue("10sec")
-          .setDescription("The interval between Alluxio master and worker heartbeats.")
+          .setDescription("The interval between Alluxio master detections to find lost workers "
+              + "and files based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -1536,8 +1537,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_BLOCK_HEARTBEAT_INTERVAL_MS =
       new Builder(Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS)
           .setAlias(new String[]{"alluxio.worker.block.heartbeat.interval.ms"})
-          .setDefaultValue("10sec")
-          .setDescription("The interval between block workers' heartbeats.")
+          .setDefaultValue("1sec")
+          .setDescription("The interval between block workers' heartbeats to update "
+              + "block status, pin list and other workers' information to Alluxio Master.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();


### PR DESCRIPTION
This is a manual cherry-pick of changes from #10588 
In branch-1.8, I removed the changes of modifying property key name and maintained the heartbeat and description changes