### PR TITLE
Process worker metrics asynchronously

### DIFF
--- a/core/common/src/main/java/alluxio/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/PropertyKey.java
@@ -1307,6 +1307,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METRICS_SERVICE_THREADS =
+      new Builder(Name.MASTER_METRICS_SERVICE_THREADS)
+          .setDefaultValue(5)
+          .setDescription("The number of threads in executor pool for parallel processing "
+              + "metrics submitted by workers or clients")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR =
       new Builder(Name.MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR)
           .setDefaultValue(true)
@@ -3438,6 +3446,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.inode.inherit.owner.and.group";
     public static final String MASTER_LOG_CONFIG_REPORT_HEARTBEAT_INTERVAL =
         "alluxio.master.log.config.report.heartbeat.interval";
+    public static final String MASTER_METRICS_SERVICE_THREADS =
+        "alluxio.master.metrics.service.threads";
     public static final String MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR =
         "alluxio.master.periodic.block.integrity.check.repair";
     public static final String MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_INTERVAL =

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Default implementation of the metrics master.
@@ -59,6 +60,7 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
       new HashSet<>();
   private final MetricsStore mMetricsStore;
   private final HeartbeatThread mClusterMetricsUpdater;
+  private final ExecutorService mExecutorService;
 
   /**
    * Creates a new instance of {@link MetricsMaster}.
@@ -67,7 +69,8 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
    */
   DefaultMetricsMaster(MasterContext masterContext) {
     this(masterContext, new SystemClock(), ExecutorServiceFactories
-        .fixedThreadPoolExecutorServiceFactory(Constants.METRICS_MASTER_NAME, 2));
+        .fixedThreadPoolExecutorServiceFactory(Constants.METRICS_MASTER_NAME,
+            Configuration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS)));
   }
 
   /**
@@ -87,6 +90,7 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
         new HeartbeatThread(HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER,
             new ClusterMetricsUpdater(),
             Configuration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL));
+    mExecutorService = executorServiceFactory.create();
   }
 
   @VisibleForTesting
@@ -205,7 +209,7 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
 
   @Override
   public void clientHeartbeat(String clientId, String hostname, List<Metric> metrics) {
-    mMetricsStore.putClientMetrics(hostname, clientId, metrics);
+    submitMetrics(hostname, clientId, metrics);
   }
 
   @Override
@@ -215,7 +219,24 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
 
   @Override
   public void workerHeartbeat(String hostname, List<Metric> metrics) {
-    mMetricsStore.putWorkerMetrics(hostname, metrics);
+    submitMetrics(hostname, null, metrics);
+  }
+
+  /**
+   * Submits the worker or client metrics to executor service.
+   *
+   * @param clientId the client id, or null if submitting worker metrics
+   * @param hostname the worker or client hostname
+   * @param metrics worker or client metrics
+   */
+  private void submitMetrics(String hostname, String clientId, List<Metric> metrics) {
+    mExecutorService.submit(() -> {
+      if (clientId == null) {
+        mMetricsStore.putWorkerMetrics(hostname, metrics);
+      } else {
+        mMetricsStore.putClientMetrics(hostname, clientId, metrics);
+      }
+    });
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -11,8 +11,9 @@
 
 package alluxio.master.metrics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import alluxio.Constants;
 import alluxio.clock.ManualClock;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
@@ -23,7 +24,9 @@ import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.aggregator.SingleTagValueAggregator;
 import alluxio.metrics.aggregator.SumInstancesAggregator;
+import alluxio.util.CommonUtils;
 import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.executor.ExecutorServiceFactories;
 
 import com.google.common.collect.Lists;
@@ -35,6 +38,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
 /**
  * Unit tests for {@link MetricsMaster}.
@@ -43,6 +47,8 @@ public class MetricsMasterTest {
   @ClassRule
   public static ManuallyScheduleHeartbeat sManuallyScheduleRule = new ManuallyScheduleHeartbeat(
       HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER);
+
+  private static final int TIMEOUT_MS = 5 * Constants.SECOND_MS;
 
   private DefaultMetricsMaster mMetricsMaster;
   private MasterRegistry mRegistry;
@@ -70,7 +76,7 @@ public class MetricsMasterTest {
   }
 
   @Test
-  public void testAggregator() {
+  public void testAggregator() throws Exception {
     mMetricsMaster.addAggregator(
         new SumInstancesAggregator("metricA", MetricsSystem.InstanceType.WORKER, "metricA"));
     mMetricsMaster.addAggregator(
@@ -81,13 +87,13 @@ public class MetricsMasterTest {
     List<Metric> metrics2 = Lists.newArrayList(Metric.from("worker.192_1_1_2.metricA", 1),
         Metric.from("worker.192_1_1_2.metricB", 2));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics2);
-    assertEquals(11L, getGauge("metricA"));
-    assertEquals(22L, getGauge("metricB"));
+    checkMetricValue("metricA", 11L);
+    checkMetricValue("metricB", 22L);
     // override metrics from hostname 192_1_1_2
     List<Metric> metrics3 = Lists.newArrayList(Metric.from("worker.192_1_1_2.metricA", 3));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics3);
-    assertEquals(13L, getGauge("metricA"));
-    assertEquals(20L, getGauge("metricB"));
+    checkMetricValue("metricA", 13L);
+    checkMetricValue("metricB", 20L);
   }
 
   @Test
@@ -101,12 +107,12 @@ public class MetricsMasterTest {
         Metric.from("worker.192_1_1_2.metric.tag:v2", 2));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics2);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER);
-    assertEquals(11L, getGauge("metric", "tag", "v1"));
-    assertEquals(22L, getGauge("metric", "tag", "v2"));
+    checkMetricValue("metric", 11L, "tag", "v1");
+    checkMetricValue("metric", 22L, "tag", "v2");
   }
 
   @Test
-  public void testClientHeartbeat() {
+  public void testClientHeartbeat() throws Exception {
     mMetricsMaster.addAggregator(
         new SumInstancesAggregator("metric1", MetricsSystem.InstanceType.CLIENT, "metric1"));
     mMetricsMaster.addAggregator(
@@ -120,8 +126,8 @@ public class MetricsMasterTest {
     List<Metric> metrics3 = Lists.newArrayList(Metric.from("client.192_1_1_2:C.metric1", 1),
         Metric.from("client.192_1_1_2:C.metric2", 2));
     mMetricsMaster.clientHeartbeat("C", "192.1.1.2", metrics3);
-    assertEquals(26L, getGauge("metric1"));
-    assertEquals(47L, getGauge("metric2"));
+    checkMetricValue("metric1", 26L);
+    checkMetricValue("metric2", 47L);
   }
 
   private Object getGauge(String name) {
@@ -134,5 +140,25 @@ public class MetricsMasterTest {
         .get(MetricsSystem
             .getClusterMetricName(Metric.getMetricNameWithTags(metricName, tagName, tagValue)))
         .getValue();
+  }
+
+  private void checkMetricValue(String metricsName, Long value) throws Exception {
+    checkMetricValue(metricsName, value, null, null);
+  }
+
+  private void checkMetricValue(String metricsName, Long value,
+      String tagName, String tagValue) throws Exception {
+    Supplier<Boolean> condition;
+    if (tagName == null) {
+      condition = () -> getGauge(metricsName) == value;
+    } else {
+      condition = () -> getGauge(metricsName, tagName, tagValue) == value;
+    }
+    if (!condition.get()) {
+      // Wait for the async metrics updater to finish
+      CommonUtils.waitFor("metrics processed", input -> condition.get(),
+          WaitForOptions.defaults().setTimeoutMs(TIMEOUT_MS));
+      assertTrue(condition.get());
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10470
Previously we process worker metrics synchronously in the
MasterWorkerInfo lock and also the WorkerMetrics lock. This will
(1) Make each worker heartbeat takes longer. Worker heartbeat need to
wait for the submitted metrics to be processed.
(2) Make worker heartbeats block each other. We can only process one
worker metrics at a time.

Process worker metrics asynchronously will help unblock worker
heartbeats.

pr-link: Alluxio/alluxio#10485
change-id: cid-5f0e458dde3273c716477df5cc2bbef750542703