### PR TITLE
Improve concurrency for MetricsStore

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -686,5 +686,31 @@ public final class CommonUtils {
         mins, secs);
   }
 
+  /**
+   * Memoize implementation for java.util.function.supplier.
+   *
+   * @param original the original supplier
+   * @param <T> the object type
+   * @return the supplier with memorization
+   */
+  public static <T> Supplier<T> memoize(Supplier<T> original) {
+    return new Supplier<T>() {
+      Supplier<T> mDelegate = this::firstTime;
+      boolean mInitialized;
+      public T get() {
+        return mDelegate.get();
+      }
+
+      private synchronized T firstTime() {
+        if (!mInitialized) {
+          T value = original.get();
+          mDelegate = () -> value;
+          mInitialized = true;
+        }
+        return mDelegate.get();
+      }
+    };
+  }
+
   private CommonUtils() {} // prevent instantiation
 }

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -199,6 +199,7 @@ public class DefaultMetricsMaster extends AbstractMaster implements MetricsMaste
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
     if (isLeader) {
+      mMetricsStore.clear();
       getExecutorService().submit(mClusterMetricsUpdater);
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -87,7 +87,7 @@ public class MetricsMasterTest {
     List<Metric> metrics3 = Lists.newArrayList(Metric.from("worker.192_1_1_2.metricA", 3));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics3);
     assertEquals(13L, getGauge("metricA"));
-    assertEquals(20L, getGauge("metricB"));
+    assertEquals(22L, getGauge("metricB"));
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10470
This PR aims to improve concurrency in MetricsStore when processing
worker/client metrics.
It removes the synchronized lock on the metrics sets.
Atomically updates metric values instead of removing and constructing
new objects.
This memoizes the Metrics.getFullMetricName(), since it is costly in
time and allocations.

When Metric.getFullMetricName() runs normally, it bumps up the
heartbeats can be processed per second from 1000-3000 heartbeats/second
to 2000-5000 heartbeats/second.
When Metric.getFullMetricName() is unexpectedly slow, the performance
improvement can be really big (when 100 worker heartbeats with 50
executor threads, before my change takes 11 min, after my change takes
18 second if getFullMetricName sleep for 15ms).

pr-link: Alluxio/alluxio#10493
change-id: cid-3c92e89a816d57dceeb257c69f506a51793fd078