### PR TITLE
Avoid registering listener for channel state change

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -26,7 +26,6 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptors;
-import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -160,11 +159,8 @@ public class ChannelAuthenticator {
             SaslAuthenticationServiceGrpc.newStub(mManagedChannel).authenticate(mClientDriver);
         mClientDriver.setServerObserver(requestObserver);
         // Start authentication traffic with the target.
+        // Successful return from this method means success.
         mClientDriver.start();
-        // Authentication succeeded!
-        mManagedChannel.notifyWhenStateChanged(ConnectivityState.READY, () -> {
-          mAuthenticated.set(false);
-        });
         // Intercept authenticated channel with channel-Id injector.
         mChannel = ClientInterceptors.intercept(mManagedChannel,
             new ChannelIdInjector(mChannelKey.getChannelId()));

--- a/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/SaslStreamClientDriver.java
@@ -126,6 +126,8 @@ public class SaslStreamClientDriver implements StreamObserver<SaslMessage> {
     } else {
       LOG.warn(errorMsg);
     }
+    // Authentication failed either during or after handshake.
+    mAuthenticated.set(false);
   }
 
   @Override


### PR DESCRIPTION
Calling `notifyWhenStateChanged()` on managed channel will cause accumulation of listeners and could potentially cause OOM in massive channel create/delete scenarios.

We can safely discard making this call since we keep channel's authentication stream active. Server state changes that effect authentication will reflect in authentication stream's `onError()` method as well. This provides more stable accounting as earlier tracking was sensitive to unrelated connection level state changes as well.