### PR TITLE
Port changes of [#10589] to branch-2.1

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -114,7 +114,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
       JobInfo jobInfo;
       try {
-        jobInfo = mClient.getJobStatus(mJobId);
+        jobInfo = mClient.getStatus(mJobId);
       } catch (IOException e) {
         LOG.warn("Failed to get status for job (jobId={})", mJobId, e);
         return Status.FAILED;


### PR DESCRIPTION
Premise: Each job has an overhead of at least 1~2 seconds because of it
takes at least JobWorker heartbeats (once for the work to go from
JobMaster to JobWorker and once more for the JobWorker work completion
to be reported backed to JobMaster) so it is important that when there
are a lot of jobs to be done, that many jobs get submitted at the same
time.

What was done:
- Remove creating threads per job (only 1 thread)
- Increase number of default outgoing jobs from 10 -> 1000 (also
configurable)
- Client round robins all of the outgoing active jobs, handles retries,
and when they succeed, remove from the list to be filled with new jobs.

Test Environment:

- Local machine
- 12000 Files
- Approximately 450 bytes each
- Ran fs free followed by fs distributedLoad, checked that
distributedLoad was actually loading files and timed the run

New Code: 59 seconds
Old Code: 43 minutes 33 seconds

This is about a 45x speedup.

Memory Usage: Both the old version and new version memory leaked (the
new version memory leaked much faster because it executes much faster)
but the addition of https://github.com/Alluxio/alluxio/pull/10606 fixed
the issue.

pr-link: Alluxio/alluxio#10589
change-id: cid-49cf529032666a3800563379b97e4f834e62658a