### PR TITLE
Use 2.2 hive client for greater compatibility

### DIFF
--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -26,7 +26,8 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
-    <hive-metastore.version>2.3.6</hive-metastore.version>
+    <!-- 2.2.0 client works with a wide range of HMS, from 1.0 to 3.1 -->
+    <hive-metastore.version>2.2.0</hive-metastore.version>
   </properties>
 
   <dependencies>

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -30,6 +30,7 @@ import alluxio.table.under.hive.util.PathTranslator;
 import alluxio.util.io.PathUtils;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
@@ -55,6 +56,7 @@ import java.util.stream.Collectors;
  */
 public class HiveDatabase implements UnderDatabase {
   private static final Logger LOG = LoggerFactory.getLogger(HiveDatabase.class);
+  private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
 
   private final UdbContext mUdbContext;
   private final UdbConfiguration mConfiguration;
@@ -252,7 +254,8 @@ public class HiveDatabase implements UnderDatabase {
       Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
       HiveConf conf = new HiveConf();
       conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
-      mHive = RetryingMetaStoreClient.getProxy(conf, null, HiveMetaStoreClient.class.getName());
+      mHive =
+          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName());
       mHive.getDatabase(mHiveDbName);
       return mHive;
     } catch (NoSuchObjectException e) {


### PR DESCRIPTION
The 2.3 client uses a new thrift API (`get_table_req`) which older HMS versions do not have. Therefore, for compatibility with older HMS versions, an older client must be used. 2.2 is the latest client version which still works with HMS versions <= 2.2.

This 2.2 hive client has been tested and works with HMS versions: 1.0.1, 1.1.0, 1.2.2, 2.0.1, 2.1.1, 2.2.0, 2.3.6, 3.0.0, 3.1.2