### PR TITLE
Fix JobMaster.cancel(jobId)

### DIFF
--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -75,12 +75,6 @@ public final class TaskExecutor implements Runnable {
     Serializable result;
     try {
       result = definition.runTask(mJobConfig, mTaskArgs, mContext);
-      if (Thread.interrupted()) {
-        mTaskExecutorManager.notifyTaskCancellation(mJobId, mTaskId);
-      }
-    } catch (InterruptedException e) {
-      mTaskExecutorManager.notifyTaskCancellation(mJobId, mTaskId);
-      return;
     } catch (Throwable t) {
       if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
         mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, ExceptionUtils.getStackTrace(t));

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -75,6 +75,10 @@ public final class TaskExecutor implements Runnable {
     Serializable result;
     try {
       result = definition.runTask(mJobConfig, mTaskArgs, mContext);
+    } catch (InterruptedException e) {
+      // Cleanup around the interruption should already have been handled by a different thread
+      Thread.currentThread().interrupt();
+      return;
     } catch (Throwable t) {
       if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
         mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, ExceptionUtils.getStackTrace(t));

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
@@ -143,20 +143,6 @@ public class TaskExecutorManager {
   }
 
   /**
-   * Notifies the cancellation of the task.
-   *
-   * @param jobId the job id
-   * @param taskId the task id
-   */
-  public synchronized void notifyTaskCancellation(long jobId, long taskId) {
-    Pair<Long, Long> id = new Pair<>(jobId, taskId);
-    TaskInfo taskInfo = mUnfinishedTasks.get(id);
-    taskInfo.setStatus(Status.CANCELED);
-    finishTask(id);
-    LOG.info("Task {} for job {} canceled", taskId, jobId);
-  }
-
-  /**
    * Executes the given task.
    *
    * @param jobId the job id
@@ -192,10 +178,14 @@ public class TaskExecutorManager {
       return;
     }
 
+    LOG.info("Task {} for job {} canceled", taskId, jobId);
     Future<?> future = mTaskFutures.get(id);
     if (!future.cancel(true)) {
       taskInfo.setStatus(Status.FAILED);
       taskInfo.setErrorMessage("Failed to cancel the task");
+      finishTask(id);
+    } else {
+      taskInfo.setStatus(Status.CANCELED);
       finishTask(id);
     }
   }

--- a/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
+++ b/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
@@ -89,25 +89,4 @@ public final class TaskExecutorTest {
     Mockito.verify(mTaskExecutorManager).notifyTaskFailure(Mockito.eq(jobId), Mockito.eq(taskId),
         Mockito.anyString());
   }
-
-  @Test
-  public void runCancelation() throws Exception {
-    long jobId = 1;
-    long taskId = 2;
-    JobConfig jobConfig = Mockito.mock(JobConfig.class);
-    Serializable taskArgs = Lists.newArrayList(1);
-    RunTaskContext context = Mockito.mock(RunTaskContext.class);
-    @SuppressWarnings("unchecked")
-    PlanDefinition<JobConfig, Serializable, Serializable> planDefinition =
-        Mockito.mock(PlanDefinition.class);
-    Mockito.when(mRegistry.getJobDefinition(jobConfig)).thenReturn(planDefinition);
-    Mockito.doThrow(new InterruptedException("interupt")).when(planDefinition).runTask(jobConfig,
-        taskArgs, context);
-
-    TaskExecutor executor =
-        new TaskExecutor(jobId, taskId, jobConfig, taskArgs, context, mTaskExecutorManager);
-    executor.run();
-
-    Mockito.verify(mTaskExecutorManager).notifyTaskCancellation(jobId, taskId);
-  }
 }

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -40,6 +40,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -195,7 +196,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
     JobTestUtils.waitForJobStatus(mJobMaster, jobId0,
         Sets.newHashSet(Status.RUNNING, Status.COMPLETED));
 
-    long jobId1 = mJobMaster.run(new SleepJobConfig(5000));
+    long jobId1 = mJobMaster.run(new SleepJobConfig(50000));
     JobTestUtils.waitForJobStatus(mJobMaster, jobId1, Status.RUNNING);
     JobTestUtils.waitForJobStatus(mJobMaster, jobId0, Status.COMPLETED);
 
@@ -211,5 +212,10 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
 
     assertEquals(1, mJobMaster.getAllWorkerHealth().get(0).getTaskPoolSize());
     assertEquals(1, mJobMaster.getAllWorkerHealth().get(0).getNumActiveTasks());
+
+    mJobMaster.cancel(jobId1);
+
+    JobTestUtils.waitForJobStatus(mJobMaster, jobId2, Status.COMPLETED);
+    JobTestUtils.waitForJobStatus(mJobMaster, jobId3, Status.COMPLETED);
   }
 }

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -40,7 +40,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;


### PR DESCRIPTION
JobMaster.cancel() previously cleaned up properly only if the JobWorker thread was actually executing the task. But in reality, almost all of the tasks are in the executor queue. 