### PR TITLE
Shutdown channel immediately if health-check failed

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -94,6 +94,7 @@ public class GrpcManagedChannelPool {
         existingRefCount = chHolder.getRefCount();
         LOG.debug("Shutting down an existing unhealthy managed channel. "
             + "ChannelKey: {}. Existing Ref-count: {}", key, existingRefCount);
+        // Shutdown the channel forcefully as it's already unhealthy.
         shutdownManagedChannel(chHolder.get(), true, shutdownTimeoutMs);
       }
 
@@ -115,6 +116,7 @@ public class GrpcManagedChannelPool {
       Preconditions.checkNotNull(chHolder, "Releasing nonexistent channel");
       if (chHolder.dereference() == 0) {
         LOG.debug("Released managed channel for: {}. Ref-count: {}", key, chHolder.getRefCount());
+        // Shutdown the channel gracefully.
         shutdownManagedChannel(chHolder.get(), false, shutdownTimeoutMs);
         return null;
       }

--- a/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcManagedChannelPool.java
@@ -222,7 +222,7 @@ public class GrpcManagedChannelPool {
   /**
    * Forcefully shuts down the managed channel.
    */
-  private void forceShutdownManagedChannel(ManagedChannel managedChannel, long shutdownTimeoutMs){
+  private void forceShutdownManagedChannel(ManagedChannel managedChannel, long shutdownTimeoutMs) {
     managedChannel.shutdownNow();
     try {
       if (!managedChannel.awaitTermination(shutdownTimeoutMs, TimeUnit.MILLISECONDS)) {


### PR DESCRIPTION
`awaitTermination()` on channel that has been shutdown gracefully will not return if a health check was triggered on it. This causes `PollingMasterInquireClient` to be blocked for the full channel shutdown timeout per master. (master count x channel shutdown timeout)