### PR TITLE
Fix Command Execution order on workers

### DIFF
--- a/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
@@ -21,7 +21,6 @@ import alluxio.grpc.JobInfo;
 import alluxio.grpc.RunTaskCommand;
 import alluxio.grpc.SetTaskPoolSizeCommand;
 import alluxio.heartbeat.HeartbeatExecutor;
-import alluxio.job.JobConfig;
 import alluxio.job.JobServerContext;
 import alluxio.job.RunTaskContext;
 import alluxio.job.wire.JobWorkerHealth;

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -107,8 +107,8 @@ public final class TaskExecutor implements Runnable {
       mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, t.getMessage());
     }
     LOG.warn("Exception running task for job {}({}) : {}",
-        (jobConfig == null) ? "" : jobConfig.getName(),
-        (taskArgs == null) ? "" : taskArgs.toString(), t.getMessage());
+        (jobConfig == null) ? "Undefined" : jobConfig.getName(),
+        (taskArgs == null) ? "Undefined" : taskArgs.toString(), t.getMessage());
     return;
   }
 }

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -73,7 +73,7 @@ public final class TaskExecutor implements Runnable {
         taskArgs = SerializationUtils.deserialize(mRunTaskCommand.getTaskArgs().toByteArray());
       }
     } catch (IOException | ClassNotFoundException e) {
-      fail(e, jobConfig, taskArgs);
+      fail(e, jobConfig, null);
     }
 
     PlanDefinition<JobConfig, Serializable, Serializable> definition;

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -13,17 +13,20 @@ package alluxio.worker.job.task;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.grpc.RunTaskCommand;
 import alluxio.job.JobConfig;
 import alluxio.job.plan.PlanDefinition;
 import alluxio.job.plan.PlanDefinitionRegistry;
 import alluxio.exception.JobDoesNotExistException;
 import alluxio.job.RunTaskContext;
+import alluxio.job.util.SerializationUtils;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -37,8 +40,7 @@ public final class TaskExecutor implements Runnable {
 
   private final long mJobId;
   private final long mTaskId;
-  private final JobConfig mJobConfig;
-  private final Serializable mTaskArgs;
+  private final RunTaskCommand mRunTaskCommand;
   private final RunTaskContext mContext;
   private final TaskExecutorManager mTaskExecutorManager;
 
@@ -47,50 +49,66 @@ public final class TaskExecutor implements Runnable {
    *
    * @param jobId the job id
    * @param taskId the task id
-   * @param jobConfig the job configuration
-   * @param taskArgs the arguments passed to the task
+   * @param runTaskCommand the run task command
    * @param context the context on the worker
    * @param taskExecutorManager the task executor manager
    */
-  public TaskExecutor(long jobId, long taskId, JobConfig jobConfig, Serializable taskArgs,
+  public TaskExecutor(long jobId, long taskId, RunTaskCommand runTaskCommand,
       RunTaskContext context, TaskExecutorManager taskExecutorManager) {
     mJobId = jobId;
     mTaskId = taskId;
-    mJobConfig = jobConfig;
-    mTaskArgs = taskArgs;
+    mRunTaskCommand = runTaskCommand;
     mContext = Preconditions.checkNotNull(context);
     mTaskExecutorManager = Preconditions.checkNotNull(taskExecutorManager);
   }
 
   @Override
   public void run() {
-    // TODO(yupeng) set other logger
+    JobConfig jobConfig = null;
+    Serializable taskArgs = null;
+    try {
+      jobConfig = (JobConfig) SerializationUtils.deserialize(
+          mRunTaskCommand.getJobConfig().toByteArray());
+      if (mRunTaskCommand.hasTaskArgs()) {
+        taskArgs = SerializationUtils.deserialize(mRunTaskCommand.getTaskArgs().toByteArray());
+      }
+    } catch (IOException | ClassNotFoundException e) {
+      fail(e, jobConfig, taskArgs);
+    }
+
     PlanDefinition<JobConfig, Serializable, Serializable> definition;
     try {
-      definition = PlanDefinitionRegistry.INSTANCE.getJobDefinition(mJobConfig);
+      definition = PlanDefinitionRegistry.INSTANCE.getJobDefinition(jobConfig);
     } catch (JobDoesNotExistException e) {
-      LOG.error("The job definition for config {} does not exist.", mJobConfig.getName());
+      LOG.error("The job definition for config {} does not exist.", jobConfig.getName());
+      fail(e, jobConfig, taskArgs);
       return;
     }
 
     mTaskExecutorManager.notifyTaskRunning(mJobId, mTaskId);
     Serializable result;
     try {
-      result = definition.runTask(mJobConfig, mTaskArgs, mContext);
+      result = definition.runTask(jobConfig, taskArgs, mContext);
     } catch (InterruptedException e) {
       // Cleanup around the interruption should already have been handled by a different thread
       Thread.currentThread().interrupt();
       return;
     } catch (Throwable t) {
-      if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
-        mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, ExceptionUtils.getStackTrace(t));
-      } else {
-        mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, t.getMessage());
-      }
-      LOG.warn("Exception running task for job {}({}) : {}", mJobConfig.getName(),
-          mTaskArgs.toString(), t.getMessage());
+      fail(t, jobConfig, taskArgs);
       return;
     }
     mTaskExecutorManager.notifyTaskCompletion(mJobId, mTaskId, result);
+  }
+
+  private void fail(Throwable t, JobConfig jobConfig, Serializable taskArgs) {
+    if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
+      mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, ExceptionUtils.getStackTrace(t));
+    } else {
+      mTaskExecutorManager.notifyTaskFailure(mJobId, mTaskId, t.getMessage());
+    }
+    LOG.warn("Exception running task for job {}({}) : {}",
+        (jobConfig == null) ? "" : jobConfig.getName(),
+        (taskArgs == null) ? "" : taskArgs.toString(), t.getMessage());
+    return;
   }
 }

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
@@ -199,7 +199,7 @@ public class TaskExecutorManager {
    * @param context the context of the worker
    */
   public synchronized void executeTask(long jobId, long taskId, RunTaskCommand runTaskCommand,
-                                       RunTaskContext context) {
+      RunTaskContext context) {
     Future<?> future = mTaskExecutionService
         .submit(new TaskExecutor(jobId, taskId, runTaskCommand, context, this));
     Pair<Long, Long> id = new Pair<>(jobId, taskId);
@@ -220,7 +220,6 @@ public class TaskExecutorManager {
   public synchronized void cancelTask(long jobId, long taskId) {
     Pair<Long, Long> id = new Pair<>(jobId, taskId);
     TaskInfo taskInfo = mUnfinishedTasks.get(id);
-    LOG.info("Task {} for job {} attempting to be cancelled", taskId, jobId);
     if (!mTaskFutures.containsKey(id) || taskInfo.getStatus().equals(Status.CANCELED)) {
       // job has finished, or failed, or canceled
       return;

--- a/job/server/src/test/java/alluxio/job/command/CommandHandlingExecutorTest.java
+++ b/job/server/src/test/java/alluxio/job/command/CommandHandlingExecutorTest.java
@@ -101,6 +101,6 @@ public final class CommandHandlingExecutorTest {
 
     Mockito.verify(mTaskExecutorManager).getAndClearTaskUpdates();
     Mockito.verify(mTaskExecutorManager).executeTask(Mockito.eq(jobId), Mockito.eq(taskId),
-        Mockito.eq(jobConfig), Mockito.eq(taskArgs), Mockito.any(RunTaskContext.class));
+        Mockito.eq(runTaskCommand.build()), Mockito.any(RunTaskContext.class));
   }
 }

--- a/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
+++ b/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
@@ -25,8 +25,8 @@ import alluxio.job.plan.PlanDefinition;
 import alluxio.job.plan.PlanDefinitionRegistry;
 import alluxio.job.JobServerContext;
 import alluxio.job.RunTaskContext;
-
 import alluxio.job.util.SerializationUtils;
+
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import org.junit.Before;
@@ -70,7 +70,6 @@ public final class TaskExecutorTest {
     when(mRegistry.getJobDefinition(any(JobConfig.class))).thenReturn(planDefinition);
     when(planDefinition.runTask(any(JobConfig.class), eq(taskArgs), any(RunTaskContext.class)))
         .thenReturn(taskResult);
-
 
     RunTaskCommand command = RunTaskCommand.newBuilder()
         .setJobConfig(ByteString.copyFrom(SerializationUtils.serialize(jobConfig)))

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -241,11 +241,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
     long child2 = children.get(2).getId();
 
     mJobMaster.cancel(child0);
-    try {
-      JobTestUtils.waitForJobStatus(mJobMaster, child0, Status.CANCELED);
-    } catch (Exception e) {
-      assertEquals(Status.CANCELED, mJobMaster.getStatus(child0).getStatus());
-    }
+    JobTestUtils.waitForJobStatus(mJobMaster, child0, Status.CANCELED);
     JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.CANCELED);
     JobTestUtils.waitForJobStatus(mJobMaster, child1, Status.RUNNING);
     JobTestUtils.waitForJobStatus(mJobMaster, child2, Status.RUNNING);

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -83,6 +83,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   public void multipleTasksPerWorker() throws Exception {
     long jobId = mJobMaster.run(new SleepJobConfig(1, 2));
 
@@ -96,6 +97,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "1",
       PropertyKey.Name.JOB_MASTER_FINISHED_JOB_RETENTION_TIME, "0"})
   public void flowControl() throws Exception {
@@ -113,6 +115,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   public void restartMasterAndLoseWorker() throws Exception {
     long jobId = mJobMaster.run(new SleepJobConfig(1));
     JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.COMPLETED);
@@ -127,6 +130,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   @LocalAlluxioClusterResource.Config(
       confParams = {PropertyKey.Name.JOB_MASTER_LOST_WORKER_INTERVAL, "10000000"})
   public void restartMasterAndReregisterWorker() throws Exception {
@@ -148,6 +152,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   public void getAllWorkerHealth() throws Exception {
     final AtomicReference<List<JobWorkerHealth>> singleton = new AtomicReference<>();
     CommonUtils.waitFor("allWorkerHealth", () -> {
@@ -163,6 +168,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "20"})
   public void stopJobWorkerTasks() throws Exception {
     long jobId0 = mJobMaster.run(new SleepJobConfig(5000));
@@ -190,6 +196,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "20"})
   public void throttleJobWorkerTasks() throws Exception {
     mJobMaster.setTaskPoolSize(1);
@@ -222,7 +229,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void cancel() throws Exception {
     SleepJobConfig childJob1 = new SleepJobConfig(50000);
     SleepJobConfig childJob2 = new SleepJobConfig(45000);
@@ -243,7 +249,11 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
     long child2 = children.get(2).getId();
 
     mJobMaster.cancel(child0);
-    JobTestUtils.waitForJobStatus(mJobMaster, child0, Status.CANCELED);
+    try {
+      JobTestUtils.waitForJobStatus(mJobMaster, child0, Status.CANCELED);
+    } catch (Exception e) {
+      assertEquals(mJobMaster.getStatus(child0).getStatus(), Status.CANCELED);
+    }
     JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.CANCELED);
     JobTestUtils.waitForJobStatus(mJobMaster, child1, Status.RUNNING);
     JobTestUtils.waitForJobStatus(mJobMaster, child2, Status.RUNNING);

--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -83,7 +82,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void multipleTasksPerWorker() throws Exception {
     long jobId = mJobMaster.run(new SleepJobConfig(1, 2));
 
@@ -97,7 +95,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "1",
       PropertyKey.Name.JOB_MASTER_FINISHED_JOB_RETENTION_TIME, "0"})
   public void flowControl() throws Exception {
@@ -115,7 +112,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void restartMasterAndLoseWorker() throws Exception {
     long jobId = mJobMaster.run(new SleepJobConfig(1));
     JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.COMPLETED);
@@ -130,7 +126,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   @LocalAlluxioClusterResource.Config(
       confParams = {PropertyKey.Name.JOB_MASTER_LOST_WORKER_INTERVAL, "10000000"})
   public void restartMasterAndReregisterWorker() throws Exception {
@@ -152,7 +147,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void getAllWorkerHealth() throws Exception {
     final AtomicReference<List<JobWorkerHealth>> singleton = new AtomicReference<>();
     CommonUtils.waitFor("allWorkerHealth", () -> {
@@ -168,7 +162,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "20"})
   public void stopJobWorkerTasks() throws Exception {
     long jobId0 = mJobMaster.run(new SleepJobConfig(5000));
@@ -196,7 +189,6 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore
   @LocalAlluxioClusterResource.Config(confParams = {PropertyKey.Name.JOB_MASTER_JOB_CAPACITY, "20"})
   public void throttleJobWorkerTasks() throws Exception {
     mJobMaster.setTaskPoolSize(1);
@@ -252,7 +244,7 @@ public final class JobMasterIntegrationTest extends BaseIntegrationTest {
     try {
       JobTestUtils.waitForJobStatus(mJobMaster, child0, Status.CANCELED);
     } catch (Exception e) {
-      assertEquals(mJobMaster.getStatus(child0).getStatus(), Status.CANCELED);
+      assertEquals(Status.CANCELED, mJobMaster.getStatus(child0).getStatus());
     }
     JobTestUtils.waitForJobStatus(mJobMaster, jobId, Status.CANCELED);
     JobTestUtils.waitForJobStatus(mJobMaster, child1, Status.RUNNING);


### PR DESCRIPTION
Previously, the order of commands was not honored by the workers because there were 4 threads handling the command handling service. But the benefit of these threads is minimal because underlying TaskExecutorManager is synchronized.

Resolve this by moving the expensive portion that could be executed in parallel under TaskExecutor and making CommandHandlingService single threaded.