### PR TITLE
Add SSH and SCP command utility and refactor shell utility

### DIFF
--- a/core/common/src/main/java/alluxio/shell/CommandReturn.java
+++ b/core/common/src/main/java/alluxio/shell/CommandReturn.java
@@ -1,0 +1,72 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell;
+
+/**
+ * Object representation of a command execution.
+ */
+public class CommandReturn {
+  private int mExitCode;
+  private String mStdOut;
+  private String mStdErr;
+
+  /**
+   * Creates object from the contents.
+   *
+   * @param code exit code
+   * @param stdOut stdout content
+   * @param stdErr stderr content
+   */
+  public CommandReturn(int code, String stdOut, String stdErr) {
+    mExitCode = code;
+    mStdOut = stdOut;
+    mStdErr = stdErr;
+  }
+
+  /**
+   * Gets the stdout content.
+   *
+   * @return stdout content
+   */
+  public String getStdOut() {
+    return mStdOut;
+  }
+
+  /**
+   * Gets the stderr content.
+   *
+   * @return stderr content
+   */
+  public String getStdErr() {
+    return mStdErr;
+  }
+
+  /**
+   * Gets the exit code.
+   *
+   * @return exit code of execution
+   */
+  public int getExitCode() {
+    return mExitCode;
+  }
+
+  /**
+   * Formats the object to more readable format.
+   * This is not done in toString() because stdout and stderr may be long.
+   *
+   * @return pretty formatted output
+   */
+  public String getFormattedOutput() {
+    return String.format("StatusCode:%s%nStdOut:%n%s%nStdErr:%n%s", getExitCode(),
+            getStdOut(), getStdErr());
+  }
+}

--- a/core/common/src/main/java/alluxio/shell/CommandReturn.java
+++ b/core/common/src/main/java/alluxio/shell/CommandReturn.java
@@ -16,20 +16,17 @@ package alluxio.shell;
  */
 public class CommandReturn {
   private int mExitCode;
-  private String mStdOut;
-  private String mStdErr;
+  private String mOutput;
 
   /**
    * Creates object from the contents.
    *
    * @param code exit code
-   * @param stdOut stdout content
-   * @param stdErr stderr content
+   * @param output stdout content
    */
-  public CommandReturn(int code, String stdOut, String stdErr) {
+  public CommandReturn(int code, String output) {
     mExitCode = code;
-    mStdOut = stdOut;
-    mStdErr = stdErr;
+    mOutput = output;
   }
 
   /**
@@ -37,17 +34,8 @@ public class CommandReturn {
    *
    * @return stdout content
    */
-  public String getStdOut() {
-    return mStdOut;
-  }
-
-  /**
-   * Gets the stderr content.
-   *
-   * @return stderr content
-   */
-  public String getStdErr() {
-    return mStdErr;
+  public String getOutput() {
+    return mOutput;
   }
 
   /**
@@ -66,7 +54,7 @@ public class CommandReturn {
    * @return pretty formatted output
    */
   public String getFormattedOutput() {
-    return String.format("StatusCode:%s%nStdOut:%n%s%nStdErr:%n%s", getExitCode(),
-            getStdOut(), getStdErr());
+    return String.format("StatusCode:%s%nOutput:%n%s", getExitCode(),
+            getOutput());
   }
 }

--- a/core/common/src/main/java/alluxio/shell/ScpCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ScpCommand.java
@@ -15,14 +15,33 @@ import alluxio.util.ShellUtils;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+/**
+ * Object representation of a remote scp command.
+ * The scp command copies a file/dir from remote host to local.
+ */
 @NotThreadSafe
 public class ScpCommand extends ShellCommand {
   protected String mHostName;
 
-  private ScpCommand(String remoteHost, String fromFile, String toFile) {
+  /**
+   * Creates a remote scp command to copy a file to local.
+   *
+   * @param remoteHost remote hostname
+   * @param fromFile the remote file
+   * @param toFile target location to copy to
+   */
+  public ScpCommand(String remoteHost, String fromFile, String toFile) {
     this(remoteHost, fromFile, toFile, false);
   }
 
+  /**
+   * Creates a remote scp command to copy a file/dir to local.
+   *
+   * @param remoteHost the remote hostname
+   * @param fromFile the remote file/dir to copy
+   * @param toFile target path to copy to
+   * @param isDir if true, the remote file is a directory
+   */
   public ScpCommand(String remoteHost, String fromFile, String toFile, boolean isDir) {
     super(new String[]{});
 
@@ -38,7 +57,12 @@ public class ScpCommand extends ShellCommand {
     mHostName = remoteHost;
   }
 
-  protected String getHostName() {
+  /**
+   * Returns the remote target hostname.
+   *
+   * @return target hostname
+   */
+  public String getHostName() {
     return mHostName;
   }
 }

--- a/core/common/src/main/java/alluxio/shell/ScpCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ScpCommand.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class ScpCommand extends ShellCommand {
-  protected String mHostName;
+  private final String mHostName;
 
   /**
    * Creates a remote scp command to copy a file to local.
@@ -43,17 +43,10 @@ public class ScpCommand extends ShellCommand {
    * @param isDir if true, the remote file is a directory
    */
   public ScpCommand(String remoteHost, String fromFile, String toFile, boolean isDir) {
-    super(new String[]{});
-
-    String template = "scp %s %s:%s localhost:%s";
-    if (isDir) {
-      template = "scp -r %s %s:%s localhost:%s";
-    }
-
-    // copy from hostname to local
-    mCommand = new String[]{"bash", "-c",
-            String.format(template, ShellUtils.COMMON_SSH_OPTS, remoteHost, fromFile, toFile)
-    };
+    super(new String[]{"bash", "-c",
+            String.format(isDir ? "scp -r %s %s:%s localhost:%s" : "scp %s %s:%s localhost:%s",
+                    ShellUtils.COMMON_SSH_OPTS, remoteHost, fromFile, toFile)
+    });
     mHostName = remoteHost;
   }
 

--- a/core/common/src/main/java/alluxio/shell/ScpCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ScpCommand.java
@@ -1,0 +1,44 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell;
+
+import alluxio.util.ShellUtils;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class ScpCommand extends ShellCommand {
+  protected String mHostName;
+
+  private ScpCommand(String remoteHost, String fromFile, String toFile) {
+    this(remoteHost, fromFile, toFile, false);
+  }
+
+  public ScpCommand(String remoteHost, String fromFile, String toFile, boolean isDir) {
+    super(new String[]{});
+
+    String template = "scp %s %s:%s localhost:%s";
+    if (isDir) {
+      template = "scp -r %s %s:%s localhost:%s";
+    }
+
+    // copy from hostname to local
+    mCommand = new String[]{"bash", "-c",
+            String.format(template, ShellUtils.COMMON_SSH_OPTS, remoteHost, fromFile, toFile)
+    };
+    mHostName = remoteHost;
+  }
+
+  protected String getHostName() {
+    return mHostName;
+  }
+}

--- a/core/common/src/main/java/alluxio/shell/ShellCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ShellCommand.java
@@ -12,6 +12,7 @@
 package alluxio.shell;
 
 import alluxio.util.ShellUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class ShellCommand {
   /**
    * Creates a ShellCommand object with the command to exec.
    *
-   * @param execString
+   * @param execString shell command
    */
   public ShellCommand(String[] execString) {
     mCommand = execString.clone();

--- a/core/common/src/main/java/alluxio/shell/ShellCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ShellCommand.java
@@ -1,0 +1,145 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell;
+
+import alluxio.util.ShellUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+@NotThreadSafe
+public class ShellCommand {
+  private static final Logger LOG = LoggerFactory.getLogger(ShellCommand.class);
+
+  protected String[] mCommand;
+
+  public ShellCommand(String[] execString) {
+    mCommand = execString.clone();
+  }
+
+  /**
+   * Runs a command and returns its stdout on success.
+   *
+   * @return the output
+   * @throws ShellUtils.ExitCodeException if the command returns a non-zero exit code
+   */
+  public String run() throws ShellUtils.ExitCodeException, IOException {
+    Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
+
+    BufferedReader inReader =
+            new BufferedReader(new InputStreamReader(process.getInputStream(),
+                    Charset.defaultCharset()));
+
+    try {
+      // read the output of the command
+      StringBuilder output = new StringBuilder();
+      String line = inReader.readLine();
+      while (line != null) {
+        output.append(line);
+        output.append("\n");
+        line = inReader.readLine();
+      }
+      // wait for the process to finish and check the exit code
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        throw new ShellUtils.ExitCodeException(exitCode, output.toString());
+      }
+      return output.toString();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(e);
+    } finally {
+      // close the input stream
+      try {
+        // JDK 7 tries to automatically drain the input streams for us
+        // when the process exits, but since close is not synchronized,
+        // it creates a race if we close the stream first and the same
+        // fd is recycled. the stream draining thread will attempt to
+        // drain that fd!! it may block, OOM, or cause bizarre behavior
+        // see: https://bugs.openjdk.java.net/browse/JDK-8024521
+        // issue is fixed in build 7u60
+        InputStream stdout = process.getInputStream();
+        synchronized (stdout) {
+          inReader.close();
+        }
+      } catch (IOException e) {
+        LOG.warn("Error while closing the input stream", e);
+      }
+      process.destroy();
+    }
+  }
+
+  /**
+   * Runs a command and returns its stdout, stderr and exit code.
+   * No matter it succeeds or not.
+   *
+   * @return {@link CommandReturn} object representation of stdout, stderr and exit code
+   */
+  public CommandReturn runTolerateFailure() throws IOException {
+    Process process = new ProcessBuilder(mCommand).start();
+    CommandReturn cr = null;
+
+    try (BufferedReader inReader =
+                 new BufferedReader(new InputStreamReader(process.getInputStream()));
+         BufferedReader errReader =
+                 new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+      // read the output of the command
+      StringBuilder stdout = new StringBuilder();
+      String outLine = inReader.readLine();
+      while (outLine != null) {
+        stdout.append(outLine);
+        stdout.append("\n");
+        outLine = inReader.readLine();
+      }
+
+      // read the stderr of the command
+      StringBuilder stderr = new StringBuilder();
+      String errLine = errReader.readLine();
+      while (errLine != null) {
+        stderr.append(errLine);
+        stderr.append("\n");
+        errLine = inReader.readLine();
+      }
+
+      // wait for the process to finish and check the exit code
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        // log error instead of throwing exception
+        LOG.warn(String.format("Failed to run command %s%nExit Code: %s%nStderr: %s",
+                Arrays.toString(mCommand), exitCode, stderr.toString()));
+      }
+
+      cr = new CommandReturn(exitCode, stdout.toString(), stderr.toString());
+
+      // destroy the process
+      if (process != null) {
+        process.destroy();
+      }
+
+      return cr;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(e);
+    } finally {
+      if (process != null) {
+        process.destroy();
+      }
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/shell/ShellCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ShellCommand.java
@@ -23,12 +23,20 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
+/**
+ * Object representation of a shell command.
+ */
 @NotThreadSafe
 public class ShellCommand {
   private static final Logger LOG = LoggerFactory.getLogger(ShellCommand.class);
 
   protected String[] mCommand;
 
+  /**
+   * Creates a ShellCommand object with the command to exec.
+   *
+   * @param execString
+   */
   public ShellCommand(String[] execString) {
     mCommand = execString.clone();
   }
@@ -37,9 +45,9 @@ public class ShellCommand {
    * Runs a command and returns its stdout on success.
    *
    * @return the output
-   * @throws ShellUtils.ExitCodeException if the command returns a non-zero exit code
+   * @throws IOException if the command returns a non-zero exit code
    */
-  public String run() throws ShellUtils.ExitCodeException, IOException {
+  public String run() throws IOException {
     Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
 
     BufferedReader inReader =

--- a/core/common/src/main/java/alluxio/shell/ShellCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ShellCommand.java
@@ -12,7 +12,6 @@
 package alluxio.shell;
 
 import alluxio.util.ShellUtils;
-import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/common/src/main/java/alluxio/shell/ShellCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ShellCommand.java
@@ -44,6 +44,7 @@ public class ShellCommand {
 
   /**
    * Runs a command and returns its stdout on success.
+   * Stderr is redirected to stdout.
    *
    * @return the output
    * @throws IOException if the command returns a non-zero exit code
@@ -95,8 +96,9 @@ public class ShellCommand {
   }
 
   /**
-   * Runs a command and returns its stdout, stderr and exit code.
+   * Runs a command and returns its output and exit code.
    * No matter it succeeds or not.
+   * Stderr is redirected to stdout.
    *
    * @return {@link CommandReturn} object representation of stdout, stderr and exit code
    */

--- a/core/common/src/main/java/alluxio/shell/SshCommand.java
+++ b/core/common/src/main/java/alluxio/shell/SshCommand.java
@@ -20,7 +20,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class SshCommand extends ShellCommand {
-  protected String mHostName;
+  private final String mHostName;
 
   /**
    * Creates a SshCommand instance from the remote hostname and command.
@@ -29,11 +29,10 @@ public class SshCommand extends ShellCommand {
    * @param execString the command to execute
    */
   public SshCommand(String hostname, String[] execString) {
-    super(execString);
-    mHostName = hostname;
-    mCommand = new String[]{"bash", "-c",
+    super(new String[]{"bash", "-c",
             String.format("ssh %s %s %s", ShellUtils.COMMON_SSH_OPTS, hostname,
-                    String.join(" ", execString))};
+                    String.join(" ", execString))});
+    mHostName = hostname;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/shell/SshCommand.java
+++ b/core/common/src/main/java/alluxio/shell/SshCommand.java
@@ -15,10 +15,19 @@ import alluxio.util.ShellUtils;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+/**
+ * Object representation of a remote shell command by SSH.
+ */
 @NotThreadSafe
 public class SshCommand extends ShellCommand {
   protected String mHostName;
 
+  /**
+   * Creates a SshCommand instance from the remote hostname and command.
+   *
+   * @param hostname the remote target hostname
+   * @param execString the command to execute
+   */
   public SshCommand(String hostname, String[] execString) {
     super(execString);
     mHostName = hostname;
@@ -27,7 +36,12 @@ public class SshCommand extends ShellCommand {
                     String.join(" ", execString))};
   }
 
-  protected String getHostName() {
+  /**
+   * Returns the remote target hostname.
+   *
+   * @return target hostname
+   */
+  public String getHostName() {
     return mHostName;
   }
 }

--- a/core/common/src/main/java/alluxio/shell/SshCommand.java
+++ b/core/common/src/main/java/alluxio/shell/SshCommand.java
@@ -1,0 +1,34 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell;
+
+import alluxio.util.ShellUtils;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class SshCommand extends ShellCommand {
+  protected String mHostName;
+
+  public SshCommand(String hostname, String[] execString) {
+    super(execString);
+    mHostName = hostname;
+    mCommand = new String[]{"bash", "-c",
+            String.format("ssh %s %s %s", ShellUtils.COMMON_SSH_OPTS, hostname,
+                    String.join(" ", execString))};
+  }
+
+  protected String getHostName() {
+    return mHostName;
+  }
+}
+

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -149,7 +149,7 @@ public final class ShellUtils {
      * @return the output
      * @throws ExitCodeException if the command returns a non-zero exit code
      */
-    String run() throws ExitCodeException, IOException {
+    protected String run() throws ExitCodeException, IOException {
       Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
 
       BufferedReader inReader =
@@ -201,7 +201,7 @@ public final class ShellUtils {
      *
      * @return {@link CommandReturn} object representation of stdout, stderr and exit code
      */
-    CommandReturn runTolerateFailure() throws IOException {
+    protected CommandReturn runTolerateFailure() throws IOException {
       Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
 
       BufferedReader inReader =

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -199,7 +199,7 @@ public final class ShellUtils {
    *  2. execution interrupted
    *  3. other normal reasons for IOException
    */
-  public static CommandReturn execCommandTolerateFailure(String... cmd) throws IOException {
+  public static CommandReturn execCommandWithOutput(String... cmd) throws IOException {
     return new ShellCommand(cmd).runWithOutput();
   }
 
@@ -216,7 +216,7 @@ public final class ShellUtils {
    *  2. execution interrupted
    *  3. other normal reasons for IOException
    */
-  public static CommandReturn sshExecCommandTolerateFailure(String hostname, String... cmd)
+  public static CommandReturn sshExecCommandWithOutput(String hostname, String... cmd)
           throws IOException {
     return new SshCommand(hostname, cmd).runWithOutput();
   }
@@ -235,7 +235,7 @@ public final class ShellUtils {
    *  2. execution interrupted
    *  3. other normal reasons for IOException
    */
-  public static CommandReturn scpCommandTolerateFailure(
+  public static CommandReturn scpCommandWithOutput(
           String hostname, String fromFile, String toFile, boolean isDir) throws IOException {
     return new ScpCommand(hostname, fromFile, toFile, isDir).runWithOutput();
   }

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -137,7 +137,7 @@ public final class ShellUtils {
 
   @NotThreadSafe
   private static class Command {
-    private String[] mCommand;
+    protected String[] mCommand;
 
     private Command(String[] execString) {
       mCommand = execString.clone();
@@ -202,7 +202,7 @@ public final class ShellUtils {
      * @return {@link CommandReturn} object representation of stdout, stderr and exit code
      */
     protected CommandReturn runTolerateFailure() throws IOException {
-      Process process = new ProcessBuilder(mCommand).redirectErrorStream(true).start();
+      Process process = new ProcessBuilder(mCommand).start();
 
       BufferedReader inReader =
               new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -232,7 +232,7 @@ public final class ShellUtils {
         int exitCode = process.waitFor();
         if (exitCode != 0) {
           // log error instead of throwing exception
-          LOG.warn(String.format("Failed to run command %s\nExit Code: %s\nStderr: %s",
+          LOG.warn(String.format("Failed to run command %s%nExit Code: %s%nStderr: %s",
                   Arrays.toString(mCommand), exitCode, stderr.toString()));
         }
 
@@ -267,8 +267,7 @@ public final class ShellUtils {
 
   @NotThreadSafe
   private static class SshCommand extends Command {
-    private String mHostName;
-    private String[] mCommand;
+    protected String mHostName;
 
     private SshCommand(String[] execString) {
       this("localhost", execString);
@@ -280,6 +279,10 @@ public final class ShellUtils {
       mCommand = new String[]{"bash", "-c",
               String.format("ssh %s %s %s", ShellUtils.COMMON_SSH_OPTS, hostname,
                       String.join(" ", execString))};
+    }
+
+    protected String getHostName() {
+      return mHostName;
     }
   }
 
@@ -376,7 +379,7 @@ public final class ShellUtils {
      * @return pretty formatted output
      */
     public String getFormattedOutput() {
-      return String.format("StatusCode:%s\nStdOut:\n%s\nStdErr:\n%s", getExitCode(),
+      return String.format("StatusCode:%s%nStdOut:%n%s%nStdErr:%n%s", getExitCode(),
               getStdOut(), getStdErr());
     }
   }

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -19,18 +19,12 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -465,8 +465,8 @@ public final class ShellUtils {
    *  2. execution interrupted
    *  3. other normal reasons for IOException
    */
-  public static CommandReturn scpCommandTolerateFailure(String hostname, String fromFile, String toFile, boolean isDir)
-          throws IOException {
+  public static CommandReturn scpCommandTolerateFailure(
+          String hostname, String fromFile, String toFile, boolean isDir) throws IOException {
     return new ScpCommand(hostname, fromFile, toFile, isDir).runTolerateFailure();
   }
 

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -387,7 +387,7 @@ public final class ShellUtils {
    *
    * @param cmd shell command to execute
    * @return the output of the executed command
-   * @throws {@link IOException} in various situations:
+   * @throws IOException in various situations:
    *  1. {@link ExitCodeException} when exit code is non-zero
    *  2. when the executable is not valid, i.e. running ls in Windows
    *  3. execution interrupted
@@ -403,7 +403,7 @@ public final class ShellUtils {
    *
    * @param cmd shell command to execute
    * @return the output of the executed command
-   * @throws {@link IOException} in various situations:
+   * @throws IOException in various situations:
    *  1. when the executable is not valid, i.e. running ls in Windows
    *  2. execution interrupted
    *  3. other normal reasons for IOException
@@ -420,7 +420,7 @@ public final class ShellUtils {
    * @param hostname Hostname where the command should execute
    * @param cmd shell command to execute
    * @return the output of the executed command
-   * @throws {@link IOException} in various situations:
+   * @throws IOException in various situations:
    *  1. when the executable is not valid, i.e. running ls in Windows
    *  2. execution interrupted
    *  3. other normal reasons for IOException

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -196,7 +196,7 @@ public final class ShellUtils {
     }
 
     /**
-     * Runs a command and returns its stdout, stderr and exit code
+     * Runs a command and returns its stdout, stderr and exit code,
      * no matter it succeeds or not
      *
      * @return {@link CommandReturn} object representation of stdout, stderr and exit code
@@ -278,7 +278,8 @@ public final class ShellUtils {
       super(execString);
       mHostName = hostname;
       mCommand = new String[]{"bash", "-c",
-              String.format("ssh %s %s %s", ShellUtils.COMMON_SSH_OPTS, hostname, String.join(" ", execString))};
+              String.format("ssh %s %s %s", ShellUtils.COMMON_SSH_OPTS, hostname,
+                      String.join(" ", execString))};
     }
   }
 
@@ -320,32 +321,59 @@ public final class ShellUtils {
     }
   }
 
+  /**
+   * Object representation of a command execution
+   */
   public static class CommandReturn {
-    int mStatusCode;
-    String mStdOut;
-    String mStdErr;
+    private int mExitCode;
+    private String mStdOut;
+    private String mStdErr;
 
+    /**
+     * Constructor
+     */
     public CommandReturn(int code, String stdOut, String stdErr) {
-      mStatusCode = code;
+      mExitCode = code;
       mStdOut = stdOut;
       mStdErr = stdErr;
     }
 
+    /**
+     * Gets the stdout content
+     *
+     * @return stdout content
+     */
     public String getStdOut() {
       return mStdOut;
     }
 
+    /**
+     * Gets the stderr content
+     *
+     * @return stderr content
+     */
     public String getStdErr() {
       return mStdErr;
     }
 
-    public int getStatusCode() {
-      return mStatusCode;
+    /**
+     * Gets the exit code
+     *
+     * @return exit code of execution
+     */
+    public int getExitCode() {
+      return mExitCode;
     }
 
+    /**
+     * Formats the object to more readable format.
+     * This is not done in toString() because stdout and stderr may be long.
+     *
+     * @return
+     */
     public String getFormattedOutput() {
-      return String.format("StatusCode:%s\nStdOut:\n%s\nStdErr:\n%s", this.getStatusCode(),
-              this.getStdOut(), this.getStdErr());
+      return String.format("StatusCode:%s\nStdOut:\n%s\nStdErr:\n%s", getExitCode(),
+              getStdOut(), getStdErr());
     }
   }
 
@@ -385,6 +413,7 @@ public final class ShellUtils {
    * Preserve exit code, stderr and stdout in object.
    * SSH must be password-less.
    *
+   * @param hostname Hostname where the command should execute
    * @param cmd shell command to execute
    * @return the output of the executed command
    * @throws {@link IOException} in various situations:

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -250,15 +250,20 @@ public final class ShellUtils {
           // see: https://bugs.openjdk.java.net/browse/JDK-8024521
           // issue is fixed in build 7u60
           InputStream stdoutStream = process.getInputStream();
-          InputStream stderrStream = process.getErrorStream();
+
           synchronized (stdoutStream) {
             inReader.close();
           }
+        } catch (IOException e) {
+          LOG.warn("Error while closing the input stream", e);
+        }
+        try {
+          InputStream stderrStream = process.getErrorStream();
           synchronized (stderrStream) {
             errReader.close();
           }
         } catch (IOException e) {
-          LOG.warn("Error while closing the input stream and error stream", e);
+          LOG.warn("Error while closing the error stream", e);
         }
         process.destroy();
       }

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -196,8 +196,8 @@ public final class ShellUtils {
     }
 
     /**
-     * Runs a command and returns its stdout, stderr and exit code,
-     * no matter it succeeds or not
+     * Runs a command and returns its stdout, stderr and exit code.
+     * No matter it succeeds or not.
      *
      * @return {@link CommandReturn} object representation of stdout, stderr and exit code
      */
@@ -322,7 +322,7 @@ public final class ShellUtils {
   }
 
   /**
-   * Object representation of a command execution
+   * Object representation of a command execution.
    */
   public static class CommandReturn {
     private int mExitCode;
@@ -330,7 +330,11 @@ public final class ShellUtils {
     private String mStdErr;
 
     /**
-     * Constructor
+     * Creates object from the contents.
+     *
+     * @param code exit code
+     * @param stdOut stdout content
+     * @param stdErr stderr content
      */
     public CommandReturn(int code, String stdOut, String stdErr) {
       mExitCode = code;
@@ -339,7 +343,7 @@ public final class ShellUtils {
     }
 
     /**
-     * Gets the stdout content
+     * Gets the stdout content.
      *
      * @return stdout content
      */
@@ -348,7 +352,7 @@ public final class ShellUtils {
     }
 
     /**
-     * Gets the stderr content
+     * Gets the stderr content.
      *
      * @return stderr content
      */
@@ -357,7 +361,7 @@ public final class ShellUtils {
     }
 
     /**
-     * Gets the exit code
+     * Gets the exit code.
      *
      * @return exit code of execution
      */
@@ -369,7 +373,7 @@ public final class ShellUtils {
      * Formats the object to more readable format.
      * This is not done in toString() because stdout and stderr may be long.
      *
-     * @return
+     * @return pretty formatted output
      */
     public String getFormattedOutput() {
       return String.format("StatusCode:%s\nStdOut:\n%s\nStdErr:\n%s", getExitCode(),
@@ -421,7 +425,8 @@ public final class ShellUtils {
    *  2. execution interrupted
    *  3. other normal reasons for IOException
    */
-  public static CommandReturn sshExecCommandTolerateFailure(String hostname, String... cmd) throws IOException {
+  public static CommandReturn sshExecCommandTolerateFailure(String hostname, String... cmd)
+          throws IOException {
     return new SshCommand(hostname, cmd).runTolerateFailure();
   }
 

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -15,6 +15,7 @@ import alluxio.shell.CommandReturn;
 import alluxio.shell.ScpCommand;
 import alluxio.shell.ShellCommand;
 import alluxio.shell.SshCommand;
+
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -202,8 +202,6 @@ public final class ShellUtils {
      * @return {@link CommandReturn} object representation of stdout, stderr and exit code
      */
     protected CommandReturn runTolerateFailure() throws IOException {
-      System.out.println(String.join(" ", mCommand));
-
       Process process = new ProcessBuilder(mCommand).start();
       CommandReturn cr = null;
 
@@ -289,7 +287,6 @@ public final class ShellUtils {
 
       String template = "scp %s %s:%s localhost:%s";
       if (isDir) {
-        System.out.println("Copy dir");
         template = "scp -r %s %s:%s localhost:%s";
       }
 

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -200,7 +200,7 @@ public final class ShellUtils {
    *  3. other normal reasons for IOException
    */
   public static CommandReturn execCommandTolerateFailure(String... cmd) throws IOException {
-    return new ShellCommand(cmd).runTolerateFailure();
+    return new ShellCommand(cmd).runWithOutput();
   }
 
   /**
@@ -218,7 +218,7 @@ public final class ShellUtils {
    */
   public static CommandReturn sshExecCommandTolerateFailure(String hostname, String... cmd)
           throws IOException {
-    return new SshCommand(hostname, cmd).runTolerateFailure();
+    return new SshCommand(hostname, cmd).runWithOutput();
   }
 
   /**
@@ -237,7 +237,7 @@ public final class ShellUtils {
    */
   public static CommandReturn scpCommandTolerateFailure(
           String hostname, String fromFile, String toFile, boolean isDir) throws IOException {
-    return new ScpCommand(hostname, fromFile, toFile, isDir).runTolerateFailure();
+    return new ScpCommand(hostname, fromFile, toFile, isDir).runWithOutput();
   }
 
   private ShellUtils() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/util/ShellUtils.java
+++ b/core/common/src/main/java/alluxio/util/ShellUtils.java
@@ -190,7 +190,7 @@ public final class ShellUtils {
 
   /**
    * Static method to execute a shell command and tolerate non-zero exit code.
-   * Preserve exit code, stderr and stdout in object.
+   * Preserves exit code. Stderr is redirected to stdout.
    *
    * @param cmd shell command to execute
    * @return the output of the executed command
@@ -205,7 +205,7 @@ public final class ShellUtils {
 
   /**
    * Static method to execute a shell command remotely via ssh.
-   * Preserve exit code, stderr and stdout in object.
+   * Preserves exit code. Stderr redirected to stdout.
    * SSH must be password-less.
    *
    * @param hostname Hostname where the command should execute
@@ -223,6 +223,7 @@ public final class ShellUtils {
 
   /**
    * Static method to execute an scp command to copy a remote file/dir to local.
+   * Preserves exit code. Stderr redirected to stdout.
    *
    * @param hostname Hostname where the command should execute
    * @param fromFile File path on remote host

--- a/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
+++ b/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
@@ -11,8 +11,13 @@
 
 package alluxio.shell;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.AlluxioTestDirectory;
 import alluxio.util.ShellUtils;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -20,10 +25,6 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ShellCommandTest {
   public static File createFileInDir(File dir, String fileName) throws IOException {
@@ -55,7 +56,7 @@ public class ShellCommandTest {
     // run a command that guarantees to fail
     String[] cmd = new String[]{"bash", "-c", "false"};
     String result = new ShellCommand(cmd).run();
-    assertEquals( "false\n", result);
+    assertEquals("false\n", result);
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
+++ b/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
@@ -32,12 +32,6 @@ public class ShellCommandTest {
     return newFile;
   }
 
-  public static File createDirInDir(File dir, String fileName) throws IOException {
-    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
-    newFile.mkdir();
-    return newFile;
-  }
-
   @Rule
   public ExpectedException mExceptionRule = ExpectedException.none();
 
@@ -64,8 +58,6 @@ public class ShellCommandTest {
     assertEquals( "false\n", result);
   }
 
-  // TODO(jiacheng): Test
-
   @Test
   public void execCommandTolerateFailureSucceed() throws Exception {
     // create temp file
@@ -78,8 +70,7 @@ public class ShellCommandTest {
             String.format("%s", testDir.getAbsolutePath())};
     CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
     assertEquals(0, crs.getExitCode());
-    assertTrue(crs.getStdOut().contains(testFile.getName()));
-    assertEquals("", crs.getStdErr());
+    assertTrue(crs.getOutput().contains(testFile.getName()));
   }
 
   @Test
@@ -92,7 +83,9 @@ public class ShellCommandTest {
             String.format("%saaaa", testDir.getAbsolutePath())};
     CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
     assertNotEquals(0, crf.getExitCode());
-    assertTrue(crf.getStdErr().length() > 0);
+    // The error is redirected into stdout
+    assertTrue(crf.getOutput().length() > 0);
+    assertNotEquals("", crf.getOutput());
 
     // if there's no such command there will be IOException
     mExceptionRule.expect(IOException.class);

--- a/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
+++ b/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
@@ -86,7 +86,7 @@ public class ShellCommandTest {
     assertNotEquals(0, crf.getExitCode());
     // The error is redirected into stdout
     assertTrue(crf.getOutput().length() > 0);
-    assertNotEquals("", crf.getOutput());;
+    assertNotEquals("", crf.getOutput());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
+++ b/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
@@ -1,0 +1,119 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.shell;
+
+import alluxio.AlluxioTestDirectory;
+import alluxio.util.ShellUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ShellCommandTest {
+  public static File createFileInDir(File dir, String fileName) throws IOException {
+    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+    newFile.createNewFile();
+    return newFile;
+  }
+
+  public static File createDirInDir(File dir, String fileName) throws IOException {
+    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+    newFile.mkdir();
+    return newFile;
+  }
+
+  @Rule
+  public ExpectedException mExceptionRule = ExpectedException.none();
+
+  /**
+   * Tests the {@link ShellUtils#execCommand(String...)} method.
+   *
+   * @throws Throwable when the execution of the command fails
+   */
+  @Test
+  public void execCommand() throws Exception {
+    String testString = "alluxio";
+    // Execute echo for testing command execution.
+    String[] cmd = new String[]{"bash", "-c", "echo " + testString};
+    String result = new ShellCommand(cmd).run();
+    assertEquals(testString + "\n", result);
+  }
+
+  @Test
+  public void execCommandFail() throws Exception {
+    mExceptionRule.expect(ShellUtils.ExitCodeException.class);
+    // run a command that guarantees to fail
+    String[] cmd = new String[]{"bash", "-c", "false"};
+    String result = new ShellCommand(cmd).run();
+    assertEquals( "false\n", result);
+  }
+
+  // TODO(jiacheng): Test
+
+  @Test
+  public void execCommandTolerateFailureSucceed() throws Exception {
+    // create temp file
+    File testDir = AlluxioTestDirectory.createTemporaryDirectory("command");
+
+    File testFile = createFileInDir(testDir, "testFile");
+
+    // ls temp file
+    String[] testCommandSucceed = new String[]{"ls",
+            String.format("%s", testDir.getAbsolutePath())};
+    CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
+    assertEquals(0, crs.getExitCode());
+    assertTrue(crs.getStdOut().contains(testFile.getName()));
+    assertEquals("", crs.getStdErr());
+  }
+
+  @Test
+  public void execCommandTolerateFailureFailed() throws Exception {
+    // create temp file
+    File testDir = AlluxioTestDirectory.createTemporaryDirectory("command");
+
+    // do sth wrong
+    String[] testCommandFail = new String[]{"ls",
+            String.format("%saaaa", testDir.getAbsolutePath())};
+    CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
+    assertNotEquals(0, crf.getExitCode());
+    assertTrue(crf.getStdErr().length() > 0);
+
+    // if there's no such command there will be IOException
+    mExceptionRule.expect(IOException.class);
+    mExceptionRule.expectMessage("No such file or directory");
+    String[] testCommandExcept = new String[]{"lsa",
+            String.format("%s", testDir.getAbsolutePath())};
+    // lsa is not a valid executable
+    ShellUtils.execCommandTolerateFailure(testCommandExcept);
+  }
+
+  @Test
+  public void execCommandTolerateFailureInvalidCommand() throws Exception {
+    // create temp file
+    File testDir = AlluxioTestDirectory.createTemporaryDirectory("command");
+
+    // if there's no such command there will be IOException
+    mExceptionRule.expect(IOException.class);
+    mExceptionRule.expectMessage("No such file or directory");
+    String[] testCommandExcept = new String[]{"lsa",
+            String.format("%s", testDir.getAbsolutePath())};
+    // lsa is not a valid executable
+    ShellUtils.execCommandTolerateFailure(testCommandExcept);
+  }
+}

--- a/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
+++ b/core/common/src/test/java/alluxio/shell/ShellCommandTest.java
@@ -69,7 +69,7 @@ public class ShellCommandTest {
     // ls temp file
     String[] testCommandSucceed = new String[]{"ls",
             String.format("%s", testDir.getAbsolutePath())};
-    CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
+    CommandReturn crs = new ShellCommand(testCommandSucceed).runWithOutput();
     assertEquals(0, crs.getExitCode());
     assertTrue(crs.getOutput().contains(testFile.getName()));
   }
@@ -82,19 +82,11 @@ public class ShellCommandTest {
     // do sth wrong
     String[] testCommandFail = new String[]{"ls",
             String.format("%saaaa", testDir.getAbsolutePath())};
-    CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
+    CommandReturn crf = new ShellCommand(testCommandFail).runWithOutput();
     assertNotEquals(0, crf.getExitCode());
     // The error is redirected into stdout
     assertTrue(crf.getOutput().length() > 0);
-    assertNotEquals("", crf.getOutput());
-
-    // if there's no such command there will be IOException
-    mExceptionRule.expect(IOException.class);
-    mExceptionRule.expectMessage("No such file or directory");
-    String[] testCommandExcept = new String[]{"lsa",
-            String.format("%s", testDir.getAbsolutePath())};
-    // lsa is not a valid executable
-    ShellUtils.execCommandTolerateFailure(testCommandExcept);
+    assertNotEquals("", crf.getOutput());;
   }
 
   @Test
@@ -108,6 +100,6 @@ public class ShellCommandTest {
     String[] testCommandExcept = new String[]{"lsa",
             String.format("%s", testDir.getAbsolutePath())};
     // lsa is not a valid executable
-    ShellUtils.execCommandTolerateFailure(testCommandExcept);
+    new ShellCommand(testCommandExcept).runWithOutput();
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 public final class ShellUtilsTest {
 
   @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
+  public ExpectedException mExceptionRule = ExpectedException.none();
 
   public static File createFileInDir(File dir, String fileName) throws IOException {
     File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
@@ -59,7 +59,7 @@ public final class ShellUtilsTest {
   @Test
   public void execCommandFail() throws Exception {
     String testString = "false";
-    exceptionRule.expect(ShellUtils.ExitCodeException.class);
+    mExceptionRule.expect(ShellUtils.ExitCodeException.class);
     // run a command that guarantees to fail
     String result = ShellUtils.execCommand("bash", "-c", " " + testString);
     assertEquals(testString + "\n", result);
@@ -143,21 +143,24 @@ public final class ShellUtilsTest {
     File testFile = createFileInDir(testDir, "testFile");
 
     // ls temp file
-    String[] testCommandSucceed = new String[]{"ls", String.format("%s", testDir.getAbsolutePath())};
+    String[] testCommandSucceed = new String[]{"ls",
+            String.format("%s", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
     assertEquals(0, crs.getExitCode());
     assertTrue(crs.getStdOut().contains(testFile.getName()));
 
     // do sth wrong
-    String[] testCommandFail = new String[]{"ls", String.format("%saaaa", testDir.getAbsolutePath())};
+    String[] testCommandFail = new String[]{"ls",
+            String.format("%saaaa", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
     System.out.println(crf.getFormattedOutput());
     assertFalse(crf.getExitCode() == 0);
 
     // if there's no such command there will be IOException
-    exceptionRule.expect(IOException.class);
-    exceptionRule.expectMessage("No such file or directory");
-    String[] testCommandExcept = new String[]{"lsa", String.format("%s", testDir.getAbsolutePath())};
+    mExceptionRule.expect(IOException.class);
+    mExceptionRule.expectMessage("No such file or directory");
+    String[] testCommandExcept = new String[]{"lsa",
+            String.format("%s", testDir.getAbsolutePath())};
     // lsa is not a valid executable
     ShellUtils.execCommandTolerateFailure(testCommandExcept);
   }
@@ -170,21 +173,27 @@ public final class ShellUtilsTest {
     File testFile = createFileInDir(testDir, "testFile");
 
     // the temp file is found
-    String[] testCommandSucceed = new String[]{"ls", String.format("%s", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crs = ShellUtils.sshExecCommandTolerateFailure("localhost", testCommandSucceed);
+    String[] testCommandSucceed = new String[]{"ls",
+            String.format("%s", testDir.getAbsolutePath())};
+    ShellUtils.CommandReturn crs = ShellUtils.sshExecCommandTolerateFailure("localhost",
+            testCommandSucceed);
     assertEquals(0, crs.getExitCode());
     assertTrue(crs.getStdOut().contains(testFile.getName()));
 
     // do sth wrong
-    String[] testCommandFail = new String[]{"ls", String.format("%saaaa", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crf = ShellUtils.sshExecCommandTolerateFailure("localhost", testCommandFail);
+    String[] testCommandFail = new String[]{"ls",
+            String.format("%saaaa", testDir.getAbsolutePath())};
+    ShellUtils.CommandReturn crf = ShellUtils.sshExecCommandTolerateFailure("localhost",
+            testCommandFail);
     assertFalse(crf.getExitCode() == 0);
 
     // if there's no such command there will be IOException
-    String[] testCommandExcept = new String[]{"lsa", String.format("%s", testDir.getAbsolutePath())};
-    exceptionRule.expect(IOException.class);
-    exceptionRule.expectMessage("No such file or directory");
+    String[] testCommandExcept = new String[]{"lsa",
+            String.format("%s", testDir.getAbsolutePath())};
+    mExceptionRule.expect(IOException.class);
+    mExceptionRule.expectMessage("No such file or directory");
     // lsa is not a valid executable
-    ShellUtils.CommandReturn cre = ShellUtils.sshExecCommandTolerateFailure("localhost", testCommandExcept);
+    ShellUtils.CommandReturn cre = ShellUtils.sshExecCommandTolerateFailure("localhost",
+            testCommandExcept);
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -64,6 +64,15 @@ public final class ShellUtilsTest {
     assertEquals(testString + "\n", result);
   }
 
+  @Test
+  public void execCommandFail() throws Exception {
+    String testString = "false";
+    exceptionRule.expect(ShellUtils.ExitCodeException.class);
+    // run a command that guarantees to fail
+    String result = ShellUtils.execCommand("bash", "-c", " " + testString);
+    assertEquals(testString + "\n", result);
+  }
+
   /**
    * Tests the {@link ShellUtils#execCommand(String...)} method for a group of commands.
    *

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -28,7 +28,6 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -19,23 +19,15 @@ import static org.junit.Assume.assumeTrue;
 import alluxio.AlluxioTestDirectory;
 import alluxio.Constants;
 
-import alluxio.grpc.Command;
 import com.google.common.base.Optional;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 /**
  * Tests the {@link ShellUtils} class.
@@ -153,14 +145,14 @@ public final class ShellUtilsTest {
     // ls temp file
     String[] testCommandSucceed = new String[]{"ls", String.format("%s", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
-    assertEquals(0, crs.getStatusCode());
+    assertEquals(0, crs.getExitCode());
     assertTrue(crs.getStdOut().contains(testFile.getName()));
 
     // do sth wrong
     String[] testCommandFail = new String[]{"ls", String.format("%saaaa", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
     System.out.println(crf.getFormattedOutput());
-    assertFalse(crf.getStatusCode() == 0);
+    assertFalse(crf.getExitCode() == 0);
 
     // if there's no such command there will be IOException
     exceptionRule.expect(IOException.class);
@@ -180,13 +172,13 @@ public final class ShellUtilsTest {
     // the temp file is found
     String[] testCommandSucceed = new String[]{"ls", String.format("%s", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crs = ShellUtils.sshExecCommandTolerateFailure("localhost", testCommandSucceed);
-    assertEquals(0, crs.getStatusCode());
+    assertEquals(0, crs.getExitCode());
     assertTrue(crs.getStdOut().contains(testFile.getName()));
 
     // do sth wrong
     String[] testCommandFail = new String[]{"ls", String.format("%saaaa", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crf = ShellUtils.sshExecCommandTolerateFailure("localhost", testCommandFail);
-    assertFalse(crf.getStatusCode() == 0);
+    assertFalse(crf.getExitCode() == 0);
 
     // if there's no such command there will be IOException
     String[] testCommandExcept = new String[]{"lsa", String.format("%s", testDir.getAbsolutePath())};

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -38,18 +38,6 @@ public final class ShellUtilsTest {
   @Rule
   public ExpectedException mExceptionRule = ExpectedException.none();
 
-  public static File createFileInDir(File dir, String fileName) throws IOException {
-    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
-    newFile.createNewFile();
-    return newFile;
-  }
-
-  public static File createDirInDir(File dir, String fileName) throws IOException {
-    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
-    newFile.mkdir();
-    return newFile;
-  }
-
   /**
    * Tests the {@link ShellUtils#execCommand(String...)} method.
    *
@@ -140,36 +128,5 @@ public final class ShellUtilsTest {
     assumeTrue(OSUtils.isMacOS() || OSUtils.isLinux());
     List<UnixMountInfo> info = ShellUtils.getUnixMountInfo();
     assertTrue(info.size() > 0);
-  }
-
-  @Test
-  public void execCommandTolerateFailure() throws Exception {
-    // create temp file
-    File testDir = AlluxioTestDirectory.createTemporaryDirectory("command");
-
-    File testFile = createFileInDir(testDir, "testFile");
-
-    // ls temp file
-    String[] testCommandSucceed = new String[]{"ls",
-            String.format("%s", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
-    assertEquals(0, crs.getExitCode());
-    assertTrue(crs.getStdOut().contains(testFile.getName()));
-    assertEquals("", crs.getStdErr());
-
-    // do sth wrong
-    String[] testCommandFail = new String[]{"ls",
-            String.format("%saaaa", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
-    assertNotEquals(0, crf.getExitCode());
-    assertTrue(crf.getStdErr().length() > 0);
-
-    // if there's no such command there will be IOException
-    mExceptionRule.expect(IOException.class);
-    mExceptionRule.expectMessage("No such file or directory");
-    String[] testCommandExcept = new String[]{"lsa",
-            String.format("%s", testDir.getAbsolutePath())};
-    // lsa is not a valid executable
-    ShellUtils.execCommandTolerateFailure(testCommandExcept);
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -164,36 +164,4 @@ public final class ShellUtilsTest {
     // lsa is not a valid executable
     ShellUtils.execCommandTolerateFailure(testCommandExcept);
   }
-
-  @Test
-  public void sshExecuteCommandTolerateFailure() throws Exception {
-    // create temp file
-    File testDir = AlluxioTestDirectory.createTemporaryDirectory("command");
-
-    File testFile = createFileInDir(testDir, "testFile");
-
-    // the temp file is found
-    String[] testCommandSucceed = new String[]{"ls",
-            String.format("%s", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crs = ShellUtils.sshExecCommandTolerateFailure("localhost",
-            testCommandSucceed);
-    assertEquals(0, crs.getExitCode());
-    assertTrue(crs.getStdOut().contains(testFile.getName()));
-
-    // do sth wrong
-    String[] testCommandFail = new String[]{"ls",
-            String.format("%saaaa", testDir.getAbsolutePath())};
-    ShellUtils.CommandReturn crf = ShellUtils.sshExecCommandTolerateFailure("localhost",
-            testCommandFail);
-    assertFalse(crf.getExitCode() == 0);
-
-    // if there's no such command there will be no IOException because ssh is a valid cmd
-    String[] testCommandExcept = new String[]{"lsa",
-            String.format("%s", testDir.getAbsolutePath())};
-
-    // lsa is not a valid executable
-    ShellUtils.CommandReturn cre = ShellUtils.sshExecCommandTolerateFailure("localhost",
-            testCommandExcept);
-    assertNotEquals(0, cre);
-  }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -41,6 +42,12 @@ public final class ShellUtilsTest {
   public static File createFileInDir(File dir, String fileName) throws IOException {
     File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
     newFile.createNewFile();
+    return newFile;
+  }
+
+  public static File createDirInDir(File dir, String fileName) throws IOException {
+    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+    newFile.mkdir();
     return newFile;
   }
 

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -155,12 +155,14 @@ public final class ShellUtilsTest {
     ShellUtils.CommandReturn crs = ShellUtils.execCommandTolerateFailure(testCommandSucceed);
     assertEquals(0, crs.getExitCode());
     assertTrue(crs.getStdOut().contains(testFile.getName()));
+    assertEquals("", crs.getStdErr());
 
     // do sth wrong
     String[] testCommandFail = new String[]{"ls",
             String.format("%saaaa", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
     assertNotEquals(0, crf.getExitCode());
+    assertTrue(crf.getStdErr().length() > 0);
 
     // if there's no such command there will be IOException
     mExceptionRule.expect(IOException.class);

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -13,6 +13,7 @@ package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -153,8 +154,7 @@ public final class ShellUtilsTest {
     String[] testCommandFail = new String[]{"ls",
             String.format("%saaaa", testDir.getAbsolutePath())};
     ShellUtils.CommandReturn crf = ShellUtils.execCommandTolerateFailure(testCommandFail);
-    System.out.println(crf.getFormattedOutput());
-    assertFalse(crf.getExitCode() == 0);
+    assertNotEquals(0, crf.getExitCode());
 
     // if there's no such command there will be IOException
     mExceptionRule.expect(IOException.class);
@@ -187,13 +187,13 @@ public final class ShellUtilsTest {
             testCommandFail);
     assertFalse(crf.getExitCode() == 0);
 
-    // if there's no such command there will be IOException
+    // if there's no such command there will be no IOException because ssh is a valid cmd
     String[] testCommandExcept = new String[]{"lsa",
             String.format("%s", testDir.getAbsolutePath())};
-    mExceptionRule.expect(IOException.class);
-    mExceptionRule.expectMessage("No such file or directory");
+
     // lsa is not a valid executable
     ShellUtils.CommandReturn cre = ShellUtils.sshExecCommandTolerateFailure("localhost",
             testCommandExcept);
+    assertNotEquals(0, cre);
   }
 }

--- a/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ShellUtilsTest.java
@@ -13,21 +13,17 @@ package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import alluxio.AlluxioTestDirectory;
 import alluxio.Constants;
 
 import com.google.common.base.Optional;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 /**


### PR DESCRIPTION
This change adds a wrapper to SSH executing a command to ShellUtils, together with SCP commands.

`ShellUtils` class refactored with inner classed extracted to standalone classes.

PR https://github.com/Alluxio/alluxio/pull/10596 relies on this utility as it extensively invokes commands over SSH.