### PR TITLE
Make DistributedCp/Mv not retry

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -64,8 +64,8 @@ public final class DistributedCpCommand extends AbstractFileSystemCommand {
     try {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
-          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
-          false), 3, mFsContext.getPathConf(dstPath));
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), false,
+          false), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return -1;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -64,7 +64,7 @@ public final class DistributedCpCommand extends AbstractFileSystemCommand {
     try {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
-          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), false,
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
           false), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
@@ -66,7 +66,7 @@ public final class DistributedMvCommand extends AbstractFileSystemCommand {
     try {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
-          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), false,
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
           true), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
@@ -66,8 +66,8 @@ public final class DistributedMvCommand extends AbstractFileSystemCommand {
     try {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
-          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
-          true), 3, mFsContext.getPathConf(dstPath));
+          conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), false,
+          true), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return -1;


### PR DESCRIPTION
Reason: overwrite has been broken. Overwrite hasn't appeared to have worked since at least 2.0 or perhaps further back.

Both the createDirectory and createFile calls in MigrateDefinition is not overwriting version.

Thus, retrying is pointless because retries will always fail with the message of being unable to overwrite.