### PR TITLE
Change DistributedMv writeType and deleteSource

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -343,7 +343,7 @@ public final class MigrateDefinition
     // keep the destination to be persisted by changing its write type
     if (deleteSource && writeType.equals(WritePType.ASYNC_THROUGH)) {
       if (fileSystem.getStatus(new AlluxioURI(source)).isPersisted()) {
-        writeType = WritePType.THROUGH;
+        writeType = WritePType.CACHE_THROUGH;
       }
     }
 

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -365,6 +365,8 @@ public final class MigrateDefinition
       }
     }
     if (deleteSource) {
+      // Delete the source unchecked because there is no guarantee that the source
+      // has been fulled persisted yet if the source was written using ASYNC_THROUGH
       fileSystem.delete(new AlluxioURI(source),
           DeletePOptions.newBuilder().setUnchecked(true).build());
     }

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -365,7 +365,8 @@ public final class MigrateDefinition
       }
     }
     if (deleteSource) {
-      fileSystem.delete(new AlluxioURI(source), DeletePOptions.newBuilder().setUnchecked(true).build());
+      fileSystem.delete(new AlluxioURI(source),
+          DeletePOptions.newBuilder().setUnchecked(true).build());
     }
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -109,9 +109,10 @@ public final class MigrateDefinitionRunTaskTest {
     runTask(TEST_SOURCE, TEST_SOURCE, TEST_DESTINATION, WriteType.THROUGH);
     Assert.assertArrayEquals(TEST_SOURCE_CONTENTS, mMockOutStream.toByteArray());
     if (mDeleteSource) {
-      verify(mMockFileSystem).delete(new AlluxioURI(TEST_SOURCE));
+      DeletePOptions options = DeletePOptions.newBuilder().setUnchecked(true).build();
+      verify(mMockFileSystem).delete(new AlluxioURI(TEST_SOURCE), options);
     } else {
-      verify(mMockFileSystem, never()).delete(new AlluxioURI(TEST_SOURCE));
+      verify(mMockFileSystem, never()).delete(eq(new AlluxioURI(TEST_SOURCE)), any());
     }
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -182,7 +182,7 @@ public final class MigrateDefinitionRunTaskTest {
 
   /**
    * Tests the edge case where performing an WriteType.AsyncThrough with deleteSource of a
-   * persisted file writes the move synchronously
+   * persisted file writes the move synchronously.
    */
   @Test
   public void writeTypeAsyncThroughPersistedTest() throws Exception {

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -195,7 +195,7 @@ public final class MigrateDefinitionRunTaskTest {
 
     if (mDeleteSource) {
       verify(mMockFileSystem).createFile(eq(new AlluxioURI(TEST_DESTINATION)), Matchers
-          .eq(CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).build()));
+          .eq(CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build()));
     } else {
       verify(mMockFileSystem).createFile(eq(new AlluxioURI(TEST_DESTINATION)), Matchers
           .eq(CreateFilePOptions.newBuilder().setWriteType(WritePType.ASYNC_THROUGH).build()));

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -181,6 +181,28 @@ public final class MigrateDefinitionRunTaskTest {
   }
 
   /**
+   * Tests the edge case where performing an WriteType.AsyncThrough with deleteSource of a
+   * persisted file writes the move synchronously
+   */
+  @Test
+  public void writeTypeAsyncThroughPersistedTest() throws Exception {
+    FileInfo fileInfo = new FileInfo();
+    fileInfo.setPersisted(true);
+    when(mMockFileSystem.getStatus(eq(new AlluxioURI(TEST_SOURCE))))
+        .thenReturn(new URIStatus(fileInfo));
+
+    runTask(TEST_SOURCE, TEST_SOURCE, TEST_DESTINATION, WriteType.ASYNC_THROUGH);
+
+    if (mDeleteSource) {
+      verify(mMockFileSystem).createFile(eq(new AlluxioURI(TEST_DESTINATION)), Matchers
+          .eq(CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH).build()));
+    } else {
+      verify(mMockFileSystem).createFile(eq(new AlluxioURI(TEST_DESTINATION)), Matchers
+          .eq(CreateFilePOptions.newBuilder().setWriteType(WritePType.ASYNC_THROUGH).build()));
+    }
+  }
+
+  /**
    * Runs the task.
    *
    * @param configSource {@link MigrateConfig} source


### PR DESCRIPTION
1. When deleting the source, delete it unchecked because if the source is not fully persisted, move should still be successful.
2. When performing a move operation, change the writeType to THROUGH if the source is persisted to not make files unpersisted.