### PR TITLE
[WIP] Reuse LocalAlluxioCluster to speedup CLI tests

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -163,6 +163,6 @@ public final class FileSystemUtils {
         throw new RuntimeException(e);
       }
     }, WaitForOptions.defaults().setTimeoutMs(timeoutMs)
-        .setInterval(Constants.SECOND_MS));
+        .setInterval(100));
   }
 }

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -116,7 +116,9 @@ public final class ConfigurationTestUtils {
     conf.put(PropertyKey.WEB_RESOURCES,
         PathUtils.concatPath(System.getProperty("user.dir"), "../webui"));
     conf.put(PropertyKey.WORKER_MEMORY_SIZE, "100MB");
+    conf.put(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "15ms");
     conf.put(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "15ms");
+    conf.put(PropertyKey.MASTER_WORKER_TIMEOUT_MS, "500ms");
     conf.put(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS, "2");
 
     // Shutdown data server quickly. Graceful shutdown is unnecessarily slow.

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -258,6 +258,13 @@ public abstract class AbstractLocalAlluxioCluster {
   }
 
   /**
+   * @return true if the workers are started, and not stopped
+   */
+  public boolean isStartedWorkers() {
+    return !mWorkerThreads.isEmpty();
+  }
+
+  /**
    * Creates a default {@link ServerConfiguration} for testing.
    *
    * @param name the name of the test/cluster

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -333,6 +333,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
     }
     if (cl.hasOption(PRESERVE_OPTION.getLongOpt())) {
       mPreservePermissions = true;
+    } else {
+      mPreservePermissions = false;
     }
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -36,8 +36,9 @@ import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.Lists;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,12 +55,12 @@ import javax.annotation.Nullable;
  * The base class for all the {@link FileSystemShell} test classes.
  */
 public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrationTest {
-  public LocalAlluxioCluster mLocalAlluxioCluster = null;
-  public FileSystem mFileSystem = null;
-  public FileSystemShell mFsShell = null;
-  protected JobMaster mJobMaster;
-  protected LocalAlluxioJobCluster mLocalAlluxioJobCluster = null;
-  protected JobShell mJobShell = null;
+  public static LocalAlluxioCluster mLocalAlluxioCluster = null;
+  public static FileSystem mFileSystem = null;
+  public static FileSystemShell mFsShell = null;
+  protected static JobMaster mJobMaster;
+  protected static LocalAlluxioJobCluster mLocalAlluxioJobCluster = null;
+  protected static JobShell mJobShell = null;
 
   /*
    * The user and group mappings for testing are:
@@ -116,9 +117,9 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
     }
   }
 
-  @Before
-  public final void before() throws Exception {
-    mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    mLocalAlluxioCluster = sLocalAlluxioClusterResource.get();
     mLocalAlluxioJobCluster = new LocalAlluxioJobCluster();
     mLocalAlluxioJobCluster.start();
     mFileSystem = mLocalAlluxioCluster.getClient();
@@ -127,8 +128,8 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
     mFsShell = new FileSystemShell(ServerConfiguration.global());
   }
 
-  @After
-  public final void after() throws Exception {
+  @AfterClass
+  public static void afterClass() throws Exception {
     mFsShell.close();
     mLocalAlluxioJobCluster.stop();
     mJobShell.close();

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
@@ -18,8 +18,10 @@ import alluxio.conf.PropertyKey;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
 
 import java.io.ByteArrayOutputStream;
 
@@ -29,8 +31,8 @@ import java.io.ByteArrayOutputStream;
 public abstract class AbstractShellIntegrationTest extends BaseIntegrationTest {
   protected static final int SIZE_BYTES = Constants.MB * 16;
 
-  @Rule
-  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+  @ClassRule
+  public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
           .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
@@ -40,6 +42,9 @@ public abstract class AbstractShellIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.MAX_VALUE)
           .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")
           .build();
+
+  @Rule
+  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
 
   public ByteArrayOutputStream mOutput = new ByteArrayOutputStream();
   public ByteArrayOutputStream mErrOutput = new ByteArrayOutputStream();

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -170,34 +170,34 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
     // avoid chown on UFS since test might not be run with root
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
-    mFsShell = new FileSystemShell(conf);
-
-    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
-    AlluxioURI srcFile = new AlluxioURI(testDir + "/foobar4");
-    String owner = TEST_USER_1.getUser();
-    String group = "staff";
-    short mode = 0422;
-    List<AclEntry> entries = new ArrayList<>();
-    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
-        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
-        .addAction(AclAction.EXECUTE).build());
-    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
-        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
-    mFileSystem.setAttribute(srcFile,
-        SetAttributePOptions.newBuilder()
-            .setOwner(owner).setGroup(group)
-            .setMode(new Mode(mode).toProto())
-            .setPinned(true)
-            .setReplicationMin(2)
-            .setReplicationMax(4)
-            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
-            .build());
-    mFileSystem.setAcl(srcFile, SetAclAction.MODIFY, entries);
-    int ret = mFsShell.run("cp", "-p", testDir + "/foobar4", testDir + "/bar");
-    AlluxioURI dstFile = new AlluxioURI(testDir + "/bar/foobar4");
-    Assert.assertEquals(0, ret);
-    Assert.assertTrue(mFileSystem.exists(dstFile));
-    verifyPreservedAttributes(srcFile, dstFile);
+    try (FileSystemShell fsShell = new FileSystemShell(conf)) {
+      String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+      AlluxioURI srcFile = new AlluxioURI(testDir + "/foobar4");
+      String owner = TEST_USER_1.getUser();
+      String group = "staff";
+      short mode = 0422;
+      List<AclEntry> entries = new ArrayList<>();
+      entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+          .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+          .addAction(AclAction.EXECUTE).build());
+      entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+          .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+      mFileSystem.setAttribute(srcFile,
+          SetAttributePOptions.newBuilder()
+              .setOwner(owner).setGroup(group)
+              .setMode(new Mode(mode).toProto())
+              .setPinned(true)
+              .setReplicationMin(2)
+              .setReplicationMax(4)
+              .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
+              .build());
+      mFileSystem.setAcl(srcFile, SetAclAction.MODIFY, entries);
+      int ret = fsShell.run("cp", "-p", testDir + "/foobar4", testDir + "/bar");
+      AlluxioURI dstFile = new AlluxioURI(testDir + "/bar/foobar4");
+      Assert.assertEquals(0, ret);
+      Assert.assertTrue(mFileSystem.exists(dstFile));
+      verifyPreservedAttributes(srcFile, dstFile);
+    }
   }
 
   /**
@@ -207,40 +207,40 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   public void copyDirectoryWithPreservedAttributes() throws Exception {
     InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
-    mFsShell = new FileSystemShell(conf);
-
-    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
-    String newDir = "/copy";
-    String subDir = "/foo";
-    String file = "/foobar4";
-    String owner = TEST_USER_1.getUser();
-    String group = "staff";
-    short mode = 0422;
-    List<AclEntry> entries = new ArrayList<>();
-    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
-        .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
-        .addAction(AclAction.EXECUTE).build());
-    entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
-        .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
-    AlluxioURI srcDir = new AlluxioURI(testDir);
-    mFileSystem.setAttribute(srcDir,
-        SetAttributePOptions.newBuilder().setRecursive(true)
-            .setOwner(owner).setGroup(group)
-            .setMode(new Mode(mode).toProto())
-            .setPinned(true)
-            .setReplicationMin(2)
-            .setReplicationMax(4)
-            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
-            .build());
-    mFileSystem.setAcl(srcDir, SetAclAction.MODIFY, entries,
-        SetAclPOptions.newBuilder().setRecursive(true).build());
-    int ret = mFsShell.run("cp", "-R",  "-p", testDir, newDir);
-    AlluxioURI dstDir = new AlluxioURI(newDir);
-    Assert.assertEquals(0, ret);
-    Assert.assertTrue(mFileSystem.exists(dstDir));
-    verifyPreservedAttributes(srcDir, dstDir);
-    verifyPreservedAttributes(srcDir.join(subDir), dstDir.join(subDir));
-    verifyPreservedAttributes(srcDir.join(file), dstDir.join(file));
+    try (FileSystemShell fsShell = new FileSystemShell(conf)) {
+      String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
+      String newDir = "/copy";
+      String subDir = "/foo";
+      String file = "/foobar4";
+      String owner = TEST_USER_1.getUser();
+      String group = "staff";
+      short mode = 0422;
+      List<AclEntry> entries = new ArrayList<>();
+      entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_USER)
+          .setSubject(TEST_USER_2.getUser()).addAction(AclAction.READ).addAction(AclAction.WRITE)
+          .addAction(AclAction.EXECUTE).build());
+      entries.add(new AclEntry.Builder().setType(AclEntryType.NAMED_GROUP).setSubject(group)
+          .addAction(AclAction.WRITE).addAction(AclAction.EXECUTE).build());
+      AlluxioURI srcDir = new AlluxioURI(testDir);
+      mFileSystem.setAttribute(srcDir,
+          SetAttributePOptions.newBuilder().setRecursive(true)
+              .setOwner(owner).setGroup(group)
+              .setMode(new Mode(mode).toProto())
+              .setPinned(true)
+              .setReplicationMin(2)
+              .setReplicationMax(4)
+              .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(12345))
+              .build());
+      mFileSystem.setAcl(srcDir, SetAclAction.MODIFY, entries,
+          SetAclPOptions.newBuilder().setRecursive(true).build());
+      int ret = fsShell.run("cp", "-R",  "-p", testDir, newDir);
+      AlluxioURI dstDir = new AlluxioURI(newDir);
+      Assert.assertEquals(0, ret);
+      Assert.assertTrue(mFileSystem.exists(dstDir));
+      verifyPreservedAttributes(srcDir, dstDir);
+      verifyPreservedAttributes(srcDir.join(subDir), dstDir.join(subDir));
+      verifyPreservedAttributes(srcDir.join(file), dstDir.join(file));
+    }
   }
 
   private void verifyPreservedAttributes(AlluxioURI src, AlluxioURI dst)
@@ -279,8 +279,8 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
 
   @Test
   public void copyAfterWorkersNotAvailable() throws Exception {
-    FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
     File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
+    testFile.delete();
     testFile.createNewFile();
     FileOutputStream fos = new FileOutputStream(testFile);
     byte[] toWrite = BufferUtils.getIncreasingByteArray(100);
@@ -298,20 +298,20 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   public void copyAfterWorkersNotAvailableMustCache() throws Exception {
     InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
-    mFsShell = new FileSystemShell(conf);
+    try (FileSystemShell fsShell = new FileSystemShell(conf)) {
+      File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
+      testFile.createNewFile();
+      FileOutputStream fos = new FileOutputStream(testFile);
+      byte[] toWrite = BufferUtils.getIncreasingByteArray(100);
+      fos.write(toWrite);
+      fos.close();
 
-    File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
-    testFile.createNewFile();
-    FileOutputStream fos = new FileOutputStream(testFile);
-    byte[] toWrite = BufferUtils.getIncreasingByteArray(100);
-    fos.write(toWrite);
-    fos.close();
-
-    mFsShell.run("copyFromLocal", testFile.getPath(), "/");
-    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/testFile")));
-    mLocalAlluxioCluster.stopWorkers();
-    mFsShell.run("cp", "/testFile", "/testFile2");
-    Assert.assertFalse(mFileSystem.exists(new AlluxioURI("/testFile2")));
+      fsShell.run("copyFromLocal", testFile.getPath(), "/");
+      Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/testFile")));
+      mLocalAlluxioCluster.stopWorkers();
+      fsShell.run("cp", "/testFile", "/testFile2");
+      Assert.assertFalse(mFileSystem.exists(new AlluxioURI("/testFile2")));
+    }
   }
 
   private boolean equals(AlluxioURI file1, AlluxioURI file2) throws Exception {
@@ -421,6 +421,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   @Test
   public void copyFromLocalLarge() throws Exception {
     File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testFile");
+    testFile.delete();
     testFile.createNewFile();
     FileOutputStream fos = new FileOutputStream(testFile);
     byte[] toWrite = BufferUtils.getIncreasingByteArray(SIZE_BYTES);
@@ -603,7 +604,9 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   public void copyToLocalWildcardNotDir() throws Exception {
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
     new File(mLocalAlluxioCluster.getAlluxioHome() + "/testDir").mkdir();
-    new File(mLocalAlluxioCluster.getAlluxioHome() + "/testDir/testFile").createNewFile();
+    File testFile = new File(mLocalAlluxioCluster.getAlluxioHome() + "/testDir/testFile");
+    testFile.delete();
+    testFile.createNewFile();
 
     int ret = mFsShell.run("cp", testDir + "/*/foo*",
         "file://" + mLocalAlluxioCluster.getAlluxioHome() + "/testDir/testFile");

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LeaderCommandIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 /**
  * Tests for leader command.
  */
-public final class LeaderCommandIntegrationTest extends AbstractFileSystemShellTest {
+public final class  LeaderCommandIntegrationTest extends AbstractFileSystemShellTest {
 
   @Test
   public void leader() {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
@@ -21,27 +21,25 @@ import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AlluxioException;
-import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
-import alluxio.security.authorization.AclEntry;
 import alluxio.security.user.TestUserState;
 import alluxio.testutils.LocalAlluxioClusterResource;
-import alluxio.util.CommonUtils;
 
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.function.Function;
 
 /**
  * Tests for ls command.
  */
+@LocalAlluxioClusterResource.ServerConfig(
+    confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
+        PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL",
+        PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"})
 public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest {
   // Helper function to create a set of files in the file system
   private void createFiles(String user) throws Exception {
@@ -61,9 +59,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsNoAcl() throws Exception {
     createFiles(null);
     mFsShell.run("ls", "/testRoot");
@@ -77,9 +72,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command when arguments are multiple directories and security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsMultipleDirs() throws Exception {
     createFiles(null);
     mFsShell.run("ls", "/testRoot", "/testRoot/testDir/");
@@ -94,9 +86,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls -h command when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsHumanReadable() throws Exception {
     createFiles(null);
     mFsShell.run("ls", "-h", "/testRoot");
@@ -110,9 +99,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls -p command when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsPinned() throws Exception {
     createFiles(null);
     AlluxioURI fileURI1 = new AlluxioURI("/testRoot/testDir/testFileB");
@@ -131,9 +117,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls -d command when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsDirectoryAsPlainFileNoAcl() throws Exception {
     createFiles(null);
     mFsShell.run("ls", "-d", "/testRoot");
@@ -144,42 +127,15 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls -d command on root directory when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsRootNoAcl() throws Exception {
     mFsShell.run("ls", "-d", "/");
     checkOutput("              0       PERSISTED .+ .+  DIR /    ");
   }
 
   /**
-   * Tests ls command when security is enabled.
-   */
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls"})
-  public void ls() throws Exception {
-    createFiles("test_user_ls");
-    mFsShell.run("ls", "/testRoot");
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
-        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED .+ .+ 100% /testRoot/testFileA",
-        "-rw-r--r--  test_user_ls   test_user_ls                30       PERSISTED .+ .+   0% /testRoot/testFileC");
-    // CHECKSTYLE.ON: LineLengthExceed
-  }
-
-  /**
    * Tests ls command with wildcard when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWildcardNoAcl() throws Exception {
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
 
@@ -200,46 +156,9 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
   }
 
   /**
-   * Tests ls command with wildcard when security is enabled.
-   */
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP,
-          "test_user_lsWildcard"})
-  public void lsWildcard() throws Exception {
-    FileSystem fs = mLocalAlluxioCluster.getClient(FileSystemContext.create(
-        new TestUserState("test_user_lsWildcard", ServerConfiguration.global()).getSubject(),
-        ServerConfiguration.global()));
-
-    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(fs);
-    mFsShell.run("ls", testDir + "/*/foo*");
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             30   NOT_PERSISTED .+ .+ 100% /testDir/bar/foobar3",
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             10   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar1",
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             20   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar2");
-    mOutput.reset();
-
-    mFsShell.run("ls", testDir + "/*");
-    checkOutput(
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             30   NOT_PERSISTED .+ .+ 100% /testDir/bar/foobar3",
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             10   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar1",
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             20   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar2",
-        "-rw-r--r--  test_user_lsWildcardtest_user_lsWildcard             40   NOT_PERSISTED .+ .+ 100% /testDir/foobar4");
-    // CHECKSTYLE.ON: LineLengthExceed
-  }
-
-  /**
    * Tests ls -R command with wildcard when security is not enabled.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsrNoAcl() throws Exception {
     createFiles(null);
     mFsShell.run("ls", "-R", "/testRoot");
@@ -251,35 +170,9 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
   }
 
   /**
-   * Tests ls -R command with wildcard when security is enabled.
-   */
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP,
-          "test_user_lsr"})
-  public void lsr() throws Exception {
-    createFiles("test_user_lsr");
-    mFsShell.run("ls", "-R", "/testRoot");
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "drwxr-xr-x  test_user_lsr  test_user_lsr                1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
-        "-rw-r--r--  test_user_lsr  test_user_lsr               20   NOT_PERSISTED .+ .+ 100% /testRoot/testDir/testFileB",
-        "-rw-r--r--  test_user_lsr  test_user_lsr               10   NOT_PERSISTED .+ .+ 100% /testRoot/testFileA",
-        "-rw-r--r--  test_user_lsr  test_user_lsr               30       PERSISTED .+ .+   0% /testRoot/testFileC");
-    // CHECKSTYLE.ON: LineLengthExceed
-  }
-
-  /**
    * Tests ls command with a file where the file name includes a specifier character.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWithFormatSpecifierCharacter() throws IOException, AlluxioException {
     String fileName = "/localhost%2C61764%2C1476207067267..meta.1476207073442.meta";
     FileSystemTestUtils.createByteFile(mFileSystem, fileName, WritePType.MUST_CACHE, 10);
@@ -293,9 +186,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with sort by path option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWithSortByPath() throws IOException, AlluxioException {
     FileSystemTestUtils
             .createByteFile(mFileSystem, "/testRoot/testLongFile", WritePType.MUST_CACHE, 100);
@@ -314,10 +204,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with sort by access time option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL",
-          PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"})
   public void lsWithSortByAccessTime() throws IOException, AlluxioException {
     String oldFileRecentlyAccessed = "/testRoot/testFileRecent";
     String oldFileName = "/testRoot/testFile";
@@ -337,10 +223,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with sort by creation time option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL",
-          PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"})
   public void lsWithSortByCreationTime() throws IOException, AlluxioException {
     String oldFileRecentlyAccessed = "/testRoot/testFileRecent";
     String oldFileName = "/testRoot/testFile";
@@ -360,9 +242,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with sort by size option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWithSortBySize() throws IOException, AlluxioException {
     FileSystemTestUtils
             .createByteFile(mFileSystem, "/testRoot/testFileA", WritePType.MUST_CACHE, 50, 50);
@@ -381,9 +260,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with sort by size and reverse order option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWithSortBySizeAndReverse() throws IOException, AlluxioException {
     FileSystemTestUtils
             .createByteFile(mFileSystem, "/testRoot/testFileA", WritePType.MUST_CACHE, 50, 50);
@@ -402,9 +278,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with an invalid sort option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsWithInvalidSortOption() throws IOException, AlluxioException {
     FileSystemTestUtils.createByteFile(mFileSystem, "/testRoot/testFileA",
         WritePType.MUST_CACHE, 50, 50);
@@ -417,9 +290,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
    * Tests ls command with reverse sort order option.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-          confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false",
-                  PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "NOSASL"})
   public void lsReverseWithoutSort() throws IOException, AlluxioException {
     FileSystemTestUtils
             .createByteFile(mFileSystem, "/testRoot/testFileA", WritePType.MUST_CACHE, 50, 50);
@@ -432,110 +302,6 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
         "            100   NOT_PERSISTED .+ .+ 100% /testRoot/testLongFile",
         "             10   NOT_PERSISTED .+ .+ 100% /testRoot/testFileZ",
         "             50   NOT_PERSISTED .+ .+ 100% /testRoot/testFileA");
-  }
-
-  private String getDisplayTime(long timestamp) {
-    String formatString = ServerConfiguration.get(PropertyKey.USER_DATE_FORMAT_PATTERN);
-    return CommonUtils.convertMsToDate(timestamp, formatString);
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls",
-          PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"
-      })
-  public void lsWithCreationTime() throws Exception {
-    checkLsWithTimestamp("creationTime", URIStatus::getCreationTimeMs);
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls",
-          PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"
-      })
-  public void lsWithModificationTime() throws Exception {
-    checkLsWithTimestamp("lastModificationTime", URIStatus::getLastModificationTimeMs);
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls",
-          PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"
-      })
-  public void lsWithAccessTime() throws Exception {
-    checkLsWithTimestamp("lastAccessTime", URIStatus::getLastAccessTimeMs);
-  }
-
-  private void checkLsWithTimestamp(String parameter, Function<URIStatus, Long> timestampFunc)
-      throws Exception {
-    createFiles("test_user_ls");
-    String testDir = "/testRoot/testDir";
-    String testFileA = "/testRoot/testFileA";
-    String testFileC = "/testRoot/testFileC";
-    mFileSystem.listStatus(new AlluxioURI(testDir));
-    FileSystemTestUtils.loadFile(mFileSystem, testFileA);
-    FileSystemTestUtils.loadFile(mFileSystem, testFileC);
-    mFsShell.run("ls", "--timestamp", parameter, "/testRoot");
-    long time1 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testDir)));
-    long time2 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testFileA)));
-    long time3 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testFileC)));
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED " +  getDisplayTime(time1) + "  DIR /testRoot/testDir",
-        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED " +  getDisplayTime(time2) + " 100% /testRoot/testFileA",
-        "-rw-r--r--  test_user_ls   test_user_ls                30       PERSISTED " +  getDisplayTime(time3) + " 100% /testRoot/testFileC");
-    // CHECKSTYLE.ON: LineLengthExceed
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_extended"})
-  public void lsWithExtendedAcl() throws IOException, AlluxioException {
-    int size = 50;
-
-    FileSystem fs = mLocalAlluxioCluster.getClient(FileSystemContext
-        .create(new TestUserState("test_user_extended", ServerConfiguration.global()).getSubject(),
-            ServerConfiguration.global()));
-    FileSystemTestUtils.createByteFile(fs, "/testRoot/testDir/testFileB",
-        WritePType.MUST_CACHE, 20);
-    FileSystemTestUtils.createByteFile(fs, "/testRoot/testFile",
-        WritePType.MUST_CACHE, size, size);
-
-    mFsShell.run("ls", "--sort", "path", "/testRoot");
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "drwxr-xr-x  test_user_extendedtest_user_extended              1   NOT_PERSISTED .+ .+ DIR /testRoot/testDir",
-        "-rw-r--r--  test_user_extendedtest_user_extended             50   NOT_PERSISTED .+ .+ 100% /testRoot/testFile");
-    // CHECKSTYLE.ON: LineLengthExceed
-    mOutput.reset();
-
-    fs.setAcl(new AlluxioURI("/testRoot/testDir"), SetAclAction.MODIFY,
-        Arrays.asList(AclEntry.fromCliString("default:user:nameduser:rwx")));
-    fs.setAcl(new AlluxioURI("/testRoot/testFile"), SetAclAction.MODIFY,
-        Arrays.asList(AclEntry.fromCliString("user:nameduser:rwx")));
-
-    mFsShell.run("ls", "--sort", "path", "/testRoot");
-    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
-    checkOutput(
-        "drwxr-xr-x\\+ test_user_extendedtest_user_extended              1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
-        "-rw-r--r--\\+ test_user_extendedtest_user_extended             50   NOT_PERSISTED .+ .+ 100% /testRoot/testFile");
-    // CHECKSTYLE.ON: LineLengthExceed
   }
 
   private void checkOutput(String... linePatterns) {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandSecurityIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandSecurityIntegrationTest.java
@@ -1,0 +1,202 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import alluxio.AlluxioURI;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.cli.fs.FileSystemShellUtilsTest;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.SetAclAction;
+import alluxio.grpc.WritePType;
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.user.TestUserState;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.CommonUtils;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Function;
+
+/**
+ * Tests for ls command, with security enabled.
+ */
+@LocalAlluxioClusterResource.ServerConfig(
+    confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
+        PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
+        PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
+        "alluxio.security.group.provider.IdentityUserGroupsMapping",
+        PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_ls",
+        PropertyKey.Name.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0"})
+public final class LsCommandSecurityIntegrationTest extends AbstractFileSystemShellTest {
+  // Helper function to create a set of files in the file system
+  private void createFiles() throws Exception {
+    FileSystem fs = mLocalAlluxioCluster.getClient(FileSystemContext
+        .create(new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
+            ServerConfiguration.global()));
+    FileSystemTestUtils.createByteFile(fs, "/testRoot/testFileA", WritePType.MUST_CACHE, 10);
+    FileSystemTestUtils
+        .createByteFile(fs, "/testRoot/testDir/testFileB", WritePType.MUST_CACHE, 20);
+    FileSystemTestUtils.createByteFile(fs, "/testRoot/testFileC", WritePType.THROUGH, 30);
+  }
+
+  /**
+   * Tests ls command when security is enabled.
+   */
+  @Test
+  public void ls() throws Exception {
+    createFiles();
+    mFsShell.run("ls", "/testRoot");
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
+        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED .+ .+ 100% /testRoot/testFileA",
+        "-rw-r--r--  test_user_ls   test_user_ls                30       PERSISTED .+ .+   0% /testRoot/testFileC");
+    // CHECKSTYLE.ON: LineLengthExceed
+  }
+
+  /**
+   * Tests ls command with wildcard when security is enabled.
+   */
+  @Test
+  public void lsWildcard() throws Exception {
+    FileSystem fs = mLocalAlluxioCluster.getClient(FileSystemContext.create(
+        new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
+        ServerConfiguration.global()));
+
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(fs);
+    mFsShell.run("ls", testDir + "/*/foo*");
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "-rw-r--r--  test_user_ls   test_user_ls                30   NOT_PERSISTED .+ .+ 100% /testDir/bar/foobar3",
+        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar1",
+        "-rw-r--r--  test_user_ls   test_user_ls                20   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar2");
+    mOutput.reset();
+
+    mFsShell.run("ls", testDir + "/*");
+    checkOutput(
+        "-rw-r--r--  test_user_ls   test_user_ls                30   NOT_PERSISTED .+ .+ 100% /testDir/bar/foobar3",
+        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar1",
+        "-rw-r--r--  test_user_ls   test_user_ls                20   NOT_PERSISTED .+ .+ 100% /testDir/foo/foobar2",
+        "-rw-r--r--  test_user_ls   test_user_ls                40   NOT_PERSISTED .+ .+ 100% /testDir/foobar4");
+    // CHECKSTYLE.ON: LineLengthExceed
+  }
+
+  /**
+   * Tests ls -R command with wildcard when security is enabled.
+   */
+  @Test
+  public void lsr() throws Exception {
+    createFiles();
+    mFsShell.run("ls", "-R", "/testRoot");
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
+        "-rw-r--r--  test_user_ls   test_user_ls                20   NOT_PERSISTED .+ .+ 100% /testRoot/testDir/testFileB",
+        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED .+ .+ 100% /testRoot/testFileA",
+        "-rw-r--r--  test_user_ls   test_user_ls                30       PERSISTED .+ .+   0% /testRoot/testFileC");
+    // CHECKSTYLE.ON: LineLengthExceed
+  }
+
+  private String getDisplayTime(long timestamp) {
+    String formatString = ServerConfiguration.get(PropertyKey.USER_DATE_FORMAT_PATTERN);
+    return CommonUtils.convertMsToDate(timestamp, formatString);
+  }
+
+  @Test
+  public void lsWithCreationTime() throws Exception {
+    checkLsWithTimestamp("creationTime", URIStatus::getCreationTimeMs);
+  }
+
+  @Test
+  public void lsWithModificationTime() throws Exception {
+    checkLsWithTimestamp("lastModificationTime", URIStatus::getLastModificationTimeMs);
+  }
+
+  @Test
+  public void lsWithAccessTime() throws Exception {
+    checkLsWithTimestamp("lastAccessTime", URIStatus::getLastAccessTimeMs);
+  }
+
+  private void checkLsWithTimestamp(String parameter, Function<URIStatus, Long> timestampFunc)
+      throws Exception {
+    createFiles();
+    String testDir = "/testRoot/testDir";
+    String testFileA = "/testRoot/testFileA";
+    String testFileC = "/testRoot/testFileC";
+    mFileSystem.listStatus(new AlluxioURI(testDir));
+    FileSystemTestUtils.loadFile(mFileSystem, testFileA);
+    FileSystemTestUtils.loadFile(mFileSystem, testFileC);
+    mFsShell.run("ls", "--timestamp", parameter, "/testRoot");
+    long time1 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testDir)));
+    long time2 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testFileA)));
+    long time3 = timestampFunc.apply(mFileSystem.getStatus(new AlluxioURI(testFileC)));
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED " +  getDisplayTime(time1) + "  DIR /testRoot/testDir",
+        "-rw-r--r--  test_user_ls   test_user_ls                10   NOT_PERSISTED " +  getDisplayTime(time2) + " 100% /testRoot/testFileA",
+        "-rw-r--r--  test_user_ls   test_user_ls                30       PERSISTED " +  getDisplayTime(time3) + " 100% /testRoot/testFileC");
+    // CHECKSTYLE.ON: LineLengthExceed
+  }
+
+  @Test
+  public void lsWithExtendedAcl() throws IOException, AlluxioException {
+    int size = 50;
+
+    FileSystem fs = mLocalAlluxioCluster.getClient(FileSystemContext
+        .create(new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
+            ServerConfiguration.global()));
+    FileSystemTestUtils.createByteFile(fs, "/testRoot/testDir/testFileB",
+        WritePType.MUST_CACHE, 20);
+    FileSystemTestUtils.createByteFile(fs, "/testRoot/testFile",
+        WritePType.MUST_CACHE, size, size);
+
+    mFsShell.run("ls", "--sort", "path", "/testRoot");
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "drwxr-xr-x  test_user_ls   test_user_ls                 1   NOT_PERSISTED .+ .+ DIR /testRoot/testDir",
+        "-rw-r--r--  test_user_ls   test_user_ls                50   NOT_PERSISTED .+ .+ 100% /testRoot/testFile");
+    // CHECKSTYLE.ON: LineLengthExceed
+    mOutput.reset();
+
+    fs.setAcl(new AlluxioURI("/testRoot/testDir"), SetAclAction.MODIFY,
+        Arrays.asList(AclEntry.fromCliString("default:user:nameduser:rwx")));
+    fs.setAcl(new AlluxioURI("/testRoot/testFile"), SetAclAction.MODIFY,
+        Arrays.asList(AclEntry.fromCliString("user:nameduser:rwx")));
+
+    mFsShell.run("ls", "--sort", "path", "/testRoot");
+    // CHECKSTYLE.OFF: LineLengthExceed - Improve readability
+    checkOutput(
+        "drwxr-xr-x\\+ test_user_ls   test_user_ls                 1   NOT_PERSISTED .+ .+  DIR /testRoot/testDir",
+        "-rw-r--r--\\+ test_user_ls   test_user_ls                50   NOT_PERSISTED .+ .+ 100% /testRoot/testFile");
+    // CHECKSTYLE.ON: LineLengthExceed
+  }
+
+  private void checkOutput(String... linePatterns) {
+    String[] actualLines = mOutput.toString().split("\n");
+    assertEquals("Output: " + mOutput.toString(), linePatterns.length, actualLines.length);
+    for (int i = 0; i < linePatterns.length; i++) {
+      assertThat("mOutput: " + mOutput.toString(), actualLines[i], matchesPattern(linePatterns[i]));
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandIntegrationTest.java
@@ -11,36 +11,21 @@
 
 package alluxio.client.cli.fs.command;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
-import alluxio.cli.fs.FileSystemShell;
-import alluxio.client.file.FileSystemTestUtils;
-import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
-import alluxio.grpc.WritePType;
-import alluxio.heartbeat.HeartbeatContext;
-import alluxio.heartbeat.HeartbeatScheduler;
-import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.grpc.WritePType;
 
-import com.google.common.io.Files;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
  * Tests the "pin" and "unpin" commands.
  */
 public final class PinCommandIntegrationTest extends AbstractFileSystemShellTest {
-  @ClassRule
-  public static ManuallyScheduleHeartbeat sManuallyScheduleRule = new ManuallyScheduleHeartbeat(
-      HeartbeatContext.MASTER_TTL_CHECK,
-      HeartbeatContext.WORKER_BLOCK_SYNC,
-      HeartbeatContext.WORKER_PIN_LIST_SYNC,
-      HeartbeatContext.MASTER_REPLICATION_CHECK);
-
   /**
    * Tests the "pin" and "unpin" commands. Creates a file and tests unpinning it, then pinning
    * it and finally unpinning
@@ -83,21 +68,16 @@ public final class PinCommandIntegrationTest extends AbstractFileSystemShellTest
 
     FileSystemTestUtils.createByteFile(mFileSystem, filePathA, WritePType.MUST_CACHE,
         fileSize);
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
     assertTrue(fileExists(filePathA));
     assertEquals(0, mFsShell.run("pin", filePathA.toString()));
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_PIN_LIST_SYNC);
 
     FileSystemTestUtils.createByteFile(mFileSystem, filePathB, WritePType.MUST_CACHE,
         fileSize);
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
     assertTrue(fileExists(filePathB));
     assertEquals(0, mFsShell.run("unpin", filePathB.toString()));
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_PIN_LIST_SYNC);
 
     FileSystemTestUtils.createByteFile(mFileSystem, filePathC, WritePType.MUST_CACHE,
         fileSize);
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
     assertTrue(fileExists(filePathC));
 
     // fileA is in memory because it is pinned, but fileB should have been evicted to hold fileC.
@@ -105,59 +85,5 @@ public final class PinCommandIntegrationTest extends AbstractFileSystemShellTest
     assertEquals(0, mFileSystem.getStatus(filePathB).getInAlluxioPercentage());
     // fileC should be in memory because fileB is evicted.
     assertEquals(100, mFileSystem.getStatus(filePathC).getInAlluxioPercentage());
-  }
-
-  /**
-   * Test pinned file with specific medium.
-   */
-  @Test
-  public void setPinToSpecificMedia() throws Exception {
-    final long CAPACITY_BYTES = SIZE_BYTES;
-
-    ServerConfiguration
-        .set(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2");
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD");
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
-            Files.createTempDir().getAbsolutePath());
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(1),
-            Files.createTempDir().getAbsolutePath());
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(0),
-            String.valueOf(CAPACITY_BYTES));
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(1),
-            String.valueOf(CAPACITY_BYTES));
-    ServerConfiguration.set(
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(0), "SSD");
-    ServerConfiguration.set(
-        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(1), "SSD");
-    mLocalAlluxioCluster.restartMasters();
-    mLocalAlluxioCluster.stopWorkers();
-    mLocalAlluxioCluster.startWorkers();
-    mFileSystem = mLocalAlluxioCluster.getClient();
-    mFsShell = new FileSystemShell(ServerConfiguration.global());
-
-    AlluxioURI filePathA = new AlluxioURI("/testFileA");
-    AlluxioURI filePathB = new AlluxioURI("/testFileB");
-
-    int fileSize = SIZE_BYTES / 2;
-
-    FileSystemTestUtils.createByteFile(mFileSystem, filePathA, WritePType.MUST_CACHE,
-        fileSize);
-    assertTrue(fileExists(filePathA));
-
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-    assertTrue(fileExists(filePathA));
-    assertEquals(0, mFsShell.run("pin", filePathA.toString(), "SSD"));
-    int ret = mFsShell.run("setReplication", "-min", "2", filePathA.toString());
-    assertEquals(0, ret);
-
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_PIN_LIST_SYNC);
-    HeartbeatScheduler.execute(HeartbeatContext.MASTER_REPLICATION_CHECK);
-
-    HeartbeatScheduler.execute(HeartbeatContext.WORKER_BLOCK_SYNC);
-
-    assertEquals("SSD", mFileSystem.getStatus(filePathA).getFileBlockInfos()
-        .get(0).getBlockInfo().getLocations().get(0).getMediumType());
-
-    assertEquals(-1, mFsShell.run("pin", filePathB.toString(), "NVRAM"));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.cli.fs.FileSystemShell;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import com.google.common.io.Files;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+/**
+ * Tests the pin command with multiple media.
+ */
+public final class PinCommandMultipleMediaIntegrationTest extends BaseIntegrationTest {
+  private static final int SIZE_BYTES = Constants.MB * 16;
+
+  @ClassRule
+  public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
+          .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
+          .setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "200ms")
+          .setProperty(PropertyKey.WORKER_MEMORY_SIZE, SIZE_BYTES)
+          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, SIZE_BYTES)
+          .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.MAX_VALUE)
+          .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")
+          // multiple media
+          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
+              Files.createTempDir().getAbsolutePath())
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(1),
+              Files.createTempDir().getAbsolutePath())
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(0),
+              String.valueOf(SIZE_BYTES))
+          .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(1),
+              String.valueOf(SIZE_BYTES))
+          .setProperty(
+              PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(0), "SSD")
+          .setProperty(
+              PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(1), "SSD")
+          .build();
+
+  @Rule
+  public TestRule mResetRule = sLocalAlluxioClusterResource.getResetResource();
+
+  @Test
+  public void setPinToSpecificMedia() throws Exception {
+    FileSystem fileSystem = sLocalAlluxioClusterResource.get().getClient();
+    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+
+    AlluxioURI filePathA = new AlluxioURI("/testFileA");
+    AlluxioURI filePathB = new AlluxioURI("/testFileB");
+
+    int fileSize = SIZE_BYTES / 2;
+
+    FileSystemTestUtils.createByteFile(fileSystem, filePathA, WritePType.MUST_CACHE,
+        fileSize);
+    assertTrue(fileSystem.exists(filePathA));
+
+    assertEquals(0, fsShell.run("pin", filePathA.toString(), "SSD"));
+    int ret = fsShell.run("setReplication", "-min", "2", filePathA.toString());
+    assertEquals(0, ret);
+
+    assertEquals("SSD", fileSystem.getStatus(filePathA).getFileBlockInfos()
+        .get(0).getBlockInfo().getLocations().get(0).getMediumType());
+
+    assertEquals(-1, fsShell.run("pin", filePathB.toString(), "NVRAM"));
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
@@ -35,6 +35,13 @@ import java.util.List;
 /**
  * Tests for setfacl command.
  */
+@LocalAlluxioClusterResource.ServerConfig(
+    confParams = {
+        PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
+        PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
+        PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
+        "alluxio.security.group.provider.IdentityUserGroupsMapping",
+        PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "setfacl_test_user"})
 public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShellTest {
   private static final List<String> FACL_STRING_ENTRIES
       = Arrays.asList("user::rw-", "group::r--", "other::r--");
@@ -49,14 +56,8 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
    * Tests setfacl command.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test_user_setfacl"})
   public void setfacl() throws Exception {
-    String testOwner = "test_user_setfacl";
+    String testOwner = "setfacl_test_user";
     String expected = "";
     URIStatus[] files = createFiles(testOwner);
 
@@ -83,15 +84,8 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
    * Tests setfacl command to set default facl.
    */
   @Test
-  @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true",
-          PropertyKey.Name.SECURITY_AUTHENTICATION_TYPE, "SIMPLE",
-          PropertyKey.Name.SECURITY_GROUP_MAPPING_CLASS,
-          "alluxio.security.group.provider.IdentityUserGroupsMapping",
-          PropertyKey.Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP,
-          "test_user_setDefaultFacl"})
   public void setDefaultFacl() throws Exception {
-    String testOwner = "test_user_setDefaultFacl";
+    String testOwner = "setfacl_test_user";
     URIStatus[] files = createFiles(testOwner);
     mFsShell.run("setfacl", "-m", "default:user:testuser:rwx", "/testRoot/testDir");
     mFsShell.run("getfacl", "/testRoot/testDir");

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/AbstractFsAdminShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/AbstractFsAdminShellTest.java
@@ -25,7 +25,7 @@ public class AbstractFsAdminShellTest extends AbstractShellIntegrationTest {
 
   @Before
   public final void before() throws Exception {
-    mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
+    mLocalAlluxioCluster = sLocalAlluxioClusterResource.get();
     mFsAdminShell = new FileSystemAdminShell(ServerConfiguration.global());
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/CheckpointCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/CheckpointCommandIntegrationTest.java
@@ -27,6 +27,6 @@ public final class CheckpointCommandIntegrationTest extends AbstractFsAdminShell
     Assert.assertEquals(0, ret);
     Assert.assertThat(mOutput.toString(), CoreMatchers.containsString(String
         .format("Successfully took a checkpoint on master %s%n",
-        mLocalAlluxioClusterResource.get().getHostname())));
+        sLocalAlluxioClusterResource.get().getHostname())));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
@@ -132,7 +132,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
       Assert.assertEquals(0,
           fsAdminShell.run("pathConf", "add", "--property", WRITE_TYPE_CACHE_THROUGH, PATH2));
 
-      FileSystem fs = mLocalAlluxioClusterResource.get().getClient();
+      FileSystem fs = sLocalAlluxioClusterResource.get().getClient();
       String file = "/file";
       FileSystemTestUtils.createByteFile(fs, file, 100, CreateFilePOptions.getDefaultInstance());
 

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
@@ -52,7 +52,7 @@ public class ListCommandIntegrationTest extends AbstractShellIntegrationTest {
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY1, PROPERTY_VALUE1);
     client.setPathConfiguration(new AlluxioURI(DIR2), PROPERTY_KEY2, PROPERTY_VALUE2);
-    InetSocketAddress address = mLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
+    InetSocketAddress address = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
         .getAddress();
     FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
     fsCtx.getClientContext().loadConf(address, true, true);

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
@@ -57,7 +57,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY11, PROPERTY_VALUE11);
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY12, PROPERTY_VALUE12);
     client.setPathConfiguration(new AlluxioURI(DIR2), PROPERTY_KEY2, PROPERTY_VALUE2);
-    InetSocketAddress address = mLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
+    InetSocketAddress address = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
         .getAddress();
     FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
     fsCtx.getClientContext().loadConf(address, true, true);


### PR DESCRIPTION
This speeds up the cli integration tests, by reusing the LocalAlluxioCluster throughout each test class. This avoids tearing down and recreating the cluster between each individual test case. When a new cluster configuration was required, a new test class was created and those test cases were moved into the new file.