### PR TITLE
Set raft-client policy to connect to leader for journal writes

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -275,6 +275,11 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
   private CopycatClient createClient() {
     return CopycatClient.builder(getClusterAddresses(mConf))
         .withRecoveryStrategy(RecoveryStrategies.RECOVER)
+        /*
+         * We use raft clients for journal writes and writes are only allowed on leader. Forcing
+         * client to connect to leader will improve performance by eliminating extra hops and will
+         * make transport level traces less confusing for investigation.
+         */
         .withServerSelectionStrategy(ServerSelectionStrategies.LEADER)
         .withConnectionStrategy(attempt -> attempt.retry(Duration.ofMillis(
             Math.min(Math.round(100D * Math.pow(2D, (double) attempt.attempt())), 1000L))))

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -39,6 +39,7 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.RecoveryStrategies;
+import io.atomix.copycat.client.ServerSelectionStrategies;
 import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.StateMachine;
 import io.atomix.copycat.server.cluster.Member;
@@ -274,6 +275,7 @@ public final class RaftJournalSystem extends AbstractJournalSystem {
   private CopycatClient createClient() {
     return CopycatClient.builder(getClusterAddresses(mConf))
         .withRecoveryStrategy(RecoveryStrategies.RECOVER)
+        .withServerSelectionStrategy(ServerSelectionStrategies.LEADER)
         .withConnectionStrategy(attempt -> attempt.retry(Duration.ofMillis(
             Math.min(Math.round(100D * Math.pow(2D, (double) attempt.attempt())), 1000L))))
         .withTransport(new GrpcMessagingTransport(


### PR DESCRIPTION
Default server selection policy will select a random server while connecting to cluster. When a connected server is not the leader, client requests will simply be forwarded to the leader.

We use raft clients for journal writes and writes are only allowed on leader. Forcing client to connect to leader will improve performance by eliminating extra hops and will make transport level traces less confusing for investigation.