### PR TITLE
Parallelize load definition within a worker

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -717,5 +717,27 @@ public final class CommonUtils {
     };
   }
 
+  /**
+   * Partitions a list into numLists many lists each with around list.size() / numLists elements.
+   *
+   * @param list the list to partition
+   * @param numLists number of lists to return
+   * @param <T> the object type
+   * @return partitioned list
+   */
+  public static <T> List<List<T>> partition(List<T> list, int numLists) {
+    ArrayList<List<T>> result = new ArrayList<>(numLists);
+
+    for (int i = 0; i < numLists; i++) {
+      result.add(new ArrayList<>(list.size() / numLists + 1));
+    }
+
+    for (int i = 0; i < list.size(); i++) {
+      result.get(i % numLists).add(list.get(i));
+    }
+
+    return result;
+  }
+
   private CommonUtils() {} // prevent instantiation
 }

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -54,7 +54,6 @@ public final class LoadDefinition
     extends AbstractVoidPlanDefinition<LoadConfig, ArrayList<LoadTask>> {
   private static final Logger LOG = LoggerFactory.getLogger(LoadDefinition.class);
   private static final int MAX_BUFFER_SIZE = 500 * Constants.MB;
-
   private static final int JOBS_PER_WORKER = 10;
 
   /**

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -23,6 +23,7 @@ import alluxio.job.SelectExecutorsContext;
 import alluxio.job.plan.load.LoadDefinition.LoadTask;
 import alluxio.job.util.JobUtils;
 import alluxio.job.util.SerializableVoid;
+import alluxio.util.CommonUtils;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerInfo;
 
@@ -53,6 +54,8 @@ public final class LoadDefinition
     extends AbstractVoidPlanDefinition<LoadConfig, ArrayList<LoadTask>> {
   private static final Logger LOG = LoggerFactory.getLogger(LoadDefinition.class);
   private static final int MAX_BUFFER_SIZE = 500 * Constants.MB;
+
+  private static final int JOBS_PER_WORKER = 10;
 
   /**
    * Constructs a new {@link LoadDefinition}.
@@ -105,7 +108,15 @@ public final class LoadDefinition
 
     Set<Pair<WorkerInfo, ArrayList<LoadTask>>> result = Sets.newHashSet();
     for (Map.Entry<WorkerInfo, Collection<LoadTask>> assignment : assignments.asMap().entrySet()) {
-      result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(assignment.getValue())));
+      Collection<LoadTask> loadTasks = assignment.getValue();
+      List<List<LoadTask>> partitionedTasks =
+          CommonUtils.partition(Lists.newArrayList(loadTasks), JOBS_PER_WORKER);
+
+      for (List<LoadTask> tasks : partitionedTasks) {
+        if (!tasks.isEmpty()) {
+          result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(tasks)));
+        }
+      }
     }
 
     return result;

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -123,8 +123,8 @@ public class LoadDefinitionTest {
     Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
         new LoadDefinition().selectExecutors(config, JOB_WORKERS,
             new SelectExecutorsContext(1, mJobServerContext));
-    Assert.assertEquals(1, assignments.size());
-    Assert.assertEquals(10, assignments.iterator().next().getSecond().size());
+    Assert.assertEquals(10, assignments.size());
+    Assert.assertEquals(1, assignments.iterator().next().getSecond().size());
   }
 
   @Test

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -63,16 +63,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
           .build();
 
   private static final int DEFAULT_ACTIVE_JOBS = 1000;
-  private static final Option ACTIVE_JOBS_OPTION =
-      Option.builder()
-          .longOpt("active_jobs")
-          .required(false)
-          .hasArg(true)
-          .numberOfArgs(1)
-          .type(Number.class)
-          .argName("jobs")
-          .desc("Maximum number of active outgoing jobs, default: " + DEFAULT_ACTIVE_JOBS)
-          .build();
 
   private class JobAttempt {
     private final JobConfig mJobConfig;
@@ -149,11 +139,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   }
 
   @Override
-  public Options getOptions() {
-    return new Options().addOption(REPLICATION_OPTION).addOption(ACTIVE_JOBS_OPTION);
-  }
-
-  @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
     CommandUtils.checkNumOfArgsEquals(this, cl, 1);
   }
@@ -163,7 +148,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);
     int replication = FileSystemShellUtils.getIntArg(cl, REPLICATION_OPTION, DEFAULT_REPLICATION);
-    mActiveJobs = FileSystemShellUtils.getIntArg(cl, ACTIVE_JOBS_OPTION, DEFAULT_ACTIVE_JOBS);
+    mActiveJobs = DEFAULT_ACTIVE_JOBS;
     distributedLoad(path, replication);
     return 0;
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -139,6 +139,11 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   }
 
   @Override
+  public Options getOptions() {
+    return new Options().addOption(REPLICATION_OPTION);
+  }
+
+  @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
     CommandUtils.checkNumOfArgsEquals(this, cl, 1);
   }
@@ -266,7 +271,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "distributedLoad [--replication <num>] [--parallelism <num>] <path>";
+    return "distributedLoad [--replication <num>] <path>";
   }
 
   @Override


### PR DESCRIPTION
Also removed active_jobs parameter from the command because it's needlessly confusing. 