### PR TITLE
Reduce client heartbeat frequency and heartbeat on context close

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/metrics/MetricsHeartbeatContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/MetricsHeartbeatContext.java
@@ -90,8 +90,10 @@ public class MetricsHeartbeatContext {
     // increment and lazily schedule the new heartbeat task if it is the first one
     if (mCtxCount++ == 0) {
       mMetricsMasterHeartbeatTask =
-          sExecutorService.scheduleWithFixedDelay(mClientMasterSync::heartbeat, 0,
-              mConf.getMs(PropertyKey.USER_METRICS_HEARTBEAT_INTERVAL_MS), TimeUnit.MILLISECONDS);
+          sExecutorService.scheduleWithFixedDelay(mClientMasterSync::heartbeat,
+              mConf.getMs(PropertyKey.USER_METRICS_HEARTBEAT_INTERVAL_MS),
+              mConf.getMs(PropertyKey.USER_METRICS_HEARTBEAT_INTERVAL_MS),
+              TimeUnit.MILLISECONDS);
     }
   }
 
@@ -126,6 +128,8 @@ public class MetricsHeartbeatContext {
       mMetricsMasterHeartbeatTask.cancel(false);
     }
     MASTER_METRICS_HEARTBEAT.remove(mConnectDetails);
+    // Trigger the last heartbeat to preserve the client side metrics changes
+    heartbeat();
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/metrics/MetricsHeartbeatContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/MetricsHeartbeatContext.java
@@ -123,13 +123,13 @@ public class MetricsHeartbeatContext {
    * this reference should be discarded.
    */
   private synchronized void close() {
-    mMetricsMasterClient.close();
     if (mMetricsMasterHeartbeatTask != null) {
       mMetricsMasterHeartbeatTask.cancel(false);
     }
     MASTER_METRICS_HEARTBEAT.remove(mConnectDetails);
     // Trigger the last heartbeat to preserve the client side metrics changes
     heartbeat();
+    mMetricsMasterClient.close();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3102,7 +3102,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_METRICS_HEARTBEAT_INTERVAL_MS =
       new Builder(Name.USER_METRICS_HEARTBEAT_INTERVAL_MS)
           .setAlias("alluxio.user.metrics.heartbeat.interval.ms")
-          .setDefaultValue("3sec")
+          .setDefaultValue("1min")
           .setDescription("The time period of client master heartbeat to "
               + "send the client-side metrics.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)


### PR DESCRIPTION
This PR reduces the client heartbeat frequency by enlarging the heartbeat interval and add the initial delay.
To prevent incomplete client metrics for short-life clients, add the last heartbeat when close the last FileSystemContext with the same connect details.
