### PR TITLE
Cache getFileSystem for path

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
@@ -1,0 +1,111 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.job.plan.transform.format;
+
+import alluxio.client.ReadType;
+import alluxio.client.WriteType;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+
+import com.google.common.base.Objects;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.StringUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of {@link Path} that has a cache for getting file system.
+ */
+public class CachedPath extends Path {
+
+  private static final ConcurrentHashMap<FileSystemKey, FileSystem> CACHE =
+      new ConcurrentHashMap<>();
+
+  private static class FileSystemKey {
+
+    final String mScheme;
+    final String mAuthority;
+    final UserGroupInformation mUgi;
+    final ReadType mReadType;
+    final WriteType mWriteType;
+
+    public FileSystemKey(CachedPath path, Configuration conf) throws IOException {
+      URI uri = path.toUri();
+      mScheme = uri.getScheme() == null ? "" : StringUtils.toLowerCase(uri.getScheme());
+      mAuthority = uri.getAuthority() == null ? "" : StringUtils.toLowerCase(uri.getAuthority());
+      mUgi = UserGroupInformation.getCurrentUser();
+      mReadType = conf.getEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(),
+          InstancedConfiguration.defaults().getEnum(
+              PropertyKey.USER_FILE_READ_TYPE_DEFAULT, ReadType.class));
+      mWriteType = conf.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT.getName(),
+          InstancedConfiguration.defaults().getEnum(
+              PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mScheme, mAuthority, mUgi, mReadType, mWriteType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null) {
+        return false;
+      }
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof FileSystemKey)) {
+        return false;
+      }
+      FileSystemKey that = (FileSystemKey) o;
+      return Objects.equal(mScheme, that.mScheme)
+          && Objects.equal(mAuthority, that.mAuthority)
+          && Objects.equal(mUgi, that.mUgi)
+          && Objects.equal(mReadType, that.mReadType)
+          && Objects.equal(mWriteType, that.mWriteType);
+    }
+  }
+
+  /**
+   * Copy of the constructor in {@link Path}.
+   * @param scheme the scheme
+   * @param authority the authority
+   * @param path the path
+   */
+  public CachedPath(String scheme, String authority, String path) {
+    super(scheme, authority, path);
+  }
+
+  @Override
+  public FileSystem getFileSystem(Configuration conf) throws IOException {
+    try {
+      return CACHE.computeIfAbsent(new FileSystemKey(this, conf), (key) -> {
+        try {
+          return super.getFileSystem(conf);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
+      throw e;
+    }
+  }
+}

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
@@ -101,8 +101,9 @@ public class CachedPath extends Path {
         }
       });
     } catch (RuntimeException e) {
-      if (e.getCause() instanceof IOException) {
-        throw (IOException) e.getCause();
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
       }
       throw e;
     }

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/CachedPath.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.StringUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -45,8 +44,8 @@ public class CachedPath extends Path {
 
     public FileSystemKey(CachedPath path, Configuration conf) throws IOException {
       URI uri = path.toUri();
-      mScheme = uri.getScheme() == null ? "" : StringUtils.toLowerCase(uri.getScheme());
-      mAuthority = uri.getAuthority() == null ? "" : StringUtils.toLowerCase(uri.getAuthority());
+      mScheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
+      mAuthority = uri.getAuthority() == null ? "" : uri.getScheme().toLowerCase();
       mUgi = UserGroupInformation.getCurrentUser();
       mReadType = conf.getEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(),
           InstancedConfiguration.defaults().getEnum(

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
@@ -38,7 +38,6 @@ public class JobPath extends Path {
 
     final String mScheme;
     final String mAuthority;
-    final String mPath;
     final UserGroupInformation mUgi;
     final ReadType mReadType;
     final WriteType mWriteType;
@@ -47,7 +46,6 @@ public class JobPath extends Path {
       URI uri = path.toUri();
       mScheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
       mAuthority = uri.getAuthority() == null ? "" : uri.getScheme().toLowerCase();
-      mPath = uri.getPath() == null ? "" : uri.getPath().toLowerCase();
       mUgi = UserGroupInformation.getCurrentUser();
       mReadType = conf.getEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(),
           InstancedConfiguration.defaults().getEnum(
@@ -59,7 +57,7 @@ public class JobPath extends Path {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(mScheme, mAuthority, mPath, mUgi, mReadType, mWriteType);
+      return Objects.hashCode(mScheme, mAuthority, mUgi, mReadType, mWriteType);
     }
 
     @Override
@@ -76,7 +74,6 @@ public class JobPath extends Path {
       FileSystemKey that = (FileSystemKey) o;
       return Objects.equal(mScheme, that.mScheme)
           && Objects.equal(mAuthority, that.mAuthority)
-          && Objects.equal(mPath, that.mPath)
           && Objects.equal(mUgi, that.mUgi)
           && Objects.equal(mReadType, that.mReadType)
           && Objects.equal(mWriteType, that.mWriteType);

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
@@ -45,7 +45,7 @@ public class JobPath extends Path {
     public FileSystemKey(JobPath path, Configuration conf) throws IOException {
       URI uri = path.toUri();
       mScheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
-      mAuthority = uri.getAuthority() == null ? "" : uri.getScheme().toLowerCase();
+      mAuthority = uri.getAuthority() == null ? "" : uri.getAuthority().toLowerCase();
       mUgi = UserGroupInformation.getCurrentUser();
       mReadType = conf.getEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(),
           InstancedConfiguration.defaults().getEnum(
@@ -71,6 +71,7 @@ public class JobPath extends Path {
       if (!(o instanceof FileSystemKey)) {
         return false;
       }
+
       FileSystemKey that = (FileSystemKey) o;
       return Objects.equal(mScheme, that.mScheme)
           && Objects.equal(mAuthority, that.mAuthority)

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
@@ -38,6 +38,7 @@ public class JobPath extends Path {
 
     final String mScheme;
     final String mAuthority;
+    final String mPath;
     final UserGroupInformation mUgi;
     final ReadType mReadType;
     final WriteType mWriteType;
@@ -46,6 +47,7 @@ public class JobPath extends Path {
       URI uri = path.toUri();
       mScheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
       mAuthority = uri.getAuthority() == null ? "" : uri.getScheme().toLowerCase();
+      mPath = uri.getPath() == null ? "" : uri.getPath().toLowerCase();
       mUgi = UserGroupInformation.getCurrentUser();
       mReadType = conf.getEnum(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.getName(),
           InstancedConfiguration.defaults().getEnum(
@@ -57,7 +59,7 @@ public class JobPath extends Path {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(mScheme, mAuthority, mUgi, mReadType, mWriteType);
+      return Objects.hashCode(mScheme, mAuthority, mPath, mUgi, mReadType, mWriteType);
     }
 
     @Override
@@ -74,6 +76,7 @@ public class JobPath extends Path {
       FileSystemKey that = (FileSystemKey) o;
       return Objects.equal(mScheme, that.mScheme)
           && Objects.equal(mAuthority, that.mAuthority)
+          && Objects.equal(mPath, that.mPath)
           && Objects.equal(mUgi, that.mUgi)
           && Objects.equal(mReadType, that.mReadType)
           && Objects.equal(mWriteType, that.mWriteType);

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/JobPath.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Implementation of {@link Path} that has a cache for getting file system.
  */
-public class CachedPath extends Path {
+public class JobPath extends Path {
 
   private static final ConcurrentHashMap<FileSystemKey, FileSystem> CACHE =
       new ConcurrentHashMap<>();
@@ -42,7 +42,7 @@ public class CachedPath extends Path {
     final ReadType mReadType;
     final WriteType mWriteType;
 
-    public FileSystemKey(CachedPath path, Configuration conf) throws IOException {
+    public FileSystemKey(JobPath path, Configuration conf) throws IOException {
       URI uri = path.toUri();
       mScheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
       mAuthority = uri.getAuthority() == null ? "" : uri.getScheme().toLowerCase();
@@ -86,7 +86,7 @@ public class CachedPath extends Path {
    * @param authority the authority
    * @param path the path
    */
-  public CachedPath(String scheme, String authority, String path) {
+  public JobPath(String scheme, String authority, String path) {
     super(scheme, authority, path);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.job.plan.transform.Format;
 import alluxio.job.plan.transform.HiveConstants;
 import alluxio.job.plan.transform.PartitionInfo;
-import alluxio.job.plan.transform.format.CachedPath;
+import alluxio.job.plan.transform.format.JobPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableReader;
 import alluxio.job.plan.transform.format.TableRow;
@@ -110,7 +110,7 @@ public final class CsvReader implements TableReader {
    * @throws IOException when failed to create the reader
    */
   public static CsvReader create(AlluxioURI uri, PartitionInfo pInfo) throws IOException {
-    Path path = new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
+    Path path = new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
     return new CsvReader(path, pInfo);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -52,13 +52,13 @@ public final class CsvReader implements TableReader {
    * @param pInfo the partition info
    * @throws IOException when failed to open the input
    */
-  private CsvReader(Path inputPath, PartitionInfo pInfo) throws IOException {
+  private CsvReader(JobPath inputPath, PartitionInfo pInfo) throws IOException {
     mCloser = Closer.create();
     try {
       mSchema = new CsvSchema(pInfo.getFields());
 
       Configuration conf = ReadWriterUtils.readNoCacheConf();
-      mFs = mCloser.register(inputPath.getFileSystem(conf));
+      mFs = inputPath.getFileSystem(conf);
       boolean isGzipped = pInfo.getFormat(inputPath.getName()).equals(Format.GZIP_CSV);
       InputStream input = open(mFs, inputPath, isGzipped);
 
@@ -110,7 +110,7 @@ public final class CsvReader implements TableReader {
    * @throws IOException when failed to create the reader
    */
   public static CsvReader create(AlluxioURI uri, PartitionInfo pInfo) throws IOException {
-    Path path = new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
+    JobPath path = new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
     return new CsvReader(path, pInfo);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.job.plan.transform.Format;
 import alluxio.job.plan.transform.HiveConstants;
 import alluxio.job.plan.transform.PartitionInfo;
+import alluxio.job.plan.transform.format.CachedPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableReader;
 import alluxio.job.plan.transform.format.TableRow;
@@ -109,7 +110,7 @@ public final class CsvReader implements TableReader {
    * @throws IOException when failed to create the reader
    */
   public static CsvReader create(AlluxioURI uri, PartitionInfo pInfo) throws IOException {
-    Path path = new Path(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
+    Path path = new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
     return new CsvReader(path, pInfo);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.transform.format.parquet;
 
 import alluxio.AlluxioURI;
+import alluxio.job.plan.transform.format.CachedPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableReader;
 import alluxio.job.plan.transform.format.TableRow;
@@ -56,7 +57,7 @@ public final class ParquetReader implements TableReader {
    * @throws IOException when failed to create the reader
    */
   public static ParquetReader create(AlluxioURI uri) throws IOException {
-    Path inputPath = new Path(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
+    Path inputPath = new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
     Configuration conf = ReadWriterUtils.readNoCacheConf();
     InputFile inputFile = HadoopInputFile.fromPath(inputPath, conf);
     org.apache.parquet.hadoop.ParquetReader<Record> reader =

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
@@ -12,7 +12,7 @@
 package alluxio.job.plan.transform.format.parquet;
 
 import alluxio.AlluxioURI;
-import alluxio.job.plan.transform.format.CachedPath;
+import alluxio.job.plan.transform.format.JobPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableReader;
 import alluxio.job.plan.transform.format.TableRow;
@@ -57,7 +57,7 @@ public final class ParquetReader implements TableReader {
    * @throws IOException when failed to create the reader
    */
   public static ParquetReader create(AlluxioURI uri) throws IOException {
-    Path inputPath = new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
+    Path inputPath = new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath());
     Configuration conf = ReadWriterUtils.readNoCacheConf();
     InputFile inputFile = HadoopInputFile.fromPath(inputPath, conf);
     org.apache.parquet.hadoop.ParquetReader<Record> reader =

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.transform.format.parquet;
 
 import alluxio.AlluxioURI;
+import alluxio.job.plan.transform.format.CachedPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableRow;
 import alluxio.job.plan.transform.format.TableSchema;
@@ -20,7 +21,6 @@ import alluxio.job.plan.transform.format.TableWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -63,7 +63,7 @@ public final class ParquetWriter implements TableWriter {
     ParquetSchema parquetSchema = schema.toParquet();
     return new ParquetWriter(AvroParquetWriter.<Record>builder(
         HadoopOutputFile.fromPath(
-            new Path(uri.getScheme(), uri.getAuthority().toString(), uri.getPath()), conf))
+            new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath()), conf))
         .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
         .withConf(conf)
         .withCompressionCodec(CompressionCodecName.SNAPPY)

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
@@ -12,7 +12,7 @@
 package alluxio.job.plan.transform.format.parquet;
 
 import alluxio.AlluxioURI;
-import alluxio.job.plan.transform.format.CachedPath;
+import alluxio.job.plan.transform.format.JobPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableRow;
 import alluxio.job.plan.transform.format.TableSchema;
@@ -63,7 +63,7 @@ public final class ParquetWriter implements TableWriter {
     ParquetSchema parquetSchema = schema.toParquet();
     return new ParquetWriter(AvroParquetWriter.<Record>builder(
         HadoopOutputFile.fromPath(
-            new CachedPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath()), conf))
+            new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath()), conf))
         .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
         .withConf(conf)
         .withCompressionCodec(CompressionCodecName.SNAPPY)

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -52,26 +52,31 @@ public class JobPathTest {
     Configuration conf = new Configuration();
     JobPath jobPath = new JobPath("foo", "bar", "/baz");
 
-    when(FileSystem.get(eq(jobPath.toUri()), any())).thenAnswer((p) -> mock(FileSystem.class));
+    when(FileSystem.get(any(), any())).thenAnswer((p) -> mock(FileSystem.class));
 
     FileSystem fileSystem = jobPath.getFileSystem(conf);
 
     verifyStatic(times(1));
-    FileSystem.get(eq(jobPath.toUri()), any());
+    FileSystem.get(any(), any());
 
     assertEquals(fileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(1));
-    FileSystem.get(eq(jobPath.toUri()), any());
+    FileSystem.get(any(), any());
 
     conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.toString(), ReadType.NO_CACHE.toString());
     FileSystem newFileSystem = jobPath.getFileSystem(conf);
     assertNotEquals(fileSystem, newFileSystem);
     verifyStatic(times(2));
-    FileSystem.get(eq(jobPath.toUri()), any());
+    FileSystem.get(any(), any());
 
     conf.set("foo", "bar");
     assertEquals(newFileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(2));
-    FileSystem.get(eq(jobPath.toUri()), any());
+    FileSystem.get(any(), any());
+
+    jobPath = new JobPath("foo", "bar", "/bar");
+    assertNotEquals(newFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(3));
+    FileSystem.get(any(), any());
   }
 }

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -14,7 +14,6 @@ package alluxio.job.plan.transform.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -23,6 +23,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import alluxio.client.ReadType;
 import alluxio.conf.PropertyKey;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -32,48 +33,45 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.IOException;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileSystem.class, UserGroupInformation.class})
 public class JobPathTest {
 
-    @Before
-    public void before() throws Exception {
-        mockStatic(UserGroupInformation.class);
+  @Before
+  public void before() throws Exception {
+    mockStatic(UserGroupInformation.class);
 
-        when(UserGroupInformation.getCurrentUser()).thenReturn(null);
-    }
+    when(UserGroupInformation.getCurrentUser()).thenReturn(null);
+  }
 
-    @Test
-    public void testCache() throws Exception {
-        mockStatic(FileSystem.class);
+  @Test
+  public void testCache() throws Exception {
+    mockStatic(FileSystem.class);
 
-        Configuration conf = new Configuration();
-        JobPath jobPath = new JobPath("foo", "bar", "/baz");
+    Configuration conf = new Configuration();
+    JobPath jobPath = new JobPath("foo", "bar", "/baz");
 
-        FileSystem mockFileSystem = mock(FileSystem.class);
+    FileSystem mockFileSystem = mock(FileSystem.class);
 
-        when(FileSystem.get(eq(jobPath.toUri()), any())).thenReturn(mockFileSystem);
+    when(FileSystem.get(eq(jobPath.toUri()), any())).thenReturn(mockFileSystem);
 
-        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
 
-        verifyStatic(times(1));
-        FileSystem.get(eq(jobPath.toUri()), any());
+    verifyStatic(times(1));
+    FileSystem.get(eq(jobPath.toUri()), any());
 
-        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
-        verifyStatic(times(1));
-        FileSystem.get(eq(jobPath.toUri()), any());
+    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(1));
+    FileSystem.get(eq(jobPath.toUri()), any());
 
-        conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.toString(), ReadType.NO_CACHE.toString());
-        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
-        verifyStatic(times(2));
-        FileSystem.get(eq(jobPath.toUri()), any());
+    conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.toString(), ReadType.NO_CACHE.toString());
+    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(2));
+    FileSystem.get(eq(jobPath.toUri()), any());
 
-        conf.set("foo", "bar");
-        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
-        verifyStatic(times(2));
-        FileSystem.get(eq(jobPath.toUri()), any());
-    }
-
+    conf.set("foo", "bar");
+    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(2));
+    FileSystem.get(eq(jobPath.toUri()), any());
+  }
 }

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -74,6 +74,11 @@ public class JobPathTest {
     FileSystem.get(any(), any());
 
     jobPath = new JobPath("foo", "bar", "/bar");
+    assertEquals(newFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(2));
+    FileSystem.get(any(), any());
+
+    jobPath = new JobPath("foo", "baz", "/bar");
     assertNotEquals(newFileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(3));
     FileSystem.get(any(), any());

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -1,0 +1,79 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.job.plan.transform.format;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import alluxio.client.ReadType;
+import alluxio.conf.PropertyKey;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileSystem.class, UserGroupInformation.class})
+public class JobPathTest {
+
+    @Before
+    public void before() throws Exception {
+        mockStatic(UserGroupInformation.class);
+
+        when(UserGroupInformation.getCurrentUser()).thenReturn(null);
+    }
+
+    @Test
+    public void testCache() throws Exception {
+        mockStatic(FileSystem.class);
+
+        Configuration conf = new Configuration();
+        JobPath jobPath = new JobPath("foo", "bar", "/baz");
+
+        FileSystem mockFileSystem = mock(FileSystem.class);
+
+        when(FileSystem.get(eq(jobPath.toUri()), any())).thenReturn(mockFileSystem);
+
+        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+
+        verifyStatic(times(1));
+        FileSystem.get(eq(jobPath.toUri()), any());
+
+        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+        verifyStatic(times(1));
+        FileSystem.get(eq(jobPath.toUri()), any());
+
+        conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.toString(), ReadType.NO_CACHE.toString());
+        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+        verifyStatic(times(2));
+        FileSystem.get(eq(jobPath.toUri()), any());
+
+        conf.set("foo", "bar");
+        assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+        verifyStatic(times(2));
+        FileSystem.get(eq(jobPath.toUri()), any());
+    }
+
+}

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -82,5 +82,10 @@ public class JobPathTest {
     assertNotEquals(newFileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(3));
     FileSystem.get(any(), any());
+
+    jobPath = new JobPath("bar", "bar", "/bar");
+    assertNotEquals(newFileSystem, jobPath.getFileSystem(conf));
+    verifyStatic(times(4));
+    FileSystem.get(any(), any());
   }
 }

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/JobPathTest.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.transform.format;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -51,26 +52,25 @@ public class JobPathTest {
     Configuration conf = new Configuration();
     JobPath jobPath = new JobPath("foo", "bar", "/baz");
 
-    FileSystem mockFileSystem = mock(FileSystem.class);
+    when(FileSystem.get(eq(jobPath.toUri()), any())).thenAnswer((p) -> mock(FileSystem.class));
 
-    when(FileSystem.get(eq(jobPath.toUri()), any())).thenReturn(mockFileSystem);
-
-    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    FileSystem fileSystem = jobPath.getFileSystem(conf);
 
     verifyStatic(times(1));
     FileSystem.get(eq(jobPath.toUri()), any());
 
-    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    assertEquals(fileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(1));
     FileSystem.get(eq(jobPath.toUri()), any());
 
     conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT.toString(), ReadType.NO_CACHE.toString());
-    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    FileSystem newFileSystem = jobPath.getFileSystem(conf);
+    assertNotEquals(fileSystem, newFileSystem);
     verifyStatic(times(2));
     FileSystem.get(eq(jobPath.toUri()), any());
 
     conf.set("foo", "bar");
-    assertEquals(mockFileSystem, jobPath.getFileSystem(conf));
+    assertEquals(newFileSystem, jobPath.getFileSystem(conf));
     verifyStatic(times(2));
     FileSystem.get(eq(jobPath.toUri()), any());
   }


### PR DESCRIPTION
JobServerContext provides a FileSystem to be shared amongst its workers.
However, Hadoop Path has its own API for getting FileSystem which ends up creating too many filesystems that can be shared.

This extends Path to cache values of getFileSystem to prevent opening of too many FileSystems.

As a result, CsvReader now no longer closes the FileSystem

Known Issue (For future fix):

Multiple threads can get into creating the same FileSystem at the same time. The problem with this is that, not only there can be 9 extra copies, because only one actually makes it into the cache, there are 9 that just never get closed. 