### PR TITLE
Fix case when workers submit the same task completion more than once

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
@@ -194,7 +194,9 @@ public class WorkflowTracker {
 
     ConcurrentHashSet<Long> siblings = mWaitingOn.get(parentJobId);
 
-    siblings.remove(jobId);
+    if (!siblings.remove(jobId)) {
+      return;
+    }
 
     if (siblings.isEmpty()) {
       next(parentJobId);
@@ -218,6 +220,10 @@ public class WorkflowTracker {
 
   private synchronized void next(long jobId) throws ResourceExhaustedException {
     WorkflowExecution workflowExecution = mWorkflows.get(jobId);
+
+    if (workflowExecution.getStatus().isFinished()) {
+      return;
+    }
 
     Set<JobConfig> childJobConfigs = workflowExecution.next();
 

--- a/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
@@ -85,7 +85,6 @@ public class WorkflowTrackerTest {
     jobs.add(child2);
 
     CompositeConfig config = new CompositeConfig(jobs, true);
-
     mWorkflowTracker.run(config, 0);
 
     verify(mMockJobMaster).run(child1, 100);
@@ -113,6 +112,28 @@ public class WorkflowTrackerTest {
     when(mMockJobMaster.getStatus(101)).thenReturn(plan101);
     mWorkflowTracker.workerHeartbeat(taskInfos);
 
+    assertEquals(Status.COMPLETED, mWorkflowTracker.getStatus(0, true).getStatus());
+  }
+
+  @Test
+  public void testDuplicateSubmission() throws Exception {
+    ArrayList<JobConfig> jobs = Lists.newArrayList();
+    TestPlanConfig child1 = new TestPlanConfig("1");
+    jobs.add(child1);
+
+    CompositeConfig config = new CompositeConfig(jobs, true);
+    mWorkflowTracker.run(config, 0);
+
+    PlanInfo plan100 = new PlanInfo(100, "test", Status.COMPLETED, 0, null);
+    when(mMockJobMaster.getStatus(100)).thenReturn(plan100);
+
+    TaskInfo task100 = new TaskInfo(100, 0, Status.COMPLETED, new WorkerNetAddress());
+    ArrayList<TaskInfo> taskInfos = Lists.newArrayList(task100);
+    mWorkflowTracker.workerHeartbeat(taskInfos);
+    assertEquals(Status.COMPLETED, mWorkflowTracker.getStatus(0, true).getStatus());
+
+    // Submit the same heartbeat again.
+    mWorkflowTracker.workerHeartbeat(taskInfos);
     assertEquals(Status.COMPLETED, mWorkflowTracker.getStatus(0, true).getStatus());
   }
 


### PR DESCRIPTION
WorkflowTracker currently makes an assumption that workers won't submit the same results twice but it occasionally does. 