### PR TITLE
Fix Distributed Load Retry Logic

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -21,7 +21,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.job.JobMasterClient;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
-import alluxio.job.JobConfig;
 import alluxio.job.plan.load.LoadConfig;
 
 import alluxio.job.wire.JobInfo;
@@ -89,7 +88,8 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         }
         return true;
       }
-      System.out.println(String.format("Failed to complete loading %s after retries.", mJobConfig.getFilePath()));
+      System.out.println(String.format("Failed to complete loading %s after retries.",
+          mJobConfig.getFilePath()));
       return false;
     }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -88,8 +88,8 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         }
         return true;
       }
-      System.out.println(String.format("Failed to complete loading %s after retries.",
-          mJobConfig.getFilePath()));
+      System.out.println(String.format("Failed to complete loading %s after %d retries.",
+          mJobConfig.getFilePath(), mRetryPolicy.getAttemptCount()));
       return false;
     }
 
@@ -122,12 +122,12 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
       if (finished) {
         if (jobInfo.getStatus().equals(Status.FAILED)) {
-          System.out.println(String.format("Attempt %s to load %s failed because: %s",
+          System.out.println(String.format("Attempt %d to load %s failed because: %s",
               mRetryPolicy.getAttemptCount(), mJobConfig.getFilePath(),
               jobInfo.getErrorMessage()));
         } else if (jobInfo.getStatus().equals(Status.COMPLETED)) {
-          System.out.println(String.format("Attempt %s to load %s completed",
-              mRetryPolicy.getAttemptCount(), mJobConfig.getFilePath()));
+          System.out.println(String.format("Successfully loaded path %s after %d attempts",
+                  mJobConfig.getFilePath(), mRetryPolicy.getAttemptCount()));
         }
         return jobInfo.getStatus();
       }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -122,9 +122,12 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
       if (finished) {
         if (jobInfo.getStatus().equals(Status.FAILED)) {
-          System.out.println(String.format("Attempt %i to load %s failed because: %s",
+          System.out.println(String.format("Attempt %s to load %s failed because: %s",
               mRetryPolicy.getAttemptCount(), mJobConfig.getFilePath(),
               jobInfo.getErrorMessage()));
+        } else if (jobInfo.getStatus().equals(Status.COMPLETED)) {
+          System.out.println(String.format("Attempt %s to load %s completed",
+              mRetryPolicy.getAttemptCount(), mJobConfig.getFilePath()));
         }
         return jobInfo.getStatus();
       }


### PR DESCRIPTION
Hypothetical Environment:

3 nodes, each with a job worker and a worker.
Suppose a file x.txt has 10 blocks to load but one of its blocks (**Block 1**) is in the middle of being read on (**Worker A**), Attempting to load this file creates 10 tasks and the task to load **Block 1** is assigned to be in **Worker A**.

Previous behavior:

The task in an attempt to load **Block 1** in **Worker A** fails. This fails the job but the other 9 tasks are still continuing. The client notices the failure and triggers a retry. Retry notices that none of the 10 blocks are still loaded yet and shuffles the location of where they are getting loaded.

New behavior:

The task in an attempt to load **Block 1** in **Worker A** fails. This fails the job but the other 9 tasks are still continuing. The client waits for all of its 10 tasks to finish despite knowing that the job has already failed. After all the tasks are complete/failed, it reruns the job again. This time, the server knows that 9 of its blocks are already loaded and only one more needs to get loaded.
