### PR TITLE
Cache list status results

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
@@ -88,18 +87,13 @@ public class CachingFileSystem extends BaseFileSystem {
   public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
+
     if (options.getRecursive()) {
-      List<URIStatus> statuses = super.listStatus(path, options);
-      // Cache only the direct level of children.
-      List<URIStatus> directChildren = new ArrayList<>();
-      for (URIStatus status : statuses) {
-        AlluxioURI uri = new AlluxioURI(status.getPath());
-        if (uri.getParent().equals(path)) {
-          directChildren.add(status);
-        }
-      }
-      mMetadataCache.put(path, directChildren);
-      return statuses;
+      // Do not cache results of recursive list status,
+      // because some results might be cached multiple times.
+      // Otherwise, needs more complicated logic inside the cache,
+      // that might not worth the effort of caching.
+      return super.listStatus(path, options);
     }
 
     List<URIStatus> statuses = mMetadataCache.listStatus(path);

--- a/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/CachingFileSystem.java
@@ -87,9 +87,10 @@ public class CachingFileSystem extends BaseFileSystem {
   public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
-    List<URIStatus> statuses = super.listStatus(path, options);
-    for (URIStatus status : statuses) {
-      mMetadataCache.put(status.getPath(), status);
+    List<URIStatus> statuses = mMetadataCache.listStatus(path);
+    if (statuses == null) {
+      statuses = super.listStatus(path, options);
+      mMetadataCache.put(path, statuses);
     }
     return statuses;
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
@@ -112,6 +112,14 @@ public class CachingFileSystemTest {
   }
 
   @Test
+  public void listStatusRecursive() throws Exception {
+    mFs.listStatus(DIR, LIST_STATUS_OPTIONS.toBuilder().setRecursive(true).build());
+    verifyListStatusThroughRPC(DIR, 1);
+    mFs.listStatus(DIR, LIST_STATUS_OPTIONS.toBuilder().setRecursive(true).build());
+    verifyListStatusThroughRPC(DIR, 2);
+  }
+
+  @Test
   public void openFile() throws Exception {
     mFs.openFile(FILE, OpenFilePOptions.getDefaultInstance());
     verifyGetStatusThroughRPC(FILE, 1);

--- a/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/CachingFileSystemTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -39,6 +40,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
+import java.util.List;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileSystemContext.class, FileSystemMasterClient.class})
@@ -97,11 +99,16 @@ public class CachingFileSystemTest {
 
   @Test
   public void listStatus() throws Exception {
-    mFs.listStatus(DIR, LIST_STATUS_OPTIONS);
+    List<URIStatus> expectedStatuses = mFs.listStatus(DIR, LIST_STATUS_OPTIONS);
     verifyListStatusThroughRPC(DIR, 1);
     // List status has cached the file status, so no RPC will be made.
     mFs.getStatus(FILE, GET_STATUS_OPTIONS);
     verifyGetStatusThroughRPC(FILE, 0);
+    List<URIStatus> gotStatuses = mFs.listStatus(DIR, LIST_STATUS_OPTIONS);
+    // List status results have been cached, so listStatus RPC was only called once
+    // at the beginning of the method.
+    verifyListStatusThroughRPC(DIR, 1);
+    assertEquals(expectedStatuses, gotStatuses);
   }
 
   @Test


### PR DESCRIPTION
Note that after caching the list status results, if there are files added to or deleted from the directory, then these updates might not be reflected until the cache is invalidated.