### PR TITLE
[SMALLFIX] Fix error message for existing transform job running

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
+++ b/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
@@ -176,7 +176,7 @@ public class TransformManager implements DelegatingJournaled {
         throw new IOException("A concurrent transformation request is going to be executed");
       } else {
         throw new IOException(ExceptionMessage.TABLE_BEING_TRANSFORMED
-            .getMessage(existingJobId, tableName, dbName));
+            .getMessage(existingJobId.toString(), tableName, dbName));
       }
     }
 

--- a/table/server/master/src/test/java/alluxio/master/table/transform/TransformManagerTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/transform/TransformManagerTest.java
@@ -133,7 +133,7 @@ public class TransformManagerTest {
     // Try to run another transformation on the same table, since the previous transformation on
     // the table hasn't finished, this transformation should not be able to proceed.
     expectException(IOException.class,
-        ExceptionMessage.TABLE_BEING_TRANSFORMED.getMessage(jobId, TABLE1, DB));
+        ExceptionMessage.TABLE_BEING_TRANSFORMED.getMessage(Long.toString(jobId), TABLE1, DB));
     transform(TABLE1, DEFINITION2);
   }
 


### PR DESCRIPTION
Previously was printing something like:

`Existing job 1,578,584,820,526 is transforming table ratings in database movielens`

new message is:

`Existing job 1578584820526 is transforming table ratings in database movielens`