### PR TITLE
Release clients back into pools during even during context reinit

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -95,8 +95,6 @@ public final class LocalFileDataReader implements DataReader {
   @NotThreadSafe
   public static class Factory implements DataReader.Factory {
     private final CloseableResource<BlockWorkerClient> mBlockWorker;
-    private final FileSystemContext mContext;
-    private final WorkerNetAddress mAddress;
     private final long mBlockId;
     private final String mPath;
     private final long mLocalReaderChunkSize;
@@ -119,8 +117,6 @@ public final class LocalFileDataReader implements DataReader {
     public Factory(FileSystemContext context, WorkerNetAddress address, long blockId,
         long localReaderChunkSize, InStreamOptions options) throws IOException {
       AlluxioConfiguration conf = context.getClusterConf();
-      mContext = context;
-      mAddress = address;
       mBlockId = blockId;
       mLocalReaderChunkSize = localReaderChunkSize;
       mReadBufferSize = conf.getInt(PropertyKey.USER_NETWORK_READER_BUFFER_SIZE_MESSAGES);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -29,6 +29,8 @@ import alluxio.grpc.GrpcServerAddress;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
+import alluxio.resource.DynamicResourcePool;
+import alluxio.resource.ResourcePool;
 import alluxio.security.authentication.AuthenticationUserUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.network.NettyUtils;
@@ -424,31 +426,7 @@ public final class FileSystemContext implements Closeable {
    * @return the acquired file system master client resource
    */
   public CloseableResource<FileSystemMasterClient> acquireMasterClientResource() {
-    try {
-      return new CloseableResource<FileSystemMasterClient>(mFileSystemMasterClientPool.acquire()) {
-        @Override
-        public void close() {
-          releaseMasterClient(get());
-        }
-      };
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private BlockMasterClient acquireBlockMasterClient() throws IOException {
-    try (ReinitBlockerResource r = blockReinit()) {
-      return mBlockMasterClientPool.acquire();
-    }
-  }
-
-  private void releaseBlockMasterClient(BlockMasterClient client) {
-    try (ReinitBlockerResource r = blockReinit()) {
-      if (!client.isClosed()) {
-        // The client might have been closed during reinitialization.
-        mBlockMasterClientPool.release(client);
-      }
-    }
+    return acquireClosableClientResource(mFileSystemMasterClientPool);
   }
 
   /**
@@ -458,11 +436,42 @@ public final class FileSystemContext implements Closeable {
    * @return the acquired block master client resource
    */
   public CloseableResource<BlockMasterClient> acquireBlockMasterClientResource() {
-    try {
-      return new CloseableResource<BlockMasterClient>(mBlockMasterClientPool.acquire()) {
+    return acquireClosableClientResource(mBlockMasterClientPool);
+  }
+
+  /**
+   * Acquire a client resource from {@link #mBlockMasterClientPool} or
+   * {@link #mFileSystemMasterClientPool}.
+   *
+   * Because it's possible for a context re-initialization to occur while the resource is
+   * acquired this method uses an inline class which will save the reference to the pool used to
+   * acquire the resource.
+   *
+   * There are three different cases to which may occur during the release of the resource
+   *
+   * 1. release while the context is re-initializing
+   *    - The original {@link #mBlockMasterClientPool} or {@link #mFileSystemMasterClientPool}
+   *    may be null, closed, or overwritten with a difference pool. The inner class here saves
+   *    the original pool from being GCed because it holds a reference to the pool that was used
+   *    to acquire the client initially. Releasing into the closed pool is harmless.
+   * 2. release after the context has been re-initialized
+   *    - Similar to the above scenario the original {@link #mBlockMasterClientPool} or
+   *    {@link #mFileSystemMasterClientPool} are going to be using an entirely new pool. Since
+   *    this method will save the original pool reference, this method would result in releasing
+   *    into a closed pool which is harmless
+   * 3. release before any re-initialization
+   *    - This is the normal case. There are no special considerations
+   *
+   * @param pool the pool to acquire from and release to
+   * @param <T> the resource type
+   * @return a {@link CloseableResource}
+   */
+  private <T> CloseableResource<T> acquireClosableClientResource(DynamicResourcePool<T> pool) {
+    try (ReinitBlockerResource r = blockReinit()) {
+      return new CloseableResource<T>(pool.acquire()) {
         @Override
         public void close() {
-          releaseBlockMasterClient(get());
+          pool.release(get());
         }
       };
     } catch (IOException e) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -426,7 +426,9 @@ public final class FileSystemContext implements Closeable {
    * @return the acquired file system master client resource
    */
   public CloseableResource<FileSystemMasterClient> acquireMasterClientResource() {
-    return acquireClosableClientResource(mFileSystemMasterClientPool);
+    try (ReinitBlockerResource r = blockReinit()) {
+      return acquireClosableClientResource(mFileSystemMasterClientPool);
+    }
   }
 
   /**
@@ -436,7 +438,9 @@ public final class FileSystemContext implements Closeable {
    * @return the acquired block master client resource
    */
   public CloseableResource<BlockMasterClient> acquireBlockMasterClientResource() {
-    return acquireClosableClientResource(mBlockMasterClientPool);
+    try (ReinitBlockerResource r = blockReinit()) {
+      return acquireClosableClientResource(mBlockMasterClientPool);
+    }
   }
 
   /**
@@ -467,7 +471,7 @@ public final class FileSystemContext implements Closeable {
    * @return a {@link CloseableResource}
    */
   private <T> CloseableResource<T> acquireClosableClientResource(DynamicResourcePool<T> pool) {
-    try (ReinitBlockerResource r = blockReinit()) {
+    try {
       return new CloseableResource<T>(pool.acquire()) {
         @Override
         public void close() {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -404,21 +404,6 @@ public final class FileSystemContext implements Closeable {
     return mUriValidationEnabled;
   }
 
-  private FileSystemMasterClient acquireMasterClient() throws IOException {
-    try (ReinitBlockerResource r = blockReinit()) {
-      return mFileSystemMasterClientPool.acquire();
-    }
-  }
-
-  private void releaseMasterClient(FileSystemMasterClient client) {
-    try (ReinitBlockerResource r = blockReinit()) {
-      if (!client.isClosed()) {
-        // The client might have been closed during reinitialization.
-        mFileSystemMasterClientPool.release(client);
-      }
-    }
-  }
-
   /**
    * Acquires a file system master client from the file system master client pool. The resource is
    * {@code Closeable}.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -30,7 +30,6 @@ import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
 import alluxio.resource.DynamicResourcePool;
-import alluxio.resource.ResourcePool;
 import alluxio.security.authentication.AuthenticationUserUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.network.NettyUtils;

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -25,6 +25,7 @@ import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.block.stream.BlockOutStream;
 import alluxio.client.block.stream.BlockWorkerClient;
+import alluxio.client.block.stream.NoopClosableResource;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
@@ -175,7 +176,7 @@ public final class AlluxioBlockStoreTest {
         TieredIdentityFactory.fromString("node=" + WORKER_HOSTNAME_LOCAL, sConf));
 
     when(mContext.acquireBlockWorkerClient(any(WorkerNetAddress.class)))
-        .thenReturn(mWorkerClient);
+        .thenReturn(new NoopClosableResource<>(mWorkerClient));
     mStreamObserver = PowerMockito.mock(ClientCallStreamObserver.class);
     when(mWorkerClient.writeBlock(any(StreamObserver.class)))
         .thenReturn(mStreamObserver);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -78,12 +78,9 @@ public class BlockInStreamTest {
     }).when(requestObserver).onNext(any(OpenLocalBlockRequest.class));
     mMockContext = PowerMockito.mock(FileSystemContext.class);
     PowerMockito.when(mMockContext.acquireBlockWorkerClient(Matchers.any(WorkerNetAddress.class)))
-        .thenReturn(workerClient);
+        .thenReturn(new NoopClosableResource<>(workerClient));
     PowerMockito.when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
     PowerMockito.when(mMockContext.getClusterConf()).thenReturn(mConf);
-    PowerMockito.doNothing().when(mMockContext)
-        .releaseBlockWorkerClient(Matchers.any(WorkerNetAddress.class),
-            Matchers.any(BlockWorkerClient.class));
     mInfo = new BlockInfo().setBlockId(1);
     mOptions = new InStreamOptions(new URIStatus(new FileInfo().setBlockIds(Collections
         .singletonList(1L))), mConf);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
@@ -79,8 +79,8 @@ public final class GrpcDataReaderTest {
 
     mClient = mock(BlockWorkerClient.class);
     mRequestObserver = mock(ClientCallStreamObserver.class);
-    when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(mClient);
-    PowerMockito.doNothing().when(mContext).releaseBlockWorkerClient(mAddress, mClient);
+    when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(
+        new NoopClosableResource<>(mClient));
     when(mClient.readBlock(any(StreamObserver.class))).thenReturn(mRequestObserver);
     when(mRequestObserver.isReady()).thenReturn(true);
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
@@ -91,10 +91,10 @@ public final class GrpcDataWriterTest {
 
     mClient = mock(BlockWorkerClient.class);
     mRequestObserver = mock(ClientCallStreamObserver.class);
-    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(mClient);
+    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(
+        new NoopClosableResource<>(mClient));
     PowerMockito.when(mContext.getClientContext()).thenReturn(mClientContext);
     PowerMockito.when(mContext.getClusterConf()).thenReturn(mConf);
-    PowerMockito.doNothing().when(mContext).releaseBlockWorkerClient(mAddress, mClient);
     PowerMockito.when(mClient.writeBlock(any(StreamObserver.class))).thenReturn(mRequestObserver);
     PowerMockito.when(mRequestObserver.isReady()).thenReturn(true);
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -66,10 +66,10 @@ public class LocalFileDataWriterTest {
     mAddress = mock(WorkerNetAddress.class);
 
     mClient = mock(BlockWorkerClient.class);
-    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(mClient);
+    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(
+        new NoopClosableResource<>(mClient));
     PowerMockito.when(mContext.getClientContext()).thenReturn(mClientContext);
     PowerMockito.when(mContext.getClusterConf()).thenReturn(mConf);
-    PowerMockito.doNothing().when(mContext).releaseBlockWorkerClient(mAddress, mClient);
 
     mStream = mock(GrpcBlockingStream.class);
     PowerMockito.doNothing().when(mStream).send(Matchers.any(), Matchers.anyLong());

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/NoopClosableResource.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/NoopClosableResource.java
@@ -1,0 +1,36 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.stream;
+
+import alluxio.resource.CloseableResource;
+
+/**
+ * A closable resource that does nothing when {@link #close()} is called.
+ *
+ * @param <T> closable type
+ */
+public class NoopClosableResource<T> extends CloseableResource<T> {
+
+  /**
+   * Creates a {@link CloseableResource} wrapper around the given resource. This resource will
+   * be returned by the {@link CloseableResource#get()} method.
+   *
+   * @param resource the resource to wrap
+   */
+  public NoopClosableResource(T resource) {
+    super(resource);
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
@@ -160,8 +160,8 @@ public class UfsFallbackLocalFileDataWriterTest {
     mRequestObserver = mock(ClientCallStreamObserver.class);
     PowerMockito.when(mContext.getClientContext()).thenReturn(mClientContext);
     PowerMockito.when(mContext.getClusterConf()).thenReturn(mConf);
-    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(mClient);
-    PowerMockito.doNothing().when(mContext).releaseBlockWorkerClient(mAddress, mClient);
+    PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(
+        new NoopClosableResource<>(mClient));
     PowerMockito.when(mClient.writeBlock(any(StreamObserver.class))).thenReturn(mRequestObserver);
     PowerMockito.when(mRequestObserver.isReady()).thenReturn(true);
   }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -22,6 +22,7 @@ import alluxio.job.plan.AbstractVoidPlanDefinition;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.SerializableVoid;
+import alluxio.resource.CloseableResource;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.wire.BlockInfo;
@@ -120,18 +121,13 @@ public final class EvictDefinition
     }
 
     RemoveBlockRequest request = RemoveBlockRequest.newBuilder().setBlockId(blockId).build();
-    BlockWorkerClient blockWorker = null;
-    try {
-      blockWorker = context.getFsContext().acquireBlockWorkerClient(localNetAddress);
-      blockWorker.removeBlock(request);
+    try (CloseableResource<BlockWorkerClient> blockWorker =
+             context.getFsContext().acquireBlockWorkerClient(localNetAddress)) {
+      blockWorker.get().removeBlock(request);
     } catch (NotFoundException e) {
       // Instead of throwing this exception, we continue here because the block to evict does not
       // exist on this worker anyway.
       LOG.warn("Failed to delete block {} on {}: block does not exist", blockId, localNetAddress);
-    } finally {
-      if (blockWorker != null) {
-        context.getFsContext().releaseBlockWorkerClient(localNetAddress, blockWorker);
-      }
     }
     return null;
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
@@ -22,6 +22,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.ClearMetricsRequest;
+import alluxio.resource.CloseableResource;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.wire.WorkerNetAddress;
 
@@ -250,11 +251,10 @@ public final class ClearCommand extends AbstractFsAdminCommand {
    */
   private void clearWorkerMetrics(WorkerNetAddress worker,
       FileSystemContext context) throws IOException {
-    BlockWorkerClient blockWorkerClient = context.acquireBlockWorkerClient(worker);
-    try {
-      blockWorkerClient.clearMetrics(ClearMetricsRequest.newBuilder().build());
-    } finally {
-      context.releaseBlockWorkerClient(worker, blockWorkerClient);
+
+    try (CloseableResource<BlockWorkerClient> blockWorkerClient =
+             context.acquireBlockWorkerClient(worker)) {
+      blockWorkerClient.get().clearMetrics(ClearMetricsRequest.newBuilder().build());
     }
     System.out.printf("Successfully cleared metrics of worker %s.%n", worker.getHost());
   }

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
@@ -53,9 +53,9 @@ public final class BlockWorkerClientCloseIntegrationTest extends BaseIntegration
       CloseableResource<BlockWorkerClient> client = mFsContext
           .acquireBlockWorkerClient(mWorkerNetAddress);
       Assert.assertFalse(client.get().isShutdown());
-      client.close();
+      client.get().close();
       Assert.assertTrue(client.get().isShutdown());
-      client.close();
+      client.get().close();
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
@@ -14,6 +14,7 @@ package alluxio.client.fs;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.ServerConfiguration;
+import alluxio.resource.CloseableResource;
 import alluxio.security.user.TestUserState;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -49,12 +50,12 @@ public final class BlockWorkerClientCloseIntegrationTest extends BaseIntegration
   @Test
   public void close() throws Exception {
     for (int i = 0; i < 1000; i++) {
-      BlockWorkerClient client = mFsContext
+      CloseableResource<BlockWorkerClient> client = mFsContext
           .acquireBlockWorkerClient(mWorkerNetAddress);
-      Assert.assertFalse(client.isShutdown());
+      Assert.assertFalse(client.get().isShutdown());
       client.close();
-      Assert.assertTrue(client.isShutdown());
-      mFsContext.releaseBlockWorkerClient(mWorkerNetAddress, client);
+      Assert.assertTrue(client.get().isShutdown());
+      client.close();
     }
   }
 }


### PR DESCRIPTION
This removes a resource leak which may occur when a thread on a client is interrupted while performing any kind of operation.

Because it's possible for a fs context re-initialization to occur while the resource is
acquired this solution removes the `blockReinit` which throws a runtime exception during
an interrupt and is the root cause of the resource leak.

There are three different cases to which may occur during the release of the resource

1. Release while the context is re-initializing
   - The original mBlockMasterClientPool or mFileSystemMasterClientPool
   may be null, closed, or overwritten with a difference pool. The inner class here saves
   the original pool reference used to acquire the client initially. Releasing into the closed pool
   is harmless.
2. Release after the context has been re-initialized
   - Similar to the above scenario the original mBlockMasterClientPool or
   mFileSystemMasterClientPool are going to be using an entirely new pool. Since
   this method will save the original pool reference, this method would result in releasing
   into a closed pool which is harmless
3. Release before any re-initialization
   - This is the normal case. There are no special considerations

The issues mainly affected the FSMaster and BlockMaster clients, however upon inspection, BlockWorker clients have a similar issue, but seems to happen less frequently than the master clients. This PR also applies a similar strategy for BlockWorker clients to hold onto the references of the pool used during the acquire method to make a best-effort to release the resource when finished being used. 


Closes #9922 #10468