### PR TITLE
Fix tests on ubuntu

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -47,7 +47,6 @@ import alluxio.wire.WorkerNetAddress;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,7 +54,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,11 +69,10 @@ import java.util.List;
  * It is a parameterized test that checks different caching behaviors when the blocks are located at
  * different locations.
  */
-@RunWith(Parameterized.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({FileSystemContext.class, AlluxioBlockStore.class, BlockInStream.class})
 public final class AlluxioFileInStreamTest {
-  @Rule
-  public PowerMockRule mPowerMockRule = new PowerMockRule();
   private static final long BLOCK_LENGTH = 100L;
   private static final long FILE_LENGTH = 350L;
   private static final long NUM_STREAMS = ((FILE_LENGTH - 1) / BLOCK_LENGTH) + 1;

--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -42,7 +42,9 @@ public class MetricsHeartbeatContextTest {
   @Test
   public void testExecutorInitialized() {
 
-    ClientContext ctx = ClientContext.create();
+    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
+    ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory
         .create(ctx.getClusterConf(), ctx.getUserState());
 
@@ -75,7 +77,9 @@ public class MetricsHeartbeatContextTest {
         getContextMap();
     assertTrue(map.isEmpty());
 
-    ClientContext ctx = ClientContext.create();
+    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
+    ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory
         .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);
@@ -88,7 +92,8 @@ public class MetricsHeartbeatContextTest {
     map.forEach((details, context) ->
         assertEquals(2, (int) Whitebox.getInternalState(context, "mCtxCount")));
 
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     conf.set(PropertyKey.MASTER_RPC_ADDRESSES, "master1:19998,master2:19998,master3:19998");
     ClientContext haCtx = ClientContext.create(conf);
     MetricsHeartbeatContext.addHeartbeat(haCtx, MasterInquireClient.Factory


### PR DESCRIPTION
I ran these tests on an Ubuntu 18.04 server with a fresh install of the
latest  java and maven versions. The AlluxioFileInStreamTest failed due
to an issue with PowerMock. The MetricsHeartbeatContextTest took
\> 120s to complete due to needing to wait for the connect RPC to time
out.

```
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /home/zac/.local/apache-maven-3.6.3
Java version: 1.8.0_232, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-74-generic", arch: "amd64", family: "unix"
```