### PR TITLE
Keep worker client open after creating data reader/writer

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -93,12 +93,14 @@ public final class GrpcDataWriter implements DataWriter {
   public static GrpcDataWriter create(FileSystemContext context, WorkerNetAddress address,
       long id, long length, RequestType type, OutStreamOptions options)
       throws IOException {
-    long chunkSize = context.getClusterConf().getBytes(
-        PropertyKey.USER_NETWORK_WRITER_CHUNK_SIZE_BYTES);
-    try (CloseableResource<BlockWorkerClient> grpcClient =
-             context.acquireBlockWorkerClient(address)) {
-      return new GrpcDataWriter(context, address, id, length, chunkSize, type, options,
-          grpcClient);
+    long chunkSize = context.getClusterConf()
+        .getBytes(PropertyKey.USER_NETWORK_WRITER_CHUNK_SIZE_BYTES);
+    CloseableResource<BlockWorkerClient> grpcClient = context.acquireBlockWorkerClient(address);
+    try {
+      return new GrpcDataWriter(context, address, id, length, chunkSize, type, options, grpcClient);
+    } catch (Exception e) {
+      grpcClient.close();
+      throw e;
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -163,10 +163,10 @@ public final class LocalFileDataReader implements DataReader {
       if (mClosed) {
         return;
       }
-      if (mReader != null) {
-        mReader.close();
-      }
       try {
+        if (mReader != null) {
+          mReader.close();
+        }
         mStream.close();
         mStream.waitForComplete(mDataTimeoutMs);
       } finally {

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
@@ -55,7 +55,7 @@ public final class BlockWorkerClientCloseIntegrationTest extends BaseIntegration
       Assert.assertFalse(client.get().isShutdown());
       client.get().close();
       Assert.assertTrue(client.get().isShutdown());
-      client.get().close();
+      client.close();
     }
   }
 }


### PR DESCRIPTION
This fix keeps the BlockWorkerClient open after returning the GrpcDataWriter.
Previously, we used a try-with-resources which would close the client before
being returned to the user. This could result in poor behavior if the writer
is used after the #create() call.

Also, to prevent a leak in the LocalFileDataReader, we attempt to close the
reader within the try block inside of its close method.

This is a follow-up to #10719 