### PR TITLE
Cleanup LocalCacheManager  Unit Test

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -85,7 +85,7 @@ import javax.security.auth.Subject;
  * so, because thread A holds the lock on {@link FileSystemContext}.
  */
 @ThreadSafe
-public final class FileSystemContext implements Closeable {
+public class FileSystemContext implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemContext.class);
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultMetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultMetaStore.java
@@ -11,45 +11,45 @@
 
 package alluxio.client.file.cache;
 
-import javax.annotation.Nullable;
+import alluxio.exception.PageNotFoundException;
 
 /**
- * Interface for client-side cache eviction policy.
+ * The default implementation of a metadata store for pages stored in cache.
  */
-public interface CacheEvictor {
+public class DefaultMetaStore implements MetaStore {
 
   /**
-   * @return a CacheEvictor instance
+   * Default constructor.
    */
-  static CacheEvictor create() {
-    // return corresponding CacheEvictor impl
-    return null;
+  public DefaultMetaStore() {
   }
 
   /**
-   * Updates evictor after a get operation.
+   * @param pageId page identifier
+   * @return if a page is stored in cache
+   */
+  @Override
+  public boolean hasPage(PageId pageId) {
+    return true;
+  }
+
+  /**
+   * Adds a new page to the cache.
+   *
+   * @param pageId page identifier
+   * @return true if added successfully
+   */
+  @Override
+  public boolean addPage(PageId pageId) {
+    return true;
+  }
+
+  /**
+   * Removes a page.
    *
    * @param pageId page identifier
    */
-  void updateOnGet(PageId pageId);
-
-  /**
-   * Updates evictor after a put operation.
-   *
-   * @param pageId page identifier
-   */
-  void updateOnPut(PageId pageId);
-
-  /**
-   * Updates evictor after a delete operation.
-   *
-   * @param pageId page identifier
-   */
-  void updateOnDelete(PageId pageId);
-
-  /**
-   * @return a page to evict or null if no page available to evict
-   */
-  @Nullable
-  PageId evict();
+  @Override
+  public void removePage(PageId pageId) throws PageNotFoundException {
+  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -37,6 +37,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * A class to manage cached pages. This class coordinates different components to respond for
  * thread-safety and operate cache replacement policies.
  *
+ * Creating client-side Alluxio cache is motivated by "Improving In-Memory File System Reading
+ * Performance by Fine-Grained User-Space Cache Mechanisms" by Gu et al.
+ *
  * Lock hierarchy in this class: All operations must follow this order to operate on pages:
  * <ul>
  * <li>1. Acquire page lock</li>

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -37,8 +37,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * A class to manage cached pages. This class coordinates different components to respond for
  * thread-safety and operate cache replacement policies.
  *
- * Creating client-side Alluxio cache is motivated by "Improving In-Memory File System Reading
- * Performance by Fine-Grained User-Space Cache Mechanisms" by Gu et al.
+ * One of the motivations of creating a client-side cache is from "Improving In-Memory File System
+ * Reading Performance by Fine-Grained User-Space Cache Mechanisms" by Gu et al, which illustrates
+ * performance benefits for various read workloads.
  *
  * Lock hierarchy in this class: All operations must follow this order to operate on pages:
  * <ul>

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -66,7 +66,7 @@ public class LocalCacheManager implements CacheManager {
    * @param fsContext filesystem context
    */
   public LocalCacheManager(FileSystemContext fsContext) {
-    this(fsContext, new MetaStore(), PageStore.create(), CacheEvictor.create());
+    this(fsContext, MetaStore.create(), PageStore.create(), CacheEvictor.create());
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
@@ -20,7 +20,7 @@ import alluxio.exception.PageNotFoundException;
 public interface MetaStore {
 
   /**
-   * Default constructor.
+   * @return an instance of MetaStore.
    */
   static MetaStore create() {
     return new DefaultMetaStore();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
@@ -7,6 +7,7 @@
  * either express or implied, as more fully set forth in the License.
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ *
  */
 
 package alluxio.client.file.cache;
@@ -16,21 +17,20 @@ import alluxio.exception.PageNotFoundException;
 /**
  * The metadata store for pages stored in cache.
  */
-public class MetaStore {
+public interface MetaStore {
 
   /**
    * Default constructor.
    */
-  public MetaStore() {
+  static MetaStore create() {
+    return new DefaultMetaStore();
   }
 
   /**
    * @param pageId page identifier
    * @return if a page is stored in cache
    */
-  boolean hasPage(PageId pageId) {
-    return true;
-  }
+  boolean hasPage(PageId pageId);
 
   /**
    * Adds a new page to the cache.
@@ -38,15 +38,12 @@ public class MetaStore {
    * @param pageId page identifier
    * @return true if added successfully
    */
-  boolean addPage(PageId pageId) {
-    return true;
-  }
+  boolean addPage(PageId pageId);
 
   /**
    * Removes a page.
    *
    * @param pageId page identifier
    */
-  void removePage(PageId pageId) throws PageNotFoundException {
-  }
+  void removePage(PageId pageId) throws PageNotFoundException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
@@ -7,7 +7,6 @@
  * either express or implied, as more fully set forth in the License.
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
- *
  */
 
 package alluxio.client.file.cache;
@@ -20,7 +19,7 @@ import alluxio.exception.PageNotFoundException;
 public interface MetaStore {
 
   /**
-   * @return an instance of MetaStore.
+   * @return an instance of MetaStore
    */
   static MetaStore create() {
     return new DefaultMetaStore();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -11,161 +11,285 @@
 
 package alluxio.client.file.cache;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationTestUtils;
+import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PageNotFoundException;
 import alluxio.util.io.BufferUtils;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import javax.annotation.Nullable;
 
 /**
  * Tests for the {@link LocalCacheManager} class.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({FileSystemContext.class})
 public final class LocalCacheManagerTest {
+  private static int PAGE_SIZE_BYTES = Constants.KB;
+  private static int CACHE_SIZE_BYTES = 512 * Constants.KB;
+
   private LocalCacheManager mCacheManager;
   private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
   private FileSystemContext mFileContext;
-  private MetaStore mMetaStore;
-  private PageStore mPageStore;
+  private HashSetMetaStore mMetaStore;
+  private HashMapPageStore mPageStore;
   private CacheEvictor mEvictor;
-  private final PageId mPage1 = new PageId(0L, 0L);
-  private final PageId mPage2 = new PageId(1L, 1L);
+  private final PageId mPageId1 = new PageId(0L, 0L);
+  private final PageId mPageId2 = new PageId(1L, 1L);
+  private final byte[] mPage1 = BufferUtils.getIncreasingByteArray(PAGE_SIZE_BYTES);
+  private final byte[] mPage2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
 
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
-  /**
-   * Sets up the mocks.
-   */
   @Before
-  public void before() throws Exception {
-    mFileContext = PowerMockito.mock(FileSystemContext.class);
+  public void before() {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE, PAGE_SIZE_BYTES);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
+    mFileContext = Mockito.mock(FileSystemContext.class);
     when(mFileContext.getClusterConf()).thenReturn(mConf);
     when(mFileContext.getPathConf(any())).thenReturn(mConf);
     when(mFileContext.getUriValidationEnabled()).thenReturn(true);
-    mMetaStore = mock(MetaStore.class);
-    mPageStore = mock(PageStore.class);
-    mEvictor = mock(CacheEvictor.class);
+    mMetaStore = new HashSetMetaStore();
+    mPageStore = new HashMapPageStore();
+    mEvictor = new FIFOEvictor(mMetaStore);
     mCacheManager = new LocalCacheManager(mFileContext, mMetaStore, mPageStore, mEvictor);
   }
 
   @Test
   public void putNew() throws Exception {
-    byte[] data = BufferUtils.getIncreasingByteArray(1);
-    when(mMetaStore.hasPage(mPage1)).thenReturn(false);
-    when(mPageStore.size()).thenReturn(0);
-    mCacheManager.put(mPage1, data);
-    verify(mMetaStore).addPage(mPage1);
-    verify(mPageStore).put(mPage1, data);
+    mCacheManager.put(mPageId1, mPage1);
+    assertEquals(1, mPageStore.size());
+    assertTrue(mMetaStore.hasPage(mPageId1));
+    assertArrayEquals(mPage1, (byte[]) mPageStore.mStore.get(mPageId1));
   }
 
   @Test
   public void putExist() throws Exception {
-    byte[] data = BufferUtils.getIncreasingByteArray(1);
-    when(mMetaStore.hasPage(mPage1)).thenReturn(true);
-    when(mPageStore.size()).thenReturn(1);
-    mCacheManager.put(mPage1, data);
-    verify(mMetaStore, never()).addPage(mPage1);
-    verify(mPageStore).delete(mPage1);
-    verify(mPageStore).put(mPage1, data);
+    mCacheManager.put(mPageId1, mPage1);
+    mCacheManager.put(mPageId1, mPage2);
+    assertEquals(1, mPageStore.size());
+    assertTrue(mMetaStore.hasPage(mPageId1));
+    assertArrayEquals(mPage2, (byte[]) mPageStore.mStore.get(mPageId1));
   }
 
   @Test
   public void putEvict() throws Exception {
-    byte[] data = BufferUtils.getIncreasingByteArray(1);
-    when(mMetaStore.hasPage(mPage1)).thenReturn(false);
-    when(mMetaStore.hasPage(mPage2)).thenReturn(true);
-    when(mPageStore.size()).thenReturn((int) mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE));
-    when(mEvictor.evict()).thenReturn(mPage2);
-    mCacheManager.put(mPage1, data);
-    verify(mMetaStore).addPage(mPage1);
-    verify(mMetaStore).removePage(mPage2);
-    verify(mPageStore).delete(mPage2);
-    verify(mPageStore).put(mPage1, data);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
+    mCacheManager = new LocalCacheManager(mFileContext, mMetaStore, mPageStore, mEvictor);
+    mCacheManager.put(mPageId1, mPage1);
+    assertEquals(1, mPageStore.size());
+    mCacheManager.put(mPageId2, mPage2);
+    assertEquals(1, mPageStore.size());
+    assertFalse(mMetaStore.hasPage(mPageId1));
+    assertTrue(mMetaStore.hasPage(mPageId2));
+    assertArrayEquals(mPage2, (byte[]) mPageStore.mStore.get(mPageId2));
+  }
+
+  @Test
+  public void putGetPartialPage() throws Exception {
+    int[] sizeArray = {1, PAGE_SIZE_BYTES / 2, PAGE_SIZE_BYTES - 1};
+    for (int size: sizeArray) {
+      PageId pageId = new PageId(3, size);
+      byte[] page = BufferUtils.getIncreasingByteArray(size);
+      mCacheManager.put(pageId, page);
+      try (ReadableByteChannel ret = mCacheManager.get(pageId)) {
+        ByteBuffer buf = ByteBuffer.allocate(PAGE_SIZE_BYTES);
+        assertEquals(size, ret.read(buf));
+        buf.flip();
+        assertEquals(ByteBuffer.wrap(page), buf);
+      }
+    }
+  }
+
+  @Test
+  public void putMoreThanCacheCapacity() throws Exception {
+    int cacheSize = CACHE_SIZE_BYTES / PAGE_SIZE_BYTES;
+    for (int i = 0; i < 2 * cacheSize; i++) {
+      PageId pageId = new PageId(3, i);
+      mCacheManager.put(pageId, BufferUtils.getIncreasingByteArray(i, PAGE_SIZE_BYTES));
+      if (i >= cacheSize) {
+        assertNull(mCacheManager.get(new PageId(3, i - cacheSize)));
+        try (ReadableByteChannel ret = mCacheManager.get(new PageId(3, i - cacheSize + 1))) {
+          ByteBuffer buf = ByteBuffer.allocate(PAGE_SIZE_BYTES);
+          ret.read(buf);
+          buf.flip();
+          assertArrayEquals(
+              BufferUtils.getIncreasingByteArray(i - cacheSize + 1, PAGE_SIZE_BYTES), buf.array());
+        }
+      }
+    }
   }
 
   @Test
   public void getExist() throws Exception {
-    ReadableByteChannel channel = mock(ReadableByteChannel.class);
-    when(mMetaStore.hasPage(mPage1)).thenReturn(true);
-    when(mPageStore.size()).thenReturn((int) mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE));
-    when(mPageStore.get(mPage1)).thenReturn(channel);
-    ReadableByteChannel ret = mCacheManager.get(mPage1);
-    Assert.assertEquals(channel, ret);
-    verify(mEvictor).updateOnGet(mPage1);
-    verify(mPageStore).get(mPage1);
+    mCacheManager.put(mPageId1, mPage1);
+    try (ReadableByteChannel ret = mCacheManager.get(mPageId1)) {
+      ByteBuffer buf = ByteBuffer.allocate(PAGE_SIZE_BYTES);
+      assertEquals(mPage1.length, ret.read(buf));
+      assertArrayEquals(mPage1, buf.array());
+    }
   }
 
   @Test
   public void getNotExist() throws Exception {
-    when(mMetaStore.hasPage(mPage1)).thenReturn(false);
-    ReadableByteChannel ret = mCacheManager.get(mPage1);
-    Assert.assertNull(ret);
-    verify(mEvictor, never()).updateOnGet(mPage1);
-    verify(mPageStore, never()).get(mPage1);
+    assertNull(mCacheManager.get(mPageId1));
   }
 
   @Test
   public void getOffset() throws Exception {
-    long pageSize = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
-    ByteBuffer buf = BufferUtils.getIncreasingByteBuffer((int) pageSize);
-    ByteBuffer retBuf = ByteBuffer.allocate((int) pageSize);
-    try (ReadableByteChannel channel = Channels.newChannel(new ByteArrayInputStream(buf.array()))) {
-      when(mMetaStore.hasPage(mPage1)).thenReturn(true);
-      when(mPageStore.size()).thenReturn((int) mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE));
-      when(mPageStore.get(mPage1)).thenReturn(channel);
-      try (ReadableByteChannel ret = mCacheManager.get(mPage1, 1)) {
-        Assert.assertEquals(pageSize - 1, ret.read(retBuf));
+    mCacheManager.put(mPageId1, mPage1);
+    int[] offsetArray = {0, 1, PAGE_SIZE_BYTES / 2, PAGE_SIZE_BYTES - 1};
+    for (int offset: offsetArray) {
+      try (ReadableByteChannel ret = mCacheManager.get(mPageId1, offset)) {
+        ByteBuffer buf = ByteBuffer.allocate(PAGE_SIZE_BYTES);
+        assertEquals(mPage1.length - offset, ret.read(buf));
+        buf.flip();
+        assertEquals(ByteBuffer.wrap(mPage1, offset, mPage1.length - offset),
+            buf);
       }
     }
-    retBuf.flip();
-    verify(mEvictor).updateOnGet(mPage1);
-    verify(mPageStore).get(mPage1);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(1, (int) pageSize - 1, retBuf));
   }
 
   @Test
   public void deleteExist() throws Exception {
-    when(mMetaStore.hasPage(mPage1)).thenReturn(true);
-    mCacheManager.delete(mPage1);
-    verify(mMetaStore).removePage(mPage1);
-    verify(mPageStore).delete(mPage1);
+    mCacheManager.put(mPageId1, mPage1);
+    mCacheManager.delete(mPageId1);
+    assertNull(mCacheManager.get(mPageId1));
   }
 
   @Test
   public void deleteNotExist() throws Exception {
-    when(mMetaStore.hasPage(mPage1)).thenReturn(false);
-    doThrow(new PageNotFoundException("test")).when(mMetaStore).removePage(mPage1);
-    doThrow(new PageNotFoundException("test")).when(mPageStore).delete(mPage1);
     mThrown.expect(PageNotFoundException.class);
-    try {
-      mCacheManager.delete(mPage1);
-    } finally {
-      verify(mMetaStore).removePage(mPage1);
+    mCacheManager.delete(mPageId1);
+  }
+
+  /**
+   * Implementation of page store that stores cached data in memory.
+   */
+  class HashMapPageStore implements PageStore {
+
+    HashMap mStore = new HashMap<PageId, byte[]>();
+
+    public HashMapPageStore() {
+    }
+
+    @Override
+    public void put(PageId pageId, byte[] page) throws IOException {
+      mStore.put(pageId, page);
+    }
+
+    @Override
+    public ReadableByteChannel get(PageId pageId) throws IOException, PageNotFoundException {
+      byte[] buf = (byte[]) mStore.get(pageId);
+      return Channels.newChannel(new ByteArrayInputStream(buf));
+    }
+
+    @Override
+    public void delete(PageId pageId) throws IOException, PageNotFoundException {
+      if (null == mStore.remove(pageId)) {
+        throw new PageNotFoundException("not found key " + pageId);
+      }
+    }
+
+    @Override
+    public void close() {
+      // noop
+    }
+
+    @Override
+    public int size() {
+      return mStore.size();
+    }
+  }
+
+  /**
+   * Implementation of meta store that stores cached data in memory.
+   */
+  class HashSetMetaStore implements MetaStore {
+    HashSet mPages = new HashSet<PageId>();
+
+    @Override
+    public boolean hasPage(PageId pageId) {
+      return mPages.contains(pageId);
+    }
+
+    @Override
+    public boolean addPage(PageId pageId) {
+      return mPages.add(pageId);
+    }
+
+    @Override
+    public void removePage(PageId pageId) throws PageNotFoundException {
+      if (!mPages.contains(pageId)) {
+        throw new PageNotFoundException("page not found " + pageId);
+      }
+      mPages.remove(pageId);
+    }
+  }
+
+  /**
+   * Implementation of Evictor using FIFO eviction policy for the test.
+   */
+  class FIFOEvictor implements CacheEvictor {
+    final Queue<PageId> mQueue = new LinkedList<>();
+    final MetaStore  mMetaStore;
+
+    public FIFOEvictor(MetaStore metaStore) {
+      mMetaStore = metaStore;
+    }
+
+    @Override
+    public void updateOnGet(PageId pageId) {
+      // noop
+    }
+
+    @Override
+    public void updateOnPut(PageId pageId) {
+      mQueue.add(pageId);
+    }
+
+    @Override
+    public void updateOnDelete(PageId pageId) {
+      // noop
+    }
+
+    @Nullable
+    @Override
+    public PageId evict() {
+      PageId pageId;
+      while ((pageId = mQueue.peek()) != null) {
+        if (mMetaStore.hasPage(pageId)) {
+          return pageId;
+        }
+        // this page has been deleted
+        mQueue.poll();
+      }
+      return null;
     }
   }
 }


### PR DESCRIPTION
Improve unit test of `LocalCacheManager` by
- removing PowerMock
- instead of asserting on internal implementation (counting func calls), assert on cache state before and after.