### PR TITLE
Implement basic version of getDatabase in catalog service

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -200,7 +200,7 @@ public class AlluxioCatalog implements Journaled {
    * Get Database by its name.
    *
    * @param dbName database name
-   * @return a databae object
+   * @return a database object
    */
   public alluxio.grpc.table.Database getDatabase(String dbName)  throws IOException {
     try (LockResource l = getLock(dbName, true)) {

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -196,6 +196,13 @@ public class AlluxioCatalog implements Journaled {
     return new ArrayList<>(mDBs.keySet());
   }
 
+  public alluxio.grpc.table.Database getDatabase(String dbName)  throws IOException {
+    try (LockResource l = getLock(dbName, true)) {
+      Database db = getDatabaseByName(dbName);
+      return alluxio.grpc.table.Database.newBuilder().setDbName(db.getName()).build();
+    }
+  }
+
   private Database getDatabaseByName(String dbName) throws NotFoundException {
     Database db = mDBs.get(dbName);
     if (db == null) {

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -196,6 +196,12 @@ public class AlluxioCatalog implements Journaled {
     return new ArrayList<>(mDBs.keySet());
   }
 
+  /**
+   * Get Database by its name.
+   *
+   * @param dbName database name
+   * @return a databae object
+   */
   public alluxio.grpc.table.Database getDatabase(String dbName)  throws IOException {
     try (LockResource l = getLock(dbName, true)) {
       Database db = getDatabaseByName(dbName);

--- a/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
@@ -21,6 +21,7 @@ import alluxio.grpc.ServiceType;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.ColumnStatisticsList;
 import alluxio.grpc.table.Constraint;
+import alluxio.grpc.table.Database;
 import alluxio.grpc.table.Partition;
 import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
@@ -148,6 +149,11 @@ public class DefaultTableMaster extends CoreMaster
   @Override
   public boolean syncDatabase(String dbName) throws IOException {
     return mCatalog.syncDatabase(createJournalContext(), dbName);
+  }
+
+  @Override
+  public Database getDatabase(String dbName) throws IOException {
+    return mCatalog.getDatabase(dbName);
   }
 
   @Override

--- a/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
@@ -14,6 +14,7 @@ package alluxio.master.table;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.ColumnStatisticsList;
 import alluxio.grpc.table.Constraint;
+import alluxio.grpc.table.Database;
 import alluxio.grpc.table.Partition;
 import alluxio.master.Master;
 import alluxio.master.table.transform.TransformJobInfo;
@@ -138,4 +139,12 @@ public interface TableMaster extends Master {
    * @return true if the database was changed as a result
    */
   boolean syncDatabase(String dbName) throws IOException;
+
+  /**
+   * Gets a database object
+   *
+   * @param dbName the database name
+   * @return a database object
+   */
+  Database getDatabase(String dbName) throws IOException;
 }

--- a/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
@@ -141,7 +141,7 @@ public interface TableMaster extends Master {
   boolean syncDatabase(String dbName) throws IOException;
 
   /**
-   * Gets a database object
+   * Gets a database object.
    *
    * @param dbName the database name
    * @return a database object

--- a/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMaster.java
@@ -67,6 +67,14 @@ public interface TableMaster extends Master {
   List<String> getAllTables(String databaseName) throws IOException;
 
   /**
+   * Gets a database object.
+   *
+   * @param dbName the database name
+   * @return a database object
+   */
+  Database getDatabase(String dbName) throws IOException;
+
+  /**
    * Get a table.
    *
    * @param databaseName database name
@@ -139,12 +147,4 @@ public interface TableMaster extends Master {
    * @return true if the database was changed as a result
    */
   boolean syncDatabase(String dbName) throws IOException;
-
-  /**
-   * Gets a database object.
-   *
-   * @param dbName the database name
-   * @return a database object
-   */
-  Database getDatabase(String dbName) throws IOException;
 }

--- a/table/server/master/src/main/java/alluxio/master/table/TableMasterClientServiceHandler.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMasterClientServiceHandler.java
@@ -14,12 +14,15 @@ package alluxio.master.table;
 import alluxio.RpcUtils;
 import alluxio.grpc.table.AttachDatabasePRequest;
 import alluxio.grpc.table.AttachDatabasePResponse;
+import alluxio.grpc.table.Database;
 import alluxio.grpc.table.DetachDatabasePRequest;
 import alluxio.grpc.table.DetachDatabasePResponse;
 import alluxio.grpc.table.GetAllDatabasesPRequest;
 import alluxio.grpc.table.GetAllDatabasesPResponse;
 import alluxio.grpc.table.GetAllTablesPRequest;
 import alluxio.grpc.table.GetAllTablesPResponse;
+import alluxio.grpc.table.GetDatabasePRequest;
+import alluxio.grpc.table.GetDatabasePResponse;
 import alluxio.grpc.table.GetPartitionColumnStatisticsPRequest;
 import alluxio.grpc.table.GetPartitionColumnStatisticsPResponse;
 import alluxio.grpc.table.GetTableColumnStatisticsPRequest;
@@ -95,6 +98,14 @@ public class TableMasterClientServiceHandler
     RpcUtils.call(LOG, () -> GetAllTablesPResponse.newBuilder()
         .addAllTable(mTableMaster.getAllTables(request.getDatabase())).build(),
         "getAllTables", "", responseObserver);
+  }
+
+  @Override
+  public void getDatabase(GetDatabasePRequest request,
+      StreamObserver<GetDatabasePResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> GetDatabasePResponse.newBuilder().setDb(
+        mTableMaster.getDatabase(request.getDbName())).build(),
+        "getDatabase", "", responseObserver);
   }
 
   @Override

--- a/table/server/master/src/main/java/alluxio/master/table/TableMasterClientServiceHandler.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMasterClientServiceHandler.java
@@ -14,7 +14,6 @@ package alluxio.master.table;
 import alluxio.RpcUtils;
 import alluxio.grpc.table.AttachDatabasePRequest;
 import alluxio.grpc.table.AttachDatabasePResponse;
-import alluxio.grpc.table.Database;
 import alluxio.grpc.table.DetachDatabasePRequest;
 import alluxio.grpc.table.DetachDatabasePResponse;
 import alluxio.grpc.table.GetAllDatabasesPRequest;

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -14,6 +14,7 @@ package alluxio.master.table;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.PropertyKey;
@@ -104,8 +105,14 @@ public class AlluxioCatalogTest {
   public void getDb() throws Exception {
     String dbName = "testdb";
     TestDatabase.genTable(1, 2);
-    mException.expect(NotFoundException.class);
-    mCatalog.getDatabase(dbName);
+
+    try {
+      mCatalog.getDatabase(dbName);
+      fail();
+    } catch (IOException e) {
+      assertEquals("Database " + dbName + " does not exist", e.getMessage());
+    }
+
     mCatalog.attachDatabase(NoopJournalContext.INSTANCE,
         TestUdbFactory.TYPE, "connect_URI", TestDatabase.TEST_UDB_NAME, dbName,
         Collections.emptyMap());

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -101,6 +101,18 @@ public class AlluxioCatalogTest {
   }
 
   @Test
+  public void getDb() throws Exception {
+    String dbName = "testdb";
+    TestDatabase.genTable(1, 2);
+    mException.expect(NotFoundException.class);
+    mCatalog.getDatabase(dbName);
+    mCatalog.attachDatabase(NoopJournalContext.INSTANCE,
+        TestUdbFactory.TYPE, "connect_URI", TestDatabase.TEST_UDB_NAME, dbName,
+        Collections.emptyMap());
+    assertEquals(dbName, mCatalog.getDatabase(dbName).getDbName());
+  }
+
+  @Test
   public void testGetAllDatabase() throws Exception {
     addMockDbs();
     assertEquals(2, mCatalog.getAllDatabases().size());

--- a/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
@@ -24,6 +24,7 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -37,6 +38,9 @@ public class TableMasterJournalIntegrationTest {
   public LocalAlluxioClusterResource mClusterResource =
       new LocalAlluxioClusterResource.Builder().setStartCluster(false)
           .build();
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
 
   private static final String DB_NAME = TestDatabase.TEST_UDB_NAME;
 
@@ -92,8 +96,12 @@ public class TableMasterJournalIntegrationTest {
     TableMaster tableMaster =
         mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
 
+    mException.expect(IOException.class);
+    tableMaster.getDatabase(DB_NAME);
+
     tableMaster
         .attachDatabase(TestUdbFactory.TYPE, "connect", DB_NAME, DB_NAME, Collections.emptyMap());
+    assertEquals(DB_NAME, tableMaster.getDatabase(DB_NAME).getDbName());
     List<String> oldTableNames = tableMaster.getAllTables(DB_NAME);
     Table tableOld = tableMaster.getTable(DB_NAME, oldTableNames.get(0));
 

--- a/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
@@ -13,6 +13,7 @@ package alluxio.server.ft.journal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.table.Table;
@@ -24,7 +25,6 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -38,9 +38,6 @@ public class TableMasterJournalIntegrationTest {
   public LocalAlluxioClusterResource mClusterResource =
       new LocalAlluxioClusterResource.Builder().setStartCluster(false)
           .build();
-
-  @Rule
-  public ExpectedException mException = ExpectedException.none();
 
   private static final String DB_NAME = TestDatabase.TEST_UDB_NAME;
 
@@ -95,10 +92,12 @@ public class TableMasterJournalIntegrationTest {
     LocalAlluxioCluster mCluster = mClusterResource.get();
     TableMaster tableMaster =
         mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
-
-    mException.expect(IOException.class);
-    tableMaster.getDatabase(DB_NAME);
-
+    try {
+      tableMaster.getDatabase(DB_NAME);
+      fail();
+    } catch (IOException e) {
+      assertEquals("Database " + DB_NAME + " does not exist", e.getMessage());
+    }
     tableMaster
         .attachDatabase(TestUdbFactory.TYPE, "connect", DB_NAME, DB_NAME, Collections.emptyMap());
     assertEquals(DB_NAME, tableMaster.getDatabase(DB_NAME).getDbName());


### PR DESCRIPTION
Note here `getDatabase` returns an object that contains only the database name.
A subsequent PR will add more content into this database object and the associated Udb object to populate this database object. 