### PR TITLE
Fix some bugs and add new properties for client-side cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -70,7 +70,7 @@ public class LocalCacheManager implements CacheManager {
    * @param fsContext filesystem context
    */
   public LocalCacheManager(FileSystemContext fsContext) {
-    this(fsContext, MetaStore.create(), PageStore.create(),
+    this(fsContext, MetaStore.create(), PageStore.create(fsContext.getClusterConf()),
         CacheEvictor.create(fsContext.getClusterConf()));
   }
 
@@ -103,7 +103,7 @@ public class LocalCacheManager implements CacheManager {
    * @return the corresponding page lock
    */
   private ReadWriteLock getPageLock(PageId pageId) {
-    return mPageLocks[(int) (pageId.getFileId() + pageId.getPageIndex()) % LOCK_SIZE];
+    return mPageLocks[Math.floorMod((int) (pageId.getFileId() + pageId.getPageIndex()), LOCK_SIZE)];
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -15,6 +15,7 @@ import alluxio.client.file.cache.store.LocalPageStore;
 import alluxio.client.file.cache.store.LocalPageStoreOptions;
 import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.client.file.cache.store.RocksPageStore;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.PageNotFoundException;
 
 import java.io.IOException;
@@ -50,6 +51,15 @@ public interface PageStore extends AutoCloseable {
    */
   static PageStore create() {
     return create(new LocalPageStoreOptions());
+  }
+
+  /**
+   * Creates a new instance of {@link PageStore} based on configuration.
+   * @param conf configuration
+   * @return the {@link PageStore}
+   */
+  static PageStore create(AlluxioConfiguration conf) {
+    return create(PageStoreOptions.create(conf));
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
@@ -11,10 +11,38 @@
 
 package alluxio.client.file.cache.store;
 
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+
 /**
  * Options used to instantiate a {@link alluxio.client.file.cache.PageStore}.
  */
 public abstract class PageStoreOptions {
+
+  /**
+   * Creates an instance of the {@link PageStoreOptions} based on configurations.
+   * @param conf the Alluxio configuration
+   * @return the created page store options
+   */
+  public static PageStoreOptions create(AlluxioConfiguration conf) {
+    PageStoreOptions options;
+    PageStoreType storeType = conf.getEnum(
+        PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, PageStoreType.class);
+    // TODO(feng): add more configurable options
+    switch (storeType) {
+      case LOCAL:
+        options = new LocalPageStoreOptions();
+        break;
+      case ROCKS:
+        options = new RocksPageStoreOptions();
+        break;
+      default:
+        throw new IllegalArgumentException(String.format("Unrecognized store type %s",
+            storeType.name()));
+    }
+    options.setRootDir(conf.get(PropertyKey.USER_CLIENT_CACHE_DIR));
+    return options;
+  }
 
   /**
    * @return the type corresponding to the page store

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -197,6 +197,28 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
+  public void readOversizedBuffer() throws Exception {
+    int fileSize = PAGE_SIZE;
+    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
+
+    // cache miss
+    byte[] cacheMiss = new byte[fileSize * 2];
+    Assert.assertEquals(fileSize, stream.read(cacheMiss));
+    Assert.assertArrayEquals(testData, Arrays.copyOfRange(cacheMiss, 0, fileSize));
+    Assert.assertEquals(0, manager.mPagesServed);
+    Assert.assertEquals(1, manager.mPagesCached);
+
+    // cache hit
+    stream.seek(0);
+    byte[] cacheHit = new byte[fileSize * 2];
+    Assert.assertEquals(fileSize, stream.read(cacheHit));
+    Assert.assertArrayEquals(testData, Arrays.copyOfRange(cacheHit, 0, fileSize));
+    Assert.assertEquals(1, manager.mPagesServed);
+  }
+
+  @Test
   public void positionedReadPartialPage() throws Exception {
     int fileSize = PAGE_SIZE;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -146,6 +146,15 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
+  public void putLargeId() throws Exception {
+    PageId largeId = new PageId(Long.MAX_VALUE, 0);
+    mCacheManager.put(largeId, PAGE1);
+    assertEquals(1, mPageStore.size());
+    assertTrue(mMetaStore.hasPage(largeId));
+    assertArrayEquals(PAGE1, (byte[]) mPageStore.mStore.get(largeId));
+  }
+
+  @Test
   public void getExist() throws Exception {
     mCacheManager.put(PAGE_ID1, PAGE1);
     try (ReadableByteChannel ret = mCacheManager.get(PAGE_ID1)) {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3122,7 +3122,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_DIR =
       new Builder(Name.USER_CLIENT_CACHE_DIR)
-          .setDefaultValue("/tmp")
+          .setDefaultValue("/tmp/alluxio_cache")
           .setDescription("The directory where client-side cache is stored.")
           .setScope(Scope.CLIENT)
           .build();
@@ -3130,7 +3130,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.USER_CLIENT_CACHE_STORE_TYPE)
           .setDefaultValue("LOCAL")
           .setDescription("The type of page store to use for client-side cache. Can be either "
-              + "`LOCAL` or `ROCKS`.")
+              + "`LOCAL` or `ROCKS`. The `LOCAL` page store stores all pages in a directory, "
+              + "the `ROCKS` page store utilizes rocksDB to persist the data.")
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3120,6 +3120,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "`alluxio.client.file.cache.LRUCacheEvictor`.")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_DIR =
+      new Builder(Name.USER_CLIENT_CACHE_DIR)
+          .setDefaultValue("/tmp")
+          .setDescription("The directory where client-side cache is stored.")
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_STORE_TYPE =
+      new Builder(Name.USER_CLIENT_CACHE_STORE_TYPE)
+          .setDefaultValue("LOCAL")
+          .setDescription("The type of page store to use for client-side cache. Can be either "
+              + "`LOCAL` or `ROCKS`.")
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_SIZE =
       new Builder(Name.USER_CLIENT_CACHE_SIZE)
           .setDefaultValue("512MB")
@@ -4492,10 +4505,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.enabled";
     public static final String USER_CLIENT_CACHE_EVICTOR_CLASS =
         "alluxio.user.client.cache.evictor.class";
-    public static final String USER_CLIENT_CACHE_SIZE =
-        "alluxio.user.client.cache.size";
+    public static final String USER_CLIENT_CACHE_DIR =
+        "alluxio.user.client.cache.dir";
     public static final String USER_CLIENT_CACHE_PAGE_SIZE =
         "alluxio.user.client.cache.page.size";
+    public static final String USER_CLIENT_CACHE_SIZE =
+        "alluxio.user.client.cache.size";
+    public static final String USER_CLIENT_CACHE_STORE_TYPE =
+        "alluxio.user.client.cache.store.type";
     public static final String USER_CONF_CLUSTER_DEFAULT_ENABLED =
         "alluxio.user.conf.cluster.default.enabled";
     public static final String USER_CONF_SYNC_INTERVAL = "alluxio.user.conf.sync.interval";


### PR DESCRIPTION
Fixed index out of bound exception for cache manager locking.
Fixed exception when reading from stream with oversized buffer.
Added properties to configure page store directory and type.