### PR TITLE
Fail nested jobs correctly in all of the jobs for JobMaster failures

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
@@ -250,6 +250,7 @@ public class WorkflowTracker {
         mJobMaster.run(childJobConfig, childJobId);
       } catch (JobDoesNotExistException | ResourceExhaustedException e) {
         LOG.warn(e.getMessage());
+        workflowExecution.stop(Status.FAILED, e.getMessage());
         stop(jobId, Status.FAILED, e.getMessage());
       }
     }


### PR DESCRIPTION
For errors like ResourceExhaustedException and JobDoesNotExistException, the WorkflowTracker will only stamp Status.FAILED from a level above.

Reproduction: (see Test)

mJobMaster.run(new Composite..([new Composite(new DummyJob....

Expected:

Name: Composite
..
Status: FAILED
Message: The job definition for config bleh does not exist
Task 0
    Name: Composite
    ...
    Status: FAILED
    Message: The job definition for config bleh does not exist

Actual:

Name: Composite
..
Status: FAILED
Message: The job definition for config bleh does not exist
Task 0
    Name: Composite
    ...
    Status: RUNNING