### PR TITLE
Add metrics for cache hit/miss

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
@@ -20,5 +20,10 @@ public final class ClientMetrics {
   public static final String BYTES_READ_LOCAL_THROUGHPUT = "BytesReadLocalThroughput";
   public static final String BYTES_WRITTEN_UFS = "BytesWrittenUfs";
 
+  /** Metrics for LocalCacheFileSystem, prefixed with Cache. */
+  public static final String CACHE_BYTES_READ_CACHE = "CacheBytesReadCache";
+  public static final String CACHE_BYTES_READ_EXTERNAL = "CacheBytesReadExternal";
+  public static final String CACHE_BYTES_REQUESTED_EXTERNAL = "CacheBytesRequestedExternal";
+
   private ClientMetrics() {} // prevent instantiation
 }


### PR DESCRIPTION
Adds 3 metrics
number of bytes read from local cache
number of bytes read from external store
number of bytes requested from external store (may be less than bytes read because we read full pages)