### PR TITLE
Optimize offset read from page store

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -78,7 +78,21 @@ public interface PageStore extends AutoCloseable {
    * @throws IOException
    * @throws PageNotFoundException when the page isn't found in the store
    */
-  ReadableByteChannel get(PageId pageId) throws IOException,
+  default ReadableByteChannel get(PageId pageId) throws IOException,
+      PageNotFoundException {
+    return get(pageId, 0);
+  }
+
+  /**
+   * Gets part of a page from the store to the destination channel.
+   *
+   * @param pageId page identifier
+   * @param pageOffset offset within page
+   * @return the number of bytes read
+   * @throws IOException
+   * @throws PageNotFoundException when the page isn't found in the store
+   */
+  ReadableByteChannel get(PageId pageId, int pageOffset) throws IOException,
       PageNotFoundException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -91,6 +91,7 @@ public interface PageStore extends AutoCloseable {
    * @return the number of bytes read
    * @throws IOException
    * @throws PageNotFoundException when the page isn't found in the store
+   * @throws IllegalArgumentException when the page offset exceeds the page size
    */
   ReadableByteChannel get(PageId pageId, int pageOffset) throws IOException,
       PageNotFoundException;

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -69,12 +69,14 @@ public class LocalPageStore implements PageStore, AutoCloseable {
   }
 
   @Override
-  public ReadableByteChannel get(PageId pageId) throws IOException, PageNotFoundException {
+  public ReadableByteChannel get(PageId pageId, int pageOffset)
+      throws IOException, PageNotFoundException {
     Path p = getFilePath(pageId);
     if (!Files.exists(p)) {
       throw new PageNotFoundException(p.toString());
     }
     FileInputStream fis = new FileInputStream(p.toFile());
+    fis.skip(pageOffset);
     return fis.getChannel();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -78,11 +78,14 @@ public class RocksPageStore implements PageStore, AutoCloseable {
   @Override
   public ReadableByteChannel get(PageId pageId, int pageOffset)
       throws IOException, PageNotFoundException {
+    Preconditions.checkArgument(pageOffset >= 0, "page offset should be non-negative");
     try {
       byte[] page = mDb.get(getPageKey(pageId));
       if (page == null) {
         throw new PageNotFoundException(new String(getPageKey(pageId)));
       }
+      Preconditions.checkArgument(pageOffset <= page.length,
+          "page offset %s exceeded page size %s", pageOffset, page.length);
       ByteArrayInputStream bais = new ByteArrayInputStream(page);
       bais.skip(pageOffset);
       return Channels.newChannel(bais);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -76,14 +76,15 @@ public class RocksPageStore implements PageStore, AutoCloseable {
   }
 
   @Override
-  public ReadableByteChannel get(PageId pageId) throws IOException,
-      PageNotFoundException {
+  public ReadableByteChannel get(PageId pageId, int pageOffset)
+      throws IOException, PageNotFoundException {
     try {
       byte[] page = mDb.get(getPageKey(pageId));
       if (page == null) {
         throw new PageNotFoundException(new String(getPageKey(pageId)));
       }
       ByteArrayInputStream bais = new ByteArrayInputStream(page);
+      bais.skip(pageOffset);
       return Channels.newChannel(bais);
     } catch (RocksDBException e) {
       throw new IOException("Failed to retrieve page", e);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -213,9 +213,12 @@ public final class LocalCacheManagerTest {
     }
 
     @Override
-    public ReadableByteChannel get(PageId pageId) throws IOException, PageNotFoundException {
+    public ReadableByteChannel get(PageId pageId, int pageOffset)
+        throws IOException, PageNotFoundException {
       byte[] buf = (byte[]) mStore.get(pageId);
-      return Channels.newChannel(new ByteArrayInputStream(buf));
+      ByteArrayInputStream is = new ByteArrayInputStream(buf);
+      is.skip(pageOffset);
+      return Channels.newChannel(is);
     }
 
     @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -30,7 +30,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -12,12 +12,14 @@
 package alluxio.client.file.cache.store;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.Constants;
 import alluxio.client.file.cache.PageId;
 import alluxio.exception.PageNotFoundException;
 import alluxio.client.file.cache.PageStore;
+import alluxio.util.io.BufferUtils;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -28,6 +30,8 @@ import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channel;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +62,23 @@ public class PageStoreTest {
     mOptions.setRootDir(mTemp.getRoot().getAbsolutePath());
     try (PageStore store = PageStore.create(mOptions)) {
       helloWorldTest(store);
+    }
+  }
+
+  @Test
+  public void getOffset() throws Exception {
+    mOptions.setRootDir(mTemp.getRoot().getAbsolutePath());
+    int len = 32;
+    int offset = 3;
+    try (PageStore store = PageStore.create(mOptions)) {
+      PageId id = new PageId(0, 0);
+      store.put(id, BufferUtils.getIncreasingByteArray(len));
+      ByteBuffer buf = ByteBuffer.allocate(1024);
+      try (ReadableByteChannel channel = store.get(id, offset)) {
+        channel.read(buf);
+      }
+      buf.flip();
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(3, len - offset, buf));
     }
   }
 


### PR DESCRIPTION
Add a new offset read API on page store to eliminate buffer copy in `LocalCacheManager`.