### PR TITLE
Update spring maven repository to use HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
       <!-- for Pivotal's distribution -->
       <id>spring-releases</id>
       <name>Spring Release Repository</name>
-      <url>http://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-release</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
repo.spring.io recently started enforcing the use of `https` to connect and download artifacts. This change updates the root POM to reflect this requirement. Builds off of a fresh maven cache should now succeed.