### PR TITLE
Add client config load before initializing metrics heartbeat

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -229,6 +229,15 @@ public final class FileSystemContext implements Closeable {
     mClosed.set(false);
     mMasterClientContext = MasterClientContext.newBuilder(ctx)
         .setMasterInquireClient(masterInquireClient).build();
+    try {
+      InetSocketAddress masterAddr = masterInquireClient.getPrimaryRpcAddress();
+      mMasterClientContext.loadConf(masterAddr, true, true);
+    } catch (UnavailableException e) {
+      LOG.error("Failed to get master address during initialization", e);
+    } catch (AlluxioStatusException ae) {
+      LOG.error("Failed to load configuration from "
+          + "meta master during initialization", ae);
+    }
     mFileSystemMasterClientPool = new FileSystemMasterClientPool(mMasterClientContext);
     mBlockMasterClientPool = new BlockMasterClientPool(mMasterClientContext);
     mWorkerGroup = NettyUtils.createEventLoop(NettyUtils.getUserChannel(getClusterConf()),


### PR DESCRIPTION
When client-side configuration is wrong or missing, client heartbeat may have connection issues (ie due to security settings).  This PR adds client side load configuration before initializign metrics heartbeat to solve the issue.