### PR TITLE
Fix cancel 2.1 (Port #10634 to branch-2.1)

### DIFF
--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutor.java
@@ -75,11 +75,9 @@ public final class TaskExecutor implements Runnable {
     Object result;
     try {
       result = definition.runTask(mJobConfig, mTaskArgs, mContext);
-      if (Thread.interrupted()) {
-        mTaskExecutorManager.notifyTaskCancellation(mJobId, mTaskId);
-      }
     } catch (InterruptedException e) {
-      mTaskExecutorManager.notifyTaskCancellation(mJobId, mTaskId);
+      // Cleanup around the interruption should already have been handled by a different thread
+      Thread.currentThread().interrupt();
       return;
     } catch (Throwable t) {
       if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
@@ -106,20 +106,6 @@ public class TaskExecutorManager {
   }
 
   /**
-   * Notifies the cancellation of the task.
-   *
-   * @param jobId the job id
-   * @param taskId the task id
-   */
-  public synchronized void notifyTaskCancellation(long jobId, int taskId) {
-    Pair<Long, Integer> id = new Pair<>(jobId, taskId);
-    TaskInfo.Builder taskInfo = mUnfinishedTasks.get(id);
-    taskInfo.setStatus(Status.CANCELED);
-    finishTask(id);
-    LOG.info("Task {} for job {} canceled", taskId, jobId);
-  }
-
-  /**
    * Executes the given task.
    *
    * @param jobId the job id
@@ -157,10 +143,14 @@ public class TaskExecutorManager {
       return;
     }
 
+    LOG.info("Task {} for job {} canceled", taskId, jobId);
     Future<?> future = mTaskFutures.get(id);
     if (!future.cancel(true)) {
       taskInfo.setStatus(Status.FAILED);
       taskInfo.setErrorMessage("Failed to cancel the task");
+      finishTask(id);
+    } else {
+      taskInfo.setStatus(Status.CANCELED);
       finishTask(id);
     }
   }

--- a/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
+++ b/job/server/src/test/java/alluxio/worker/job/task/TaskExecutorTest.java
@@ -89,25 +89,4 @@ public final class TaskExecutorTest {
     Mockito.verify(mTaskExecutorManager).notifyTaskFailure(Mockito.eq(jobId), Mockito.eq(taskId),
         Mockito.anyString());
   }
-
-  @Test
-  public void runCancelation() throws Exception {
-    long jobId = 1;
-    int taskId = 2;
-    JobConfig jobConfig = Mockito.mock(JobConfig.class);
-    Serializable taskArgs = Lists.newArrayList(1);
-    RunTaskContext context = Mockito.mock(RunTaskContext.class);
-    @SuppressWarnings("unchecked")
-    JobDefinition<JobConfig, Serializable, Serializable> jobDefinition =
-        Mockito.mock(JobDefinition.class);
-    Mockito.when(mRegistry.getJobDefinition(jobConfig)).thenReturn(jobDefinition);
-    Mockito.doThrow(new InterruptedException("interupt")).when(jobDefinition).runTask(jobConfig,
-        taskArgs, context);
-
-    TaskExecutor executor =
-        new TaskExecutor(jobId, taskId, jobConfig, taskArgs, context, mTaskExecutorManager);
-    executor.run();
-
-    Mockito.verify(mTaskExecutorManager).notifyTaskCancellation(jobId, taskId);
-  }
 }


### PR DESCRIPTION
JobMaster.cancel() previously cleaned up properly only if the JobWorker
thread was actually executing the task. But in reality, almost all of
the tasks are in the executor queue.

pr-link: Alluxio/alluxio#10634
change-id: cid-a9af8ad612139b0540e8de972380f8f61c00bcb1