### PR TITLE
Fix client leaks of copyFromLocal command

### DIFF
--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -61,6 +61,8 @@ public abstract class AbstractShell implements Closeable {
     mUnstableAlias = unstableAlias;
     mCommandAlias = commandAlias;
     mCommands = loadCommands();
+    // Register all loaded commands under closer.
+    mCommands.values().stream().forEach((cmd) -> mCloser.register(cmd));
   }
 
   /**

--- a/core/common/src/main/java/alluxio/cli/Command.java
+++ b/core/common/src/main/java/alluxio/cli/Command.java
@@ -20,6 +20,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.Map;
 /**
  * An interface for all the commands that can be run from a shell.
  */
-public interface Command {
+public interface Command extends Closeable {
 
   /**
    * Gets the command name as input from the shell.
@@ -108,4 +109,11 @@ public interface Command {
    * @return the description information of the command
    */
   String getDescription();
+
+  /**
+   * Used to close resources created by commands.
+   *
+   * @throws IOException if closing resources fails
+   */
+  default void close() throws IOException {}
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
@@ -62,6 +62,13 @@ public final class CopyFromLocalCommand extends AbstractFileSystemCommand {
   }
 
   @Override
+  public void close() throws IOException {
+    // Close updated {@link FileSystem} instance that is created for internal cp command.
+    // This will close the {@link FileSystemContext} associated with it.
+    mFileSystem.close();
+  }
+
+  @Override
   public String getCommandName() {
     return "copyFromLocal";
   }


### PR DESCRIPTION
`copyFromLocal`command creates its own fs-context but it never gets closed. This fix lays necessary plumbing and properly closes the command.