### PR TITLE
Stop Alluxio processes properly

### DIFF
--- a/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
+++ b/core/server/common/src/main/java/alluxio/worker/AbstractWorker.java
@@ -11,10 +11,17 @@
 
 package alluxio.worker;
 
+import alluxio.Constants;
+import alluxio.util.executor.ExecutorServiceFactory;
+import alluxio.wire.WorkerNetAddress;
+
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -23,14 +30,20 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public abstract class AbstractWorker implements Worker {
-  /** The executor service for the master sync. */
-  private final ExecutorService mExecutorService;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractWorker.class);
+  private static final long SHUTDOWN_TIMEOUT_MS = 10 * Constants.SECOND_MS;
+
+  /** A factory for creating executor services when they are needed. */
+  private final ExecutorServiceFactory mExecutorServiceFactory;
+  /** The executor service for the worker. */
+  private ExecutorService mExecutorService;
 
   /**
-   * @param executorService executor service to use internally
+   * @param executorServiceFactory executor service factory to use internally
    */
-  protected AbstractWorker(ExecutorService executorService)  {
-    mExecutorService = Preconditions.checkNotNull(executorService, "executorService");
+  protected AbstractWorker(ExecutorServiceFactory executorServiceFactory) {
+    mExecutorServiceFactory =
+        Preconditions.checkNotNull(executorServiceFactory, "executorServiceFactory");
   }
 
   /**
@@ -38,6 +51,34 @@ public abstract class AbstractWorker implements Worker {
    */
   protected ExecutorService getExecutorService() {
     return mExecutorService;
+  }
+
+  @Override
+  public void start(WorkerNetAddress address) throws IOException {
+    Preconditions.checkState(mExecutorService == null);
+    mExecutorService = mExecutorServiceFactory.create();
+  }
+
+  @Override
+  public void stop() throws IOException {
+    // Shut down the executor service, interrupting any running threads.
+    if (mExecutorService != null) {
+      try {
+        mExecutorService.shutdownNow();
+        String awaitFailureMessage =
+            "waiting for {} executor service to shut down. Daemons may still be running";
+        try {
+          if (!mExecutorService.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            LOG.warn("Timed out " + awaitFailureMessage, this.getClass().getSimpleName());
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          LOG.warn("Interrupted while " + awaitFailureMessage, this.getClass().getSimpleName());
+        }
+      } finally {
+        mExecutorService = null;
+      }
+    }
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -75,6 +75,8 @@ public final class AlluxioWorker {
       // fatalError will exit, so we shouldn't reach here.
       throw t;
     }
+
+    ProcessUtils.stopProcessOnShutdown(process);
     ProcessUtils.run(process);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -271,8 +271,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       if (mJvmPauseMonitor != null) {
         mJvmPauseMonitor.stop();
       }
-      stopWorkers();
     }
+    stopWorkers();
   }
 
   private boolean isServing() {

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ import java.util.List;
  * worker-to-master heartbeat configurations.
  */
 @NotThreadSafe
-public final class SessionCleaner implements Runnable {
+public final class SessionCleaner implements Runnable, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(SessionCleaner.class);
 
   /** The object which supports cleaning up sessions. */
@@ -88,7 +89,7 @@ public final class SessionCleaner implements Runnable {
   /**
    * Stops the checking, once this method is called, the object should be discarded.
    */
-  public void stop() {
+  public void close() {
     mRunning = false;
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
- * Asychronous block removal service.
+ * Asynchronous block removal service.
  */
 @ThreadSafe
 public class AsyncBlockRemover {
@@ -106,12 +106,13 @@ public class AsyncBlockRemover {
           mBlockWorker.removeBlock(Sessions.MASTER_COMMAND_SESSION_ID, blockToBeRemoved);
           LOG.debug("Block {} is removed in thread {}.", blockToBeRemoved, mThreadName);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           // Only log warning if interrupted not due to a shutdown.
           if (!mShutdown) {
-            Thread.currentThread().interrupt();
             LOG.warn("{} got interrupted while it was cleaning block {}.", mThreadName,
                 blockToBeRemoved);
           }
+          break;
         } catch (IOException e) {
           LOG.warn("IOException occurred while {} was cleaning block {}, exception is {}.",
               mThreadName, blockToBeRemoved, e.getMessage());

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -63,8 +63,10 @@ public final class BlockMasterSync implements HeartbeatExecutor {
   /** Milliseconds between heartbeats before a timeout. */
   private final int mHeartbeatTimeoutMs;
 
+  /** Client-pool for all master communication. */
+  private final BlockMasterClientPool mMasterClientPool;
   /** Client for all master communication. */
-  private final BlockMasterClient mMasterClient;
+  private BlockMasterClient mMasterClient;
 
   /** An async service to remove block. */
   private final AsyncBlockRemover mAsyncBlockRemover;
@@ -78,14 +80,15 @@ public final class BlockMasterSync implements HeartbeatExecutor {
    * @param blockWorker the {@link BlockWorker} this syncer is updating to
    * @param workerId the worker id of the worker, assigned by the block master
    * @param workerAddress the net address of the worker
-   * @param masterClient the Alluxio master client
+   * @param masterClientPool the Alluxio master client pool
    */
   BlockMasterSync(BlockWorker blockWorker, AtomicReference<Long> workerId,
-      WorkerNetAddress workerAddress, BlockMasterClient masterClient) throws IOException {
+      WorkerNetAddress workerAddress, BlockMasterClientPool masterClientPool) throws IOException {
     mBlockWorker = blockWorker;
     mWorkerId = workerId;
     mWorkerAddress = workerAddress;
-    mMasterClient = masterClient;
+    mMasterClientPool = masterClientPool;
+    mMasterClient = mMasterClientPool.acquire();
     mHeartbeatTimeoutMs = (int) ServerConfiguration
         .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS);
     mAsyncBlockRemover = new AsyncBlockRemover(mBlockWorker);
@@ -153,6 +156,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
   @Override
   public void close() {
     mAsyncBlockRemover.shutDown();
+    mMasterClientPool.release(mMasterClient);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -149,7 +149,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   DefaultBlockWorker(BlockMasterClientPool blockMasterClientPool,
       FileSystemMasterClient fileSystemMasterClient, Sessions sessions, BlockStore blockStore,
       UfsManager ufsManager) {
-    super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 4));
+    super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 5));
     mBlockMasterClientPool = blockMasterClientPool;
     mBlockMasterClient = mBlockMasterClientPool.acquire();
     mFileSystemMasterClient = fileSystemMasterClient;

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -148,8 +148,8 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
       UfsManager ufsManager) {
     super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 5));
     mResourceCloser = Closer.create();
-    mResourceCloser.register(mBlockMasterClientPool = blockMasterClientPool);
-    mResourceCloser.register(mFileSystemMasterClient = fileSystemMasterClient);
+    mBlockMasterClientPool = mResourceCloser.register(blockMasterClientPool);
+    mFileSystemMasterClient = mResourceCloser.register(fileSystemMasterClient);
     mHeartbeatReporter = new BlockHeartbeatReporter();
     mMetricsReporter = new BlockMetricsReporter();
     mSessions = sessions;

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMaster.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMaster.java
@@ -49,6 +49,8 @@ public final class AlluxioJobMaster {
       System.exit(-1);
       throw t;
     }
+
+    ProcessUtils.stopProcessOnShutdown(process);
     ProcessUtils.run(process);
   }
 

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorker.java
@@ -83,6 +83,8 @@ public final class AlluxioJobWorker {
       // fatalError will exit, so we shouldn't reach here.
       throw t;
     }
+
+    ProcessUtils.stopProcessOnShutdown(process);
     ProcessUtils.run(process);
   }
 


### PR DESCRIPTION
There are 3 main categories of fixes:
- Register shutdown hooks for all processes
- Make abstract worker implementation restartable in compliance with `Server` interface
- Fix various resource disposal issues

Thse all together will prevent many gRPC level warnings. 