### PR TITLE
Fix fingerprints for persisted files

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4187,6 +4187,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 job.getUri(), fileId, inode.getPersistenceState());
             break;
           case TO_BE_PERSISTED:
+            UpdateInodeEntry.Builder builder = UpdateInodeEntry.newBuilder();
             try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
               UnderFileSystem ufs = ufsResource.get();
               String ufsPath = resolution.getUri().toString();
@@ -4201,6 +4202,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
               }
               ufs.setOwner(ufsPath, inode.getOwner(), inode.getGroup());
               ufs.setMode(ufsPath, inode.getMode());
+              builder.setUfsFingerprint(ufs.getFingerprint(ufsPath));
             }
 
             mInodeTree.updateInodeFile(journalContext, UpdateInodeFileEntry.newBuilder()
@@ -4208,7 +4210,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 .setPersistJobId(Constants.PERSISTENCE_INVALID_JOB_ID)
                 .setTempUfsPath(Constants.PERSISTENCE_INVALID_UFS_PATH)
                 .build());
-            mInodeTree.updateInode(journalContext, UpdateInodeEntry.newBuilder()
+            mInodeTree.updateInode(journalContext, builder
                 .setId(inode.getId())
                 .setPersistenceState(PersistenceState.PERSISTED.name())
                 .build());

--- a/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
@@ -485,6 +485,7 @@ public final class PersistenceTest {
     CommonUtils.waitFor("persist jobs list to be empty", () -> persistJobs.isEmpty(),
         WaitForOptions.defaults().setTimeoutMs(5 * Constants.SECOND_MS));
     Assert.assertEquals(PersistenceState.PERSISTED.toString(), fileInfo.getPersistenceState());
+    Assert.assertNotEquals(Constants.INVALID_UFS_FINGERPRINT, fileInfo.getUfsFingerprint());
   }
 
   private void checkPersistenceInProgress(AlluxioURI testFile, long jobId) throws Exception {


### PR DESCRIPTION
We used to update fingerprint for persisted files during worker heartbeat but that code is deprecated in favor of job based persistence. This fix add it to the persist job success handler to add the fingerprints to persisted files.