### PR TITLE
Fix K8s template indentation for secret volumes

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -121,9 +121,9 @@ resources:
 
 {{- define "alluxio.master.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.master }}
-          - name: secret-{{ $key }}-volume
-            mountPath: /secrets/{{ $val }}
-            readOnly: true
+            - name: secret-{{ $key }}-volume
+              mountPath: /secrets/{{ $val }}
+              readOnly: true
   {{- end }}
 {{- end -}}
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -74,9 +74,9 @@ spec:
           - containerPort: 19200
             name: embedded
           volumeMounts:
-          - name: secret-alluxio-hdfs-config-volume
-            mountPath: /secrets/hdfsConfig
-            readOnly: true
+            - name: secret-alluxio-hdfs-config-volume
+              mountPath: /secrets/hdfsConfig
+              readOnly: true
         - name: alluxio-job-master
           image: alluxio/alluxio:2.2.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
@@ -102,9 +102,9 @@ spec:
           - containerPort: 20002
             name: job-web
           volumeMounts:
-          - name: secret-alluxio-hdfs-config-volume
-            mountPath: /secrets/hdfsConfig
-            readOnly: true
+            - name: secret-alluxio-hdfs-config-volume
+              mountPath: /secrets/hdfsConfig
+              readOnly: true
       restartPolicy: Always
       volumes:
         - name: secret-alluxio-hdfs-config-volume


### PR DESCRIPTION
The secret volume mount is not indented uniformly b/w journal and secret volume mounts.