### PR TITLE
Improve Metrics System docs and add description for web UI metrics

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -18,6 +18,8 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
+import alluxio.metrics.ClientMetrics;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerNetAddress;
@@ -127,6 +129,8 @@ public final class LocalFileDataWriter implements DataWriter {
       ensureReserved(mPos + sz);
       mPos += sz;
       Preconditions.checkState(mWriter.append(buf) == sz);
+      MetricsSystem.counter(ClientMetrics.BYTES_WRITTEN_LOCAL).inc(sz);
+      MetricsSystem.meter(ClientMetrics.BYTES_WRITTEN_LOCAL_THROUGHPUT).mark(sz);
     } finally {
       buf.release();
     }

--- a/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
+++ b/core/common/src/main/java/alluxio/metrics/ClientMetrics.java
@@ -18,6 +18,8 @@ public final class ClientMetrics {
   /** Total number of bytes short-circuit read from local storage. */
   public static final String BYTES_READ_LOCAL = "BytesReadLocal";
   public static final String BYTES_READ_LOCAL_THROUGHPUT = "BytesReadLocalThroughput";
+  public static final String BYTES_WRITTEN_LOCAL = "BytesWrittenLocal";
+  public static final String BYTES_WRITTEN_LOCAL_THROUGHPUT = "BytesWrittenLocalThroughput";
   public static final String BYTES_WRITTEN_UFS = "BytesWrittenUfs";
 
   private ClientMetrics() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -51,6 +51,8 @@ public final class MasterWebUIMetrics implements Serializable {
   private String mTotalBytesReadDomainSocketThroughput;
   private String mTotalBytesReadUfs;
   private String mTotalBytesReadUfsThroughput;
+  private String mTotalBytesWrittenLocal;
+  private String mTotalBytesWrittenLocalThroughput;
   private String mTotalBytesWrittenAlluxio;
   private String mTotalBytesWrittenAlluxioThroughput;
   private String mTotalBytesWrittenDomainSocket;
@@ -197,6 +199,24 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public String getTotalBytesReadUfsThroughput() {
     return mTotalBytesReadUfsThroughput;
+  }
+
+  /**
+   * Gets total bytes written local.
+   *
+   * @return the total bytes written local
+   */
+  public String getTotalBytesWrittenLocal() {
+    return mTotalBytesWrittenLocal;
+  }
+
+  /**
+   * Gets total bytes written local throughput.
+   *
+   * @return the total bytes written local throughput
+   */
+  public String getTotalBytesWrittenLocalThroughput() {
+    return mTotalBytesWrittenLocalThroughput;
   }
 
   /**
@@ -475,6 +495,29 @@ public final class MasterWebUIMetrics implements Serializable {
   }
 
   /**
+   * Sets total bytes written local.
+   *
+   * @param TotalBytesWrittenLocal the total bytes written local
+   * @return the updated masterWebUIMetrics object
+   */
+  public MasterWebUIMetrics setTotalBytesWrittenLocal(String TotalBytesWrittenLocal) {
+    mTotalBytesWrittenLocal = TotalBytesWrittenLocal;
+    return this;
+  }
+
+  /**
+   * Sets total bytes written local throughput.
+   *
+   * @param TotalBytesWrittenLocalThroughput the total bytes written local throughput
+   * @return the updated masterWebUIMetrics object
+   */
+  public MasterWebUIMetrics setTotalBytesWrittenLocalThroughput(
+      String TotalBytesWrittenLocalThroughput) {
+    mTotalBytesWrittenLocalThroughput = TotalBytesWrittenLocalThroughput;
+    return this;
+  }
+
+  /**
    * Sets total bytes written alluxio.
    *
    * @param TotalBytesWrittenAlluxio the total bytes written alluxio
@@ -615,12 +658,16 @@ public final class MasterWebUIMetrics implements Serializable {
         .add("masterCapacityUsedPercentage", mMasterCapacityUsedPercentage)
         .add("masterUnderfsCapacityFreePercentage", mMasterUnderfsCapacityFreePercentage)
         .add("masterUnderfsCapacityUsedPercentage", mMasterUnderfsCapacityUsedPercentage)
+        .add("totalBytesReadDomainSocket", mTotalBytesReadDomainSocket)
+        .add("totalBytesReadDomainSocketThroughput", mTotalBytesReadDomainSocketThroughput)
         .add("totalBytesReadLocal", mTotalBytesReadLocal)
         .add("totalBytesReadLocalThroughput", mTotalBytesReadLocalThroughput)
         .add("totalBytesReadRemote", mTotalBytesReadRemote)
         .add("totalBytesReadRemoteThroughput", mTotalBytesReadRemoteThroughput)
         .add("totalBytesReadUfs", mTotalBytesReadUfs)
         .add("totalBytesReadUfsThroughput", mTotalBytesReadUfsThroughput)
+        .add("totalBytesWrittenLocal", mTotalBytesWrittenLocal)
+        .add("totalBytesWrittenLocalThroughput", mTotalBytesWrittenLocalThroughput)
         .add("totalBytesWrittenAlluxio", mTotalBytesWrittenAlluxio)
         .add("totalBytesWrittenAlluxioThroughput", mTotalBytesWrittenAlluxioThroughput)
         .add("totalBytesWrittenUfs", mTotalBytesWrittenUfs)

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -905,13 +905,16 @@ public final class AlluxioMasterRestServiceHandler {
           .setCacheMiss(String.format("%.2f", cacheMissPercentage));
 
       // cluster write size
+      Long bytesWrittenLocal = (Long) mr.getGauges()
+          .get(MetricsSystem.getClusterMetricName(ClientMetrics.BYTES_WRITTEN_LOCAL)).getValue();
       Long bytesWrittenAlluxio = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_ALLUXIO)).getValue();
       Long bytesWrittenDomainSocket = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_DOMAIN)).getValue();
       Long bytesWrittenUfs = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_UFS_ALL)).getValue();
-      response.setTotalBytesWrittenAlluxio(FormatUtils.getSizeFromBytes(bytesWrittenAlluxio))
+      response.setTotalBytesWrittenLocal(FormatUtils.getSizeFromBytes(bytesWrittenLocal))
+          .setTotalBytesWrittenAlluxio(FormatUtils.getSizeFromBytes(bytesWrittenAlluxio))
           .setTotalBytesWrittenDomainSocket(FormatUtils.getSizeFromBytes(bytesWrittenDomainSocket))
           .setTotalBytesWrittenUfs(FormatUtils.getSizeFromBytes(bytesWrittenUfs));
 
@@ -937,6 +940,9 @@ public final class AlluxioMasterRestServiceHandler {
           .setTotalBytesReadUfsThroughput(FormatUtils.getSizeFromBytes(bytesReadUfsThroughput));
 
       // cluster write throughput
+      Long bytesWrittenLocalThroughput = (Long) mr.getGauges()
+          .get(MetricsSystem.getClusterMetricName(ClientMetrics.BYTES_WRITTEN_LOCAL_THROUGHPUT))
+          .getValue();
       Long bytesWrittenAlluxioThroughput = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_ALLUXIO_THROUGHPUT))
           .getValue();
@@ -946,8 +952,8 @@ public final class AlluxioMasterRestServiceHandler {
       Long bytesWrittenUfsThroughput = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_UFS_THROUGHPUT))
           .getValue();
-      response.setTotalBytesWrittenAlluxioThroughput(
-          FormatUtils.getSizeFromBytes(bytesWrittenAlluxioThroughput))
+      response.setTotalBytesWrittenLocalThroughput(FormatUtils.getSizeFromBytes(bytesWrittenLocalThroughput))
+          .setTotalBytesWrittenAlluxioThroughput(FormatUtils.getSizeFromBytes(bytesWrittenAlluxioThroughput))
           .setTotalBytesWrittenDomainSocketThroughput(
               FormatUtils.getSizeFromBytes(bytesWrittenDomainSocketThroughput))
           .setTotalBytesWrittenUfsThroughput(

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -952,8 +952,10 @@ public final class AlluxioMasterRestServiceHandler {
       Long bytesWrittenUfsThroughput = (Long) mr.getGauges()
           .get(MetricsSystem.getClusterMetricName(WorkerMetrics.BYTES_WRITTEN_UFS_THROUGHPUT))
           .getValue();
-      response.setTotalBytesWrittenLocalThroughput(FormatUtils.getSizeFromBytes(bytesWrittenLocalThroughput))
-          .setTotalBytesWrittenAlluxioThroughput(FormatUtils.getSizeFromBytes(bytesWrittenAlluxioThroughput))
+      response.setTotalBytesWrittenLocalThroughput(
+              FormatUtils.getSizeFromBytes(bytesWrittenLocalThroughput))
+          .setTotalBytesWrittenAlluxioThroughput(
+              FormatUtils.getSizeFromBytes(bytesWrittenAlluxioThroughput))
           .setTotalBytesWrittenDomainSocketThroughput(
               FormatUtils.getSizeFromBytes(bytesWrittenDomainSocketThroughput))
           .setTotalBytesWrittenUfsThroughput(

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -158,6 +158,10 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
         MetricsSystem.InstanceType.CLIENT, ClientMetrics.BYTES_READ_LOCAL));
     addAggregator(new SumInstancesAggregator(ClientMetrics.BYTES_READ_LOCAL_THROUGHPUT,
         MetricsSystem.InstanceType.CLIENT, ClientMetrics.BYTES_READ_LOCAL_THROUGHPUT));
+    addAggregator(new SumInstancesAggregator(ClientMetrics.BYTES_WRITTEN_LOCAL,
+        MetricsSystem.InstanceType.CLIENT, ClientMetrics.BYTES_WRITTEN_LOCAL));
+    addAggregator(new SumInstancesAggregator(ClientMetrics.BYTES_WRITTEN_LOCAL_THROUGHPUT,
+        MetricsSystem.InstanceType.CLIENT, ClientMetrics.BYTES_WRITTEN_LOCAL_THROUGHPUT));
 
     // multi-value aggregators
     addAggregator(new SingleTagValueAggregator(WorkerMetrics.BYTES_READ_UFS,

--- a/docs/en/operation/Metrics-System.md
+++ b/docs/en/operation/Metrics-System.md
@@ -171,7 +171,7 @@ so multiple clients can be combined into a logical application.
 Total amount of data transferred through Alluxio and I/O throughput estimates (meter statistics)
 
 | Metric Name | Description |
-|--------------------------------------|---------------------------------------------------------------------------|
+|-----------------------------------------|---------------------------------------------------------------------------|
 | cluster.BytesReadAlluxio | Total number of bytes read from Alluxio storage reported by Alluxio workers. This does not include UFS reads |
 | cluster.BytesReadAlluxioThroughput | Bytes read throughput from Alluxio storage |
 | cluster.BytesReadDomain | Total number of bytes read from Alluxio storage via domain socket reported by Alluxio workers. |
@@ -180,6 +180,7 @@ Total amount of data transferred through Alluxio and I/O throughput estimates (m
 | cluster.BytesReadLocalThroughput | Bytes read throughput from local filesystem |
 | cluster.BytesReadUfsAll | Total number of bytes read from all Alluxio UFSes reported by Alluxio workers |
 | cluster.BytesReadUfsThroughput | Bytes read throughput from all Alluxio UFSes |
+| cluster.BytesReadPerUfs.UFS:<UFS_ADDRESS> | Total number of bytes read from Alluxio UFS <UFS_ADDRESS> reported by Alluxio workers |
 | cluster.BytesWrittenAlluxio | Total number of bytes written to Alluxio storage reported by Alluxio workers. This does not include UFS writes |
 | cluster.BytesWrittenAlluxioThroughput | Bytes write throughput to Alluxio storage |
 | cluster.BytesWrittenDomain | Total number of bytes written to Alluxio storage via domain socket reported by Alluxio workers |
@@ -188,6 +189,7 @@ Total amount of data transferred through Alluxio and I/O throughput estimates (m
 | cluster.BytesWrittenLocalThroughput | Bytes read throughput from local filesystem |
 | cluster.BytesWrittenUfsAll | Total number of bytes written to all Alluxio UFSes reported by Alluxio workers | 
 | cluster.BytesWrittenUfsThroughput | Bytes write throughput to all Alluxio UFSes |
+| cluster.BytesWrittenPerUfs.UFS:<UFS_ADDRESS> | Total number of bytes written to UFS <UFS_ADDRESS> reported by Alluxio workers | 
 
 #### Under storage RPCs
 
@@ -264,11 +266,13 @@ how many failures an operation runs into (in the format of `Master.<RPC_NAME>Fai
 
 ### Worker Metrics
 
+#### Worker Status information
+
 | Metric Name | Description |
 |---------------------------------------------|-----------------------------------------------------|
-| Worker.<WORKER_HOSTNAME>.CapacityTotal | Total capacity of this worker in bytes
-| Worker.<WORKER_HOSTNAME>.CapacityUsed | Used capacity of this worker in bytes
-| Worker.<WORKER_HOSTNAME>.CapacityFree | Free capacity of this worker in bytes
+| Worker.<WORKER_HOSTNAME>.CapacityTotal | Total capacity of this worker in bytes |
+| Worker.<WORKER_HOSTNAME>.CapacityUsed | Used capacity of this worker in bytes |
+| Worker.<WORKER_HOSTNAME>.CapacityFree | Free capacity of this worker in bytes |
 | Worker.<WORKER_HOSTNAME>.BlocksCached | Total number of blocks in Alluxio worker storages |
 | Worker.<WORKER_HOSTNAME>.BlocksAccessed | Total number of times blocks in this worker are accessed |
 | Worker.<WORKER_HOSTNAME>.BlocksCanceled | Total number of aborted temporary blocks |
@@ -282,6 +286,36 @@ how many failures an operation runs into (in the format of `Master.<RPC_NAME>Fai
 | Worker.<WORKER_HOSTNAME>.AsyncCacheFailedBlocks | Total number of blocks failed to be cached asynchronously |
 | Worker.<WORKER_HOSTNAME>.AsyncCacheUfsBlocks | Total number of async cache blocks which have local source |
 | Worker.<WORKER_HOSTNAME>.AsyncCacheRemoteBlocks | Total number of remote blocks to async cache locally |
+| Worker.<WORKER_HOSTNAME>.UfsSessionCount-Ufs:<UFS_ADDRESS> | The total number of currently opened UFS sessions to connect to the given <UFS_ADDRESS> from this worker |
+
+#### Worker I/O data
+
+| Metric Name | Description |
+|---------------------------------------------|-----------------------------------------------------|
+| Worker.<WORKER_HOSTNAME>.BytesReadAlluxio |  Total number of bytes read from the Alluxio storage in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesReadAlluxioThroughput | Bytes read throughput from Alluxio storage in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesReadDomain | Total number of bytes read from Alluxio storage in worker <WORKER_HOSTNAME> via domain socket |
+| Worker.<WORKER_HOSTNAME>.BytesReadDomainThroughput | Bytes read throughput from Alluxio storage in worker <WORKER_HOSTNAME> via domain socket |
+| Worker.<WORKER_HOSTNAME>.BytesReadPerUfs.UFS:<UFS_ADDRESS> | Total number of bytes read from UFS <UFS_ADDRESS> in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesReadUfsThroughput.UFS:<UFS_ADDRESS> | Bytes read throughput from UFS <UFS_ADDRESS> in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenAlluxio |  Total number of bytes written to the Alluxio storage in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenAlluxioThroughput | Bytes written throughput to Alluxio storage in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenDomain | Total number of bytes written to the Alluxio storage in worker <WORKER_HOSTNAME> via domain socket |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenDomainThroughput | Bytes written throughput to Alluxio storage in worker <WORKER_HOSTNAME> via domain socket |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenPerUfs.UFS:<UFS_ADDRESS> | Total number of bytes written from UFS <UFS_ADDRESS> in worker <WORKER_HOSTNAME> |
+| Worker.<WORKER_HOSTNAME>.BytesWrittenUfsThroughput.UFS:<UFS_ADDRESS> | Bytes written throughput from UFS <UFS_ADDRESS> in worker <WORKER_HOSTNAME> |
+
+#### Worker operations metrics
+
+Alluxio workers record timer metrics of all the requests they received from either Alluxio leading master or Alluxio clients.
+The following is a subset of the recorded operation metrics:
+| Metric Name | Description |
+|---------------------------------------------|-----------------------------------------------------|
+| Worker.<WORKER_HOSTNAME>.OpenBlock.User:<USER_NAME> | The total number and duration of the OpenBlock operation processed by worker <WORKER_HOSTNAME> called by user <USER_NAME> |
+| Worker.<WORKER_HOSTNAME>.CloseBlock.User:<USER_NAME> | The total number and duration of the CloseBlock operation processed by worker <WORKER_HOSTNAME> called by user <USER_NAME> |
+| Worker.<WORKER_HOSTNAME>.CreateBlock.User:<USER_NAME> | The total number and duration of the CreateBlock operation processed by worker <WORKER_HOSTNAME> called by user <USER_NAME> |
+| Worker.<WORKER_HOSTNAME>.CommitBlock.User:<USER_NAME> | The total number and duration of the CommitBlock operation processed by worker <WORKER_HOSTNAME> called by user <USER_NAME> |
+| Worker.<WORKER_HOSTNAME>.asyncCache.User:<USER_NAME> | The total number and duration of the caching a block asynchronously operation processed by worker <WORKER_HOSTNAME> called by user <USER_NAME> |
 
 ### Process Common Metrics
 
@@ -331,14 +365,14 @@ A subset of the memory usage metrics are listed as following:
 ## View Transformed Metrics
 
 Besides the raw metrics shown via metrics servlet or custom metrics configuration,
-users can view more human-readable metrics stored in the leading master via leading master web UI 
+users can view more human-readable metrics stored in the leading master via leading master web UI metrics page
 or [fsadmin report metrics]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#report) CLI.
 
 ![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
 
 The nick name and original metric name corresponding are shown:
 | Nick Name | Original Metric Name |
-|-----------------------------------|---------------------------------------------|
+|-----------------------------------|------------------------------|
 | Local Alluxio (Domain Socket) Read | cluster.BytesReadDomain |
 | Local Alluxio (Domain Socket) Write | cluster.BytesWrittenDomain |
 | Local Alluxio (Short-circuit) Read | cluster.BytesReadLocal |
@@ -349,3 +383,7 @@ The nick name and original metric name corresponding are shown:
 | Under Filesystem Write | cluster.BytesWrittenUfsAll |
 Detailed descriptions of those metrics are in [cluster metrics section](#cluster-metrics)
 
+`Mounted Under FileSystem Read` shows the `cluster.BytesReadPerUfs.UFS:<UFS_ADDRESS>` of each Alluxio UFS.
+`Mounted Under FileSystem Write` shows the `cluster.BytesWrittenPerUfs.UFS:<UFS_ADDRESS>` of each Alluxio UFS.
+
+`Logical Operations` and `RPC Invocations` presents [master logical operation metrics](#master-logical-operations-and-results).

--- a/docs/en/operation/Metrics-System.md
+++ b/docs/en/operation/Metrics-System.md
@@ -32,7 +32,7 @@ Each instance can report to zero or more sinks.
 * `GraphiteSink`: Sends metrics to a Graphite server.
 * `MetricsServlet`: Adds a servlet in Web UI to serve metrics data as JSON data.
 
-## Configuration
+## Metrics Sink Configuration
 
 The metrics system is configured via a configuration file that Alluxio expects to be present at `$ALLUXIO_HOME/conf/metrics.properties`. 
 A custom file location can be specified via the `alluxio.metrics.conf.file` configuration property. 
@@ -94,6 +94,22 @@ The filename will correspond with the metric name.
 
 Refer to `metrics.properties.template` for all possible sink specific configurations. 
 
+## View Transformed Metrics
+
+Besides the raw metrics shown via metrics servlet or custom metrics configuration,
+users can view more human-readable metrics stored in the leading master via leading master web UI 
+or [fsadmin report metrics]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#report) CLI.
+
+![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
+
+Total IO Size
+| Nick Name | Origin Metric Name |
+|-----------------------------------|---------------------------------------------|
+| Remote Alluxio Read | cluster.BytesReadAlluxio |
+| Remote Alluxio Write | cluster.BytesWrittenAlluxio |
+| Under Filesystem Read | cluster.BytesReadUfsAll | 
+| Under Filesystem Write | cluster.BytesWrittenUfsAll |
+
 ## Metric Types
 
 Each metric falls into one of the following metric types:
@@ -132,8 +148,6 @@ Tags can be used to further filter or aggregate on various characteristics.
 
 ### Cluster Metrics
 
-![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
-
 Workers and clients send metrics data to the Alluxio master through heartbeats.
 The interval is defined by property `alluxio.master.worker.heartbeat.interval` and `alluxio.user.metrics.heartbeat.interval` respectively.
 
@@ -143,13 +157,13 @@ By default, this will be in the form of 'app-[random number]'.
 This value can be configured through the property `alluxio.user.app.id`, 
 so multiple clients can be combined into a logical application.
 
-* Alluxio cluster information
+#### Alluxio Cluster Information
 
 | Metric Name | Description |
 |-------------------------|-----------------------------------------------|
 | Master.Workers | Total number of active Alluxio workers in this cluster |
 
-* Alluxio storage capacity
+#### Alluxio Storage Capacity
 
 | Metric Name | Description |
 |--------------------------------|--------------------------------------------------------------------------|
@@ -160,7 +174,7 @@ so multiple clients can be combined into a logical application.
 | Master.CapacityFree | Free capacity of the Alluxio file system in bytes |
 | Master.CapacityFreeTier<TIER> | Free capacity in tier <TIER> of the Alluxio file system in bytes |
 
-* Under storage capacity
+#### Under Storage Capacity
 
 | Metric Name | Description |
 |-------------------------|--------------------------------------------------|
@@ -168,7 +182,9 @@ so multiple clients can be combined into a logical application.
 | Master.UfsCapacityUsed | Used capacity of the under file system in bytes |
 | Master.UfsCapacityFree | Free capacity of the under file system in bytes |
 
-* Total amount of data transferred through Alluxio and I/O throughput estimates (meter statistics)
+### Alluxio I/O Data
+
+Total amount of data transferred through Alluxio and I/O throughput estimates (meter statistics)
 
 | Metric Name | Description |
 |--------------------------------------|---------------------------------------------------------------------------|
@@ -183,7 +199,7 @@ so multiple clients can be combined into a logical application.
 | cluster.BytesWrittenDomain | Total number of bytes written to Alluxio storage via domain socket |
 | cluster.BytesWrittenDomainThroughput | Throughput of bytes written to Alluxio storage via domain socket |
 
-* I/O to under storages
+### Under Storage I/O Data
 
 | Metric Name | Description |
 |-----------------------------------|---------------------------------------------|
@@ -192,7 +208,7 @@ so multiple clients can be combined into a logical application.
 | cluster.BytesWrittenUfsAll | Total number of bytes written to all Alluxio UFSes | 
 | cluster.BytesWrittenUfsThroughput | Bytes write throughput to all Alluxio UFSes |
 
-* Under storage RPCs
+#### Under storage RPCs
 
 For all th UFS RPCs (e.g. create file, delete file, get file status), 
 the timer metrics of each RPC will be recorded as well as the failure counters if any.
@@ -201,14 +217,14 @@ For example: `cluster.UfsOp<RPC_NAME>.UFS:<UFS_ADDRESS>` records the number of U
 
 ### Master Metrics
 
-* Master summary information
+#### Master Summary Information
 
 | Metric Name | Description |
 |-------------------------|-----------------------------------------------------|
 | Master.TotalPaths | Total number of files and directory in Alluxio namespace |
 | Master.UfsSessionCount-Ufs:<UFS_ADDRESS> | The total number of currently opened UFS sessions to connect to the given <UFS_ADDRESS> |
 
-* Master Logical operations and results
+#### Master Logical Operations and Results
 
 | Metric Name | Description |
 |---------------------------|-----------------------------------------------------|
@@ -243,7 +259,7 @@ All the Alluxio filesystem client operations come with a retry mechanism
 where master metrics record how many retries an operation has (in the format of `Master.<RPC_NAME>Retries`) and 
 how many failures an operation runs into (in the format of `Master.<RPC_NAME>Failures`).
 
-* Master timer metrics
+#### Master Timer Metrics
 
 | Metric Name | Description |
 |----------------------------|-----------------------------------------------------|
@@ -256,7 +272,7 @@ how many failures an operation runs into (in the format of `Master.<RPC_NAME>Fai
 | Master.getWorkerId | The duration statistics of getting worker id |
 | Master.registerWorker | The duration statistics of registering worker to master |
 
-* Other Master metrics
+#### Other Master Metrics
 
 | Metric Name | Description |
 |---------------------------------|-----------------------------------------------------|
@@ -290,7 +306,7 @@ how many failures an operation runs into (in the format of `Master.<RPC_NAME>Fai
 
 The following metrics are collected on each instance (Master, Worker or Client).
 
-* JVM attributes
+#### JVM Attributes
 
 | Metric Name | Description |
 |-------------------------|-----------------------------------------------------|
@@ -298,7 +314,7 @@ The following metrics are collected on each instance (Master, Worker or Client).
 | uptime | The uptime of the JVM |
 | vendor | The current JVM vendor |
 
-* Garbage collector statistics
+#### Garbage Collector Statistics
 
 | Metric Name | Description |
 |-------------------------|-----------------------------------------------------|
@@ -307,7 +323,7 @@ The following metrics are collected on each instance (Master, Worker or Client).
 | PS-Scavenge.count | Total number of scavenge |
 | PS-Scavenge.time | The time used to scavenge |
 
-* Memory usage
+#### Memory Usage
 
 Alluxio provides overall and detailed memory usage information.
 Detailed memory usage information of code cache, compressed class space, metaspace, PS Eden space, PS old gen, and PS survivor space

--- a/docs/en/operation/Metrics-System.md
+++ b/docs/en/operation/Metrics-System.md
@@ -191,6 +191,9 @@ Total amount of data transferred through Alluxio and I/O throughput estimates (m
 | cluster.BytesWrittenUfsThroughput | Bytes write throughput to all Alluxio UFSes |
 | cluster.BytesWrittenPerUfs.UFS:<UFS_ADDRESS> | Total number of bytes written to UFS <UFS_ADDRESS> reported by Alluxio workers | 
 
+Workers/clients report the one minute rate (one-minute exponentially-weighted moving average rate at which events have
+occurred since the meter was created) to leading master. The leading master aggregates those values to provide cluster-wise read/write throughput information.
+
 #### Under storage RPCs
 
 For all th UFS RPCs (e.g. create file, delete file, get file status), 

--- a/docs/en/operation/Metrics-System.md
+++ b/docs/en/operation/Metrics-System.md
@@ -94,22 +94,6 @@ The filename will correspond with the metric name.
 
 Refer to `metrics.properties.template` for all possible sink specific configurations. 
 
-## View Transformed Metrics
-
-Besides the raw metrics shown via metrics servlet or custom metrics configuration,
-users can view more human-readable metrics stored in the leading master via leading master web UI 
-or [fsadmin report metrics]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#report) CLI.
-
-![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
-
-Total IO Size
-| Nick Name | Origin Metric Name |
-|-----------------------------------|---------------------------------------------|
-| Remote Alluxio Read | cluster.BytesReadAlluxio |
-| Remote Alluxio Write | cluster.BytesWrittenAlluxio |
-| Under Filesystem Read | cluster.BytesReadUfsAll | 
-| Under Filesystem Write | cluster.BytesWrittenUfsAll |
-
 ## Metric Types
 
 Each metric falls into one of the following metric types:
@@ -182,30 +166,27 @@ so multiple clients can be combined into a logical application.
 | Master.UfsCapacityUsed | Used capacity of the under file system in bytes |
 | Master.UfsCapacityFree | Free capacity of the under file system in bytes |
 
-### Alluxio I/O Data
+#### Cluster I/O Data
 
 Total amount of data transferred through Alluxio and I/O throughput estimates (meter statistics)
 
 | Metric Name | Description |
 |--------------------------------------|---------------------------------------------------------------------------|
-| cluster.BytesReadAlluxio | Total number of bytes read from Alluxio storage. This does not include UFS reads |
+| cluster.BytesReadAlluxio | Total number of bytes read from Alluxio storage reported by Alluxio workers. This does not include UFS reads |
 | cluster.BytesReadAlluxioThroughput | Bytes read throughput from Alluxio storage |
-| cluster.BytesReadDomain | Total number of bytes read from Alluxio storage via domain socket |
+| cluster.BytesReadDomain | Total number of bytes read from Alluxio storage via domain socket reported by Alluxio workers. |
 | cluster.BytesReadDomainThroughput | Bytes read throughput from Alluxio storage via domain socket |
-| cluster.BytesReadLocal | Total number of bytes read from local filesystem |
+| cluster.BytesReadLocal | Total number of bytes read from local filesystem by Alluxio clients |
 | cluster.BytesReadLocalThroughput | Bytes read throughput from local filesystem |
-| cluster.BytesWrittenAlluxio | Total number of bytes written to Alluxio storage. This does not include UFS writes |
-| cluster.BytesWrittenAlluxioThroughput | Bytes write throughput to Alluxio storage |
-| cluster.BytesWrittenDomain | Total number of bytes written to Alluxio storage via domain socket |
-| cluster.BytesWrittenDomainThroughput | Throughput of bytes written to Alluxio storage via domain socket |
-
-### Under Storage I/O Data
-
-| Metric Name | Description |
-|-----------------------------------|---------------------------------------------|
-| cluster.BytesReadUfsAll | Total number of bytes read from all Alluxio UFSes |
+| cluster.BytesReadUfsAll | Total number of bytes read from all Alluxio UFSes reported by Alluxio workers |
 | cluster.BytesReadUfsThroughput | Bytes read throughput from all Alluxio UFSes |
-| cluster.BytesWrittenUfsAll | Total number of bytes written to all Alluxio UFSes | 
+| cluster.BytesWrittenAlluxio | Total number of bytes written to Alluxio storage reported by Alluxio workers. This does not include UFS writes |
+| cluster.BytesWrittenAlluxioThroughput | Bytes write throughput to Alluxio storage |
+| cluster.BytesWrittenDomain | Total number of bytes written to Alluxio storage via domain socket reported by Alluxio workers |
+| cluster.BytesWrittenDomainThroughput | Throughput of bytes written to Alluxio storage via domain socket |
+| cluster.BytesWrittenLocal | Total number of bytes written to local filesystem by Alluxio clients |
+| cluster.BytesWrittenLocalThroughput | Bytes read throughput from local filesystem |
+| cluster.BytesWrittenUfsAll | Total number of bytes written to all Alluxio UFSes reported by Alluxio workers | 
 | cluster.BytesWrittenUfsThroughput | Bytes write throughput to all Alluxio UFSes |
 
 #### Under storage RPCs
@@ -346,3 +327,25 @@ A subset of the memory usage metrics are listed as following:
 | pools.Compressed-Class-Space.used | Used memory of collection usage from the pool from which memory is use for class metadata |
 | pools.PS-Eden-Space.used | Used memory of collection usage from the pool from which memory is initially allocated for most objects |
 | pools.PS-Survivor-Space.used | Used memory of collection usage from the pool containing objects that have survived the garbage collection of the Eden space |
+
+## View Transformed Metrics
+
+Besides the raw metrics shown via metrics servlet or custom metrics configuration,
+users can view more human-readable metrics stored in the leading master via leading master web UI 
+or [fsadmin report metrics]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#report) CLI.
+
+![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
+
+The nick name and original metric name corresponding are shown:
+| Nick Name | Original Metric Name |
+|-----------------------------------|---------------------------------------------|
+| Local Alluxio (Domain Socket) Read | cluster.BytesReadDomain |
+| Local Alluxio (Domain Socket) Write | cluster.BytesWrittenDomain |
+| Local Alluxio (Short-circuit) Read | cluster.BytesReadLocal |
+| Local Alluxio (Short-circuit) Write | cluster.BytesWrittenLocal |
+| Remote Alluxio Read | cluster.BytesReadAlluxio |
+| Remote Alluxio Write | cluster.BytesWrittenAlluxio |
+| Under Filesystem Read | cluster.BytesReadUfsAll | 
+| Under Filesystem Write | cluster.BytesWrittenUfsAll |
+Detailed descriptions of those metrics are in [cluster metrics section](#cluster-metrics)
+

--- a/docs/en/operation/Metrics-System.md
+++ b/docs/en/operation/Metrics-System.md
@@ -365,11 +365,10 @@ A subset of the memory usage metrics are listed as following:
 | pools.PS-Eden-Space.used | Used memory of collection usage from the pool from which memory is initially allocated for most objects |
 | pools.PS-Survivor-Space.used | Used memory of collection usage from the pool containing objects that have survived the garbage collection of the Eden space |
 
-## View Transformed Metrics
+## Master Web UI Metrics
 
 Besides the raw metrics shown via metrics servlet or custom metrics configuration,
-users can view more human-readable metrics stored in the leading master via leading master web UI metrics page
-or [fsadmin report metrics]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#report) CLI.
+users can view more human-readable metrics stored in the leading master via leading master web UI metrics page.
 
 ![Master Metrics]({{ '/img/screenshot_generalMetrics.png' | relativize_url }})
 
@@ -389,4 +388,4 @@ Detailed descriptions of those metrics are in [cluster metrics section](#cluster
 `Mounted Under FileSystem Read` shows the `cluster.BytesReadPerUfs.UFS:<UFS_ADDRESS>` of each Alluxio UFS.
 `Mounted Under FileSystem Write` shows the `cluster.BytesWrittenPerUfs.UFS:<UFS_ADDRESS>` of each Alluxio UFS.
 
-`Logical Operations` and `RPC Invocations` presents [master logical operation metrics](#master-logical-operations-and-results).
+`Logical Operations` and `RPC Invocations` present [master logical operation metrics](#master-logical-operations-and-results).

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -72,9 +72,9 @@ export class MetricsPresenter extends React.Component<AllProps> {
               </tr>
               <tr>
                 <th>Local Alluxio (Short-circuit) Read</th>
-                <td>{'N/A'}</td>
+                <td>{data.totalBytesReadLocal}</td>
                 <th>Local Alluxio (Short-circuit) Write</th>
-                <td>{'N/A'}</td>
+                <td>{data.totalBytesWrittenLocal}</td>
               </tr>
               <tr>
                 <th>Remote Alluxio Read</th>
@@ -103,9 +103,9 @@ export class MetricsPresenter extends React.Component<AllProps> {
               </tr>
               <tr>
                 <th>Local Alluxio (Short-circuit) Read</th>
-                <td>{'N/A'}</td>
+                <td>{data.totalBytesReadLocalThroughput}</td>
                 <th>Local Alluxio (Short-circuit) Write</th>
-                <td>{'N/A'}</td>
+                <td>{data.totalBytesWrittenLocalThroughput}</td>
               </tr>
               <tr>
                 <th>Remote Alluxio Read</th>

--- a/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
+++ b/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
@@ -35,15 +35,11 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
           <th>
             Local Alluxio (Short-circuit) Read
           </th>
-          <td>
-            N/A
-          </td>
+          <td />
           <th>
             Local Alluxio (Short-circuit) Write
           </th>
-          <td>
-            N/A
-          </td>
+          <td />
         </tr>
         <tr>
           <th>
@@ -94,15 +90,11 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
           <th>
             Local Alluxio (Short-circuit) Read
           </th>
-          <td>
-            N/A
-          </td>
+          <td />
           <th>
             Local Alluxio (Short-circuit) Write
           </th>
-          <td>
-            N/A
-          </td>
+          <td />
         </tr>
         <tr>
           <th>

--- a/webui/master/src/store/metrics/reducer.tsx
+++ b/webui/master/src/store/metrics/reducer.tsx
@@ -35,6 +35,8 @@ export const initialMetricsState: IMetricsState = {
     totalBytesReadRemoteThroughput: '',
     totalBytesReadUfs: '',
     totalBytesReadUfsThroughput: '',
+    totalBytesWrittenLocal: '',
+    totalBytesWrittenLocalThroughput: '',
     totalBytesWrittenAlluxio: '',
     totalBytesWrittenAlluxioThroughput: '',
     totalBytesWrittenDomainSocket: '',

--- a/webui/master/src/store/metrics/types.tsx
+++ b/webui/master/src/store/metrics/types.tsx
@@ -34,6 +34,8 @@ export interface IMetrics {
   totalBytesReadRemoteThroughput: string;
   totalBytesReadUfs: string;
   totalBytesReadUfsThroughput: string;
+  totalBytesWrittenLocal: string;
+  totalBytesWrittenLocalThroughput: string;
   totalBytesWrittenAlluxio: string;
   totalBytesWrittenAlluxioThroughput: string;
   totalBytesWrittenDomainSocket: string;


### PR DESCRIPTION
Add `ClientMetrics.BYTES_WRITTEN_LOCAL`
Modify master Web UI metrics `Local Alluxio (Short-circuit) Read` to use `cluster.BYTES_READ_LOCAL` and `Local Alluxio (Short-circuit) Write` to use `cluster.BYTES_WRITTEN_LOCAL`
Improve metrics system docs to include more worker metrics and have detailed description of web ui metrics.