### PR TITLE
Fix directory index after disk failure

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -174,7 +174,7 @@ public final class BlockMetadataManager {
 
     int dirIndex = location.dir();
     StorageDir dir = tier.getDir(dirIndex);
-    return dir.getAvailableBytes();
+    return dir == null ? 0 : dir.getAvailableBytes();
   }
 
   /**
@@ -202,10 +202,15 @@ public final class BlockMetadataManager {
    *
    * @param blockId the id of the block
    * @param location location of a particular {@link StorageDir} to store this block
-   * @return the path of this block in this location
+   * @return the path of this block in this location, or null if the location is not available
    */
+  @Nullable
   public String getBlockPath(long blockId, BlockStoreLocation location) {
-    return AbstractBlockMeta.commitPath(getDir(location), blockId);
+    StorageDir dir = getDir(location);
+    if (dir == null) {
+      return null;
+    }
+    return AbstractBlockMeta.commitPath(dir, blockId);
   }
 
   /**
@@ -424,7 +429,7 @@ public final class BlockMetadataManager {
       }
     } else {
       StorageDir dir = newTier.getDir(newLocation.dir());
-      if (dir.getAvailableBytes() >= blockSize) {
+      if (dir != null && dir.getAvailableBytes() >= blockSize) {
         newDir = dir;
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
@@ -100,7 +100,7 @@ public final class GreedyAllocator implements Allocator {
 
     int dirIndex = location.dir();
     StorageDirView dirView = tierView.getDirView(dirIndex);
-    if (dirView.getAvailableBytes() >= blockSize) {
+    if (dirView != null && dirView.getAvailableBytes() >= blockSize) {
       return dirView;
     }
     return null;

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
@@ -80,7 +80,7 @@ public final class MaxFreeAllocator implements Allocator {
     } else {
       StorageTierView tierView = mMetadataView.getTierView(location.tierAlias());
       StorageDirView dirView = tierView.getDirView(location.dir());
-      if (dirView.getAvailableBytes() >= blockSize) {
+      if (dirView != null && dirView.getAvailableBytes() >= blockSize) {
         candidateDirView = dirView;
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -20,6 +20,7 @@ import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.allocator.Allocator;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.StorageDirEvictorView;
+import alluxio.worker.block.meta.StorageDirView;
 import alluxio.worker.block.meta.StorageTierView;
 
 import com.google.common.base.Preconditions;
@@ -97,8 +98,10 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
           if (block.getBlockLocation().belongsTo(location)) {
             String tierAlias = block.getParentDir().getParentTier().getTierAlias();
             int dirIndex = block.getParentDir().getDirIndex();
-            dirCandidates.add((StorageDirEvictorView) mMetadataView.getTierView(tierAlias)
-                .getDirView(dirIndex), blockId, block.getBlockSize());
+            StorageDirView dirView = mMetadataView.getTierView(tierAlias).getDirView(dirIndex);
+            if (dirView != null) {
+              dirCandidates.add((StorageDirEvictorView) dirView, blockId, block.getBlockSize());
+            }
           }
         }
       } catch (BlockDoesNotExistException e) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/EvictorUtils.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/EvictorUtils.java
@@ -63,7 +63,8 @@ public final class EvictorUtils {
       } else {
         int dirIndex = location.dir();
         StorageDirView dirView = tierView.getDirView(dirIndex);
-        if (dirView.getCommittedBytes() + dirView.getAvailableBytes() >= bytesToBeAvailable
+        if (dirView != null
+            && dirView.getCommittedBytes() + dirView.getAvailableBytes() >= bytesToBeAvailable
             && dirView.getAvailableBytes() > maxFreeSize) {
           selectedDirView = dirView;
         }
@@ -107,7 +108,7 @@ public final class EvictorUtils {
     }
 
     StorageDirView dirView = tierView.getDirView(location.dir());
-    return (dirView.getAvailableBytes() >= bytesToBeAvailable) ? dirView : null;
+    return (dirView != null && dirView.getAvailableBytes() >= bytesToBeAvailable) ? dirView : null;
   }
 
   private EvictorUtils() {} // prevent instantiation

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/GreedyEvictor.java
@@ -72,7 +72,7 @@ public final class GreedyEvictor implements Evictor {
       } else {
         int dirIndex = location.dir();
         StorageDirEvictorView dir = (StorageDirEvictorView) tierView.getDirView(dirIndex);
-        if (canEvictBlocksFromDir(dir, availableBytes)) {
+        if (dir != null && canEvictBlocksFromDir(dir, availableBytes)) {
           selectedDirView = dir;
         }
       }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -11,9 +11,9 @@
 
 package alluxio.worker.block.meta;
 
-import alluxio.conf.ServerConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.WorkerStorageTierAssoc;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
@@ -33,9 +33,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -53,7 +54,7 @@ public final class StorageTier {
   private final int mTierOrdinal;
   /** Total capacity of all StorageDirs in bytes. */
   private long mCapacityBytes;
-  private List<StorageDir> mDirs;
+  private HashMap<Integer, StorageDir> mDirs;
   /** The lost storage paths that are failed to initialize or lost. */
   private List<String> mLostStorage;
 
@@ -86,7 +87,7 @@ public final class StorageTier {
         "Tier medium type configuration should not be blank");
     String[] dirMedium = rawDirMedium.split(",");
 
-    mDirs = new ArrayList<>(dirPaths.length);
+    mDirs = new HashMap<>(dirPaths.length);
     mLostStorage = new ArrayList<>();
 
     long totalCapacity = 0;
@@ -98,7 +99,7 @@ public final class StorageTier {
         StorageDir dir = StorageDir.newStorageDir(this, i, capacity, dirPaths[i],
             dirMedium[mediumTypeindex]);
         totalCapacity += capacity;
-        mDirs.add(dir);
+        mDirs.put(i, dir);
       } catch (IOException e) {
         LOG.error("Unable to initialize storage directory at {}: {}", dirPaths[i], e.getMessage());
         mLostStorage.add(dirPaths[i]);
@@ -217,7 +218,7 @@ public final class StorageTier {
    */
   public long getAvailableBytes() {
     long availableBytes = 0;
-    for (StorageDir dir : mDirs) {
+    for (StorageDir dir : mDirs.values()) {
       availableBytes += dir.getAvailableBytes();
     }
     return availableBytes;
@@ -227,8 +228,9 @@ public final class StorageTier {
    * Returns a directory for the given index.
    *
    * @param dirIndex the directory index
-   * @return a directory
+   * @return a directory, or null if the directory does not exist
    */
+  @Nullable
   public StorageDir getDir(int dirIndex) {
     return mDirs.get(dirIndex);
   }
@@ -237,7 +239,7 @@ public final class StorageTier {
    * @return a list of directories in this tier
    */
   public List<StorageDir> getStorageDirs() {
-    return Collections.unmodifiableList(mDirs);
+    return new ArrayList<>(mDirs.values());
   }
 
   /**
@@ -252,7 +254,7 @@ public final class StorageTier {
    * @param dir directory to be removed
    */
   public void removeStorageDir(StorageDir dir) {
-    if (mDirs.remove(dir)) {
+    if (mDirs.remove(dir.getDirIndex()) != null) {
       mCapacityBytes -=  dir.getCapacityBytes();
     }
     mLostStorage.add(dir.getDirPath());

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -118,7 +118,7 @@ public final class StorageTier {
     }
     mCapacityBytes = totalCapacity;
     if (mTierAlias.equals("MEM") && mDirs.size() == 1) {
-      checkEnoughMemSpace(mDirs.get(0));
+      checkEnoughMemSpace(mDirs.values().iterator().next());
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierAllocatorView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierAllocatorView.java
@@ -28,7 +28,7 @@ public class StorageTierAllocatorView extends StorageTierView {
     super(tier);
     for (StorageDir dir : mTier.getStorageDirs()) {
       StorageDirAllocatorView dirView = new StorageDirAllocatorView(dir, this);
-      mDirViews.add(dirView);
+      mDirViews.put(dirView.getDirViewIndex(), dirView);
     }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierEvictorView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierEvictorView.java
@@ -39,7 +39,7 @@ public class StorageTierEvictorView extends StorageTierView {
 
     for (StorageDir dir : mTier.getStorageDirs()) {
       StorageDirEvictorView dirView = new StorageDirEvictorView(dir, this, view);
-      mDirViews.add(dirView);
+      mDirViews.put(dirView.getDirViewIndex(), dirView);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierView.java
@@ -14,8 +14,9 @@ package alluxio.worker.block.meta;
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class is an abstract class for allocators and evictors to extend to provide
@@ -26,7 +27,7 @@ public abstract class StorageTierView {
   /** The {@link StorageTier} this view is derived from. */
   final StorageTier mTier;
   /** A list of {@link StorageDirView} under this StorageTierView. */
-  final List<StorageDirView> mDirViews = new ArrayList<>();
+  final Map<Integer, StorageDirView> mDirViews = new HashMap<>();
 
   /**
    * Creates a {@link StorageTierView} using the actual {@link StorageTier}.
@@ -41,7 +42,7 @@ public abstract class StorageTierView {
    * @return a list of directory views in this storage tier view
    */
   public List<StorageDirView> getDirViews() {
-    return Collections.unmodifiableList(mDirViews);
+    return new ArrayList<>(mDirViews.values());
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -392,6 +392,23 @@ public final class TieredBlockStoreTest {
   }
 
   /**
+   * Tests the {@link TieredBlockStore#freeSpace(long, long, BlockStoreLocation)} method.
+   */
+  @Test
+  public void freeSpaceAfterDirRemoval() throws Exception {
+    TieredBlockStoreTestUtils.cache(SESSION_ID1, BLOCK_ID1, BLOCK_SIZE, mTestDir1, mMetaManager,
+        mEvictor);
+    mBlockStore.removeDir(mTestDir3);
+    mBlockStore.freeSpace(SESSION_ID1, mTestDir1.getCapacityBytes(),
+        mTestDir1.toBlockStoreLocation());
+    // Expect BLOCK_ID1 to be moved out of mTestDir1
+    assertEquals(mTestDir1.getCapacityBytes(), mTestDir1.getAvailableBytes());
+    assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID1));
+    assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID1)));
+    assertTrue(mTestDir4.hasBlockMeta(BLOCK_ID1));
+  }
+
+  /**
    * Tests the {@link TieredBlockStore#requestSpace(long, long, long)} method.
    */
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.worker.block.meta.StorageTier;
 
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.Reflection;
@@ -104,6 +105,40 @@ public final class AllocatorContractTest extends AllocatorTestBase {
         assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_SSD_SIZE - 1, true);
       }
       for (int i = 0; i < DEFAULT_HDD_NUM; i++) {
+        assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_HDD_SIZE - 1, true);
+      }
+    }
+  }
+
+  @Test
+  public void allocateAfterDirDeletion() throws Exception {
+    for (String strategyName : mStrategies) {
+      ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
+      resetManagerView();
+      for (int i = 0; i < TIER_ALIAS.length; i++) {
+        StorageTier tier = mManager.getTier(TIER_ALIAS[i]);
+        tier.removeStorageDir(tier.getDir(0));
+      }
+      Allocator tierAllocator = Allocator.Factory.create(getMetadataEvictorView());
+      for (int i = 0; i < DEFAULT_RAM_NUM - 1; i++) {
+        assertTempBlockMeta(tierAllocator, mAnyDirInTierLoc1, DEFAULT_RAM_SIZE - 1, true);
+      }
+      for (int i = 0; i < DEFAULT_SSD_NUM - 1; i++) {
+        assertTempBlockMeta(tierAllocator, mAnyDirInTierLoc2, DEFAULT_SSD_SIZE - 1, true);
+      }
+      for (int i = 0; i < DEFAULT_HDD_NUM - 1; i++) {
+        assertTempBlockMeta(tierAllocator, mAnyDirInTierLoc3, DEFAULT_HDD_SIZE - 1, true);
+      }
+
+      resetManagerView();
+      Allocator anyAllocator = Allocator.Factory.create(getMetadataEvictorView());
+      for (int i = 0; i < DEFAULT_RAM_NUM - 1; i++) {
+        assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_RAM_SIZE - 1, true);
+      }
+      for (int i = 0; i < DEFAULT_SSD_NUM - 1; i++) {
+        assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_SSD_SIZE - 1, true);
+      }
+      for (int i = 0; i < DEFAULT_HDD_NUM - 1; i++) {
         assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_HDD_SIZE - 1, true);
       }
     }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
@@ -122,13 +122,12 @@ public class StorageTierTest {
    */
   @Test
   public void getDir() {
-    mThrown.expect(IndexOutOfBoundsException.class);
     StorageDir dir1 = mTier.getDir(0);
     Assert.assertEquals(mTestBlockDirPath1, dir1.getDirPath());
     StorageDir dir2 = mTier.getDir(1);
     Assert.assertEquals(mTestBlockDirPath2, dir2.getDirPath());
     // Get dir by a non-existing index, expect getDir to fail and throw IndexOutOfBoundsException
-    mTier.getDir(2);
+    Assert.assertNull(mTier.getDir(2));
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierViewTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierViewTest.java
@@ -81,9 +81,8 @@ public class StorageTierViewTest {
    */
   @Test
   public void getDirViewBadIndex() {
-    mThrown.expect(IndexOutOfBoundsException.class);
     int badDirIndex = TieredBlockStoreTestUtils.TIER_PATH[TEST_TIER_LEVEL].length;
-    Assert.assertEquals(badDirIndex, mTestTierView.getDirView(badDirIndex).getDirViewIndex());
+    Assert.assertNull(mTestTierView.getDirView(badDirIndex));
   }
 
   /**


### PR DESCRIPTION
Worker uses directory index to find a directory in a tier. When a disk goes down we detect that and remove the dir, which mess up the index. To avoid the confusion, this fix makes the index absolute in the tier so removing any dir does not alter its index. As a side effect, `getDir(index)` can return null if the corresponding directory is removed. Evictors and Allocators have been updated to handle the null values.