### PR TITLE
Port changes of [#10704] to branch-2.1

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -63,16 +63,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
           .build();
 
   private static final int DEFAULT_ACTIVE_JOBS = 1000;
-  private static final Option ACTIVE_JOBS_OPTION =
-      Option.builder()
-          .longOpt("active_jobs")
-          .required(false)
-          .hasArg(true)
-          .numberOfArgs(1)
-          .type(Number.class)
-          .argName("jobs")
-          .desc("Maximum number of active outgoing jobs, default: " + DEFAULT_ACTIVE_JOBS)
-          .build();
 
   private class JobAttempt {
     private final LoadConfig mJobConfig;
@@ -171,7 +161,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(REPLICATION_OPTION).addOption(ACTIVE_JOBS_OPTION);
+    return new Options().addOption(REPLICATION_OPTION);
   }
 
   @Override
@@ -184,7 +174,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);
     int replication = FileSystemShellUtils.getIntArg(cl, REPLICATION_OPTION, DEFAULT_REPLICATION);
-    mActiveJobs = FileSystemShellUtils.getIntArg(cl, ACTIVE_JOBS_OPTION, DEFAULT_ACTIVE_JOBS);
+    mActiveJobs = DEFAULT_ACTIVE_JOBS;
     distributedLoad(path, replication);
     return 0;
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -22,10 +22,10 @@ import alluxio.client.job.JobMasterClient;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.load.LoadConfig;
-import alluxio.job.JobConfig;
 
 import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.Status;
+import alluxio.job.wire.TaskInfo;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.worker.job.JobMasterClientContext;
@@ -75,13 +75,13 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
           .build();
 
   private class JobAttempt {
-    private final JobConfig mJobConfig;
+    private final LoadConfig mJobConfig;
     private final RetryPolicy mRetryPolicy;
     private final JobMasterClient mClient;
 
     private Long mJobId;
 
-    private JobAttempt(JobConfig jobConfig, RetryPolicy retryPolicy, ClientContext clientContext) {
+    private JobAttempt(LoadConfig jobConfig, RetryPolicy retryPolicy, ClientContext clientContext) {
       mJobConfig = jobConfig;
       mRetryPolicy = retryPolicy;
       mClient = JobMasterClient.Factory.create(
@@ -99,7 +99,8 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         }
         return true;
       }
-      LOG.warn("Failed to complete job after retries: {}", mJobConfig);
+      System.out.println(String.format("Failed to complete loading %s after %d retries.",
+          mJobConfig.getFilePath(), mRetryPolicy.getAttemptCount()));
       return false;
     }
 
@@ -121,7 +122,27 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
         return Status.FAILED;
       }
 
-      return jobInfo.getStatus();
+      // This make an assumption that this job tree only goes 1 level deep
+      boolean finished = true;
+      for (TaskInfo child : jobInfo.getTaskInfoList()) {
+        if (!child.getStatus().isFinished()) {
+          finished = false;
+          break;
+        }
+      }
+
+      if (finished) {
+        if (jobInfo.getStatus().equals(Status.FAILED)) {
+          System.out.println(String.format("Attempt %d to load %s failed because: %s",
+              mRetryPolicy.getAttemptCount(), mJobConfig.getFilePath(),
+              jobInfo.getErrorMessage()));
+        } else if (jobInfo.getStatus().equals(Status.COMPLETED)) {
+          System.out.println(String.format("Successfully loaded path %s after %d attempts",
+                  mJobConfig.getFilePath(), mRetryPolicy.getAttemptCount()));
+        }
+        return jobInfo.getStatus();
+      }
+      return Status.RUNNING;
     }
 
     private void close() throws IOException {
@@ -281,7 +302,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "distributedLoad [--replication <num>] [--parallelism <num>] <path>";
+    return "distributedLoad [--replication <num>] <path>";
   }
 
   @Override


### PR DESCRIPTION
Hypothetical Environment:

3 nodes, each with a job worker and a worker.
Suppose a file x.txt has 10 blocks to load but one of its blocks
(**Block 1**) is in the middle of being read on (**Worker A**),
Attempting to load this file creates 10 tasks and the task to load
**Block 1** is assigned to be in **Worker A**.

Previous behavior:

The task in an attempt to load **Block 1** in **Worker A** fails. This
fails the job but the other 9 tasks are still continuing. The client
notices the failure and triggers a retry. Retry notices that none of the
10 blocks are still loaded yet and shuffles the location of where they
are getting loaded.

New behavior:

The task in an attempt to load **Block 1** in **Worker A** fails. This
fails the job but the other 9 tasks are still continuing. The client
waits for all of its 10 tasks to finish despite knowing that the job has
already failed. After all the tasks are complete/failed, it reruns the
job again. This time, the server knows that 9 of its blocks are already
loaded and only one more needs to get loaded.

pr-link: #10704
change-id: cid-ac0708727c706624c6b30ede5165b60ed476b7e0

Also removed the active_jobs option because it was needlessly confusing.