### PR TITLE
Fix eventual consistency in contract test

### DIFF
--- a/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
+++ b/examples/src/main/java/alluxio/examples/UnderFileSystemCommonOperations.java
@@ -352,7 +352,7 @@ public final class UnderFileSystemCommonOperations {
       "listObjectsV2", "getObjectMetadata"})
   public void deleteLargeDirectoryTest() throws IOException {
     LargeDirectoryConfig config = prepareLargeDirectory();
-    mUfs.deleteDirectory(config.getTopLevelDirectory(),
+    mUfs.deleteExistingDirectory(config.getTopLevelDirectory(),
         DeleteOptions.defaults().setRecursive(true));
 
     String[] children = config.getChildren();


### PR DESCRIPTION
Deleting directory in object UFS is eventual consistent. Use the new API in contract test that properly retries delete for object UFS.