### PR TITLE
Refactor HiveConstant type checking

### DIFF
--- a/job/common/src/main/java/alluxio/job/plan/transform/HiveConstants.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/HiveConstants.java
@@ -97,5 +97,15 @@ public class HiveConstants {
     public static final String DECIMAL = "decimal";
     /** Hive binary type. */
     public static final String BINARY = "binary";
+
+    public static String getHiveConstantType(String type) {
+      // filters out the non hive type information from types like "char(10)"
+
+      int i = type.indexOf('(');
+      if (i == -1) {
+        return type;
+      }
+      return type.substring(0, i);
+    }
   }
 }

--- a/job/common/src/main/java/alluxio/job/plan/transform/HiveConstants.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/HiveConstants.java
@@ -98,6 +98,12 @@ public class HiveConstants {
     /** Hive binary type. */
     public static final String BINARY = "binary";
 
+    /**
+     * Filters out parts of type information to match the types constant for type checking.
+     *
+     * @param type the type
+     * @return type name matching the types constants
+     */
     public static String getHiveConstantType(String type) {
       // filters out the non hive type information from types like "char(10)"
 

--- a/job/common/src/test/java/alluxio/job/plan/transform/HiveConstantsTest.java
+++ b/job/common/src/test/java/alluxio/job/plan/transform/HiveConstantsTest.java
@@ -11,12 +11,12 @@
 
 package alluxio.job.plan.transform;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+
 /**
- * Test for {@link HiveConstants}
+ * Test for {@link HiveConstants}.
  */
 public class HiveConstantsTest {
 
@@ -28,5 +28,4 @@ public class HiveConstantsTest {
     assertEquals(HiveConstants.Types.DECIMAL,
         HiveConstants.Types.getHiveConstantType("decimal(10, 20)"));
   }
-
 }

--- a/job/common/src/test/java/alluxio/job/plan/transform/HiveConstantsTest.java
+++ b/job/common/src/test/java/alluxio/job/plan/transform/HiveConstantsTest.java
@@ -1,0 +1,32 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.job.plan.transform;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link HiveConstants}
+ */
+public class HiveConstantsTest {
+
+  @Test
+  public void testGetHiveConstantType() {
+    assertEquals(HiveConstants.Types.CHAR, HiveConstants.Types.getHiveConstantType("char(20)"));
+    assertEquals(HiveConstants.Types.VARCHAR,
+        HiveConstants.Types.getHiveConstantType("varchar(20)"));
+    assertEquals(HiveConstants.Types.DECIMAL,
+        HiveConstants.Types.getHiveConstantType("decimal(10, 20)"));
+  }
+
+}

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
@@ -89,7 +89,7 @@ public final class CsvRow implements TableRow {
     // cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes-dates
     // github.com/apache/parquet-format/blob/master/LogicalTypes.md
 
-    switch(HiveConstants.Types.getHiveConstantType(type)) {
+    switch (HiveConstants.Types.getHiveConstantType(type)) {
       case HiveConstants.Types.DECIMAL:
         // CSV: 12.34, precision=2, scale=4
         // Parquet: byte[] representation of number 123400

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
@@ -89,36 +89,35 @@ public final class CsvRow implements TableRow {
     // cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes-dates
     // github.com/apache/parquet-format/blob/master/LogicalTypes.md
 
-    if (type.startsWith(HiveConstants.Types.DECIMAL)) {
-      // CSV: 12.34, precision=2, scale=4
-      // Parquet: byte[] representation of number 123400
-      Decimal decimal = new Decimal(type);
-      return decimal.toParquetBytes(v);
+    switch(HiveConstants.Types.getHiveConstantType(type)) {
+      case HiveConstants.Types.DECIMAL:
+        // CSV: 12.34, precision=2, scale=4
+        // Parquet: byte[] representation of number 123400
+        Decimal decimal = new Decimal(type);
+        return decimal.toParquetBytes(v);
+      case HiveConstants.Types.BINARY:
+        // CSV: binary is encoded into base64, then encoded as UTF-8
+        // Parquet: the decoded byte array
+        return Base64.getDecoder().decode(v.getBytes(StandardCharsets.UTF_8));
+      case HiveConstants.Types.DATE:
+        // CSV: 2019-01-02
+        // Parquet: days from the Unix epoch
+        try {
+          return LocalDate.parse(v).toEpochDay();
+        } catch (Throwable e) {
+          throw new IOException("Failed to parse '" + v + "' as DATE: " + e);
+        }
+      case HiveConstants.Types.TIMESTAMP:
+        // CSV: 2019-10-29 10:17:42.338
+        // Parquet: milliseconds from the Unix epoch
+        try {
+          return Timestamp.valueOf(v).getTime();
+        } catch (Throwable e) {
+          throw new IOException("Failed to parse '" + v + "' as TIMESTAMP: " + e);
+        }
+      default:
+        throw new IOException("Unsupported type " + type + " for field " + name);
     }
-    if (type.equals(HiveConstants.Types.BINARY)) {
-      // CSV: binary is encoded into base64, then encoded as UTF-8
-      // Parquet: the decoded byte array
-      return Base64.getDecoder().decode(v.getBytes(StandardCharsets.UTF_8));
-    }
-    if (type.equals(HiveConstants.Types.DATE)) {
-      // CSV: 2019-01-02
-      // Parquet: days from the Unix epoch
-      try {
-        return LocalDate.parse(v).toEpochDay();
-      } catch (Throwable e) {
-        throw new IOException("Failed to parse '" + v + "' as DATE: " + e);
-      }
-    }
-    if (type.equals(HiveConstants.Types.TIMESTAMP)) {
-      // CSV: 2019-10-29 10:17:42.338
-      // Parquet: milliseconds from the Unix epoch
-      try {
-        return Timestamp.valueOf(v).getTime();
-      } catch (Throwable e) {
-        throw new IOException("Failed to parse '" + v + "' as TIMESTAMP: " + e);
-      }
-    }
-    throw new IOException("Unsupported type " + type + " for field " + name);
   }
 
   @Override

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvSchema.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvSchema.java
@@ -133,7 +133,7 @@ public final class CsvSchema implements TableSchema {
     String name = field.getName();
     String type = field.getType();
 
-    switch(HiveConstants.Types.getHiveConstantType(type)) {
+    switch (HiveConstants.Types.getHiveConstantType(type)) {
       case HiveConstants.Types.BOOLEAN:
         return assembler.optionalBoolean(name);
       case HiveConstants.Types.TINYINT:
@@ -185,7 +185,7 @@ public final class CsvSchema implements TableSchema {
     String type = field.getType();
     Schema schema;
 
-    switch(HiveConstants.Types.getHiveConstantType(type)) {
+    switch (HiveConstants.Types.getHiveConstantType(type)) {
       case HiveConstants.Types.DECIMAL:
         Decimal decimal = new Decimal(type);
         schema = LogicalTypes.decimal(decimal.getPrecision(), decimal.getScale())


### PR DESCRIPTION
Because of types like char(20) and what not, we use startswith instead of equals for some cases and this also prevents us from using switch statements. Standardize the types before checking to enable us to use switch statements.