### PR TITLE
Replace Source Code Pro with Anonymous Pro font

### DIFF
--- a/webui/common/package.json
+++ b/webui/common/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-regular-svg-icons": "5.7.2",
     "@fortawesome/free-solid-svg-icons": "5.7.2",
     "@fortawesome/react-fontawesome": "0.1.4",
+    "@openfonts/anonymous-pro_all": "^1.44.0",
     "bootstrap": "4.3.1",
     "bootswatch": "4.3.1",
     "jquery": "1.9.1",
@@ -17,7 +18,6 @@
     "react-router-dom": "4.3.1",
     "react-scripts": "2.1.5",
     "reactstrap": "7.1.0",
-    "source-code-pro": "^2.30.1",
     "source-sans-pro": "^2.45.0",
     "source-serif-pro": "^2.10.0"
   },

--- a/webui/common/src/constants/scss/_themeVariables.scss
+++ b/webui/common/src/constants/scss/_themeVariables.scss
@@ -13,5 +13,5 @@
 $web-font-path: ''; // override default font download path
 $font-family-sans-serif: 'Source Sans Pro', sans-serif !default;
 $font-family-serif: 'Source Serif Pro', serif !default;
-$font-family-monospace: 'Source Code Pro', monospace !default;
+$font-family-monospace: 'Anonymous Pro', monospace !default;
 $font-family-base: $font-family-sans-serif !default;

--- a/webui/common/src/index.tsx
+++ b/webui/common/src/index.tsx
@@ -17,7 +17,7 @@ import App from './App';
 
 import 'source-sans-pro/source-sans-pro.css';
 import 'source-serif-pro/source-serif-pro.css';
-import 'source-code-pro/source-code-pro.css';
+import '@openfonts/anonymous-pro_all';
 
 import './index.css';
 

--- a/webui/master/package.json
+++ b/webui/master/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/free-regular-svg-icons": "5.7.2",
     "@fortawesome/free-solid-svg-icons": "5.7.2",
     "@fortawesome/react-fontawesome": "0.1.4",
+    "@openfonts/anonymous-pro_all": "^1.44.0",
     "@nivo/line": "^0.52.1",
     "axios": "0.18.0",
     "babel-polyfill": "6.26.0",
@@ -25,7 +26,6 @@
     "reactstrap": "7.1.0",
     "redux": "4.0.1",
     "redux-saga": "1.0.1",
-    "source-code-pro": "^2.30.1",
     "source-sans-pro": "^2.45.0",
     "source-serif-pro": "^2.10.0",
     "typesafe-actions": "3.1.0"

--- a/webui/master/src/index.tsx
+++ b/webui/master/src/index.tsx
@@ -23,7 +23,7 @@ import { initialState } from './store';
 
 import 'source-sans-pro/source-sans-pro.css';
 import 'source-serif-pro/source-serif-pro.css';
-import 'source-code-pro/source-code-pro.css';
+import '@openfonts/anonymous-pro_all';
 
 import './index.css';
 import { IAppProps } from './containers/App/App';

--- a/webui/npm-shrinkwrap.json
+++ b/webui/npm-shrinkwrap.json
@@ -2135,6 +2135,11 @@
         "url-template": "^2.0.8"
       }
     },
+    "@openfonts/anonymous-pro_all": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/anonymous-pro_all/-/anonymous-pro_all-1.44.0.tgz",
+      "integrity": "sha512-ij3oL6OlNuWp/ZGSHG+DQazJ72oZWshAEjg020PyuqaYTY6qRkHaUCQBu0ViH7pVMqB1W1z+8TmzbKjepIIr0A=="
+    },
     "@redux-saga/core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
@@ -18975,11 +18980,6 @@
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
-    },
-    "source-code-pro": {
-      "version": "2.30.2",
-      "resolved": "https://registry.npmjs.org/source-code-pro/-/source-code-pro-2.30.2.tgz",
-      "integrity": "sha512-KctdxE5xBzf9wjYjTO9JWEQ1F2tdAR+yloz1rUmP5n0p6wEXB33B0myGTz49K6I3/EQpnJ9zot10r9ThQ+GARg=="
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/webui/worker/package.json
+++ b/webui/worker/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/free-regular-svg-icons": "5.7.2",
     "@fortawesome/free-solid-svg-icons": "5.7.2",
     "@fortawesome/react-fontawesome": "0.1.4",
+    "@openfonts/anonymous-pro_all": "^1.44.0",
     "axios": "0.18.0",
     "babel-polyfill": "6.26.0",
     "bootstrap": "4.3.1",
@@ -24,7 +25,6 @@
     "reactstrap": "7.1.0",
     "redux": "4.0.1",
     "redux-saga": "1.0.1",
-    "source-code-pro": "^2.30.1",
     "source-sans-pro": "^2.45.0",
     "source-serif-pro": "^2.10.0",
     "typesafe-actions": "3.1.0"

--- a/webui/worker/src/index.tsx
+++ b/webui/worker/src/index.tsx
@@ -23,7 +23,7 @@ import { initialState } from './store';
 
 import 'source-sans-pro/source-sans-pro.css';
 import 'source-serif-pro/source-serif-pro.css';
-import 'source-code-pro/source-code-pro.css';
+import '@openfonts/anonymous-pro_all';
 
 import './index.css';
 import { IAppProps } from './containers/App/App';


### PR DESCRIPTION
The reason I'm proposing replacing SCP with AP is because there is a
bug in  firefox and/or MacOS which causes this  font to render
incorrectly.

See:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1534503
- https://bugzilla.mozilla.org/show_bug.cgi?id=1520157

Anonymous Pro is a bit more lightweight and has at least  been recently
updated  by its maintainers (1.44.0 was 3 months ago). SCP is definitely
more ubiquitous  and well-maintained but I would rather have a font that
works everywhere. As an added bonus, this font is *much* more
lightweight than SCP.

Additionally, it seems the maintainers of the project have no desire to
address or look into what triggered the regression:
https://github.com/adobe-fonts/source-code-pro/issues/217