### PR TITLE
[DOCFIX] Remove ALLUXIO_RELEASED_VERSION from docs/_config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,19 +4,19 @@ kramdown:
   hard_wrap: false
   syntax_highlighter: rouge
 
-# For release candidates and release branches, this should match the pom.xml Alluxio version, e.g. "1.5.0" or "1.5.0-RC1"
-# For master branch, this should be the latest released version, e.g. "1.5.0"
-ALLUXIO_RELEASED_VERSION: 2.1.0
-# This should be the same as ALLUXIO_RELEASED_VERSION, except on master branch, where it should be "master"
-ALLUXIO_MASTER_VERSION_SHORT: master
-# For release candidates and release branches, this should be the major Alluxio version, e.g. both 1.5.0 and 1.5.0-RC1 should use "1.5"
-# For master branch, this should be "master"
-ALLUXIO_MAJOR_VERSION: master
-# The version string must match the version string part of the client jar path
+# The full version string
+# Used to match the version string portion of file paths, URLs, and dependency versions
+# e.g. client jar path,
 ALLUXIO_VERSION_STRING: 2.2.0-SNAPSHOT
 # We must inline the version string (e.g., "1.4.0-SNAPSHOT") rather than using the macro of Alluxio version.
 # Otherwise the macro name remains in the output.
 ALLUXIO_CLIENT_JAR_PATH: /<PATH_TO_ALLUXIO>/client/alluxio-2.2.0-SNAPSHOT-client.jar
+# For release branches, this should be the Alluxio version in the form of <major>.<minor>, e.g. both 1.5.0 and 1.5.0-RC1 should use "1.5"
+# For master branch, this should be "edge"
+# This should be used to reference versioned pages that are not relative to the docs/ directory
+# e.g. Javadoc:      https://docs.alluxio.io/os/javadoc/{{site.ALLUXIO_MAJOR_VERSION}}/master/index.html
+# e.g. REST API doc: https://docs.alluxio.io/os/restdoc/{{site.ALLUXIO_MAJOR_VERSION}}/master/index.html
+ALLUXIO_MAJOR_VERSION: edge
 # The version string must match the version of the K8s helm chart
 ALLUXIO_HELM_VERSION_STRING: 0.5.2
 

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -13,7 +13,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>{{ page.title }} - Alluxio {{site.ALLUXIO_MASTER_VERSION_SHORT}} Documentation</title>
+  <title>{{ page.title }} - Alluxio Documentation</title>
   <meta name="description" content="">
 
   <link rel="stylesheet" href="{{site.baseurl}}/css/bootstrap.min.css">
@@ -40,24 +40,6 @@
     your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install
     Google Chrome Frame</a> to better experience this site.</p>
 <![endif]-->
-
-  <!-- As a heading -->
-  <div class="">
-    <nav class="navbar navbar-dark bg-dark">
-      <div class="container">
-        <a href="/">
-          <div class="brand" style="display:table;">
-            <div style="position:relative;display:table-cell;vertical-align:middle;">
-              <img src="{{site.baseurl}}/img/logo-white.png" alt="Alluxio Logo" style="height:34px;" />
-              <div style="position:absolute;right:0;top:32px;text-shadow:none;">
-                <span class="navbar-brand mb-0 version">{{site.ALLUXIO_MASTER_VERSION_SHORT}}</span>
-              </div>
-            </div>
-          </div>
-        </a>
-      </div>
-    </nav>
-  </div>
 
   <div class="container">
     <div class="row">
@@ -112,7 +94,7 @@
                   <div class="dropdown-menu" aria-labelledby="LANGUAGE">
                     {% for singleLanguage in multiLanguagePages %}
                       <a href="{{site.baseurl}}{{singleLanguage.url}}" class="dropdown-item">{{singleLanguage.languageName}}</a>
-                    {% endfor %}    
+                    {% endfor %}
                   </div>
               </div>
             </li>

--- a/docs/cn/contributor/Building-Alluxio-From-Source.md
+++ b/docs/cn/contributor/Building-Alluxio-From-Source.md
@@ -23,10 +23,11 @@ priority: 0
 $ git clone git://github.com/alluxio/alluxio.git
 $ cd alluxio
 ```
-您可以编译特定版本的Alluxio，例如{{site.ALLUXIO_RELEASED_VERSION}}。否则这将编译源码的master分支。
+您可以编译特定版本的Alluxio否则这将编译源码的master分支。
 
 ```console
-$ git checkout v{{site.ALLUXIO_RELEASED_VERSION}}
+$ git tag
+$ git checkout <TAG_NAME>
 ```
 
 ### 编译

--- a/docs/cn/contributor/Building-Alluxio-From-Source.md
+++ b/docs/cn/contributor/Building-Alluxio-From-Source.md
@@ -23,7 +23,7 @@ priority: 0
 $ git clone git://github.com/alluxio/alluxio.git
 $ cd alluxio
 ```
-您可以编译特定版本的Alluxio否则这将编译源码的master分支。
+您可以编译特定版本的Alluxio，否则这将编译源码的master分支。
 
 ```console
 $ git tag

--- a/docs/cn/deploy/Running-Alluxio-Locally.md
+++ b/docs/cn/deploy/Running-Alluxio-Locally.md
@@ -13,7 +13,7 @@ priority: 1
 
 这部分的前提条件是你安装了[Java](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)(JDK 8或更高版本)。
 
-下载 [Alluxio](https://alluxio.io/download) 二进制发行版 {{site.ALLUXIO_RELEASED_VERSION}}:
+下载 [Alluxio](https://alluxio.io/download) 二进制发行版。
 
 在独立模式下运行，请执行以下操作：
 

--- a/docs/cn/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/cn/deploy/Running-Alluxio-On-Docker.md
@@ -141,7 +141,7 @@ $ docker build -t alluxio --build-arg ALLUXIO_TARBALL=alluxio-snapshot.tar.gz .
 
 远程压缩包:
 ```console
-$ docker build -t alluxio --build-arg ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz .
+$ docker build -t alluxio --build-arg ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_VERSION_STRING}}/alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz .
 ```
 
 # Alluxio配置属性

--- a/docs/cn/overview/Getting-Started.md
+++ b/docs/cn/overview/Getting-Started.md
@@ -35,16 +35,16 @@ priority: 1
 
 ## 下载 Alluxio
 
-首先，从[这里](http://www.alluxio.io/download)下载 Alluxio。选择为默认 Hadoop 版本构建的{{site.ALLUXIO_RELEASED_VERSION}}预编译版。
+首先，从[这里](http://www.alluxio.io/download)下载 Alluxio。选择为默认Hadoop版本构建的相应预编译版。
 
 接着，你可以用如下命令解压下载包。
 
 ```console
-$ tar -xzf alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz
-$ cd alluxio-{{site.ALLUXIO_RELEASED_VERSION}}
+$ tar -xzf alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz
+$ cd alluxio-{{site.ALLUXIO_VERSION_STRING}}
 ```
 
-这会创建一个包含所有的 Alluxio 源文件和 Java 二进制文件的文件夹`alluxio-{{site.ALLUXIO_RELEASED_VERSION}}`。在本教程中，这个文件夹的路径将被引用为`${ALLUXIO_HOME}`。
+这会创建一个包含所有的 Alluxio 源文件和 Java 二进制文件的文件夹`alluxio-{{site.ALLUXIO_VERSION_STRING}}`。在本教程中，这个文件夹的路径将被引用为`${ALLUXIO_HOME}`。
 
 ## 配置 Alluxio
 

--- a/docs/cn/overview/Getting-Started.md
+++ b/docs/cn/overview/Getting-Started.md
@@ -35,7 +35,7 @@ priority: 1
 
 ## 下载 Alluxio
 
-首先，从[这里](http://www.alluxio.io/download)下载 Alluxio。选择为默认Hadoop版本构建的相应预编译版。
+首先，从[这里](http://www.alluxio.io/download)下载 Alluxio。
 
 接着，你可以用如下命令解压下载包。
 

--- a/docs/cn/ufs/GCS.md
+++ b/docs/cn/ufs/GCS.md
@@ -47,26 +47,6 @@ fs.gcs.secretAccessKey=<GCS_SECRET_ACCESS_KEY>
 
 执行完以上步骤后，Alluxio应该已经配置GCS作为其底层文件系统，然后你可以尝试[使用GCS本地运行Alluxio](#running-alluxio-locally-with-gcs).
 
-## 配置应用依赖
-
-当使用Alluxio构建你的应用时，你的应用需要包含一个client模块，如果要使用[Alluxio file system interface](File-System-API.html)，那么需要配置`alluxio-core-client-fs`模块，如果需要使用[Hadoop file system interface](https://wiki.apache.org/hadoop/HCFS)，则需要使用`alluxio-core-client-hdfs`模块。
-举例来说，如果你正在使用 [maven](https://maven.apache.org/)，你可以通过添加以下代码来添加你的应用的依赖：
-
-```xml
-<!-- Alluxio file system interface -->
-<dependency>
-  <groupId>org.alluxio</groupId>
-  <artifactId>alluxio-core-client-fs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
-</dependency>
-<!-- HDFS file system interface -->
-<dependency>
-  <groupId>org.alluxio</groupId>
-  <artifactId>alluxio-core-client-hdfs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
-</dependency>
-```
-
 ## 使用GCS本地运行Alluxio
 
 完成所有的配置之后，你可以本地运行Alluxio,观察是否一切运行正常。

--- a/docs/cn/ufs/S3.md
+++ b/docs/cn/ufs/S3.md
@@ -106,13 +106,13 @@ alluxio.underfs.s3.proxy.port=<PROXY_PORT>
 <dependency>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-core-client-fs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
+  <version>{{site.ALLUXIO_VERSION_STRING}}</version>
 </dependency>
 <!-- HDFS file system interface -->
 <dependency>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-core-client-hdfs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
+  <version>{{site.ALLUXIO_VERSION_STRING}}</version>
 </dependency>
 ```
 

--- a/docs/en/cloud/AWS-EMR.md
+++ b/docs/en/cloud/AWS-EMR.md
@@ -74,17 +74,17 @@ The default instance type for the AMI is `r4.4xlarge`.
 - `applications`: Specify `Name=Spark Name=Presto Name=Hive` to bootstrap the three additional services
 - `name`: The EMR cluster name
 - `bootstrap-actions`:
-  - `Path`: The path to the bootstrap script, hosted in a publicly readable S3 bucket: `s3://alluxio-public/emr/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-emr.sh`
+  - `Path`: The path to the bootstrap script, hosted in a publicly readable S3 bucket: `s3://alluxio-public/emr/{{site.ALLUXIO_VERSION_STRING}}/alluxio-emr.sh`
   - `Args`: The arguments passed to the bootstrap script.
     - The first argument, the root UFS URI, is required.
     This S3 URI designates the root mount of the Alluxio file system and should be of the form `s3://bucket-name/mount-point`.
     The mount point should be a folder; follow [these instructions](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-folder.html) to create a folder in S3.
     - Specify the path to a publicly accessible Alluxio tarball with the `-d` flag.
-    For example, you can use the URL: `https://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz`
+    For example, you can use the URL: `https://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_VERSION_STRING}}/alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz`
     - You can also specify additional Alluxio properties as a delimited list of key-value pairs in the format `key=value`.
     For example, `alluxio.user.file.writetype.default=CACHE_THROUGH` instructs Alluxio to write files synchronously to the underlying storage system.
     See more about [write type options]({{ '/en/overview/Architecture.html#data-flow-write' | relativize_url }}).
-- `configurations`: The path to the configuration json file, also hosted in a publicly readable S3 bucket: `s3://alluxio-public/emr/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-emr.json`
+- `configurations`: The path to the configuration json file, also hosted in a publicly readable S3 bucket: `s3://alluxio-public/emr/{{site.ALLUXIO_VERSION_STRING}}/alluxio-emr.json`
 - `ec2-attributes`: EC2 settings to provide, most notably the name of the key pair to use to connect to the cluster
 
 Below is a sample command with all of the above flags populated:
@@ -99,12 +99,12 @@ $ aws emr create-cluster \
 --applications Name=Spark Name=Presto Name=Hive \
 --name try-alluxio \
 --bootstrap-actions \
-Path=s3://alluxio-public/emr/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-emr.sh,\
+Path=s3://alluxio-public/emr/{{site.ALLUXIO_VERSION_STRING}}/alluxio-emr.sh,\
 Args=[s3://myBucketName/mountPointFolder,\
--d,"https://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz",\
+-d,"https://downloads.alluxio.io/downloads/files/{{site.ALLUXIO_VERSION_STRING}}/alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz",\
 -p,"alluxio.user.block.size.bytes.default=122M|alluxio.user.file.writetype.default=CACHE_THROUGH",\
 -s,"|"] \
---configurations https://alluxio-public.s3.amazonaws.com/emr/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-emr.json \
+--configurations https://alluxio-public.s3.amazonaws.com/emr/{{site.ALLUXIO_VERSION_STRING}}/alluxio-emr.json \
 --ec2-attributes KeyName=myKeyPairName
 ```
 where `s3://myBucketName/mountPointFolder` should be replaced with a S3 URI that your AWS account can read and write to

--- a/docs/en/cloud/Google-Dataproc.md
+++ b/docs/en/cloud/Google-Dataproc.md
@@ -39,19 +39,19 @@ When creating a Dataproc cluster, Alluxio can be installed using an
 [initialization action](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/init-actions)
 
 The Alluxio initialization action is hosted in a publicly readable
-GCS location at **gs://alluxio-public/dataproc/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-dataproc.sh**.
+GCS location at **gs://alluxio-public/dataproc/{{site.ALLUXIO_VERSION_STRING}}/alluxio-dataproc.sh**.
 * A required argument is the root UFS URI using **alluxio_root_ufs_uri**.
 * Additional properties can be specified using the metadata key **alluxio_site_properties** delimited
 using `;`
 ```console
 $ gcloud dataproc clusters create <cluster_name> \
---initialization-actions gs://alluxio-public/dataproc/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-dataproc.sh \
+--initialization-actions gs://alluxio-public/dataproc/{{site.ALLUXIO_VERSION_STRING}}/alluxio-dataproc.sh \
 --metadata alluxio_root_ufs_uri=<gs://my_bucket>,alluxio_site_properties="alluxio.master.mount.table.root.option.fs.gcs.accessKeyId=<gcs_access_key_id>;alluxio.master.mount.table.root.option.fs.gcs.secretAccessKey=<gcs_secret_access_key>"
 ```
 * Additional files can be downloaded into `/opt/alluxio/conf` using the metadata key `alluxio_download_files_list` by specifying `http(s)` or `gs` uris delimited using `;`
 ```console
 $ gcloud dataproc clusters create <cluster_name> \
---initialization-actions gs://alluxio-public/dataproc/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-dataproc.sh \
+--initialization-actions gs://alluxio-public/dataproc/{{site.ALLUXIO_VERSION_STRING}}/alluxio-dataproc.sh \
 --metadata alluxio_root_ufs_uri=<under_storage_address>,alluxio_download_files_list="gs://$my_bucket/$my_file;https://$server/$file"
 ```
 
@@ -122,7 +122,7 @@ The Alluxio initialization script configures Presto for Alluxio.
 If installing the optional Presto component, Presto must be installed before Alluxio.
 Initialization action are executed sequentially and the Presto action must precede the Alluxio action.
 For instance, the sequence should be
-`--initialization-actions gs://dataproc-initialization-actions/presto/presto.sh,gs://alluxio-public/dataproc/{{site.ALLUXIO_RELEASED_VERSION}}/alluxio-dataproc.sh`
+`--initialization-actions gs://dataproc-initialization-actions/presto/presto.sh,gs://alluxio-public/dataproc/{{site.ALLUXIO_VERSION_STRING}}/alluxio-dataproc.sh`
 > Note: The Presto initialization action should install in the home directory `/opt/presto-server`
 > for Alluxio to be configured correctly.
 

--- a/docs/en/contributor/Building-Alluxio-From-Source.md
+++ b/docs/en/contributor/Building-Alluxio-From-Source.md
@@ -29,16 +29,9 @@ $ cd alluxio
 By default, cloning the repository will check out the master branch. If you are looking to build a
 particular version of the code you may check out the version using a git tag.
 
-For example to checkout the source for version v{{site.ALLUXIO_RELEASED_VERSION}}, run:
-
-```console
-$ git checkout v{{site.ALLUXIO_RELEASED_VERSION}}
-```
-
-To view a list of all possible versions you can run
-
 ```console
 $ git tag
+$ git checkout <TAG_NAME>
 ```
 
 ## Build

--- a/docs/en/core-services/Unified-Namespace.md
+++ b/docs/en/core-services/Unified-Namespace.md
@@ -121,7 +121,7 @@ Note that mount points can be nested as well. For example, if a UFS is mounted a
 
 ### Mount UFS with Specific Versions
 
-Alluxio v{{site.ALLUXIO_RELEASED_VERSION}} supports mounting HDFS with specified versions.
+Alluxio supports mounting HDFS with specified versions.
 As a result, users can mount HDFS with different versions into a single Alluxio namespace. Please
 refer to [HDFS Under Store]({{ '/en/ufs/HDFS.html' | relativize_url }}) for more details.
 

--- a/docs/en/deploy/Running-Alluxio-Locally.md
+++ b/docs/en/deploy/Running-Alluxio-Locally.md
@@ -17,8 +17,7 @@ The prerequisite for this part is that you have
 [Java](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (JDK 8
 or above) installed.
 
-[Download](https://alluxio.io/download) the binary distribution of Alluxio
-{{site.ALLUXIO_RELEASED_VERSION}}
+[Download](https://alluxio.io/download) the binary distribution of Alluxio.
 
 To run in standalone mode, do the following:
 

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -25,7 +25,7 @@ To deploy Alluxio in production, we highly recommend running Alluxio masters in
   nodes (including nodes running masters and workers).
   
   ```console
-  $ tar -xvzpf alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz
+  $ tar -xvzpf alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz
   ```
   
 * Enable SSH login without password from master node to worker nodes. You can add a public SSH key for

--- a/docs/en/overview/Getting-Started.md
+++ b/docs/en/overview/Getting-Started.md
@@ -33,9 +33,6 @@ If you are trying to speedup SQL analytics, you can try the Presto Alluxio Getti
  <img src="https://www.alluxio.io/app/uploads/2019/07/amazon-aws-ami.png" width="250" alt="AWS with AMI"/></a>
 </p>
 
-In addition, you can try more advanced testing with a cluster of Alluxio. 
-- Request [a sandbox cluster](https://www.alluxio.io/sandbox-request/) with Alluxio and Spark installed on AWS for free
-
 ## Prerequisites
 
 * MacOS or Linux
@@ -46,15 +43,15 @@ In addition, you can try more advanced testing with a cluster of Alluxio.
 ## Downloading Alluxio
 
 Download Alluxio from [this page](https://www.alluxio.io/download). Select the
-{{site.ALLUXIO_RELEASED_VERSION}} release followed by the distribution built for default Hadoop.
+desired release followed by the distribution built for default Hadoop.
 Unpack the downloaded file with the following commands.
 
 ```console
-$ tar -xzf alluxio-{{site.ALLUXIO_RELEASED_VERSION}}-bin.tar.gz
-$ cd alluxio-{{site.ALLUXIO_RELEASED_VERSION}}
+$ tar -xzf alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz
+$ cd alluxio-{{site.ALLUXIO_VERSION_STRING}}
 ```
 
-This creates a directory `alluxio-{{site.ALLUXIO_RELEASED_VERSION}}` with all of the Alluxio
+This creates a directory `alluxio-{{site.ALLUXIO_VERSION_STRING}}` with all of the Alluxio
 source files and Java binaries. Through this tutorial, the path of this directory will be referred
 to as `${ALLUXIO_HOME}`.
 

--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -47,7 +47,7 @@ Please visit the
 page for more information about support for other distributions.
 
 If everything succeeds, you should see
-`alluxio-assembly-server-{{site.ALLUXIO_RELEASED_VERSION}}-jar-with-dependencies.jar` created in
+`alluxio-assembly-server-{{site.ALLUXIO_VERSION_STRING}}-jar-with-dependencies.jar` created in
 the `${ALLUXIO_HOME}/assembly/server/target` directory.
 
 ## Basic Setup
@@ -245,7 +245,7 @@ alluxio.master.mount.table.root.option.alluxio.underfs.version=2.2
 
 #### Supported HDFS Versions
 
-Alluxio v{{site.ALLUXIO_RELEASED_VERSION}} supports the following versions of HDFS as a valid argument of mount option `alluxio.underfs.version`:
+Alluxio supports the following versions of HDFS as a valid argument of mount option `alluxio.underfs.version`:
 
 - Apache Hadoop: 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1
 

--- a/docs/en/ufs/S3.md
+++ b/docs/en/ufs/S3.md
@@ -175,7 +175,7 @@ Alluxio file system interface
 <dependency>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-core-client-fs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
+  <version>{{site.ALLUXIO_VERSION_STRING}}</version>
 </dependency>
 ```
 
@@ -184,7 +184,7 @@ HDFS file system interface
 <dependency>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-core-client-hdfs</artifactId>
-  <version>{{site.ALLUXIO_RELEASED_VERSION}}</version>
+  <version>{{site.ALLUXIO_VERSION_STRING}}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Update references to ALLUXIO_RELEASED_VERSION to be ALLUXIO_VERSION_STRING
Remove the even more obscure ALLUXIO_MASTER_VERSION_SHORT
Update ALLUXIO_MAJOR_VERSION on master to be "edge"

The concept of "most recently release version" changes as patches are released, but this update is not reflected outside of the branch where the patch was cut from
Instead of trying to update ALLUXIO_RELEASED_VERSION across multiple branches, use ALLUXIO_VERSION_STRING which will be correct in all branches except for master.
In the case of master, which is currently at 2.2.0-SNAPSHOT, it is likely there will be invalid references (ex. <version>2.2.0-SNAPSHOT</version> in the maven dependency declaration).
But I find this is to be more acceptable since it is a development branch.

In summary, this PR introduces inconsistencies in the master branch but corrects and simplifies version strings across all other release branches.