### PR TITLE
Support compiling with Java 11

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -92,6 +92,9 @@
     </profile>
     <profile>
       <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>javax.annotation</groupId>

--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -90,6 +90,15 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java11</id>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <build>

--- a/integration/checker/pom.xml
+++ b/integration/checker/pom.xml
@@ -119,6 +119,9 @@
   <profiles>
     <profile>
       <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>

--- a/integration/checker/pom.xml
+++ b/integration/checker/pom.xml
@@ -115,4 +115,38 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java11</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+          <version>${checker.hadoop.version}</version>
+          <exclusions>
+              <exclusion>
+                <groupId>jdk.tools</groupId>
+                <artifactId>jdk.tools</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>2.3.2</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.jamon</groupId>
+              <artifactId>jamon-runtime</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>jdk.tools</groupId>
+              <artifactId>jdk.tools</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     </repository>
     <repository>
       <id>alluxio.artifacts</id>
-      <url>https://alluxio.artifacts.s3-website-us-east-1.amazonaws.com/release</url>
+      <url>http://alluxio.artifacts.s3-website-us-east-1.amazonaws.com/release</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -977,6 +977,13 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>javax.xml.bind</groupId>
+              <artifactId>jaxb-api</artifactId>
+              <version>2.3.1</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1273,6 +1280,30 @@
       <modules>
         <module>integration/yarn</module>
       </modules>
+    </profile>
+
+    <profile>
+      <id>java11</id>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>8</source>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <!-- profile that Alluxio developers should use -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <repository>
       <id>mapr-repo</id>
       <name>MapR Repository</name>
-      <url>http://repository.mapr.com/maven/</url>
+      <url>https://repository.mapr.com/maven/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -103,7 +103,7 @@
       <!-- for Pivotal's distribution -->
       <id>spring-releases</id>
       <name>Spring Release Repository</name>
-      <url>http://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-release</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -114,7 +114,7 @@
     <repository>
       <id>HDPReleases</id>
       <name>HDP Releases</name>
-      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <url>https://repo.hortonworks.com/content/repositories/releases/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>
@@ -129,7 +129,7 @@
     </repository>
     <repository>
       <id>alluxio.artifacts</id>
-      <url>http://alluxio.artifacts.s3-website-us-east-1.amazonaws.com/release</url>
+      <url>https://alluxio.artifacts.s3-website-us-east-1.amazonaws.com/release</url>
     </repository>
   </repositories>
 
@@ -857,7 +857,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.8.1</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -1284,6 +1284,12 @@
 
     <profile>
       <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <properties>
+        <java.version>11</java.version>
+      </properties>
       <dependencyManagement>
         <dependencies>
           <dependency>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -50,6 +50,7 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
+
       </exclusions>
     </dependency>
 
@@ -124,4 +125,32 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java11</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>${hive-metastore.version}</version>
+          <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-1.2-api</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-slf4j-impl</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>jdk.tools</groupId>
+              <artifactId>jdk.tools</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -128,6 +128,9 @@
   <profiles>
     <profile>
       <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.hive</groupId>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -50,7 +50,6 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
-
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Use maven 3.6+ with JDK 11 and the flag -Pjava11 to enable the Java 11
profile. However, maven should activate the profile by default if it detects
your default is JDK 11

There is a long list of changes and incompatibilities between Java 8
and Java 11, only a few affected us for the most part though.

- The `jdk.tools` system dependency which is transitively depended
upon by `org.apache.hbase:hbase-annotations` no longer exists in
Java 11, so we exclude `jdk.tools:jdk.tools` throughout the codebase.
- The javax annotations are no longer a part of the JDK distribution,
but they are available as a backwards-compatible maven dependency
so we add that if we're compiling with Java 11.
- The swagger maven plugin which is used to generate the REST API
docs depends on a JAXB class which isn't a part of the JDK in Java 11
so we add that dependency for the plugin to function properly.
- The maven javadoc plugin has incompatibilities for docs in a certain
format from Java 8. Configure the plugin with `<source>8</source>`
to tell the plugin the sources use some Java 8 formats. See this
OpenJDK bug for more info:
https://bugs.openjdk.java.net/browse/JDK-8212233

Partially addresses #9856