### PR TITLE
Update table metadata from changes in UDB

### DIFF
--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -44,8 +44,19 @@ public final class AlluxioTestDirectory {
    * @return the created directory
    */
   public static File createTemporaryDirectory(String prefix) {
-    final File file = new File(ALLUXIO_TEST_DIRECTORY, prefix + "-" + UUID.randomUUID());
-    if (!file.mkdir()) {
+    return createTemporaryDirectory(ALLUXIO_TEST_DIRECTORY, prefix);
+  }
+
+  /**
+   * Creates a directory with the given prefix inside the Alluxio temporary directory.
+   *
+   * @param parent a parent directory
+   * @param prefix a prefix to use in naming the temporary directory
+   * @return the created directory
+   */
+  public static File createTemporaryDirectory(File parent, String prefix) {
+    final File file = new File(parent, prefix + "-" + UUID.randomUUID());
+    if (!file.mkdirs()) {
       throw new RuntimeException("Failed to create directory " + file.getAbsolutePath());
     }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryAssociation.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryAssociation.java
@@ -59,6 +59,7 @@ public final class JournalEntryAssociation {
     }
     if (entry.hasAttachDb()
         || entry.hasAddTable()
+        || entry.hasRemoveTable()
         || entry.hasDetachDb()
         || entry.hasUpdateDatabaseInfo()
         || entry.hasAddTransformJobInfo()

--- a/core/server/common/src/test/java/alluxio/master/journal/JournalEntryAssociationTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/JournalEntryAssociationTest.java
@@ -86,6 +86,7 @@ public class JournalEntryAssociationTest {
       JournalEntry.newBuilder().setPersistDirectory(PersistDirectoryEntry.getDefaultInstance()).build(),
       JournalEntry.newBuilder().setRemovePathProperties(RemovePathPropertiesEntry.getDefaultInstance()).build(),
       JournalEntry.newBuilder().setRemoveSyncPoint(RemoveSyncPointEntry.getDefaultInstance()).build(),
+      JournalEntry.newBuilder().setRemoveTable(Table.RemoveTableEntry.getDefaultInstance()).build(),
       JournalEntry.newBuilder().setRename(RenameEntry.getDefaultInstance()).build(),
       JournalEntry.newBuilder().setSetAcl(SetAclEntry.getDefaultInstance()).build(),
       JournalEntry.newBuilder().setSetAttribute(SetAttributeEntry.getDefaultInstance()).build(),

--- a/core/transport/src/grpc/table/table_master.proto
+++ b/core/transport/src/grpc/table/table_master.proto
@@ -35,6 +35,7 @@ message Database {
     optional string comment = 7;
 }
 
+// next available id: 12
 message TableInfo {
     optional string db_name = 1;
     optional string table_name = 2;
@@ -50,6 +51,10 @@ message TableInfo {
 
     // partitioning scheme
     repeated FieldSchema partition_cols = 8;
+
+    optional int64 previous_version = 9;
+    optional int64 version = 10;
+    optional int64 version_creation_time = 11;
 }
 
 // TODO(gpang): update

--- a/core/transport/src/grpc/table/table_master.proto
+++ b/core/transport/src/grpc/table/table_master.proto
@@ -79,6 +79,7 @@ message Transformation {
     optional string definition = 2;
 }
 
+// next available id: 6
 message Partition {
     optional PartitionSpec partition_spec = 1;
     optional Layout base_layout = 2;
@@ -86,6 +87,8 @@ message Partition {
      * The latest transformation is in the back of the list.
      */
     repeated Transformation transformations = 3;
+    optional int64 version = 4;
+    optional int64 version_creation_time = 5;
 }
 
 message ColumnStatisticsInfo {

--- a/core/transport/src/main/java/alluxio/grpc/MetricValue.java
+++ b/core/transport/src/main/java/alluxio/grpc/MetricValue.java
@@ -5,7 +5,7 @@ package alluxio.grpc;
 
 /**
  * <pre>
- * This type is used as a union, only one of doubleValue or longValue should be set
+ * This type is used as a union, only one of doubleValue or stringValue should be set
  * </pre>
  *
  * Protobuf type {@code alluxio.grpc.metric.MetricValue}
@@ -367,7 +367,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * This type is used as a union, only one of doubleValue or longValue should be set
+   * This type is used as a union, only one of doubleValue or stringValue should be set
    * </pre>
    *
    * Protobuf type {@code alluxio.grpc.metric.MetricValue}

--- a/core/transport/src/main/java/alluxio/grpc/table/Partition.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/Partition.java
@@ -4,6 +4,10 @@
 package alluxio.grpc.table;
 
 /**
+ * <pre>
+ * next available id: 6
+ * </pre>
+ *
  * Protobuf type {@code alluxio.grpc.table.Partition}
  */
 public  final class Partition extends
@@ -17,6 +21,8 @@ private static final long serialVersionUID = 0L;
   }
   private Partition() {
     transformations_ = java.util.Collections.emptyList();
+    version_ = 0L;
+    versionCreationTime_ = 0L;
   }
 
   @java.lang.Override
@@ -83,6 +89,16 @@ private static final long serialVersionUID = 0L;
             }
             transformations_.add(
                 input.readMessage(alluxio.grpc.table.Transformation.PARSER, extensionRegistry));
+            break;
+          }
+          case 32: {
+            bitField0_ |= 0x00000004;
+            version_ = input.readInt64();
+            break;
+          }
+          case 40: {
+            bitField0_ |= 0x00000008;
+            versionCreationTime_ = input.readInt64();
             break;
           }
         }
@@ -215,6 +231,36 @@ private static final long serialVersionUID = 0L;
     return transformations_.get(index);
   }
 
+  public static final int VERSION_FIELD_NUMBER = 4;
+  private long version_;
+  /**
+   * <code>optional int64 version = 4;</code>
+   */
+  public boolean hasVersion() {
+    return ((bitField0_ & 0x00000004) == 0x00000004);
+  }
+  /**
+   * <code>optional int64 version = 4;</code>
+   */
+  public long getVersion() {
+    return version_;
+  }
+
+  public static final int VERSION_CREATION_TIME_FIELD_NUMBER = 5;
+  private long versionCreationTime_;
+  /**
+   * <code>optional int64 version_creation_time = 5;</code>
+   */
+  public boolean hasVersionCreationTime() {
+    return ((bitField0_ & 0x00000008) == 0x00000008);
+  }
+  /**
+   * <code>optional int64 version_creation_time = 5;</code>
+   */
+  public long getVersionCreationTime() {
+    return versionCreationTime_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -248,6 +294,12 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < transformations_.size(); i++) {
       output.writeMessage(3, transformations_.get(i));
     }
+    if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      output.writeInt64(4, version_);
+    }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      output.writeInt64(5, versionCreationTime_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -267,6 +319,14 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < transformations_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, transformations_.get(i));
+    }
+    if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(4, version_);
+    }
+    if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(5, versionCreationTime_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -296,6 +356,16 @@ private static final long serialVersionUID = 0L;
     }
     result = result && getTransformationsList()
         .equals(other.getTransformationsList());
+    result = result && (hasVersion() == other.hasVersion());
+    if (hasVersion()) {
+      result = result && (getVersion()
+          == other.getVersion());
+    }
+    result = result && (hasVersionCreationTime() == other.hasVersionCreationTime());
+    if (hasVersionCreationTime()) {
+      result = result && (getVersionCreationTime()
+          == other.getVersionCreationTime());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -318,6 +388,16 @@ private static final long serialVersionUID = 0L;
     if (getTransformationsCount() > 0) {
       hash = (37 * hash) + TRANSFORMATIONS_FIELD_NUMBER;
       hash = (53 * hash) + getTransformationsList().hashCode();
+    }
+    if (hasVersion()) {
+      hash = (37 * hash) + VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getVersion());
+    }
+    if (hasVersionCreationTime()) {
+      hash = (37 * hash) + VERSION_CREATION_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getVersionCreationTime());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -413,6 +493,10 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * next available id: 6
+   * </pre>
+   *
    * Protobuf type {@code alluxio.grpc.table.Partition}
    */
   public static final class Builder extends
@@ -469,6 +553,10 @@ private static final long serialVersionUID = 0L;
       } else {
         transformationsBuilder_.clear();
       }
+      version_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000008);
+      versionCreationTime_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000010);
       return this;
     }
 
@@ -518,6 +606,14 @@ private static final long serialVersionUID = 0L;
       } else {
         result.transformations_ = transformationsBuilder_.build();
       }
+      if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        to_bitField0_ |= 0x00000004;
+      }
+      result.version_ = version_;
+      if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        to_bitField0_ |= 0x00000008;
+      }
+      result.versionCreationTime_ = versionCreationTime_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -591,6 +687,12 @@ private static final long serialVersionUID = 0L;
             transformationsBuilder_.addAllMessages(other.transformations_);
           }
         }
+      }
+      if (other.hasVersion()) {
+        setVersion(other.getVersion());
+      }
+      if (other.hasVersionCreationTime()) {
+        setVersionCreationTime(other.getVersionCreationTime());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1194,6 +1296,70 @@ private static final long serialVersionUID = 0L;
         transformations_ = null;
       }
       return transformationsBuilder_;
+    }
+
+    private long version_ ;
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public long getVersion() {
+      return version_;
+    }
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public Builder setVersion(long value) {
+      bitField0_ |= 0x00000008;
+      version_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public Builder clearVersion() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      version_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private long versionCreationTime_ ;
+    /**
+     * <code>optional int64 version_creation_time = 5;</code>
+     */
+    public boolean hasVersionCreationTime() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional int64 version_creation_time = 5;</code>
+     */
+    public long getVersionCreationTime() {
+      return versionCreationTime_;
+    }
+    /**
+     * <code>optional int64 version_creation_time = 5;</code>
+     */
+    public Builder setVersionCreationTime(long value) {
+      bitField0_ |= 0x00000010;
+      versionCreationTime_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 version_creation_time = 5;</code>
+     */
+    public Builder clearVersionCreationTime() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      versionCreationTime_ = 0L;
+      onChanged();
+      return this;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/table/PartitionOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/PartitionOrBuilder.java
@@ -81,4 +81,22 @@ public interface PartitionOrBuilder extends
    */
   alluxio.grpc.table.TransformationOrBuilder getTransformationsOrBuilder(
       int index);
+
+  /**
+   * <code>optional int64 version = 4;</code>
+   */
+  boolean hasVersion();
+  /**
+   * <code>optional int64 version = 4;</code>
+   */
+  long getVersion();
+
+  /**
+   * <code>optional int64 version_creation_time = 5;</code>
+   */
+  boolean hasVersionCreationTime();
+  /**
+   * <code>optional int64 version_creation_time = 5;</code>
+   */
+  long getVersionCreationTime();
 }

--- a/core/transport/src/main/java/alluxio/grpc/table/TableInfo.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/TableInfo.java
@@ -4,6 +4,10 @@
 package alluxio.grpc.table;
 
 /**
+ * <pre>
+ * next available id: 12
+ * </pre>
+ *
  * Protobuf type {@code alluxio.grpc.table.TableInfo}
  */
 public  final class TableInfo extends
@@ -21,6 +25,9 @@ private static final long serialVersionUID = 0L;
     type_ = 0;
     owner_ = "";
     partitionCols_ = java.util.Collections.emptyList();
+    previousVersion_ = 0L;
+    version_ = 0L;
+    versionCreationTime_ = 0L;
   }
 
   @java.lang.Override
@@ -129,6 +136,21 @@ private static final long serialVersionUID = 0L;
             }
             partitionCols_.add(
                 input.readMessage(alluxio.grpc.table.FieldSchema.PARSER, extensionRegistry));
+            break;
+          }
+          case 72: {
+            bitField0_ |= 0x00000040;
+            previousVersion_ = input.readInt64();
+            break;
+          }
+          case 80: {
+            bitField0_ |= 0x00000080;
+            version_ = input.readInt64();
+            break;
+          }
+          case 88: {
+            bitField0_ |= 0x00000100;
+            versionCreationTime_ = input.readInt64();
             break;
           }
         }
@@ -575,6 +597,51 @@ private static final long serialVersionUID = 0L;
     return partitionCols_.get(index);
   }
 
+  public static final int PREVIOUS_VERSION_FIELD_NUMBER = 9;
+  private long previousVersion_;
+  /**
+   * <code>optional int64 previous_version = 9;</code>
+   */
+  public boolean hasPreviousVersion() {
+    return ((bitField0_ & 0x00000040) == 0x00000040);
+  }
+  /**
+   * <code>optional int64 previous_version = 9;</code>
+   */
+  public long getPreviousVersion() {
+    return previousVersion_;
+  }
+
+  public static final int VERSION_FIELD_NUMBER = 10;
+  private long version_;
+  /**
+   * <code>optional int64 version = 10;</code>
+   */
+  public boolean hasVersion() {
+    return ((bitField0_ & 0x00000080) == 0x00000080);
+  }
+  /**
+   * <code>optional int64 version = 10;</code>
+   */
+  public long getVersion() {
+    return version_;
+  }
+
+  public static final int VERSION_CREATION_TIME_FIELD_NUMBER = 11;
+  private long versionCreationTime_;
+  /**
+   * <code>optional int64 version_creation_time = 11;</code>
+   */
+  public boolean hasVersionCreationTime() {
+    return ((bitField0_ & 0x00000100) == 0x00000100);
+  }
+  /**
+   * <code>optional int64 version_creation_time = 11;</code>
+   */
+  public long getVersionCreationTime() {
+    return versionCreationTime_;
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -620,6 +687,15 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < partitionCols_.size(); i++) {
       output.writeMessage(8, partitionCols_.get(i));
     }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      output.writeInt64(9, previousVersion_);
+    }
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      output.writeInt64(10, version_);
+    }
+    if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      output.writeInt64(11, versionCreationTime_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -662,6 +738,18 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < partitionCols_.size(); i++) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(8, partitionCols_.get(i));
+    }
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(9, previousVersion_);
+    }
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(10, version_);
+    }
+    if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(11, versionCreationTime_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -712,6 +800,21 @@ private static final long serialVersionUID = 0L;
         other.internalGetParameters());
     result = result && getPartitionColsList()
         .equals(other.getPartitionColsList());
+    result = result && (hasPreviousVersion() == other.hasPreviousVersion());
+    if (hasPreviousVersion()) {
+      result = result && (getPreviousVersion()
+          == other.getPreviousVersion());
+    }
+    result = result && (hasVersion() == other.hasVersion());
+    if (hasVersion()) {
+      result = result && (getVersion()
+          == other.getVersion());
+    }
+    result = result && (hasVersionCreationTime() == other.hasVersionCreationTime());
+    if (hasVersionCreationTime()) {
+      result = result && (getVersionCreationTime()
+          == other.getVersionCreationTime());
+    }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
   }
@@ -754,6 +857,21 @@ private static final long serialVersionUID = 0L;
     if (getPartitionColsCount() > 0) {
       hash = (37 * hash) + PARTITION_COLS_FIELD_NUMBER;
       hash = (53 * hash) + getPartitionColsList().hashCode();
+    }
+    if (hasPreviousVersion()) {
+      hash = (37 * hash) + PREVIOUS_VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getPreviousVersion());
+    }
+    if (hasVersion()) {
+      hash = (37 * hash) + VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getVersion());
+    }
+    if (hasVersionCreationTime()) {
+      hash = (37 * hash) + VERSION_CREATION_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getVersionCreationTime());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -849,6 +967,10 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * next available id: 12
+   * </pre>
+   *
    * Protobuf type {@code alluxio.grpc.table.TableInfo}
    */
   public static final class Builder extends
@@ -936,6 +1058,12 @@ private static final long serialVersionUID = 0L;
       } else {
         partitionColsBuilder_.clear();
       }
+      previousVersion_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000100);
+      version_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000200);
+      versionCreationTime_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000400);
       return this;
     }
 
@@ -1003,6 +1131,18 @@ private static final long serialVersionUID = 0L;
       } else {
         result.partitionCols_ = partitionColsBuilder_.build();
       }
+      if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+        to_bitField0_ |= 0x00000040;
+      }
+      result.previousVersion_ = previousVersion_;
+      if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+        to_bitField0_ |= 0x00000080;
+      }
+      result.version_ = version_;
+      if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
+        to_bitField0_ |= 0x00000100;
+      }
+      result.versionCreationTime_ = versionCreationTime_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -1096,6 +1236,15 @@ private static final long serialVersionUID = 0L;
             partitionColsBuilder_.addAllMessages(other.partitionCols_);
           }
         }
+      }
+      if (other.hasPreviousVersion()) {
+        setPreviousVersion(other.getPreviousVersion());
+      }
+      if (other.hasVersion()) {
+        setVersion(other.getVersion());
+      }
+      if (other.hasVersionCreationTime()) {
+        setVersionCreationTime(other.getVersionCreationTime());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -2063,6 +2212,102 @@ private static final long serialVersionUID = 0L;
         partitionCols_ = null;
       }
       return partitionColsBuilder_;
+    }
+
+    private long previousVersion_ ;
+    /**
+     * <code>optional int64 previous_version = 9;</code>
+     */
+    public boolean hasPreviousVersion() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional int64 previous_version = 9;</code>
+     */
+    public long getPreviousVersion() {
+      return previousVersion_;
+    }
+    /**
+     * <code>optional int64 previous_version = 9;</code>
+     */
+    public Builder setPreviousVersion(long value) {
+      bitField0_ |= 0x00000100;
+      previousVersion_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 previous_version = 9;</code>
+     */
+    public Builder clearPreviousVersion() {
+      bitField0_ = (bitField0_ & ~0x00000100);
+      previousVersion_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private long version_ ;
+    /**
+     * <code>optional int64 version = 10;</code>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional int64 version = 10;</code>
+     */
+    public long getVersion() {
+      return version_;
+    }
+    /**
+     * <code>optional int64 version = 10;</code>
+     */
+    public Builder setVersion(long value) {
+      bitField0_ |= 0x00000200;
+      version_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 version = 10;</code>
+     */
+    public Builder clearVersion() {
+      bitField0_ = (bitField0_ & ~0x00000200);
+      version_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private long versionCreationTime_ ;
+    /**
+     * <code>optional int64 version_creation_time = 11;</code>
+     */
+    public boolean hasVersionCreationTime() {
+      return ((bitField0_ & 0x00000400) == 0x00000400);
+    }
+    /**
+     * <code>optional int64 version_creation_time = 11;</code>
+     */
+    public long getVersionCreationTime() {
+      return versionCreationTime_;
+    }
+    /**
+     * <code>optional int64 version_creation_time = 11;</code>
+     */
+    public Builder setVersionCreationTime(long value) {
+      bitField0_ |= 0x00000400;
+      versionCreationTime_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 version_creation_time = 11;</code>
+     */
+    public Builder clearVersionCreationTime() {
+      bitField0_ = (bitField0_ & ~0x00000400);
+      versionCreationTime_ = 0L;
+      onChanged();
+      return this;
     }
     public final Builder setUnknownFields(
         final com.google.protobuf.UnknownFieldSet unknownFields) {

--- a/core/transport/src/main/java/alluxio/grpc/table/TableInfoOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/TableInfoOrBuilder.java
@@ -161,4 +161,31 @@ public interface TableInfoOrBuilder extends
    */
   alluxio.grpc.table.FieldSchemaOrBuilder getPartitionColsOrBuilder(
       int index);
+
+  /**
+   * <code>optional int64 previous_version = 9;</code>
+   */
+  boolean hasPreviousVersion();
+  /**
+   * <code>optional int64 previous_version = 9;</code>
+   */
+  long getPreviousVersion();
+
+  /**
+   * <code>optional int64 version = 10;</code>
+   */
+  boolean hasVersion();
+  /**
+   * <code>optional int64 version = 10;</code>
+   */
+  long getVersion();
+
+  /**
+   * <code>optional int64 version_creation_time = 11;</code>
+   */
+  boolean hasVersionCreationTime();
+  /**
+   * <code>optional int64 version_creation_time = 11;</code>
+   */
+  long getVersionCreationTime();
 }

--- a/core/transport/src/main/java/alluxio/grpc/table/TableMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/TableMasterProto.java
@@ -362,164 +362,165 @@ public final class TableMasterProto {
       "\0227\n\005value\030\002 \001(\0132(.alluxio.grpc.table.Col" +
       "umnStatisticsInfo:\0028\001\"P\n\016Transformation\022" +
       "*\n\006layout\030\001 \001(\0132\032.alluxio.grpc.table.Lay" +
-      "out\022\022\n\ndefinition\030\002 \001(\t\"\264\001\n\tPartition\0229\n" +
+      "out\022\022\n\ndefinition\030\002 \001(\t\"\344\001\n\tPartition\0229\n" +
       "\016partition_spec\030\001 \001(\0132!.alluxio.grpc.tab" +
       "le.PartitionSpec\022/\n\013base_layout\030\002 \001(\0132\032." +
       "alluxio.grpc.table.Layout\022;\n\017transformat" +
       "ions\030\003 \003(\0132\".alluxio.grpc.table.Transfor" +
-      "mation\"r\n\024ColumnStatisticsInfo\022\020\n\010col_na" +
-      "me\030\001 \001(\t\022\020\n\010col_type\030\002 \001(\t\0226\n\004data\030\003 \001(\013" +
-      "2(.alluxio.grpc.table.ColumnStatisticsDa" +
-      "ta\"\357\003\n\024ColumnStatisticsData\022C\n\rboolean_s" +
-      "tats\030\001 \001(\0132*.alluxio.grpc.table.BooleanC" +
-      "olumnStatsDataH\000\022=\n\nlong_stats\030\002 \001(\0132\'.a" +
-      "lluxio.grpc.table.LongColumnStatsDataH\000\022" +
-      "A\n\014double_stats\030\003 \001(\0132).alluxio.grpc.tab" +
-      "le.DoubleColumnStatsDataH\000\022A\n\014string_sta" +
-      "ts\030\004 \001(\0132).alluxio.grpc.table.StringColu" +
-      "mnStatsDataH\000\022A\n\014binary_stats\030\005 \001(\0132).al" +
-      "luxio.grpc.table.BinaryColumnStatsDataH\000" +
-      "\022C\n\rdecimal_stats\030\006 \001(\0132*.alluxio.grpc.t" +
-      "able.DecimalColumnStatsDataH\000\022=\n\ndate_st" +
-      "ats\030\007 \001(\0132\'.alluxio.grpc.table.DateColum" +
-      "nStatsDataH\000B\006\n\004data\"g\n\026BooleanColumnSta" +
-      "tsData\022\021\n\tnum_trues\030\001 \001(\003\022\022\n\nnum_falses\030" +
-      "\002 \001(\003\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_vectors\030" +
-      "\004 \001(\t\"{\n\023LongColumnStatsData\022\021\n\tlow_valu" +
-      "e\030\001 \001(\003\022\022\n\nhigh_value\030\002 \001(\003\022\021\n\tnum_nulls" +
-      "\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013bit_vec" +
-      "tors\030\005 \001(\t\"}\n\025DoubleColumnStatsData\022\021\n\tl" +
-      "ow_value\030\001 \001(\001\022\022\n\nhigh_value\030\002 \001(\001\022\021\n\tnu" +
-      "m_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013" +
-      "bit_vectors\030\005 \001(\t\"*\n\007Decimal\022\r\n\005scale\030\001 " +
-      "\002(\005\022\020\n\010unscaled\030\002 \002(\014\"\270\001\n\026DecimalColumnS" +
-      "tatsData\022.\n\tlow_value\030\001 \001(\0132\033.alluxio.gr" +
-      "pc.table.Decimal\022/\n\nhigh_value\030\002 \001(\0132\033.a" +
-      "lluxio.grpc.table.Decimal\022\021\n\tnum_nulls\030\003" +
-      " \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013bit_vecto" +
-      "rs\030\005 \001(\t\"\200\001\n\025StringColumnStatsData\022\023\n\013ma" +
-      "x_col_len\030\001 \001(\003\022\023\n\013avg_col_len\030\002 \001(\001\022\021\n\t" +
-      "num_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023" +
-      "\n\013bit_vectors\030\005 \001(\t\"i\n\025BinaryColumnStats" +
-      "Data\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg_col_len" +
-      "\030\002 \001(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_vectors" +
-      "\030\004 \001(\t\" \n\004Date\022\030\n\020days_since_epoch\030\001 \002(\003" +
-      "\"\257\001\n\023DateColumnStatsData\022+\n\tlow_value\030\001 " +
-      "\001(\0132\030.alluxio.grpc.table.Date\022,\n\nhigh_va" +
-      "lue\030\002 \001(\0132\030.alluxio.grpc.table.Date\022\021\n\tn" +
+      "mation\022\017\n\007version\030\004 \001(\003\022\035\n\025version_creat" +
+      "ion_time\030\005 \001(\003\"r\n\024ColumnStatisticsInfo\022\020" +
+      "\n\010col_name\030\001 \001(\t\022\020\n\010col_type\030\002 \001(\t\0226\n\004da" +
+      "ta\030\003 \001(\0132(.alluxio.grpc.table.ColumnStat" +
+      "isticsData\"\357\003\n\024ColumnStatisticsData\022C\n\rb" +
+      "oolean_stats\030\001 \001(\0132*.alluxio.grpc.table." +
+      "BooleanColumnStatsDataH\000\022=\n\nlong_stats\030\002" +
+      " \001(\0132\'.alluxio.grpc.table.LongColumnStat" +
+      "sDataH\000\022A\n\014double_stats\030\003 \001(\0132).alluxio." +
+      "grpc.table.DoubleColumnStatsDataH\000\022A\n\014st" +
+      "ring_stats\030\004 \001(\0132).alluxio.grpc.table.St" +
+      "ringColumnStatsDataH\000\022A\n\014binary_stats\030\005 " +
+      "\001(\0132).alluxio.grpc.table.BinaryColumnSta" +
+      "tsDataH\000\022C\n\rdecimal_stats\030\006 \001(\0132*.alluxi" +
+      "o.grpc.table.DecimalColumnStatsDataH\000\022=\n" +
+      "\ndate_stats\030\007 \001(\0132\'.alluxio.grpc.table.D" +
+      "ateColumnStatsDataH\000B\006\n\004data\"g\n\026BooleanC" +
+      "olumnStatsData\022\021\n\tnum_trues\030\001 \001(\003\022\022\n\nnum" +
+      "_falses\030\002 \001(\003\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_" +
+      "vectors\030\004 \001(\t\"{\n\023LongColumnStatsData\022\021\n\t" +
+      "low_value\030\001 \001(\003\022\022\n\nhigh_value\030\002 \001(\003\022\021\n\tn" +
       "um_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n" +
-      "\013bit_vectors\030\005 \001(\t\"\031\n\027GetAllDatabasesPRe" +
-      "quest\",\n\030GetAllDatabasesPResponse\022\020\n\010dat" +
-      "abase\030\001 \003(\t\"(\n\024GetAllTablesPRequest\022\020\n\010d" +
-      "atabase\030\001 \001(\t\"&\n\025GetAllTablesPResponse\022\r" +
-      "\n\005table\030\001 \003(\t\"&\n\023GetDatabasePRequest\022\017\n\007" +
-      "db_name\030\001 \001(\t\"@\n\024GetDatabasePResponse\022(\n" +
-      "\002db\030\001 \001(\0132\034.alluxio.grpc.table.Database\"" +
-      "7\n\020GetTablePRequest\022\017\n\007db_name\030\001 \001(\t\022\022\n\n" +
-      "table_name\030\002 \001(\t\"F\n\021GetTablePResponse\0221\n" +
-      "\ntable_info\030\001 \001(\0132\035.alluxio.grpc.table.T" +
-      "ableInfo\"\346\001\n\026AttachDatabasePRequest\022\020\n\010u" +
-      "db_type\030\001 \001(\t\022\032\n\022udb_connection_uri\030\002 \001(" +
-      "\t\022\023\n\013udb_db_name\030\003 \001(\t\022\017\n\007db_name\030\004 \001(\t\022" +
-      "H\n\007options\030\005 \003(\01327.alluxio.grpc.table.At" +
-      "tachDatabasePRequest.OptionsEntry\032.\n\014Opt" +
-      "ionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028" +
-      "\001\"*\n\027AttachDatabasePResponse\022\017\n\007success\030" +
-      "\001 \001(\010\")\n\026DetachDatabasePRequest\022\017\n\007db_na" +
-      "me\030\001 \001(\t\"*\n\027DetachDatabasePResponse\022\017\n\007s" +
-      "uccess\030\001 \001(\010\"\'\n\024SyncDatabasePRequest\022\017\n\007" +
-      "db_name\030\001 \001(\t\"(\n\025SyncDatabasePResponse\022\017" +
-      "\n\007success\030\001 \001(\010\"\251\001\n\016FileStatistics\022>\n\006co" +
-      "lumn\030\001 \003(\0132..alluxio.grpc.table.FileStat" +
-      "istics.ColumnEntry\032W\n\013ColumnEntry\022\013\n\003key" +
-      "\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.alluxio.grpc.tab" +
-      "le.ColumnStatisticsInfo:\0028\001\"Z\n GetTableC" +
-      "olumnStatisticsPRequest\022\017\n\007db_name\030\001 \001(\t" +
-      "\022\022\n\ntable_name\030\002 \001(\t\022\021\n\tcol_names\030\003 \003(\t\"" +
-      "r\n$GetPartitionColumnStatisticsPRequest\022" +
-      "\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\021\n\t" +
-      "col_names\030\003 \003(\t\022\022\n\npart_names\030\004 \003(\t\"a\n!G" +
-      "etTableColumnStatisticsPResponse\022<\n\nstat" +
-      "istics\030\001 \003(\0132(.alluxio.grpc.table.Column" +
-      "StatisticsInfo\"T\n\024ColumnStatisticsList\022<" +
-      "\n\nstatistics\030\001 \003(\0132(.alluxio.grpc.table." +
-      "ColumnStatisticsInfo\"\377\001\n%GetPartitionCol" +
-      "umnStatisticsPResponse\022p\n\024partition_stat" +
-      "istics\030\001 \003(\0132R.alluxio.grpc.table.GetPar" +
-      "titionColumnStatisticsPResponse.Partitio" +
-      "nStatisticsEntry\032d\n\030PartitionStatisticsE" +
-      "ntry\022\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.allux" +
-      "io.grpc.table.ColumnStatisticsList:\0028\001\"k" +
-      "\n\005Value\022\023\n\tlong_type\030\001 \001(\003H\000\022\025\n\013double_t" +
-      "ype\030\002 \001(\001H\000\022\025\n\013string_type\030\003 \001(\tH\000\022\026\n\014bo" +
-      "olean_type\030\004 \001(\010H\000B\007\n\005value\"X\n\005Range\022&\n\003" +
-      "low\030\001 \001(\0132\031.alluxio.grpc.table.Value\022\'\n\004" +
-      "high\030\002 \001(\0132\031.alluxio.grpc.table.Value\"5\n" +
-      "\010RangeSet\022)\n\006ranges\030\001 \003(\0132\031.alluxio.grpc" +
-      ".table.Range\"V\n\021EquatableValueSet\022-\n\ncan" +
-      "didates\030\001 \003(\0132\031.alluxio.grpc.table.Value" +
-      "\022\022\n\nwhite_list\030\002 \001(\010\"\033\n\014AllOrNoneSet\022\013\n\003" +
-      "all\030\001 \001(\010\"\271\001\n\006Domain\022-\n\005range\030\001 \001(\0132\034.al" +
-      "luxio.grpc.table.RangeSetH\000\022:\n\tequatable" +
-      "\030\002 \001(\0132%.alluxio.grpc.table.EquatableVal" +
-      "ueSetH\000\0227\n\013all_or_none\030\003 \001(\0132 .alluxio.g" +
-      "rpc.table.AllOrNoneSetH\000B\013\n\tvalue_set\"\265\001" +
-      "\n\nConstraint\022Q\n\022column_constraints\030\001 \003(\013" +
-      "25.alluxio.grpc.table.Constraint.ColumnC" +
-      "onstraintsEntry\032T\n\026ColumnConstraintsEntr" +
-      "y\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.alluxio." +
-      "grpc.table.Domain:\0028\001\"l\n\021ReadTablePReque" +
-      "st\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022" +
-      "2\n\nconstraint\030\003 \001(\0132\036.alluxio.grpc.table" +
-      ".Constraint\"G\n\022ReadTablePResponse\0221\n\npar" +
-      "titions\030\001 \003(\0132\035.alluxio.grpc.table.Parti" +
-      "tion\"Q\n\026TransformTablePRequest\022\017\n\007db_nam" +
-      "e\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\022\n\ndefinitio" +
-      "n\030\003 \001(\t\")\n\027TransformTablePResponse\022\016\n\006jo" +
-      "b_id\030\001 \001(\003\"-\n\033GetTransformJobInfoPReques" +
-      "t\022\016\n\006job_id\030\001 \001(\003\"\234\001\n\020TransformJobInfo\022\017" +
+      "\013bit_vectors\030\005 \001(\t\"}\n\025DoubleColumnStatsD" +
+      "ata\022\021\n\tlow_value\030\001 \001(\001\022\022\n\nhigh_value\030\002 \001" +
+      "(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004" +
+      " \001(\003\022\023\n\013bit_vectors\030\005 \001(\t\"*\n\007Decimal\022\r\n\005" +
+      "scale\030\001 \002(\005\022\020\n\010unscaled\030\002 \002(\014\"\270\001\n\026Decima" +
+      "lColumnStatsData\022.\n\tlow_value\030\001 \001(\0132\033.al" +
+      "luxio.grpc.table.Decimal\022/\n\nhigh_value\030\002" +
+      " \001(\0132\033.alluxio.grpc.table.Decimal\022\021\n\tnum" +
+      "_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013b" +
+      "it_vectors\030\005 \001(\t\"\200\001\n\025StringColumnStatsDa" +
+      "ta\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg_col_len\030\002" +
+      " \001(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts" +
+      "\030\004 \001(\003\022\023\n\013bit_vectors\030\005 \001(\t\"i\n\025BinaryCol" +
+      "umnStatsData\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg" +
+      "_col_len\030\002 \001(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit" +
+      "_vectors\030\004 \001(\t\" \n\004Date\022\030\n\020days_since_epo" +
+      "ch\030\001 \002(\003\"\257\001\n\023DateColumnStatsData\022+\n\tlow_" +
+      "value\030\001 \001(\0132\030.alluxio.grpc.table.Date\022,\n" +
+      "\nhigh_value\030\002 \001(\0132\030.alluxio.grpc.table.D" +
+      "ate\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030" +
+      "\004 \001(\003\022\023\n\013bit_vectors\030\005 \001(\t\"\031\n\027GetAllData" +
+      "basesPRequest\",\n\030GetAllDatabasesPRespons" +
+      "e\022\020\n\010database\030\001 \003(\t\"(\n\024GetAllTablesPRequ" +
+      "est\022\020\n\010database\030\001 \001(\t\"&\n\025GetAllTablesPRe" +
+      "sponse\022\r\n\005table\030\001 \003(\t\"&\n\023GetDatabasePReq" +
+      "uest\022\017\n\007db_name\030\001 \001(\t\"@\n\024GetDatabasePRes" +
+      "ponse\022(\n\002db\030\001 \001(\0132\034.alluxio.grpc.table.D" +
+      "atabase\"7\n\020GetTablePRequest\022\017\n\007db_name\030\001" +
+      " \001(\t\022\022\n\ntable_name\030\002 \001(\t\"F\n\021GetTablePRes" +
+      "ponse\0221\n\ntable_info\030\001 \001(\0132\035.alluxio.grpc" +
+      ".table.TableInfo\"\346\001\n\026AttachDatabasePRequ" +
+      "est\022\020\n\010udb_type\030\001 \001(\t\022\032\n\022udb_connection_" +
+      "uri\030\002 \001(\t\022\023\n\013udb_db_name\030\003 \001(\t\022\017\n\007db_nam" +
+      "e\030\004 \001(\t\022H\n\007options\030\005 \003(\01327.alluxio.grpc." +
+      "table.AttachDatabasePRequest.OptionsEntr" +
+      "y\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030" +
+      "\002 \001(\t:\0028\001\"*\n\027AttachDatabasePResponse\022\017\n\007" +
+      "success\030\001 \001(\010\")\n\026DetachDatabasePRequest\022" +
+      "\017\n\007db_name\030\001 \001(\t\"*\n\027DetachDatabasePRespo" +
+      "nse\022\017\n\007success\030\001 \001(\010\"\'\n\024SyncDatabasePReq" +
+      "uest\022\017\n\007db_name\030\001 \001(\t\"(\n\025SyncDatabasePRe" +
+      "sponse\022\017\n\007success\030\001 \001(\010\"\251\001\n\016FileStatisti" +
+      "cs\022>\n\006column\030\001 \003(\0132..alluxio.grpc.table." +
+      "FileStatistics.ColumnEntry\032W\n\013ColumnEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.alluxio." +
+      "grpc.table.ColumnStatisticsInfo:\0028\001\"Z\n G" +
+      "etTableColumnStatisticsPRequest\022\017\n\007db_na" +
+      "me\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\021\n\tcol_name" +
+      "s\030\003 \003(\t\"r\n$GetPartitionColumnStatisticsP" +
+      "Request\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002" +
+      " \001(\t\022\021\n\tcol_names\030\003 \003(\t\022\022\n\npart_names\030\004 " +
+      "\003(\t\"a\n!GetTableColumnStatisticsPResponse" +
+      "\022<\n\nstatistics\030\001 \003(\0132(.alluxio.grpc.tabl" +
+      "e.ColumnStatisticsInfo\"T\n\024ColumnStatisti" +
+      "csList\022<\n\nstatistics\030\001 \003(\0132(.alluxio.grp" +
+      "c.table.ColumnStatisticsInfo\"\377\001\n%GetPart" +
+      "itionColumnStatisticsPResponse\022p\n\024partit" +
+      "ion_statistics\030\001 \003(\0132R.alluxio.grpc.tabl" +
+      "e.GetPartitionColumnStatisticsPResponse." +
+      "PartitionStatisticsEntry\032d\n\030PartitionSta" +
+      "tisticsEntry\022\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\013" +
+      "2(.alluxio.grpc.table.ColumnStatisticsLi" +
+      "st:\0028\001\"k\n\005Value\022\023\n\tlong_type\030\001 \001(\003H\000\022\025\n\013" +
+      "double_type\030\002 \001(\001H\000\022\025\n\013string_type\030\003 \001(\t" +
+      "H\000\022\026\n\014boolean_type\030\004 \001(\010H\000B\007\n\005value\"X\n\005R" +
+      "ange\022&\n\003low\030\001 \001(\0132\031.alluxio.grpc.table.V" +
+      "alue\022\'\n\004high\030\002 \001(\0132\031.alluxio.grpc.table." +
+      "Value\"5\n\010RangeSet\022)\n\006ranges\030\001 \003(\0132\031.allu" +
+      "xio.grpc.table.Range\"V\n\021EquatableValueSe" +
+      "t\022-\n\ncandidates\030\001 \003(\0132\031.alluxio.grpc.tab" +
+      "le.Value\022\022\n\nwhite_list\030\002 \001(\010\"\033\n\014AllOrNon" +
+      "eSet\022\013\n\003all\030\001 \001(\010\"\271\001\n\006Domain\022-\n\005range\030\001 " +
+      "\001(\0132\034.alluxio.grpc.table.RangeSetH\000\022:\n\te" +
+      "quatable\030\002 \001(\0132%.alluxio.grpc.table.Equa" +
+      "tableValueSetH\000\0227\n\013all_or_none\030\003 \001(\0132 .a" +
+      "lluxio.grpc.table.AllOrNoneSetH\000B\013\n\tvalu" +
+      "e_set\"\265\001\n\nConstraint\022Q\n\022column_constrain" +
+      "ts\030\001 \003(\01325.alluxio.grpc.table.Constraint" +
+      ".ColumnConstraintsEntry\032T\n\026ColumnConstra" +
+      "intsEntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032." +
+      "alluxio.grpc.table.Domain:\0028\001\"l\n\021ReadTab" +
+      "lePRequest\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_nam" +
+      "e\030\002 \001(\t\0222\n\nconstraint\030\003 \001(\0132\036.alluxio.gr" +
+      "pc.table.Constraint\"G\n\022ReadTablePRespons" +
+      "e\0221\n\npartitions\030\001 \003(\0132\035.alluxio.grpc.tab" +
+      "le.Partition\"Q\n\026TransformTablePRequest\022\017" +
       "\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\022\n\nd" +
-      "efinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(\003\022,\n\njob_s" +
-      "tatus\030\005 \001(\0162\030.alluxio.grpc.job.Status\022\021\n" +
-      "\tjob_error\030\006 \001(\t\"R\n\034GetTransformJobInfoP" +
-      "Response\0222\n\004info\030\001 \003(\0132$.alluxio.grpc.ta" +
-      "ble.TransformJobInfo*#\n\rPrincipalType\022\010\n" +
-      "\004USER\020\000\022\010\n\004ROLE\020\0012\304\n\n\030TableMasterClientS" +
-      "ervice\022l\n\017GetAllDatabases\022+.alluxio.grpc" +
-      ".table.GetAllDatabasesPRequest\032,.alluxio" +
-      ".grpc.table.GetAllDatabasesPResponse\022c\n\014" +
-      "GetAllTables\022(.alluxio.grpc.table.GetAll" +
-      "TablesPRequest\032).alluxio.grpc.table.GetA" +
-      "llTablesPResponse\022`\n\013GetDatabase\022\'.allux" +
-      "io.grpc.table.GetDatabasePRequest\032(.allu" +
-      "xio.grpc.table.GetDatabasePResponse\022W\n\010G" +
-      "etTable\022$.alluxio.grpc.table.GetTablePRe" +
-      "quest\032%.alluxio.grpc.table.GetTablePResp" +
-      "onse\022i\n\016AttachDatabase\022*.alluxio.grpc.ta" +
-      "ble.AttachDatabasePRequest\032+.alluxio.grp" +
-      "c.table.AttachDatabasePResponse\022i\n\016Detac" +
-      "hDatabase\022*.alluxio.grpc.table.DetachDat" +
-      "abasePRequest\032+.alluxio.grpc.table.Detac" +
-      "hDatabasePResponse\022c\n\014SyncDatabase\022(.all" +
-      "uxio.grpc.table.SyncDatabasePRequest\032).a" +
-      "lluxio.grpc.table.SyncDatabasePResponse\022" +
-      "\207\001\n\030GetTableColumnStatistics\0224.alluxio.g" +
-      "rpc.table.GetTableColumnStatisticsPReque" +
-      "st\0325.alluxio.grpc.table.GetTableColumnSt" +
-      "atisticsPResponse\022\223\001\n\034GetPartitionColumn" +
-      "Statistics\0228.alluxio.grpc.table.GetParti" +
-      "tionColumnStatisticsPRequest\0329.alluxio.g" +
-      "rpc.table.GetPartitionColumnStatisticsPR" +
-      "esponse\022Z\n\tReadTable\022%.alluxio.grpc.tabl" +
-      "e.ReadTablePRequest\032&.alluxio.grpc.table" +
-      ".ReadTablePResponse\022i\n\016TransformTable\022*." +
-      "alluxio.grpc.table.TransformTablePReques" +
-      "t\032+.alluxio.grpc.table.TransformTablePRe" +
-      "sponse\022x\n\023GetTransformJobInfo\022/.alluxio." +
-      "grpc.table.GetTransformJobInfoPRequest\0320" +
-      ".alluxio.grpc.table.GetTransformJobInfoP" +
-      "ResponseB(\n\022alluxio.grpc.tableB\020TableMas" +
-      "terProtoP\001"
+      "efinition\030\003 \001(\t\")\n\027TransformTablePRespon" +
+      "se\022\016\n\006job_id\030\001 \001(\003\"-\n\033GetTransformJobInf" +
+      "oPRequest\022\016\n\006job_id\030\001 \001(\003\"\234\001\n\020TransformJ" +
+      "obInfo\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 " +
+      "\001(\t\022\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(\003\022" +
+      ",\n\njob_status\030\005 \001(\0162\030.alluxio.grpc.job.S" +
+      "tatus\022\021\n\tjob_error\030\006 \001(\t\"R\n\034GetTransform" +
+      "JobInfoPResponse\0222\n\004info\030\001 \003(\0132$.alluxio" +
+      ".grpc.table.TransformJobInfo*#\n\rPrincipa" +
+      "lType\022\010\n\004USER\020\000\022\010\n\004ROLE\020\0012\304\n\n\030TableMaste" +
+      "rClientService\022l\n\017GetAllDatabases\022+.allu" +
+      "xio.grpc.table.GetAllDatabasesPRequest\032," +
+      ".alluxio.grpc.table.GetAllDatabasesPResp" +
+      "onse\022c\n\014GetAllTables\022(.alluxio.grpc.tabl" +
+      "e.GetAllTablesPRequest\032).alluxio.grpc.ta" +
+      "ble.GetAllTablesPResponse\022`\n\013GetDatabase" +
+      "\022\'.alluxio.grpc.table.GetDatabasePReques" +
+      "t\032(.alluxio.grpc.table.GetDatabasePRespo" +
+      "nse\022W\n\010GetTable\022$.alluxio.grpc.table.Get" +
+      "TablePRequest\032%.alluxio.grpc.table.GetTa" +
+      "blePResponse\022i\n\016AttachDatabase\022*.alluxio" +
+      ".grpc.table.AttachDatabasePRequest\032+.all" +
+      "uxio.grpc.table.AttachDatabasePResponse\022" +
+      "i\n\016DetachDatabase\022*.alluxio.grpc.table.D" +
+      "etachDatabasePRequest\032+.alluxio.grpc.tab" +
+      "le.DetachDatabasePResponse\022c\n\014SyncDataba" +
+      "se\022(.alluxio.grpc.table.SyncDatabasePReq" +
+      "uest\032).alluxio.grpc.table.SyncDatabasePR" +
+      "esponse\022\207\001\n\030GetTableColumnStatistics\0224.a" +
+      "lluxio.grpc.table.GetTableColumnStatisti" +
+      "csPRequest\0325.alluxio.grpc.table.GetTable" +
+      "ColumnStatisticsPResponse\022\223\001\n\034GetPartiti" +
+      "onColumnStatistics\0228.alluxio.grpc.table." +
+      "GetPartitionColumnStatisticsPRequest\0329.a" +
+      "lluxio.grpc.table.GetPartitionColumnStat" +
+      "isticsPResponse\022Z\n\tReadTable\022%.alluxio.g" +
+      "rpc.table.ReadTablePRequest\032&.alluxio.gr" +
+      "pc.table.ReadTablePResponse\022i\n\016Transform" +
+      "Table\022*.alluxio.grpc.table.TransformTabl" +
+      "ePRequest\032+.alluxio.grpc.table.Transform" +
+      "TablePResponse\022x\n\023GetTransformJobInfo\022/." +
+      "alluxio.grpc.table.GetTransformJobInfoPR" +
+      "equest\0320.alluxio.grpc.table.GetTransform" +
+      "JobInfoPResponseB(\n\022alluxio.grpc.tableB\020" +
+      "TableMasterProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -606,7 +607,7 @@ public final class TableMasterProto {
     internal_static_alluxio_grpc_table_Partition_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_table_Partition_descriptor,
-        new java.lang.String[] { "PartitionSpec", "BaseLayout", "Transformations", });
+        new java.lang.String[] { "PartitionSpec", "BaseLayout", "Transformations", "Version", "VersionCreationTime", });
     internal_static_alluxio_grpc_table_ColumnStatisticsInfo_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_alluxio_grpc_table_ColumnStatisticsInfo_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/table/TableMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/table/TableMasterProto.java
@@ -340,7 +340,7 @@ public final class TableMasterProto {
       "wner_name\030\005 \001(\t\0225\n\nowner_type\030\006 \001(\0162!.al" +
       "luxio.grpc.table.PrincipalType\022\017\n\007commen" +
       "t\030\007 \001(\t\0320\n\016ParameterEntry\022\013\n\003key\030\001 \001(\t\022\r" +
-      "\n\005value\030\002 \001(\t:\0028\001\"\244\003\n\tTableInfo\022\017\n\007db_na" +
+      "\n\005value\030\002 \001(\t:\0028\001\"\356\003\n\tTableInfo\022\017\n\007db_na" +
       "me\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\0225\n\004type\030\003 \001" +
       "(\0162\'.alluxio.grpc.table.TableInfo.TableT" +
       "ype\022\r\n\005owner\030\004 \001(\t\022*\n\006schema\030\005 \001(\0132\032.all" +
@@ -348,176 +348,178 @@ public final class TableMasterProto {
       ".alluxio.grpc.table.Layout\022A\n\nparameters" +
       "\030\007 \003(\0132-.alluxio.grpc.table.TableInfo.Pa" +
       "rametersEntry\0227\n\016partition_cols\030\010 \003(\0132\037." +
-      "alluxio.grpc.table.FieldSchema\0321\n\017Parame" +
-      "tersEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028" +
-      "\001\"%\n\tTableType\022\n\n\006NATIVE\020\000\022\014\n\010IMPORTED\020\001" +
-      "\"\032\n\nLayoutSpec\022\014\n\004spec\030\001 \001(\t\"\035\n\rPartitio" +
-      "nSpec\022\014\n\004spec\030\001 \001(\t\"\365\001\n\006Layout\022\023\n\013layout" +
-      "_type\030\001 \001(\t\0223\n\013layout_spec\030\002 \001(\0132\036.allux" +
-      "io.grpc.table.LayoutSpec\022\023\n\013layout_data\030" +
-      "\003 \001(\014\0224\n\005stats\030\004 \003(\0132%.alluxio.grpc.tabl" +
-      "e.Layout.StatsEntry\032V\n\nStatsEntry\022\013\n\003key" +
+      "alluxio.grpc.table.FieldSchema\022\030\n\020previo" +
+      "us_version\030\t \001(\003\022\017\n\007version\030\n \001(\003\022\035\n\025ver" +
+      "sion_creation_time\030\013 \001(\003\0321\n\017ParametersEn" +
+      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"%\n\tT" +
+      "ableType\022\n\n\006NATIVE\020\000\022\014\n\010IMPORTED\020\001\"\032\n\nLa" +
+      "youtSpec\022\014\n\004spec\030\001 \001(\t\"\035\n\rPartitionSpec\022" +
+      "\014\n\004spec\030\001 \001(\t\"\365\001\n\006Layout\022\023\n\013layout_type\030" +
+      "\001 \001(\t\0223\n\013layout_spec\030\002 \001(\0132\036.alluxio.grp" +
+      "c.table.LayoutSpec\022\023\n\013layout_data\030\003 \001(\014\022" +
+      "4\n\005stats\030\004 \003(\0132%.alluxio.grpc.table.Layo" +
+      "ut.StatsEntry\032V\n\nStatsEntry\022\013\n\003key\030\001 \001(\t" +
+      "\0227\n\005value\030\002 \001(\0132(.alluxio.grpc.table.Col" +
+      "umnStatisticsInfo:\0028\001\"P\n\016Transformation\022" +
+      "*\n\006layout\030\001 \001(\0132\032.alluxio.grpc.table.Lay" +
+      "out\022\022\n\ndefinition\030\002 \001(\t\"\264\001\n\tPartition\0229\n" +
+      "\016partition_spec\030\001 \001(\0132!.alluxio.grpc.tab" +
+      "le.PartitionSpec\022/\n\013base_layout\030\002 \001(\0132\032." +
+      "alluxio.grpc.table.Layout\022;\n\017transformat" +
+      "ions\030\003 \003(\0132\".alluxio.grpc.table.Transfor" +
+      "mation\"r\n\024ColumnStatisticsInfo\022\020\n\010col_na" +
+      "me\030\001 \001(\t\022\020\n\010col_type\030\002 \001(\t\0226\n\004data\030\003 \001(\013" +
+      "2(.alluxio.grpc.table.ColumnStatisticsDa" +
+      "ta\"\357\003\n\024ColumnStatisticsData\022C\n\rboolean_s" +
+      "tats\030\001 \001(\0132*.alluxio.grpc.table.BooleanC" +
+      "olumnStatsDataH\000\022=\n\nlong_stats\030\002 \001(\0132\'.a" +
+      "lluxio.grpc.table.LongColumnStatsDataH\000\022" +
+      "A\n\014double_stats\030\003 \001(\0132).alluxio.grpc.tab" +
+      "le.DoubleColumnStatsDataH\000\022A\n\014string_sta" +
+      "ts\030\004 \001(\0132).alluxio.grpc.table.StringColu" +
+      "mnStatsDataH\000\022A\n\014binary_stats\030\005 \001(\0132).al" +
+      "luxio.grpc.table.BinaryColumnStatsDataH\000" +
+      "\022C\n\rdecimal_stats\030\006 \001(\0132*.alluxio.grpc.t" +
+      "able.DecimalColumnStatsDataH\000\022=\n\ndate_st" +
+      "ats\030\007 \001(\0132\'.alluxio.grpc.table.DateColum" +
+      "nStatsDataH\000B\006\n\004data\"g\n\026BooleanColumnSta" +
+      "tsData\022\021\n\tnum_trues\030\001 \001(\003\022\022\n\nnum_falses\030" +
+      "\002 \001(\003\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_vectors\030" +
+      "\004 \001(\t\"{\n\023LongColumnStatsData\022\021\n\tlow_valu" +
+      "e\030\001 \001(\003\022\022\n\nhigh_value\030\002 \001(\003\022\021\n\tnum_nulls" +
+      "\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013bit_vec" +
+      "tors\030\005 \001(\t\"}\n\025DoubleColumnStatsData\022\021\n\tl" +
+      "ow_value\030\001 \001(\001\022\022\n\nhigh_value\030\002 \001(\001\022\021\n\tnu" +
+      "m_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013" +
+      "bit_vectors\030\005 \001(\t\"*\n\007Decimal\022\r\n\005scale\030\001 " +
+      "\002(\005\022\020\n\010unscaled\030\002 \002(\014\"\270\001\n\026DecimalColumnS" +
+      "tatsData\022.\n\tlow_value\030\001 \001(\0132\033.alluxio.gr" +
+      "pc.table.Decimal\022/\n\nhigh_value\030\002 \001(\0132\033.a" +
+      "lluxio.grpc.table.Decimal\022\021\n\tnum_nulls\030\003" +
+      " \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013bit_vecto" +
+      "rs\030\005 \001(\t\"\200\001\n\025StringColumnStatsData\022\023\n\013ma" +
+      "x_col_len\030\001 \001(\003\022\023\n\013avg_col_len\030\002 \001(\001\022\021\n\t" +
+      "num_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023" +
+      "\n\013bit_vectors\030\005 \001(\t\"i\n\025BinaryColumnStats" +
+      "Data\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg_col_len" +
+      "\030\002 \001(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_vectors" +
+      "\030\004 \001(\t\" \n\004Date\022\030\n\020days_since_epoch\030\001 \002(\003" +
+      "\"\257\001\n\023DateColumnStatsData\022+\n\tlow_value\030\001 " +
+      "\001(\0132\030.alluxio.grpc.table.Date\022,\n\nhigh_va" +
+      "lue\030\002 \001(\0132\030.alluxio.grpc.table.Date\022\021\n\tn" +
+      "um_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n" +
+      "\013bit_vectors\030\005 \001(\t\"\031\n\027GetAllDatabasesPRe" +
+      "quest\",\n\030GetAllDatabasesPResponse\022\020\n\010dat" +
+      "abase\030\001 \003(\t\"(\n\024GetAllTablesPRequest\022\020\n\010d" +
+      "atabase\030\001 \001(\t\"&\n\025GetAllTablesPResponse\022\r" +
+      "\n\005table\030\001 \003(\t\"&\n\023GetDatabasePRequest\022\017\n\007" +
+      "db_name\030\001 \001(\t\"@\n\024GetDatabasePResponse\022(\n" +
+      "\002db\030\001 \001(\0132\034.alluxio.grpc.table.Database\"" +
+      "7\n\020GetTablePRequest\022\017\n\007db_name\030\001 \001(\t\022\022\n\n" +
+      "table_name\030\002 \001(\t\"F\n\021GetTablePResponse\0221\n" +
+      "\ntable_info\030\001 \001(\0132\035.alluxio.grpc.table.T" +
+      "ableInfo\"\346\001\n\026AttachDatabasePRequest\022\020\n\010u" +
+      "db_type\030\001 \001(\t\022\032\n\022udb_connection_uri\030\002 \001(" +
+      "\t\022\023\n\013udb_db_name\030\003 \001(\t\022\017\n\007db_name\030\004 \001(\t\022" +
+      "H\n\007options\030\005 \003(\01327.alluxio.grpc.table.At" +
+      "tachDatabasePRequest.OptionsEntry\032.\n\014Opt" +
+      "ionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028" +
+      "\001\"*\n\027AttachDatabasePResponse\022\017\n\007success\030" +
+      "\001 \001(\010\")\n\026DetachDatabasePRequest\022\017\n\007db_na" +
+      "me\030\001 \001(\t\"*\n\027DetachDatabasePResponse\022\017\n\007s" +
+      "uccess\030\001 \001(\010\"\'\n\024SyncDatabasePRequest\022\017\n\007" +
+      "db_name\030\001 \001(\t\"(\n\025SyncDatabasePResponse\022\017" +
+      "\n\007success\030\001 \001(\010\"\251\001\n\016FileStatistics\022>\n\006co" +
+      "lumn\030\001 \003(\0132..alluxio.grpc.table.FileStat" +
+      "istics.ColumnEntry\032W\n\013ColumnEntry\022\013\n\003key" +
       "\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.alluxio.grpc.tab" +
-      "le.ColumnStatisticsInfo:\0028\001\"P\n\016Transform" +
-      "ation\022*\n\006layout\030\001 \001(\0132\032.alluxio.grpc.tab" +
-      "le.Layout\022\022\n\ndefinition\030\002 \001(\t\"\264\001\n\tPartit" +
-      "ion\0229\n\016partition_spec\030\001 \001(\0132!.alluxio.gr" +
-      "pc.table.PartitionSpec\022/\n\013base_layout\030\002 " +
-      "\001(\0132\032.alluxio.grpc.table.Layout\022;\n\017trans" +
-      "formations\030\003 \003(\0132\".alluxio.grpc.table.Tr" +
-      "ansformation\"r\n\024ColumnStatisticsInfo\022\020\n\010" +
-      "col_name\030\001 \001(\t\022\020\n\010col_type\030\002 \001(\t\0226\n\004data" +
-      "\030\003 \001(\0132(.alluxio.grpc.table.ColumnStatis" +
-      "ticsData\"\357\003\n\024ColumnStatisticsData\022C\n\rboo" +
-      "lean_stats\030\001 \001(\0132*.alluxio.grpc.table.Bo" +
-      "oleanColumnStatsDataH\000\022=\n\nlong_stats\030\002 \001" +
-      "(\0132\'.alluxio.grpc.table.LongColumnStatsD" +
-      "ataH\000\022A\n\014double_stats\030\003 \001(\0132).alluxio.gr" +
-      "pc.table.DoubleColumnStatsDataH\000\022A\n\014stri" +
-      "ng_stats\030\004 \001(\0132).alluxio.grpc.table.Stri" +
-      "ngColumnStatsDataH\000\022A\n\014binary_stats\030\005 \001(" +
-      "\0132).alluxio.grpc.table.BinaryColumnStats" +
-      "DataH\000\022C\n\rdecimal_stats\030\006 \001(\0132*.alluxio." +
-      "grpc.table.DecimalColumnStatsDataH\000\022=\n\nd" +
-      "ate_stats\030\007 \001(\0132\'.alluxio.grpc.table.Dat" +
-      "eColumnStatsDataH\000B\006\n\004data\"g\n\026BooleanCol" +
-      "umnStatsData\022\021\n\tnum_trues\030\001 \001(\003\022\022\n\nnum_f" +
-      "alses\030\002 \001(\003\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_ve" +
-      "ctors\030\004 \001(\t\"{\n\023LongColumnStatsData\022\021\n\tlo" +
-      "w_value\030\001 \001(\003\022\022\n\nhigh_value\030\002 \001(\003\022\021\n\tnum" +
-      "_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013b" +
-      "it_vectors\030\005 \001(\t\"}\n\025DoubleColumnStatsDat" +
-      "a\022\021\n\tlow_value\030\001 \001(\001\022\022\n\nhigh_value\030\002 \001(\001" +
-      "\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001" +
-      "(\003\022\023\n\013bit_vectors\030\005 \001(\t\"*\n\007Decimal\022\r\n\005sc" +
-      "ale\030\001 \002(\005\022\020\n\010unscaled\030\002 \002(\014\"\270\001\n\026DecimalC" +
-      "olumnStatsData\022.\n\tlow_value\030\001 \001(\0132\033.allu" +
-      "xio.grpc.table.Decimal\022/\n\nhigh_value\030\002 \001" +
-      "(\0132\033.alluxio.grpc.table.Decimal\022\021\n\tnum_n" +
-      "ulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 \001(\003\022\023\n\013bit" +
-      "_vectors\030\005 \001(\t\"\200\001\n\025StringColumnStatsData" +
-      "\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg_col_len\030\002 \001" +
-      "(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004" +
-      " \001(\003\022\023\n\013bit_vectors\030\005 \001(\t\"i\n\025BinaryColum" +
-      "nStatsData\022\023\n\013max_col_len\030\001 \001(\003\022\023\n\013avg_c" +
-      "ol_len\030\002 \001(\001\022\021\n\tnum_nulls\030\003 \001(\003\022\023\n\013bit_v" +
-      "ectors\030\004 \001(\t\" \n\004Date\022\030\n\020days_since_epoch" +
-      "\030\001 \002(\003\"\257\001\n\023DateColumnStatsData\022+\n\tlow_va" +
-      "lue\030\001 \001(\0132\030.alluxio.grpc.table.Date\022,\n\nh" +
-      "igh_value\030\002 \001(\0132\030.alluxio.grpc.table.Dat" +
-      "e\022\021\n\tnum_nulls\030\003 \001(\003\022\025\n\rnum_distincts\030\004 " +
-      "\001(\003\022\023\n\013bit_vectors\030\005 \001(\t\"\031\n\027GetAllDataba" +
-      "sesPRequest\",\n\030GetAllDatabasesPResponse\022" +
-      "\020\n\010database\030\001 \003(\t\"(\n\024GetAllTablesPReques" +
-      "t\022\020\n\010database\030\001 \001(\t\"&\n\025GetAllTablesPResp" +
-      "onse\022\r\n\005table\030\001 \003(\t\"&\n\023GetDatabasePReque" +
-      "st\022\017\n\007db_name\030\001 \001(\t\"@\n\024GetDatabasePRespo" +
-      "nse\022(\n\002db\030\001 \001(\0132\034.alluxio.grpc.table.Dat" +
-      "abase\"7\n\020GetTablePRequest\022\017\n\007db_name\030\001 \001" +
-      "(\t\022\022\n\ntable_name\030\002 \001(\t\"F\n\021GetTablePRespo" +
-      "nse\0221\n\ntable_info\030\001 \001(\0132\035.alluxio.grpc.t" +
-      "able.TableInfo\"\346\001\n\026AttachDatabasePReques" +
-      "t\022\020\n\010udb_type\030\001 \001(\t\022\032\n\022udb_connection_ur" +
-      "i\030\002 \001(\t\022\023\n\013udb_db_name\030\003 \001(\t\022\017\n\007db_name\030" +
-      "\004 \001(\t\022H\n\007options\030\005 \003(\01327.alluxio.grpc.ta" +
-      "ble.AttachDatabasePRequest.OptionsEntry\032" +
-      ".\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 " +
-      "\001(\t:\0028\001\"*\n\027AttachDatabasePResponse\022\017\n\007su" +
-      "ccess\030\001 \001(\010\")\n\026DetachDatabasePRequest\022\017\n" +
-      "\007db_name\030\001 \001(\t\"*\n\027DetachDatabasePRespons" +
-      "e\022\017\n\007success\030\001 \001(\010\"\'\n\024SyncDatabasePReque" +
-      "st\022\017\n\007db_name\030\001 \001(\t\"(\n\025SyncDatabasePResp" +
-      "onse\022\017\n\007success\030\001 \001(\010\"\251\001\n\016FileStatistics" +
-      "\022>\n\006column\030\001 \003(\0132..alluxio.grpc.table.Fi" +
-      "leStatistics.ColumnEntry\032W\n\013ColumnEntry\022" +
-      "\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.alluxio.gr" +
-      "pc.table.ColumnStatisticsInfo:\0028\001\"Z\n Get" +
-      "TableColumnStatisticsPRequest\022\017\n\007db_name" +
-      "\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\021\n\tcol_names\030" +
-      "\003 \003(\t\"r\n$GetPartitionColumnStatisticsPRe" +
-      "quest\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001" +
-      "(\t\022\021\n\tcol_names\030\003 \003(\t\022\022\n\npart_names\030\004 \003(" +
-      "\t\"a\n!GetTableColumnStatisticsPResponse\022<" +
+      "le.ColumnStatisticsInfo:\0028\001\"Z\n GetTableC" +
+      "olumnStatisticsPRequest\022\017\n\007db_name\030\001 \001(\t" +
+      "\022\022\n\ntable_name\030\002 \001(\t\022\021\n\tcol_names\030\003 \003(\t\"" +
+      "r\n$GetPartitionColumnStatisticsPRequest\022" +
+      "\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\021\n\t" +
+      "col_names\030\003 \003(\t\022\022\n\npart_names\030\004 \003(\t\"a\n!G" +
+      "etTableColumnStatisticsPResponse\022<\n\nstat" +
+      "istics\030\001 \003(\0132(.alluxio.grpc.table.Column" +
+      "StatisticsInfo\"T\n\024ColumnStatisticsList\022<" +
       "\n\nstatistics\030\001 \003(\0132(.alluxio.grpc.table." +
-      "ColumnStatisticsInfo\"T\n\024ColumnStatistics" +
-      "List\022<\n\nstatistics\030\001 \003(\0132(.alluxio.grpc." +
-      "table.ColumnStatisticsInfo\"\377\001\n%GetPartit" +
-      "ionColumnStatisticsPResponse\022p\n\024partitio" +
-      "n_statistics\030\001 \003(\0132R.alluxio.grpc.table." +
-      "GetPartitionColumnStatisticsPResponse.Pa" +
-      "rtitionStatisticsEntry\032d\n\030PartitionStati" +
-      "sticsEntry\022\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(" +
-      ".alluxio.grpc.table.ColumnStatisticsList" +
-      ":\0028\001\"k\n\005Value\022\023\n\tlong_type\030\001 \001(\003H\000\022\025\n\013do" +
-      "uble_type\030\002 \001(\001H\000\022\025\n\013string_type\030\003 \001(\tH\000" +
-      "\022\026\n\014boolean_type\030\004 \001(\010H\000B\007\n\005value\"X\n\005Ran" +
-      "ge\022&\n\003low\030\001 \001(\0132\031.alluxio.grpc.table.Val" +
-      "ue\022\'\n\004high\030\002 \001(\0132\031.alluxio.grpc.table.Va" +
-      "lue\"5\n\010RangeSet\022)\n\006ranges\030\001 \003(\0132\031.alluxi" +
-      "o.grpc.table.Range\"V\n\021EquatableValueSet\022" +
-      "-\n\ncandidates\030\001 \003(\0132\031.alluxio.grpc.table" +
-      ".Value\022\022\n\nwhite_list\030\002 \001(\010\"\033\n\014AllOrNoneS" +
-      "et\022\013\n\003all\030\001 \001(\010\"\271\001\n\006Domain\022-\n\005range\030\001 \001(" +
-      "\0132\034.alluxio.grpc.table.RangeSetH\000\022:\n\tequ" +
-      "atable\030\002 \001(\0132%.alluxio.grpc.table.Equata" +
-      "bleValueSetH\000\0227\n\013all_or_none\030\003 \001(\0132 .all" +
-      "uxio.grpc.table.AllOrNoneSetH\000B\013\n\tvalue_" +
-      "set\"\265\001\n\nConstraint\022Q\n\022column_constraints" +
-      "\030\001 \003(\01325.alluxio.grpc.table.Constraint.C" +
-      "olumnConstraintsEntry\032T\n\026ColumnConstrain" +
-      "tsEntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.al" +
-      "luxio.grpc.table.Domain:\0028\001\"l\n\021ReadTable" +
-      "PRequest\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030" +
-      "\002 \001(\t\0222\n\nconstraint\030\003 \001(\0132\036.alluxio.grpc" +
-      ".table.Constraint\"G\n\022ReadTablePResponse\022" +
-      "1\n\npartitions\030\001 \003(\0132\035.alluxio.grpc.table" +
-      ".Partition\"Q\n\026TransformTablePRequest\022\017\n\007" +
-      "db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\022\n\ndef" +
-      "inition\030\003 \001(\t\")\n\027TransformTablePResponse" +
-      "\022\016\n\006job_id\030\001 \001(\003\"-\n\033GetTransformJobInfoP" +
-      "Request\022\016\n\006job_id\030\001 \001(\003\"\234\001\n\020TransformJob" +
-      "Info\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(" +
-      "\t\022\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(\003\022,\n" +
-      "\njob_status\030\005 \001(\0162\030.alluxio.grpc.job.Sta" +
-      "tus\022\021\n\tjob_error\030\006 \001(\t\"R\n\034GetTransformJo" +
-      "bInfoPResponse\0222\n\004info\030\001 \003(\0132$.alluxio.g" +
-      "rpc.table.TransformJobInfo*#\n\rPrincipalT" +
-      "ype\022\010\n\004USER\020\000\022\010\n\004ROLE\020\0012\304\n\n\030TableMasterC" +
-      "lientService\022l\n\017GetAllDatabases\022+.alluxi" +
-      "o.grpc.table.GetAllDatabasesPRequest\032,.a" +
-      "lluxio.grpc.table.GetAllDatabasesPRespon" +
-      "se\022c\n\014GetAllTables\022(.alluxio.grpc.table." +
-      "GetAllTablesPRequest\032).alluxio.grpc.tabl" +
-      "e.GetAllTablesPResponse\022`\n\013GetDatabase\022\'" +
-      ".alluxio.grpc.table.GetDatabasePRequest\032" +
-      "(.alluxio.grpc.table.GetDatabasePRespons" +
-      "e\022W\n\010GetTable\022$.alluxio.grpc.table.GetTa" +
-      "blePRequest\032%.alluxio.grpc.table.GetTabl" +
-      "ePResponse\022i\n\016AttachDatabase\022*.alluxio.g" +
-      "rpc.table.AttachDatabasePRequest\032+.allux" +
-      "io.grpc.table.AttachDatabasePResponse\022i\n" +
-      "\016DetachDatabase\022*.alluxio.grpc.table.Det" +
-      "achDatabasePRequest\032+.alluxio.grpc.table" +
-      ".DetachDatabasePResponse\022c\n\014SyncDatabase" +
-      "\022(.alluxio.grpc.table.SyncDatabasePReque" +
-      "st\032).alluxio.grpc.table.SyncDatabasePRes" +
-      "ponse\022\207\001\n\030GetTableColumnStatistics\0224.all" +
-      "uxio.grpc.table.GetTableColumnStatistics" +
-      "PRequest\0325.alluxio.grpc.table.GetTableCo" +
-      "lumnStatisticsPResponse\022\223\001\n\034GetPartition" +
-      "ColumnStatistics\0228.alluxio.grpc.table.Ge" +
-      "tPartitionColumnStatisticsPRequest\0329.all" +
-      "uxio.grpc.table.GetPartitionColumnStatis" +
-      "ticsPResponse\022Z\n\tReadTable\022%.alluxio.grp" +
-      "c.table.ReadTablePRequest\032&.alluxio.grpc" +
-      ".table.ReadTablePResponse\022i\n\016TransformTa" +
-      "ble\022*.alluxio.grpc.table.TransformTableP" +
-      "Request\032+.alluxio.grpc.table.TransformTa" +
-      "blePResponse\022x\n\023GetTransformJobInfo\022/.al" +
-      "luxio.grpc.table.GetTransformJobInfoPReq" +
-      "uest\0320.alluxio.grpc.table.GetTransformJo" +
-      "bInfoPResponseB(\n\022alluxio.grpc.tableB\020Ta" +
-      "bleMasterProtoP\001"
+      "ColumnStatisticsInfo\"\377\001\n%GetPartitionCol" +
+      "umnStatisticsPResponse\022p\n\024partition_stat" +
+      "istics\030\001 \003(\0132R.alluxio.grpc.table.GetPar" +
+      "titionColumnStatisticsPResponse.Partitio" +
+      "nStatisticsEntry\032d\n\030PartitionStatisticsE" +
+      "ntry\022\013\n\003key\030\001 \001(\t\0227\n\005value\030\002 \001(\0132(.allux" +
+      "io.grpc.table.ColumnStatisticsList:\0028\001\"k" +
+      "\n\005Value\022\023\n\tlong_type\030\001 \001(\003H\000\022\025\n\013double_t" +
+      "ype\030\002 \001(\001H\000\022\025\n\013string_type\030\003 \001(\tH\000\022\026\n\014bo" +
+      "olean_type\030\004 \001(\010H\000B\007\n\005value\"X\n\005Range\022&\n\003" +
+      "low\030\001 \001(\0132\031.alluxio.grpc.table.Value\022\'\n\004" +
+      "high\030\002 \001(\0132\031.alluxio.grpc.table.Value\"5\n" +
+      "\010RangeSet\022)\n\006ranges\030\001 \003(\0132\031.alluxio.grpc" +
+      ".table.Range\"V\n\021EquatableValueSet\022-\n\ncan" +
+      "didates\030\001 \003(\0132\031.alluxio.grpc.table.Value" +
+      "\022\022\n\nwhite_list\030\002 \001(\010\"\033\n\014AllOrNoneSet\022\013\n\003" +
+      "all\030\001 \001(\010\"\271\001\n\006Domain\022-\n\005range\030\001 \001(\0132\034.al" +
+      "luxio.grpc.table.RangeSetH\000\022:\n\tequatable" +
+      "\030\002 \001(\0132%.alluxio.grpc.table.EquatableVal" +
+      "ueSetH\000\0227\n\013all_or_none\030\003 \001(\0132 .alluxio.g" +
+      "rpc.table.AllOrNoneSetH\000B\013\n\tvalue_set\"\265\001" +
+      "\n\nConstraint\022Q\n\022column_constraints\030\001 \003(\013" +
+      "25.alluxio.grpc.table.Constraint.ColumnC" +
+      "onstraintsEntry\032T\n\026ColumnConstraintsEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.alluxio." +
+      "grpc.table.Domain:\0028\001\"l\n\021ReadTablePReque" +
+      "st\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022" +
+      "2\n\nconstraint\030\003 \001(\0132\036.alluxio.grpc.table" +
+      ".Constraint\"G\n\022ReadTablePResponse\0221\n\npar" +
+      "titions\030\001 \003(\0132\035.alluxio.grpc.table.Parti" +
+      "tion\"Q\n\026TransformTablePRequest\022\017\n\007db_nam" +
+      "e\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\022\n\ndefinitio" +
+      "n\030\003 \001(\t\")\n\027TransformTablePResponse\022\016\n\006jo" +
+      "b_id\030\001 \001(\003\"-\n\033GetTransformJobInfoPReques" +
+      "t\022\016\n\006job_id\030\001 \001(\003\"\234\001\n\020TransformJobInfo\022\017" +
+      "\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\022\n\nd" +
+      "efinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(\003\022,\n\njob_s" +
+      "tatus\030\005 \001(\0162\030.alluxio.grpc.job.Status\022\021\n" +
+      "\tjob_error\030\006 \001(\t\"R\n\034GetTransformJobInfoP" +
+      "Response\0222\n\004info\030\001 \003(\0132$.alluxio.grpc.ta" +
+      "ble.TransformJobInfo*#\n\rPrincipalType\022\010\n" +
+      "\004USER\020\000\022\010\n\004ROLE\020\0012\304\n\n\030TableMasterClientS" +
+      "ervice\022l\n\017GetAllDatabases\022+.alluxio.grpc" +
+      ".table.GetAllDatabasesPRequest\032,.alluxio" +
+      ".grpc.table.GetAllDatabasesPResponse\022c\n\014" +
+      "GetAllTables\022(.alluxio.grpc.table.GetAll" +
+      "TablesPRequest\032).alluxio.grpc.table.GetA" +
+      "llTablesPResponse\022`\n\013GetDatabase\022\'.allux" +
+      "io.grpc.table.GetDatabasePRequest\032(.allu" +
+      "xio.grpc.table.GetDatabasePResponse\022W\n\010G" +
+      "etTable\022$.alluxio.grpc.table.GetTablePRe" +
+      "quest\032%.alluxio.grpc.table.GetTablePResp" +
+      "onse\022i\n\016AttachDatabase\022*.alluxio.grpc.ta" +
+      "ble.AttachDatabasePRequest\032+.alluxio.grp" +
+      "c.table.AttachDatabasePResponse\022i\n\016Detac" +
+      "hDatabase\022*.alluxio.grpc.table.DetachDat" +
+      "abasePRequest\032+.alluxio.grpc.table.Detac" +
+      "hDatabasePResponse\022c\n\014SyncDatabase\022(.all" +
+      "uxio.grpc.table.SyncDatabasePRequest\032).a" +
+      "lluxio.grpc.table.SyncDatabasePResponse\022" +
+      "\207\001\n\030GetTableColumnStatistics\0224.alluxio.g" +
+      "rpc.table.GetTableColumnStatisticsPReque" +
+      "st\0325.alluxio.grpc.table.GetTableColumnSt" +
+      "atisticsPResponse\022\223\001\n\034GetPartitionColumn" +
+      "Statistics\0228.alluxio.grpc.table.GetParti" +
+      "tionColumnStatisticsPRequest\0329.alluxio.g" +
+      "rpc.table.GetPartitionColumnStatisticsPR" +
+      "esponse\022Z\n\tReadTable\022%.alluxio.grpc.tabl" +
+      "e.ReadTablePRequest\032&.alluxio.grpc.table" +
+      ".ReadTablePResponse\022i\n\016TransformTable\022*." +
+      "alluxio.grpc.table.TransformTablePReques" +
+      "t\032+.alluxio.grpc.table.TransformTablePRe" +
+      "sponse\022x\n\023GetTransformJobInfo\022/.alluxio." +
+      "grpc.table.GetTransformJobInfoPRequest\0320" +
+      ".alluxio.grpc.table.GetTransformJobInfoP" +
+      "ResponseB(\n\022alluxio.grpc.tableB\020TableMas" +
+      "terProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -562,7 +564,7 @@ public final class TableMasterProto {
     internal_static_alluxio_grpc_table_TableInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_table_TableInfo_descriptor,
-        new java.lang.String[] { "DbName", "TableName", "Type", "Owner", "Schema", "Layout", "Parameters", "PartitionCols", });
+        new java.lang.String[] { "DbName", "TableName", "Type", "Owner", "Schema", "Layout", "Parameters", "PartitionCols", "PreviousVersion", "Version", "VersionCreationTime", });
     internal_static_alluxio_grpc_table_TableInfo_ParametersEntry_descriptor =
       internal_static_alluxio_grpc_table_TableInfo_descriptor.getNestedTypes().get(0);
     internal_static_alluxio_grpc_table_TableInfo_ParametersEntry_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/proto/journal/Journal.java
+++ b/core/transport/src/main/java/alluxio/proto/journal/Journal.java
@@ -314,6 +314,19 @@ public final class Journal {
     alluxio.proto.journal.Meta.RemovePathPropertiesEntryOrBuilder getRemovePathPropertiesOrBuilder();
 
     /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    boolean hasRemoveTable();
+    /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    alluxio.proto.journal.Table.RemoveTableEntry getRemoveTable();
+    /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    alluxio.proto.journal.Table.RemoveTableEntryOrBuilder getRemoveTableOrBuilder();
+
+    /**
      * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
      */
     boolean hasRemoveTransformJobInfo();
@@ -520,7 +533,7 @@ public final class Journal {
   }
   /**
    * <pre>
-   * next available id: 50
+   * next available id: 51
    * </pre>
    *
    * Protobuf type {@code alluxio.proto.journal.JournalEntry}
@@ -734,7 +747,7 @@ public final class Journal {
             }
             case 154: {
               alluxio.proto.journal.File.RenameEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x02000000) == 0x02000000)) {
+              if (((bitField0_ & 0x04000000) == 0x04000000)) {
                 subBuilder = rename_.toBuilder();
               }
               rename_ = input.readMessage(alluxio.proto.journal.File.RenameEntry.PARSER, extensionRegistry);
@@ -742,12 +755,12 @@ public final class Journal {
                 subBuilder.mergeFrom(rename_);
                 rename_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x02000000;
+              bitField0_ |= 0x04000000;
               break;
             }
             case 218: {
               alluxio.proto.journal.File.SetAttributeEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x08000000) == 0x08000000)) {
+              if (((bitField0_ & 0x10000000) == 0x10000000)) {
                 subBuilder = setAttribute_.toBuilder();
               }
               setAttribute_ = input.readMessage(alluxio.proto.journal.File.SetAttributeEntry.PARSER, extensionRegistry);
@@ -755,7 +768,7 @@ public final class Journal {
                 subBuilder.mergeFrom(setAttribute_);
                 setAttribute_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x08000000;
+              bitField0_ |= 0x10000000;
               break;
             }
             case 234: {
@@ -773,7 +786,7 @@ public final class Journal {
             }
             case 242: {
               alluxio.proto.journal.File.UpdateUfsModeEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x80000000) == 0x80000000)) {
+              if (((bitField1_ & 0x00000001) == 0x00000001)) {
                 subBuilder = updateUfsMode_.toBuilder();
               }
               updateUfsMode_ = input.readMessage(alluxio.proto.journal.File.UpdateUfsModeEntry.PARSER, extensionRegistry);
@@ -781,12 +794,12 @@ public final class Journal {
                 subBuilder.mergeFrom(updateUfsMode_);
                 updateUfsMode_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x80000000;
+              bitField1_ |= 0x00000001;
               break;
             }
             case 250: {
               alluxio.proto.journal.File.SetAclEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x04000000) == 0x04000000)) {
+              if (((bitField0_ & 0x08000000) == 0x08000000)) {
                 subBuilder = setAcl_.toBuilder();
               }
               setAcl_ = input.readMessage(alluxio.proto.journal.File.SetAclEntry.PARSER, extensionRegistry);
@@ -794,7 +807,7 @@ public final class Journal {
                 subBuilder.mergeFrom(setAcl_);
                 setAcl_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x04000000;
+              bitField0_ |= 0x08000000;
               break;
             }
             case 258: {
@@ -812,7 +825,7 @@ public final class Journal {
             }
             case 266: {
               alluxio.proto.journal.File.RemoveSyncPointEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x01000000) == 0x01000000)) {
+              if (((bitField0_ & 0x02000000) == 0x02000000)) {
                 subBuilder = removeSyncPoint_.toBuilder();
               }
               removeSyncPoint_ = input.readMessage(alluxio.proto.journal.File.RemoveSyncPointEntry.PARSER, extensionRegistry);
@@ -820,7 +833,7 @@ public final class Journal {
                 subBuilder.mergeFrom(removeSyncPoint_);
                 removeSyncPoint_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x01000000;
+              bitField0_ |= 0x02000000;
               break;
             }
             case 274: {
@@ -838,7 +851,7 @@ public final class Journal {
             }
             case 282: {
               alluxio.proto.journal.File.UpdateInodeEntry.Builder subBuilder = null;
-              if (((bitField1_ & 0x00000001) == 0x00000001)) {
+              if (((bitField1_ & 0x00000002) == 0x00000002)) {
                 subBuilder = updateInode_.toBuilder();
               }
               updateInode_ = input.readMessage(alluxio.proto.journal.File.UpdateInodeEntry.PARSER, extensionRegistry);
@@ -846,12 +859,12 @@ public final class Journal {
                 subBuilder.mergeFrom(updateInode_);
                 updateInode_ = subBuilder.buildPartial();
               }
-              bitField1_ |= 0x00000001;
+              bitField1_ |= 0x00000002;
               break;
             }
             case 290: {
               alluxio.proto.journal.File.UpdateInodeDirectoryEntry.Builder subBuilder = null;
-              if (((bitField1_ & 0x00000002) == 0x00000002)) {
+              if (((bitField1_ & 0x00000004) == 0x00000004)) {
                 subBuilder = updateInodeDirectory_.toBuilder();
               }
               updateInodeDirectory_ = input.readMessage(alluxio.proto.journal.File.UpdateInodeDirectoryEntry.PARSER, extensionRegistry);
@@ -859,12 +872,12 @@ public final class Journal {
                 subBuilder.mergeFrom(updateInodeDirectory_);
                 updateInodeDirectory_ = subBuilder.buildPartial();
               }
-              bitField1_ |= 0x00000002;
+              bitField1_ |= 0x00000004;
               break;
             }
             case 298: {
               alluxio.proto.journal.File.UpdateInodeFileEntry.Builder subBuilder = null;
-              if (((bitField1_ & 0x00000004) == 0x00000004)) {
+              if (((bitField1_ & 0x00000008) == 0x00000008)) {
                 subBuilder = updateInodeFile_.toBuilder();
               }
               updateInodeFile_ = input.readMessage(alluxio.proto.journal.File.UpdateInodeFileEntry.PARSER, extensionRegistry);
@@ -872,7 +885,7 @@ public final class Journal {
                 subBuilder.mergeFrom(updateInodeFile_);
                 updateInodeFile_ = subBuilder.buildPartial();
               }
-              bitField1_ |= 0x00000004;
+              bitField1_ |= 0x00000008;
               break;
             }
             case 306: {
@@ -889,9 +902,9 @@ public final class Journal {
               break;
             }
             case 314: {
-              if (!((mutable_bitField1_ & 0x00000008) == 0x00000008)) {
+              if (!((mutable_bitField1_ & 0x00000010) == 0x00000010)) {
                 journalEntries_ = new java.util.ArrayList<alluxio.proto.journal.Journal.JournalEntry>();
-                mutable_bitField1_ |= 0x00000008;
+                mutable_bitField1_ |= 0x00000010;
               }
               journalEntries_.add(
                   input.readMessage(alluxio.proto.journal.Journal.JournalEntry.PARSER, extensionRegistry));
@@ -977,7 +990,7 @@ public final class Journal {
             }
             case 370: {
               alluxio.proto.journal.Table.AddTransformJobInfoEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x10000000) == 0x10000000)) {
+              if (((bitField0_ & 0x20000000) == 0x20000000)) {
                 subBuilder = addTransformJobInfo_.toBuilder();
               }
               addTransformJobInfo_ = input.readMessage(alluxio.proto.journal.Table.AddTransformJobInfoEntry.PARSER, extensionRegistry);
@@ -985,12 +998,12 @@ public final class Journal {
                 subBuilder.mergeFrom(addTransformJobInfo_);
                 addTransformJobInfo_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x10000000;
+              bitField0_ |= 0x20000000;
               break;
             }
             case 378: {
               alluxio.proto.journal.Table.RemoveTransformJobInfoEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x00800000) == 0x00800000)) {
+              if (((bitField0_ & 0x01000000) == 0x01000000)) {
                 subBuilder = removeTransformJobInfo_.toBuilder();
               }
               removeTransformJobInfo_ = input.readMessage(alluxio.proto.journal.Table.RemoveTransformJobInfoEntry.PARSER, extensionRegistry);
@@ -998,12 +1011,12 @@ public final class Journal {
                 subBuilder.mergeFrom(removeTransformJobInfo_);
                 removeTransformJobInfo_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00800000;
+              bitField0_ |= 0x01000000;
               break;
             }
             case 386: {
               alluxio.proto.journal.Table.CompleteTransformTableEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x20000000) == 0x20000000)) {
+              if (((bitField0_ & 0x40000000) == 0x40000000)) {
                 subBuilder = completeTransformTable_.toBuilder();
               }
               completeTransformTable_ = input.readMessage(alluxio.proto.journal.Table.CompleteTransformTableEntry.PARSER, extensionRegistry);
@@ -1011,12 +1024,12 @@ public final class Journal {
                 subBuilder.mergeFrom(completeTransformTable_);
                 completeTransformTable_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x20000000;
+              bitField0_ |= 0x40000000;
               break;
             }
             case 394: {
               alluxio.proto.journal.Table.UpdateDatabaseInfoEntry.Builder subBuilder = null;
-              if (((bitField0_ & 0x40000000) == 0x40000000)) {
+              if (((bitField0_ & 0x80000000) == 0x80000000)) {
                 subBuilder = updateDatabaseInfo_.toBuilder();
               }
               updateDatabaseInfo_ = input.readMessage(alluxio.proto.journal.Table.UpdateDatabaseInfoEntry.PARSER, extensionRegistry);
@@ -1024,7 +1037,20 @@ public final class Journal {
                 subBuilder.mergeFrom(updateDatabaseInfo_);
                 updateDatabaseInfo_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x40000000;
+              bitField0_ |= 0x80000000;
+              break;
+            }
+            case 402: {
+              alluxio.proto.journal.Table.RemoveTableEntry.Builder subBuilder = null;
+              if (((bitField0_ & 0x00800000) == 0x00800000)) {
+                subBuilder = removeTable_.toBuilder();
+              }
+              removeTable_ = input.readMessage(alluxio.proto.journal.Table.RemoveTableEntry.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(removeTable_);
+                removeTable_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00800000;
               break;
             }
           }
@@ -1035,7 +1061,7 @@ public final class Journal {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField1_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField1_ & 0x00000010) == 0x00000010)) {
           journalEntries_ = java.util.Collections.unmodifiableList(journalEntries_);
         }
         this.unknownFields = unknownFields.build();
@@ -1533,13 +1559,34 @@ public final class Journal {
       return removePathProperties_ == null ? alluxio.proto.journal.Meta.RemovePathPropertiesEntry.getDefaultInstance() : removePathProperties_;
     }
 
+    public static final int REMOVE_TABLE_FIELD_NUMBER = 50;
+    private alluxio.proto.journal.Table.RemoveTableEntry removeTable_;
+    /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    public boolean hasRemoveTable() {
+      return ((bitField0_ & 0x00800000) == 0x00800000);
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    public alluxio.proto.journal.Table.RemoveTableEntry getRemoveTable() {
+      return removeTable_ == null ? alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance() : removeTable_;
+    }
+    /**
+     * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+     */
+    public alluxio.proto.journal.Table.RemoveTableEntryOrBuilder getRemoveTableOrBuilder() {
+      return removeTable_ == null ? alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance() : removeTable_;
+    }
+
     public static final int REMOVE_TRANSFORM_JOB_INFO_FIELD_NUMBER = 47;
     private alluxio.proto.journal.Table.RemoveTransformJobInfoEntry removeTransformJobInfo_;
     /**
      * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
      */
     public boolean hasRemoveTransformJobInfo() {
-      return ((bitField0_ & 0x00800000) == 0x00800000);
+      return ((bitField0_ & 0x01000000) == 0x01000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
@@ -1560,7 +1607,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.RemoveSyncPointEntry remove_sync_point = 33;</code>
      */
     public boolean hasRemoveSyncPoint() {
-      return ((bitField0_ & 0x01000000) == 0x01000000);
+      return ((bitField0_ & 0x02000000) == 0x02000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.RemoveSyncPointEntry remove_sync_point = 33;</code>
@@ -1581,7 +1628,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.RenameEntry rename = 19;</code>
      */
     public boolean hasRename() {
-      return ((bitField0_ & 0x02000000) == 0x02000000);
+      return ((bitField0_ & 0x04000000) == 0x04000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.RenameEntry rename = 19;</code>
@@ -1602,7 +1649,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.SetAclEntry set_acl = 31;</code>
      */
     public boolean hasSetAcl() {
-      return ((bitField0_ & 0x04000000) == 0x04000000);
+      return ((bitField0_ & 0x08000000) == 0x08000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.SetAclEntry set_acl = 31;</code>
@@ -1623,7 +1670,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.SetAttributeEntry set_attribute = 27;</code>
      */
     public boolean hasSetAttribute() {
-      return ((bitField0_ & 0x08000000) == 0x08000000);
+      return ((bitField0_ & 0x10000000) == 0x10000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.SetAttributeEntry set_attribute = 27;</code>
@@ -1644,7 +1691,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.AddTransformJobInfoEntry add_transform_job_info = 46;</code>
      */
     public boolean hasAddTransformJobInfo() {
-      return ((bitField0_ & 0x10000000) == 0x10000000);
+      return ((bitField0_ & 0x20000000) == 0x20000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.AddTransformJobInfoEntry add_transform_job_info = 46;</code>
@@ -1665,7 +1712,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.CompleteTransformTableEntry complete_transform_table = 48;</code>
      */
     public boolean hasCompleteTransformTable() {
-      return ((bitField0_ & 0x20000000) == 0x20000000);
+      return ((bitField0_ & 0x40000000) == 0x40000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.CompleteTransformTableEntry complete_transform_table = 48;</code>
@@ -1686,7 +1733,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.UpdateDatabaseInfoEntry update_database_info = 49;</code>
      */
     public boolean hasUpdateDatabaseInfo() {
-      return ((bitField0_ & 0x40000000) == 0x40000000);
+      return ((bitField0_ & 0x80000000) == 0x80000000);
     }
     /**
      * <code>optional .alluxio.proto.journal.UpdateDatabaseInfoEntry update_database_info = 49;</code>
@@ -1707,7 +1754,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.UpdateUfsModeEntry update_ufs_mode = 30;</code>
      */
     public boolean hasUpdateUfsMode() {
-      return ((bitField0_ & 0x80000000) == 0x80000000);
+      return ((bitField1_ & 0x00000001) == 0x00000001);
     }
     /**
      * <code>optional .alluxio.proto.journal.UpdateUfsModeEntry update_ufs_mode = 30;</code>
@@ -1728,7 +1775,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.UpdateInodeEntry update_inode = 35;</code>
      */
     public boolean hasUpdateInode() {
-      return ((bitField1_ & 0x00000001) == 0x00000001);
+      return ((bitField1_ & 0x00000002) == 0x00000002);
     }
     /**
      * <code>optional .alluxio.proto.journal.UpdateInodeEntry update_inode = 35;</code>
@@ -1749,7 +1796,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.UpdateInodeDirectoryEntry update_inode_directory = 36;</code>
      */
     public boolean hasUpdateInodeDirectory() {
-      return ((bitField1_ & 0x00000002) == 0x00000002);
+      return ((bitField1_ & 0x00000004) == 0x00000004);
     }
     /**
      * <code>optional .alluxio.proto.journal.UpdateInodeDirectoryEntry update_inode_directory = 36;</code>
@@ -1770,7 +1817,7 @@ public final class Journal {
      * <code>optional .alluxio.proto.journal.UpdateInodeFileEntry update_inode_file = 37;</code>
      */
     public boolean hasUpdateInodeFile() {
-      return ((bitField1_ & 0x00000004) == 0x00000004);
+      return ((bitField1_ & 0x00000008) == 0x00000008);
     }
     /**
      * <code>optional .alluxio.proto.journal.UpdateInodeFileEntry update_inode_file = 37;</code>
@@ -1920,37 +1967,37 @@ public final class Journal {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeMessage(16, getAsyncPersistRequest());
       }
-      if (((bitField0_ & 0x02000000) == 0x02000000)) {
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
         output.writeMessage(19, getRename());
       }
-      if (((bitField0_ & 0x08000000) == 0x08000000)) {
+      if (((bitField0_ & 0x10000000) == 0x10000000)) {
         output.writeMessage(27, getSetAttribute());
       }
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
         output.writeMessage(29, getDeleteBlock());
       }
-      if (((bitField0_ & 0x80000000) == 0x80000000)) {
+      if (((bitField1_ & 0x00000001) == 0x00000001)) {
         output.writeMessage(30, getUpdateUfsMode());
       }
-      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+      if (((bitField0_ & 0x08000000) == 0x08000000)) {
         output.writeMessage(31, getSetAcl());
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(32, getAddSyncPoint());
       }
-      if (((bitField0_ & 0x01000000) == 0x01000000)) {
+      if (((bitField0_ & 0x02000000) == 0x02000000)) {
         output.writeMessage(33, getRemoveSyncPoint());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeMessage(34, getActiveSyncTxId());
       }
-      if (((bitField1_ & 0x00000001) == 0x00000001)) {
+      if (((bitField1_ & 0x00000002) == 0x00000002)) {
         output.writeMessage(35, getUpdateInode());
       }
-      if (((bitField1_ & 0x00000002) == 0x00000002)) {
+      if (((bitField1_ & 0x00000004) == 0x00000004)) {
         output.writeMessage(36, getUpdateInodeDirectory());
       }
-      if (((bitField1_ & 0x00000004) == 0x00000004)) {
+      if (((bitField1_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(37, getUpdateInodeFile());
       }
       if (((bitField0_ & 0x00080000) == 0x00080000)) {
@@ -1977,17 +2024,20 @@ public final class Journal {
       if (((bitField0_ & 0x00004000) == 0x00004000)) {
         output.writeMessage(45, getDetachDb());
       }
-      if (((bitField0_ & 0x10000000) == 0x10000000)) {
+      if (((bitField0_ & 0x20000000) == 0x20000000)) {
         output.writeMessage(46, getAddTransformJobInfo());
       }
-      if (((bitField0_ & 0x00800000) == 0x00800000)) {
+      if (((bitField0_ & 0x01000000) == 0x01000000)) {
         output.writeMessage(47, getRemoveTransformJobInfo());
       }
-      if (((bitField0_ & 0x20000000) == 0x20000000)) {
+      if (((bitField0_ & 0x40000000) == 0x40000000)) {
         output.writeMessage(48, getCompleteTransformTable());
       }
-      if (((bitField0_ & 0x40000000) == 0x40000000)) {
+      if (((bitField0_ & 0x80000000) == 0x80000000)) {
         output.writeMessage(49, getUpdateDatabaseInfo());
+      }
+      if (((bitField0_ & 0x00800000) == 0x00800000)) {
+        output.writeMessage(50, getRemoveTable());
       }
       unknownFields.writeTo(output);
     }
@@ -2049,11 +2099,11 @@ public final class Journal {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(16, getAsyncPersistRequest());
       }
-      if (((bitField0_ & 0x02000000) == 0x02000000)) {
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(19, getRename());
       }
-      if (((bitField0_ & 0x08000000) == 0x08000000)) {
+      if (((bitField0_ & 0x10000000) == 0x10000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(27, getSetAttribute());
       }
@@ -2061,11 +2111,11 @@ public final class Journal {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(29, getDeleteBlock());
       }
-      if (((bitField0_ & 0x80000000) == 0x80000000)) {
+      if (((bitField1_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(30, getUpdateUfsMode());
       }
-      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+      if (((bitField0_ & 0x08000000) == 0x08000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(31, getSetAcl());
       }
@@ -2073,7 +2123,7 @@ public final class Journal {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(32, getAddSyncPoint());
       }
-      if (((bitField0_ & 0x01000000) == 0x01000000)) {
+      if (((bitField0_ & 0x02000000) == 0x02000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(33, getRemoveSyncPoint());
       }
@@ -2081,15 +2131,15 @@ public final class Journal {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(34, getActiveSyncTxId());
       }
-      if (((bitField1_ & 0x00000001) == 0x00000001)) {
+      if (((bitField1_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(35, getUpdateInode());
       }
-      if (((bitField1_ & 0x00000002) == 0x00000002)) {
+      if (((bitField1_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(36, getUpdateInodeDirectory());
       }
-      if (((bitField1_ & 0x00000004) == 0x00000004)) {
+      if (((bitField1_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(37, getUpdateInodeFile());
       }
@@ -2125,21 +2175,25 @@ public final class Journal {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(45, getDetachDb());
       }
-      if (((bitField0_ & 0x10000000) == 0x10000000)) {
+      if (((bitField0_ & 0x20000000) == 0x20000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(46, getAddTransformJobInfo());
       }
-      if (((bitField0_ & 0x00800000) == 0x00800000)) {
+      if (((bitField0_ & 0x01000000) == 0x01000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(47, getRemoveTransformJobInfo());
       }
-      if (((bitField0_ & 0x20000000) == 0x20000000)) {
+      if (((bitField0_ & 0x40000000) == 0x40000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(48, getCompleteTransformTable());
       }
-      if (((bitField0_ & 0x40000000) == 0x40000000)) {
+      if (((bitField0_ & 0x80000000) == 0x80000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(49, getUpdateDatabaseInfo());
+      }
+      if (((bitField0_ & 0x00800000) == 0x00800000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(50, getRemoveTable());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2271,6 +2325,11 @@ public final class Journal {
       if (hasRemovePathProperties()) {
         result = result && getRemovePathProperties()
             .equals(other.getRemovePathProperties());
+      }
+      result = result && (hasRemoveTable() == other.hasRemoveTable());
+      if (hasRemoveTable()) {
+        result = result && getRemoveTable()
+            .equals(other.getRemoveTable());
       }
       result = result && (hasRemoveTransformJobInfo() == other.hasRemoveTransformJobInfo());
       if (hasRemoveTransformJobInfo()) {
@@ -2438,6 +2497,10 @@ public final class Journal {
         hash = (37 * hash) + REMOVE_PATH_PROPERTIES_FIELD_NUMBER;
         hash = (53 * hash) + getRemovePathProperties().hashCode();
       }
+      if (hasRemoveTable()) {
+        hash = (37 * hash) + REMOVE_TABLE_FIELD_NUMBER;
+        hash = (53 * hash) + getRemoveTable().hashCode();
+      }
       if (hasRemoveTransformJobInfo()) {
         hash = (37 * hash) + REMOVE_TRANSFORM_JOB_INFO_FIELD_NUMBER;
         hash = (53 * hash) + getRemoveTransformJobInfo().hashCode();
@@ -2585,7 +2648,7 @@ public final class Journal {
     }
     /**
      * <pre>
-     * next available id: 50
+     * next available id: 51
      * </pre>
      *
      * Protobuf type {@code alluxio.proto.journal.JournalEntry}
@@ -2641,6 +2704,7 @@ public final class Journal {
           getPathPropertiesFieldBuilder();
           getPersistDirectoryFieldBuilder();
           getRemovePathPropertiesFieldBuilder();
+          getRemoveTableFieldBuilder();
           getRemoveTransformJobInfoFieldBuilder();
           getRemoveSyncPointFieldBuilder();
           getRenameFieldBuilder();
@@ -2792,81 +2856,87 @@ public final class Journal {
           removePathPropertiesBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00400000);
+        if (removeTableBuilder_ == null) {
+          removeTable_ = null;
+        } else {
+          removeTableBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00800000);
         if (removeTransformJobInfoBuilder_ == null) {
           removeTransformJobInfo_ = null;
         } else {
           removeTransformJobInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00800000);
+        bitField0_ = (bitField0_ & ~0x01000000);
         if (removeSyncPointBuilder_ == null) {
           removeSyncPoint_ = null;
         } else {
           removeSyncPointBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x01000000);
+        bitField0_ = (bitField0_ & ~0x02000000);
         if (renameBuilder_ == null) {
           rename_ = null;
         } else {
           renameBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x02000000);
+        bitField0_ = (bitField0_ & ~0x04000000);
         if (setAclBuilder_ == null) {
           setAcl_ = null;
         } else {
           setAclBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x04000000);
+        bitField0_ = (bitField0_ & ~0x08000000);
         if (setAttributeBuilder_ == null) {
           setAttribute_ = null;
         } else {
           setAttributeBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x08000000);
+        bitField0_ = (bitField0_ & ~0x10000000);
         if (addTransformJobInfoBuilder_ == null) {
           addTransformJobInfo_ = null;
         } else {
           addTransformJobInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x10000000);
+        bitField0_ = (bitField0_ & ~0x20000000);
         if (completeTransformTableBuilder_ == null) {
           completeTransformTable_ = null;
         } else {
           completeTransformTableBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x20000000);
+        bitField0_ = (bitField0_ & ~0x40000000);
         if (updateDatabaseInfoBuilder_ == null) {
           updateDatabaseInfo_ = null;
         } else {
           updateDatabaseInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x40000000);
+        bitField0_ = (bitField0_ & ~0x80000000);
         if (updateUfsModeBuilder_ == null) {
           updateUfsMode_ = null;
         } else {
           updateUfsModeBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x80000000);
+        bitField1_ = (bitField1_ & ~0x00000001);
         if (updateInodeBuilder_ == null) {
           updateInode_ = null;
         } else {
           updateInodeBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000001);
+        bitField1_ = (bitField1_ & ~0x00000002);
         if (updateInodeDirectoryBuilder_ == null) {
           updateInodeDirectory_ = null;
         } else {
           updateInodeDirectoryBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000002);
+        bitField1_ = (bitField1_ & ~0x00000004);
         if (updateInodeFileBuilder_ == null) {
           updateInodeFile_ = null;
         } else {
           updateInodeFileBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000004);
+        bitField1_ = (bitField1_ & ~0x00000008);
         if (journalEntriesBuilder_ == null) {
           journalEntries_ = java.util.Collections.emptyList();
-          bitField1_ = (bitField1_ & ~0x00000008);
+          bitField1_ = (bitField1_ & ~0x00000010);
         } else {
           journalEntriesBuilder_.clear();
         }
@@ -3079,93 +3149,101 @@ public final class Journal {
         if (((from_bitField0_ & 0x00800000) == 0x00800000)) {
           to_bitField0_ |= 0x00800000;
         }
+        if (removeTableBuilder_ == null) {
+          result.removeTable_ = removeTable_;
+        } else {
+          result.removeTable_ = removeTableBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x01000000) == 0x01000000)) {
+          to_bitField0_ |= 0x01000000;
+        }
         if (removeTransformJobInfoBuilder_ == null) {
           result.removeTransformJobInfo_ = removeTransformJobInfo_;
         } else {
           result.removeTransformJobInfo_ = removeTransformJobInfoBuilder_.build();
         }
-        if (((from_bitField0_ & 0x01000000) == 0x01000000)) {
-          to_bitField0_ |= 0x01000000;
+        if (((from_bitField0_ & 0x02000000) == 0x02000000)) {
+          to_bitField0_ |= 0x02000000;
         }
         if (removeSyncPointBuilder_ == null) {
           result.removeSyncPoint_ = removeSyncPoint_;
         } else {
           result.removeSyncPoint_ = removeSyncPointBuilder_.build();
         }
-        if (((from_bitField0_ & 0x02000000) == 0x02000000)) {
-          to_bitField0_ |= 0x02000000;
+        if (((from_bitField0_ & 0x04000000) == 0x04000000)) {
+          to_bitField0_ |= 0x04000000;
         }
         if (renameBuilder_ == null) {
           result.rename_ = rename_;
         } else {
           result.rename_ = renameBuilder_.build();
         }
-        if (((from_bitField0_ & 0x04000000) == 0x04000000)) {
-          to_bitField0_ |= 0x04000000;
+        if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
+          to_bitField0_ |= 0x08000000;
         }
         if (setAclBuilder_ == null) {
           result.setAcl_ = setAcl_;
         } else {
           result.setAcl_ = setAclBuilder_.build();
         }
-        if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
-          to_bitField0_ |= 0x08000000;
+        if (((from_bitField0_ & 0x10000000) == 0x10000000)) {
+          to_bitField0_ |= 0x10000000;
         }
         if (setAttributeBuilder_ == null) {
           result.setAttribute_ = setAttribute_;
         } else {
           result.setAttribute_ = setAttributeBuilder_.build();
         }
-        if (((from_bitField0_ & 0x10000000) == 0x10000000)) {
-          to_bitField0_ |= 0x10000000;
+        if (((from_bitField0_ & 0x20000000) == 0x20000000)) {
+          to_bitField0_ |= 0x20000000;
         }
         if (addTransformJobInfoBuilder_ == null) {
           result.addTransformJobInfo_ = addTransformJobInfo_;
         } else {
           result.addTransformJobInfo_ = addTransformJobInfoBuilder_.build();
         }
-        if (((from_bitField0_ & 0x20000000) == 0x20000000)) {
-          to_bitField0_ |= 0x20000000;
+        if (((from_bitField0_ & 0x40000000) == 0x40000000)) {
+          to_bitField0_ |= 0x40000000;
         }
         if (completeTransformTableBuilder_ == null) {
           result.completeTransformTable_ = completeTransformTable_;
         } else {
           result.completeTransformTable_ = completeTransformTableBuilder_.build();
         }
-        if (((from_bitField0_ & 0x40000000) == 0x40000000)) {
-          to_bitField0_ |= 0x40000000;
+        if (((from_bitField0_ & 0x80000000) == 0x80000000)) {
+          to_bitField0_ |= 0x80000000;
         }
         if (updateDatabaseInfoBuilder_ == null) {
           result.updateDatabaseInfo_ = updateDatabaseInfo_;
         } else {
           result.updateDatabaseInfo_ = updateDatabaseInfoBuilder_.build();
         }
-        if (((from_bitField0_ & 0x80000000) == 0x80000000)) {
-          to_bitField0_ |= 0x80000000;
+        if (((from_bitField1_ & 0x00000001) == 0x00000001)) {
+          to_bitField1_ |= 0x00000001;
         }
         if (updateUfsModeBuilder_ == null) {
           result.updateUfsMode_ = updateUfsMode_;
         } else {
           result.updateUfsMode_ = updateUfsModeBuilder_.build();
         }
-        if (((from_bitField1_ & 0x00000001) == 0x00000001)) {
-          to_bitField1_ |= 0x00000001;
+        if (((from_bitField1_ & 0x00000002) == 0x00000002)) {
+          to_bitField1_ |= 0x00000002;
         }
         if (updateInodeBuilder_ == null) {
           result.updateInode_ = updateInode_;
         } else {
           result.updateInode_ = updateInodeBuilder_.build();
         }
-        if (((from_bitField1_ & 0x00000002) == 0x00000002)) {
-          to_bitField1_ |= 0x00000002;
+        if (((from_bitField1_ & 0x00000004) == 0x00000004)) {
+          to_bitField1_ |= 0x00000004;
         }
         if (updateInodeDirectoryBuilder_ == null) {
           result.updateInodeDirectory_ = updateInodeDirectory_;
         } else {
           result.updateInodeDirectory_ = updateInodeDirectoryBuilder_.build();
         }
-        if (((from_bitField1_ & 0x00000004) == 0x00000004)) {
-          to_bitField1_ |= 0x00000004;
+        if (((from_bitField1_ & 0x00000008) == 0x00000008)) {
+          to_bitField1_ |= 0x00000008;
         }
         if (updateInodeFileBuilder_ == null) {
           result.updateInodeFile_ = updateInodeFile_;
@@ -3173,9 +3251,9 @@ public final class Journal {
           result.updateInodeFile_ = updateInodeFileBuilder_.build();
         }
         if (journalEntriesBuilder_ == null) {
-          if (((bitField1_ & 0x00000008) == 0x00000008)) {
+          if (((bitField1_ & 0x00000010) == 0x00000010)) {
             journalEntries_ = java.util.Collections.unmodifiableList(journalEntries_);
-            bitField1_ = (bitField1_ & ~0x00000008);
+            bitField1_ = (bitField1_ & ~0x00000010);
           }
           result.journalEntries_ = journalEntries_;
         } else {
@@ -3293,6 +3371,9 @@ public final class Journal {
         if (other.hasRemovePathProperties()) {
           mergeRemovePathProperties(other.getRemovePathProperties());
         }
+        if (other.hasRemoveTable()) {
+          mergeRemoveTable(other.getRemoveTable());
+        }
         if (other.hasRemoveTransformJobInfo()) {
           mergeRemoveTransformJobInfo(other.getRemoveTransformJobInfo());
         }
@@ -3333,7 +3414,7 @@ public final class Journal {
           if (!other.journalEntries_.isEmpty()) {
             if (journalEntries_.isEmpty()) {
               journalEntries_ = other.journalEntries_;
-              bitField1_ = (bitField1_ & ~0x00000008);
+              bitField1_ = (bitField1_ & ~0x00000010);
             } else {
               ensureJournalEntriesIsMutable();
               journalEntries_.addAll(other.journalEntries_);
@@ -3346,7 +3427,7 @@ public final class Journal {
               journalEntriesBuilder_.dispose();
               journalEntriesBuilder_ = null;
               journalEntries_ = other.journalEntries_;
-              bitField1_ = (bitField1_ & ~0x00000008);
+              bitField1_ = (bitField1_ & ~0x00000010);
               journalEntriesBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getJournalEntriesFieldBuilder() : null;
@@ -6032,6 +6113,124 @@ public final class Journal {
         return removePathPropertiesBuilder_;
       }
 
+      private alluxio.proto.journal.Table.RemoveTableEntry removeTable_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          alluxio.proto.journal.Table.RemoveTableEntry, alluxio.proto.journal.Table.RemoveTableEntry.Builder, alluxio.proto.journal.Table.RemoveTableEntryOrBuilder> removeTableBuilder_;
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public boolean hasRemoveTable() {
+        return ((bitField0_ & 0x00800000) == 0x00800000);
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public alluxio.proto.journal.Table.RemoveTableEntry getRemoveTable() {
+        if (removeTableBuilder_ == null) {
+          return removeTable_ == null ? alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance() : removeTable_;
+        } else {
+          return removeTableBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public Builder setRemoveTable(alluxio.proto.journal.Table.RemoveTableEntry value) {
+        if (removeTableBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          removeTable_ = value;
+          onChanged();
+        } else {
+          removeTableBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public Builder setRemoveTable(
+          alluxio.proto.journal.Table.RemoveTableEntry.Builder builderForValue) {
+        if (removeTableBuilder_ == null) {
+          removeTable_ = builderForValue.build();
+          onChanged();
+        } else {
+          removeTableBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public Builder mergeRemoveTable(alluxio.proto.journal.Table.RemoveTableEntry value) {
+        if (removeTableBuilder_ == null) {
+          if (((bitField0_ & 0x00800000) == 0x00800000) &&
+              removeTable_ != null &&
+              removeTable_ != alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance()) {
+            removeTable_ =
+              alluxio.proto.journal.Table.RemoveTableEntry.newBuilder(removeTable_).mergeFrom(value).buildPartial();
+          } else {
+            removeTable_ = value;
+          }
+          onChanged();
+        } else {
+          removeTableBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public Builder clearRemoveTable() {
+        if (removeTableBuilder_ == null) {
+          removeTable_ = null;
+          onChanged();
+        } else {
+          removeTableBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00800000);
+        return this;
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public alluxio.proto.journal.Table.RemoveTableEntry.Builder getRemoveTableBuilder() {
+        bitField0_ |= 0x00800000;
+        onChanged();
+        return getRemoveTableFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      public alluxio.proto.journal.Table.RemoveTableEntryOrBuilder getRemoveTableOrBuilder() {
+        if (removeTableBuilder_ != null) {
+          return removeTableBuilder_.getMessageOrBuilder();
+        } else {
+          return removeTable_ == null ?
+              alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance() : removeTable_;
+        }
+      }
+      /**
+       * <code>optional .alluxio.proto.journal.RemoveTableEntry remove_table = 50;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          alluxio.proto.journal.Table.RemoveTableEntry, alluxio.proto.journal.Table.RemoveTableEntry.Builder, alluxio.proto.journal.Table.RemoveTableEntryOrBuilder> 
+          getRemoveTableFieldBuilder() {
+        if (removeTableBuilder_ == null) {
+          removeTableBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              alluxio.proto.journal.Table.RemoveTableEntry, alluxio.proto.journal.Table.RemoveTableEntry.Builder, alluxio.proto.journal.Table.RemoveTableEntryOrBuilder>(
+                  getRemoveTable(),
+                  getParentForChildren(),
+                  isClean());
+          removeTable_ = null;
+        }
+        return removeTableBuilder_;
+      }
+
       private alluxio.proto.journal.Table.RemoveTransformJobInfoEntry removeTransformJobInfo_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           alluxio.proto.journal.Table.RemoveTransformJobInfoEntry, alluxio.proto.journal.Table.RemoveTransformJobInfoEntry.Builder, alluxio.proto.journal.Table.RemoveTransformJobInfoEntryOrBuilder> removeTransformJobInfoBuilder_;
@@ -6039,7 +6238,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
        */
       public boolean hasRemoveTransformJobInfo() {
-        return ((bitField0_ & 0x00800000) == 0x00800000);
+        return ((bitField0_ & 0x01000000) == 0x01000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
@@ -6064,7 +6263,7 @@ public final class Journal {
         } else {
           removeTransformJobInfoBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00800000;
+        bitField0_ |= 0x01000000;
         return this;
       }
       /**
@@ -6078,7 +6277,7 @@ public final class Journal {
         } else {
           removeTransformJobInfoBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00800000;
+        bitField0_ |= 0x01000000;
         return this;
       }
       /**
@@ -6086,7 +6285,7 @@ public final class Journal {
        */
       public Builder mergeRemoveTransformJobInfo(alluxio.proto.journal.Table.RemoveTransformJobInfoEntry value) {
         if (removeTransformJobInfoBuilder_ == null) {
-          if (((bitField0_ & 0x00800000) == 0x00800000) &&
+          if (((bitField0_ & 0x01000000) == 0x01000000) &&
               removeTransformJobInfo_ != null &&
               removeTransformJobInfo_ != alluxio.proto.journal.Table.RemoveTransformJobInfoEntry.getDefaultInstance()) {
             removeTransformJobInfo_ =
@@ -6098,7 +6297,7 @@ public final class Journal {
         } else {
           removeTransformJobInfoBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00800000;
+        bitField0_ |= 0x01000000;
         return this;
       }
       /**
@@ -6111,14 +6310,14 @@ public final class Journal {
         } else {
           removeTransformJobInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00800000);
+        bitField0_ = (bitField0_ & ~0x01000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.RemoveTransformJobInfoEntry remove_transform_job_info = 47;</code>
        */
       public alluxio.proto.journal.Table.RemoveTransformJobInfoEntry.Builder getRemoveTransformJobInfoBuilder() {
-        bitField0_ |= 0x00800000;
+        bitField0_ |= 0x01000000;
         onChanged();
         return getRemoveTransformJobInfoFieldBuilder().getBuilder();
       }
@@ -6157,7 +6356,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.RemoveSyncPointEntry remove_sync_point = 33;</code>
        */
       public boolean hasRemoveSyncPoint() {
-        return ((bitField0_ & 0x01000000) == 0x01000000);
+        return ((bitField0_ & 0x02000000) == 0x02000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.RemoveSyncPointEntry remove_sync_point = 33;</code>
@@ -6182,7 +6381,7 @@ public final class Journal {
         } else {
           removeSyncPointBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x01000000;
+        bitField0_ |= 0x02000000;
         return this;
       }
       /**
@@ -6196,7 +6395,7 @@ public final class Journal {
         } else {
           removeSyncPointBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x01000000;
+        bitField0_ |= 0x02000000;
         return this;
       }
       /**
@@ -6204,7 +6403,7 @@ public final class Journal {
        */
       public Builder mergeRemoveSyncPoint(alluxio.proto.journal.File.RemoveSyncPointEntry value) {
         if (removeSyncPointBuilder_ == null) {
-          if (((bitField0_ & 0x01000000) == 0x01000000) &&
+          if (((bitField0_ & 0x02000000) == 0x02000000) &&
               removeSyncPoint_ != null &&
               removeSyncPoint_ != alluxio.proto.journal.File.RemoveSyncPointEntry.getDefaultInstance()) {
             removeSyncPoint_ =
@@ -6216,7 +6415,7 @@ public final class Journal {
         } else {
           removeSyncPointBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x01000000;
+        bitField0_ |= 0x02000000;
         return this;
       }
       /**
@@ -6229,14 +6428,14 @@ public final class Journal {
         } else {
           removeSyncPointBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x01000000);
+        bitField0_ = (bitField0_ & ~0x02000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.RemoveSyncPointEntry remove_sync_point = 33;</code>
        */
       public alluxio.proto.journal.File.RemoveSyncPointEntry.Builder getRemoveSyncPointBuilder() {
-        bitField0_ |= 0x01000000;
+        bitField0_ |= 0x02000000;
         onChanged();
         return getRemoveSyncPointFieldBuilder().getBuilder();
       }
@@ -6275,7 +6474,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.RenameEntry rename = 19;</code>
        */
       public boolean hasRename() {
-        return ((bitField0_ & 0x02000000) == 0x02000000);
+        return ((bitField0_ & 0x04000000) == 0x04000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.RenameEntry rename = 19;</code>
@@ -6300,7 +6499,7 @@ public final class Journal {
         } else {
           renameBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x02000000;
+        bitField0_ |= 0x04000000;
         return this;
       }
       /**
@@ -6314,7 +6513,7 @@ public final class Journal {
         } else {
           renameBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x02000000;
+        bitField0_ |= 0x04000000;
         return this;
       }
       /**
@@ -6322,7 +6521,7 @@ public final class Journal {
        */
       public Builder mergeRename(alluxio.proto.journal.File.RenameEntry value) {
         if (renameBuilder_ == null) {
-          if (((bitField0_ & 0x02000000) == 0x02000000) &&
+          if (((bitField0_ & 0x04000000) == 0x04000000) &&
               rename_ != null &&
               rename_ != alluxio.proto.journal.File.RenameEntry.getDefaultInstance()) {
             rename_ =
@@ -6334,7 +6533,7 @@ public final class Journal {
         } else {
           renameBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x02000000;
+        bitField0_ |= 0x04000000;
         return this;
       }
       /**
@@ -6347,14 +6546,14 @@ public final class Journal {
         } else {
           renameBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x02000000);
+        bitField0_ = (bitField0_ & ~0x04000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.RenameEntry rename = 19;</code>
        */
       public alluxio.proto.journal.File.RenameEntry.Builder getRenameBuilder() {
-        bitField0_ |= 0x02000000;
+        bitField0_ |= 0x04000000;
         onChanged();
         return getRenameFieldBuilder().getBuilder();
       }
@@ -6393,7 +6592,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.SetAclEntry set_acl = 31;</code>
        */
       public boolean hasSetAcl() {
-        return ((bitField0_ & 0x04000000) == 0x04000000);
+        return ((bitField0_ & 0x08000000) == 0x08000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.SetAclEntry set_acl = 31;</code>
@@ -6418,7 +6617,7 @@ public final class Journal {
         } else {
           setAclBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x04000000;
+        bitField0_ |= 0x08000000;
         return this;
       }
       /**
@@ -6432,7 +6631,7 @@ public final class Journal {
         } else {
           setAclBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x04000000;
+        bitField0_ |= 0x08000000;
         return this;
       }
       /**
@@ -6440,7 +6639,7 @@ public final class Journal {
        */
       public Builder mergeSetAcl(alluxio.proto.journal.File.SetAclEntry value) {
         if (setAclBuilder_ == null) {
-          if (((bitField0_ & 0x04000000) == 0x04000000) &&
+          if (((bitField0_ & 0x08000000) == 0x08000000) &&
               setAcl_ != null &&
               setAcl_ != alluxio.proto.journal.File.SetAclEntry.getDefaultInstance()) {
             setAcl_ =
@@ -6452,7 +6651,7 @@ public final class Journal {
         } else {
           setAclBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x04000000;
+        bitField0_ |= 0x08000000;
         return this;
       }
       /**
@@ -6465,14 +6664,14 @@ public final class Journal {
         } else {
           setAclBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x04000000);
+        bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.SetAclEntry set_acl = 31;</code>
        */
       public alluxio.proto.journal.File.SetAclEntry.Builder getSetAclBuilder() {
-        bitField0_ |= 0x04000000;
+        bitField0_ |= 0x08000000;
         onChanged();
         return getSetAclFieldBuilder().getBuilder();
       }
@@ -6511,7 +6710,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.SetAttributeEntry set_attribute = 27;</code>
        */
       public boolean hasSetAttribute() {
-        return ((bitField0_ & 0x08000000) == 0x08000000);
+        return ((bitField0_ & 0x10000000) == 0x10000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.SetAttributeEntry set_attribute = 27;</code>
@@ -6536,7 +6735,7 @@ public final class Journal {
         } else {
           setAttributeBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x08000000;
+        bitField0_ |= 0x10000000;
         return this;
       }
       /**
@@ -6550,7 +6749,7 @@ public final class Journal {
         } else {
           setAttributeBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x08000000;
+        bitField0_ |= 0x10000000;
         return this;
       }
       /**
@@ -6558,7 +6757,7 @@ public final class Journal {
        */
       public Builder mergeSetAttribute(alluxio.proto.journal.File.SetAttributeEntry value) {
         if (setAttributeBuilder_ == null) {
-          if (((bitField0_ & 0x08000000) == 0x08000000) &&
+          if (((bitField0_ & 0x10000000) == 0x10000000) &&
               setAttribute_ != null &&
               setAttribute_ != alluxio.proto.journal.File.SetAttributeEntry.getDefaultInstance()) {
             setAttribute_ =
@@ -6570,7 +6769,7 @@ public final class Journal {
         } else {
           setAttributeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x08000000;
+        bitField0_ |= 0x10000000;
         return this;
       }
       /**
@@ -6583,14 +6782,14 @@ public final class Journal {
         } else {
           setAttributeBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x08000000);
+        bitField0_ = (bitField0_ & ~0x10000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.SetAttributeEntry set_attribute = 27;</code>
        */
       public alluxio.proto.journal.File.SetAttributeEntry.Builder getSetAttributeBuilder() {
-        bitField0_ |= 0x08000000;
+        bitField0_ |= 0x10000000;
         onChanged();
         return getSetAttributeFieldBuilder().getBuilder();
       }
@@ -6629,7 +6828,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.AddTransformJobInfoEntry add_transform_job_info = 46;</code>
        */
       public boolean hasAddTransformJobInfo() {
-        return ((bitField0_ & 0x10000000) == 0x10000000);
+        return ((bitField0_ & 0x20000000) == 0x20000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.AddTransformJobInfoEntry add_transform_job_info = 46;</code>
@@ -6654,7 +6853,7 @@ public final class Journal {
         } else {
           addTransformJobInfoBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x10000000;
+        bitField0_ |= 0x20000000;
         return this;
       }
       /**
@@ -6668,7 +6867,7 @@ public final class Journal {
         } else {
           addTransformJobInfoBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x10000000;
+        bitField0_ |= 0x20000000;
         return this;
       }
       /**
@@ -6676,7 +6875,7 @@ public final class Journal {
        */
       public Builder mergeAddTransformJobInfo(alluxio.proto.journal.Table.AddTransformJobInfoEntry value) {
         if (addTransformJobInfoBuilder_ == null) {
-          if (((bitField0_ & 0x10000000) == 0x10000000) &&
+          if (((bitField0_ & 0x20000000) == 0x20000000) &&
               addTransformJobInfo_ != null &&
               addTransformJobInfo_ != alluxio.proto.journal.Table.AddTransformJobInfoEntry.getDefaultInstance()) {
             addTransformJobInfo_ =
@@ -6688,7 +6887,7 @@ public final class Journal {
         } else {
           addTransformJobInfoBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x10000000;
+        bitField0_ |= 0x20000000;
         return this;
       }
       /**
@@ -6701,14 +6900,14 @@ public final class Journal {
         } else {
           addTransformJobInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x10000000);
+        bitField0_ = (bitField0_ & ~0x20000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.AddTransformJobInfoEntry add_transform_job_info = 46;</code>
        */
       public alluxio.proto.journal.Table.AddTransformJobInfoEntry.Builder getAddTransformJobInfoBuilder() {
-        bitField0_ |= 0x10000000;
+        bitField0_ |= 0x20000000;
         onChanged();
         return getAddTransformJobInfoFieldBuilder().getBuilder();
       }
@@ -6747,7 +6946,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.CompleteTransformTableEntry complete_transform_table = 48;</code>
        */
       public boolean hasCompleteTransformTable() {
-        return ((bitField0_ & 0x20000000) == 0x20000000);
+        return ((bitField0_ & 0x40000000) == 0x40000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.CompleteTransformTableEntry complete_transform_table = 48;</code>
@@ -6772,7 +6971,7 @@ public final class Journal {
         } else {
           completeTransformTableBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x20000000;
+        bitField0_ |= 0x40000000;
         return this;
       }
       /**
@@ -6786,7 +6985,7 @@ public final class Journal {
         } else {
           completeTransformTableBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x20000000;
+        bitField0_ |= 0x40000000;
         return this;
       }
       /**
@@ -6794,7 +6993,7 @@ public final class Journal {
        */
       public Builder mergeCompleteTransformTable(alluxio.proto.journal.Table.CompleteTransformTableEntry value) {
         if (completeTransformTableBuilder_ == null) {
-          if (((bitField0_ & 0x20000000) == 0x20000000) &&
+          if (((bitField0_ & 0x40000000) == 0x40000000) &&
               completeTransformTable_ != null &&
               completeTransformTable_ != alluxio.proto.journal.Table.CompleteTransformTableEntry.getDefaultInstance()) {
             completeTransformTable_ =
@@ -6806,7 +7005,7 @@ public final class Journal {
         } else {
           completeTransformTableBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x20000000;
+        bitField0_ |= 0x40000000;
         return this;
       }
       /**
@@ -6819,14 +7018,14 @@ public final class Journal {
         } else {
           completeTransformTableBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x20000000);
+        bitField0_ = (bitField0_ & ~0x40000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.CompleteTransformTableEntry complete_transform_table = 48;</code>
        */
       public alluxio.proto.journal.Table.CompleteTransformTableEntry.Builder getCompleteTransformTableBuilder() {
-        bitField0_ |= 0x20000000;
+        bitField0_ |= 0x40000000;
         onChanged();
         return getCompleteTransformTableFieldBuilder().getBuilder();
       }
@@ -6865,7 +7064,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.UpdateDatabaseInfoEntry update_database_info = 49;</code>
        */
       public boolean hasUpdateDatabaseInfo() {
-        return ((bitField0_ & 0x40000000) == 0x40000000);
+        return ((bitField0_ & 0x80000000) == 0x80000000);
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateDatabaseInfoEntry update_database_info = 49;</code>
@@ -6890,7 +7089,7 @@ public final class Journal {
         } else {
           updateDatabaseInfoBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x40000000;
+        bitField0_ |= 0x80000000;
         return this;
       }
       /**
@@ -6904,7 +7103,7 @@ public final class Journal {
         } else {
           updateDatabaseInfoBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x40000000;
+        bitField0_ |= 0x80000000;
         return this;
       }
       /**
@@ -6912,7 +7111,7 @@ public final class Journal {
        */
       public Builder mergeUpdateDatabaseInfo(alluxio.proto.journal.Table.UpdateDatabaseInfoEntry value) {
         if (updateDatabaseInfoBuilder_ == null) {
-          if (((bitField0_ & 0x40000000) == 0x40000000) &&
+          if (((bitField0_ & 0x80000000) == 0x80000000) &&
               updateDatabaseInfo_ != null &&
               updateDatabaseInfo_ != alluxio.proto.journal.Table.UpdateDatabaseInfoEntry.getDefaultInstance()) {
             updateDatabaseInfo_ =
@@ -6924,7 +7123,7 @@ public final class Journal {
         } else {
           updateDatabaseInfoBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x40000000;
+        bitField0_ |= 0x80000000;
         return this;
       }
       /**
@@ -6937,14 +7136,14 @@ public final class Journal {
         } else {
           updateDatabaseInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x40000000);
+        bitField0_ = (bitField0_ & ~0x80000000);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateDatabaseInfoEntry update_database_info = 49;</code>
        */
       public alluxio.proto.journal.Table.UpdateDatabaseInfoEntry.Builder getUpdateDatabaseInfoBuilder() {
-        bitField0_ |= 0x40000000;
+        bitField0_ |= 0x80000000;
         onChanged();
         return getUpdateDatabaseInfoFieldBuilder().getBuilder();
       }
@@ -6983,7 +7182,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.UpdateUfsModeEntry update_ufs_mode = 30;</code>
        */
       public boolean hasUpdateUfsMode() {
-        return ((bitField0_ & 0x80000000) == 0x80000000);
+        return ((bitField1_ & 0x00000001) == 0x00000001);
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateUfsModeEntry update_ufs_mode = 30;</code>
@@ -7008,7 +7207,7 @@ public final class Journal {
         } else {
           updateUfsModeBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x80000000;
+        bitField1_ |= 0x00000001;
         return this;
       }
       /**
@@ -7022,7 +7221,7 @@ public final class Journal {
         } else {
           updateUfsModeBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x80000000;
+        bitField1_ |= 0x00000001;
         return this;
       }
       /**
@@ -7030,7 +7229,7 @@ public final class Journal {
        */
       public Builder mergeUpdateUfsMode(alluxio.proto.journal.File.UpdateUfsModeEntry value) {
         if (updateUfsModeBuilder_ == null) {
-          if (((bitField0_ & 0x80000000) == 0x80000000) &&
+          if (((bitField1_ & 0x00000001) == 0x00000001) &&
               updateUfsMode_ != null &&
               updateUfsMode_ != alluxio.proto.journal.File.UpdateUfsModeEntry.getDefaultInstance()) {
             updateUfsMode_ =
@@ -7042,7 +7241,7 @@ public final class Journal {
         } else {
           updateUfsModeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x80000000;
+        bitField1_ |= 0x00000001;
         return this;
       }
       /**
@@ -7055,14 +7254,14 @@ public final class Journal {
         } else {
           updateUfsModeBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x80000000);
+        bitField1_ = (bitField1_ & ~0x00000001);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateUfsModeEntry update_ufs_mode = 30;</code>
        */
       public alluxio.proto.journal.File.UpdateUfsModeEntry.Builder getUpdateUfsModeBuilder() {
-        bitField0_ |= 0x80000000;
+        bitField1_ |= 0x00000001;
         onChanged();
         return getUpdateUfsModeFieldBuilder().getBuilder();
       }
@@ -7101,7 +7300,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.UpdateInodeEntry update_inode = 35;</code>
        */
       public boolean hasUpdateInode() {
-        return ((bitField1_ & 0x00000001) == 0x00000001);
+        return ((bitField1_ & 0x00000002) == 0x00000002);
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeEntry update_inode = 35;</code>
@@ -7126,7 +7325,7 @@ public final class Journal {
         } else {
           updateInodeBuilder_.setMessage(value);
         }
-        bitField1_ |= 0x00000001;
+        bitField1_ |= 0x00000002;
         return this;
       }
       /**
@@ -7140,7 +7339,7 @@ public final class Journal {
         } else {
           updateInodeBuilder_.setMessage(builderForValue.build());
         }
-        bitField1_ |= 0x00000001;
+        bitField1_ |= 0x00000002;
         return this;
       }
       /**
@@ -7148,7 +7347,7 @@ public final class Journal {
        */
       public Builder mergeUpdateInode(alluxio.proto.journal.File.UpdateInodeEntry value) {
         if (updateInodeBuilder_ == null) {
-          if (((bitField1_ & 0x00000001) == 0x00000001) &&
+          if (((bitField1_ & 0x00000002) == 0x00000002) &&
               updateInode_ != null &&
               updateInode_ != alluxio.proto.journal.File.UpdateInodeEntry.getDefaultInstance()) {
             updateInode_ =
@@ -7160,7 +7359,7 @@ public final class Journal {
         } else {
           updateInodeBuilder_.mergeFrom(value);
         }
-        bitField1_ |= 0x00000001;
+        bitField1_ |= 0x00000002;
         return this;
       }
       /**
@@ -7173,14 +7372,14 @@ public final class Journal {
         } else {
           updateInodeBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000001);
+        bitField1_ = (bitField1_ & ~0x00000002);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeEntry update_inode = 35;</code>
        */
       public alluxio.proto.journal.File.UpdateInodeEntry.Builder getUpdateInodeBuilder() {
-        bitField1_ |= 0x00000001;
+        bitField1_ |= 0x00000002;
         onChanged();
         return getUpdateInodeFieldBuilder().getBuilder();
       }
@@ -7219,7 +7418,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.UpdateInodeDirectoryEntry update_inode_directory = 36;</code>
        */
       public boolean hasUpdateInodeDirectory() {
-        return ((bitField1_ & 0x00000002) == 0x00000002);
+        return ((bitField1_ & 0x00000004) == 0x00000004);
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeDirectoryEntry update_inode_directory = 36;</code>
@@ -7244,7 +7443,7 @@ public final class Journal {
         } else {
           updateInodeDirectoryBuilder_.setMessage(value);
         }
-        bitField1_ |= 0x00000002;
+        bitField1_ |= 0x00000004;
         return this;
       }
       /**
@@ -7258,7 +7457,7 @@ public final class Journal {
         } else {
           updateInodeDirectoryBuilder_.setMessage(builderForValue.build());
         }
-        bitField1_ |= 0x00000002;
+        bitField1_ |= 0x00000004;
         return this;
       }
       /**
@@ -7266,7 +7465,7 @@ public final class Journal {
        */
       public Builder mergeUpdateInodeDirectory(alluxio.proto.journal.File.UpdateInodeDirectoryEntry value) {
         if (updateInodeDirectoryBuilder_ == null) {
-          if (((bitField1_ & 0x00000002) == 0x00000002) &&
+          if (((bitField1_ & 0x00000004) == 0x00000004) &&
               updateInodeDirectory_ != null &&
               updateInodeDirectory_ != alluxio.proto.journal.File.UpdateInodeDirectoryEntry.getDefaultInstance()) {
             updateInodeDirectory_ =
@@ -7278,7 +7477,7 @@ public final class Journal {
         } else {
           updateInodeDirectoryBuilder_.mergeFrom(value);
         }
-        bitField1_ |= 0x00000002;
+        bitField1_ |= 0x00000004;
         return this;
       }
       /**
@@ -7291,14 +7490,14 @@ public final class Journal {
         } else {
           updateInodeDirectoryBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000002);
+        bitField1_ = (bitField1_ & ~0x00000004);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeDirectoryEntry update_inode_directory = 36;</code>
        */
       public alluxio.proto.journal.File.UpdateInodeDirectoryEntry.Builder getUpdateInodeDirectoryBuilder() {
-        bitField1_ |= 0x00000002;
+        bitField1_ |= 0x00000004;
         onChanged();
         return getUpdateInodeDirectoryFieldBuilder().getBuilder();
       }
@@ -7337,7 +7536,7 @@ public final class Journal {
        * <code>optional .alluxio.proto.journal.UpdateInodeFileEntry update_inode_file = 37;</code>
        */
       public boolean hasUpdateInodeFile() {
-        return ((bitField1_ & 0x00000004) == 0x00000004);
+        return ((bitField1_ & 0x00000008) == 0x00000008);
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeFileEntry update_inode_file = 37;</code>
@@ -7362,7 +7561,7 @@ public final class Journal {
         } else {
           updateInodeFileBuilder_.setMessage(value);
         }
-        bitField1_ |= 0x00000004;
+        bitField1_ |= 0x00000008;
         return this;
       }
       /**
@@ -7376,7 +7575,7 @@ public final class Journal {
         } else {
           updateInodeFileBuilder_.setMessage(builderForValue.build());
         }
-        bitField1_ |= 0x00000004;
+        bitField1_ |= 0x00000008;
         return this;
       }
       /**
@@ -7384,7 +7583,7 @@ public final class Journal {
        */
       public Builder mergeUpdateInodeFile(alluxio.proto.journal.File.UpdateInodeFileEntry value) {
         if (updateInodeFileBuilder_ == null) {
-          if (((bitField1_ & 0x00000004) == 0x00000004) &&
+          if (((bitField1_ & 0x00000008) == 0x00000008) &&
               updateInodeFile_ != null &&
               updateInodeFile_ != alluxio.proto.journal.File.UpdateInodeFileEntry.getDefaultInstance()) {
             updateInodeFile_ =
@@ -7396,7 +7595,7 @@ public final class Journal {
         } else {
           updateInodeFileBuilder_.mergeFrom(value);
         }
-        bitField1_ |= 0x00000004;
+        bitField1_ |= 0x00000008;
         return this;
       }
       /**
@@ -7409,14 +7608,14 @@ public final class Journal {
         } else {
           updateInodeFileBuilder_.clear();
         }
-        bitField1_ = (bitField1_ & ~0x00000004);
+        bitField1_ = (bitField1_ & ~0x00000008);
         return this;
       }
       /**
        * <code>optional .alluxio.proto.journal.UpdateInodeFileEntry update_inode_file = 37;</code>
        */
       public alluxio.proto.journal.File.UpdateInodeFileEntry.Builder getUpdateInodeFileBuilder() {
-        bitField1_ |= 0x00000004;
+        bitField1_ |= 0x00000008;
         onChanged();
         return getUpdateInodeFileFieldBuilder().getBuilder();
       }
@@ -7451,9 +7650,9 @@ public final class Journal {
       private java.util.List<alluxio.proto.journal.Journal.JournalEntry> journalEntries_ =
         java.util.Collections.emptyList();
       private void ensureJournalEntriesIsMutable() {
-        if (!((bitField1_ & 0x00000008) == 0x00000008)) {
+        if (!((bitField1_ & 0x00000010) == 0x00000010)) {
           journalEntries_ = new java.util.ArrayList<alluxio.proto.journal.Journal.JournalEntry>(journalEntries_);
-          bitField1_ |= 0x00000008;
+          bitField1_ |= 0x00000010;
          }
       }
 
@@ -7658,7 +7857,7 @@ public final class Journal {
       public Builder clearJournalEntries() {
         if (journalEntriesBuilder_ == null) {
           journalEntries_ = java.util.Collections.emptyList();
-          bitField1_ = (bitField1_ & ~0x00000008);
+          bitField1_ = (bitField1_ & ~0x00000010);
           onChanged();
         } else {
           journalEntriesBuilder_.clear();
@@ -7770,7 +7969,7 @@ public final class Journal {
           journalEntriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               alluxio.proto.journal.Journal.JournalEntry, alluxio.proto.journal.Journal.JournalEntry.Builder, alluxio.proto.journal.Journal.JournalEntryOrBuilder>(
                   journalEntries_,
-                  ((bitField1_ & 0x00000008) == 0x00000008),
+                  ((bitField1_ & 0x00000010) == 0x00000010),
                   getParentForChildren(),
                   isClean());
           journalEntries_ = null;
@@ -7843,7 +8042,7 @@ public final class Journal {
       "\n\033proto/journal/journal.proto\022\025alluxio.p" +
       "roto.journal\032\031proto/journal/block.proto\032" +
       "\030proto/journal/file.proto\032\030proto/journal" +
-      "/meta.proto\032\031proto/journal/table.proto\"\271" +
+      "/meta.proto\032\031proto/journal/table.proto\"\370" +
       "\023\n\014JournalEntry\022\027\n\017sequence_number\030\001 \001(\003" +
       "\022E\n\021active_sync_tx_id\030\" \001(\0132*.alluxio.pr" +
       "oto.journal.ActiveSyncTxIdEntry\0227\n\tadd_t" +
@@ -7883,30 +8082,32 @@ public final class Journal {
       "\0132,.alluxio.proto.journal.PersistDirecto" +
       "ryEntry\022P\n\026remove_path_properties\030) \001(\0132" +
       "0.alluxio.proto.journal.RemovePathProper" +
-      "tiesEntry\022U\n\031remove_transform_job_info\030/" +
-      " \001(\01322.alluxio.proto.journal.RemoveTrans" +
-      "formJobInfoEntry\022F\n\021remove_sync_point\030! " +
-      "\001(\0132+.alluxio.proto.journal.RemoveSyncPo" +
-      "intEntry\0222\n\006rename\030\023 \001(\0132\".alluxio.proto" +
-      ".journal.RenameEntry\0223\n\007set_acl\030\037 \001(\0132\"." +
-      "alluxio.proto.journal.SetAclEntry\022?\n\rset" +
-      "_attribute\030\033 \001(\0132(.alluxio.proto.journal" +
-      ".SetAttributeEntry\022O\n\026add_transform_job_" +
-      "info\030. \001(\0132/.alluxio.proto.journal.AddTr" +
-      "ansformJobInfoEntry\022T\n\030complete_transfor" +
-      "m_table\0300 \001(\01322.alluxio.proto.journal.Co" +
-      "mpleteTransformTableEntry\022L\n\024update_data" +
-      "base_info\0301 \001(\0132..alluxio.proto.journal." +
-      "UpdateDatabaseInfoEntry\022B\n\017update_ufs_mo" +
-      "de\030\036 \001(\0132).alluxio.proto.journal.UpdateU" +
-      "fsModeEntry\022=\n\014update_inode\030# \001(\0132\'.allu" +
-      "xio.proto.journal.UpdateInodeEntry\022P\n\026up" +
-      "date_inode_directory\030$ \001(\01320.alluxio.pro" +
-      "to.journal.UpdateInodeDirectoryEntry\022F\n\021" +
-      "update_inode_file\030% \001(\0132+.alluxio.proto." +
-      "journal.UpdateInodeFileEntry\022<\n\017journal_" +
-      "entries\030\' \003(\0132#.alluxio.proto.journal.Jo" +
-      "urnalEntryB\027\n\025alluxio.proto.journal"
+      "tiesEntry\022=\n\014remove_table\0302 \001(\0132\'.alluxi" +
+      "o.proto.journal.RemoveTableEntry\022U\n\031remo" +
+      "ve_transform_job_info\030/ \001(\01322.alluxio.pr" +
+      "oto.journal.RemoveTransformJobInfoEntry\022" +
+      "F\n\021remove_sync_point\030! \001(\0132+.alluxio.pro" +
+      "to.journal.RemoveSyncPointEntry\0222\n\006renam" +
+      "e\030\023 \001(\0132\".alluxio.proto.journal.RenameEn" +
+      "try\0223\n\007set_acl\030\037 \001(\0132\".alluxio.proto.jou" +
+      "rnal.SetAclEntry\022?\n\rset_attribute\030\033 \001(\0132" +
+      "(.alluxio.proto.journal.SetAttributeEntr" +
+      "y\022O\n\026add_transform_job_info\030. \001(\0132/.allu" +
+      "xio.proto.journal.AddTransformJobInfoEnt" +
+      "ry\022T\n\030complete_transform_table\0300 \001(\01322.a" +
+      "lluxio.proto.journal.CompleteTransformTa" +
+      "bleEntry\022L\n\024update_database_info\0301 \001(\0132." +
+      ".alluxio.proto.journal.UpdateDatabaseInf" +
+      "oEntry\022B\n\017update_ufs_mode\030\036 \001(\0132).alluxi" +
+      "o.proto.journal.UpdateUfsModeEntry\022=\n\014up" +
+      "date_inode\030# \001(\0132\'.alluxio.proto.journal" +
+      ".UpdateInodeEntry\022P\n\026update_inode_direct" +
+      "ory\030$ \001(\01320.alluxio.proto.journal.Update" +
+      "InodeDirectoryEntry\022F\n\021update_inode_file" +
+      "\030% \001(\0132+.alluxio.proto.journal.UpdateIno" +
+      "deFileEntry\022<\n\017journal_entries\030\' \003(\0132#.a" +
+      "lluxio.proto.journal.JournalEntryB\027\n\025all" +
+      "uxio.proto.journal"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -7929,7 +8130,7 @@ public final class Journal {
     internal_static_alluxio_proto_journal_JournalEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_JournalEntry_descriptor,
-        new java.lang.String[] { "SequenceNumber", "ActiveSyncTxId", "AddTable", "AddSyncPoint", "AddMountPoint", "AsyncPersistRequest", "AttachDb", "BlockContainerIdGenerator", "BlockInfo", "ClusterInfo", "CompleteFile", "DeleteBlock", "DeleteFile", "DeleteMountPoint", "DetachDb", "InodeDirectory", "InodeDirectoryIdGenerator", "InodeFile", "InodeLastModificationTime", "NewBlock", "PathProperties", "PersistDirectory", "RemovePathProperties", "RemoveTransformJobInfo", "RemoveSyncPoint", "Rename", "SetAcl", "SetAttribute", "AddTransformJobInfo", "CompleteTransformTable", "UpdateDatabaseInfo", "UpdateUfsMode", "UpdateInode", "UpdateInodeDirectory", "UpdateInodeFile", "JournalEntries", });
+        new java.lang.String[] { "SequenceNumber", "ActiveSyncTxId", "AddTable", "AddSyncPoint", "AddMountPoint", "AsyncPersistRequest", "AttachDb", "BlockContainerIdGenerator", "BlockInfo", "ClusterInfo", "CompleteFile", "DeleteBlock", "DeleteFile", "DeleteMountPoint", "DetachDb", "InodeDirectory", "InodeDirectoryIdGenerator", "InodeFile", "InodeLastModificationTime", "NewBlock", "PathProperties", "PersistDirectory", "RemovePathProperties", "RemoveTable", "RemoveTransformJobInfo", "RemoveSyncPoint", "Rename", "SetAcl", "SetAttribute", "AddTransformJobInfo", "CompleteTransformTable", "UpdateDatabaseInfo", "UpdateUfsMode", "UpdateInode", "UpdateInodeDirectory", "UpdateInodeFile", "JournalEntries", });
     alluxio.proto.journal.Block.getDescriptor();
     alluxio.proto.journal.File.getDescriptor();
     alluxio.proto.journal.Meta.getDescriptor();

--- a/core/transport/src/main/java/alluxio/proto/journal/Table.java
+++ b/core/transport/src/main/java/alluxio/proto/journal/Table.java
@@ -5057,6 +5057,825 @@ public final class Table {
 
   }
 
+  public interface RemoveTableEntryOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:alluxio.proto.journal.RemoveTableEntry)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    boolean hasDbName();
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    java.lang.String getDbName();
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getDbNameBytes();
+
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    boolean hasTableName();
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    java.lang.String getTableName();
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getTableNameBytes();
+
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    boolean hasVersion();
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    long getVersion();
+  }
+  /**
+   * <pre>
+   * next available id: 5
+   * </pre>
+   *
+   * Protobuf type {@code alluxio.proto.journal.RemoveTableEntry}
+   */
+  public  static final class RemoveTableEntry extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:alluxio.proto.journal.RemoveTableEntry)
+      RemoveTableEntryOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RemoveTableEntry.newBuilder() to construct.
+    private RemoveTableEntry(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RemoveTableEntry() {
+      dbName_ = "";
+      tableName_ = "";
+      version_ = 0L;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RemoveTableEntry(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              dbName_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              tableName_ = bs;
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000004;
+              version_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return alluxio.proto.journal.Table.internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return alluxio.proto.journal.Table.internal_static_alluxio_proto_journal_RemoveTableEntry_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              alluxio.proto.journal.Table.RemoveTableEntry.class, alluxio.proto.journal.Table.RemoveTableEntry.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int DB_NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object dbName_;
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    public boolean hasDbName() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    public java.lang.String getDbName() {
+      java.lang.Object ref = dbName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          dbName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string db_name = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getDbNameBytes() {
+      java.lang.Object ref = dbName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        dbName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TABLE_NAME_FIELD_NUMBER = 2;
+    private volatile java.lang.Object tableName_;
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    public boolean hasTableName() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    public java.lang.String getTableName() {
+      java.lang.Object ref = tableName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          tableName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string table_name = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTableNameBytes() {
+      java.lang.Object ref = tableName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        tableName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VERSION_FIELD_NUMBER = 4;
+    private long version_;
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int64 version = 4;</code>
+     */
+    public long getVersion() {
+      return version_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, dbName_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, tableName_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(4, version_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, dbName_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, tableName_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, version_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof alluxio.proto.journal.Table.RemoveTableEntry)) {
+        return super.equals(obj);
+      }
+      alluxio.proto.journal.Table.RemoveTableEntry other = (alluxio.proto.journal.Table.RemoveTableEntry) obj;
+
+      boolean result = true;
+      result = result && (hasDbName() == other.hasDbName());
+      if (hasDbName()) {
+        result = result && getDbName()
+            .equals(other.getDbName());
+      }
+      result = result && (hasTableName() == other.hasTableName());
+      if (hasTableName()) {
+        result = result && getTableName()
+            .equals(other.getTableName());
+      }
+      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion()) {
+        result = result && (getVersion()
+            == other.getVersion());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasDbName()) {
+        hash = (37 * hash) + DB_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getDbName().hashCode();
+      }
+      if (hasTableName()) {
+        hash = (37 * hash) + TABLE_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getTableName().hashCode();
+      }
+      if (hasVersion()) {
+        hash = (37 * hash) + VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getVersion());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static alluxio.proto.journal.Table.RemoveTableEntry parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(alluxio.proto.journal.Table.RemoveTableEntry prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * next available id: 5
+     * </pre>
+     *
+     * Protobuf type {@code alluxio.proto.journal.RemoveTableEntry}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:alluxio.proto.journal.RemoveTableEntry)
+        alluxio.proto.journal.Table.RemoveTableEntryOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return alluxio.proto.journal.Table.internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return alluxio.proto.journal.Table.internal_static_alluxio_proto_journal_RemoveTableEntry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                alluxio.proto.journal.Table.RemoveTableEntry.class, alluxio.proto.journal.Table.RemoveTableEntry.Builder.class);
+      }
+
+      // Construct using alluxio.proto.journal.Table.RemoveTableEntry.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      public Builder clear() {
+        super.clear();
+        dbName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        tableName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        version_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return alluxio.proto.journal.Table.internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor;
+      }
+
+      public alluxio.proto.journal.Table.RemoveTableEntry getDefaultInstanceForType() {
+        return alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance();
+      }
+
+      public alluxio.proto.journal.Table.RemoveTableEntry build() {
+        alluxio.proto.journal.Table.RemoveTableEntry result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public alluxio.proto.journal.Table.RemoveTableEntry buildPartial() {
+        alluxio.proto.journal.Table.RemoveTableEntry result = new alluxio.proto.journal.Table.RemoveTableEntry(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.dbName_ = dbName_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.tableName_ = tableName_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.version_ = version_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof alluxio.proto.journal.Table.RemoveTableEntry) {
+          return mergeFrom((alluxio.proto.journal.Table.RemoveTableEntry)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(alluxio.proto.journal.Table.RemoveTableEntry other) {
+        if (other == alluxio.proto.journal.Table.RemoveTableEntry.getDefaultInstance()) return this;
+        if (other.hasDbName()) {
+          bitField0_ |= 0x00000001;
+          dbName_ = other.dbName_;
+          onChanged();
+        }
+        if (other.hasTableName()) {
+          bitField0_ |= 0x00000002;
+          tableName_ = other.tableName_;
+          onChanged();
+        }
+        if (other.hasVersion()) {
+          setVersion(other.getVersion());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        alluxio.proto.journal.Table.RemoveTableEntry parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (alluxio.proto.journal.Table.RemoveTableEntry) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object dbName_ = "";
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public boolean hasDbName() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public java.lang.String getDbName() {
+        java.lang.Object ref = dbName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            dbName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getDbNameBytes() {
+        java.lang.Object ref = dbName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          dbName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public Builder setDbName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        dbName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public Builder clearDbName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        dbName_ = getDefaultInstance().getDbName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string db_name = 1;</code>
+       */
+      public Builder setDbNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        dbName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object tableName_ = "";
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public boolean hasTableName() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public java.lang.String getTableName() {
+        java.lang.Object ref = tableName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            tableName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTableNameBytes() {
+        java.lang.Object ref = tableName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          tableName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public Builder setTableName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        tableName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public Builder clearTableName() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        tableName_ = getDefaultInstance().getTableName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string table_name = 2;</code>
+       */
+      public Builder setTableNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        tableName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long version_ ;
+      /**
+       * <code>optional int64 version = 4;</code>
+       */
+      public boolean hasVersion() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int64 version = 4;</code>
+       */
+      public long getVersion() {
+        return version_;
+      }
+      /**
+       * <code>optional int64 version = 4;</code>
+       */
+      public Builder setVersion(long value) {
+        bitField0_ |= 0x00000004;
+        version_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 version = 4;</code>
+       */
+      public Builder clearVersion() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        version_ = 0L;
+        onChanged();
+        return this;
+      }
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:alluxio.proto.journal.RemoveTableEntry)
+    }
+
+    // @@protoc_insertion_point(class_scope:alluxio.proto.journal.RemoveTableEntry)
+    private static final alluxio.proto.journal.Table.RemoveTableEntry DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new alluxio.proto.journal.Table.RemoveTableEntry();
+    }
+
+    public static alluxio.proto.journal.Table.RemoveTableEntry getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<RemoveTableEntry>
+        PARSER = new com.google.protobuf.AbstractParser<RemoveTableEntry>() {
+      public RemoveTableEntry parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RemoveTableEntry(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RemoveTableEntry> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RemoveTableEntry> getParserForType() {
+      return PARSER;
+    }
+
+    public alluxio.proto.journal.Table.RemoveTableEntry getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface CompleteTransformTableEntryOrBuilder extends
       // @@protoc_insertion_point(interface_extends:alluxio.proto.journal.CompleteTransformTableEntry)
       com.google.protobuf.MessageOrBuilder {
@@ -9856,6 +10675,11 @@ public final class Table {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_alluxio_proto_journal_AddTableEntry_ParametersEntry_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_alluxio_proto_journal_RemoveTableEntry_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_alluxio_proto_journal_CompleteTransformTableEntry_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -9920,30 +10744,32 @@ public final class Table {
       "ble.Partition\022\030\n\020previous_version\030\n \001(\003\022" +
       "\017\n\007version\030\013 \001(\003\022\035\n\025version_creation_tim" +
       "e\030\014 \001(\003\0321\n\017ParametersEntry\022\013\n\003key\030\001 \001(\t\022" +
-      "\r\n\005value\030\002 \001(\t:\0028\001\"\226\002\n\033CompleteTransform" +
-      "TableEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_nam" +
-      "e\030\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022g\n\023transform" +
-      "ed_layouts\030\004 \003(\0132J.alluxio.proto.journal" +
-      ".CompleteTransformTableEntry.Transformed" +
-      "LayoutsEntry\032U\n\027TransformedLayoutsEntry\022" +
-      "\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.alluxio.gr" +
-      "pc.table.Layout:\0028\001\"\240\002\n\030AddTransformJobI" +
-      "nfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030" +
-      "\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(" +
-      "\003\022d\n\023transformed_layouts\030\005 \003(\0132G.alluxio" +
-      ".proto.journal.AddTransformJobInfoEntry." +
-      "TransformedLayoutsEntry\032U\n\027TransformedLa" +
-      "youtsEntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032" +
-      ".alluxio.grpc.table.Layout:\0028\001\"B\n\033Remove" +
-      "TransformJobInfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022" +
-      "\n\ntable_name\030\002 \001(\t\"\234\002\n\027UpdateDatabaseInf" +
-      "oEntry\022\017\n\007db_name\030\001 \001(\t\022\020\n\010location\030\002 \001(" +
-      "\t\022P\n\tparameter\030\003 \003(\0132=.alluxio.proto.jou" +
-      "rnal.UpdateDatabaseInfoEntry.ParameterEn" +
-      "try\022\022\n\nowner_name\030\004 \001(\t\0225\n\nowner_type\030\005 " +
-      "\001(\0162!.alluxio.grpc.table.PrincipalType\022\017" +
-      "\n\007comment\030\006 \001(\t\0320\n\016ParameterEntry\022\013\n\003key" +
-      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001"
+      "\r\n\005value\030\002 \001(\t:\0028\001\"H\n\020RemoveTableEntry\022\017" +
+      "\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\017\n\007v" +
+      "ersion\030\004 \001(\003\"\226\002\n\033CompleteTransformTableE" +
+      "ntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(" +
+      "\t\022\022\n\ndefinition\030\003 \001(\t\022g\n\023transformed_lay" +
+      "outs\030\004 \003(\0132J.alluxio.proto.journal.Compl" +
+      "eteTransformTableEntry.TransformedLayout" +
+      "sEntry\032U\n\027TransformedLayoutsEntry\022\013\n\003key" +
+      "\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.alluxio.grpc.tab" +
+      "le.Layout:\0028\001\"\240\002\n\030AddTransformJobInfoEnt" +
+      "ry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022" +
+      "\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(\003\022d\n\023t" +
+      "ransformed_layouts\030\005 \003(\0132G.alluxio.proto" +
+      ".journal.AddTransformJobInfoEntry.Transf" +
+      "ormedLayoutsEntry\032U\n\027TransformedLayoutsE" +
+      "ntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.allux" +
+      "io.grpc.table.Layout:\0028\001\"B\n\033RemoveTransf" +
+      "ormJobInfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntabl" +
+      "e_name\030\002 \001(\t\"\234\002\n\027UpdateDatabaseInfoEntry" +
+      "\022\017\n\007db_name\030\001 \001(\t\022\020\n\010location\030\002 \001(\t\022P\n\tp" +
+      "arameter\030\003 \003(\0132=.alluxio.proto.journal.U" +
+      "pdateDatabaseInfoEntry.ParameterEntry\022\022\n" +
+      "\nowner_name\030\004 \001(\t\0225\n\nowner_type\030\005 \001(\0162!." +
+      "alluxio.grpc.table.PrincipalType\022\017\n\007comm" +
+      "ent\030\006 \001(\t\0320\n\016ParameterEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022\r\n\005value\030\002 \001(\t:\0028\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -9988,8 +10814,14 @@ public final class Table {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_AddTableEntry_ParametersEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_alluxio_proto_journal_CompleteTransformTableEntry_descriptor =
+    internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor =
       getDescriptor().getMessageTypes().get(3);
+    internal_static_alluxio_proto_journal_RemoveTableEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_alluxio_proto_journal_RemoveTableEntry_descriptor,
+        new java.lang.String[] { "DbName", "TableName", "Version", });
+    internal_static_alluxio_proto_journal_CompleteTransformTableEntry_descriptor =
+      getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_proto_journal_CompleteTransformTableEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_CompleteTransformTableEntry_descriptor,
@@ -10001,7 +10833,7 @@ public final class Table {
         internal_static_alluxio_proto_journal_CompleteTransformTableEntry_TransformedLayoutsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_alluxio_proto_journal_AddTransformJobInfoEntry_descriptor =
-      getDescriptor().getMessageTypes().get(4);
+      getDescriptor().getMessageTypes().get(5);
     internal_static_alluxio_proto_journal_AddTransformJobInfoEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_AddTransformJobInfoEntry_descriptor,
@@ -10013,13 +10845,13 @@ public final class Table {
         internal_static_alluxio_proto_journal_AddTransformJobInfoEntry_TransformedLayoutsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_alluxio_proto_journal_RemoveTransformJobInfoEntry_descriptor =
-      getDescriptor().getMessageTypes().get(5);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_alluxio_proto_journal_RemoveTransformJobInfoEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_RemoveTransformJobInfoEntry_descriptor,
         new java.lang.String[] { "DbName", "TableName", });
     internal_static_alluxio_proto_journal_UpdateDatabaseInfoEntry_descriptor =
-      getDescriptor().getMessageTypes().get(6);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_alluxio_proto_journal_UpdateDatabaseInfoEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_UpdateDatabaseInfoEntry_descriptor,

--- a/core/transport/src/main/java/alluxio/proto/journal/Table.java
+++ b/core/transport/src/main/java/alluxio/proto/journal/Table.java
@@ -2144,10 +2144,37 @@ public final class Table {
      */
     alluxio.grpc.table.PartitionOrBuilder getPartitionsOrBuilder(
         int index);
+
+    /**
+     * <code>optional int64 previous_version = 10;</code>
+     */
+    boolean hasPreviousVersion();
+    /**
+     * <code>optional int64 previous_version = 10;</code>
+     */
+    long getPreviousVersion();
+
+    /**
+     * <code>optional int64 version = 11;</code>
+     */
+    boolean hasVersion();
+    /**
+     * <code>optional int64 version = 11;</code>
+     */
+    long getVersion();
+
+    /**
+     * <code>optional int64 version_creation_time = 12;</code>
+     */
+    boolean hasVersionCreationTime();
+    /**
+     * <code>optional int64 version_creation_time = 12;</code>
+     */
+    long getVersionCreationTime();
   }
   /**
    * <pre>
-   * next available id: 10
+   * next available id: 13
    * </pre>
    *
    * Protobuf type {@code alluxio.proto.journal.AddTableEntry}
@@ -2168,6 +2195,9 @@ public final class Table {
       tableStats_ = java.util.Collections.emptyList();
       partitionCols_ = java.util.Collections.emptyList();
       partitions_ = java.util.Collections.emptyList();
+      previousVersion_ = 0L;
+      version_ = 0L;
+      versionCreationTime_ = 0L;
     }
 
     @java.lang.Override
@@ -2283,6 +2313,21 @@ public final class Table {
               }
               partitions_.add(
                   input.readMessage(alluxio.grpc.table.Partition.PARSER, extensionRegistry));
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000020;
+              previousVersion_ = input.readInt64();
+              break;
+            }
+            case 88: {
+              bitField0_ |= 0x00000040;
+              version_ = input.readInt64();
+              break;
+            }
+            case 96: {
+              bitField0_ |= 0x00000080;
+              versionCreationTime_ = input.readInt64();
               break;
             }
           }
@@ -2699,6 +2744,51 @@ public final class Table {
       return partitions_.get(index);
     }
 
+    public static final int PREVIOUS_VERSION_FIELD_NUMBER = 10;
+    private long previousVersion_;
+    /**
+     * <code>optional int64 previous_version = 10;</code>
+     */
+    public boolean hasPreviousVersion() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional int64 previous_version = 10;</code>
+     */
+    public long getPreviousVersion() {
+      return previousVersion_;
+    }
+
+    public static final int VERSION_FIELD_NUMBER = 11;
+    private long version_;
+    /**
+     * <code>optional int64 version = 11;</code>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional int64 version = 11;</code>
+     */
+    public long getVersion() {
+      return version_;
+    }
+
+    public static final int VERSION_CREATION_TIME_FIELD_NUMBER = 12;
+    private long versionCreationTime_;
+    /**
+     * <code>optional int64 version_creation_time = 12;</code>
+     */
+    public boolean hasVersionCreationTime() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional int64 version_creation_time = 12;</code>
+     */
+    public long getVersionCreationTime() {
+      return versionCreationTime_;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2759,6 +2849,15 @@ public final class Table {
       for (int i = 0; i < partitions_.size(); i++) {
         output.writeMessage(9, partitions_.get(i));
       }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeInt64(10, previousVersion_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeInt64(11, version_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeInt64(12, versionCreationTime_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -2805,6 +2904,18 @@ public final class Table {
       for (int i = 0; i < partitions_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(9, partitions_.get(i));
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(10, previousVersion_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(11, version_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(12, versionCreationTime_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2855,6 +2966,21 @@ public final class Table {
           .equals(other.getPartitionColsList());
       result = result && getPartitionsList()
           .equals(other.getPartitionsList());
+      result = result && (hasPreviousVersion() == other.hasPreviousVersion());
+      if (hasPreviousVersion()) {
+        result = result && (getPreviousVersion()
+            == other.getPreviousVersion());
+      }
+      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion()) {
+        result = result && (getVersion()
+            == other.getVersion());
+      }
+      result = result && (hasVersionCreationTime() == other.hasVersionCreationTime());
+      if (hasVersionCreationTime()) {
+        result = result && (getVersionCreationTime()
+            == other.getVersionCreationTime());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2901,6 +3027,21 @@ public final class Table {
       if (getPartitionsCount() > 0) {
         hash = (37 * hash) + PARTITIONS_FIELD_NUMBER;
         hash = (53 * hash) + getPartitionsList().hashCode();
+      }
+      if (hasPreviousVersion()) {
+        hash = (37 * hash) + PREVIOUS_VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getPreviousVersion());
+      }
+      if (hasVersion()) {
+        hash = (37 * hash) + VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getVersion());
+      }
+      if (hasVersionCreationTime()) {
+        hash = (37 * hash) + VERSION_CREATION_TIME_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getVersionCreationTime());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2997,7 +3138,7 @@ public final class Table {
     }
     /**
      * <pre>
-     * next available id: 10
+     * next available id: 13
      * </pre>
      *
      * Protobuf type {@code alluxio.proto.journal.AddTableEntry}
@@ -3099,6 +3240,12 @@ public final class Table {
         } else {
           partitionsBuilder_.clear();
         }
+        previousVersion_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000200);
+        version_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000400);
+        versionCreationTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000800);
         return this;
       }
 
@@ -3180,6 +3327,18 @@ public final class Table {
         } else {
           result.partitions_ = partitionsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.previousVersion_ = previousVersion_;
+        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.version_ = version_;
+        if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        result.versionCreationTime_ = versionCreationTime_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3322,6 +3481,15 @@ public final class Table {
               partitionsBuilder_.addAllMessages(other.partitions_);
             }
           }
+        }
+        if (other.hasPreviousVersion()) {
+          setPreviousVersion(other.getPreviousVersion());
+        }
+        if (other.hasVersion()) {
+          setVersion(other.getVersion());
+        }
+        if (other.hasVersionCreationTime()) {
+          setVersionCreationTime(other.getVersionCreationTime());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -4743,6 +4911,102 @@ public final class Table {
           partitions_ = null;
         }
         return partitionsBuilder_;
+      }
+
+      private long previousVersion_ ;
+      /**
+       * <code>optional int64 previous_version = 10;</code>
+       */
+      public boolean hasPreviousVersion() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional int64 previous_version = 10;</code>
+       */
+      public long getPreviousVersion() {
+        return previousVersion_;
+      }
+      /**
+       * <code>optional int64 previous_version = 10;</code>
+       */
+      public Builder setPreviousVersion(long value) {
+        bitField0_ |= 0x00000200;
+        previousVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 previous_version = 10;</code>
+       */
+      public Builder clearPreviousVersion() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        previousVersion_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long version_ ;
+      /**
+       * <code>optional int64 version = 11;</code>
+       */
+      public boolean hasVersion() {
+        return ((bitField0_ & 0x00000400) == 0x00000400);
+      }
+      /**
+       * <code>optional int64 version = 11;</code>
+       */
+      public long getVersion() {
+        return version_;
+      }
+      /**
+       * <code>optional int64 version = 11;</code>
+       */
+      public Builder setVersion(long value) {
+        bitField0_ |= 0x00000400;
+        version_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 version = 11;</code>
+       */
+      public Builder clearVersion() {
+        bitField0_ = (bitField0_ & ~0x00000400);
+        version_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long versionCreationTime_ ;
+      /**
+       * <code>optional int64 version_creation_time = 12;</code>
+       */
+      public boolean hasVersionCreationTime() {
+        return ((bitField0_ & 0x00000800) == 0x00000800);
+      }
+      /**
+       * <code>optional int64 version_creation_time = 12;</code>
+       */
+      public long getVersionCreationTime() {
+        return versionCreationTime_;
+      }
+      /**
+       * <code>optional int64 version_creation_time = 12;</code>
+       */
+      public Builder setVersionCreationTime(long value) {
+        bitField0_ |= 0x00000800;
+        versionCreationTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 version_creation_time = 12;</code>
+       */
+      public Builder clearVersionCreationTime() {
+        bitField0_ = (bitField0_ & ~0x00000800);
+        versionCreationTime_ = 0L;
+        onChanged();
+        return this;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -9643,7 +9907,7 @@ public final class Table {
       "0.alluxio.proto.journal.AttachDbEntry.Co" +
       "nfigEntry\032-\n\013ConfigEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
       "\005value\030\002 \001(\t:\0028\001\" \n\rDetachDbEntry\022\017\n\007db_" +
-      "name\030\001 \001(\t\"\303\003\n\rAddTableEntry\022\017\n\007db_name\030" +
+      "name\030\001 \001(\t\"\215\004\n\rAddTableEntry\022\017\n\007db_name\030" +
       "\001 \001(\t\022\022\n\ntable_name\030\002 \001(\t\022\r\n\005owner\030\003 \001(\t" +
       "\022*\n\006schema\030\004 \001(\0132\032.alluxio.grpc.table.Sc" +
       "hema\022*\n\006layout\030\005 \001(\0132\032.alluxio.grpc.tabl" +
@@ -9653,31 +9917,33 @@ public final class Table {
       "ableEntry.ParametersEntry\0227\n\016partition_c" +
       "ols\030\010 \003(\0132\037.alluxio.grpc.table.FieldSche" +
       "ma\0221\n\npartitions\030\t \003(\0132\035.alluxio.grpc.ta" +
-      "ble.Partition\0321\n\017ParametersEntry\022\013\n\003key\030" +
-      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\226\002\n\033CompleteTra" +
-      "nsformTableEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntab" +
-      "le_name\030\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022g\n\023tra" +
-      "nsformed_layouts\030\004 \003(\0132J.alluxio.proto.j" +
-      "ournal.CompleteTransformTableEntry.Trans" +
-      "formedLayoutsEntry\032U\n\027TransformedLayouts" +
-      "Entry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.allu" +
-      "xio.grpc.table.Layout:\0028\001\"\240\002\n\030AddTransfo" +
-      "rmJobInfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable" +
-      "_name\030\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_i" +
-      "d\030\004 \001(\003\022d\n\023transformed_layouts\030\005 \003(\0132G.a" +
-      "lluxio.proto.journal.AddTransformJobInfo" +
-      "Entry.TransformedLayoutsEntry\032U\n\027Transfo" +
-      "rmedLayoutsEntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002" +
-      " \001(\0132\032.alluxio.grpc.table.Layout:\0028\001\"B\n\033" +
-      "RemoveTransformJobInfoEntry\022\017\n\007db_name\030\001" +
-      " \001(\t\022\022\n\ntable_name\030\002 \001(\t\"\234\002\n\027UpdateDatab" +
-      "aseInfoEntry\022\017\n\007db_name\030\001 \001(\t\022\020\n\010locatio" +
-      "n\030\002 \001(\t\022P\n\tparameter\030\003 \003(\0132=.alluxio.pro" +
-      "to.journal.UpdateDatabaseInfoEntry.Param" +
-      "eterEntry\022\022\n\nowner_name\030\004 \001(\t\0225\n\nowner_t" +
-      "ype\030\005 \001(\0162!.alluxio.grpc.table.Principal" +
-      "Type\022\017\n\007comment\030\006 \001(\t\0320\n\016ParameterEntry\022" +
-      "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001"
+      "ble.Partition\022\030\n\020previous_version\030\n \001(\003\022" +
+      "\017\n\007version\030\013 \001(\003\022\035\n\025version_creation_tim" +
+      "e\030\014 \001(\003\0321\n\017ParametersEntry\022\013\n\003key\030\001 \001(\t\022" +
+      "\r\n\005value\030\002 \001(\t:\0028\001\"\226\002\n\033CompleteTransform" +
+      "TableEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_nam" +
+      "e\030\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022g\n\023transform" +
+      "ed_layouts\030\004 \003(\0132J.alluxio.proto.journal" +
+      ".CompleteTransformTableEntry.Transformed" +
+      "LayoutsEntry\032U\n\027TransformedLayoutsEntry\022" +
+      "\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032.alluxio.gr" +
+      "pc.table.Layout:\0028\001\"\240\002\n\030AddTransformJobI" +
+      "nfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022\n\ntable_name\030" +
+      "\002 \001(\t\022\022\n\ndefinition\030\003 \001(\t\022\016\n\006job_id\030\004 \001(" +
+      "\003\022d\n\023transformed_layouts\030\005 \003(\0132G.alluxio" +
+      ".proto.journal.AddTransformJobInfoEntry." +
+      "TransformedLayoutsEntry\032U\n\027TransformedLa" +
+      "youtsEntry\022\013\n\003key\030\001 \001(\t\022)\n\005value\030\002 \001(\0132\032" +
+      ".alluxio.grpc.table.Layout:\0028\001\"B\n\033Remove" +
+      "TransformJobInfoEntry\022\017\n\007db_name\030\001 \001(\t\022\022" +
+      "\n\ntable_name\030\002 \001(\t\"\234\002\n\027UpdateDatabaseInf" +
+      "oEntry\022\017\n\007db_name\030\001 \001(\t\022\020\n\010location\030\002 \001(" +
+      "\t\022P\n\tparameter\030\003 \003(\0132=.alluxio.proto.jou" +
+      "rnal.UpdateDatabaseInfoEntry.ParameterEn" +
+      "try\022\022\n\nowner_name\030\004 \001(\t\0225\n\nowner_type\030\005 " +
+      "\001(\0162!.alluxio.grpc.table.PrincipalType\022\017" +
+      "\n\007comment\030\006 \001(\t\0320\n\016ParameterEntry\022\013\n\003key" +
+      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -9715,7 +9981,7 @@ public final class Table {
     internal_static_alluxio_proto_journal_AddTableEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_proto_journal_AddTableEntry_descriptor,
-        new java.lang.String[] { "DbName", "TableName", "Owner", "Schema", "Layout", "TableStats", "Parameters", "PartitionCols", "Partitions", });
+        new java.lang.String[] { "DbName", "TableName", "Owner", "Schema", "Layout", "TableStats", "Parameters", "PartitionCols", "Partitions", "PreviousVersion", "Version", "VersionCreationTime", });
     internal_static_alluxio_proto_journal_AddTableEntry_ParametersEntry_descriptor =
       internal_static_alluxio_proto_journal_AddTableEntry_descriptor.getNestedTypes().get(0);
     internal_static_alluxio_proto_journal_AddTableEntry_ParametersEntry_fieldAccessorTable = new

--- a/core/transport/src/proto/journal/journal.proto
+++ b/core/transport/src/proto/journal/journal.proto
@@ -16,7 +16,7 @@ import "proto/journal/table.proto";
 // and Spark. We use protobuf version 2.5.0 instead, which is compatible with Hadoop and Spark.
 //
 
-// next available id: 50
+// next available id: 51
 message JournalEntry {
   optional int64 sequence_number = 1;
   optional ActiveSyncTxIdEntry active_sync_tx_id = 34;
@@ -41,6 +41,7 @@ message JournalEntry {
   optional PathPropertiesEntry path_properties = 40;
   optional PersistDirectoryEntry persist_directory = 15;
   optional RemovePathPropertiesEntry remove_path_properties = 41;
+  optional RemoveTableEntry remove_table = 50;
   optional RemoveTransformJobInfoEntry remove_transform_job_info = 47;
   optional RemoveSyncPointEntry remove_sync_point = 33;
   optional RenameEntry rename = 19;

--- a/core/transport/src/proto/journal/table.proto
+++ b/core/transport/src/proto/journal/table.proto
@@ -40,6 +40,13 @@ message AddTableEntry {
 }
 
 // next available id: 5
+message RemoveTableEntry {
+    optional string db_name = 1;
+    optional string table_name = 2;
+    optional int64 version = 4;
+}
+
+// next available id: 5
 message CompleteTransformTableEntry {
     optional string db_name = 1;
     optional string table_name = 2;

--- a/core/transport/src/proto/journal/table.proto
+++ b/core/transport/src/proto/journal/table.proto
@@ -20,7 +20,7 @@ message DetachDbEntry {
     optional string db_name = 1;
 }
 
-// next available id: 10
+// next available id: 13
 message AddTableEntry {
     optional string db_name = 1;
     optional string table_name = 2;
@@ -33,6 +33,10 @@ message AddTableEntry {
     // partitioning scheme
     repeated alluxio.grpc.table.FieldSchema partition_cols = 8;
     repeated alluxio.grpc.table.Partition partitions = 9;
+
+    optional int64 previous_version = 10;
+    optional int64 version = 11;
+    optional int64 version_creation_time = 12;
 }
 
 // next available id: 5

--- a/integration/docker/hms/Dockerfile
+++ b/integration/docker/hms/Dockerfile
@@ -1,0 +1,41 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+FROM openjdk:8-jdk-alpine
+
+ADD http://apache.cs.utah.edu/hive/hive-2.3.6/apache-hive-2.3.6-bin.tar.gz /opt/
+ADD http://apache.cs.utah.edu/hadoop/common/hadoop-2.9.2/hadoop-2.9.2.tar.gz /opt/
+ADD https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.48.tar.gz /opt/
+
+RUN cd /opt && \
+    (if ls | grep -q ".tar.gz"; then ls *.tar.gz | xargs -n1 tar -xzf && rm *.tar.gz; fi) && \
+    ln -s apache-hive-* hive && \
+    ln -s hadoop-* hadoop && \
+    ln -s mysql-connector-java-* mysql-connector-java
+
+RUN cp /opt/mysql-connector-java/*-bin.jar /opt/hive/lib
+
+RUN apk --no-cache --update add bash libc6-compat shadow mysql mysql-client && \
+    rm -rf /var/cache/apk/*
+
+ENV PATH="/opt/hive/bin:/opt/hadoop/bin:${PATH}"
+
+COPY initialize.sh /opt/
+COPY entrypoint.sh /opt/
+
+# initialize the hms and mysql
+RUN /opt/initialize.sh
+
+EXPOSE 9083
+
+WORKDIR /opt/
+
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/integration/docker/hms/README.md
+++ b/integration/docker/hms/README.md
@@ -1,0 +1,14 @@
+This is the docker image of the Hive Metastore, for integration tests. For some integration
+tests which use [Testcontainers](https://www.testcontainers.org/), this docker image can be used
+to launch a local Hive Metastore.
+
+## Building docker image
+To build the docker image , run
+
+```console
+$ docker build -t hms:latest .
+```
+
+## Running tests with this docker image
+Once this image is built, it can be referenced and used by integration tests, using the
+Testcontainers framework.

--- a/integration/docker/hms/entrypoint.sh
+++ b/integration/docker/hms/entrypoint.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
 
 set -e
 

--- a/integration/docker/hms/entrypoint.sh
+++ b/integration/docker/hms/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+function main {
+    # start mysql
+    /usr/bin/mysqld_safe &
+
+    # start hive metastore
+    exec hive --service metastore --hiveconf hive.root.logger=INFO,console --hiveconf hive.log.threshold=INFO
+}
+
+main "$@"

--- a/integration/docker/hms/initialize.sh
+++ b/integration/docker/hms/initialize.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+mysql_install_db --user=mysql --datadir=/var/lib/mysql
+
+# configure mysql
+cat <<EOF >> /etc/my.cnf
+skip-networking=OFF
+bind-address=0.0.0.0
+EOF
+
+# start mysql
+/usr/bin/mysqld_safe &
+sleep 2
+
+# create root user
+mysqladmin -u root password "root"
+echo "CREATE USER 'root'@'%'; GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;" | mysql -uroot -proot
+
+# configure hive metastore to access the local mysql
+cat <<EOF > /opt/hive/conf/hive-site.xml
+<configuration>
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://localhost:9083</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:mysql://localhost:3306/metastore?createDatabaseIfNotExist=true</value>
+    <description>JDBC connect string for a JDBC metastore</description>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value>com.mysql.jdbc.Driver</value>
+    <description>Driver class name for a JDBC metastore</description>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value>root</value>
+    <description>username to use against metastore database</description>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>root</value>
+    <description>password to use against metastore database</description>
+  </property>
+</configuration>
+EOF
+
+# initialize hive metastore
+cd /opt/hive/ && ./bin/schematool -dbType mysql -initSchema --verbose
+
+# stop mysql
+killall mysqld

--- a/integration/docker/hms/initialize.sh
+++ b/integration/docker/hms/initialize.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
 
 mysql_install_db --user=mysql --datadir=/var/lib/mysql
 

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbTable.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbTable.java
@@ -17,7 +17,6 @@ import alluxio.grpc.table.Layout;
 import alluxio.grpc.table.Schema;
 import alluxio.table.common.UdbPartition;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +24,7 @@ import java.util.Map;
  * The interface for the underdb table.
  */
 public interface UdbTable {
+  long UNDEFINED_TIME = -1;
 
   /**
    * @return the table name
@@ -65,5 +65,10 @@ public interface UdbTable {
   /**
    * @return returns partitions for the table
    */
-  List<UdbPartition> getPartitions() throws IOException;
+  List<UdbPartition> getPartitions();
+
+  /**
+   * @return the last modified time of the table definition (not data), or {@link #UNDEFINED_TIME}
+   */
+  long getLastModifiedTime();
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbTable.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbTable.java
@@ -24,7 +24,6 @@ import java.util.Map;
  * The interface for the underdb table.
  */
 public interface UdbTable {
-  long UNDEFINED_TIME = -1;
 
   /**
    * @return the table name
@@ -66,9 +65,4 @@ public interface UdbTable {
    * @return returns partitions for the table
    */
   List<UdbPartition> getPartitions();
-
-  /**
-   * @return the last modified time of the table definition (not data), or {@link #UNDEFINED_TIME}
-   */
-  long getLastModifiedTime();
 }

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -74,6 +74,7 @@ public class AlluxioCatalog implements Journaled {
   }
 
   private LockResource getLock(String dbName, boolean readLock) {
+    // TODO(gpang): update concurrency model to OCC for the catalog
     ReadWriteLock rwLock = mDbLocks.compute(dbName,
         (key, value) -> value == null ? new ReentrantReadWriteLock() : value);
     if (readLock) {

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -46,8 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 /**
@@ -57,7 +56,12 @@ public class AlluxioCatalog implements Journaled {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioCatalog.class);
 
   private final Map<String, Database> mDBs = new ConcurrentHashMap<>();
-  private final Map<String, ReadWriteLock> mDbLocks = new ConcurrentHashMap<>();
+  /**
+   * These locks enforce serialization of updates of the database map, {@link #mDBs}.
+   * Reads do not need to be serialized w.r.t. the writes, and the data structure
+   * (ConcurrentHashMap) is thread-safe.
+   */
+  private final Map<String, ReentrantLock> mDbLocks = new ConcurrentHashMap<>();
   private final UnderDatabaseRegistry mUdbRegistry;
   private final LayoutRegistry mLayoutRegistry;
   private final FileSystem mFileSystem;
@@ -73,15 +77,11 @@ public class AlluxioCatalog implements Journaled {
     mLayoutRegistry.refresh();
   }
 
-  private LockResource getLock(String dbName, boolean readLock) {
+  private LockResource getDbLock(String dbName) {
     // TODO(gpang): update concurrency model to OCC for the catalog
-    ReadWriteLock rwLock = mDbLocks.compute(dbName,
-        (key, value) -> value == null ? new ReentrantReadWriteLock() : value);
-    if (readLock) {
-      return new LockResource(rwLock.readLock());
-    } else {
-      return new LockResource(rwLock.writeLock());
-    }
+    ReentrantLock lock = mDbLocks.compute(dbName,
+        (key, value) -> value == null ? new ReentrantLock() : value);
+    return new LockResource(lock);
   }
   /**
    * @return the layout registry
@@ -104,7 +104,7 @@ public class AlluxioCatalog implements Journaled {
   public boolean attachDatabase(JournalContext journalContext, String udbType,
       String udbConnectionUri, String udbDbName, String dbName, Map<String, String> map)
       throws IOException {
-    try (LockResource l = getLock(dbName, false)) {
+    try (LockResource l = getDbLock(dbName)) {
       if (mDBs.containsKey(dbName)) {
         throw new IOException(String
             .format("Unable to attach database. Database name %s (type: %s) already exists.",
@@ -143,7 +143,7 @@ public class AlluxioCatalog implements Journaled {
    * @return true if the database changed as a result of fullSync
    */
   public boolean syncDatabase(JournalContext journalContext, String dbName) throws IOException {
-    try (LockResource l = getLock(dbName, false)) {
+    try (LockResource l = getDbLock(dbName)) {
       Database db = getDatabaseByName(dbName);
       return db.sync(journalContext);
     }
@@ -158,7 +158,7 @@ public class AlluxioCatalog implements Journaled {
    */
   public boolean detachDatabase(JournalContext journalContext, String dbName)
       throws IOException {
-    try (LockResource l = getLock(dbName, false)) {
+    try (LockResource l = getDbLock(dbName)) {
       if (!mDBs.containsKey(dbName)) {
         throw new IOException(String
             .format("Unable to detach database. Database name %s does not exist", dbName));
@@ -178,9 +178,7 @@ public class AlluxioCatalog implements Journaled {
    * @return a table object
    */
   public Table getTable(String dbName, String tableName) throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      return getTableInternal(dbName, tableName);
-    }
+    return getTableInternal(dbName, tableName);
   }
 
   private Table getTableInternal(String dbName, String tableName) throws IOException {
@@ -205,27 +203,25 @@ public class AlluxioCatalog implements Journaled {
    * @return a database object
    */
   public alluxio.grpc.table.Database getDatabase(String dbName)  throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      Database db = getDatabaseByName(dbName);
-      DatabaseInfo dbInfo = db.getDatabaseInfo();
+    Database db = getDatabaseByName(dbName);
+    DatabaseInfo dbInfo = db.getDatabaseInfo();
 
-      alluxio.grpc.table.Database.Builder builder = alluxio.grpc.table.Database.newBuilder()
-          .setDbName(db.getName())
-          .putAllParameter(dbInfo.getParameters());
-      if (dbInfo.getComment() != null) {
-        builder.setComment(dbInfo.getComment());
-      }
-      if (dbInfo.getLocation() != null) {
-        builder.setLocation(dbInfo.getLocation());
-      }
-      if (dbInfo.getOwnerName() != null) {
-        builder.setOwnerName(dbInfo.getOwnerName());
-      }
-      if (dbInfo.getOwnerType() != null) {
-        builder.setOwnerType(dbInfo.getOwnerType());
-      }
-      return builder.build();
+    alluxio.grpc.table.Database.Builder builder = alluxio.grpc.table.Database.newBuilder()
+        .setDbName(db.getName())
+        .putAllParameter(dbInfo.getParameters());
+    if (dbInfo.getComment() != null) {
+      builder.setComment(dbInfo.getComment());
     }
+    if (dbInfo.getLocation() != null) {
+      builder.setLocation(dbInfo.getLocation());
+    }
+    if (dbInfo.getOwnerName() != null) {
+      builder.setOwnerName(dbInfo.getOwnerName());
+    }
+    if (dbInfo.getOwnerType() != null) {
+      builder.setOwnerType(dbInfo.getOwnerType());
+    }
+    return builder.build();
   }
 
   private Database getDatabaseByName(String dbName) throws NotFoundException {
@@ -243,10 +239,8 @@ public class AlluxioCatalog implements Journaled {
    * @return a list of table names in the database
    */
   public List<String> getAllTables(String dbName) throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      Database db = getDatabaseByName(dbName);
-      return db.getTables().stream().map(Table::getName).collect(Collectors.toList());
-    }
+    Database db = getDatabaseByName(dbName);
+    return db.getTables().stream().map(Table::getName).collect(Collectors.toList());
   }
 
   /**
@@ -258,13 +252,10 @@ public class AlluxioCatalog implements Journaled {
    * @return the statistics for the specified table
    */
   public List<ColumnStatisticsInfo> getTableColumnStatistics(String dbName, String tableName,
-      List<String> colNames)
-      throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      Table table = getTableInternal(dbName, tableName);
-      return table.getStatistics().stream()
-          .filter(info -> colNames.contains(info.getColName())).collect(Collectors.toList());
-    }
+      List<String> colNames) throws IOException {
+    Table table = getTableInternal(dbName, tableName);
+    return table.getStatistics().stream().filter(info -> colNames.contains(info.getColName()))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -278,17 +269,15 @@ public class AlluxioCatalog implements Journaled {
    */
   public Map<String, ColumnStatisticsList> getPartitionColumnStatistics(String dbName,
       String tableName, List<String> partNames, List<String> colNames) throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      Table table = getTableInternal(dbName, tableName);
-      List<Partition> partitions = table.getPartitions();
-      return partitions.stream().filter(p -> partNames.contains(p.getSpec()))
-          .map(p -> new Pair<>(p.getSpec(),
-              ColumnStatisticsList.newBuilder().addAllStatistics(
-                  p.getLayout().getColumnStatsData().entrySet().stream()
-                      .filter(entry -> colNames.contains(entry.getKey()))
-                      .map(Map.Entry::getValue).collect(Collectors.toList())).build()))
-          .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond, (e1, e2) -> e2));
-    }
+    Table table = getTableInternal(dbName, tableName);
+    List<Partition> partitions = table.getPartitions();
+    return partitions.stream().filter(p -> partNames.contains(p.getSpec()))
+        .map(p -> new Pair<>(p.getSpec(),
+            ColumnStatisticsList.newBuilder().addAllStatistics(
+                p.getLayout().getColumnStatsData().entrySet().stream()
+                    .filter(entry -> colNames.contains(entry.getKey()))
+                    .map(Map.Entry::getValue).collect(Collectors.toList())).build()))
+        .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond, (e1, e2) -> e2));
   }
 
   /**
@@ -301,11 +290,9 @@ public class AlluxioCatalog implements Journaled {
    */
   public List<alluxio.grpc.table.Partition> readTable(String dbName, String tableName,
       Constraint constraint) throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      Table table = getTableInternal(dbName, tableName);
-      // TODO(david): implement partition pruning
-      return table.getPartitions().stream().map(Partition::toProto).collect(Collectors.toList());
-    }
+    Table table = getTableInternal(dbName, tableName);
+    // TODO(david): implement partition pruning
+    return table.getPartitions().stream().map(Partition::toProto).collect(Collectors.toList());
   }
 
   /**
@@ -319,7 +306,7 @@ public class AlluxioCatalog implements Journaled {
    */
   public void completeTransformTable(JournalContext journalContext, String dbName, String tableName,
       String definition, Map<String, Layout> transformedLayouts) throws IOException {
-    try (LockResource l = getLock(dbName, false)) {
+    try (LockResource l = getDbLock(dbName)) {
       // Check existence of table.
       getTableInternal(dbName, tableName);
       alluxio.proto.journal.Table.CompleteTransformTableEntry entry =
@@ -342,9 +329,7 @@ public class AlluxioCatalog implements Journaled {
    */
   public List<TransformPlan> getTransformPlan(String dbName, String tableName,
       TransformDefinition definition) throws IOException {
-    try (LockResource l = getLock(dbName, true)) {
-      return getTableInternal(dbName, tableName).getTransformPlans(definition);
-    }
+    return getTableInternal(dbName, tableName).getTransformPlans(definition);
   }
 
   private void apply(alluxio.proto.journal.Table.AttachDbEntry entry) {
@@ -382,7 +367,7 @@ public class AlluxioCatalog implements Journaled {
       Layout layout = mLayoutRegistry.create(e.getValue());
       Partition partition = table.getPartition(spec);
       partition.transform(entry.getDefinition(), layout);
-      LOG.debug("Transformed partition {} of database {} table {} to {} with definition {}",
+      LOG.debug("Transformed partition {} of table {}.{} to {} with definition {}",
           spec, dbName, tableName, layout.getLocation(), entry.getDefinition());
     }
   }

--- a/table/server/master/src/main/java/alluxio/master/table/Partition.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Partition.java
@@ -18,6 +18,7 @@ import alluxio.table.common.UdbPartition;
 import alluxio.table.common.transform.TransformContext;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
+import alluxio.util.CommonUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,10 +31,9 @@ public class Partition {
 
   private final String mPartitionSpec;
   private final Layout mBaseLayout;
-//  private final long mVersion;
-//  private final long mVersionCreationTime;
+  private final long mVersion;
+  private final long mVersionCreationTime;
   private volatile Transformation mTransformation;
-  // TODO(gpang): version number
 
   /**
    * Information kept for the latest transformation on the partition.
@@ -93,11 +93,15 @@ public class Partition {
    *
    * @param partitionSpec the partition spec
    * @param baseLayout the partition layout
+   * @param version the version
+   * @param versionCreationTime the version creation time
    */
-  private Partition(String partitionSpec, Layout baseLayout) {
+  private Partition(String partitionSpec, Layout baseLayout, long version,
+      long versionCreationTime) {
     mPartitionSpec = partitionSpec;
     mBaseLayout = baseLayout;
-//    mVersionCreationTime = CommonUtils.getCurrentMs();
+    mVersion = version;
+    mVersionCreationTime = versionCreationTime;
   }
 
   /**
@@ -106,7 +110,19 @@ public class Partition {
    * @param udbPartition the udb partition
    */
   public Partition(UdbPartition udbPartition) {
-    this(udbPartition.getSpec(), udbPartition.getLayout());
+    this(udbPartition.getSpec(), udbPartition.getLayout(), FIRST_VERSION,
+        CommonUtils.getCurrentMs());
+  }
+
+  /**
+   * Creates the next version of an existing partition.
+   *
+   * @param udbPartition the udb partition
+   * @return a new Partition instance representing the next version of this partition
+   */
+  public Partition createNext(UdbPartition udbPartition) {
+    return new Partition(udbPartition.getSpec(), udbPartition.getLayout(), getVersion() + 1,
+        CommonUtils.getCurrentMs());
   }
 
   /**
@@ -121,6 +137,13 @@ public class Partition {
    */
   public Layout getBaseLayout() {
     return mBaseLayout;
+  }
+
+  /**
+   * @return the version
+   */
+  public long getVersion() {
+    return mVersion;
   }
 
   /**
@@ -167,7 +190,9 @@ public class Partition {
   public alluxio.grpc.table.Partition toProto() {
     alluxio.grpc.table.Partition.Builder builder = alluxio.grpc.table.Partition.newBuilder()
         .setPartitionSpec(PartitionSpec.newBuilder().setSpec(mPartitionSpec).build())
-        .setBaseLayout(mBaseLayout.toProto());
+        .setBaseLayout(mBaseLayout.toProto())
+        .setVersion(mVersion)
+        .setVersionCreationTime(mVersionCreationTime);
     if (mTransformation != null) {
       builder.addTransformations(mTransformation.toProto());
     }
@@ -182,7 +207,8 @@ public class Partition {
   public static Partition fromProto(LayoutRegistry layoutRegistry,
       alluxio.grpc.table.Partition proto) {
     Partition partition = new Partition(proto.getPartitionSpec().getSpec(),
-        layoutRegistry.create(proto.getBaseLayout()));
+        layoutRegistry.create(proto.getBaseLayout()), proto.getVersion(),
+        proto.getVersionCreationTime());
     List<alluxio.grpc.table.Transformation> transformations = proto.getTransformationsList();
     if (!transformations.isEmpty()) {
       partition.mTransformation = Transformation.fromProto(layoutRegistry, transformations.get(0));

--- a/table/server/master/src/main/java/alluxio/master/table/Partition.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Partition.java
@@ -18,6 +18,7 @@ import alluxio.table.common.UdbPartition;
 import alluxio.table.common.transform.TransformContext;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
+import alluxio.util.CommonUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,9 +27,14 @@ import java.util.List;
  * The table partition class.
  */
 public class Partition {
+  private static final long FIRST_VERSION = 1;
+
   private final String mPartitionSpec;
   private final Layout mBaseLayout;
+//  private final long mVersion;
+  private final long mVersionCreationTime;
   private volatile Transformation mTransformation;
+  // TODO(gpang): version number
 
   /**
    * Information kept for the latest transformation on the partition.
@@ -89,9 +95,10 @@ public class Partition {
    * @param partitionSpec the partition spec
    * @param baseLayout the partition layout
    */
-  public Partition(String partitionSpec, Layout baseLayout) {
+  private Partition(String partitionSpec, Layout baseLayout) {
     mPartitionSpec = partitionSpec;
     mBaseLayout = baseLayout;
+    mVersionCreationTime = CommonUtils.getCurrentMs();
   }
 
   /**
@@ -108,6 +115,13 @@ public class Partition {
    */
   public Layout getLayout() {
     return mTransformation == null ? mBaseLayout : mTransformation.getLayout();
+  }
+
+  /**
+   * @return the base layout
+   */
+  public Layout getBaseLayout() {
+    return mBaseLayout;
   }
 
   /**

--- a/table/server/master/src/main/java/alluxio/master/table/Partition.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Partition.java
@@ -18,7 +18,6 @@ import alluxio.table.common.UdbPartition;
 import alluxio.table.common.transform.TransformContext;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
-import alluxio.util.CommonUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +31,7 @@ public class Partition {
   private final String mPartitionSpec;
   private final Layout mBaseLayout;
 //  private final long mVersion;
-  private final long mVersionCreationTime;
+//  private final long mVersionCreationTime;
   private volatile Transformation mTransformation;
   // TODO(gpang): version number
 
@@ -98,7 +97,7 @@ public class Partition {
   private Partition(String partitionSpec, Layout baseLayout) {
     mPartitionSpec = partitionSpec;
     mBaseLayout = baseLayout;
-    mVersionCreationTime = CommonUtils.getCurrentMs();
+//    mVersionCreationTime = CommonUtils.getCurrentMs();
   }
 
   /**

--- a/table/server/master/src/main/java/alluxio/master/table/Table.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Table.java
@@ -87,10 +87,12 @@ public class Table {
               .collect(Collectors.toMap(Partition::getSpec, Function.identity()));
       for (UdbPartition udbPartition : udbTable.getPartitions()) {
         Partition newPartition = existingPartitions.get(udbPartition.getSpec());
-        if (newPartition == null || !newPartition.getLayout()
-            .equals(udbPartition.getLayout())) {
-          // create a new partition (didnt exist, or layout was updated)
+        if (newPartition == null) {
+          // partition does not exist yet
           newPartition = new Partition(udbPartition);
+        } else if (!newPartition.getLayout().equals(udbPartition.getLayout())) {
+          // existing partition is updated
+          newPartition = newPartition.createNext(udbPartition);
         }
         partitions.add(newPartition);
       }

--- a/table/server/master/src/main/java/alluxio/master/table/Table.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Table.java
@@ -12,8 +12,6 @@
 package alluxio.master.table;
 
 import alluxio.grpc.table.ColumnStatisticsInfo;
-import alluxio.grpc.table.FieldSchema;
-import alluxio.grpc.table.Layout;
 import alluxio.grpc.table.Schema;
 import alluxio.grpc.table.TableInfo;
 import alluxio.proto.journal.Table.AddTableEntry;
@@ -22,6 +20,7 @@ import alluxio.table.common.transform.TransformContext;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
 import alluxio.table.common.udb.UdbTable;
+import alluxio.util.CommonUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -43,114 +43,108 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class Table {
   private static final Logger LOG = LoggerFactory.getLogger(Table.class);
+  private static final long UNDEFINED_VERSION = -1;
 
-  private String mName;
+  public static final long FIRST_VERSION = 1;
+
   private final Database mDatabase;
-  private Schema mSchema;
-  private PartitionScheme mPartitionScheme;
-  private String mOwner;
-  private List<ColumnStatisticsInfo> mStatistics;
-  private Map<String, String> mParameters;
+  private final String mName;
+  private final long mVersion;
+  private final long mVersionCreationTime;
+  private final long mPreviousVersion;
 
-  private Table(Database database, UdbTable udbTable) {
-    mDatabase = database;
-    sync(udbTable);
-  }
-
-  private Table(Database database, List<Partition> partitions, Schema schema, String tableName,
-      String owner, List<ColumnStatisticsInfo> columnStats,
-      Map<String, String> parameters, List<FieldSchema> partitionCols, Layout layout) {
-    mDatabase = database;
-    mName = tableName;
-    mSchema = schema;
-    mPartitionScheme = PartitionScheme.create(partitions, layout, partitionCols);
-    mOwner = owner;
-    mStatistics = columnStats;
-    mParameters = new HashMap<>(parameters);
-  }
-
-  private boolean isSyncable(UdbTable udbTable) {
-    if (mSchema == null && mPartitionScheme == null) {
-      return true;
-    }
-    if (!Objects.equals(mSchema, udbTable.getSchema())) {
-      // can't sync if the schema is different
-      return false;
-    }
-    if (mPartitionScheme == null || mPartitionScheme.getPartitionCols().isEmpty()) {
-      // can't sync if it is non-partitioned table
-      return false;
-    }
-    List<FieldSchema> partitionCols = new ArrayList<>(udbTable.getPartitionCols());
-    return Objects.equals(partitionCols, mPartitionScheme.getPartitionCols());
-  }
+  private final Schema mSchema;
+  private final PartitionScheme mPartitionScheme;
+  private final String mOwner;
+  private final List<ColumnStatisticsInfo> mStatistics;
+  private final Map<String, String> mParameters;
 
   /**
-   * Sync the table with a udbtable.
-   *
-   * @param udbTable udb table to be synced
-   * @return true if the table changed
+   * @param database the database
+   * @param udbTable the udb table to sync from
+   * @param previousTable the previous table, or {@code null} if creating first version of table
    */
-  public boolean sync(UdbTable udbTable) {
-    boolean changed = false;
-    try {
-      if (!isSyncable(udbTable)) {
-        return false;
-      }
-      // only sync these fields if the table is uninitialized
-      if (mName == null) {
-        mName = udbTable.getName();
-        mSchema = udbTable.getSchema();
-        mOwner = udbTable.getOwner();
-        mStatistics = udbTable.getStatistics();
-        mParameters = new HashMap<>(udbTable.getParameters());
-        changed = true;
-      }
-      List<Partition> partitions = mPartitionScheme == null
-          ? new ArrayList<>() : new ArrayList<>(mPartitionScheme.getPartitions());
-      Layout tableLayout = mPartitionScheme == null
-          ? udbTable.getLayout() : mPartitionScheme.getTableLayout();
-      Set<String> partNames = partitions.stream().map(Partition::getSpec)
-          .collect(Collectors.toSet());
-      for (UdbPartition udbpart : udbTable.getPartitions()) {
-        if (!partNames.contains(udbpart.getSpec())) {
-          partitions.add(new Partition(udbpart));
-          changed = true;
+  private Table(Database database, UdbTable udbTable, @Nullable Table previousTable) {
+    mDatabase = database;
+    mVersion = previousTable == null ? FIRST_VERSION : previousTable.mVersion + 1;
+    mPreviousVersion = previousTable == null ? UNDEFINED_VERSION : previousTable.mVersion;
+    mVersionCreationTime = CommonUtils.getCurrentMs();
+
+    mName = udbTable.getName();
+    mSchema = udbTable.getSchema();
+    mOwner = udbTable.getOwner();
+    mStatistics = udbTable.getStatistics();
+    mParameters = new HashMap<>(udbTable.getParameters());
+
+    // TODO(gpang): inspect listing of table or partition location?
+
+    // Compare udb partitions with the existing partitions
+    List<Partition> partitions = new ArrayList<>(udbTable.getPartitions().size());
+    if (previousTable != null) {
+      // spec to existing partition
+      Map<String, Partition> existingPartitions =
+          previousTable.mPartitionScheme.getPartitions().stream()
+              .collect(Collectors.toMap(Partition::getSpec, Function.identity()));
+      for (UdbPartition udbPartition : udbTable.getPartitions()) {
+        Partition newPartition = existingPartitions.get(udbPartition.getSpec());
+        if (newPartition == null || !newPartition.getLayout()
+            .equals(udbPartition.getLayout())) {
+          // create a new partition (didnt exist, or layout was updated)
+          newPartition = new Partition(udbPartition);
         }
+        partitions.add(newPartition);
       }
-      if (changed) {
-        mPartitionScheme = PartitionScheme.create(partitions,
-            tableLayout, udbTable.getPartitionCols());
-      }
-    } catch (IOException e) {
-      LOG.info("Sync table {} failed {}", mName, e);
+    } else {
+      // Use all the udb partitions
+      partitions =
+          udbTable.getPartitions().stream().map(Partition::new).collect(Collectors.toList());
     }
-    return changed;
+    mPartitionScheme =
+        PartitionScheme.create(partitions, udbTable.getLayout(), udbTable.getPartitionCols());
+  }
+
+  private Table(Database database, alluxio.proto.journal.Table.AddTableEntry entry) {
+    List<Partition> partitions = entry.getPartitionsList().stream()
+        .map(p -> Partition.fromProto(database.getContext().getLayoutRegistry(), p))
+        .collect(Collectors.toList());
+
+    mDatabase = database;
+    mName = entry.getTableName();
+    mPreviousVersion = entry.getPreviousVersion();
+    mVersion = entry.getVersion();
+    mVersionCreationTime = entry.getVersionCreationTime();
+    mSchema = entry.getSchema();
+    mPartitionScheme =
+        PartitionScheme.create(partitions, entry.getLayout(), entry.getPartitionColsList());
+    mOwner = entry.getOwner();
+    mStatistics = entry.getTableStatsList();
+    mParameters = new HashMap<>(entry.getParametersMap());
   }
 
   /**
    * @param database the database
    * @param udbTable the udb table
-   * @return a new instance
+   * @param previousTable the previous table, or {@code null} if creating first version of table
+   * @return a new (or first) version of the table based on the udb table, or {@code null} if there
+   *         no changes in the udb table
    */
-  public static Table create(Database database, UdbTable udbTable) throws IOException {
-    return new Table(database, udbTable);
+  public static Table create(Database database, UdbTable udbTable, @Nullable Table previousTable) {
+    if (previousTable != null && !previousTable.shouldSync(udbTable)) {
+      // no need for a new version
+      return null;
+    }
+    return new Table(database, udbTable, previousTable);
   }
 
   /**
    * @param database the database
-   * @param entry the add table entry
+   * @param entry the add table journal entry
    * @return a new instance
    */
   public static Table create(Database database, alluxio.proto.journal.Table.AddTableEntry entry) {
-    List<Partition> partitions = entry.getPartitionsList().stream()
-        .map(p -> Partition.fromProto(database.getContext().getLayoutRegistry(), p))
-        .collect(Collectors.toList());
-
-    return new Table(database, partitions, entry.getSchema(), entry.getTableName(),
-        entry.getOwner(), entry.getTableStatsList(), entry.getParametersMap(),
-        entry.getPartitionColsList(), entry.getLayout());
+    return new Table(database, entry);
   }
+
   /**
    * @return the table name
    */
@@ -188,6 +182,20 @@ public class Table {
   }
 
   /**
+   * @return the table version
+   */
+  public long getVersion() {
+    return mVersion;
+  }
+
+  /**
+   * @return the previous table version
+   */
+  public long getPreviousVersion() {
+    return mPreviousVersion;
+  }
+
+  /**
    * Returns a list of plans to transform the table, according to the transformation definition.
    *
    * @param definition the transformation definition
@@ -206,6 +214,38 @@ public class Table {
   }
 
   /**
+   * @param udbTable the udb table to check against
+   * @return true if the table should be synced, because of differences in the udb table
+   */
+  public boolean shouldSync(UdbTable udbTable) {
+    if (!Objects.equals(mName, udbTable.getName())
+        || !Objects.equals(mSchema, udbTable.getSchema())
+        || !Objects.equals(mOwner, udbTable.getOwner())
+        || !Objects.equals(mStatistics, udbTable.getStatistics())
+        || !Objects.equals(mParameters, udbTable.getParameters())) {
+      // some fields are different
+      return true;
+    }
+
+    Map<String, Partition> existingPartitions = mPartitionScheme.getPartitions().stream()
+        .collect(Collectors.toMap(Partition::getSpec, Function.identity()));
+    if (existingPartitions.size() != udbTable.getPartitions().size()) {
+      return true;
+    }
+
+    for (UdbPartition udbPartition : udbTable.getPartitions()) {
+      Partition newPartition = existingPartitions.get(udbPartition.getSpec());
+      if (newPartition == null || !newPartition.getLayout()
+          .equals(udbPartition.getLayout())) {
+        // mismatch of a partition
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * @return the proto representation
    */
   public TableInfo toProto() {
@@ -216,7 +256,10 @@ public class Table {
         .setOwner(mOwner)
         .putAllParameters(mParameters)
         .addAllPartitionCols(mPartitionScheme.getPartitionCols())
-        .setLayout(mPartitionScheme.getTableLayout());
+        .setLayout(mPartitionScheme.getTableLayout())
+        .setPreviousVersion(mPreviousVersion)
+        .setVersion(mVersion)
+        .setVersionCreationTime(mVersionCreationTime);
 
     return builder.build();
   }
@@ -235,7 +278,10 @@ public class Table {
         .setOwner(mOwner)
         .putAllParameters(mParameters)
         .addAllPartitionCols(mPartitionScheme.getPartitionCols())
-        .setLayout(mPartitionScheme.getTableLayout());
+        .setLayout(mPartitionScheme.getTableLayout())
+        .setPreviousVersion(mPreviousVersion)
+        .setVersion(mVersion)
+        .setVersionCreationTime(mVersionCreationTime);
 
     return builder.build();
   }

--- a/table/server/master/src/main/java/alluxio/master/table/Table.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Table.java
@@ -90,7 +90,7 @@ public class Table {
         if (newPartition == null) {
           // partition does not exist yet
           newPartition = new Partition(udbPartition);
-        } else if (!newPartition.getLayout().equals(udbPartition.getLayout())) {
+        } else if (!newPartition.getBaseLayout().equals(udbPartition.getLayout())) {
           // existing partition is updated
           newPartition = newPartition.createNext(udbPartition);
         }
@@ -237,8 +237,8 @@ public class Table {
 
     for (UdbPartition udbPartition : udbTable.getPartitions()) {
       Partition newPartition = existingPartitions.get(udbPartition.getSpec());
-      if (newPartition == null || !newPartition.getLayout()
-          .equals(udbPartition.getLayout())) {
+      if (newPartition == null
+          || !newPartition.getBaseLayout().equals(udbPartition.getLayout())) {
         // mismatch of a partition
         return true;
       }

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -179,7 +179,7 @@ public class AlluxioCatalogTest {
     // setup
     UdbTable tbl = createMockUdbTable("test", s);
     Database db = createMockDatabase("noop", "test", Collections.emptyList());
-    db.addTable(tbl.getName(), Table.create(db, tbl));
+    addTableToDb(db, Table.create(db, tbl, null));
     addDbToCatalog(db);
     assertEquals(1, mCatalog.getTable("test", "test").getPartitions().size());
   }
@@ -190,7 +190,7 @@ public class AlluxioCatalogTest {
     // setup
     UdbTable tbl = createMockPartitionedUdbTable("test", s);
     Database db = createMockDatabase("noop", "test", Collections.emptyList());
-    db.addTable(tbl.getName(), Table.create(db, tbl));
+    addTableToDb(db, Table.create(db, tbl, null));
     addDbToCatalog(db);
     assertEquals(2, mCatalog.getTable("test", "test").getPartitions().size());
   }
@@ -233,7 +233,7 @@ public class AlluxioCatalogTest {
     // Why does this API seem so counter intuitive?
     UdbTable tbl = createMockUdbTable("test", s);
     Database db = createMockDatabase("noop", "test", Collections.emptyList());
-    db.addTable(tbl.getName(), Table.create(db, tbl));
+    addTableToDb(db, Table.create(db, tbl, null));
     addDbToCatalog(db);
 
     // basic, filter on each col
@@ -411,6 +411,11 @@ public class AlluxioCatalogTest {
     return dbs;
   }
 
+  private void addTableToDb(Database db, Table table) {
+    Map<String, Table> dbTables = Whitebox.getInternalState(db, "mTables");
+    dbTables.put(table.getName(), table);
+  }
+
   private Database createMockDatabase(String type, String name, Collection<Table> tables) {
     UdbContext udbCtx = Mockito.mock(UdbContext.class);
     when(udbCtx.getUdbRegistry()).thenReturn(Mockito.mock(UnderDatabaseRegistry.class));
@@ -421,7 +426,7 @@ public class AlluxioCatalogTest {
         name,
         Collections.emptyMap()
     );
-    tables.forEach(table -> db.addTable(table.getName(), table));
+    tables.forEach(table -> addTableToDb(db, table));
     return db;
   }
 

--- a/table/server/master/src/test/java/alluxio/master/table/TestUdbTable.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestUdbTable.java
@@ -117,11 +117,6 @@ public class TestUdbTable implements UdbTable {
     return mTestPartitions;
   }
 
-  @Override
-  public long getLastModifiedTime() {
-    return UNDEFINED_TIME;
-  }
-
   private class TestPartition implements UdbPartition {
     private HiveLayout mLayout;
 

--- a/table/server/master/src/test/java/alluxio/master/table/TestUdbTable.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestUdbTable.java
@@ -22,7 +22,6 @@ import alluxio.table.common.UdbPartition;
 import alluxio.table.common.layout.HiveLayout;
 import alluxio.table.common.udb.UdbTable;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -114,8 +113,13 @@ public class TestUdbTable implements UdbTable {
   }
 
   @Override
-  public List<UdbPartition> getPartitions() throws IOException {
+  public List<UdbPartition> getPartitions() {
     return mTestPartitions;
+  }
+
+  @Override
+  public long getLastModifiedTime() {
+    return UNDEFINED_TIME;
   }
 
   private class TestPartition implements UdbPartition {

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
@@ -31,7 +31,6 @@ import java.util.Map;
  */
 public class HiveTable implements UdbTable {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTable.class);
-  private static final String LAST_DDL_TIME = "transient_lastDdlTime";
 
   private final String mName;
   private final Schema mSchema;
@@ -41,7 +40,6 @@ public class HiveTable implements UdbTable {
   private final List<UdbPartition> mUdbPartitions;
   private final Map<String, String> mParameters;
   private final Layout mLayout;
-  private final long mLastModifiedTime;
 
   /**
    * Creates a new instance.
@@ -64,11 +62,6 @@ public class HiveTable implements UdbTable {
     mOwner = table.getOwner();
     mParameters = (table.getParameters() != null) ? table.getParameters() : Collections.emptyMap();
     mLayout = layout;
-    if (mParameters.containsKey(LAST_DDL_TIME)) {
-      mLastModifiedTime = Long.parseLong(mParameters.get(LAST_DDL_TIME));
-    } else {
-      mLastModifiedTime = UNDEFINED_TIME;
-    }
   }
 
   @Override
@@ -109,10 +102,5 @@ public class HiveTable implements UdbTable {
   @Override
   public List<UdbPartition> getPartitions() {
     return mUdbPartitions;
-  }
-
-  @Override
-  public long getLastModifiedTime() {
-    return mLastModifiedTime;
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveTable.java
@@ -15,64 +15,48 @@ import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.FieldSchema;
 import alluxio.grpc.table.Layout;
 import alluxio.grpc.table.Schema;
-import alluxio.grpc.table.layout.hive.PartitionInfo;
 import alluxio.table.common.UdbPartition;
-import alluxio.table.common.layout.HiveLayout;
 import alluxio.table.common.udb.UdbTable;
-import alluxio.table.under.hive.util.PathTranslator;
 
-import org.apache.hadoop.hive.common.FileUtils;
-import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Hive table implementation.
  */
 public class HiveTable implements UdbTable {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTable.class);
+  private static final String LAST_DDL_TIME = "transient_lastDdlTime";
 
-  private final HiveDatabase mHiveDatabase;
-  private final PathTranslator mPathTranslator;
   private final String mName;
   private final Schema mSchema;
   private final String mOwner;
   private final List<ColumnStatisticsInfo> mStatistics;
   private final List<FieldSchema> mPartitionKeys;
-  private final Table mTable;
-  private final List<Partition> mPartitions;
+  private final List<UdbPartition> mUdbPartitions;
   private final Map<String, String> mParameters;
   private final Layout mLayout;
+  private final long mLastModifiedTime;
 
   /**
    * Creates a new instance.
    *
-   * @param hiveDatabase the hive db
-   * @param pathTranslator the path translator
    * @param name the table name
    * @param schema the table schema
    * @param statistics the table statistics
    * @param cols partition keys
-   * @param partitions partition list
+   * @param udbPartitions udb partition list
    * @param layout the table layout
    * @param table hive table object
    */
-  public HiveTable(HiveDatabase hiveDatabase, PathTranslator pathTranslator, String name,
-      Schema schema, List<ColumnStatisticsInfo> statistics, List<FieldSchema> cols,
-      List<Partition> partitions, Layout layout, Table table) {
-    mHiveDatabase = hiveDatabase;
-    mTable = table;
-    mPathTranslator = pathTranslator;
-    mPartitions = partitions;
+  public HiveTable(String name, Schema schema, List<ColumnStatisticsInfo> statistics,
+      List<FieldSchema> cols, List<UdbPartition> udbPartitions, Layout layout, Table table) {
+    mUdbPartitions = udbPartitions;
     mName = name;
     mSchema = schema;
     mStatistics = statistics;
@@ -80,6 +64,11 @@ public class HiveTable implements UdbTable {
     mOwner = table.getOwner();
     mParameters = (table.getParameters() != null) ? table.getParameters() : Collections.emptyMap();
     mLayout = layout;
+    if (mParameters.containsKey(LAST_DDL_TIME)) {
+      mLastModifiedTime = Long.parseLong(mParameters.get(LAST_DDL_TIME));
+    } else {
+      mLastModifiedTime = UNDEFINED_TIME;
+    }
   }
 
   @Override
@@ -118,57 +107,12 @@ public class HiveTable implements UdbTable {
   }
 
   @Override
-  public List<UdbPartition> getPartitions() throws IOException {
-    List<UdbPartition> udbPartitions = new ArrayList<>();
-    try {
-      List<Partition> partitions = mPartitions;
-      List<String> dataColumns = mTable.getSd().getCols().stream()
-          .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
-          .collect(Collectors.toList());
-      List<String> partitionColumns = mTable.getPartitionKeys().stream()
-          .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
-          .collect(Collectors.toList());
+  public List<UdbPartition> getPartitions() {
+    return mUdbPartitions;
+  }
 
-      if (partitionColumns.isEmpty()) {
-        // unpartitioned table, generate a partition
-        PartitionInfo.Builder pib = PartitionInfo.newBuilder()
-            .setDbName(mHiveDatabase.getUdbContext().getDbName()).setTableName(mName)
-            .addAllDataCols(HiveUtils.toProto(mTable.getSd().getCols()))
-            .setStorage(HiveUtils.toProto(mTable.getSd(), mPathTranslator))
-            .setPartitionName(mName)
-            .putAllParameters(mTable.getParameters());
-        udbPartitions.add(new HivePartition(
-            new HiveLayout(pib.build(), Collections.emptyList())));
-        return udbPartitions;
-      }
-
-      List<String> partitionNames = partitions.stream().map(
-          partition -> FileUtils.makePartName(partitionColumns,
-              partition.getValues())).collect(Collectors.toList());
-      Map<String, List<ColumnStatisticsInfo>> statsMap = mHiveDatabase.getHive()
-          .getPartitionColumnStatistics(mHiveDatabase.getName(), mName, partitionNames, dataColumns)
-          .entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
-              e -> e.getValue().stream().map(HiveUtils::toProto).collect(Collectors.toList()),
-              (e1, e2) -> e2));
-      for (Partition partition : partitions) {
-        String partName = FileUtils.makePartName(partitionColumns, partition.getValues());
-        PartitionInfo.Builder pib = PartitionInfo.newBuilder()
-            .setDbName(mHiveDatabase.getUdbContext().getDbName())
-            .setTableName(mName)
-            .addAllDataCols(HiveUtils.toProto(partition.getSd().getCols()))
-            .setStorage(HiveUtils.toProto(partition.getSd(), mPathTranslator))
-            .setPartitionName(partName)
-            .putAllParameters(partition.getParameters());
-        if (partition.getValues() != null) {
-          pib.addAllValues(partition.getValues());
-        }
-        udbPartitions.add(new HivePartition(
-            new HiveLayout(pib.build(), statsMap.getOrDefault(partName, Collections.emptyList()))));
-      }
-      return udbPartitions;
-    } catch (TException e) {
-      throw new IOException(
-          "failed to list hive partitions for table: " + mHiveDatabase.getName() + "." + mName, e);
-    }
+  @Override
+  public long getLastModifiedTime() {
+    return mLastModifiedTime;
   }
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -86,6 +86,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.12.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
     </dependency>

--- a/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
@@ -1,0 +1,177 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import alluxio.AlluxioTestDirectory;
+import alluxio.master.LocalAlluxioJobCluster;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class TableIntegrationTest extends BaseIntegrationTest {
+  private static final String DB_NAME = "test";
+  private static final File WAREHOUSE_DIR = AlluxioTestDirectory
+      .createTemporaryDirectory(new File("/tmp/alluxio-tests"), "TableIntegrationTest");
+
+  @ClassRule
+  public static TemporaryFolder sFolder = new TemporaryFolder();
+
+  @ClassRule
+  public static GenericContainer sHms =
+      new GenericContainer<>("genepang/hms:latest").withExposedPorts(9083)
+          .withFileSystemBind(WAREHOUSE_DIR.getAbsolutePath(), WAREHOUSE_DIR.getAbsolutePath());
+
+  @ClassRule
+  public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder().build();
+
+  private static LocalAlluxioJobCluster sLocalAlluxioJobCluster;
+  private static TableMaster sTableMaster;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    String hmsAddress = sHms.getContainerIpAddress();
+    int hmsPort = sHms.getMappedPort(9083);
+
+    File dbDir = new File(WAREHOUSE_DIR, DB_NAME + ".db");
+    dbDir.mkdirs();
+
+    // write data files for the tables, to avoid the insert statement, which is slow.
+    // write data files for table: test_table
+    new File(dbDir.getAbsolutePath() + "/test_table").mkdirs();
+    PrintWriter writer = new PrintWriter(dbDir.getAbsolutePath() + "/test_table/data.csv");
+    writer.println("1,11,111,1.1,1111,11111");
+    writer.println("2,22,222,2.2,2222,22222");
+    writer.close();
+
+    // write data files for table: test_table_part
+    new File(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=11111").mkdirs();
+    writer =
+        new PrintWriter(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=11111/data.csv");
+    writer.println("1,11,111,1.1,1111");
+    writer.close();
+    new File(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=22222").mkdirs();
+    writer =
+        new PrintWriter(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=22222/data.csv");
+    writer.println("2,22,222,2.2,2222");
+    writer.close();
+
+    String[] lines = {
+        String.format("CREATE DATABASE %s; USE %s;", DB_NAME, DB_NAME),
+        String.format(
+            "CREATE EXTERNAL TABLE test_table(`int1` int, `long2` bigint, `string3` string, `float4` "
+                + "float, "
+                + "`long5` bigint, `partitionint6` int) LOCATION 'file://%s';",
+            dbDir.getAbsolutePath() + "/test_table"),
+        String.format(
+            "CREATE EXTERNAL TABLE test_table_part(`int1` int, `long2` bigint, `string3` string, "
+                + "`float4` "
+                + "float, `long5` bigint) PARTITIONED BY (partitionint6 INT) LOCATION 'file://%s';",
+            dbDir.getAbsolutePath() + "/test_table_part"),
+        "MSCK REPAIR TABLE test_table_part;",
+    };
+
+    execBeeline(Arrays.asList(lines));
+
+    sLocalAlluxioJobCluster = new LocalAlluxioJobCluster();
+    sLocalAlluxioJobCluster.start();
+
+    sTableMaster = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
+        .getMaster(TableMaster.class);
+
+    sTableMaster
+        .attachDatabase("hive", "thrift://" + hmsAddress + ":" + hmsPort, DB_NAME, DB_NAME,
+            Collections.emptyMap());
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    sLocalAlluxioJobCluster.stop();
+  }
+
+  @Test
+  public void syncUnmodifiedTable() throws Exception {
+    Table table = sTableMaster.getTable(DB_NAME, "test_table");
+    long version = table.getVersion();
+    table = sTableMaster.getTable(DB_NAME, "test_table_part");
+    long versionPart = table.getVersion();
+
+    sTableMaster.syncDatabase(DB_NAME);
+    assertEquals(version, sTableMaster.getTable(DB_NAME, "test_table").getVersion());
+    assertEquals(versionPart, sTableMaster.getTable(DB_NAME, "test_table_part").getVersion());
+  }
+
+  @Test
+  public void syncModifiedTable() throws Exception {
+    Table table = sTableMaster.getTable(DB_NAME, "test_table");
+    long version = table.getVersion();
+    table = sTableMaster.getTable(DB_NAME, "test_table_part");
+    long versionPart = table.getVersion();
+
+    String[] lines = {
+        String.format("USE %s;", DB_NAME),
+        String.format("ALTER TABLE test_table SET LOCATION 'file://%s/test.db/test_table';",
+            WAREHOUSE_DIR.getAbsolutePath()),
+        String.format(
+            "ALTER TABLE test_table_part partition(partitionint6=22222) SET LOCATION "
+                + "'file://%s/test.db/test_table_part/partitionint6=22222/';",
+            WAREHOUSE_DIR.getAbsolutePath()),
+    };
+    execBeeline(Arrays.asList(lines));
+
+    sTableMaster.syncDatabase(DB_NAME);
+    long newVersion = sTableMaster.getTable(DB_NAME, "test_table").getVersion();
+    long newVersionPart = sTableMaster.getTable(DB_NAME, "test_table_part").getVersion();
+    assertNotEquals(version, newVersion);
+    assertNotEquals(versionPart, newVersionPart);
+    sTableMaster.syncDatabase(DB_NAME);
+    assertEquals(newVersion, sTableMaster.getTable(DB_NAME, "test_table").getVersion());
+    assertEquals(newVersionPart, sTableMaster.getTable(DB_NAME, "test_table_part").getVersion());
+  }
+
+  private static void execBeeline(List<String> commands) throws Exception {
+    File file = sFolder.newFile();
+    PrintWriter writer = new PrintWriter(file.getAbsolutePath());
+    for (String line : commands) {
+      writer.println(line);
+    }
+    writer.close();
+
+    sHms.copyFileToContainer(MountableFile.forHostPath(file.getAbsolutePath()),
+        "/opt/" + file.getName());
+    Container.ExecResult result =
+        sHms.execInContainer("/opt/hive/bin/beeline", "-u", "jdbc:hive2://", "-f",
+            "/opt/" + file.getName());
+
+    if (result.getExitCode() != 0) {
+      throw new IOException("beeline commands failed. stderr: " + result.getStderr());
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
@@ -86,9 +86,8 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
     String[] lines = {
         String.format("CREATE DATABASE %s; USE %s;", DB_NAME, DB_NAME),
         String.format(
-            "CREATE EXTERNAL TABLE test_table(`int1` int, `long2` bigint, `string3` string, `float4` "
-                + "float, "
-                + "`long5` bigint, `partitionint6` int) LOCATION 'file://%s';",
+            "CREATE EXTERNAL TABLE test_table(`int1` int, `long2` bigint, `string3` string, "
+                + "`float4` float, " + "`long5` bigint, `partitionint6` int) LOCATION 'file://%s';",
             dbDir.getAbsolutePath() + "/test_table"),
         String.format(
             "CREATE EXTERNAL TABLE test_table_part(`int1` int, `long2` bigint, `string3` string, "

--- a/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
@@ -22,6 +22,7 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.Container;
@@ -34,18 +35,25 @@ import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+@Ignore("Enable after docker can be used from within tests")
 public final class TableIntegrationTest extends BaseIntegrationTest {
   private static final String DB_NAME = "test";
   private static final File WAREHOUSE_DIR = AlluxioTestDirectory
       .createTemporaryDirectory(new File("/tmp/alluxio-tests"), "TableIntegrationTest");
+  /** The docker image name and tag. */
+  private static final String HMS_IMAGE = "<REPLACE WITH DOCKER IMAGE/TAG OF HMS>";
+  private static final String TEST_TABLE = "test_table";
+  private static final String TEST_TABLE_PART = "test_table_part";
 
   @ClassRule
   public static TemporaryFolder sFolder = new TemporaryFolder();
 
   @ClassRule
   public static GenericContainer sHms =
-      new GenericContainer<>("genepang/hms:latest").withExposedPorts(9083)
+      new GenericContainer<>(HMS_IMAGE).withExposedPorts(9083)
           .withFileSystemBind(WAREHOUSE_DIR.getAbsolutePath(), WAREHOUSE_DIR.getAbsolutePath());
 
   @ClassRule
@@ -65,36 +73,40 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
 
     // write data files for the tables, to avoid the insert statement, which is slow.
     // write data files for table: test_table
-    new File(dbDir.getAbsolutePath() + "/test_table").mkdirs();
-    PrintWriter writer = new PrintWriter(dbDir.getAbsolutePath() + "/test_table/data.csv");
+    String base = dbDir.getAbsolutePath() + "/" + TEST_TABLE + "/";
+    new File(base).mkdirs();
+    PrintWriter writer = new PrintWriter(base + "data.csv");
     writer.println("1,11,111,1.1,1111,11111");
     writer.println("2,22,222,2.2,2222,22222");
     writer.close();
 
     // write data files for table: test_table_part
-    new File(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=11111").mkdirs();
+    base = dbDir.getAbsolutePath() + "/" + TEST_TABLE_PART + "/partitionint6=11111/";
+    new File(base).mkdirs();
     writer =
-        new PrintWriter(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=11111/data.csv");
+        new PrintWriter(base + "data.csv");
     writer.println("1,11,111,1.1,1111");
     writer.close();
-    new File(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=22222").mkdirs();
+    base = dbDir.getAbsolutePath() + "/" + TEST_TABLE_PART + "/partitionint6=22222/";
+    new File(base).mkdirs();
     writer =
-        new PrintWriter(dbDir.getAbsolutePath() + "/test_table_part/partitionint6=22222/data.csv");
+        new PrintWriter(base + "data.csv");
     writer.println("2,22,222,2.2,2222");
     writer.close();
 
     String[] lines = {
         String.format("CREATE DATABASE %s; USE %s;", DB_NAME, DB_NAME),
         String.format(
-            "CREATE EXTERNAL TABLE test_table(`int1` int, `long2` bigint, `string3` string, "
+            "CREATE EXTERNAL TABLE %s(`int1` int, `long2` bigint, `string3` string, "
                 + "`float4` float, " + "`long5` bigint, `partitionint6` int) LOCATION 'file://%s';",
-            dbDir.getAbsolutePath() + "/test_table"),
+            TEST_TABLE, dbDir.getAbsolutePath() + "/" + TEST_TABLE),
+        String.format("MSCK REPAIR TABLE %s;", TEST_TABLE),
         String.format(
-            "CREATE EXTERNAL TABLE test_table_part(`int1` int, `long2` bigint, `string3` string, "
+            "CREATE EXTERNAL TABLE %s(`int1` int, `long2` bigint, `string3` string, "
                 + "`float4` "
                 + "float, `long5` bigint) PARTITIONED BY (partitionint6 INT) LOCATION 'file://%s';",
-            dbDir.getAbsolutePath() + "/test_table_part"),
-        "MSCK REPAIR TABLE test_table_part;",
+            TEST_TABLE_PART, dbDir.getAbsolutePath() + "/" + TEST_TABLE_PART),
+        String.format("MSCK REPAIR TABLE %s;", TEST_TABLE_PART),
     };
 
     execBeeline(Arrays.asList(lines));
@@ -117,44 +129,59 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void syncUnmodifiedTable() throws Exception {
-    Table table = sTableMaster.getTable(DB_NAME, "test_table");
+    Table table = sTableMaster.getTable(DB_NAME, TEST_TABLE);
     long version = table.getVersion();
-    table = sTableMaster.getTable(DB_NAME, "test_table_part");
+    table = sTableMaster.getTable(DB_NAME, TEST_TABLE_PART);
     long versionPart = table.getVersion();
 
     sTableMaster.syncDatabase(DB_NAME);
-    assertEquals(version, sTableMaster.getTable(DB_NAME, "test_table").getVersion());
-    assertEquals(versionPart, sTableMaster.getTable(DB_NAME, "test_table_part").getVersion());
+    assertEquals(version, sTableMaster.getTable(DB_NAME, TEST_TABLE).getVersion());
+    assertEquals(versionPart, sTableMaster.getTable(DB_NAME, TEST_TABLE_PART).getVersion());
   }
 
   @Test
   public void syncModifiedTable() throws Exception {
-    Table table = sTableMaster.getTable(DB_NAME, "test_table");
+    Table table = sTableMaster.getTable(DB_NAME, TEST_TABLE);
     long version = table.getVersion();
-    table = sTableMaster.getTable(DB_NAME, "test_table_part");
+    table = sTableMaster.getTable(DB_NAME, TEST_TABLE_PART);
     long versionPart = table.getVersion();
+    Set<Long> partitionVersions =
+        table.getPartitions().stream().map(Partition::getVersion).collect(Collectors.toSet());
 
+    // update the tables and partitions
     String[] lines = {
         String.format("USE %s;", DB_NAME),
-        String.format("ALTER TABLE test_table SET LOCATION 'file://%s/test.db/test_table';",
-            WAREHOUSE_DIR.getAbsolutePath()),
+        String.format("ALTER TABLE %s SET LOCATION 'file://%s/test.db/%s';",
+            TEST_TABLE, WAREHOUSE_DIR.getAbsolutePath(), TEST_TABLE),
         String.format(
-            "ALTER TABLE test_table_part partition(partitionint6=22222) SET LOCATION "
-                + "'file://%s/test.db/test_table_part/partitionint6=22222/';",
-            WAREHOUSE_DIR.getAbsolutePath()),
+            "ALTER TABLE %s partition(partitionint6=22222) SET LOCATION "
+                + "'file://%s/test.db/%s/partitionint6=22222/';",
+            TEST_TABLE_PART, WAREHOUSE_DIR.getAbsolutePath(), TEST_TABLE_PART),
     };
     execBeeline(Arrays.asList(lines));
 
     sTableMaster.syncDatabase(DB_NAME);
-    long newVersion = sTableMaster.getTable(DB_NAME, "test_table").getVersion();
-    long newVersionPart = sTableMaster.getTable(DB_NAME, "test_table_part").getVersion();
+    long newVersion = sTableMaster.getTable(DB_NAME, TEST_TABLE).getVersion();
+    long newVersionPart = sTableMaster.getTable(DB_NAME, TEST_TABLE_PART).getVersion();
+    Set<Long> newPartitionVersions =
+        sTableMaster.getTable(DB_NAME, TEST_TABLE_PART).getPartitions().stream()
+            .map(Partition::getVersion).collect(Collectors.toSet());
     assertNotEquals(version, newVersion);
     assertNotEquals(versionPart, newVersionPart);
+    assertNotEquals(partitionVersions, newPartitionVersions);
     sTableMaster.syncDatabase(DB_NAME);
-    assertEquals(newVersion, sTableMaster.getTable(DB_NAME, "test_table").getVersion());
-    assertEquals(newVersionPart, sTableMaster.getTable(DB_NAME, "test_table_part").getVersion());
+    assertEquals(newVersion, sTableMaster.getTable(DB_NAME, TEST_TABLE).getVersion());
+    assertEquals(newVersionPart, sTableMaster.getTable(DB_NAME, TEST_TABLE_PART).getVersion());
+    assertEquals(newPartitionVersions,
+        sTableMaster.getTable(DB_NAME, TEST_TABLE_PART).getPartitions().stream()
+            .map(Partition::getVersion).collect(Collectors.toSet()));
   }
 
+  /**
+   * Runs a sequence of commands via beeline, within the HMS container.
+   *
+   * @param commands the list of commands
+   */
   private static void execBeeline(List<String> commands) throws Exception {
     File file = sFolder.newFile();
     PrintWriter writer = new PrintWriter(file.getAbsolutePath());


### PR DESCRIPTION
This allows the sync command to update the metadata of existing partitions, not only new partitions. This means, if an existing partition is updated in hive, it will be detected and updated during a sync command.

For this functionality, table version numbers and partition version numbers have been added. The concurrency model was also updated for these changes. It is an optimistic concurrency control model, where multiple updates can be concurrent, but only 1 will succeed in updating the metadata to the next version.