### PR TITLE
Support the Java 11 runtime in core/common

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -784,22 +784,23 @@ public final class CommonUtils {
     return result;
   }
 
-  private static final String JAVA_VERSION_PROPERTY = "java.version";
-  private static final String JDK_8_VERSION = "1.8";
-  private static final String JDK_11_VERSION = "11";
+  private static final boolean IS_JDK_8 = System.getProperty("java.version")
+      .startsWith("1.8");
+  private static final boolean IS_JDK_11 =  System.getProperty("java.version")
+      .startsWith("11");
 
   /**
-   * @return if this JVM is running on Java version 8
+   * @return true if this JVM is running on Java version 8
    */
   public static boolean isJdk8() {
-    return System.getProperty(JAVA_VERSION_PROPERTY).startsWith(JDK_8_VERSION);
+    return IS_JDK_8;
   }
 
   /**
-   * @return if this JVM is running on Java version 11
+   * @return true if this JVM is running on Java version 11
    */
   public static boolean isJdk11() {
-    return System.getProperty(JAVA_VERSION_PROPERTY).startsWith(JDK_11_VERSION);
+    return IS_JDK_11;
   }
 
   private CommonUtils() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/util/interfaces/IOFunction.java
+++ b/core/common/src/main/java/alluxio/util/interfaces/IOFunction.java
@@ -1,0 +1,32 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util.interfaces;
+
+import java.io.IOException;
+
+/**
+ * A functional lambda interface that can throw an {@link IOException}.
+ *
+ * @param <I> the input type
+ * @param <T> the output type
+ */
+@FunctionalInterface
+public interface IOFunction<I, T> {
+  /**
+   *  A lambda function with an input and output.
+   *
+   * @param i input parameter
+   * @return object of type {@code T}
+   * @throws IOException
+   */
+  T apply(I i) throws IOException;
+}

--- a/core/common/src/test/java/alluxio/JdkTestUtils.java
+++ b/core/common/src/test/java/alluxio/JdkTestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.util.CommonUtils;
+
+import org.junit.Assume;
+
+/**
+ * A utility class for testing JDK versions when running unit and integration tests.
+ */
+public class JdkTestUtils {
+
+  /**
+   * Checks using a Junit {@link Assume} that the current application is running on JDK 8.
+   */
+  public static void assumeJdk8() {
+    Assume.assumeTrue(CommonUtils.isJdk8());
+  }
+
+  /**
+   * Checks using a Junit {@link Assume} that the current application is running on JDK 11.
+   */
+  public static void assumeJdk11() {
+    Assume.assumeTrue(CommonUtils.isJdk11());
+  }
+
+  private JdkTestUtils() {
+  }
+}

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -22,6 +22,7 @@ import alluxio.AlluxioTestDirectory;
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.DefaultSupplier;
+import alluxio.JdkTestUtils;
 import alluxio.SystemPropertyRule;
 import alluxio.TestLoggerRule;
 import alluxio.conf.PropertyKey.Template;
@@ -903,6 +904,7 @@ public class InstancedConfigurationTest {
 
   @Test
   public void findPropertiesFileClasspath() throws Exception {
+    JdkTestUtils.assumeJdk8(); // Adding to the system ClassLoader is only viable in Java 8
     try (Closeable p =
         new SystemPropertyRule(PropertyKey.TEST_MODE.toString(), "false").toResource()) {
       File dir = AlluxioTestDirectory.createTemporaryDirectory("findPropertiesFileClasspath");

--- a/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
+++ b/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
@@ -82,7 +82,7 @@ public class TieredIdentityFactoryTest {
 
   @Test
   public void fromScriptClasspath() throws Exception {
-    JdkTestUtils.assumeJdk8();
+    JdkTestUtils.assumeJdk8(); // Can't add URLs to classpath with JDK 11
     String customScriptName = "my-alluxio-locality.sh";
     File dir = mFolder.newFolder("fromScriptClasspath");
     Whitebox.invokeMethod(ClassLoader.getSystemClassLoader(), "addURL", dir.toURI().toURL());

--- a/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
+++ b/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
+import alluxio.JdkTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.PropertyKey.Template;
@@ -81,6 +82,7 @@ public class TieredIdentityFactoryTest {
 
   @Test
   public void fromScriptClasspath() throws Exception {
+    JdkTestUtils.assumeJdk8();
     String customScriptName = "my-alluxio-locality.sh";
     File dir = mFolder.newFolder("fromScriptClasspath");
     Whitebox.invokeMethod(ClassLoader.getSystemClassLoader(), "addURL", dir.toURI().toURL());

--- a/core/common/src/test/java/alluxio/security/authentication/CustomAuthenticationProviderTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/CustomAuthenticationProviderTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.security.authentication.plain.CustomAuthenticationProvider;
 
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -52,8 +53,14 @@ public final class CustomAuthenticationProviderTest {
   public void classNotProvider() {
     String notProviderClass = CustomAuthenticationProviderTest.class.getName();
     mThrown.expect(RuntimeException.class);
-    mThrown.expectMessage("alluxio.security.authentication.CustomAuthenticationProviderTest "
-        + "cannot be cast to alluxio.security.authentication.AuthenticationProvider");
+    mThrown.expectMessage(Matchers.anyOf(Matchers.containsString(
+        // Java 11
+        "alluxio.security.authentication.CustomAuthenticationProviderTest cannot be cast"
+            + " to class alluxio.security.authentication.AuthenticationProvider"),
+        // Java 8
+        Matchers.containsString(
+            "alluxio.security.authentication.CustomAuthenticationProviderTest cannot be cast to"
+                + " alluxio.security.authentication.AuthenticationProvider")));
     new CustomAuthenticationProvider(notProviderClass);
   }
 

--- a/core/common/src/test/java/alluxio/security/group/ShellBasedUnixGroupsMappingTest.java
+++ b/core/common/src/test/java/alluxio/security/group/ShellBasedUnixGroupsMappingTest.java
@@ -13,32 +13,19 @@ package alluxio.security.group;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.eq;
 
 import alluxio.security.group.provider.ShellBasedUnixGroupsMapping;
-import alluxio.util.CommonUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Unit test for {@link alluxio.security.group.provider.ShellBasedUnixGroupsMapping}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CommonUtils.class)
 public final class ShellBasedUnixGroupsMappingTest {
-
-  private void setupShellMocks(String username, List<String> groups) throws IOException {
-    PowerMockito.mockStatic(CommonUtils.class);
-    PowerMockito.when(CommonUtils.getUnixGroups(eq(username))).thenReturn(groups);
-  }
 
   /**
    * Tests the {@link ShellBasedUnixGroupsMapping#getGroups(String)} method.
@@ -51,9 +38,13 @@ public final class ShellBasedUnixGroupsMappingTest {
     List<String> userGroups = new ArrayList<>();
     userGroups.add(userGroup1);
     userGroups.add(userGroup2);
-    setupShellMocks(userName, userGroups);
 
-    GroupMappingService groups = new ShellBasedUnixGroupsMapping();
+    GroupMappingService groups = new ShellBasedUnixGroupsMapping((s -> {
+      if (s.equals(userName)) {
+        return userGroups;
+      }
+      return Collections.emptyList();
+    }));
 
     assertNotNull(groups);
     assertNotNull(groups.getGroups(userName));

--- a/core/common/src/test/java/alluxio/security/login/LoginModuleTest.java
+++ b/core/common/src/test/java/alluxio/security/login/LoginModuleTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 import alluxio.security.User;
+import alluxio.util.CommonUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,9 +64,11 @@ public final class LoginModuleTest {
     loginContext.logout();
     assertTrue(subject.getPrincipals(User.class).isEmpty());
 
-    // logout twice should be no-op.
-    loginContext.logout();
-    assertTrue(subject.getPrincipals(User.class).isEmpty());
+    // logout twice should be no-op on Java 8
+    if (CommonUtils.isJdk8()) {
+      loginContext.logout();
+      assertTrue(subject.getPrincipals(User.class).isEmpty());
+    }
   }
 
    /**

--- a/core/common/src/test/java/alluxio/test/util/CommonTestUtilsTest.java
+++ b/core/common/src/test/java/alluxio/test/util/CommonTestUtilsTest.java
@@ -16,19 +16,14 @@ import alluxio.underfs.UnderFileSystem.SpaceType;
 import junit.framework.AssertionFailedError;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Objects;
 
 /**
  * Unit tests for {@link CommonUtils}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CommonTestUtilsTest.HardToInstantiateClass.class)
 public final class CommonTestUtilsTest {
-  public static final class HardToInstantiateClass {
+  public static class HardToInstantiateClass {
     private HardToInstantiateClass(Object o) {}
   }
 
@@ -83,7 +78,7 @@ public final class CommonTestUtilsTest {
   private static class ManyFields {
     private String mField1;
     private boolean mField2;
-    // Use HardToInstantiateClass as an example of a final class without a no-arg constructor.
+    // Use HardToInstantiateClass as an example of a class without a no-arg constructor.
     private HardToInstantiateClass mField3;
     // Example of an enum.
     private SpaceType mField4;

--- a/core/common/src/test/java/alluxio/underfs/options/DeleteOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/DeleteOptionsTest.java
@@ -16,15 +16,12 @@ import static org.junit.Assert.assertEquals;
 import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
 /**
  * Tests for the {@link DeleteOptions} class.
  */
-@RunWith(PowerMockRunner.class)
 public final class DeleteOptionsTest {
   /**
    * Tests for default {@link DeleteOptions}.

--- a/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/FileLocationOptionsTest.java
@@ -16,15 +16,12 @@ import static org.junit.Assert.assertEquals;
 import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
 /**
  * Tests for the {@link FileLocationOptions} class.
  */
-@RunWith(PowerMockRunner.class)
 public final class FileLocationOptionsTest {
   /**
    * Tests for default {@link FileLocationOptions}.

--- a/core/common/src/test/java/alluxio/underfs/options/ListOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/ListOptionsTest.java
@@ -16,15 +16,12 @@ import static org.junit.Assert.assertEquals;
 import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
 /**
  * Tests for the {@link ListOptions} class.
  */
-@RunWith(PowerMockRunner.class)
 public final class ListOptionsTest {
   /**
    * Tests for default {@link ListOptions}.

--- a/core/common/src/test/java/alluxio/underfs/options/OpenOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/OpenOptionsTest.java
@@ -16,15 +16,12 @@ import static org.junit.Assert.assertEquals;
 import alluxio.test.util.CommonUtils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
 /**
  * Tests for the {@link OpenOptions} class.
  */
-@RunWith(PowerMockRunner.class)
 public final class OpenOptionsTest {
   /**
    * Tests for default {@link OpenOptions}.

--- a/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/BufferUtilsTest.java
@@ -15,10 +15,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import alluxio.JdkTestUtils;
+
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -293,6 +294,8 @@ public final class BufferUtilsTest {
    */
   @Test
   public void cleanDirectBuffer() {
+    // the implementation to de-allocate buffers changes after JDK 8. It is not backwards-compatible
+    JdkTestUtils.assumeJdk8();
     final int MAX_ITERATIONS = 1024;
     final int BUFFER_SIZE = 16 * 1024 * 1024;
     // bufferArray keeps reference to each buffer to avoid auto GC

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -173,4 +173,18 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+      </dependency> 
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsMasterClientServiceHandler.java
@@ -23,8 +23,8 @@ import alluxio.metrics.Metric;
 
 import com.google.common.base.Preconditions;
 
+import com.google.common.collect.Lists;
 import io.grpc.stub.StreamObserver;
-import jersey.repackaged.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
@@ -18,7 +18,7 @@ import alluxio.metrics.Metric;
 import alluxio.metrics.MetricsSystem;
 
 import com.google.common.collect.Lists;
-import jersey.repackaged.com.google.common.collect.Sets;
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/server/proxy/pom.xml
+++ b/core/server/proxy/pom.xml
@@ -134,4 +134,18 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+      </dependency> 
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -152,4 +152,18 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+      </dependency> 
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
@@ -20,9 +20,6 @@ import alluxio.job.wire.JobInfo;
 import alluxio.master.AlluxioJobMasterProcess;
 import alluxio.web.JobMasterWebServer;
 
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.jaxrs.annotation.JacksonFeatures;
-
 import java.util.List;
 
 import javax.servlet.ServletContext;
@@ -110,7 +107,6 @@ public final class JobMasterClientRestServiceHandler {
    */
   @GET
   @Path(ServiceConstants.GET_STATUS)
-  @JacksonFeatures(serializationEnable = {SerializationFeature.INDENT_OUTPUT})
   public Response getStatus(@QueryParam("jobId") final long jobId) {
     return RestUtils.call(new RestUtils.RestCallable<JobInfo>() {
       @Override

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -51,7 +51,7 @@ if [[ -z "${JAVA}" ]]; then
   fi
 fi
 
-# Check Java version == 1.8
+# Check Java version == (1.8 || 11.X)
 JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
 NUMERIC_VERSION="$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')"
 if [[ ${NUMERIC_VERSION} != 001008 && ${NUMERIC_VERSION} != 011* ]]; then

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -53,7 +53,8 @@ fi
 
 # Check Java version == 1.8
 JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
-if [[ $(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}') != 001008 ]]; then
+NUMERIC_VERSION="$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')"
+if [[ ${NUMERIC_VERSION} != 001008 && ${NUMERIC_VERSION} != 011* ]]; then
   echo "Error: Alluxio requires Java 8, currently Java $JAVA_VERSION found."
   exit 1
 fi

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -55,7 +55,7 @@ fi
 JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
 NUMERIC_VERSION="$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')"
 if [[ ${NUMERIC_VERSION} != 001008 && ${NUMERIC_VERSION} != 011* ]]; then
-  echo "Error: Alluxio requires Java 8, currently Java $JAVA_VERSION found."
+  echo "Error: Alluxio requires Java 8 or 11, currently Java $JAVA_VERSION found."
   exit 1
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -1289,6 +1289,8 @@
       </activation>
       <properties>
         <java.version>11</java.version>
+        <jersey.version>2.30</jersey.version>
+        <guava.version>27.1-jre</guava.version>
       </properties>
       <dependencyManagement>
         <dependencies>
@@ -1297,6 +1299,11 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
           </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>        
         </dependencies>
       </dependencyManagement>
       <build>

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -42,7 +42,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 
-import jersey.repackaged.com.google.common.collect.Lists;
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;


### PR DESCRIPTION
This is a follow-up PR to #10834 and continues to partially address #9856.

Issues encountered with runtime support:

- Guava needs to be updated due to issues with unsafe acceses
- Jersey is missing jars from the JDK in Java 11. Version bump resolves
the issue. This also led to a new dependency that needed to be included
along with some code changes. The code changes should be backwards
compatible with Java  8.
- libexec/alluxio-config.sh needs to allow Java 11 version strings