### PR TITLE
Remove unnecessary logging in under storage

### DIFF
--- a/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -268,7 +268,6 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
       return new ObjectStatus(key, meta.getETag(), meta.getContentLength(),
           meta.getLastModified().getTime());
     } catch (CosClientException e) {
-      LOG.warn("Failed to get Object {}, return null", key, e);
       return null;
     }
   }

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoUnderFileSystem.java
@@ -192,9 +192,8 @@ public class KodoUnderFileSystem extends ObjectUnderFileSystem {
       }
       return new ObjectStatus(key, fileInfo.hash, fileInfo.fsize, fileInfo.putTime / 10000);
     } catch (QiniuException e) {
-      LOG.warn("Failed to get Object {}, Msg: {}", key, e);
+      return null;
     }
-    return null;
   }
 
   // No ACL integration currently, returns default empty value

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -247,7 +247,6 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
       return new ObjectStatus(key, meta.getETag(), meta.getContentLength(),
           meta.getLastModified().getTime());
     } catch (ServiceException e) {
-      LOG.warn("Failed to get Object {}, return null", key, e);
       return null;
     }
   }


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/10842 but not only in OSS but a few other under storage to leave the server logs cleaner.

It is unnecessary to log again on non-existence of an object as the null value is already indicating the scenario.  Besides, the non-existence may be expected (e.g. when called from `deleteFileIfExists`