### PR TITLE
Choose HDFS read API based on Client buffer size

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -108,6 +108,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
         ReadRequest.newBuilder().setBlockId(blockId).setPromote(readType.isPromote());
     // Add UFS fallback options
     builder.setOpenUfsBlockOptions(options.getOpenUfsBlockOptions(blockId));
+    builder.setSwitch(options.getSwitch());
     AlluxioConfiguration alluxioConf = context.getClusterConf();
     boolean shortCircuit = alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED);
     boolean shortCircuitPreferred =

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -108,7 +108,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
         ReadRequest.newBuilder().setBlockId(blockId).setPromote(readType.isPromote());
     // Add UFS fallback options
     builder.setOpenUfsBlockOptions(options.getOpenUfsBlockOptions(blockId));
-    builder.setSwitch(options.getSwitch());
+    builder.setPositionShort(options.getPositionShort());
     AlluxioConfiguration alluxioConf = context.getClusterConf();
     boolean shortCircuit = alluxioConf.getBoolean(PropertyKey.USER_SHORT_CIRCUIT_ENABLED);
     boolean shortCircuitPreferred =

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -234,9 +234,8 @@ public class AlluxioFileInStream extends FileInStream {
       return -1;
     }
 
-    LOG.info("AMDEBUG pread len {} ", len);
-    if (len < 2 * Constants.MB) {
-      LOG.info("AMDEBUG set for pread len {} ", len);
+    if (len < mContext.getPathConf(new AlluxioURI(mStatus.getPath()))
+        .getBytes(PropertyKey.USER_FILE_SEQUENTIAL_PREAD_THRESHOLD)) {
       mOptions.setPositionShort(true);
     }
     int lenCopy = len;

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -12,6 +12,7 @@
 package alluxio.client.file;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.ReadType;
 import alluxio.client.block.AlluxioBlockStore;
@@ -233,6 +234,9 @@ public class AlluxioFileInStream extends FileInStream {
       return -1;
     }
 
+    if (len > 1 * Constants.MB) {
+      mOptions.setSwitch(true);
+    }
     int lenCopy = len;
     CountingRetry retry = new CountingRetry(mBlockWorkerClientReadRetry);
     IOException lastException = null;

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -234,7 +234,9 @@ public class AlluxioFileInStream extends FileInStream {
       return -1;
     }
 
+    LOG.info("AMDEBUG pread len {} ", len);
     if (len > 1 * Constants.MB) {
+      LOG.info("AMDEBUG set switch for pread len {} ", len);
       mOptions.setSwitch(true);
     }
     int lenCopy = len;

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -12,7 +12,6 @@
 package alluxio.client.file;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.ReadType;
 import alluxio.client.block.AlluxioBlockStore;

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -235,9 +235,9 @@ public class AlluxioFileInStream extends FileInStream {
     }
 
     LOG.info("AMDEBUG pread len {} ", len);
-    if (len > 1 * Constants.MB) {
-      LOG.info("AMDEBUG set switch for pread len {} ", len);
-      mOptions.setSwitch(true);
+    if (len < 2 * Constants.MB) {
+      LOG.info("AMDEBUG set for pread len {} ", len);
+      mOptions.setPositionShort(true);
     }
     int lenCopy = len;
     CountingRetry retry = new CountingRetry(mBlockWorkerClientReadRetry);

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -42,7 +42,7 @@ public final class InStreamOptions {
   private final URIStatus mStatus;
   private final OpenFilePOptions mProtoOptions;
   private BlockLocationPolicy mUfsReadLocationPolicy;
-  private boolean mSwitch;
+  private boolean mIsPositionShort;
 
   /**
    * Creates with the default {@link OpenFilePOptions}.
@@ -75,7 +75,7 @@ public final class InStreamOptions {
     mProtoOptions = openOptions;
     mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
         alluxioConf.get(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
-    mSwitch = false;
+    mIsPositionShort = false;
   }
 
   /**
@@ -96,8 +96,11 @@ public final class InStreamOptions {
     mUfsReadLocationPolicy = Preconditions.checkNotNull(ufsReadLocationPolicy);
   }
 
-  public void setSwitch(boolean s) {
-    mSwitch = s;
+  /**
+   * Sets whether the operation is positioned read to a small buffer.
+   */
+  public void setPositionShort(boolean positionShort) {
+    mIsPositionShort = positionShort;
   }
 
   /**
@@ -114,8 +117,11 @@ public final class InStreamOptions {
     return mStatus;
   }
 
-  public boolean getSwitch() {
-    return mSwitch;
+  /**
+   * @return is this operation using positioned read to a small buffer size
+   */
+  public boolean getPositionShort() {
+    return mIsPositionShort;
   }
 
   /**
@@ -170,14 +176,16 @@ public final class InStreamOptions {
     }
     InStreamOptions that = (InStreamOptions) o;
     return Objects.equal(mStatus, that.mStatus)
-        && Objects.equal(mProtoOptions, that.mProtoOptions);
+        && Objects.equal(mProtoOptions, that.mProtoOptions)
+        && Objects.equal(mIsPositionShort, that.mIsPositionShort);
   }
 
   @Override
   public int hashCode() {
     return Objects.hashCode(
         mStatus,
-        mProtoOptions
+        mProtoOptions,
+        mIsPositionShort
     );
   }
 
@@ -186,6 +194,7 @@ public final class InStreamOptions {
     return MoreObjects.toStringHelper(this)
         .add("URIStatus", mStatus)
         .add("OpenFileOptions", mProtoOptions)
+        .add("IsPositionShort", mIsPositionShort)
         .toString();
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -42,6 +42,7 @@ public final class InStreamOptions {
   private final URIStatus mStatus;
   private final OpenFilePOptions mProtoOptions;
   private BlockLocationPolicy mUfsReadLocationPolicy;
+  private boolean mSwitch;
 
   /**
    * Creates with the default {@link OpenFilePOptions}.
@@ -74,6 +75,7 @@ public final class InStreamOptions {
     mProtoOptions = openOptions;
     mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
         alluxioConf.get(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
+    mSwitch = false;
   }
 
   /**
@@ -94,6 +96,10 @@ public final class InStreamOptions {
     mUfsReadLocationPolicy = Preconditions.checkNotNull(ufsReadLocationPolicy);
   }
 
+  public void setSwitch(boolean s) {
+    mSwitch = s;
+  }
+
   /**
    * @return the {@link BlockLocationPolicy} associated with the instream
    */
@@ -106,6 +112,10 @@ public final class InStreamOptions {
    */
   public URIStatus getStatus() {
     return mStatus;
+  }
+
+  public boolean getSwitch() {
+    return mSwitch;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -42,7 +42,7 @@ public final class InStreamOptions {
   private final URIStatus mStatus;
   private final OpenFilePOptions mProtoOptions;
   private BlockLocationPolicy mUfsReadLocationPolicy;
-  private boolean mIsPositionShort;
+  private boolean mPositionShort;
 
   /**
    * Creates with the default {@link OpenFilePOptions}.
@@ -75,7 +75,7 @@ public final class InStreamOptions {
     mProtoOptions = openOptions;
     mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
         alluxioConf.get(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
-    mIsPositionShort = false;
+    mPositionShort = false;
   }
 
   /**
@@ -100,7 +100,7 @@ public final class InStreamOptions {
    * Sets whether the operation is positioned read to a small buffer.
    */
   public void setPositionShort(boolean positionShort) {
-    mIsPositionShort = positionShort;
+    mPositionShort = positionShort;
   }
 
   /**
@@ -118,10 +118,10 @@ public final class InStreamOptions {
   }
 
   /**
-   * @return is this operation using positioned read to a small buffer size
+   * @return true, if the operation is using positioned read to a small buffer size
    */
   public boolean getPositionShort() {
-    return mIsPositionShort;
+    return mPositionShort;
   }
 
   /**
@@ -177,7 +177,7 @@ public final class InStreamOptions {
     InStreamOptions that = (InStreamOptions) o;
     return Objects.equal(mStatus, that.mStatus)
         && Objects.equal(mProtoOptions, that.mProtoOptions)
-        && Objects.equal(mIsPositionShort, that.mIsPositionShort);
+        && Objects.equal(mPositionShort, that.mPositionShort);
   }
 
   @Override
@@ -185,7 +185,7 @@ public final class InStreamOptions {
     return Objects.hashCode(
         mStatus,
         mProtoOptions,
-        mIsPositionShort
+        mPositionShort
     );
   }
 
@@ -194,7 +194,7 @@ public final class InStreamOptions {
     return MoreObjects.toStringHelper(this)
         .add("URIStatus", mStatus)
         .add("OpenFileOptions", mProtoOptions)
-        .add("IsPositionShort", mIsPositionShort)
+        .add("PositionShort", mPositionShort)
         .toString();
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -98,6 +98,8 @@ public final class InStreamOptions {
 
   /**
    * Sets whether the operation is positioned read to a small buffer.
+   *
+   * @param positionShort whether the operation is positioned read to a small buffer
    */
   public void setPositionShort(boolean positionShort) {
     mPositionShort = positionShort;

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2916,11 +2916,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_FILE_SEQUENTIAL_PREAD_THRESHOLD =
       new Builder(Name.USER_FILE_SEQUENTIAL_PREAD_THRESHOLD)
           .setDefaultValue("2MB")
-          .setDescription("An upper bound on the client buffer size for positioned read to hint " +
-              "at the sequential nature of reads. For reads with a buffer size greater than this " +
-              "threshold, the read op is treated to be sequential and the worker may handle the " +
-              "read differently. For instance, cold reads from the HDFS ufs may use a different " +
-              "HDFS client API.")
+          .setDescription("An upper bound on the client buffer size for positioned read to hint "
+              + "at the sequential nature of reads. For reads with a buffer size greater than this "
+              + "threshold, the read op is treated to be sequential and the worker may handle the "
+              + "read differently. For instance, cold reads from the HDFS ufs may use a different "
+              + "HDFS client API.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2913,6 +2913,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "before this file is persisted.")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_FILE_SEQUENTIAL_PREAD_THRESHOLD =
+      new Builder(Name.USER_FILE_SEQUENTIAL_PREAD_THRESHOLD)
+          .setDefaultValue("2MB")
+          .setDescription("An upper bound on the client buffer size for positioned read to hint " +
+              "at the sequential nature of reads. For reads with a buffer size greater than this " +
+              "threshold, the read op is treated to be sequential and the worker may handle the " +
+              "read differently. For instance, cold reads from the HDFS ufs may use a different " +
+              "HDFS client API.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_BLOCK_SIZE_BYTES_DEFAULT =
       new Builder(Name.USER_BLOCK_SIZE_BYTES_DEFAULT)
           .setDefaultValue("64MB")
@@ -4493,6 +4504,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_FILE_REPLICATION_MIN = "alluxio.user.file.replication.min";
     public static final String USER_FILE_REPLICATION_DURABLE =
         "alluxio.user.file.replication.durable";
+    public static final String USER_FILE_SEQUENTIAL_PREAD_THRESHOLD =
+        "alluxio.user.file.sequential.pread.threshold";
     public static final String USER_FILE_UFS_TIER_ENABLED = "alluxio.user.file.ufs.tier.enabled";
     public static final String USER_FILE_WAITCOMPLETED_POLL_MS =
         "alluxio.user.file.waitcompleted.poll";

--- a/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
@@ -29,7 +29,7 @@ public final class OpenOptions {
 
   private long mLength;
 
-  private boolean mIsPositionShort;
+  private boolean mPositionShort;
 
   /**
    * If true, attempt to recover after failed opened attempts. Extra effort may be required in
@@ -51,7 +51,7 @@ public final class OpenOptions {
     mOffset = 0;
     mLength = Long.MAX_VALUE;
     mRecoverFailedOpen = false;
-    mIsPositionShort = false;
+    mPositionShort = false;
   }
 
   /**
@@ -76,10 +76,10 @@ public final class OpenOptions {
   }
 
   /**
-   * @return true if this is positioned read to a small buffer
+   * @return true, if the operation is using positioned read to a small buffer size
    */
   public boolean getPositionShort() {
-    return mIsPositionShort;
+    return mPositionShort;
   }
 
   /**
@@ -112,10 +112,11 @@ public final class OpenOptions {
   }
 
   /**
+   * @param positionShort whether the operation is positioned read to a small buffer
    * @return the updated option object
    */
   public OpenOptions setPositionShort(boolean positionShort) {
-    mIsPositionShort = positionShort;
+    mPositionShort = positionShort;
     return this;
   }
 
@@ -131,12 +132,12 @@ public final class OpenOptions {
     return Objects.equal(mOffset, that.mOffset)
         && Objects.equal(mLength, that.mLength)
         && Objects.equal(mRecoverFailedOpen, that.mRecoverFailedOpen)
-        && Objects.equal(mIsPositionShort, that.mIsPositionShort);
+        && Objects.equal(mPositionShort, that.mPositionShort);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mOffset, mLength, mRecoverFailedOpen, mIsPositionShort);
+    return Objects.hashCode(mOffset, mLength, mRecoverFailedOpen, mPositionShort);
   }
 
   @Override
@@ -145,7 +146,7 @@ public final class OpenOptions {
         .add("offset", mOffset)
         .add("length", mLength)
         .add("recoverFailedOpen", mRecoverFailedOpen)
-        .add("isPositionShort", mIsPositionShort)
+        .add("positionShort", mPositionShort)
         .toString();
   }
 }

--- a/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
@@ -29,7 +29,7 @@ public final class OpenOptions {
 
   private long mLength;
 
-  private boolean mSwitch;
+  private boolean mIsPositionShort;
 
   /**
    * If true, attempt to recover after failed opened attempts. Extra effort may be required in
@@ -51,7 +51,7 @@ public final class OpenOptions {
     mOffset = 0;
     mLength = Long.MAX_VALUE;
     mRecoverFailedOpen = false;
-    mSwitch = false;
+    mIsPositionShort = false;
   }
 
   /**
@@ -75,8 +75,11 @@ public final class OpenOptions {
     return mRecoverFailedOpen;
   }
 
-  public boolean getSwitch() {
-    return mSwitch;
+  /**
+   * @return true if this is positioned read to a small buffer
+   */
+  public boolean getPositionShort() {
+    return mIsPositionShort;
   }
 
   /**
@@ -108,8 +111,11 @@ public final class OpenOptions {
     return this;
   }
 
-  public OpenOptions setSwitch(boolean sw) {
-    mSwitch = sw;
+  /**
+   * @return the updated option object
+   */
+  public OpenOptions setPositionShort(boolean positionShort) {
+    mIsPositionShort = positionShort;
     return this;
   }
 
@@ -124,12 +130,13 @@ public final class OpenOptions {
     OpenOptions that = (OpenOptions) o;
     return Objects.equal(mOffset, that.mOffset)
         && Objects.equal(mLength, that.mLength)
-        && Objects.equal(mRecoverFailedOpen, that.mRecoverFailedOpen);
+        && Objects.equal(mRecoverFailedOpen, that.mRecoverFailedOpen)
+        && Objects.equal(mIsPositionShort, that.mIsPositionShort);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mOffset, mLength, mRecoverFailedOpen);
+    return Objects.hashCode(mOffset, mLength, mRecoverFailedOpen, mIsPositionShort);
   }
 
   @Override
@@ -138,6 +145,7 @@ public final class OpenOptions {
         .add("offset", mOffset)
         .add("length", mLength)
         .add("recoverFailedOpen", mRecoverFailedOpen)
+        .add("isPositionShort", mIsPositionShort)
         .toString();
   }
 }

--- a/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/OpenOptions.java
@@ -29,6 +29,8 @@ public final class OpenOptions {
 
   private long mLength;
 
+  private boolean mSwitch;
+
   /**
    * If true, attempt to recover after failed opened attempts. Extra effort may be required in
    * order to recover from a failed open.
@@ -49,6 +51,7 @@ public final class OpenOptions {
     mOffset = 0;
     mLength = Long.MAX_VALUE;
     mRecoverFailedOpen = false;
+    mSwitch = false;
   }
 
   /**
@@ -70,6 +73,10 @@ public final class OpenOptions {
    */
   public boolean getRecoverFailedOpen() {
     return mRecoverFailedOpen;
+  }
+
+  public boolean getSwitch() {
+    return mSwitch;
   }
 
   /**
@@ -98,6 +105,11 @@ public final class OpenOptions {
    */
   public OpenOptions setRecoverFailedOpen(boolean recover) {
     mRecoverFailedOpen = recover;
+    return this;
+  }
+
+  public OpenOptions setSwitch(boolean sw) {
+    mSwitch = sw;
     return this;
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -162,7 +162,7 @@ public class AsyncCacheRequestManager {
       return true;
     }
     try (BlockReader reader = mBlockWorker
-        .readUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, 0)) {
+        .readUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, 0, false)) {
       // Read the entire block, caching to block store will be handled internally in UFS block store
       // Note that, we read from UFS with a smaller buffer to avoid high pressure on heap
       // memory when concurrent async requests are received and thus trigger GC.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -317,7 +317,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param sessionId the client session ID
    * @param blockId the ID of the UFS block to read
    * @param offset the offset within the block
-   * @param positionShort if this is a positioned read to a small buffer
+   * @param positionShort whether the operation is using positioned read to a small buffer size
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the block does not exist in the UFS block store
    */

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -320,7 +320,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the block does not exist in the UFS block store
    */
-  BlockReader readUfsBlock(long sessionId, long blockId, long offset)
+  BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean sw)
       throws BlockDoesNotExistException, IOException;
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -317,10 +317,11 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param sessionId the client session ID
    * @param blockId the ID of the UFS block to read
    * @param offset the offset within the block
+   * @param positionShort if this is a positioned read to a small buffer
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the block does not exist in the UFS block store
    */
-  BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean sw)
+  BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean positionShort)
       throws BlockDoesNotExistException, IOException;
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -468,9 +468,9 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  public BlockReader readUfsBlock(long sessionId, long blockId, long offset)
+  public BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean sw)
       throws BlockDoesNotExistException, IOException {
-    return mUnderFileSystemBlockStore.getBlockReader(sessionId, blockId, offset);
+    return mUnderFileSystemBlockStore.getBlockReader(sessionId, blockId, offset, sw);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -468,9 +468,9 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  public BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean sw)
+  public BlockReader readUfsBlock(long sessionId, long blockId, long offset, boolean positionShort)
       throws BlockDoesNotExistException, IOException {
-    return mUnderFileSystemBlockStore.getBlockReader(sessionId, blockId, offset, sw);
+    return mUnderFileSystemBlockStore.getBlockReader(sessionId, blockId, offset, positionShort);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
@@ -242,7 +242,7 @@ public class UfsInputStreamManager {
           inputStream = mUnderFileInputStreamCache.get(nextId, () -> {
             SeekableUnderFileInputStream ufsStream
                 = (SeekableUnderFileInputStream) ufs.openExistingFile(path,
-                OpenOptions.defaults().setSwitch(openOptions.getSwitch()).setOffset(openOptions.getOffset()));
+                OpenOptions.defaults().setPositionShort(openOptions.getPositionShort()).setOffset(openOptions.getOffset()));
             LOG.debug("Created the under file input stream resource of {}", newId);
             return new CachedSeekableInputStream(ufsStream, newId, fileId, path);
           });

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
@@ -242,7 +242,7 @@ public class UfsInputStreamManager {
           inputStream = mUnderFileInputStreamCache.get(nextId, () -> {
             SeekableUnderFileInputStream ufsStream
                 = (SeekableUnderFileInputStream) ufs.openExistingFile(path,
-                OpenOptions.defaults().setOffset(openOptions.getOffset()));
+                OpenOptions.defaults().setSwitch(openOptions.getSwitch()).setOffset(openOptions.getOffset()));
             LOG.debug("Created the under file input stream resource of {}", newId);
             return new CachedSeekableInputStream(ufsStream, newId, fileId, path);
           });

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamManager.java
@@ -242,7 +242,9 @@ public class UfsInputStreamManager {
           inputStream = mUnderFileInputStreamCache.get(nextId, () -> {
             SeekableUnderFileInputStream ufsStream
                 = (SeekableUnderFileInputStream) ufs.openExistingFile(path,
-                OpenOptions.defaults().setPositionShort(openOptions.getPositionShort()).setOffset(openOptions.getOffset()));
+                OpenOptions.defaults()
+                    .setPositionShort(openOptions.getPositionShort())
+                    .setOffset(openOptions.getOffset()));
             LOG.debug("Created the under file input stream resource of {}", newId);
             return new CachedSeekableInputStream(ufsStream, newId, fileId, path);
           });

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -94,14 +94,15 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    * @param localBlockStore the Local block store
    * @param ufsManager the manager of ufs
    * @param ufsInstreamManager the manager of ufs instreams
-   * @param positionShort if this is a positioned read to a small buffer
+   * @param positionShort whether the client op is a positioned read to a small buffer
    * @return the block reader
    */
   public static UnderFileSystemBlockReader create(UnderFileSystemBlockMeta blockMeta, long offset,
-      boolean positionShort, BlockStore localBlockStore, UfsManager ufsManager, UfsInputStreamManager ufsInstreamManager)
-      throws IOException {
+      boolean positionShort, BlockStore localBlockStore, UfsManager ufsManager,
+      UfsInputStreamManager ufsInstreamManager) throws IOException {
     UnderFileSystemBlockReader ufsBlockReader =
-        new UnderFileSystemBlockReader(blockMeta, positionShort, localBlockStore, ufsManager, ufsInstreamManager);
+        new UnderFileSystemBlockReader(blockMeta, positionShort, localBlockStore, ufsManager,
+            ufsInstreamManager);
     ufsBlockReader.init(offset);
     return ufsBlockReader;
   }
@@ -112,11 +113,12 @@ public final class UnderFileSystemBlockReader implements BlockReader {
    * @param blockMeta the block meta
    * @param localBlockStore the Local block store
    * @param ufsManager the manager of ufs
-   * @param positionShort if this is a positioned read to a small buffer
+   * @param positionShort whether the client op is a positioned read to a small buffer
    * @param ufsInstreamManager the manager of ufs instreams
    */
-  private UnderFileSystemBlockReader(UnderFileSystemBlockMeta blockMeta, boolean positionShort, BlockStore localBlockStore,
-      UfsManager ufsManager, UfsInputStreamManager ufsInstreamManager) throws IOException {
+  private UnderFileSystemBlockReader(UnderFileSystemBlockMeta blockMeta, boolean positionShort,
+      BlockStore localBlockStore, UfsManager ufsManager, UfsInputStreamManager ufsInstreamManager)
+      throws IOException {
     mInitialBlockSize = ServerConfiguration.getBytes(PropertyKey.WORKER_FILE_BUFFER_SIZE);
     mBlockMeta = blockMeta;
     mLocalBlockStore = localBlockStore;
@@ -306,7 +308,9 @@ public final class UnderFileSystemBlockReader implements BlockReader {
       UnderFileSystem ufs = mUfsResource.get();
       mUnderFileSystemInputStream = mUfsInstreamManager.acquire(ufs,
           mBlockMeta.getUnderFileSystemPath(), IdUtils.fileIdFromBlockId(mBlockMeta.getBlockId()),
-          OpenOptions.defaults().setOffset(mBlockMeta.getOffset() + offset).setPositionShort(mIsPositionShort));
+          OpenOptions.defaults()
+              .setOffset(mBlockMeta.getOffset() + offset)
+              .setPositionShort(mIsPositionShort));
       mInStreamPos = offset;
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -224,13 +224,13 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
    * @param sessionId the client session ID that requested this read
    * @param blockId the ID of the block to read
    * @param offset the read offset within the block (NOT the file)
-   * @param positionShort if this is a positioned read to a small buffer
+   * @param positionShort whether the client op is a positioned read to a small buffer
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    * {@link UnderFileSystemBlockStore}
    */
-  public BlockReader getBlockReader(final long sessionId, long blockId, long offset, boolean positionShort)
-      throws BlockDoesNotExistException, IOException {
+  public BlockReader getBlockReader(final long sessionId, long blockId, long offset,
+      boolean positionShort) throws BlockDoesNotExistException, IOException {
     final BlockInfo blockInfo;
     try (LockResource lr = new LockResource(mLock)) {
       blockInfo = getBlockInfo(sessionId, blockId);
@@ -240,8 +240,8 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
       }
     }
     BlockReader reader =
-        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, positionShort, mLocalBlockStore,
-            mUfsManager, mUfsInstreamManager);
+        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, positionShort,
+            mLocalBlockStore, mUfsManager, mUfsInstreamManager);
     blockInfo.setBlockReader(reader);
     return reader;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -228,7 +228,7 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    * {@link UnderFileSystemBlockStore}
    */
-  public BlockReader getBlockReader(final long sessionId, long blockId, long offset)
+  public BlockReader getBlockReader(final long sessionId, long blockId, long offset, boolean sw)
       throws BlockDoesNotExistException, IOException {
     final BlockInfo blockInfo;
     try (LockResource lr = new LockResource(mLock)) {
@@ -239,7 +239,7 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
       }
     }
     BlockReader reader =
-        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, mLocalBlockStore,
+        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, sw, mLocalBlockStore,
             mUfsManager, mUfsInstreamManager);
     blockInfo.setBlockReader(reader);
     return reader;

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -224,11 +224,12 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
    * @param sessionId the client session ID that requested this read
    * @param blockId the ID of the block to read
    * @param offset the read offset within the block (NOT the file)
+   * @param positionShort if this is a positioned read to a small buffer
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    * {@link UnderFileSystemBlockStore}
    */
-  public BlockReader getBlockReader(final long sessionId, long blockId, long offset, boolean sw)
+  public BlockReader getBlockReader(final long sessionId, long blockId, long offset, boolean positionShort)
       throws BlockDoesNotExistException, IOException {
     final BlockInfo blockInfo;
     try (LockResource lr = new LockResource(mLock)) {
@@ -239,7 +240,7 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
       }
     }
     BlockReader reader =
-        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, sw, mLocalBlockStore,
+        UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, positionShort, mLocalBlockStore,
             mUfsManager, mUfsInstreamManager);
     blockInfo.setBlockReader(reader);
     return reader;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -172,7 +172,7 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
           if (mWorker.openUfsBlock(request.getSessionId(), request.getId(),
                 Protocol.OpenUfsBlockOptions.parseFrom(openUfsBlockOptions.toByteString()))) {
             BlockReader reader =
-                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart(), request.isSwitch());
+                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart(), request.isPositionShort());
             AlluxioURI ufsMountPointUri =
                 ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
             String ufsString = MetricsSystem.escape(ufsMountPointUri);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -172,7 +172,8 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
           if (mWorker.openUfsBlock(request.getSessionId(), request.getId(),
                 Protocol.OpenUfsBlockOptions.parseFrom(openUfsBlockOptions.toByteString()))) {
             BlockReader reader =
-                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart(), request.isPositionShort());
+                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart(),
+                    request.isPositionShort());
             AlluxioURI ufsMountPointUri =
                 ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
             String ufsString = MetricsSystem.escape(ufsMountPointUri);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -172,7 +172,7 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
           if (mWorker.openUfsBlock(request.getSessionId(), request.getId(),
                 Protocol.OpenUfsBlockOptions.parseFrom(openUfsBlockOptions.toByteString()))) {
             BlockReader reader =
-                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart());
+                mWorker.readUfsBlock(request.getSessionId(), request.getId(), request.getStart(), request.isSwitch());
             AlluxioURI ufsMountPointUri =
                 ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
             String ufsString = MetricsSystem.escape(ufsMountPointUri);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
@@ -24,6 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class BlockReadRequest extends ReadRequest {
   private final Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
   private final boolean mPromote;
+  private final boolean mSwitch;
 
   /**
    * Creates an instance of {@link BlockReadRequest}.
@@ -40,6 +41,7 @@ public final class BlockReadRequest extends ReadRequest {
       mOpenUfsBlockOptions = null;
     }
     mPromote = request.getPromote();
+    mSwitch = request.getSwitch();
     // Note that we do not need to seek to offset since the block worker is created at the offset.
   }
 
@@ -48,6 +50,10 @@ public final class BlockReadRequest extends ReadRequest {
    */
   public boolean isPromote() {
     return mPromote;
+  }
+
+  public boolean isSwitch() {
+    return mSwitch;
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadRequest.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class BlockReadRequest extends ReadRequest {
   private final Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
   private final boolean mPromote;
-  private final boolean mSwitch;
+  private final boolean mPositionShort;
 
   /**
    * Creates an instance of {@link BlockReadRequest}.
@@ -41,7 +41,7 @@ public final class BlockReadRequest extends ReadRequest {
       mOpenUfsBlockOptions = null;
     }
     mPromote = request.getPromote();
-    mSwitch = request.getSwitch();
+    mPositionShort = request.getPositionShort();
     // Note that we do not need to seek to offset since the block worker is created at the offset.
   }
 
@@ -52,8 +52,11 @@ public final class BlockReadRequest extends ReadRequest {
     return mPromote;
   }
 
-  public boolean isSwitch() {
-    return mSwitch;
+  /**
+   * @return if this is a positioned read to a small buffer
+   */
+  public boolean isPositionShort() {
+    return mPositionShort;
   }
 
   /**
@@ -80,6 +83,7 @@ public final class BlockReadRequest extends ReadRequest {
         .add("promote", mPromote)
         .add("sessionId", getSessionId())
         .add("start", getStart())
+        .add("positionShort", isPositionShort())
         .toString();
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -112,8 +112,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readFullBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -122,8 +122,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readPartialBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE - 1);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE - 1, buffer));
     mReader.close();
@@ -133,8 +133,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void offset() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
@@ -145,8 +145,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readOverlap() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
     buffer = mReader.read(0, TEST_BLOCK_SIZE - 2);
@@ -162,8 +162,8 @@ public final class UnderFileSystemBlockReaderTest {
   public void readFullBlockNoCache() throws Exception {
     mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     // read should succeed even if error is thrown when caching
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -201,8 +201,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void transferFullBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE * 2, (int) TEST_BLOCK_SIZE * 2);
     try {
@@ -219,8 +219,8 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void transferPartialBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
-        mUfsManager, mUfsInstreamManager);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE / 2, (int) TEST_BLOCK_SIZE / 2);
     try {

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -112,7 +112,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readFullBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -122,7 +122,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readPartialBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE - 1);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE - 1, buffer));
@@ -133,7 +133,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void offset() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     Assert.assertTrue(BufferUtils
@@ -145,7 +145,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readOverlap() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
@@ -162,7 +162,7 @@ public final class UnderFileSystemBlockReaderTest {
   public void readFullBlockNoCache() throws Exception {
     mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     // read should succeed even if error is thrown when caching
@@ -177,7 +177,7 @@ public final class UnderFileSystemBlockReaderTest {
     doThrow(new WorkerOutOfSpaceException("Ignored"))
         .when(errorThrowingBlockStore)
         .requestSpace(anyLong(), anyLong(), anyLong());
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
         errorThrowingBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -191,7 +191,7 @@ public final class UnderFileSystemBlockReaderTest {
     doThrow(new WorkerOutOfSpaceException("Ignored")).when(errorThrowingBlockStore)
         .createBlock(anyLong(), anyLong(), any(BlockStoreLocation.class),
             anyLong());
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
         errorThrowingBlockStore, mUfsManager, mUfsInstreamManager);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -201,7 +201,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void transferFullBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE * 2, (int) TEST_BLOCK_SIZE * 2);
@@ -219,7 +219,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void transferPartialBlock() throws Exception {
-    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, mAlluxioBlockStore,
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false, mAlluxioBlockStore,
         mUfsManager, mUfsInstreamManager);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE / 2, (int) TEST_BLOCK_SIZE / 2);

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -57,13 +57,15 @@ message ReadRequest {
   // Whether the block should be promoted before reading
   optional bool promote = 4;
   optional int64 chunk_size = 5;
-  optional bool switch = 8;
 
   // This is only set for UFS block read.
   optional alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;
 
   // Read receipt
   optional int64 offset_received = 7;
+
+  // Is position read to a small buffer
+  optional bool position_short = 8;
 }
 
 // The read response.

--- a/core/transport/src/grpc/block_worker.proto
+++ b/core/transport/src/grpc/block_worker.proto
@@ -49,7 +49,7 @@ enum RequestType {
 }
 
 // The read request.
-// next available id: 6
+// next available id: 9
 message ReadRequest {
   optional int64 block_id = 1;
   optional int64 offset = 2;
@@ -57,6 +57,7 @@ message ReadRequest {
   // Whether the block should be promoted before reading
   optional bool promote = 4;
   optional int64 chunk_size = 5;
+  optional bool switch = 8;
 
   // This is only set for UFS block read.
   optional alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -126,67 +126,67 @@ public final class BlockWorkerProto {
       "\n\027grpc/block_worker.proto\022\022alluxio.grpc." +
       "block\032\037proto/dataserver/protocol.proto\032\021" +
       "grpc/common.proto\"\016\n\014CheckRequest\"\017\n\rChe" +
-      "ckResponse\"\025\n\005Chunk\022\014\n\004data\030\001 \001(\014\"\314\001\n\013Re" +
+      "ckResponse\"\025\n\005Chunk\022\014\n\004data\030\001 \001(\014\"\334\001\n\013Re" +
       "adRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006offset\030\002 " +
       "\001(\003\022\016\n\006length\030\003 \001(\003\022\017\n\007promote\030\004 \001(\010\022\022\n\n" +
-      "chunk_size\030\005 \001(\003\022M\n\026open_ufs_block_optio" +
-      "ns\030\006 \001(\0132-.alluxio.proto.dataserver.Open" +
-      "UfsBlockOptions\022\027\n\017offset_received\030\007 \001(\003" +
-      "\"8\n\014ReadResponse\022(\n\005chunk\030\001 \001(\0132\031.alluxi" +
-      "o.grpc.block.Chunk\"\315\002\n\023WriteRequestComma" +
-      "nd\022-\n\004type\030\001 \001(\0162\037.alluxio.grpc.block.Re" +
-      "questType\022\n\n\002id\030\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n" +
-      "\004tier\030\004 \001(\005\022\r\n\005flush\030\005 \001(\010\022O\n\027create_ufs" +
-      "_file_options\030\006 \001(\0132..alluxio.proto.data" +
-      "server.CreateUfsFileOptions\022Q\n\030create_uf" +
-      "s_block_options\030\007 \001(\0132/.alluxio.proto.da" +
-      "taserver.CreateUfsBlockOptions\022\023\n\013medium" +
-      "_type\030\010 \001(\t\022\025\n\rpin_on_create\030\t \001(\010\"\177\n\014Wr" +
-      "iteRequest\022:\n\007command\030\001 \001(\0132\'.alluxio.gr" +
-      "pc.block.WriteRequestCommandH\000\022*\n\005chunk\030" +
-      "\002 \001(\0132\031.alluxio.grpc.block.ChunkH\000B\007\n\005va" +
-      "lue\"\037\n\rWriteResponse\022\016\n\006offset\030\001 \001(\003\"\256\001\n" +
-      "\021AsyncCacheRequest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013" +
-      "source_host\030\002 \001(\t\022\023\n\013source_port\030\003 \001(\005\022M" +
-      "\n\026open_ufs_block_options\030\004 \001(\0132-.alluxio" +
-      ".proto.dataserver.OpenUfsBlockOptions\022\016\n" +
-      "\006length\030\005 \001(\003\"\024\n\022AsyncCacheResponse\":\n\025O" +
-      "penLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\017" +
-      "\n\007promote\030\002 \001(\010\"&\n\026OpenLocalBlockRespons" +
-      "e\022\014\n\004path\030\001 \001(\t\"\267\001\n\027CreateLocalBlockRequ" +
-      "est\022\020\n\010block_id\030\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020s" +
-      "pace_to_reserve\030\004 \001(\003\022\032\n\022only_reserve_sp" +
-      "ace\030\005 \001(\010\022\032\n\022cleanup_on_failure\030\006 \001(\010\022\023\n" +
-      "\013medium_type\030\007 \001(\t\022\025\n\rpin_on_create\030\010 \001(" +
-      "\010\"(\n\030CreateLocalBlockResponse\022\014\n\004path\030\001 " +
-      "\001(\t\"&\n\022RemoveBlockRequest\022\020\n\010block_id\030\001 " +
-      "\001(\003\"\025\n\023RemoveBlockResponse\"9\n\020MoveBlockR" +
-      "equest\022\020\n\010block_id\030\001 \001(\003\022\023\n\013medium_type\030" +
-      "\002 \001(\t\"\023\n\021MoveBlockResponse\"\025\n\023ClearMetri" +
-      "csRequest\"\026\n\024ClearMetricsResponse*F\n\013Req" +
-      "uestType\022\021\n\rALLUXIO_BLOCK\020\000\022\014\n\010UFS_FILE\020" +
-      "\001\022\026\n\022UFS_FALLBACK_BLOCK\020\0022\222\006\n\013BlockWorke" +
-      "r\022R\n\tReadBlock\022\037.alluxio.grpc.block.Read" +
-      "Request\032 .alluxio.grpc.block.ReadRespons" +
-      "e(\0010\001\022U\n\nWriteBlock\022 .alluxio.grpc.block" +
-      ".WriteRequest\032!.alluxio.grpc.block.Write" +
-      "Response(\0010\001\022k\n\016OpenLocalBlock\022).alluxio" +
-      ".grpc.block.OpenLocalBlockRequest\032*.allu" +
-      "xio.grpc.block.OpenLocalBlockResponse(\0010" +
-      "\001\022q\n\020CreateLocalBlock\022+.alluxio.grpc.blo" +
-      "ck.CreateLocalBlockRequest\032,.alluxio.grp" +
-      "c.block.CreateLocalBlockResponse(\0010\001\022[\n\n" +
-      "AsyncCache\022%.alluxio.grpc.block.AsyncCac" +
-      "heRequest\032&.alluxio.grpc.block.AsyncCach" +
-      "eResponse\022^\n\013RemoveBlock\022&.alluxio.grpc." +
-      "block.RemoveBlockRequest\032\'.alluxio.grpc." +
-      "block.RemoveBlockResponse\022X\n\tMoveBlock\022$" +
-      ".alluxio.grpc.block.MoveBlockRequest\032%.a" +
-      "lluxio.grpc.block.MoveBlockResponse\022a\n\014C" +
-      "learMetrics\022\'.alluxio.grpc.block.ClearMe" +
-      "tricsRequest\032(.alluxio.grpc.block.ClearM" +
-      "etricsResponseB\"\n\014alluxio.grpcB\020BlockWor" +
-      "kerProtoP\001"
+      "chunk_size\030\005 \001(\003\022\016\n\006switch\030\010 \001(\010\022M\n\026open" +
+      "_ufs_block_options\030\006 \001(\0132-.alluxio.proto" +
+      ".dataserver.OpenUfsBlockOptions\022\027\n\017offse" +
+      "t_received\030\007 \001(\003\"8\n\014ReadResponse\022(\n\005chun" +
+      "k\030\001 \001(\0132\031.alluxio.grpc.block.Chunk\"\315\002\n\023W" +
+      "riteRequestCommand\022-\n\004type\030\001 \001(\0162\037.allux" +
+      "io.grpc.block.RequestType\022\n\n\002id\030\002 \001(\003\022\016\n" +
+      "\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\r\n\005flush\030\005 \001" +
+      "(\010\022O\n\027create_ufs_file_options\030\006 \001(\0132..al" +
+      "luxio.proto.dataserver.CreateUfsFileOpti" +
+      "ons\022Q\n\030create_ufs_block_options\030\007 \001(\0132/." +
+      "alluxio.proto.dataserver.CreateUfsBlockO" +
+      "ptions\022\023\n\013medium_type\030\010 \001(\t\022\025\n\rpin_on_cr" +
+      "eate\030\t \001(\010\"\177\n\014WriteRequest\022:\n\007command\030\001 " +
+      "\001(\0132\'.alluxio.grpc.block.WriteRequestCom" +
+      "mandH\000\022*\n\005chunk\030\002 \001(\0132\031.alluxio.grpc.blo" +
+      "ck.ChunkH\000B\007\n\005value\"\037\n\rWriteResponse\022\016\n\006" +
+      "offset\030\001 \001(\003\"\256\001\n\021AsyncCacheRequest\022\020\n\010bl" +
+      "ock_id\030\001 \001(\003\022\023\n\013source_host\030\002 \001(\t\022\023\n\013sou" +
+      "rce_port\030\003 \001(\005\022M\n\026open_ufs_block_options" +
+      "\030\004 \001(\0132-.alluxio.proto.dataserver.OpenUf" +
+      "sBlockOptions\022\016\n\006length\030\005 \001(\003\"\024\n\022AsyncCa" +
+      "cheResponse\":\n\025OpenLocalBlockRequest\022\020\n\010" +
+      "block_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"&\n\026OpenL" +
+      "ocalBlockResponse\022\014\n\004path\030\001 \001(\t\"\267\001\n\027Crea" +
+      "teLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n" +
+      "\004tier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n" +
+      "\022only_reserve_space\030\005 \001(\010\022\032\n\022cleanup_on_" +
+      "failure\030\006 \001(\010\022\023\n\013medium_type\030\007 \001(\t\022\025\n\rpi" +
+      "n_on_create\030\010 \001(\010\"(\n\030CreateLocalBlockRes" +
+      "ponse\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlockReques" +
+      "t\022\020\n\010block_id\030\001 \001(\003\"\025\n\023RemoveBlockRespon" +
+      "se\"9\n\020MoveBlockRequest\022\020\n\010block_id\030\001 \001(\003" +
+      "\022\023\n\013medium_type\030\002 \001(\t\"\023\n\021MoveBlockRespon" +
+      "se\"\025\n\023ClearMetricsRequest\"\026\n\024ClearMetric" +
+      "sResponse*F\n\013RequestType\022\021\n\rALLUXIO_BLOC" +
+      "K\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_BLOCK\020" +
+      "\0022\222\006\n\013BlockWorker\022R\n\tReadBlock\022\037.alluxio" +
+      ".grpc.block.ReadRequest\032 .alluxio.grpc.b" +
+      "lock.ReadResponse(\0010\001\022U\n\nWriteBlock\022 .al" +
+      "luxio.grpc.block.WriteRequest\032!.alluxio." +
+      "grpc.block.WriteResponse(\0010\001\022k\n\016OpenLoca" +
+      "lBlock\022).alluxio.grpc.block.OpenLocalBlo" +
+      "ckRequest\032*.alluxio.grpc.block.OpenLocal" +
+      "BlockResponse(\0010\001\022q\n\020CreateLocalBlock\022+." +
+      "alluxio.grpc.block.CreateLocalBlockReque" +
+      "st\032,.alluxio.grpc.block.CreateLocalBlock" +
+      "Response(\0010\001\022[\n\nAsyncCache\022%.alluxio.grp" +
+      "c.block.AsyncCacheRequest\032&.alluxio.grpc" +
+      ".block.AsyncCacheResponse\022^\n\013RemoveBlock" +
+      "\022&.alluxio.grpc.block.RemoveBlockRequest" +
+      "\032\'.alluxio.grpc.block.RemoveBlockRespons" +
+      "e\022X\n\tMoveBlock\022$.alluxio.grpc.block.Move" +
+      "BlockRequest\032%.alluxio.grpc.block.MoveBl" +
+      "ockResponse\022a\n\014ClearMetrics\022\'.alluxio.gr" +
+      "pc.block.ClearMetricsRequest\032(.alluxio.g" +
+      "rpc.block.ClearMetricsResponseB\"\n\014alluxi" +
+      "o.grpcB\020BlockWorkerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -225,7 +225,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_ReadRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_ReadRequest_descriptor,
-        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "OpenUfsBlockOptions", "OffsetReceived", });
+        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "Switch", "OpenUfsBlockOptions", "OffsetReceived", });
     internal_static_alluxio_grpc_block_ReadResponse_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_grpc_block_ReadResponse_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/BlockWorkerProto.java
@@ -126,67 +126,67 @@ public final class BlockWorkerProto {
       "\n\027grpc/block_worker.proto\022\022alluxio.grpc." +
       "block\032\037proto/dataserver/protocol.proto\032\021" +
       "grpc/common.proto\"\016\n\014CheckRequest\"\017\n\rChe" +
-      "ckResponse\"\025\n\005Chunk\022\014\n\004data\030\001 \001(\014\"\334\001\n\013Re" +
+      "ckResponse\"\025\n\005Chunk\022\014\n\004data\030\001 \001(\014\"\344\001\n\013Re" +
       "adRequest\022\020\n\010block_id\030\001 \001(\003\022\016\n\006offset\030\002 " +
       "\001(\003\022\016\n\006length\030\003 \001(\003\022\017\n\007promote\030\004 \001(\010\022\022\n\n" +
-      "chunk_size\030\005 \001(\003\022\016\n\006switch\030\010 \001(\010\022M\n\026open" +
-      "_ufs_block_options\030\006 \001(\0132-.alluxio.proto" +
-      ".dataserver.OpenUfsBlockOptions\022\027\n\017offse" +
-      "t_received\030\007 \001(\003\"8\n\014ReadResponse\022(\n\005chun" +
-      "k\030\001 \001(\0132\031.alluxio.grpc.block.Chunk\"\315\002\n\023W" +
-      "riteRequestCommand\022-\n\004type\030\001 \001(\0162\037.allux" +
-      "io.grpc.block.RequestType\022\n\n\002id\030\002 \001(\003\022\016\n" +
-      "\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\r\n\005flush\030\005 \001" +
-      "(\010\022O\n\027create_ufs_file_options\030\006 \001(\0132..al" +
-      "luxio.proto.dataserver.CreateUfsFileOpti" +
-      "ons\022Q\n\030create_ufs_block_options\030\007 \001(\0132/." +
-      "alluxio.proto.dataserver.CreateUfsBlockO" +
-      "ptions\022\023\n\013medium_type\030\010 \001(\t\022\025\n\rpin_on_cr" +
-      "eate\030\t \001(\010\"\177\n\014WriteRequest\022:\n\007command\030\001 " +
-      "\001(\0132\'.alluxio.grpc.block.WriteRequestCom" +
-      "mandH\000\022*\n\005chunk\030\002 \001(\0132\031.alluxio.grpc.blo" +
-      "ck.ChunkH\000B\007\n\005value\"\037\n\rWriteResponse\022\016\n\006" +
-      "offset\030\001 \001(\003\"\256\001\n\021AsyncCacheRequest\022\020\n\010bl" +
-      "ock_id\030\001 \001(\003\022\023\n\013source_host\030\002 \001(\t\022\023\n\013sou" +
-      "rce_port\030\003 \001(\005\022M\n\026open_ufs_block_options" +
-      "\030\004 \001(\0132-.alluxio.proto.dataserver.OpenUf" +
-      "sBlockOptions\022\016\n\006length\030\005 \001(\003\"\024\n\022AsyncCa" +
-      "cheResponse\":\n\025OpenLocalBlockRequest\022\020\n\010" +
-      "block_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"&\n\026OpenL" +
-      "ocalBlockResponse\022\014\n\004path\030\001 \001(\t\"\267\001\n\027Crea" +
-      "teLocalBlockRequest\022\020\n\010block_id\030\001 \001(\003\022\014\n" +
-      "\004tier\030\003 \001(\005\022\030\n\020space_to_reserve\030\004 \001(\003\022\032\n" +
-      "\022only_reserve_space\030\005 \001(\010\022\032\n\022cleanup_on_" +
-      "failure\030\006 \001(\010\022\023\n\013medium_type\030\007 \001(\t\022\025\n\rpi" +
-      "n_on_create\030\010 \001(\010\"(\n\030CreateLocalBlockRes" +
-      "ponse\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlockReques" +
-      "t\022\020\n\010block_id\030\001 \001(\003\"\025\n\023RemoveBlockRespon" +
-      "se\"9\n\020MoveBlockRequest\022\020\n\010block_id\030\001 \001(\003" +
-      "\022\023\n\013medium_type\030\002 \001(\t\"\023\n\021MoveBlockRespon" +
-      "se\"\025\n\023ClearMetricsRequest\"\026\n\024ClearMetric" +
-      "sResponse*F\n\013RequestType\022\021\n\rALLUXIO_BLOC" +
-      "K\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBACK_BLOCK\020" +
-      "\0022\222\006\n\013BlockWorker\022R\n\tReadBlock\022\037.alluxio" +
-      ".grpc.block.ReadRequest\032 .alluxio.grpc.b" +
-      "lock.ReadResponse(\0010\001\022U\n\nWriteBlock\022 .al" +
-      "luxio.grpc.block.WriteRequest\032!.alluxio." +
-      "grpc.block.WriteResponse(\0010\001\022k\n\016OpenLoca" +
-      "lBlock\022).alluxio.grpc.block.OpenLocalBlo" +
-      "ckRequest\032*.alluxio.grpc.block.OpenLocal" +
-      "BlockResponse(\0010\001\022q\n\020CreateLocalBlock\022+." +
-      "alluxio.grpc.block.CreateLocalBlockReque" +
-      "st\032,.alluxio.grpc.block.CreateLocalBlock" +
-      "Response(\0010\001\022[\n\nAsyncCache\022%.alluxio.grp" +
-      "c.block.AsyncCacheRequest\032&.alluxio.grpc" +
-      ".block.AsyncCacheResponse\022^\n\013RemoveBlock" +
-      "\022&.alluxio.grpc.block.RemoveBlockRequest" +
-      "\032\'.alluxio.grpc.block.RemoveBlockRespons" +
-      "e\022X\n\tMoveBlock\022$.alluxio.grpc.block.Move" +
-      "BlockRequest\032%.alluxio.grpc.block.MoveBl" +
-      "ockResponse\022a\n\014ClearMetrics\022\'.alluxio.gr" +
-      "pc.block.ClearMetricsRequest\032(.alluxio.g" +
-      "rpc.block.ClearMetricsResponseB\"\n\014alluxi" +
-      "o.grpcB\020BlockWorkerProtoP\001"
+      "chunk_size\030\005 \001(\003\022M\n\026open_ufs_block_optio" +
+      "ns\030\006 \001(\0132-.alluxio.proto.dataserver.Open" +
+      "UfsBlockOptions\022\027\n\017offset_received\030\007 \001(\003" +
+      "\022\026\n\016position_short\030\010 \001(\010\"8\n\014ReadResponse" +
+      "\022(\n\005chunk\030\001 \001(\0132\031.alluxio.grpc.block.Chu" +
+      "nk\"\315\002\n\023WriteRequestCommand\022-\n\004type\030\001 \001(\016" +
+      "2\037.alluxio.grpc.block.RequestType\022\n\n\002id\030" +
+      "\002 \001(\003\022\016\n\006offset\030\003 \001(\003\022\014\n\004tier\030\004 \001(\005\022\r\n\005f" +
+      "lush\030\005 \001(\010\022O\n\027create_ufs_file_options\030\006 " +
+      "\001(\0132..alluxio.proto.dataserver.CreateUfs" +
+      "FileOptions\022Q\n\030create_ufs_block_options\030" +
+      "\007 \001(\0132/.alluxio.proto.dataserver.CreateU" +
+      "fsBlockOptions\022\023\n\013medium_type\030\010 \001(\t\022\025\n\rp" +
+      "in_on_create\030\t \001(\010\"\177\n\014WriteRequest\022:\n\007co" +
+      "mmand\030\001 \001(\0132\'.alluxio.grpc.block.WriteRe" +
+      "questCommandH\000\022*\n\005chunk\030\002 \001(\0132\031.alluxio." +
+      "grpc.block.ChunkH\000B\007\n\005value\"\037\n\rWriteResp" +
+      "onse\022\016\n\006offset\030\001 \001(\003\"\256\001\n\021AsyncCacheReque" +
+      "st\022\020\n\010block_id\030\001 \001(\003\022\023\n\013source_host\030\002 \001(" +
+      "\t\022\023\n\013source_port\030\003 \001(\005\022M\n\026open_ufs_block" +
+      "_options\030\004 \001(\0132-.alluxio.proto.dataserve" +
+      "r.OpenUfsBlockOptions\022\016\n\006length\030\005 \001(\003\"\024\n" +
+      "\022AsyncCacheResponse\":\n\025OpenLocalBlockReq" +
+      "uest\022\020\n\010block_id\030\001 \001(\003\022\017\n\007promote\030\002 \001(\010\"" +
+      "&\n\026OpenLocalBlockResponse\022\014\n\004path\030\001 \001(\t\"" +
+      "\267\001\n\027CreateLocalBlockRequest\022\020\n\010block_id\030" +
+      "\001 \001(\003\022\014\n\004tier\030\003 \001(\005\022\030\n\020space_to_reserve\030" +
+      "\004 \001(\003\022\032\n\022only_reserve_space\030\005 \001(\010\022\032\n\022cle" +
+      "anup_on_failure\030\006 \001(\010\022\023\n\013medium_type\030\007 \001" +
+      "(\t\022\025\n\rpin_on_create\030\010 \001(\010\"(\n\030CreateLocal" +
+      "BlockResponse\022\014\n\004path\030\001 \001(\t\"&\n\022RemoveBlo" +
+      "ckRequest\022\020\n\010block_id\030\001 \001(\003\"\025\n\023RemoveBlo" +
+      "ckResponse\"9\n\020MoveBlockRequest\022\020\n\010block_" +
+      "id\030\001 \001(\003\022\023\n\013medium_type\030\002 \001(\t\"\023\n\021MoveBlo" +
+      "ckResponse\"\025\n\023ClearMetricsRequest\"\026\n\024Cle" +
+      "arMetricsResponse*F\n\013RequestType\022\021\n\rALLU" +
+      "XIO_BLOCK\020\000\022\014\n\010UFS_FILE\020\001\022\026\n\022UFS_FALLBAC" +
+      "K_BLOCK\020\0022\222\006\n\013BlockWorker\022R\n\tReadBlock\022\037" +
+      ".alluxio.grpc.block.ReadRequest\032 .alluxi" +
+      "o.grpc.block.ReadResponse(\0010\001\022U\n\nWriteBl" +
+      "ock\022 .alluxio.grpc.block.WriteRequest\032!." +
+      "alluxio.grpc.block.WriteResponse(\0010\001\022k\n\016" +
+      "OpenLocalBlock\022).alluxio.grpc.block.Open" +
+      "LocalBlockRequest\032*.alluxio.grpc.block.O" +
+      "penLocalBlockResponse(\0010\001\022q\n\020CreateLocal" +
+      "Block\022+.alluxio.grpc.block.CreateLocalBl" +
+      "ockRequest\032,.alluxio.grpc.block.CreateLo" +
+      "calBlockResponse(\0010\001\022[\n\nAsyncCache\022%.all" +
+      "uxio.grpc.block.AsyncCacheRequest\032&.allu" +
+      "xio.grpc.block.AsyncCacheResponse\022^\n\013Rem" +
+      "oveBlock\022&.alluxio.grpc.block.RemoveBloc" +
+      "kRequest\032\'.alluxio.grpc.block.RemoveBloc" +
+      "kResponse\022X\n\tMoveBlock\022$.alluxio.grpc.bl" +
+      "ock.MoveBlockRequest\032%.alluxio.grpc.bloc" +
+      "k.MoveBlockResponse\022a\n\014ClearMetrics\022\'.al" +
+      "luxio.grpc.block.ClearMetricsRequest\032(.a" +
+      "lluxio.grpc.block.ClearMetricsResponseB\"" +
+      "\n\014alluxio.grpcB\020BlockWorkerProtoP\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -225,7 +225,7 @@ public final class BlockWorkerProto {
     internal_static_alluxio_grpc_block_ReadRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_block_ReadRequest_descriptor,
-        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "Switch", "OpenUfsBlockOptions", "OffsetReceived", });
+        new java.lang.String[] { "BlockId", "Offset", "Length", "Promote", "ChunkSize", "OpenUfsBlockOptions", "OffsetReceived", "PositionShort", });
     internal_static_alluxio_grpc_block_ReadResponse_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_alluxio_grpc_block_ReadResponse_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
@@ -26,8 +26,8 @@ private static final long serialVersionUID = 0L;
     length_ = 0L;
     promote_ = false;
     chunkSize_ = 0L;
-    switch_ = false;
     offsetReceived_ = 0L;
+    positionShort_ = false;
   }
 
   @java.lang.Override
@@ -88,7 +88,7 @@ private static final long serialVersionUID = 0L;
           }
           case 50: {
             alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder subBuilder = null;
-            if (((bitField0_ & 0x00000040) == 0x00000040)) {
+            if (((bitField0_ & 0x00000020) == 0x00000020)) {
               subBuilder = openUfsBlockOptions_.toBuilder();
             }
             openUfsBlockOptions_ = input.readMessage(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.PARSER, extensionRegistry);
@@ -96,17 +96,17 @@ private static final long serialVersionUID = 0L;
               subBuilder.mergeFrom(openUfsBlockOptions_);
               openUfsBlockOptions_ = subBuilder.buildPartial();
             }
-            bitField0_ |= 0x00000040;
+            bitField0_ |= 0x00000020;
             break;
           }
           case 56: {
-            bitField0_ |= 0x00000080;
+            bitField0_ |= 0x00000040;
             offsetReceived_ = input.readInt64();
             break;
           }
           case 64: {
-            bitField0_ |= 0x00000020;
-            switch_ = input.readBool();
+            bitField0_ |= 0x00000080;
+            positionShort_ = input.readBool();
             break;
           }
         }
@@ -217,21 +217,6 @@ private static final long serialVersionUID = 0L;
     return chunkSize_;
   }
 
-  public static final int SWITCH_FIELD_NUMBER = 8;
-  private boolean switch_;
-  /**
-   * <code>optional bool switch = 8;</code>
-   */
-  public boolean hasSwitch() {
-    return ((bitField0_ & 0x00000020) == 0x00000020);
-  }
-  /**
-   * <code>optional bool switch = 8;</code>
-   */
-  public boolean getSwitch() {
-    return switch_;
-  }
-
   public static final int OPEN_UFS_BLOCK_OPTIONS_FIELD_NUMBER = 6;
   private alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions openUfsBlockOptions_;
   /**
@@ -242,7 +227,7 @@ private static final long serialVersionUID = 0L;
    * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
    */
   public boolean hasOpenUfsBlockOptions() {
-    return ((bitField0_ & 0x00000040) == 0x00000040);
+    return ((bitField0_ & 0x00000020) == 0x00000020);
   }
   /**
    * <pre>
@@ -275,7 +260,7 @@ private static final long serialVersionUID = 0L;
    * <code>optional int64 offset_received = 7;</code>
    */
   public boolean hasOffsetReceived() {
-    return ((bitField0_ & 0x00000080) == 0x00000080);
+    return ((bitField0_ & 0x00000040) == 0x00000040);
   }
   /**
    * <pre>
@@ -286,6 +271,29 @@ private static final long serialVersionUID = 0L;
    */
   public long getOffsetReceived() {
     return offsetReceived_;
+  }
+
+  public static final int POSITION_SHORT_FIELD_NUMBER = 8;
+  private boolean positionShort_;
+  /**
+   * <pre>
+   * Is position read to a small buffer
+   * </pre>
+   *
+   * <code>optional bool position_short = 8;</code>
+   */
+  public boolean hasPositionShort() {
+    return ((bitField0_ & 0x00000080) == 0x00000080);
+  }
+  /**
+   * <pre>
+   * Is position read to a small buffer
+   * </pre>
+   *
+   * <code>optional bool position_short = 8;</code>
+   */
+  public boolean getPositionShort() {
+    return positionShort_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -315,14 +323,14 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000010) == 0x00000010)) {
       output.writeInt64(5, chunkSize_);
     }
-    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
       output.writeMessage(6, getOpenUfsBlockOptions());
     }
-    if (((bitField0_ & 0x00000080) == 0x00000080)) {
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
       output.writeInt64(7, offsetReceived_);
     }
-    if (((bitField0_ & 0x00000020) == 0x00000020)) {
-      output.writeBool(8, switch_);
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      output.writeBool(8, positionShort_);
     }
     unknownFields.writeTo(output);
   }
@@ -352,17 +360,17 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(5, chunkSize_);
     }
-    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getOpenUfsBlockOptions());
     }
-    if (((bitField0_ & 0x00000080) == 0x00000080)) {
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(7, offsetReceived_);
     }
-    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
       size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(8, switch_);
+        .computeBoolSize(8, positionShort_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -405,11 +413,6 @@ private static final long serialVersionUID = 0L;
       result = result && (getChunkSize()
           == other.getChunkSize());
     }
-    result = result && (hasSwitch() == other.hasSwitch());
-    if (hasSwitch()) {
-      result = result && (getSwitch()
-          == other.getSwitch());
-    }
     result = result && (hasOpenUfsBlockOptions() == other.hasOpenUfsBlockOptions());
     if (hasOpenUfsBlockOptions()) {
       result = result && getOpenUfsBlockOptions()
@@ -419,6 +422,11 @@ private static final long serialVersionUID = 0L;
     if (hasOffsetReceived()) {
       result = result && (getOffsetReceived()
           == other.getOffsetReceived());
+    }
+    result = result && (hasPositionShort() == other.hasPositionShort());
+    if (hasPositionShort()) {
+      result = result && (getPositionShort()
+          == other.getPositionShort());
     }
     result = result && unknownFields.equals(other.unknownFields);
     return result;
@@ -456,11 +464,6 @@ private static final long serialVersionUID = 0L;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getChunkSize());
     }
-    if (hasSwitch()) {
-      hash = (37 * hash) + SWITCH_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-          getSwitch());
-    }
     if (hasOpenUfsBlockOptions()) {
       hash = (37 * hash) + OPEN_UFS_BLOCK_OPTIONS_FIELD_NUMBER;
       hash = (53 * hash) + getOpenUfsBlockOptions().hashCode();
@@ -469,6 +472,11 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + OFFSET_RECEIVED_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getOffsetReceived());
+    }
+    if (hasPositionShort()) {
+      hash = (37 * hash) + POSITION_SHORT_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getPositionShort());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -615,15 +623,15 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000008);
       chunkSize_ = 0L;
       bitField0_ = (bitField0_ & ~0x00000010);
-      switch_ = false;
-      bitField0_ = (bitField0_ & ~0x00000020);
       if (openUfsBlockOptionsBuilder_ == null) {
         openUfsBlockOptions_ = null;
       } else {
         openUfsBlockOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000040);
+      bitField0_ = (bitField0_ & ~0x00000020);
       offsetReceived_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000040);
+      positionShort_ = false;
       bitField0_ = (bitField0_ & ~0x00000080);
       return this;
     }
@@ -672,19 +680,19 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
         to_bitField0_ |= 0x00000020;
       }
-      result.switch_ = switch_;
-      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-        to_bitField0_ |= 0x00000040;
-      }
       if (openUfsBlockOptionsBuilder_ == null) {
         result.openUfsBlockOptions_ = openUfsBlockOptions_;
       } else {
         result.openUfsBlockOptions_ = openUfsBlockOptionsBuilder_.build();
       }
+      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        to_bitField0_ |= 0x00000040;
+      }
+      result.offsetReceived_ = offsetReceived_;
       if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
         to_bitField0_ |= 0x00000080;
       }
-      result.offsetReceived_ = offsetReceived_;
+      result.positionShort_ = positionShort_;
       result.bitField0_ = to_bitField0_;
       onBuilt();
       return result;
@@ -742,14 +750,14 @@ private static final long serialVersionUID = 0L;
       if (other.hasChunkSize()) {
         setChunkSize(other.getChunkSize());
       }
-      if (other.hasSwitch()) {
-        setSwitch(other.getSwitch());
-      }
       if (other.hasOpenUfsBlockOptions()) {
         mergeOpenUfsBlockOptions(other.getOpenUfsBlockOptions());
       }
       if (other.hasOffsetReceived()) {
         setOffsetReceived(other.getOffsetReceived());
+      }
+      if (other.hasPositionShort()) {
+        setPositionShort(other.getPositionShort());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -955,38 +963,6 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean switch_ ;
-    /**
-     * <code>optional bool switch = 8;</code>
-     */
-    public boolean hasSwitch() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
-    }
-    /**
-     * <code>optional bool switch = 8;</code>
-     */
-    public boolean getSwitch() {
-      return switch_;
-    }
-    /**
-     * <code>optional bool switch = 8;</code>
-     */
-    public Builder setSwitch(boolean value) {
-      bitField0_ |= 0x00000020;
-      switch_ = value;
-      onChanged();
-      return this;
-    }
-    /**
-     * <code>optional bool switch = 8;</code>
-     */
-    public Builder clearSwitch() {
-      bitField0_ = (bitField0_ & ~0x00000020);
-      switch_ = false;
-      onChanged();
-      return this;
-    }
-
     private alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions openUfsBlockOptions_ = null;
     private com.google.protobuf.SingleFieldBuilderV3<
         alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions, alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder, alluxio.proto.dataserver.Protocol.OpenUfsBlockOptionsOrBuilder> openUfsBlockOptionsBuilder_;
@@ -998,7 +974,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
      */
     public boolean hasOpenUfsBlockOptions() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <pre>
@@ -1031,7 +1007,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.setMessage(value);
       }
-      bitField0_ |= 0x00000040;
+      bitField0_ |= 0x00000020;
       return this;
     }
     /**
@@ -1049,7 +1025,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.setMessage(builderForValue.build());
       }
-      bitField0_ |= 0x00000040;
+      bitField0_ |= 0x00000020;
       return this;
     }
     /**
@@ -1061,7 +1037,7 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeOpenUfsBlockOptions(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions value) {
       if (openUfsBlockOptionsBuilder_ == null) {
-        if (((bitField0_ & 0x00000040) == 0x00000040) &&
+        if (((bitField0_ & 0x00000020) == 0x00000020) &&
             openUfsBlockOptions_ != null &&
             openUfsBlockOptions_ != alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance()) {
           openUfsBlockOptions_ =
@@ -1073,7 +1049,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000040;
+      bitField0_ |= 0x00000020;
       return this;
     }
     /**
@@ -1090,7 +1066,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000040);
+      bitField0_ = (bitField0_ & ~0x00000020);
       return this;
     }
     /**
@@ -1101,7 +1077,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
      */
     public alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder getOpenUfsBlockOptionsBuilder() {
-      bitField0_ |= 0x00000040;
+      bitField0_ |= 0x00000020;
       onChanged();
       return getOpenUfsBlockOptionsFieldBuilder().getBuilder();
     }
@@ -1150,7 +1126,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public boolean hasOffsetReceived() {
-      return ((bitField0_ & 0x00000080) == 0x00000080);
+      return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
      * <pre>
@@ -1170,7 +1146,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public Builder setOffsetReceived(long value) {
-      bitField0_ |= 0x00000080;
+      bitField0_ |= 0x00000040;
       offsetReceived_ = value;
       onChanged();
       return this;
@@ -1183,8 +1159,56 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public Builder clearOffsetReceived() {
-      bitField0_ = (bitField0_ & ~0x00000080);
+      bitField0_ = (bitField0_ & ~0x00000040);
       offsetReceived_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private boolean positionShort_ ;
+    /**
+     * <pre>
+     * Is position read to a small buffer
+     * </pre>
+     *
+     * <code>optional bool position_short = 8;</code>
+     */
+    public boolean hasPositionShort() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <pre>
+     * Is position read to a small buffer
+     * </pre>
+     *
+     * <code>optional bool position_short = 8;</code>
+     */
+    public boolean getPositionShort() {
+      return positionShort_;
+    }
+    /**
+     * <pre>
+     * Is position read to a small buffer
+     * </pre>
+     *
+     * <code>optional bool position_short = 8;</code>
+     */
+    public Builder setPositionShort(boolean value) {
+      bitField0_ |= 0x00000080;
+      positionShort_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Is position read to a small buffer
+     * </pre>
+     *
+     * <code>optional bool position_short = 8;</code>
+     */
+    public Builder clearPositionShort() {
+      bitField0_ = (bitField0_ & ~0x00000080);
+      positionShort_ = false;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequest.java
@@ -6,7 +6,7 @@ package alluxio.grpc;
 /**
  * <pre>
  * The read request.
- * next available id: 6
+ * next available id: 9
  * </pre>
  *
  * Protobuf type {@code alluxio.grpc.block.ReadRequest}
@@ -26,6 +26,7 @@ private static final long serialVersionUID = 0L;
     length_ = 0L;
     promote_ = false;
     chunkSize_ = 0L;
+    switch_ = false;
     offsetReceived_ = 0L;
   }
 
@@ -87,7 +88,7 @@ private static final long serialVersionUID = 0L;
           }
           case 50: {
             alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder subBuilder = null;
-            if (((bitField0_ & 0x00000020) == 0x00000020)) {
+            if (((bitField0_ & 0x00000040) == 0x00000040)) {
               subBuilder = openUfsBlockOptions_.toBuilder();
             }
             openUfsBlockOptions_ = input.readMessage(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.PARSER, extensionRegistry);
@@ -95,12 +96,17 @@ private static final long serialVersionUID = 0L;
               subBuilder.mergeFrom(openUfsBlockOptions_);
               openUfsBlockOptions_ = subBuilder.buildPartial();
             }
-            bitField0_ |= 0x00000020;
+            bitField0_ |= 0x00000040;
             break;
           }
           case 56: {
-            bitField0_ |= 0x00000040;
+            bitField0_ |= 0x00000080;
             offsetReceived_ = input.readInt64();
+            break;
+          }
+          case 64: {
+            bitField0_ |= 0x00000020;
+            switch_ = input.readBool();
             break;
           }
         }
@@ -211,6 +217,21 @@ private static final long serialVersionUID = 0L;
     return chunkSize_;
   }
 
+  public static final int SWITCH_FIELD_NUMBER = 8;
+  private boolean switch_;
+  /**
+   * <code>optional bool switch = 8;</code>
+   */
+  public boolean hasSwitch() {
+    return ((bitField0_ & 0x00000020) == 0x00000020);
+  }
+  /**
+   * <code>optional bool switch = 8;</code>
+   */
+  public boolean getSwitch() {
+    return switch_;
+  }
+
   public static final int OPEN_UFS_BLOCK_OPTIONS_FIELD_NUMBER = 6;
   private alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions openUfsBlockOptions_;
   /**
@@ -221,7 +242,7 @@ private static final long serialVersionUID = 0L;
    * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
    */
   public boolean hasOpenUfsBlockOptions() {
-    return ((bitField0_ & 0x00000020) == 0x00000020);
+    return ((bitField0_ & 0x00000040) == 0x00000040);
   }
   /**
    * <pre>
@@ -254,7 +275,7 @@ private static final long serialVersionUID = 0L;
    * <code>optional int64 offset_received = 7;</code>
    */
   public boolean hasOffsetReceived() {
-    return ((bitField0_ & 0x00000040) == 0x00000040);
+    return ((bitField0_ & 0x00000080) == 0x00000080);
   }
   /**
    * <pre>
@@ -294,11 +315,14 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000010) == 0x00000010)) {
       output.writeInt64(5, chunkSize_);
     }
-    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
       output.writeMessage(6, getOpenUfsBlockOptions());
     }
-    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
       output.writeInt64(7, offsetReceived_);
+    }
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      output.writeBool(8, switch_);
     }
     unknownFields.writeTo(output);
   }
@@ -328,13 +352,17 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(5, chunkSize_);
     }
-    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+    if (((bitField0_ & 0x00000040) == 0x00000040)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getOpenUfsBlockOptions());
     }
-    if (((bitField0_ & 0x00000040) == 0x00000040)) {
+    if (((bitField0_ & 0x00000080) == 0x00000080)) {
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(7, offsetReceived_);
+    }
+    if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(8, switch_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -376,6 +404,11 @@ private static final long serialVersionUID = 0L;
     if (hasChunkSize()) {
       result = result && (getChunkSize()
           == other.getChunkSize());
+    }
+    result = result && (hasSwitch() == other.hasSwitch());
+    if (hasSwitch()) {
+      result = result && (getSwitch()
+          == other.getSwitch());
     }
     result = result && (hasOpenUfsBlockOptions() == other.hasOpenUfsBlockOptions());
     if (hasOpenUfsBlockOptions()) {
@@ -422,6 +455,11 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + CHUNK_SIZE_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getChunkSize());
+    }
+    if (hasSwitch()) {
+      hash = (37 * hash) + SWITCH_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getSwitch());
     }
     if (hasOpenUfsBlockOptions()) {
       hash = (37 * hash) + OPEN_UFS_BLOCK_OPTIONS_FIELD_NUMBER;
@@ -528,7 +566,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * The read request.
-   * next available id: 6
+   * next available id: 9
    * </pre>
    *
    * Protobuf type {@code alluxio.grpc.block.ReadRequest}
@@ -577,14 +615,16 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000008);
       chunkSize_ = 0L;
       bitField0_ = (bitField0_ & ~0x00000010);
+      switch_ = false;
+      bitField0_ = (bitField0_ & ~0x00000020);
       if (openUfsBlockOptionsBuilder_ == null) {
         openUfsBlockOptions_ = null;
       } else {
         openUfsBlockOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000020);
-      offsetReceived_ = 0L;
       bitField0_ = (bitField0_ & ~0x00000040);
+      offsetReceived_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000080);
       return this;
     }
 
@@ -632,13 +672,17 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
         to_bitField0_ |= 0x00000020;
       }
+      result.switch_ = switch_;
+      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        to_bitField0_ |= 0x00000040;
+      }
       if (openUfsBlockOptionsBuilder_ == null) {
         result.openUfsBlockOptions_ = openUfsBlockOptions_;
       } else {
         result.openUfsBlockOptions_ = openUfsBlockOptionsBuilder_.build();
       }
-      if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-        to_bitField0_ |= 0x00000040;
+      if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+        to_bitField0_ |= 0x00000080;
       }
       result.offsetReceived_ = offsetReceived_;
       result.bitField0_ = to_bitField0_;
@@ -697,6 +741,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasChunkSize()) {
         setChunkSize(other.getChunkSize());
+      }
+      if (other.hasSwitch()) {
+        setSwitch(other.getSwitch());
       }
       if (other.hasOpenUfsBlockOptions()) {
         mergeOpenUfsBlockOptions(other.getOpenUfsBlockOptions());
@@ -908,6 +955,38 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private boolean switch_ ;
+    /**
+     * <code>optional bool switch = 8;</code>
+     */
+    public boolean hasSwitch() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional bool switch = 8;</code>
+     */
+    public boolean getSwitch() {
+      return switch_;
+    }
+    /**
+     * <code>optional bool switch = 8;</code>
+     */
+    public Builder setSwitch(boolean value) {
+      bitField0_ |= 0x00000020;
+      switch_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional bool switch = 8;</code>
+     */
+    public Builder clearSwitch() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      switch_ = false;
+      onChanged();
+      return this;
+    }
+
     private alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions openUfsBlockOptions_ = null;
     private com.google.protobuf.SingleFieldBuilderV3<
         alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions, alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder, alluxio.proto.dataserver.Protocol.OpenUfsBlockOptionsOrBuilder> openUfsBlockOptionsBuilder_;
@@ -919,7 +998,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
      */
     public boolean hasOpenUfsBlockOptions() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
      * <pre>
@@ -952,7 +1031,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.setMessage(value);
       }
-      bitField0_ |= 0x00000020;
+      bitField0_ |= 0x00000040;
       return this;
     }
     /**
@@ -970,7 +1049,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.setMessage(builderForValue.build());
       }
-      bitField0_ |= 0x00000020;
+      bitField0_ |= 0x00000040;
       return this;
     }
     /**
@@ -982,7 +1061,7 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeOpenUfsBlockOptions(alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions value) {
       if (openUfsBlockOptionsBuilder_ == null) {
-        if (((bitField0_ & 0x00000020) == 0x00000020) &&
+        if (((bitField0_ & 0x00000040) == 0x00000040) &&
             openUfsBlockOptions_ != null &&
             openUfsBlockOptions_ != alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.getDefaultInstance()) {
           openUfsBlockOptions_ =
@@ -994,7 +1073,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000020;
+      bitField0_ |= 0x00000040;
       return this;
     }
     /**
@@ -1011,7 +1090,7 @@ private static final long serialVersionUID = 0L;
       } else {
         openUfsBlockOptionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000020);
+      bitField0_ = (bitField0_ & ~0x00000040);
       return this;
     }
     /**
@@ -1022,7 +1101,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional .alluxio.proto.dataserver.OpenUfsBlockOptions open_ufs_block_options = 6;</code>
      */
     public alluxio.proto.dataserver.Protocol.OpenUfsBlockOptions.Builder getOpenUfsBlockOptionsBuilder() {
-      bitField0_ |= 0x00000020;
+      bitField0_ |= 0x00000040;
       onChanged();
       return getOpenUfsBlockOptionsFieldBuilder().getBuilder();
     }
@@ -1071,7 +1150,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public boolean hasOffsetReceived() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
      * <pre>
@@ -1091,7 +1170,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public Builder setOffsetReceived(long value) {
-      bitField0_ |= 0x00000040;
+      bitField0_ |= 0x00000080;
       offsetReceived_ = value;
       onChanged();
       return this;
@@ -1104,7 +1183,7 @@ private static final long serialVersionUID = 0L;
      * <code>optional int64 offset_received = 7;</code>
      */
     public Builder clearOffsetReceived() {
-      bitField0_ = (bitField0_ & ~0x00000040);
+      bitField0_ = (bitField0_ & ~0x00000080);
       offsetReceived_ = 0L;
       onChanged();
       return this;

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
@@ -61,15 +61,6 @@ public interface ReadRequestOrBuilder extends
   long getChunkSize();
 
   /**
-   * <code>optional bool switch = 8;</code>
-   */
-  boolean hasSwitch();
-  /**
-   * <code>optional bool switch = 8;</code>
-   */
-  boolean getSwitch();
-
-  /**
    * <pre>
    * This is only set for UFS block read.
    * </pre>
@@ -110,4 +101,21 @@ public interface ReadRequestOrBuilder extends
    * <code>optional int64 offset_received = 7;</code>
    */
   long getOffsetReceived();
+
+  /**
+   * <pre>
+   * Is position read to a small buffer
+   * </pre>
+   *
+   * <code>optional bool position_short = 8;</code>
+   */
+  boolean hasPositionShort();
+  /**
+   * <pre>
+   * Is position read to a small buffer
+   * </pre>
+   *
+   * <code>optional bool position_short = 8;</code>
+   */
+  boolean getPositionShort();
 }

--- a/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/ReadRequestOrBuilder.java
@@ -61,6 +61,15 @@ public interface ReadRequestOrBuilder extends
   long getChunkSize();
 
   /**
+   * <code>optional bool switch = 8;</code>
+   */
+  boolean hasSwitch();
+  /**
+   * <code>optional bool switch = 8;</code>
+   */
+  boolean getSwitch();
+
+  /**
    * <pre>
    * This is only set for UFS block read.
    * </pre>

--- a/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
@@ -435,6 +435,44 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
     }
   }
 
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.USER_FILE_SEQUENTIAL_PREAD_THRESHOLD, "700KB"})
+  public void positionedReadWithLargeThreshold() throws Exception {
+    List<CreateFilePOptions> optionSet = new ArrayList<>(2);
+    optionSet.add(mWriteBoth);
+    optionSet.add(mWriteUnderStore);
+    for (CreateFilePOptions op : optionSet) {
+      String filename = mTestPath + "/file_" + MIN_LEN + "_" + op.hashCode();
+      AlluxioURI uri = new AlluxioURI(filename);
+
+      try (FileInStream is = mFileSystem.openFile(uri, FileSystemTestUtils.toOpenFileOptions(op))) {
+        byte[] ret = new byte[DELTA - 1];
+        Assert.assertEquals(DELTA - 1, is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
+        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
+      }
+    }
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(
+      confParams = {PropertyKey.Name.USER_FILE_SEQUENTIAL_PREAD_THRESHOLD, "200KB"})
+  public void positionedReadWithSmallThreshold() throws Exception {
+    List<CreateFilePOptions> optionSet = new ArrayList<>(2);
+    optionSet.add(mWriteBoth);
+    optionSet.add(mWriteUnderStore);
+    for (CreateFilePOptions op : optionSet) {
+      String filename = mTestPath + "/file_" + MIN_LEN + "_" + op.hashCode();
+      AlluxioURI uri = new AlluxioURI(filename);
+
+      try (FileInStream is = mFileSystem.openFile(uri, FileSystemTestUtils.toOpenFileOptions(op))) {
+        byte[] ret = new byte[DELTA - 1];
+        Assert.assertEquals(DELTA - 1, is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
+        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
+      }
+    }
+  }
+
   @Test(timeout = 10000)
   public void asyncCacheFirstBlock() throws Exception {
     String filename = mTestPath + "/file_" + MAX_LEN + "_" + mWriteUnderStore.hashCode();

--- a/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
@@ -448,8 +448,10 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
 
       try (FileInStream is = mFileSystem.openFile(uri, FileSystemTestUtils.toOpenFileOptions(op))) {
         byte[] ret = new byte[DELTA - 1];
-        Assert.assertEquals(DELTA - 1, is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
-        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
+        Assert.assertEquals(DELTA - 1,
+            is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
+        Assert.assertTrue(
+            BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
       }
     }
   }
@@ -467,8 +469,10 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
 
       try (FileInStream is = mFileSystem.openFile(uri, FileSystemTestUtils.toOpenFileOptions(op))) {
         byte[] ret = new byte[DELTA - 1];
-        Assert.assertEquals(DELTA - 1, is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
-        Assert.assertTrue(BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
+        Assert.assertEquals(DELTA - 1,
+            is.positionedRead(MIN_LEN - DELTA + 1, ret, 0, DELTA));
+        Assert.assertTrue(
+            BufferUtils.equalIncreasingByteArray(MIN_LEN - DELTA + 1, DELTA - 1, ret));
       }
     }
   }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileInputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileInputStream.java
@@ -1,0 +1,39 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import alluxio.underfs.SeekableUnderFileInputStream;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+/**
+ * The input stream of HDFS as under filesystem. This input stream supports seeking and can be
+ * cached for reuse.
+ */
+public class HdfsUnderFileInputStream extends SeekableUnderFileInputStream {
+
+  HdfsUnderFileInputStream(FSDataInputStream in) {
+    super(in);
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    ((FSDataInputStream) in).seek(position);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return ((FSDataInputStream) in).getPos();
+  }
+}

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -564,7 +564,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       try {
         FSDataInputStream inputStream = hdfs.open(new Path(path));
         if (options.getPositionShort()) {
-          LOG.info("AMDEBUG: using pread");
+          LOG.debug("Using pread API to HDFS");
           // pread API instead of seek is more efficient for FSDataInputStream.
           // A seek on FSDataInputStream uses a skip op which is implemented as read + discard
           // and hence ends up reading extra data from the datanode.
@@ -576,7 +576,6 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
           inputStream.close();
           throw e;
         }
-        LOG.info("AMDEBUG: not using pread");
         return new HdfsUnderFileInputStream(inputStream);
       } catch (IOException e) {
         LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.getMessage());

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -563,7 +563,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     while (retryPolicy.attempt()) {
       try {
         FSDataInputStream inputStream = hdfs.open(new Path(path));
-        if (options.getSwitch()) {
+        if (options.getPositionShort()) {
           try {
             inputStream.seek(options.getOffset());
           } catch (IOException e) {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -570,8 +570,10 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
             inputStream.close();
             throw e;
           }
+          LOG.info("AMDEBUG: not using pread");
           return new HdfsUnderFileInputStream(inputStream);
         }
+        LOG.info("AMDEBUG: using pread");
         // pread API instead of seek is more efficient for FSDataInputStream.
         // A seek on FSDataInputStream uses a skip op which is implemented as read + discard
         // and hence ends up reading extra data from the datanode.

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -563,6 +563,15 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     while (retryPolicy.attempt()) {
       try {
         FSDataInputStream inputStream = hdfs.open(new Path(path));
+        if (options.getSwitch()) {
+          try {
+            inputStream.seek(options.getOffset());
+          } catch (IOException e) {
+            inputStream.close();
+            throw e;
+          }
+          return new HdfsUnderFileInputStream(inputStream);
+        }
         // pread API instead of seek is more efficient for FSDataInputStream.
         // A seek on FSDataInputStream uses a skip op which is implemented as read + discard
         // and hence ends up reading extra data from the datanode.

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -564,20 +564,20 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       try {
         FSDataInputStream inputStream = hdfs.open(new Path(path));
         if (options.getPositionShort()) {
-          try {
-            inputStream.seek(options.getOffset());
-          } catch (IOException e) {
-            inputStream.close();
-            throw e;
-          }
-          LOG.info("AMDEBUG: not using pread");
-          return new HdfsUnderFileInputStream(inputStream);
+          LOG.info("AMDEBUG: using pread");
+          // pread API instead of seek is more efficient for FSDataInputStream.
+          // A seek on FSDataInputStream uses a skip op which is implemented as read + discard
+          // and hence ends up reading extra data from the datanode.
+          return new HdfsPositionedUnderFileInputStream(inputStream, options.getOffset());
         }
-        LOG.info("AMDEBUG: using pread");
-        // pread API instead of seek is more efficient for FSDataInputStream.
-        // A seek on FSDataInputStream uses a skip op which is implemented as read + discard
-        // and hence ends up reading extra data from the datanode.
-        return new HdfsPositionedUnderFileInputStream(inputStream, options.getOffset());
+        try {
+          inputStream.seek(options.getOffset());
+        } catch (IOException e) {
+          inputStream.close();
+          throw e;
+        }
+        LOG.info("AMDEBUG: not using pread");
+        return new HdfsUnderFileInputStream(inputStream);
       } catch (IOException e) {
         LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.getMessage());
         te = e;


### PR DESCRIPTION
This PR is a follow up to https://github.com/Alluxio/alluxio/pull/10763.

When the client buffer size is large ( > 2MB) and reads are guaranteed to be somewhat sequential, the `pread` API to HDFS is not as efficient as simple `read`. We introduce a heuristic to choose which API to use.