### PR TITLE
Increment cluster counter and delete orphaned meter in MetricsStore

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1283,7 +1283,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_CLUSTER_METRICS_UPDATE_INTERVAL =
       new Builder(Name.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL)
-          .setDefaultValue("1m")
+          .setDefaultValue("1min")
           .setDescription("The interval for periodically updating the cluster level metrics.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -1435,6 +1435,24 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "when the journal is formatted. The master will search for a file with this "
               + "prefix when determining if the journal is formatted.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_REPORTED_METRICS_CLEANUP_INTERVAL =
+      new Builder(Name.MASTER_REPORTED_METRICS_CLEANUP_INTERVAL)
+          .setDefaultValue("5min")
+          .setDescription("The interval for periodically cleanup the orphaned metrics "
+              + "which are reported by lost workers/clients and stored "
+              + "in the leading master metrics store.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_REPORTED_METRICS_CLEANUP_AGE =
+      new Builder(Name.MASTER_REPORTED_METRICS_CLEANUP_AGE)
+          .setDefaultValue("5min")
+          .setDescription("All the metrics which are reported by workers or clients "
+              + "which haven't reported for period longer than this cleanup age "
+              + "will be removed from the leading master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_STANDBY_HEARTBEAT_INTERVAL =
@@ -4142,6 +4160,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_FILE_ACCESS_TIME_UPDATER_SHUTDOWN_TIMEOUT =
         "alluxio.master.file.access.time.updater.shutdown.timeout";
     public static final String MASTER_FORMAT_FILE_PREFIX = "alluxio.master.format.file.prefix";
+    public static final String MASTER_REPORTED_METRICS_CLEANUP_INTERVAL =
+        "alluxio.master.reported.metrics.cleanup.interval";
+    public static final String MASTER_REPORTED_METRICS_CLEANUP_AGE =
+        "alluxio.master.reported.metrics.cleanup.age";
     public static final String MASTER_STANDBY_HEARTBEAT_INTERVAL =
         "alluxio.master.standby.heartbeat.interval";
     public static final String MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -45,6 +45,7 @@ public final class HeartbeatContext {
   public static final String MASTER_LOST_FILES_DETECTION = "Master Lost Files Detection";
   public static final String MASTER_LOST_MASTER_DETECTION = "Master Lost Master Detection";
   public static final String MASTER_LOST_WORKER_DETECTION = "Master Lost Worker Detection";
+  public static final String MASTER_ORPHANED_METRICS_CLEANER = "Master Orphaned Metrics Cleaner";
   public static final String MASTER_METRICS_SYNC = "Master Metrics Sync";
   public static final String MASTER_METRICS_TIME_SERIES = "Master Metrics Time Series";
   public static final String MASTER_UFS_CLEANUP = "Master Ufs Cleanup";
@@ -92,6 +93,7 @@ public final class HeartbeatContext {
     sTimerClasses.put(WORKER_SPACE_RESERVER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_STORAGE_HEALTH, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_METRICS_SYNC, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_ORPHANED_METRICS_CLEANER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_METRICS_TIME_SERIES, SLEEPING_TIMER_CLASS);
   }
 

--- a/core/common/src/main/java/alluxio/metrics/Metric.java
+++ b/core/common/src/main/java/alluxio/metrics/Metric.java
@@ -289,6 +289,26 @@ public final class Metric implements Serializable {
   }
 
   /**
+   * Gets value of ufs tag from the full metric name.
+   *
+   * @param fullName the full metric name
+   * @return value of ufs tag
+   */
+  public static String getTagUfsValueFromFullName(String fullName) {
+    String[] pieces = fullName.split("\\.");
+    if (pieces.length < 3) {
+      return null;
+    }
+    for (int i = 2; i < pieces.length; i++) {
+      String current = pieces[i];
+      if (current.contains(TAG_SEPARATOR) && current.contains(MetricInfo.TAG_UFS)) {
+        return current.substring(current.indexOf(TAG_SEPARATOR) + 1);
+      }
+    }
+    return null;
+  }
+
+  /**
    * Creates the metric from the full name and the value.
    *
    * @param fullName the full name

--- a/core/common/src/main/java/alluxio/metrics/Metric.java
+++ b/core/common/src/main/java/alluxio/metrics/Metric.java
@@ -36,7 +36,7 @@ public final class Metric implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(Metric.class);
   private static final long serialVersionUID = -2236393414222298333L;
 
-  private static final String ID_SEPARATOR = "-id:";
+  public static final String ID_SEPARATOR = "-id:";
   public static final String TAG_SEPARATOR = ":";
   private static final ConcurrentHashMap<UserMetricKey, String> CACHED_METRICS =
       new ConcurrentHashMap<>();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -111,6 +111,17 @@ public final class MetricKey implements Comparable<MetricKey> {
   }
 
   /**
+   * @return the name of the Metric without instance prefix
+   */
+  public String getMetricName() {
+    String[] pieces = mName.split("\\.");
+    if (pieces.length <= 1) {
+      return mName;
+    }
+    return pieces[1];
+  }
+
+  /**
    * @return the description of a Metric
    */
   public String getDescription() {

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -402,7 +402,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_READ_ALLUXIO)
           .setDescription("Total number of bytes read from Alluxio storage reported "
               + "by all workers. This does not include UFS reads.")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_READ_ALLUXIO_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_READ_ALLUXIO_THROUGHPUT)
@@ -413,7 +413,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_READ_DOMAIN)
           .setDescription("Total number of bytes read from Alluxio storage "
               + "via domain socket reported by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_READ_DOMAIN_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_READ_DOMAIN_THROUGHPUT)
@@ -425,7 +425,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_READ_LOCAL)
           .setDescription("Total number of bytes short-circuit read from local storage "
               + "by all clients")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_READ_LOCAL_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_READ_LOCAL_THROUGHPUT)
@@ -435,12 +435,12 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey CLUSTER_BYTES_READ_UFS =
       new Builder(Name.CLUSTER_BYTES_READ_UFS)
           .setDescription("Total number of bytes read from a specific UFS by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_READ_UFS_ALL =
       new Builder(Name.CLUSTER_BYTES_READ_UFS_ALL)
           .setDescription("Total number of bytes read from a all Alluxio UFSes by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_READ_UFS_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_READ_UFS_THROUGHPUT)
@@ -451,7 +451,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_WRITTEN_ALLUXIO)
           .setDescription("Total number of bytes written to Alluxio storage in all workers. "
               + "This does not include UFS writes")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_WRITTEN_ALLUXIO_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_ALLUXIO_THROUGHPUT)
@@ -462,7 +462,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_WRITTEN_DOMAIN)
           .setDescription("Total number of bytes written to Alluxio storage "
               + "via domain socket by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_WRITTEN_DOMAIN_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_DOMAIN_THROUGHPUT)
@@ -474,7 +474,7 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLUSTER_BYTES_WRITTEN_LOCAL)
           .setDescription("Total number of bytes short-circuit written to local storage "
               + "by all clients")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_WRITTEN_LOCAL_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_LOCAL_THROUGHPUT)
@@ -484,12 +484,12 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey CLUSTER_BYTES_WRITTEN_UFS =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_UFS)
           .setDescription("Total number of bytes written to a specific Alluxio UFS by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_WRITTEN_UFS_ALL =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_UFS_ALL)
           .setDescription("Total number of bytes written to all Alluxio UFSes by all workers")
-          .setMetricType(MetricType.GAUGE)
+          .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey CLUSTER_BYTES_WRITTEN_UFS_THROUGHPUT =
       new Builder(Name.CLUSTER_BYTES_WRITTEN_UFS_THROUGHPUT)

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -454,7 +454,7 @@ public final class MetricsSystem {
    * @param <T> the type
    */
   public static synchronized <T> void registerGaugeIfAbsent(String name, Gauge<T> metric) {
-    if (!METRIC_REGISTRY.getGauges().containsKey(name)) {
+    if (!METRIC_REGISTRY.getMetrics().containsKey(name)) {
       METRIC_REGISTRY.register(name, metric);
     }
   }

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -209,6 +209,9 @@ public final class MetricsSystem {
    * @return the metric with instance and id tags
    */
   public static String getMetricName(String name) {
+    if (name.startsWith(CLUSTER)) {
+      return name;
+    }
     switch (CommonUtils.PROCESS_TYPE.get()) {
       case CLIENT:
         return getClientMetricName(name);

--- a/core/common/src/test/java/alluxio/metrics/MetricTest.java
+++ b/core/common/src/test/java/alluxio/metrics/MetricTest.java
@@ -34,7 +34,7 @@ public final class MetricTest {
 
   @Test
   public void testFullNameParsing() {
-    String fullName = "Client.metric.192_1_1_1|A.tag1:A::/.tag2:B:/";
+    String fullName = "Client.metric.tag1:A::/.tag2:B:/.192_1_1_1|A";
     Metric metric = Metric.from(fullName, 1, MetricType.COUNTER);
     assertEquals(fullName, metric.getFullMetricName());
   }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -32,7 +32,6 @@ import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
-import alluxio.grpc.MetricType;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.master.AlluxioMasterProcess;
@@ -850,10 +849,12 @@ public final class AlluxioMasterRestServiceHandler {
       MasterWebUIMetrics response = new MasterWebUIMetrics();
 
       MetricRegistry mr = MetricsSystem.METRIC_REGISTRY;
+      SortedMap<String, Gauge> gauges = mr.getGauges();
+      SortedMap<String, Counter> counters = mr.getCounters();
 
-      Long masterCapacityTotal = (Long) mr.getGauges()
+      Long masterCapacityTotal = (Long) gauges
           .get(MetricKey.CLUSTER_CAPACITY_TOTAL.getName()).getValue();
-      Long masterCapacityUsed = (Long) mr.getGauges()
+      Long masterCapacityUsed = (Long) gauges
           .get(MetricKey.CLUSTER_CAPACITY_USED.getName()).getValue();
 
       int masterCapacityUsedPercentage =
@@ -861,9 +862,9 @@ public final class AlluxioMasterRestServiceHandler {
       response.setMasterCapacityUsedPercentage(masterCapacityUsedPercentage)
           .setMasterCapacityFreePercentage(100 - masterCapacityUsedPercentage);
 
-      Long masterUnderfsCapacityTotal = (Long) mr.getGauges()
+      Long masterUnderfsCapacityTotal = (Long) gauges
           .get(MetricKey.CLUSTER_ROOT_UFS_CAPACITY_TOTAL.getName()).getValue();
-      Long masterUnderfsCapacityUsed = (Long) mr.getGauges()
+      Long masterUnderfsCapacityUsed = (Long) gauges
           .get(MetricKey.CLUSTER_ROOT_UFS_CAPACITY_USED.getName()).getValue();
 
       int masterUnderfsCapacityUsedPercentage =
@@ -873,14 +874,14 @@ public final class AlluxioMasterRestServiceHandler {
           .setMasterUnderfsCapacityFreePercentage(100 - masterUnderfsCapacityUsedPercentage);
 
       // cluster read size
-      Long bytesReadLocal = (Long) mr.getGauges().get(
-          MetricKey.CLUSTER_BYTES_READ_LOCAL.getName()).getValue();
-      Long bytesReadRemote = (Long) mr.getGauges().get(
-          MetricKey.CLUSTER_BYTES_READ_ALLUXIO.getName()).getValue();
-      Long bytesReadDomainSocket = (Long) mr.getGauges().get(
-          MetricKey.CLUSTER_BYTES_READ_DOMAIN.getName()).getValue();
-      Long bytesReadUfs = (Long) mr.getGauges().get(
-          MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName()).getValue();
+      Long bytesReadLocal = counters.get(
+          MetricKey.CLUSTER_BYTES_READ_LOCAL.getName()).getCount();
+      Long bytesReadRemote = counters.get(
+          MetricKey.CLUSTER_BYTES_READ_ALLUXIO.getName()).getCount();
+      Long bytesReadDomainSocket = counters.get(
+          MetricKey.CLUSTER_BYTES_READ_DOMAIN.getName()).getCount();
+      Long bytesReadUfs = counters.get(
+          MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName()).getCount();
       response.setTotalBytesReadLocal(FormatUtils.getSizeFromBytes(bytesReadLocal))
           .setTotalBytesReadDomainSocket(FormatUtils.getSizeFromBytes(bytesReadDomainSocket))
           .setTotalBytesReadRemote(FormatUtils.getSizeFromBytes(bytesReadRemote))
@@ -901,27 +902,27 @@ public final class AlluxioMasterRestServiceHandler {
           .setCacheMiss(String.format("%.2f", cacheMissPercentage));
 
       // cluster write size
-      Long bytesWrittenLocal = (Long) mr.getGauges()
-          .get(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL.getName()).getValue();
-      Long bytesWrittenAlluxio = (Long) mr.getGauges()
-          .get(MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO.getName()).getValue();
-      Long bytesWrittenDomainSocket = (Long) mr.getGauges().get(
-          MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN.getName()).getValue();
-      Long bytesWrittenUfs = (Long) mr.getGauges()
-          .get(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName()).getValue();
+      Long bytesWrittenLocal = counters
+          .get(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL.getName()).getCount();
+      Long bytesWrittenAlluxio = counters
+          .get(MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO.getName()).getCount();
+      Long bytesWrittenDomainSocket = counters.get(
+          MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN.getName()).getCount();
+      Long bytesWrittenUfs = counters
+          .get(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName()).getCount();
       response.setTotalBytesWrittenLocal(FormatUtils.getSizeFromBytes(bytesWrittenLocal))
           .setTotalBytesWrittenAlluxio(FormatUtils.getSizeFromBytes(bytesWrittenAlluxio))
           .setTotalBytesWrittenDomainSocket(FormatUtils.getSizeFromBytes(bytesWrittenDomainSocket))
           .setTotalBytesWrittenUfs(FormatUtils.getSizeFromBytes(bytesWrittenUfs));
 
       // cluster read throughput
-      Long bytesReadLocalThroughput = (Long) mr.getGauges().get(
+      Long bytesReadLocalThroughput = (Long) gauges.get(
           MetricKey.CLUSTER_BYTES_READ_LOCAL_THROUGHPUT.getName()).getValue();
-      Long bytesReadDomainSocketThroughput = (Long) mr.getGauges()
+      Long bytesReadDomainSocketThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_READ_DOMAIN_THROUGHPUT.getName()).getValue();
-      Long bytesReadRemoteThroughput = (Long) mr.getGauges()
+      Long bytesReadRemoteThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_READ_ALLUXIO_THROUGHPUT.getName()).getValue();
-      Long bytesReadUfsThroughput = (Long) mr.getGauges()
+      Long bytesReadUfsThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_READ_UFS_THROUGHPUT.getName()).getValue();
       response
           .setTotalBytesReadLocalThroughput(FormatUtils.getSizeFromBytes(bytesReadLocalThroughput))
@@ -932,14 +933,14 @@ public final class AlluxioMasterRestServiceHandler {
           .setTotalBytesReadUfsThroughput(FormatUtils.getSizeFromBytes(bytesReadUfsThroughput));
 
       // cluster write throughput
-      Long bytesWrittenLocalThroughput = (Long) mr.getGauges()
+      Long bytesWrittenLocalThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL_THROUGHPUT.getName())
           .getValue();
-      Long bytesWrittenAlluxioThroughput = (Long) mr.getGauges()
+      Long bytesWrittenAlluxioThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO_THROUGHPUT.getName()).getValue();
-      Long bytesWrittenDomainSocketThroughput = (Long) mr.getGauges().get(
+      Long bytesWrittenDomainSocketThroughput = (Long) gauges.get(
           MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN_THROUGHPUT.getName()).getValue();
-      Long bytesWrittenUfsThroughput = (Long) mr.getGauges()
+      Long bytesWrittenUfsThroughput = (Long) gauges
           .get(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_THROUGHPUT.getName()).getValue();
       response.setTotalBytesWrittenLocalThroughput(
               FormatUtils.getSizeFromBytes(bytesWrittenLocalThroughput))
@@ -958,72 +959,56 @@ public final class AlluxioMasterRestServiceHandler {
 
       // cluster per UFS read
       Map<String, String> ufsReadSizeMap = new TreeMap<>();
-      for (Map.Entry<String, Gauge> entry : mr.getGauges((name, metric)
-          -> name.contains(MetricKey.CLUSTER_BYTES_READ_UFS.getName())).entrySet()) {
-        alluxio.metrics.Metric metric =
-            alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue(),
-                MetricType.GAUGE);
-        String ufs = metric.getTags().get(MetricInfo.TAG_UFS);
-        if (isMounted(ufs)) {
-          ufsReadSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
-        }
-      }
-      response.setUfsReadSize(ufsReadSizeMap);
-
-      // cluster per UFS write
       Map<String, String> ufsWriteSizeMap = new TreeMap<>();
-      for (Map.Entry<String, Gauge> entry : mr.getGauges((name, metric)
-          -> name.contains(MetricKey.CLUSTER_BYTES_WRITTEN_UFS.getName())).entrySet()) {
-        alluxio.metrics.Metric metric =
-            alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue(),
-                MetricType.GAUGE);
-        String ufs = metric.getTags().get(MetricInfo.TAG_UFS);
-        if (isMounted(ufs)) {
-          ufsWriteSizeMap.put(ufs, FormatUtils.getSizeFromBytes((long) metric.getValue()));
+      Map<String, Counter> rpcInvocations = new TreeMap<>();
+      Map<String, Metric> operations = new TreeMap<>();
+      for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+        String metricName = entry.getKey();
+        long value = entry.getValue().getCount();
+        if (metricName.contains(MetricKey.CLUSTER_BYTES_READ_UFS.getName())) {
+          String ufs = alluxio.metrics.Metric.getTagUfsValueFromFullName(metricName);
+          if (ufs != null && isMounted(ufs)) {
+            ufsReadSizeMap.put(ufs, FormatUtils.getSizeFromBytes(value));
+          }
+        } else if (metricName.contains(MetricKey.CLUSTER_BYTES_WRITTEN_UFS.getName())) {
+          String ufs = alluxio.metrics.Metric.getTagUfsValueFromFullName(metricName);
+          if (ufs != null && isMounted(ufs)) {
+            ufsWriteSizeMap.put(ufs, FormatUtils.getSizeFromBytes(value));
+          }
+        } else if (metricName.endsWith("Ops")) {
+          rpcInvocations
+              .put(MetricsSystem.stripInstanceAndHost(metricName), entry.getValue());
+        } else {
+          operations
+              .put(MetricsSystem.stripInstanceAndHost(metricName), entry.getValue());
         }
       }
+
+      String filesPinnedProperty = MetricKey.MASTER_FILES_PINNED.getName();
+      operations.put(MetricsSystem.stripInstanceAndHost(filesPinnedProperty),
+          gauges.get(filesPinnedProperty));
+
+      response.setOperationMetrics(operations).setRpcInvocationMetrics(rpcInvocations);
+
+      response.setUfsReadSize(ufsReadSizeMap);
       response.setUfsWriteSize(ufsWriteSizeMap);
 
       // per UFS ops
       Map<String, Map<String, Long>> ufsOpsMap = new TreeMap<>();
-      for (Map.Entry<String, Gauge> entry : mr
-          .getGauges((name, metric) -> name.contains(MetricInfo.UFS_OP_PREFIX)).entrySet()) {
-        alluxio.metrics.Metric metric =
-            alluxio.metrics.Metric.from(entry.getKey(), (long) entry.getValue().getValue(),
-                MetricType.GAUGE);
-        if (!metric.getTags().containsKey(MetricInfo.TAG_UFS)) {
-          continue;
-        }
-        String ufs = metric.getTags().get(MetricInfo.TAG_UFS);
-        if (isMounted(ufs)) {
-          // Unescape the URI for display
-          String ufsUnescaped = MetricsSystem.unescape(ufs);
-          Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
-          perUfsMap.put(ufsUnescaped, (long) metric.getValue());
-          ufsOpsMap.put(ufsUnescaped, perUfsMap);
+      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        String metricName = entry.getKey();
+        if (metricName.contains(MetricInfo.UFS_OP_PREFIX)) {
+          String ufs = alluxio.metrics.Metric.getTagUfsValueFromFullName(metricName);
+          if (ufs != null && isMounted(ufs)) {
+            // Unescape the URI for display
+            String ufsUnescaped = MetricsSystem.unescape(ufs);
+            Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
+            perUfsMap.put(ufsUnescaped, (long) entry.getValue().getValue());
+            ufsOpsMap.put(ufsUnescaped, perUfsMap);
+          }
         }
       }
       response.setUfsOps(ufsOpsMap);
-
-      Map<String, Counter> counters = mr.getCounters((name, metric) -> !(name.endsWith("Ops")));
-      Map<String, Counter> rpcInvocations = mr.getCounters((name, metric) -> name.endsWith("Ops"));
-
-      Map<String, Metric> operations = new TreeMap<>();
-      // Remove the instance name from the metrics.
-      for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-        operations.put(MetricsSystem.stripInstanceAndHost(entry.getKey()), entry.getValue());
-      }
-      String filesPinnedProperty = MetricKey.MASTER_FILES_PINNED.getName();
-      operations.put(MetricsSystem.stripInstanceAndHost(filesPinnedProperty),
-          mr.getGauges().get(filesPinnedProperty));
-
-      Map<String, Counter> rpcInvocationsUpdated = new TreeMap<>();
-      for (Map.Entry<String, Counter> entry : rpcInvocations.entrySet()) {
-        rpcInvocationsUpdated
-            .put(MetricsSystem.stripInstanceAndHost(entry.getKey()), entry.getValue());
-      }
-
-      response.setOperationMetrics(operations).setRpcInvocationMetrics(rpcInvocationsUpdated);
 
       response.setTimeSeriesMetrics(mFileSystemMaster.getTimeSeries());
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -1003,7 +1003,7 @@ public final class AlluxioMasterRestServiceHandler {
             // Unescape the URI for display
             String ufsUnescaped = MetricsSystem.unescape(ufs);
             Map<String, Long> perUfsMap = ufsOpsMap.getOrDefault(ufs, new TreeMap<>());
-            perUfsMap.put(ufsUnescaped, (long) entry.getValue().getValue());
+            perUfsMap.put(ufsUnescaped, (Long) entry.getValue().getValue());
             ufsOpsMap.put(ufsUnescaped, perUfsMap);
           }
         }

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -120,7 +120,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
     }
   }
 
-  private void cleanUpOrphaneMetrics() {
+  private void cleanUpOrphanedMetrics() {
     mMetricsStore.cleanUpOrphanedMetrics();
   }
 
@@ -191,7 +191,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
           ServerConfiguration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL),
           ServerConfiguration.global(), mMasterContext.getUserState()));
       getExecutorService().submit(new HeartbeatThread(
-          HeartbeatContext.MASTER_ORPHANED_METRICS_CLEANER, new OrphaneMetricsCleaner(),
+          HeartbeatContext.MASTER_ORPHANED_METRICS_CLEANER, new OrphanedMetricsCleaner(),
           ServerConfiguration.getMs(PropertyKey.MASTER_REPORTED_METRICS_CLEANUP_INTERVAL),
           ServerConfiguration.global(), mMasterContext.getUserState()));
     }
@@ -240,10 +240,10 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
   /**
    * Heartbeat executor that cleans the metrics reported by lost workers or clients.
    */
-  private class OrphaneMetricsCleaner implements HeartbeatExecutor {
+  private class OrphanedMetricsCleaner implements HeartbeatExecutor {
     @Override
     public void heartbeat() throws InterruptedException {
-      cleanUpOrphaneMetrics();
+      cleanUpOrphanedMetrics();
     }
 
     @Override

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -138,63 +138,39 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
 
   private void registerAggregators() {
     // worker metrics
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_READ_ALLUXIO.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_READ_ALLUXIO.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_READ_ALLUXIO_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER,
         MetricKey.WORKER_BYTES_READ_ALLUXIO_THROUGHPUT.getName()));
     addAggregator(new SumInstancesAggregator(
-        MetricKey.CLUSTER_BYTES_READ_DOMAIN.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_READ_DOMAIN.getName()));
-    addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_READ_DOMAIN_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER,
         MetricKey.WORKER_BYTES_READ_DOMAIN_THROUGHPUT.getName()));
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_READ_UFS.getName()));
     addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_READ_UFS_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT.getName()));
 
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_WRITTEN_ALLUXIO.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER,
         MetricKey.WORKER_BYTES_WRITTEN_ALLUXIO_THROUGHPUT.getName()));
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_WRITTEN_DOMAIN.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER,
         MetricKey.WORKER_BYTES_WRITTEN_DOMAIN_THROUGHPUT.getName()));
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_WRITTEN_UFS.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_WRITTEN_UFS_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.WORKER,
         MetricKey.WORKER_BYTES_WRITTEN_UFS_THROUGHPUT.getName()));
 
     // client metrics
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_READ_LOCAL.getName(),
-        MetricsSystem.InstanceType.CLIENT, MetricKey.CLIENT_BYTES_READ_LOCAL.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_READ_LOCAL_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.CLIENT, MetricKey.CLIENT_BYTES_READ_LOCAL_THROUGHPUT.getName()));
-    addAggregator(new SumInstancesAggregator(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL.getName(),
-        MetricsSystem.InstanceType.CLIENT, MetricKey.CLIENT_BYTES_WRITTEN_LOCAL.getName()));
     addAggregator(new SumInstancesAggregator(
         MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL_THROUGHPUT.getName(),
         MetricsSystem.InstanceType.CLIENT,
         MetricKey.CLIENT_BYTES_WRITTEN_LOCAL_THROUGHPUT.getName()));
 
-    // multi-value aggregators
-    addAggregator(new SingleTagValueAggregator(MetricKey.CLUSTER_BYTES_READ_UFS.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_READ_UFS.getName(),
-        MetricInfo.TAG_UFS));
-    addAggregator(new SingleTagValueAggregator(MetricKey.CLUSTER_BYTES_WRITTEN_UFS.getName(),
-        MetricsSystem.InstanceType.WORKER, MetricKey.WORKER_BYTES_WRITTEN_UFS.getName(),
-        MetricInfo.TAG_UFS));
     // TODO(lu) Create a template for dynamically construct MetricKey
     for (MetricInfo.UfsOps ufsOp : MetricInfo.UfsOps.values()) {
       addAggregator(new SingleTagValueAggregator(MetricInfo.UFS_OP_PREFIX + ufsOp,
@@ -221,6 +197,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
     super.start(isLeader);
     if (isLeader) {
       mMetricsStore.clear();
+      mMetricsStore.init();
       getExecutorService().submit(mClusterMetricsUpdater);
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -272,6 +272,7 @@ public class MetricsStore {
       mClusterCounters.put(MetricKey.CLIENT_BYTES_WRITTEN_LOCAL.getName(),
           MetricsSystem.counter(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL.getName()));
 
+      // special metrics that have multiple worker metrics to summarize from
       mClusterCounters.put(MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName(),
           MetricsSystem.counter(MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName()));
       mClusterCounters.put(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName(),

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -17,10 +17,13 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.MetricType;
 import alluxio.metrics.Metric;
+import alluxio.metrics.MetricInfo;
+import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.MetricsSystem.InstanceType;
 import alluxio.resource.LockResource;
 
+import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +103,16 @@ public class MetricsStore {
       = ServerConfiguration.getMs(PropertyKey.MASTER_REPORTED_METRICS_CLEANUP_AGE);
 
   /**
+   * A map from the name of the metric key to be aggregated
+   * to the corresponding aggregated cluster Counter.
+   * For example, Counter of cluster.BytesReadAlluxio is aggregated from
+   * the worker reported worker.BytesReadAlluxio.
+   * Two exceptions are Cluster.BytesReadUfsAll and Cluster.BytesWrittenUfsAll
+   * which record cluster metric names to their Counter directly.
+   */
+  private final ConcurrentHashMap<String, Counter> mClusterCounters = new ConcurrentHashMap<>();
+
+  /**
    * Put the metrics from a worker with a hostname. If all the old metrics associated with this
    * instance will be removed and then replaced by the latest.
    *
@@ -112,7 +125,7 @@ public class MetricsStore {
     }
     try (LockResource r = new LockResource(mLock.readLock())) {
       mLastReportedTimeMap.put(getFullInstanceId(hostname, null), System.currentTimeMillis());
-      putReportedMetrics(mWorkerMetrics, metrics);
+      putReportedMetrics(InstanceType.WORKER, metrics);
     }
   }
 
@@ -130,22 +143,27 @@ public class MetricsStore {
     }
     try (LockResource r = new LockResource(mLock.readLock())) {
       mLastReportedTimeMap.put(getFullInstanceId(hostname, clientId), System.currentTimeMillis());
-      putReportedMetrics(mClientMetrics, metrics);
+      putReportedMetrics(InstanceType.CLIENT, metrics);
     }
   }
 
   /**
-   * Update the reported metrics with the given instanceId and set of metrics received from a
+   * Update the reported metrics received from a
    * worker or client.
    *
-   * Metrics of {@link MetricType} COUNTER are incremented by the reported values.
-   * Otherwise, all metrics are simply replaced.
+   * Cluster metrics of {@link MetricType} COUNTER are directly incremented by the reported values.
+   * All other metrics are recorded in the metrics map individually, calculated periodically,
+   * and deleted when the report instance doesn't report for a period of time.
    *
-   * @param metricSet the {@link IndexedSet} of client or worker metrics to update
+   * @param instanceType the instance type that reports the metrics
    * @param reportedMetrics the metrics received by the RPC handler
    */
-  private static void putReportedMetrics(IndexedSet<Metric> metricSet,
+  private void putReportedMetrics(InstanceType instanceType,
       List<Metric> reportedMetrics) {
+    IndexedSet<Metric> metricSet = mWorkerMetrics;
+    if (instanceType.equals(InstanceType.CLIENT)) {
+      metricSet = mClientMetrics;
+    }
     for (Metric metric : reportedMetrics) {
       if (metric.getHostname() == null) {
         continue; // ignore metrics whose hostname is null
@@ -154,17 +172,48 @@ public class MetricsStore {
       // If a metric is COUNTER, the value sent via RPC should be the incremental value; i.e.
       // the amount the value has changed since the last RPC. The master should equivalently
       // increment its value based on the received metric rather than replacing it.
-      if (!metricSet.add(metric)) {
-        Metric oldMetric = metricSet.getFirstByField(FULL_NAME_INDEX, metric.getFullMetricName());
-        if (metric.getMetricType() == MetricType.COUNTER) {
-          if (metric.getValue() != 0L) {
-            oldMetric.addValue(metric.getValue());
-          }
-        } else {
-          oldMetric.setValue(metric.getValue());
+      if (metric.getMetricType() == MetricType.COUNTER) {
+        String metricKeyName = metric.getInstanceType() + "." + metric.getName();
+        Counter counter = mClusterCounters.get(metricKeyName);
+        if (counter != null) {
+          counter.inc((long) metric.getValue());
+          continue;
         }
+        if (instanceType.equals(InstanceType.CLIENT)) {
+          continue;
+        }
+        // Need to increment two metrics: one for the specific ufs the current metric recorded from
+        // and one to summarize values from all UFSes
+        if (metricKeyName.equals(MetricKey.WORKER_BYTES_READ_UFS.getName())) {
+          incrementUfsRelatedCounters(metric, MetricKey.CLUSTER_BYTES_READ_UFS.getName(),
+              MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName());
+        } else if (metricKeyName.equals(MetricKey.WORKER_BYTES_WRITTEN_UFS.getName())) {
+          incrementUfsRelatedCounters(metric, MetricKey.CLUSTER_BYTES_WRITTEN_UFS.getName(),
+              MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName());
+        }
+      } else if (!metricSet.add(metric)) {
+        metricSet.getFirstByField(FULL_NAME_INDEX, metric.getFullMetricName())
+            .setValue(metric.getValue());
       }
     }
+  }
+
+  /**
+   * Increments the related counters of a specific metric.
+   *
+   * @param metric the metric
+   * @param perUfsMetricName the per ufs metric name prefix to increment counter value of
+   * @param allUfsMetricName the all ufs metric name to increment counter value of
+   */
+  private void incrementUfsRelatedCounters(Metric metric,
+      String perUfsMetricName, String allUfsMetricName) {
+    String fullCounterName = Metric.getMetricNameWithTags(perUfsMetricName,
+        MetricInfo.TAG_UFS, metric.getTags().get(MetricInfo.TAG_UFS));
+    Counter perUfsCounter = mClusterCounters.computeIfAbsent(fullCounterName,
+        n -> MetricsSystem.counter(fullCounterName));
+    long counterValue = (long) metric.getValue();
+    perUfsCounter.inc(counterValue);
+    mClusterCounters.get(allUfsMetricName).inc(counterValue);
   }
 
   /**
@@ -202,6 +251,35 @@ public class MetricsStore {
   }
 
   /**
+   * Inits the metrics store.
+   * Defines the cluster metrics counters.
+   */
+  public void init() {
+    try (LockResource r = new LockResource(mLock.readLock())) {
+      // worker metrics
+      mClusterCounters.put(MetricKey.WORKER_BYTES_READ_ALLUXIO.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_READ_ALLUXIO.getName()));
+      mClusterCounters.put(MetricKey.WORKER_BYTES_READ_DOMAIN.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_READ_DOMAIN.getName()));
+      mClusterCounters.put(MetricKey.WORKER_BYTES_WRITTEN_ALLUXIO.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_WRITTEN_ALLUXIO.getName()));
+      mClusterCounters.put(MetricKey.WORKER_BYTES_WRITTEN_DOMAIN.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_WRITTEN_DOMAIN.getName()));
+
+      // client metrics
+      mClusterCounters.put(MetricKey.CLIENT_BYTES_READ_LOCAL.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_READ_LOCAL.getName()));
+      mClusterCounters.put(MetricKey.CLIENT_BYTES_WRITTEN_LOCAL.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_WRITTEN_LOCAL.getName()));
+
+      mClusterCounters.put(MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_READ_UFS_ALL.getName()));
+      mClusterCounters.put(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName(),
+          MetricsSystem.counter(MetricKey.CLUSTER_BYTES_WRITTEN_UFS_ALL.getName()));
+    }
+  }
+
+  /**
    * Clears all the metrics.
    *
    * This method should only be called when starting the {@link DefaultMetricsMaster}
@@ -213,6 +291,9 @@ public class MetricsStore {
     try (LockResource r = new LockResource(mLock.writeLock())) {
       mWorkerMetrics.clear();
       mClientMetrics.clear();
+      for (Counter counter : mClusterCounters.values()) {
+        counter.dec(counter.getCount());
+      }
       MetricsSystem.resetAllMetrics();
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -96,8 +96,9 @@ public class MetricsStore {
   @GuardedBy("mLock")
   private final IndexedSet<Metric> mClientMetrics =
       new IndexedSet<>(FULL_NAME_INDEX, NAME_INDEX, ID_INDEX);
+  // A map from the full instance id (hostname + client id if exists)
+  // to its last reported time
   @GuardedBy("mLock")
-  // A map from the instance id to its last reported time
   private final ConcurrentHashMap<String, Long> mLastReportedTimeMap = new ConcurrentHashMap<>();
   private final long mCleanupAge
       = ServerConfiguration.getMs(PropertyKey.MASTER_REPORTED_METRICS_CLEANUP_AGE);
@@ -110,6 +111,7 @@ public class MetricsStore {
    * Two exceptions are Cluster.BytesReadUfsAll and Cluster.BytesWrittenUfsAll
    * which record cluster metric names to their Counter directly.
    */
+  @GuardedBy("mLock")
   private final ConcurrentHashMap<String, Counter> mClusterCounters = new ConcurrentHashMap<>();
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -160,8 +160,7 @@ public class MetricsStore {
    * @param instanceType the instance type that reports the metrics
    * @param reportedMetrics the metrics received by the RPC handler
    */
-  private void putReportedMetrics(InstanceType instanceType,
-      List<Metric> reportedMetrics) {
+  private void putReportedMetrics(InstanceType instanceType, List<Metric> reportedMetrics) {
     IndexedSet<Metric> metricSet = mWorkerMetrics;
     if (instanceType.equals(InstanceType.CLIENT)) {
       metricSet = mClientMetrics;

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsMasterTest.java
@@ -102,12 +102,12 @@ public class MetricsMasterTest {
     mMetricsMaster.addAggregator(
         new SingleTagValueAggregator("metric", MetricsSystem.InstanceType.WORKER, "metric", "tag"));
     List<Metric> metrics1 = Lists.newArrayList(
-        Metric.from("worker.metric.192_1_1_1.tag:v1", 10, MetricType.GAUGE),
-        Metric.from("worker.metric.192_1_1_1.tag:v2", 20, MetricType.GAUGE));
+        Metric.from("worker.metric.tag:v1.192_1_1_1", 10, MetricType.GAUGE),
+        Metric.from("worker.metric.tag:v2.192_1_1_1", 20, MetricType.GAUGE));
     mMetricsMaster.workerHeartbeat("192_1_1_1", metrics1);
     List<Metric> metrics2 = Lists.newArrayList(
-        Metric.from("worker.metric.192_1_1_2.tag:v1", 1, MetricType.GAUGE),
-        Metric.from("worker.metric.192_1_1_2.tag:v2", 2, MetricType.GAUGE));
+        Metric.from("worker.metric.tag:v1.192_1_1_2", 1, MetricType.GAUGE),
+        Metric.from("worker.metric.tag:v2.192_1_1_2", 2, MetricType.GAUGE));
     mMetricsMaster.workerHeartbeat("192_1_1_2", metrics2);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER);
     assertEquals(11L, getGauge("metric", "tag", "v1"));

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
@@ -71,10 +71,10 @@ public class MetricsStoreTest {
   public void putTaggedMetrics() {
     String name = "test";
     Metric metric1 =
-        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.COUNTER, name, 1.0);
+        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.METER, name, 1.0);
     metric1.addTag("Tag", "1");
     Metric metric2 =
-        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.COUNTER, name, 2.0);
+        new Metric(MetricsSystem.InstanceType.WORKER, "host", MetricType.METER, name, 2.0);
     metric2.addTag("Tag", "2");
     mMetricStore.putWorkerMetrics("host", Lists.newArrayList(metric1, metric2));
     assertEquals(mMetricStore.getMetricsByInstanceTypeAndName(MetricsSystem.InstanceType.WORKER,

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -378,10 +378,11 @@ public final class AlluxioWorkerRestServiceHandler {
       WorkerWebUIMetrics response = new WorkerWebUIMetrics();
 
       MetricRegistry mr = MetricsSystem.METRIC_REGISTRY;
+      SortedMap<String, Gauge> gauges = mr.getGauges();
 
-      Long workerCapacityTotal = (Long) mr.getGauges().get(MetricsSystem
+      Long workerCapacityTotal = (Long) gauges.get(MetricsSystem
           .getMetricName(MetricKey.WORKER_CAPACITY_TOTAL.getName())).getValue();
-      Long workerCapacityUsed = (Long) mr.getGauges().get(MetricsSystem
+      Long workerCapacityUsed = (Long) gauges.get(MetricsSystem
           .getMetricName(MetricKey.WORKER_CAPACITY_USED.getName())).getValue();
 
       int workerCapacityUsedPercentage =

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/MetricsCommandIntegrationTest.java
@@ -36,7 +36,7 @@ public final class MetricsCommandIntegrationTest extends AbstractFsAdminShellTes
    */
   private void checkMetricsResults(String output) {
     Assert.assertThat(output, CoreMatchers
-        .containsString("Cluster.BytesReadAlluxio  (Type: GAUGE, Value: 0B)"));
+        .containsString("Cluster.BytesReadAlluxio  (Type: COUNTER, Value: 0B)"));
     Assert.assertThat(output, CoreMatchers
         .containsString("Cluster.BytesReadAlluxioThroughput  (Type: GAUGE, Value: 0B/min)"));
   }


### PR DESCRIPTION
Change to store the cluster counter value directly instead of remembering each counter reported by client or worker.
This is helpful: (1) to reduce the space needed to store reported metrics (2) because counter value is historical summarized value. There is no need to delete the orphaned counter value.

For all other metrics, we keep the original way: store all the original reported metrics and update the cluster metric value periodically. 
But to make it more accurate, a delete orphaned metrics logic is added. Metrics reported by worker/client which hasn't reported for a long period of time (configurable) will be deleted. This can help us to get more accurate throughput value. worker/client report throughput as the last 1 minute rate which does not make sense if it's orphaned.