### PR TITLE
Improve performance of MetricsHeartbeatContextTest

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -120,7 +120,9 @@ public class MetricsHeartbeatContextTest {
 
     ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
     when(future.cancel(any(Boolean.class))).thenReturn(true);
-    ClientContext ctx = ClientContext.create();
+    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
+    ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory
         .create(ctx.getClusterConf(), ctx.getUserState());
     MetricsHeartbeatContext.addHeartbeat(ctx, client);

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -23,8 +23,8 @@ import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.ServiceType;
 import alluxio.grpc.ServiceVersionClientServiceGrpc;
-import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
 import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
@@ -61,7 +61,10 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   public PollingMasterInquireClient(List<InetSocketAddress> masterAddresses,
       AlluxioConfiguration alluxioConf,
       UserState userState) {
-    this(masterAddresses, () -> new ExponentialBackoffRetry(20, 2000, 30),
+    this(masterAddresses, () -> RetryUtils.defaultClientRetry(
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_MAX_DURATION),
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS),
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS)),
         alluxioConf, userState);
   }
 


### PR DESCRIPTION
The test currently runs for almost 3 minutes due to client retry
configuration. This change makes the PollingMasterInquireClient
respect the USER_RPC_RETRY* configuration values which
subsequently speeds up the test from ~3min to ~5sec