### PR TITLE
Allow domain to be configured in jmx

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -75,6 +75,8 @@
 ## Examples
 # Enable JmxSink by class name
 # sink.jmx.class=alluxio.metrics.sink.JmxSink
+# Jmx domain
+# sink.jmx.domain=org.alluxio
 
 # Enable ConsoleSink by class name
 # sink.console.class=alluxio.metrics.sink.ConsoleSink

--- a/core/common/src/main/java/alluxio/metrics/sink/JmxSink.java
+++ b/core/common/src/main/java/alluxio/metrics/sink/JmxSink.java
@@ -23,6 +23,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class JmxSink implements Sink {
+  private static final String DOMAIN = "org.alluxio";
+
   private JmxReporter mReporter;
 
   /**
@@ -32,7 +34,14 @@ public final class JmxSink implements Sink {
    * @param registry the metric registry to register
    */
   public JmxSink(Properties properties, MetricRegistry registry) {
-    mReporter = JmxReporter.forRegistry(registry).build();
+    JmxReporter.Builder builder = JmxReporter.forRegistry(registry);
+    String domain = properties.getProperty("domain");
+    if (domain != null) {
+      builder.inDomain(domain);
+    } else {
+      builder.inDomain(DOMAIN);
+    }
+    mReporter = builder.build();
   }
 
   @Override


### PR DESCRIPTION
Previously our domain was always `metrics` which is not very helpful, it now defaults to `org.alluxio`