### PR TITLE
Set default logger level for InternalParquetRecordReader/Writer to WARN

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -33,6 +33,11 @@ log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 # connections. This can result in hundreds of log messages per second.
 log4j.category.io.atomix.catalyst.transport.netty=WARN
 
+# The ParquetWriter logs for every row group which is not noisy for large row group size,
+# but very noisy for small row group size.
+log4j.logger.org.apache.parquet.hadoop.InternalParquetRecordWriter=WARN
+log4j.logger.org.apache.parquet.hadoop.InternalParquetRecordReader=WARN
+
 # Appender for Job Master
 log4j.appender.JOB_MASTER_LOGGER=org.apache.log4j.RollingFileAppender
 log4j.appender.JOB_MASTER_LOGGER.File=${alluxio.logs.dir}/job_master.log


### PR DESCRIPTION
InternalParquetRecordReader/Writer gets very noisy when row group size of the parquet file writing/reading is small.