### PR TITLE
Disable authentication in client for versionService

### DIFF
--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -131,7 +131,8 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {
     GrpcChannel channel =
         GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), mConfiguration)
-            .setSubject(mUserState.getSubject()).setClientType("MasterInquireClient").build();
+            .setSubject(mUserState.getSubject()).setClientType("MasterInquireClient")
+            .disableAuthentication().build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);
     ServiceType serviceType


### PR DESCRIPTION
Client shouldn't be creating an authenticated channel for an unauthenticated service.