### PR TITLE
Enable parallel udb sync

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -217,7 +217,7 @@ public class Database implements Journaled {
     }
 
     try {
-      CommonUtils.invokeAll(tasks, 10 * Constants.MINUTE_MS);
+      CommonUtils.invokeAll(service, tasks, 10 * Constants.MINUTE_MS);
     } catch (Exception e) {
       throw new IOException("Failed to sync database " + mName, e);
     }

--- a/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
@@ -69,7 +69,7 @@ public class DefaultTableMaster extends CoreMaster
   public DefaultTableMaster(CoreMasterContext context, JobMasterClient jobMasterClient) {
     super(context, new SystemClock(),
         ExecutorServiceFactories.cachedThreadPool(Constants.TABLE_MASTER_NAME));
-    mCatalog = new AlluxioCatalog();
+    mCatalog = new AlluxioCatalog(this::getExecutorService);
     mTransformManager = new TransformManager(this::createJournalContext, mCatalog, jobMasterClient);
     mJournaledComponents = new JournaledGroup(Lists.newArrayList(mCatalog, mTransformManager),
         CheckpointName.TABLE_MASTER);

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -36,9 +36,11 @@ import alluxio.table.common.transform.TransformPlan;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabaseRegistry;
+import alluxio.util.executor.ExecutorServiceFactories;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -60,14 +63,22 @@ public class AlluxioCatalogTest {
   private static final TransformDefinition TRANSFORM_DEFINITION =
       TransformDefinition.parse("write(hive).option(hive.num.files, 100);");
 
+  private static ExecutorService sService =
+      ExecutorServiceFactories.cachedThreadPool("AlluxioCatalogTest").create();
+
   private AlluxioCatalog mCatalog;
 
   @Rule
   public ExpectedException mException = ExpectedException.none();
 
+  @AfterClass
+  public static void afterClass() {
+    sService.shutdownNow();
+  }
+
   @Before
   public void before() {
-    mCatalog = new AlluxioCatalog();
+    mCatalog = new AlluxioCatalog(() -> sService);
     TestDatabase.reset();
   }
 

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -22,21 +22,19 @@ import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.Layout;
 import alluxio.grpc.table.layout.hive.PartitionInfo;
 import alluxio.master.table.DatabaseInfo;
+import alluxio.resource.CloseableResource;
 import alluxio.table.common.UdbPartition;
 import alluxio.table.common.layout.HiveLayout;
 import alluxio.table.common.udb.UdbConfiguration;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabase;
+import alluxio.table.under.hive.util.HiveClientPool;
 import alluxio.table.under.hive.util.PathTranslator;
 import alluxio.util.io.PathUtils;
 
 import org.apache.hadoop.hive.common.FileUtils;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -63,7 +61,6 @@ import java.util.stream.Collectors;
  */
 public class HiveDatabase implements UnderDatabase {
   private static final Logger LOG = LoggerFactory.getLogger(HiveDatabase.class);
-  private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
 
   private final UdbContext mUdbContext;
   private final UdbConfiguration mConfiguration;
@@ -71,9 +68,8 @@ public class HiveDatabase implements UnderDatabase {
   private final String mConnectionUri;
   /** the name of the hive db. */
   private final String mHiveDbName;
-
-  /** The cached hive client. This should not be used directly, but via {@link #getHive()}. */
-  private IMetaStoreClient mHive = null;
+  /** Hive client is not thread-safe, so use a client pool for concurrency. */
+  private final HiveClientPool mClientPool;
 
   private HiveDatabase(UdbContext udbContext, UdbConfiguration configuration,
       String connectionUri, String hiveDbName) {
@@ -81,6 +77,7 @@ public class HiveDatabase implements UnderDatabase {
     mConfiguration = configuration;
     mConnectionUri = connectionUri;
     mHiveDbName = hiveDbName;
+    mClientPool = new HiveClientPool(mConnectionUri, mHiveDbName);
   }
 
   /**
@@ -111,8 +108,8 @@ public class HiveDatabase implements UnderDatabase {
 
   @Override
   public DatabaseInfo getDatabaseInfo() throws IOException {
-    try {
-      Database hiveDb = getHive().getDatabase(mHiveDbName);
+    try (CloseableResource<IMetaStoreClient> client = mClientPool.acquireClientResource()) {
+      Database hiveDb = client.get().getDatabase(mHiveDbName);
       alluxio.grpc.table.PrincipalType type = alluxio.grpc.table.PrincipalType.USER;
       if (hiveDb.getOwnerType().equals(PrincipalType.ROLE)) {
         type = alluxio.grpc.table.PrincipalType.ROLE;
@@ -137,8 +134,8 @@ public class HiveDatabase implements UnderDatabase {
 
   @Override
   public List<String> getTableNames() throws IOException {
-    try {
-      return getHive().getAllTables(mHiveDbName);
+    try (CloseableResource<IMetaStoreClient> client = mClientPool.acquireClientResource()) {
+      return client.get().getAllTables(mHiveDbName);
     } catch (TException  e) {
       throw new IOException("Failed to get hive tables: " + e.getMessage(), e);
     }
@@ -224,20 +221,41 @@ public class HiveDatabase implements UnderDatabase {
 
   @Override
   public UdbTable getTable(String tableName) throws IOException {
-    Table table;
     try {
-      table = getHive().getTable(mHiveDbName, tableName);
+      Table table;
+      List<Partition> partitions;
+      List<ColumnStatisticsObj> columnStats;
+      List<String> partitionColumns;
+      Map<String, List<ColumnStatisticsInfo>> statsMap;
+      // perform all the hive client operations, and release the client early.
+      try (CloseableResource<IMetaStoreClient> client = mClientPool.acquireClientResource()) {
+        table = client.get().getTable(mHiveDbName, tableName);
 
-      // Potentially expensive call
-      List<Partition> partitions =
-          getHive().listPartitions(mHiveDbName, table.getTableName(), (short) -1);
+        // Potentially expensive call
+        partitions = client.get().listPartitions(mHiveDbName, table.getTableName(), (short) -1);
+
+        List<String> colNames = table.getSd().getCols().stream().map(FieldSchema::getName)
+            .collect(Collectors.toList());
+        columnStats = client.get().getTableColumnStatistics(mHiveDbName, tableName, colNames);
+
+        // construct the partition statistics
+        List<String> dataColumns = table.getSd().getCols().stream()
+            .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
+            .collect(Collectors.toList());
+        partitionColumns = table.getPartitionKeys().stream()
+            .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
+            .collect(Collectors.toList());
+        List<String> partitionNames = partitions.stream()
+            .map(partition -> FileUtils.makePartName(partitionColumns, partition.getValues()))
+            .collect(Collectors.toList());
+        statsMap = client.get()
+            .getPartitionColumnStatistics(mHiveDbName, tableName, partitionNames, dataColumns)
+            .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                e -> e.getValue().stream().map(HiveUtils::toProto).collect(Collectors.toList()),
+                (e1, e2) -> e2));
+      }
 
       PathTranslator pathTranslator = mountAlluxioPaths(table, partitions);
-      List<String> colNames = table.getSd().getCols().stream().map(FieldSchema::getName)
-          .collect(Collectors.toList());
-      List<ColumnStatisticsObj> columnStats =
-          getHive().getTableColumnStatistics(mHiveDbName, tableName, colNames);
-
       List<ColumnStatisticsInfo> colStats =
           columnStats.stream().map(HiveUtils::toProto).collect(Collectors.toList());
       // construct table layout
@@ -254,22 +272,6 @@ public class HiveDatabase implements UnderDatabase {
           .setLayoutData(partitionInfo.toByteString())
           // ignore spec and statistics for table layout
           .build();
-
-      // construct the partition statistics
-      List<String> dataColumns = table.getSd().getCols().stream()
-          .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
-          .collect(Collectors.toList());
-      List<String> partitionColumns = table.getPartitionKeys().stream()
-          .map(org.apache.hadoop.hive.metastore.api.FieldSchema::getName)
-          .collect(Collectors.toList());
-      List<String> partitionNames = partitions.stream()
-          .map(partition -> FileUtils.makePartName(partitionColumns, partition.getValues()))
-          .collect(Collectors.toList());
-      Map<String, List<ColumnStatisticsInfo>> statsMap = getHive()
-          .getPartitionColumnStatistics(mHiveDbName, tableName, partitionNames, dataColumns)
-          .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-              e -> e.getValue().stream().map(HiveUtils::toProto).collect(Collectors.toList()),
-              (e1, e2) -> e2));
 
       // create udb partitions info
       List<UdbPartition> udbPartitions = new ArrayList<>();
@@ -308,36 +310,6 @@ public class HiveDatabase implements UnderDatabase {
       throw new NotFoundException("Table " + tableName + " does not exist.", e);
     } catch (TException e) {
       throw new IOException("Failed to get table: " + tableName + " error: " + e.getMessage(), e);
-    }
-  }
-
-  IMetaStoreClient getHive() throws IOException {
-    if (mHive != null) {
-      return mHive;
-    }
-
-    // Hive uses/saves the thread context class loader.
-    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
-    try {
-      // use the extension class loader
-      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
-      HiveConf conf = new HiveConf();
-      conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
-      mHive =
-          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName());
-      mHive.getDatabase(mHiveDbName);
-      return mHive;
-    } catch (NoSuchObjectException e) {
-      throw new IOException(String
-          .format("hive db name '%s' does not exist at metastore: %s", mHiveDbName, mConnectionUri),
-          e);
-    } catch (NullPointerException | TException e) {
-      // HiveMetaStoreClient throws a NPE if the uri is not a uri for hive metastore
-      throw new IOException(String
-          .format("Failed to create client to hive metastore: %s. error: %s", mConnectionUri,
-              e.getMessage()), e);
-    } finally {
-      Thread.currentThread().setContextClassLoader(currentClassLoader);
     }
   }
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
@@ -1,0 +1,130 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.under.hive.util;
+
+import alluxio.Constants;
+import alluxio.resource.CloseableResource;
+import alluxio.resource.DynamicResourcePool;
+import alluxio.util.ThreadFactoryUtils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A pool for hive clients, since hive clients are not thread safe.
+ */
+@ThreadSafe
+public final class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
+  private static final ScheduledExecutorService GC_EXECUTOR =
+      new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
+  private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
+
+  private final long mGcThresholdMs;
+  private final String mConnectionUri;
+  private final String mHiveDbName;
+  /** This tracks if the db exists in HMS. */
+  private volatile boolean mDbExists = false;
+
+  /**
+   * Creates a new hive client client pool.
+   *
+   * @param connectionUri the connect uri for the hive metastore
+   * @param hiveDbName the db name in hive
+   */
+  public HiveClientPool(String connectionUri, String hiveDbName) {
+    super(Options.defaultOptions()
+        .setMinCapacity(16)
+        .setMaxCapacity(128)
+        .setGcIntervalMs(5 * Constants.MINUTE_MS)
+        .setGcExecutor(GC_EXECUTOR));
+    mConnectionUri = connectionUri;
+    mHiveDbName = hiveDbName;
+    mGcThresholdMs = 5 * Constants.MINUTE_MS;
+  }
+
+  @Override
+  protected void closeResource(IMetaStoreClient client) {
+    client.close();
+  }
+
+  @Override
+  protected IMetaStoreClient createNewResource() throws IOException {
+    // Hive uses/saves the thread context class loader.
+    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // use the extension class loader
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      HiveConf conf = new HiveConf();
+      conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
+
+      IMetaStoreClient client =
+          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName());
+      if (!mDbExists) {
+        synchronized (this) {
+          // serialize the querying of the hive db
+          if (!mDbExists) {
+            client.getDatabase(mHiveDbName);
+            mDbExists = true;
+          }
+        }
+      }
+      return client;
+    } catch (NoSuchObjectException e) {
+      throw new IOException(String
+          .format("hive db name '%s' does not exist at metastore: %s", mHiveDbName, mConnectionUri),
+          e);
+    } catch (NullPointerException | TException e) {
+      // HiveMetaStoreClient throws a NPE if the uri is not a uri for hive metastore
+      throw new IOException(String
+          .format("Failed to create client to hive metastore: %s. error: %s", mConnectionUri,
+              e.getMessage()), e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(currentClassLoader);
+    }
+  }
+
+  @Override
+  protected boolean isHealthy(IMetaStoreClient client) {
+    // there is no way to check if a hive client is connected.
+    // TODO(gpang): periodically and asynchronously check the health of clients
+    return true;
+  }
+
+  @Override
+  protected boolean shouldGc(ResourceInternal<IMetaStoreClient> clientResourceInternal) {
+    return System.currentTimeMillis() - clientResourceInternal
+        .getLastAccessTimeMs() > mGcThresholdMs;
+  }
+
+  /**
+   * @return a closeable resource for the hive client
+   */
+  public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
+    return new CloseableResource<IMetaStoreClient>(acquire()) {
+      @Override
+      public void close() {
+        release(get());
+      }
+    };
+  }
+}

--- a/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
@@ -57,6 +57,9 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
   private static final String TEST_TABLE_RENAME = "test_table_rename";
   private static final String TEST_TABLE_PART = "test_table_part";
 
+  private static String sHmsAddress;
+  private static int sHmsPort;
+
   @ClassRule
   public static TemporaryFolder sFolder = new TemporaryFolder();
 
@@ -74,8 +77,8 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    String hmsAddress = sHms.getContainerIpAddress();
-    int hmsPort = sHms.getMappedPort(9083);
+    sHmsAddress = sHms.getContainerIpAddress();
+    sHmsPort = sHms.getMappedPort(9083);
 
     File dbDir = new File(WAREHOUSE_DIR, DB_NAME + ".db");
     dbDir.mkdirs();
@@ -140,13 +143,24 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
         .getMaster(TableMaster.class);
 
     sTableMaster
-        .attachDatabase("hive", "thrift://" + hmsAddress + ":" + hmsPort, DB_NAME, DB_NAME,
+        .attachDatabase("hive", "thrift://" + sHmsAddress + ":" + sHmsPort, DB_NAME, DB_NAME,
             Collections.emptyMap());
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     sLocalAlluxioJobCluster.stop();
+  }
+
+  @Test
+  public void attachWrongDb() throws Exception {
+    try {
+      sTableMaster.attachDatabase("hive", "thrift://" + sHmsAddress + ":" + sHmsPort, "wrong_db",
+          "wrong_db", Collections.emptyMap());
+      fail("Attaching wrong db name is expected to fail.");
+    } catch (Exception e) {
+      // this is expected
+    }
   }
 
   @Test


### PR DESCRIPTION
This change sync a table in a thread, instead of sequentially. This should reduce the response times of databases with a large number of tables.