### PR TITLE
Refactor the client cache to use string file id

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -112,11 +112,12 @@ public class LocalCacheFileInStream extends FileInStream {
       return -1;
     }
     int bytesRead = 0;
+    long lengthToRead = Math.min(len, mStatus.getLength() - mPosition);
     // for each page, check if it is available in the cache
-    while (bytesRead < len && mPosition < mStatus.getLength()) {
+    while (bytesRead < lengthToRead) {
       long currentPage = mPosition / mPageSize;
       int currentPageOffset = (int) (mPosition % mPageSize);
-      int bytesLeftInPage = (int) Math.min(mPageSize - currentPageOffset, len - bytesRead);
+      int bytesLeftInPage = (int) Math.min(mPageSize - currentPageOffset, lengthToRead - bytesRead);
       PageId pageId = new PageId(mStatus.getFileIdentifier(), currentPage);
       try (ReadableByteChannel cachedData = mCacheManager.get(pageId, currentPageOffset)) {
         if (cachedData != null) { // cache hit

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -117,7 +117,7 @@ public class LocalCacheFileInStream extends FileInStream {
       long currentPage = mPosition / mPageSize;
       int currentPageOffset = (int) (mPosition % mPageSize);
       int bytesLeftInPage = (int) Math.min(mPageSize - currentPageOffset, len - bytesRead);
-      PageId pageId = new PageId(mStatus.getFileId(), currentPage);
+      PageId pageId = new PageId(mStatus.getFileIdentifier(), currentPage);
       try (ReadableByteChannel cachedData = mCacheManager.get(pageId, currentPageOffset)) {
         if (cachedData != null) { // cache hit
           // wrap return byte array in a bytebuffer and set the pos/limit for the page read
@@ -193,7 +193,7 @@ public class LocalCacheFileInStream extends FileInStream {
       long currentPage = currentPosition / mPageSize;
       int currentPageOffset = (int) (currentPosition % mPageSize);
       int bytesLeftInPage = (int) Math.min(mPageSize - currentPageOffset, lengthToRead - bytesRead);
-      PageId pageId = new PageId(mStatus.getFileId(), currentPage);
+      PageId pageId = new PageId(mStatus.getFileIdentifier(), currentPage);
       try (ReadableByteChannel cachedData = mCacheManager.get(pageId, currentPageOffset)) {
         if (cachedData != null) { // cache hit
           // wrap return byte array in a bytebuffer and set the pos/limit for the page read

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -105,7 +105,8 @@ public class LocalCacheManager implements CacheManager {
     mPageStore = pageStore;
     mEvictor = evictor;
     mPageSize = conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
-    mCacheSize = conf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE);
+    mCacheSize = (long) (conf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE)
+        / (1.0 + pageStore.getOverheadRatio()));
     for (int i = 0; i < LOCK_SIZE; i++) {
       mPageLocks[i] = new ReentrantReadWriteLock();
     }
@@ -119,7 +120,7 @@ public class LocalCacheManager implements CacheManager {
    * @return the corresponding page lock
    */
   private ReadWriteLock getPageLock(PageId pageId) {
-    return mPageLocks[Math.floorMod((int) (pageId.getFileId() + pageId.getPageIndex()), LOCK_SIZE)];
+    return mPageLocks[Math.floorMod((int) (pageId.getFileId().hashCode() + pageId.getPageIndex()), LOCK_SIZE)];
   }
 
   /**
@@ -131,7 +132,8 @@ public class LocalCacheManager implements CacheManager {
    * @return the corresponding page lock pair
    */
   private Pair<ReadWriteLock, ReadWriteLock> getPageLockPair(PageId pageId, PageId pageId2) {
-    if (pageId.getFileId() + pageId.getPageIndex() < pageId2.getFileId() + pageId2.getPageIndex()) {
+    if (pageId.getFileId().hashCode() + pageId.getPageIndex()
+        < pageId2.getFileId().hashCode() + pageId2.getPageIndex()) {
       return new Pair<>(getPageLock(pageId), getPageLock(pageId2));
     } else {
       return new Pair<>(getPageLock(pageId2), getPageLock(pageId));

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -120,7 +120,8 @@ public class LocalCacheManager implements CacheManager {
    * @return the corresponding page lock
    */
   private ReadWriteLock getPageLock(PageId pageId) {
-    return mPageLocks[Math.floorMod((int) (pageId.getFileId().hashCode() + pageId.getPageIndex()), LOCK_SIZE)];
+    return mPageLocks
+        [Math.floorMod((int) (pageId.getFileId().hashCode() + pageId.getPageIndex()), LOCK_SIZE)];
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageId.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageId.java
@@ -21,14 +21,14 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class PageId {
-  private final long mFileId;
+  private final String mFileId;
   private final long mPageIndex;
 
   /**
    * @param fileId file Id
    * @param pageIndex index of the page in file
    */
-  public PageId(long fileId, long pageIndex) {
+  public PageId(String fileId, long pageIndex) {
     mFileId = fileId;
     mPageIndex = pageIndex;
   }
@@ -36,7 +36,7 @@ public class PageId {
   /**
    * @return file id
    */
-  public long getFileId() {
+  public String getFileId() {
     return mFileId;
   }
 
@@ -61,7 +61,7 @@ public class PageId {
       return false;
     }
     PageId that = (PageId) obj;
-    return mFileId == that.mFileId && mPageIndex == that.mPageIndex;
+    return mFileId.equals(that.mFileId) && mPageIndex == that.mPageIndex;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -185,4 +185,11 @@ public interface PageStore extends AutoCloseable {
    * @throws IOException if any error occurs
    */
   Collection<PageInfo> getPages() throws IOException;
+
+  /**
+   * @return an estimated ratio between the overhead storage consumption and the actual data size
+   */
+  default double getOverheadRatio() {
+    return 0;
+  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -152,7 +152,7 @@ public class LocalPageStore implements PageStore {
   }
 
   private Path getFilePath(PageId pageId) {
-    return Paths.get(mRoot, Long.toString(mPageSize), Long.toString(pageId.getFileId()),
+    return Paths.get(mRoot, Long.toString(mPageSize), pageId.getFileId(),
         Long.toString(pageId.getPageIndex()));
   }
 
@@ -167,9 +167,8 @@ public class LocalPageStore implements PageStore {
       return null;
     }
     try {
-      String parentName = Preconditions.checkNotNull(matcher.group(1));
+      String fileId = Preconditions.checkNotNull(matcher.group(1));
       String fileName = Preconditions.checkNotNull(matcher.group(2));
-      long fileId = Long.parseLong(parentName);
       long pageIndex = Long.parseLong(fileName);
       return new PageId(fileId, pageIndex);
     } catch (NumberFormatException e) {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -26,7 +26,7 @@ public final class DefaultMetaStoreTest {
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
-  private final PageId mPage = new PageId(1L, 2L);
+  private final PageId mPage = new PageId("1L", 2L);
   private final PageInfo mPageInfo = new PageInfo(mPage, 1024);
   private DefaultMetaStore mMetaStore;
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
  */
 public final class LRUCacheEvictorTest {
   private LRUCacheEvictor mEvictor;
-  private final PageId mFirst = new PageId(1L, 2L);
-  private final PageId mSecond = new PageId(3L, 4L);
-  private final PageId mThird = new PageId(5L, 6L);
+  private final PageId mFirst = new PageId("1L", 2L);
+  private final PageId mSecond = new PageId("3L", 4L);
+  private final PageId mThird = new PageId("5L", 6L);
 
   /**
    * Sets up the instances.

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
@@ -53,7 +53,7 @@ public class LocalPageStoreTest {
 
   void helloWorldTest(PageStore store) throws Exception {
     String msg = "Hello, World!";
-    PageId id = new PageId(0, 0);
+    PageId id = new PageId("0", 0);
     store.put(id, msg.getBytes());
     ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
     ByteBuffer buf = ByteBuffer.allocate(1024);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -156,11 +156,7 @@ public class PageStoreTest {
     for (int i = 1; i <= 1024; i++) {
       PageId id = new PageId(Integer.toString(i), 0);
       mPageStore.put(id, new byte[i]);
-      if (mOptions.getType() == PageStoreType.LOCAL) {
-        totalBytes += i;
-      } else {
-        totalBytes += + i;
-      }
+      totalBytes += i;
       assertEquals(i, mPageStore.pages());
       assertEquals(totalBytes, mPageStore.bytes());
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.file.cache.store;
 
-import static alluxio.client.file.cache.store.RocksPageStore.KEY_LEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -87,7 +86,7 @@ public class PageStoreTest {
   public void helloWorldTest() throws Exception {
     String msg = "Hello, World!";
     byte[] msgBytes = msg.getBytes();
-    PageId id = new PageId(0, 0);
+    PageId id = new PageId("0", 0);
     mPageStore.put(id, msgBytes);
     assertEquals(1, mPageStore.pages());
     ByteBuffer buf = ByteBuffer.allocate(1024);
@@ -110,7 +109,7 @@ public class PageStoreTest {
   public void getOffset() throws Exception {
     int len = 32;
     int offset = 3;
-    PageId id = new PageId(0, 0);
+    PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
     ByteBuffer buf = ByteBuffer.allocate(1024);
     try (ReadableByteChannel channel = mPageStore.get(id, offset)) {
@@ -124,7 +123,7 @@ public class PageStoreTest {
   public void getOffsetOverflow() throws Exception {
     int len = 32;
     int offset = 36;
-    PageId id = new PageId(0, 0);
+    PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
     ByteBuffer buf = ByteBuffer.allocate(1024);
     mThrown.expect(IllegalArgumentException.class);
@@ -140,7 +139,7 @@ public class PageStoreTest {
     byte[] data = BufferUtils.getIncreasingByteArray(len);
     Set<PageInfo> pages = new HashSet<>(count);
     for (int i = 0; i < count; i++) {
-      PageId id = new PageId(0, i);
+      PageId id = new PageId("0", i);
       mPageStore.put(id, data);
       pages.add(new PageInfo(id, data.length));
     }
@@ -155,24 +154,20 @@ public class PageStoreTest {
   public void testPagesAndBytes() throws Exception {
     long totalBytes = 0;
     for (int i = 1; i <= 1024; i++) {
-      PageId id = new PageId(i, 0);
+      PageId id = new PageId(Integer.toString(i), 0);
       mPageStore.put(id, new byte[i]);
       if (mOptions.getType() == PageStoreType.LOCAL) {
         totalBytes += i;
       } else {
-        totalBytes += KEY_LEN + i;
+        totalBytes += + i;
       }
       assertEquals(i, mPageStore.pages());
       assertEquals(totalBytes, mPageStore.bytes());
     }
     for (int i = 1024; i >= 1; i--) {
-      PageId id = new PageId(i, 0);
+      PageId id = new PageId(Integer.toString(i), 0);
       mPageStore.delete(id, i);
-      if (mOptions.getType() == PageStoreType.LOCAL) {
-        totalBytes -= i;
-      } else {
-        totalBytes -= KEY_LEN + i;
-      }
+      totalBytes -= i;
       assertEquals(i - 1, mPageStore.pages());
       assertEquals(totalBytes, mPageStore.bytes());
     }
@@ -194,7 +189,7 @@ public class PageStoreTest {
     Random r = new Random();
     for (int i = 0; i < numPages; i++) {
       int pind = r.nextInt();
-      store.put(new PageId(0, pind), b);
+      store.put(new PageId("0", pind), b);
       pages.add(pind);
     }
 
@@ -207,7 +202,7 @@ public class PageStoreTest {
       ByteBuffer buf = ByteBuffer.allocate(Constants.MB);
       for (Integer pageIndex  : pages) {
         buf.clear();
-        store.get(new PageId(0, pageIndex)).read(buf);
+        store.get(new PageId("0", pageIndex)).read(buf);
       }
       long end = System.nanoTime();
       times.add(end - start);

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -101,6 +101,14 @@ public class URIStatus {
   }
 
   /**
+   * @return the unique string identifier of the entity referenced by this uri used by Alluxio
+   *         servers, immutable
+   */
+  public String getFileIdentifier() {
+    return mInfo.getFileIdentifier();
+  }
+
+  /**
    * @return the group that owns the entity referenced by this uri, mutable
    */
   public String getGroup() {

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -685,7 +685,7 @@ public final class FileInfo implements Serializable {
         && mFileBlockInfoList.equals(that.mFileBlockInfoList) && mTtlAction == that.mTtlAction
         && mMountId == that.mMountId && mInAlluxioPercentage == that.mInAlluxioPercentage
         && mUfsFingerprint.equals(that.mUfsFingerprint)
-        && Objects.equal(mFileIdentifier, that.mFileIdentifier)
+        && Objects.equal(getFileIdentifier(), that.getFileIdentifier())
         && Objects.equal(mAcl, that.mAcl)
         && Objects.equal(mDefaultAcl, that.mDefaultAcl)
         && Objects.equal(mMediumTypes, that.mMediumTypes);
@@ -698,7 +698,7 @@ public final class FileInfo implements Serializable {
         mInMemoryPercentage, mLastModificationTimeMs, mLastAccessTimeMs, mTtl, mOwner, mGroup,
         mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfoList,
         mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes,
-        mFileIdentifier);
+        getFileIdentifier());
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -44,6 +44,7 @@ public final class FileInfo implements Serializable {
   private String mName = "";
   private String mPath = "";
   private String mUfsPath = "";
+  private String mFileIdentifier;
   private long mLength;
   private long mBlockSizeBytes;
   private long mCreationTimeMs;
@@ -87,6 +88,13 @@ public final class FileInfo implements Serializable {
    */
   public long getFileId() {
     return mFileId;
+  }
+
+  /**
+   * @return the file identifier
+   */
+  public String getFileIdentifier() {
+    return mFileIdentifier != null ? mFileIdentifier : Long.toString(mFileId);
   }
 
   /**
@@ -344,6 +352,15 @@ public final class FileInfo implements Serializable {
    */
   public FileInfo setFileId(long fileId) {
     mFileId = fileId;
+    return this;
+  }
+
+  /**
+   * @param fileIdentifier the file id to use
+   * @return the file information
+   */
+  public FileInfo setFileIdentifier(String fileIdentifier) {
+    mFileIdentifier = fileIdentifier;
     return this;
   }
 
@@ -668,6 +685,7 @@ public final class FileInfo implements Serializable {
         && mFileBlockInfoList.equals(that.mFileBlockInfoList) && mTtlAction == that.mTtlAction
         && mMountId == that.mMountId && mInAlluxioPercentage == that.mInAlluxioPercentage
         && mUfsFingerprint.equals(that.mUfsFingerprint)
+        && Objects.equal(mFileIdentifier, that.mFileIdentifier)
         && Objects.equal(mAcl, that.mAcl)
         && Objects.equal(mDefaultAcl, that.mDefaultAcl)
         && Objects.equal(mMediumTypes, that.mMediumTypes);
@@ -679,13 +697,15 @@ public final class FileInfo implements Serializable {
         mCreationTimeMs, mCompleted, mFolder, mPinned, mCacheable, mPersisted, mBlockIds,
         mInMemoryPercentage, mLastModificationTimeMs, mLastAccessTimeMs, mTtl, mOwner, mGroup,
         mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfoList,
-        mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes);
+        mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes,
+        mFileIdentifier);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("fileId", mFileId)
+        .add("fileIdentifier", mFileIdentifier)
         .add("name", mName)
         .add("path", mPath)
         .add("ufsPath", mUfsPath).add("length", mLength).add("blockSizeBytes", mBlockSizeBytes)

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -41,7 +41,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
   private static final int PAGE_SIZE_BYTES = Constants.KB;
   private static final int PAGE_COUNT = 32;
   private static final int CACHE_SIZE_BYTES = PAGE_COUNT * PAGE_SIZE_BYTES;
-  private static final PageId PAGE_ID = new PageId(0L, 0L);
+  private static final PageId PAGE_ID = new PageId("0", 0L);
   private static final byte[] PAGE = BufferUtils.getIncreasingByteArray(PAGE_SIZE_BYTES);
 
   @Rule
@@ -120,11 +120,11 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     mCacheManager = LocalCacheManager.create(mConf);
     // evicts half of the pages
     for (int i = 0; i < PAGE_COUNT / 2; i++) {
-      mCacheManager.put(new PageId(1, i), PAGE);
+      mCacheManager.put(new PageId("1", i), PAGE);
     }
     int evicted = 0;
     for (int i = 0; i < PAGE_COUNT; i++) {
-      ReadableByteChannel channel = mCacheManager.get(new PageId(0, i));
+      ReadableByteChannel channel = mCacheManager.get(new PageId("0", i));
       if (channel == null) {
         evicted++;
         continue;
@@ -138,7 +138,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     assertEquals(PAGE_COUNT / 2, evicted);
     // verifies the newly added pages are cached
     for (int i = 0; i < PAGE_COUNT / 2; i++) {
-      testPageCached(new PageId(1, i));
+      testPageCached(new PageId("1", i));
     }
   }
 
@@ -221,10 +221,10 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
   private void loadFullCache() throws Exception {
     mCacheManager = LocalCacheManager.create(mConf);
     for (int i = 0; i < PAGE_COUNT; i++) {
-      mCacheManager.put(new PageId(0, i), PAGE);
+      mCacheManager.put(new PageId("0", i), PAGE);
     }
     for (int i = 0; i < PAGE_COUNT; i++) {
-      testPageCached(new PageId(0, i));
+      testPageCached(new PageId("0", i));
     }
   }
 }


### PR DESCRIPTION
This allows certain client filesystem to use UUID as file id without worrying about collision.