### PR TITLE
Terminate initial scan on stop active sync

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1914,6 +1914,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT =
+      new Builder(Name.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)
+          .setDefaultValue("10sec")
+          .setDescription("Max time to retry failed sync operation")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
 
   public static final PropertyKey MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
       new Builder(Name.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY)
@@ -4283,6 +4290,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.ufs.active.sync.max.age";
     public static final String MASTER_UFS_ACTIVE_SYNC_INITIAL_SYNC_ENABLED =
         "alluxio.master.ufs.active.sync.initial.sync.enabled";
+    public static final String MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT =
+        "alluxio.master.ufs.active.sync.retry.timeout";
     public static final String MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY =
         "alluxio.master.ufs.block.location.cache.capacity";
     public static final String MASTER_UFS_MANAGED_BLOCKING_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1917,7 +1917,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT =
       new Builder(Name.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)
           .setDefaultValue("10sec")
-          .setDescription("Max time to retry failed sync operation")
+          .setDescription("The max total duration to retry failed active sync operations."
+              + "A large duration is useful to handle transient failures such as an "
+              + "unresponsive under storage but can lock the inode tree being synced longer.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3392,6 +3392,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
 
     // Update metadata for all the mount points
     for (String mountPoint : pathsToLoad) {
+      if (Thread.currentThread().isInterrupted()) {
+        LOG.warn("Thread syncing {} was interrupted before completion", inodePath.getUri());
+        return false;
+      }
       AlluxioURI mountPointUri = new AlluxioURI(mountPoint);
       try {
         if (PathUtils.hasPrefix(inodePath.getUri().getPath(), mountPointUri.getPath())) {
@@ -3489,6 +3493,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
       throws FileDoesNotExistException, InvalidPathException, IOException, AccessControlException {
     Preconditions.checkState(inodePath.getLockPattern() == LockPattern.WRITE_EDGE);
 
+    if (Thread.currentThread().isInterrupted()) {
+      LOG.warn("Thread syncing {} was interrupted before completion", inodePath.getUri());
+      return SyncResult.defaults();
+    }
     // Set to true if the given inode was deleted.
     boolean deletedInode = false;
     // Set of paths to sync

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -116,9 +116,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.TimeSeries;
 import alluxio.proto.journal.File;
-import alluxio.proto.journal.File.AddSyncPointEntry;
 import alluxio.proto.journal.File.NewBlockEntry;
-import alluxio.proto.journal.File.RemoveSyncPointEntry;
 import alluxio.proto.journal.File.RenameEntry;
 import alluxio.proto.journal.File.SetAclEntry;
 import alluxio.proto.journal.File.UpdateInodeEntry;
@@ -2689,7 +2687,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     long newMountId = IdUtils.createMountId();
     // lock sync manager to ensure no sync point is added before the mount point is removed
-    try (LockResource r = new LockResource(mSyncManager.getSyncManagerLock())) {
+    try (LockResource r = new LockResource(mSyncManager.getLock())) {
       List<AlluxioURI> syncPoints = mSyncManager.getFilterList(mountInfo.getMountId());
       if (syncPoints != null && !syncPoints.isEmpty()) {
         throw new InvalidArgumentException("Updating a mount point with ActiveSync enabled is not"

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -334,7 +334,7 @@ public class ActiveSyncManager implements Journaled {
    * @param syncPoint sync point to be stopped
    */
   public void stopSyncAndJournal(RpcContext rpcContext, AlluxioURI syncPoint)
-      throws InvalidPathException{
+      throws InvalidPathException {
     try (LockResource r = new LockResource(mLock)) {
       MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
       if (resolution == null) {

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -182,7 +182,9 @@ public class ActiveSyncManager implements Journaled {
     for (Map.Entry<Long, List<AlluxioURI>> entry : mFilterMap.entrySet()) {
       long mountId = entry.getKey();
       long txId = mStartingTxIdMap.getOrDefault(mountId, SyncInfo.INVALID_TXID);
-      launchPollingThread(mountId, txId);
+      if (!entry.getValue().isEmpty()) {
+        launchPollingThread(mountId, txId);
+      }
 
       try {
         if ((txId == SyncInfo.INVALID_TXID) && ServerConfiguration.getBoolean(
@@ -338,7 +340,8 @@ public class ActiveSyncManager implements Journaled {
     try (LockResource r = new LockResource(mLock)) {
       MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
       if (resolution == null) {
-        throw new InvalidPathException(syncPoint + " is not a sync point.");
+        throw new InvalidPathException("Failed to stop sync point " + syncPoint
+            + " because it is not mounted.");
       }
       LOG.debug("stop syncPoint {}", syncPoint.getPath());
       final long mountId = resolution.getMountId();

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -117,6 +117,16 @@ public class ActiveSyncManager implements Journaled {
     mExecutorService =
         Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
   }
+
+  /**
+   * Gets the lock protecting the syncManager.
+   *
+   * @return syncmanager lock
+   */
+  public Lock getSyncManagerLock() {
+    return mSyncManagerLock;
+  }
+
   /**
    * @return true if the given path is a sync point
    */

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -186,22 +186,20 @@ public class ActiveSyncManager implements Journaled {
       try {
         if ((txId == SyncInfo.INVALID_TXID) && ServerConfiguration.getBoolean(
             PropertyKey.MASTER_UFS_ACTIVE_SYNC_INITIAL_SYNC_ENABLED)) {
-          mFilterMap.get(mountId).parallelStream().forEach(
-              syncPoint ->
-                  mExecutorService.submit(
-                      () -> {
-                        MountTable.Resolution resolution;
-                        try {
-                          resolution = mMountTable.resolve(syncPoint);
-                        } catch (InvalidPathException e) {
-                          LOG.info("Invalid Path encountered during start up of ActiveSyncManager, "
-                              + "path {}, exception {}", syncPoint, e);
-                          return;
-                        }
-                        startInitSync(syncPoint, resolution);
-                      }
-                  )
-          );
+          mExecutorService.submit(
+              () -> mFilterMap.get(mountId).parallelStream().forEach(
+                  syncPoint -> {
+                    MountTable.Resolution resolution;
+                    try {
+                      resolution = mMountTable.resolve(syncPoint);
+                    } catch (InvalidPathException e) {
+                      LOG.info("Invalid Path encountered during start up of ActiveSyncManager, "
+                          + "path {}, exception {}", syncPoint, e);
+                      return;
+                    }
+                    startInitSync(syncPoint, resolution);
+                  }
+              ));
         }
       } catch (Exception e) {
         LOG.warn("exception encountered during initial sync: {}", e.toString());

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -128,6 +128,7 @@ public class ActiveSyncManager implements Journaled {
   }
 
   /**
+   * @param syncPoint the uri to check
    * @return true if the given path is a sync point
    */
   public boolean isSyncPoint(AlluxioURI syncPoint) {
@@ -159,7 +160,6 @@ public class ActiveSyncManager implements Journaled {
   public void start() throws IOException {
     // Initialize UFS states
     for (AlluxioURI syncPoint : mSyncPathList) {
-
       MountTable.Resolution resolution;
       try {
         resolution = mMountTable.resolve(syncPoint);
@@ -275,7 +275,8 @@ public class ActiveSyncManager implements Journaled {
    * @param rpcContext the master rpc or no-op context
    * @param syncPoint sync point to be start
    */
-  public void startSyncAndJournal(RpcContext rpcContext, AlluxioURI syncPoint) throws InvalidPathException {
+  public void startSyncAndJournal(RpcContext rpcContext, AlluxioURI syncPoint)
+      throws InvalidPathException {
     try (LockResource r = new LockResource(mLock)) {
       MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
       long mountId = resolution.getMountId();
@@ -628,7 +629,7 @@ public class ActiveSyncManager implements Journaled {
   }
 
   /**
-   * set the transaction id for a particular mountId.
+   * Set the transaction id for a particular mountId.
    *
    * @param mountId mount id
    * @param txId transaction id

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -179,7 +179,8 @@ public class ActiveSyncManager implements Journaled {
     }
     // attempt to restart from a past txid, if this fails, it will result in MissingEventException
     // therefore forces a sync
-    for (long mountId: mFilterMap.keySet()) {
+    for (Map.Entry<Long, List<AlluxioURI>> entry : mFilterMap.entrySet()) {
+      long mountId = entry.getKey();
       long txId = mStartingTxIdMap.getOrDefault(mountId, SyncInfo.INVALID_TXID);
       launchPollingThread(mountId, txId);
 
@@ -187,7 +188,7 @@ public class ActiveSyncManager implements Journaled {
         if ((txId == SyncInfo.INVALID_TXID) && ServerConfiguration.getBoolean(
             PropertyKey.MASTER_UFS_ACTIVE_SYNC_INITIAL_SYNC_ENABLED)) {
           mExecutorService.submit(
-              () -> mFilterMap.get(mountId).parallelStream().forEach(
+              () -> entry.getValue().parallelStream().forEach(
                   syncPoint -> {
                     MountTable.Resolution resolution;
                     try {

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -126,7 +126,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
         RetryUtils.retry("Full Sync", () -> {
           mFileSystemMaster.activeSyncMetadata(alluxioUri, null, mSyncManager.getExecutor());
         }, RetryUtils.defaultActiveSyncClientRetry(
-            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_POLL_TIMEOUT)));
+            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
       } else {
         LOG.debug("incremental sync {}", ufsUri.toString());
         RetryUtils.retry("Incremental Sync", () -> {
@@ -136,7 +136,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
                   .collect(Collectors.toSet()),
               mSyncManager.getExecutor());
         }, RetryUtils.defaultActiveSyncClientRetry(
-            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_POLL_TIMEOUT)));
+            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
       }
     } catch (IOException e) {
       LOG.warn("Failed to submit active sync job to master: ufsUri {}, syncPoint {} ", ufsUri,

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Periodically sync the files for a particular mountpoint.
+ * Periodically sync the files for a particular mount point.
  */
 @NotThreadSafe
 public class ActiveSyncer implements HeartbeatExecutor {


### PR DESCRIPTION
Fixes: https://github.com/Alluxio/alluxio/issues/10815

When stopSync is called, the thread performing the initial scan handles interrupt to return early. A full sync on a very large directory can take a long time to finish, this change enables us to cancel a full sync after partial completion.