### PR TITLE
Fix unauthenticated exception during relogin

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -239,8 +239,7 @@ public abstract class AbstractClient implements Client {
         lastConnectFailure = e;
         if (e instanceof UnauthenticatedException) {
           // If there has been a failure in opening GrpcChannel, it's possible because
-          // the authentication credential has expired. Relogin. This is a no-op for
-          // authTypes other than KERBEROS.
+          // the authentication credential has expired. Relogin.
           mContext.getUserState().relogin();
         }
         if (e instanceof NotFoundException) {

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -131,7 +131,8 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {
     GrpcChannel channel =
         GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), mConfiguration)
-            .setSubject(mUserState.getSubject()).setClientType("MasterInquireClient").build();
+            .setSubject(mUserState.getSubject()).setClientType("MasterInquireClient")
+            .disableAuthentication().build();
     ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
         ServiceVersionClientServiceGrpc.newBlockingStub(channel);
     ServiceType serviceType

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -129,6 +129,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   }
 
   private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {
+    // disable authentication in the channel since version service does not require authentication
     GrpcChannel channel =
         GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), mConfiguration)
             .setSubject(mUserState.getSubject()).setClientType("MasterInquireClient")


### PR DESCRIPTION
We recently moved relogin early before the retry loop to fix polling master client authentication. Now we start to see random unauthenticated exception during the relogin time. Since the polling master client does not really need the authentication, disabling it and move the relogin back inside the retry. The unauthenticated exception can no longer be observed after this change.