### PR TITLE
Remove remnants of MapR FS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -628,7 +628,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_HDFS_PREFIXES =
       new Builder(Name.UNDERFS_HDFS_PREFIXES)
-          .setDefaultValue("hdfs://,glusterfs:///,maprfs:///")
+          .setDefaultValue("hdfs://,glusterfs:///")
           .setDescription("Optionally, specify which prefixes should run through the HDFS "
               + "implementation of UnderFileSystem. The delimiter is any whitespace "
               + "and/or ','.")

--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>mapr-repo</id>
-      <name>MapR Repository</name>
-      <url>https://repository.mapr.com/maven/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <!-- for Pivotal's distribution -->
       <id>spring-releases</id>
       <name>Spring Release Repository</name>


### PR DESCRIPTION
We don't support maprfs:// any more. This PR deletes some remaining
parts that still reference the dependency in the codebase.