### PR TITLE
Add Wasbs support to Wasb Underfs

### DIFF
--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -45,11 +45,11 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
    * Prepares the configuration for this Wasb as an HDFS configuration.
    *
    * @param conf the configuration for this UFS
-   * @param isWasb whether to use wasb configuration or not
+   * @param isSecure whether blob storage is using https
    * @return the created configuration
    */
   public static Configuration createConfiguration(UnderFileSystemConfiguration conf,
-          Boolean isWasb) {
+          Boolean isSecure) {
     Configuration wasbConf = HdfsUnderFileSystem.createConfiguration(conf);
     for (Map.Entry<String, String> entry : conf.toMap().entrySet()) {
       String key = entry.getKey();
@@ -58,12 +58,12 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
         wasbConf.set(key, value);
       }
     }
-    if (isWasb) {
-      wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
-      wasbConf.set("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
-    } else {
+    if (isSecure) {
       wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasbs");
       wasbConf.set("fs.wasbs.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    } else {
+      wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
+      wasbConf.set("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
     }
     return wasbConf;
   }

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -36,7 +38,7 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(WasbUnderFileSystem.class);
 
   /** Constant for the wasb URI scheme. */
-  public static final String SCHEME = "wasb://";
+  public static final List<String> SCHEMES = Stream.of("wasb://", "wasbs://").collect(Collectors.toList());
 
   /**
    * Prepares the configuration for this Wasb as an HDFS configuration.

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -46,7 +46,7 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
    * @param conf the configuration for this UFS
    * @return the created configuration
    */
-  public static Configuration createConfiguration(UnderFileSystemConfiguration conf) {
+  public static Configuration createConfiguration(UnderFileSystemConfiguration conf, Boolean isWasb) {
     Configuration wasbConf = HdfsUnderFileSystem.createConfiguration(conf);
     for (Map.Entry<String, String> entry : conf.toMap().entrySet()) {
       String key = entry.getKey();
@@ -55,8 +55,13 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
         wasbConf.set(key, value);
       }
     }
-    wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
-    wasbConf.set("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    if (isWasb) {
+      wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
+      wasbConf.set("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    } else {
+      wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasbs");
+      wasbConf.set("fs.wasbs.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    }
     return wasbConf;
   }
 
@@ -69,7 +74,7 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
    */
   public static WasbUnderFileSystem createInstance(AlluxioURI uri,
       UnderFileSystemConfiguration conf) {
-    Configuration wasbConf = createConfiguration(conf);
+    Configuration wasbConf = createConfiguration(conf, uri.getScheme().startsWith("wasb://"));
     return new WasbUnderFileSystem(uri, conf, wasbConf);
   }
 

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -38,15 +38,18 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(WasbUnderFileSystem.class);
 
   /** Constant for the wasb URI scheme. */
-  public static final List<String> SCHEMES = Stream.of("wasb://", "wasbs://").collect(Collectors.toList());
+  public static final List<String> SCHEMES = Stream.of("wasb://", "wasbs://")
+          .collect(Collectors.toList());
 
   /**
    * Prepares the configuration for this Wasb as an HDFS configuration.
    *
    * @param conf the configuration for this UFS
+   * @param isWasb whether to use wasb configuration or not
    * @return the created configuration
    */
-  public static Configuration createConfiguration(UnderFileSystemConfiguration conf, Boolean isWasb) {
+  public static Configuration createConfiguration(UnderFileSystemConfiguration conf,
+          Boolean isWasb) {
     Configuration wasbConf = HdfsUnderFileSystem.createConfiguration(conf);
     for (Map.Entry<String, String> entry : conf.toMap().entrySet()) {
       String key = entry.getKey();

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -25,8 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -38,8 +36,10 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(WasbUnderFileSystem.class);
 
   /** Constant for the wasb URI scheme. */
-  public static final List<String> SCHEMES = Stream.of("wasb://", "wasbs://")
-          .collect(Collectors.toList());
+  public static final String SCHEME_INSECURE = "wasb://";
+
+  /** Constant for the wasbs URI scheme. */
+  public static final String SCHEME_SECURE = "wasbs://";
 
   /**
    * Prepares the configuration for this Wasb as an HDFS configuration.
@@ -59,7 +59,7 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
       }
     }
     if (isSecure) {
-      wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasbs");
+      wasbConf.set("fs.AbstractFileSystem.wasbs.impl", "org.apache.hadoop.fs.azure.Wasbs");
       wasbConf.set("fs.wasbs.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
     } else {
       wasbConf.set("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
@@ -77,7 +77,7 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
    */
   public static WasbUnderFileSystem createInstance(AlluxioURI uri,
       UnderFileSystemConfiguration conf) {
-    Configuration wasbConf = createConfiguration(conf, uri.getScheme().startsWith("wasb://"));
+    Configuration wasbConf = createConfiguration(conf, uri.getScheme().startsWith(SCHEME_SECURE));
     return new WasbUnderFileSystem(uri, conf, wasbConf);
   }
 

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
@@ -20,6 +20,8 @@ import com.google.common.base.Preconditions;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.stream.Stream;
+
 /**
  * Factory for creating {@link WasbUnderFileSystem}.
  */
@@ -39,6 +41,6 @@ public class WasbUnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public boolean supportsPath(String path) {
-    return path != null && path.startsWith(WasbUnderFileSystem.SCHEME);
+    return path != null && WasbUnderFileSystem.SCHEMES.stream().anyMatch(path::startsWith);
   }
 }

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
@@ -20,8 +20,6 @@ import com.google.common.base.Preconditions;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.stream.Stream;
-
 /**
  * Factory for creating {@link WasbUnderFileSystem}.
  */

--- a/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
+++ b/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystemFactory.java
@@ -39,6 +39,8 @@ public class WasbUnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public boolean supportsPath(String path) {
-    return path != null && WasbUnderFileSystem.SCHEMES.stream().anyMatch(path::startsWith);
+    return path != null
+            && (path.startsWith(WasbUnderFileSystem.SCHEME_SECURE)
+            || path.startsWith(WasbUnderFileSystem.SCHEME_INSECURE));
   }
 }

--- a/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
+++ b/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
@@ -39,7 +39,7 @@ public class WasbUnderFileSystemFactoryTest {
 
     factory = UnderFileSystemFactoryRegistry.find("wasbs://localhost/test/path", conf);
     Assert.assertNotNull(
-            "A UnderFileSystemFactory should exist for wasb paths when using this module",
+            "A UnderFileSystemFactory should exist for wasbs paths when using this module",
             factory);
 
     factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost/test/path", conf);

--- a/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
+++ b/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
@@ -37,6 +37,11 @@ public class WasbUnderFileSystemFactoryTest {
         "A UnderFileSystemFactory should exist for wasb paths when using this module",
         factory);
 
+    factory = UnderFileSystemFactoryRegistry.find("wasbs://localhost/test/path", conf);
+    Assert.assertNotNull(
+            "A UnderFileSystemFactory should exist for wasb paths when using this module",
+            factory);
+
     factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost/test/path", conf);
     Assert.assertNull("A UnderFileSystemFactory should not exist for unsupported paths when using"
         + " this module.", factory);


### PR DESCRIPTION
Azure Blob Storage over https is currently unsupported by the `wasb` underfile system; however, the version of [azure-hadoop ](https://hadoop.apache.org/docs/r2.7.3/hadoop-azure/index.html) used in the underfs supports the https scheme (wasbs). 

This PR merely changes the accepted `SCHEME` from `wasb://` to accepted `SCHEMES` including both `wasb://` and `wasbs://`

`wasbs` support was tested by running `runUfsTests` in a k8s installation. All tests were passed successfully.

