### PR TITLE
Exit worker session-cleaner without interrupt message

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -70,7 +70,10 @@ public final class SessionCleaner implements Runnable, Closeable {
       long lastIntervalMs = System.currentTimeMillis() - lastCheckMs;
       long toSleepMs = mCheckIntervalMs - lastIntervalMs;
       if (toSleepMs > 0) {
-        CommonUtils.sleepMs(LOG, toSleepMs);
+        CommonUtils.sleepMs(null, toSleepMs);
+        if (Thread.interrupted()) {
+          break;
+        }
       } else {
         LOG.warn("Session cleanup took: {}, expected: {}", lastIntervalMs, mCheckIntervalMs);
       }


### PR DESCRIPTION
To fix worker shutdown logging every time:

2020-02-13 22:31:55,587 WARN  SessionCleaner - sleep interrupted
java.lang.InterruptedException: sleep interrupted
........