### PR TITLE
Exclude dependency on rocksdb from client jar

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -44,7 +44,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A page store implementation which utilizes rocksDB to persist the data.
+ * A page store implementation which utilizes rocksDB to persist the data. This implementation
+ * will not be included to client jar by default to reduce client jar size.
  */
 @NotThreadSafe
 public class RocksPageStore implements PageStore {

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Have RocksDB dependency in provided scope by default to reduce client jar size -->
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Runtime logging dependencies -->
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Tested with my local build, client jar size reduced from 40MB to 26MB