### PR TITLE
Improve collectInfo command

### DIFF
--- a/core/common/src/main/java/alluxio/shell/ScpCommand.java
+++ b/core/common/src/main/java/alluxio/shell/ScpCommand.java
@@ -44,7 +44,7 @@ public class ScpCommand extends ShellCommand {
    */
   public ScpCommand(String remoteHost, String fromFile, String toFile, boolean isDir) {
     super(new String[]{"bash", "-c",
-            String.format(isDir ? "scp -r %s %s:%s localhost:%s" : "scp %s %s:%s localhost:%s",
+            String.format(isDir ? "scp -r %s %s:%s %s" : "scp %s %s:%s %s",
                     ShellUtils.COMMON_SSH_OPTS, remoteHost, fromFile, toFile)
     });
     mHostName = remoteHost;

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -167,8 +167,6 @@ public class CollectInfo extends AbstractShell {
     System.exit(ret);
   }
 
-  private void
-
   /**
    * Finds all nodes in the cluster.
    * Then invokes collectInfo with --local option on each of them locally.

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -146,6 +146,10 @@ public class CollectInfo extends AbstractShell {
               2, argv.length);
       shell.printUsage();
       System.exit(-1);
+    } else if (shell.findCommand(args[0]) == null) {
+      System.out.format("Command %s is not recognized.%n", args[0]);
+      shell.printUsage();
+      System.exit(-2);
     }
 
     // Choose mode based on option
@@ -162,6 +166,8 @@ public class CollectInfo extends AbstractShell {
     shell.close();
     System.exit(ret);
   }
+
+  private void
 
   /**
    * Finds all nodes in the cluster.

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
@@ -38,15 +38,15 @@ public class CollectEnvCommand extends ExecuteShellCollectInfoCommand {
   @Override
   protected void registerCommands() {
     registerCommand("Alluxio ps",
-            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep alluxio"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef", "| grep alluxio"}), null);
     registerCommand("Spark ps",
-            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep spark"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef", "| grep spark"}), null);
     registerCommand("Yarn ps",
-            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep yarn"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef", "| grep yarn"}), null);
     registerCommand("Hdfs ps",
-            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep hdfs"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef", "| grep hdfs"}), null);
     registerCommand("Presto ps",
-            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep presto"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef", "| grep presto"}), null);
     registerCommand("env",
             new ShellCommand(new String[]{"env"}), null);
     registerCommand("top", new ShellCommand(new String[]{"atop", "-b", "-n", "1"}),
@@ -63,7 +63,8 @@ public class CollectEnvCommand extends ExecuteShellCollectInfoCommand {
                     mFsContext.getClusterConf().get(PropertyKey.HOME))}), null);
     registerCommand("dig", new ShellCommand(new String[]{"dig", "$(hostname -i)"}), null);
     registerCommand("nslookup", new ShellCommand(new String[]{"nslookup", "$(hostname -i)"}), null);
-    registerCommand("dstat", new ShellCommand(new String[]{"dstat", "-cdgilmnprsty", "1", "5"}), null);
+    registerCommand("dstat", new ShellCommand(
+            new String[]{"dstat", "-cdgilmnprsty", "1", "5"}), null);
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
@@ -38,33 +38,32 @@ public class CollectEnvCommand extends ExecuteShellCollectInfoCommand {
   @Override
   protected void registerCommands() {
     registerCommand("Alluxio ps",
-            new ShellCommand(new String[]{"bash", "-c", "'ps -ef | grep alluxio'"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep alluxio"}), null);
     registerCommand("Spark ps",
-            new ShellCommand(new String[]{"bash", "-c", "'ps -ef | grep spark'"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep spark"}), null);
     registerCommand("Yarn ps",
-            new ShellCommand(new String[]{"bash", "-c", "'ps -ef | grep yarn'"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep yarn"}), null);
     registerCommand("Hdfs ps",
-            new ShellCommand(new String[]{"bash", "-c", "'ps -ef | grep hdfs'"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep hdfs"}), null);
     registerCommand("Presto ps",
-            new ShellCommand(new String[]{"bash", "-c", "'ps -ef | grep presto'"}), null);
+            new ShellCommand(new String[]{"bash", "-c", "ps", "-ef | grep presto"}), null);
     registerCommand("env",
             new ShellCommand(new String[]{"env"}), null);
     registerCommand("top", new ShellCommand(new String[]{"atop", "-b", "-n", "1"}),
             new ShellCommand(new String[]{"top", "-b", "-n", "1"}));
     registerCommand("mount", new ShellCommand(new String[]{"mount"}), null);
     registerCommand("df", new ShellCommand(new String[]{"df", "-H"}), null);
-    registerCommand("ulimit", new ShellCommand(new String[]{"ulimit -Ha"}), null);
+    registerCommand("ulimit", new ShellCommand(new String[]{"ulimit", "-Ha"}), null);
     registerCommand("uname", new ShellCommand(new String[]{"uname", "-a"}), null);
     registerCommand("hostname", new ShellCommand(new String[]{"hostname"}), null);
     registerCommand("host ip", new ShellCommand(new String[]{"hostname", "-i"}), null);
     registerCommand("host fqdn", new ShellCommand(new String[]{"hostname", "-f"}), null);
     registerCommand("list Alluxio home",
-            new ShellCommand(new String[]{String.format("ls -al -R %s",
+            new ShellCommand(new String[]{String.format("ls", "-al -R %s",
                     mFsContext.getClusterConf().get(PropertyKey.HOME))}), null);
-    registerCommand("dig", new ShellCommand(new String[]{"dig $(hostname -i)"}), null);
+    registerCommand("dig", new ShellCommand(new String[]{"dig", "$(hostname -i)"}), null);
     registerCommand("nslookup", new ShellCommand(new String[]{"nslookup", "$(hostname -i)"}), null);
-    // TODO(jiacheng): does this stop?
-    registerCommand("dstat", new ShellCommand(new String[]{"dstat", "-cdgilmnprsty"}), null);
+    registerCommand("dstat", new ShellCommand(new String[]{"dstat", "-cdgilmnprsty", "1", "5"}), null);
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
@@ -88,7 +88,15 @@ public class CollectMetricsCommand extends AbstractCollectInfoCommand {
       LOG.info(String.format("Metric address URL: %s", url));
 
       // Get metrics
-      String metricsResponse = getMetricsJson(url);
+      String metricsResponse;
+      try {
+        metricsResponse = getMetricsJson(url);
+      } catch (IOException e) {
+        // Do not break the loop since the HTTP failure can be due to many reasons
+        // Return the error message instead
+        LOG.error("Failed to get Alluxio metrics from URL %s. Exception is %s", url, e);
+        metricsResponse =  String.format("Url: %s%nError: %s", url, e.getMessage());
+      }
       outputBuffer.write(metricsResponse);
 
       // Write to file
@@ -120,12 +128,15 @@ public class CollectMetricsCommand extends AbstractCollectInfoCommand {
 
   /**
    * Probes Alluxio metrics json sink.
+   * If the HTTP request fails, return the error content
+   * instead of throwing an exception.
    *
    * @param url URL that serves Alluxio metrics
    * @return HTTP response in JSON string
    */
   public String getMetricsJson(String url) throws IOException {
-    String responseJson = HttpUtils.get(url, COLLECT_METRICS_TIMEOUT);
+    String responseJson;
+    responseJson = HttpUtils.get(url, COLLECT_METRICS_TIMEOUT);
     return String.format("Url: %s%nResponse: %s", url, responseJson);
   }
 }

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
@@ -91,7 +91,7 @@ public class CollectMetricsCommand extends AbstractCollectInfoCommand {
       String metricsResponse;
       try {
         metricsResponse = getMetricsJson(url);
-      } catch (IOException e) {
+      } catch (Exception e) {
         // Do not break the loop since the HTTP failure can be due to many reasons
         // Return the error message instead
         LOG.error("Failed to get Alluxio metrics from URL %s. Exception is %s", url, e);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
@@ -135,8 +135,7 @@ public class CollectMetricsCommand extends AbstractCollectInfoCommand {
    * @return HTTP response in JSON string
    */
   public String getMetricsJson(String url) throws IOException {
-    String responseJson;
-    responseJson = HttpUtils.get(url, COLLECT_METRICS_TIMEOUT);
+    String responseJson = HttpUtils.get(url, COLLECT_METRICS_TIMEOUT);
     return String.format("Url: %s%nResponse: %s", url, responseJson);
   }
 }


### PR DESCRIPTION
Various improvements to `collectInfo` command:
1. scp now doesn't hardcode "localhost". Specifying `localhost` works on Mac but not on a CentOS machine.
2. If the command is invalid like `alluxio collectInfo bar /dir`, early reject before distributing the command and find out it's invalid locally.
3. Catch metrics collection errors when metrics are unavailable, instead of failing the command and subsequently skips collecting tarballs.
4. Misc bash command fixes.