### PR TITLE
Allow superuser to stopActiveSync w/o a lock

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -149,7 +149,6 @@ import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.ModeUtils;
 import alluxio.util.SecurityUtils;
-import alluxio.util.SleepUtils;
 import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
@@ -3375,14 +3374,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
     Set<String> pathsToLoad = new HashSet<>();
 
     try {
-      LOG.info("syncMetadataInternal in thread {}", Thread.currentThread().getId());
       if (!inodePath.fullPathExists()) {
-        LOG.info("syncMetadataInternal in thread {} inodePath does not exist", Thread.currentThread().getId());
         // The requested path does not exist in Alluxio, so just load metadata.
         pathsToLoad.add(inodePath.getUri().getPath());
       } else {
-        // TODO(adit): this code path does not interrupt
-        LOG.info("syncMetadataInternal in thread {} inodePath exists", Thread.currentThread().getId());
         SyncResult result =
             syncInodeMetadata(rpcContext, inodePath, syncDescendantType, statusCache);
         if (result.getDeletedInode()) {
@@ -3398,9 +3393,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
     } finally {
       inodePath.downgradeToPattern(lockingScheme.getDesiredPattern());
     }
-    LOG.info("Sleeping for a minute in thread {}", Thread.currentThread().getId());
-    SleepUtils.sleepMs(60000);
-    LOG.info("Done sleeping with #paths to load = {}", pathsToLoad.size());
     // Update metadata for all the mount points
     for (String mountPoint : pathsToLoad) {
       if (Thread.currentThread().isInterrupted()) {
@@ -3504,9 +3496,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
       throws FileDoesNotExistException, InvalidPathException, IOException, AccessControlException {
     Preconditions.checkState(inodePath.getLockPattern() == LockPattern.WRITE_EDGE);
 
-    LOG.info("Sleeping for a minute w/ path {} in thread {}", inodePath.getUri(), Thread.currentThread().getId());
-    SleepUtils.sleepMs(60000);
-    LOG.info("Done sleeping");
     if (Thread.currentThread().isInterrupted()) {
       LOG.warn("Thread syncing {} was interrupted before completion", inodePath.getUri());
       return SyncResult.defaults();
@@ -3827,7 +3816,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
   @Override
   public void stopSync(AlluxioURI syncPoint)
       throws IOException, InvalidPathException, AccessControlException {
-    LockingScheme lockingScheme = new LockingScheme(syncPoint, LockPattern.READ, false);
     try (RpcContext rpcContext = createRpcContext()) {
       boolean isSuperUser = true;
       try {
@@ -3839,6 +3827,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         // Stop sync w/o acquiring an inode lock to terminate an initial full scan (if running)
         mSyncManager.stopSyncAndJournal(rpcContext, syncPoint);
       }
+      LockingScheme lockingScheme = new LockingScheme(syncPoint, LockPattern.READ, false);
       try (LockedInodePath inodePath =
                mInodeTree.lockInodePath(lockingScheme.getPath(), lockingScheme.getPattern());
            FileSystemMasterAuditContext auditContext =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3393,6 +3393,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
     } finally {
       inodePath.downgradeToPattern(lockingScheme.getDesiredPattern());
     }
+
     // Update metadata for all the mount points
     for (String mountPoint : pathsToLoad) {
       if (Thread.currentThread().isInterrupted()) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3825,6 +3825,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         isSuperUser = false;
       }
       if (isSuperUser) {
+        // TODO(AM): Remove once we don't require a write lock on the sync point during a full sync
         // Stop sync w/o acquiring an inode lock to terminate an initial full scan (if running)
         mSyncManager.stopSyncAndJournal(rpcContext, syncPoint);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
@@ -144,6 +144,17 @@ public class DefaultPermissionChecker implements PermissionChecker {
     }
   }
 
+  @Override
+  public void checkSuperUser() throws AccessControlException {
+    // collects user and groups
+    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+    List<String> groups = getGroups(user);
+    if (!isPrivilegedUser(user, groups)) {
+      throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
+          .getMessage(user + " is not a super user or in super group"));
+    }
+  }
+
   /**
    * @param user the user to get groups for
    * @return the groups for the given user
@@ -179,21 +190,6 @@ public class DefaultPermissionChecker implements PermissionChecker {
     }
 
     checkInodeList(user, groups, null, inodePath.getUri().getPath(), inodeList, true);
-  }
-
-  /**
-   * Checks whether the user is a super user or in super group.
-   *
-   * @throws AccessControlException if the user is not a super user
-   */
-  private void checkSuperUser() throws AccessControlException {
-    // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
-    List<String> groups = getGroups(user);
-    if (!isPrivilegedUser(user, groups)) {
-      throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
-          .getMessage(user + " is not a super user or in super group"));
-    }
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/PermissionChecker.java
@@ -47,6 +47,13 @@ public interface PermissionChecker {
       throws AccessControlException;
 
   /**
+   * Checks whether the user is a super user or in super group.
+   *
+   * @throws AccessControlException if the user is not a super user
+   */
+  void checkSuperUser() throws AccessControlException;
+
+  /**
    * Gets the permission to access inodePath for the current client user.
    *
    * @param inodePath the inode path

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -337,9 +337,7 @@ public class ActiveSyncManager implements Journaled {
    */
   public void stopSyncAndJournal(RpcContext rpcContext, AlluxioURI syncPoint)
       throws InvalidPathException {
-    LOG.info("Stop syncPoint {} waiting for lock", syncPoint);
     try (LockResource r = new LockResource(mLock)) {
-      LOG.info("Stop syncPoint {} acquired lock", syncPoint);
       MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
       if (resolution == null) {
         throw new InvalidPathException("Failed to stop sync point " + syncPoint
@@ -516,7 +514,6 @@ public class ActiveSyncManager implements Journaled {
       Future<?> syncFuture = mExecutorService.submit(
           () -> {
             try {
-              LOG.info("Starting initial sync for path {} in thread {}", syncPoint, Thread.currentThread().getId());
               // Notify ufs polling thread to keep track of events related to specified uri
               ufsResource.get().startSync(resolution.getUri());
               // Start the initial metadata sync between the ufs and alluxio for the specified uri
@@ -544,15 +541,12 @@ public class ActiveSyncManager implements Journaled {
    * @throws InvalidPathException
    */
   private void stopSyncInternal(AlluxioURI syncPoint) throws InvalidPathException {
-    LOG.info("Stopping syncPoint {}", syncPoint);
     MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
     // Remove initial sync thread
     Future<?> syncFuture = mSyncPathStatus.remove(syncPoint);
     if (syncFuture != null) {
-      LOG.info("syncPoint future is not null {}", syncPoint);
       syncFuture.cancel(true);
     }
-    LOG.info("done checking syncPoint future {}", syncPoint);
 
     long mountId = resolution.getMountId();
     if (mFilterMap.containsKey(mountId) && mFilterMap.get(mountId).isEmpty()) {

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -337,7 +337,9 @@ public class ActiveSyncManager implements Journaled {
    */
   public void stopSyncAndJournal(RpcContext rpcContext, AlluxioURI syncPoint)
       throws InvalidPathException {
+    LOG.info("Stop syncPoint {} waiting for lock", syncPoint);
     try (LockResource r = new LockResource(mLock)) {
+      LOG.info("Stop syncPoint {} acquired lock", syncPoint);
       MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
       if (resolution == null) {
         throw new InvalidPathException("Failed to stop sync point " + syncPoint
@@ -514,6 +516,7 @@ public class ActiveSyncManager implements Journaled {
       Future<?> syncFuture = mExecutorService.submit(
           () -> {
             try {
+              LOG.info("Starting initial sync for path {} in thread {}", syncPoint, Thread.currentThread().getId());
               // Notify ufs polling thread to keep track of events related to specified uri
               ufsResource.get().startSync(resolution.getUri());
               // Start the initial metadata sync between the ufs and alluxio for the specified uri
@@ -541,12 +544,15 @@ public class ActiveSyncManager implements Journaled {
    * @throws InvalidPathException
    */
   private void stopSyncInternal(AlluxioURI syncPoint) throws InvalidPathException {
+    LOG.info("Stopping syncPoint {}", syncPoint);
     MountTable.Resolution resolution = mMountTable.resolve(syncPoint);
     // Remove initial sync thread
     Future<?> syncFuture = mSyncPathStatus.remove(syncPoint);
     if (syncFuture != null) {
+      LOG.info("syncPoint future is not null {}", syncPoint);
       syncFuture.cancel(true);
     }
+    LOG.info("done checking syncPoint future {}", syncPoint);
 
     long mountId = resolution.getMountId();
     if (mFilterMap.containsKey(mountId) && mFilterMap.get(mountId).isEmpty()) {

--- a/docs/en/core-services/Unified-Namespace.md
+++ b/docs/en/core-services/Unified-Namespace.md
@@ -308,7 +308,7 @@ To disable active sync on a directory, issue the following Alluxio command.
 $ ./bin/alluxio fs stopSync /syncdir
 ```
 > Note: When `startSync` is issued, a full scan of the sync point is scheduled.
-> If run as the Alluxio superuser stopSync will interrupt any full scans which have not yet ended.
+> If run as the Alluxio superuser, `stopSync` will interrupt any full scans which have not yet ended.
 > If run as any other user, `stopSync` will wait for the full scan to finish before completing.
 
 You can also examine which directories are currently under active sync.

--- a/docs/en/core-services/Unified-Namespace.md
+++ b/docs/en/core-services/Unified-Namespace.md
@@ -307,6 +307,9 @@ To disable active sync on a directory, issue the following Alluxio command.
 ```console
 $ ./bin/alluxio fs stopSync /syncdir
 ```
+> Note: When `startSync` is issued, a full scan of the sync point is scheduled.
+> If run as the Alluxio superuser stopSync will interrupt any full scans which have not yet ended.
+> If run as any other user, `stopSync` will wait for the full scan to finish before completing.
 
 You can also examine which directories are currently under active sync.
 


### PR DESCRIPTION
A full scan for active sync acquires a write lock on the syncPoint which prevents the permission check for stopSync to proceed. This PR skips the read lock needed on the inode for the permission check if the user is a super user. This allows us to terminate a long-running full scan early.