### PR TITLE
Fix UpdateCheckTest

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/UpdateCheck.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/UpdateCheck.java
@@ -122,7 +122,7 @@ public final class UpdateCheck {
       // Exceptions are expected if instance is not EC2 instance
       // or get metadata operation is not allowed
     }
-    if (!userData.isEmpty()) {
+    if (userData != null && !userData.isEmpty()) {
       isEC2 = true;
       if (EnvironmentUtils.isCFT(userData)) {
         ec2Info.add("cft");

--- a/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
@@ -14,6 +14,7 @@ package alluxio.master.meta;
 import alluxio.ProjectConstants;
 import alluxio.util.EnvironmentUtils;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.util.EC2MetadataUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,6 +41,9 @@ public class UpdateCheckTest {
     Mockito.when(EnvironmentUtils.isEC2()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
+    PowerMockito.mockStatic(EC2MetadataUtils.class);
+    Mockito.when(EC2MetadataUtils.getUserData())
+        .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     System.out.println(userAgentString);
@@ -57,6 +61,9 @@ public class UpdateCheckTest {
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
+    PowerMockito.mockStatic(EC2MetadataUtils.class);
+    Mockito.when(EC2MetadataUtils.getUserData())
+        .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     Assert.assertTrue(userAgentString
@@ -73,6 +80,9 @@ public class UpdateCheckTest {
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
+    PowerMockito.mockStatic(EC2MetadataUtils.class);
+    Mockito.when(EC2MetadataUtils.getUserData())
+        .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     Assert.assertTrue(userAgentString.equals(
@@ -84,12 +94,14 @@ public class UpdateCheckTest {
     PowerMockito.mockStatic(EnvironmentUtils.class);
     Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEC2()).thenReturn(false);
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(true);
+    PowerMockito.mockStatic(EC2MetadataUtils.class);
+    Mockito.when(EC2MetadataUtils.getUserData())
+        .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     Assert.assertTrue(userAgentString.equals(

--- a/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
@@ -17,6 +17,7 @@ import alluxio.util.EnvironmentUtils;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.util.EC2MetadataUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -31,8 +32,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({EnvironmentUtils.class, EC2MetadataUtils.class})
 public class UpdateCheckTest {
 
-  @Test
-  public void userAgentStringEmpty() throws Exception {
+  @Before
+  public void before() {
     PowerMockito.mockStatic(EnvironmentUtils.class);
     Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
@@ -42,10 +43,14 @@ public class UpdateCheckTest {
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
     PowerMockito.mockStatic(EC2MetadataUtils.class);
+  }
+
+  @Test
+  public void userAgentStringEmpty() throws Exception {
+    String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     Mockito.when(EC2MetadataUtils.getUserData())
         .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
-    String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     System.out.println(userAgentString);
     Assert.assertTrue(
         userAgentString.equals(String.format("Alluxio/%s (cluster1)", ProjectConstants.VERSION)));
@@ -53,15 +58,7 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringDocker() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
     Mockito.when(EnvironmentUtils.isDocker()).thenReturn(true);
-    Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEC2()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
-    Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
-    PowerMockito.mockStatic(EC2MetadataUtils.class);
     Mockito.when(EC2MetadataUtils.getUserData())
         .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
@@ -72,15 +69,8 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringK8s() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
     Mockito.when(EnvironmentUtils.isDocker()).thenReturn(true);
     Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(true);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEC2()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
-    Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
-    PowerMockito.mockStatic(EC2MetadataUtils.class);
     Mockito.when(EC2MetadataUtils.getUserData())
         .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
@@ -91,15 +81,7 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringGCP() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
-    Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEC2()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("");
-    Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(true);
-    PowerMockito.mockStatic(EC2MetadataUtils.class);
     Mockito.when(EC2MetadataUtils.getUserData())
         .thenThrow(new SdkClientException("Unable to contact EC2 metadata service."));
 
@@ -110,14 +92,10 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringEC2AMI() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
-    Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEC2()).thenReturn(true);
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("random123code");
-    Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
+    // When no user data in this ec2, null is returned
+    Mockito.when(EC2MetadataUtils.getUserData()).thenReturn(null);
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
     Assert.assertTrue(userAgentString.equals(
@@ -127,15 +105,9 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringEC2CFT() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
-    Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEC2()).thenReturn(true);
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("random123code");
     Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(true);
-    Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(false);
-    PowerMockito.mockStatic(EC2MetadataUtils.class);
     Mockito.when(EC2MetadataUtils.getUserData()).thenReturn("{ \"cft_configure\": {}}");
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");
@@ -146,15 +118,9 @@ public class UpdateCheckTest {
 
   @Test
   public void userAgentStringEC2EMR() throws Exception {
-    PowerMockito.mockStatic(EnvironmentUtils.class);
-    Mockito.when(EnvironmentUtils.isDocker()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isKubernetes()).thenReturn(false);
-    Mockito.when(EnvironmentUtils.isGoogleComputeEngine()).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEC2()).thenReturn(true);
     Mockito.when(EnvironmentUtils.getEC2ProductCode()).thenReturn("random123code");
-    Mockito.when(EnvironmentUtils.isCFT(Mockito.anyString())).thenReturn(false);
     Mockito.when(EnvironmentUtils.isEMR(Mockito.anyString())).thenReturn(true);
-    PowerMockito.mockStatic(EC2MetadataUtils.class);
     Mockito.when(EC2MetadataUtils.getUserData()).thenReturn("emr_apps");
 
     String userAgentString = UpdateCheck.getUserAgentString("cluster1");


### PR DESCRIPTION
Avoid NPE thrown in UpdateCheckTest by mocking all the methods called.