### PR TITLE
[DOCFIX] Add collectInfo command to doc

### DIFF
--- a/docs/en/operation/Troubleshooting.md
+++ b/docs/en/operation/Troubleshooting.md
@@ -56,6 +56,69 @@ set the debug server's host and port, and start the debug session. If you set a 
 will enter debug mode and you can inspect the current context's variables, call stack, thread list, and expression
 evaluation.
 
+## Alluxio collectInfo command
+
+Alluxio has a `collectInfo` command that collect information to troubleshoot an Alluxio cluster. 
+`collectInfo` will run a set of sub-commands that each collects one aspect of system information, as explained below.
+In the end the collected information will be bundled into one tarball which contains all information regarding your Alluxio cluster.
+The tarball can then be shared with someone you trust to help troubleshoot your Alluxio cluster.
+
+The `collectInfo` will SSH to each node and execute the set of sub-commands.
+In the end of execution the collected information will be written to files and tarballed.
+Each individual tarball will be collected to the issuing node.
+Then all the tarballs will be bundled into the final tarball, which contains all information about the Alluxio cluster. 
+
+>NOTE: Be careful if your configuration contains credentials like AWS keys!
+You should ALWAYS CHECK what is in the tarball and REMOVE the sensitive information from the tarball before sharing it with someone!
+
+### Collect Alluxio cluster information
+`collectAlluxioInfo` will run a set of Alluxio commands that collect information about the Alluxio cluster, like `bin/alluxio fsadmin report` etc.
+When the Alluxio cluster is not running, this command will fail to collect some information.
+
+### Collect Alluxio configuration files
+`collectConfig` will collect all the configuration files under `${alluxio.work.dir}/conf`.
+
+### Collect Alluxio logs
+`collectLog` will collect all the logs under `${alluxio.work.dir}/logs`.
+
+### Collect Alluxio metrics
+`collectMetrics` will collect Alluxio metrics served at `http://${alluxio.master.hostname}:${alluxio.master.web.port}/metrics/json/` by default.
+The metrics will be collected multiple times to see the progress.
+
+### Collect JVM information
+`collectJvmInfo` will collect information about the existing JVMs on each node.
+This is done by running a `jps` command then `jstack` on each found JVM process.
+This will be done multiple times to see if the JVMs are making progress. 
+
+### Collect system information
+`collectEnv` will run a set of bash commands to collect information about the running node.
+This runs system troubleshooting commands like `env`, `hostname`, `top` etc.
+
+### Command options
+
+The `collectInfo` command has the below options.
+
+```console
+$ bin/alluxio collectInfo [--local] [--max-threads threadNum]
+    [all <outputPath>]
+    [collectAlluxioInfo <outputPath>]                         
+    [collectConfig <outputPath>]                              
+    [collectEnv <outputPath>]                                 
+    [collectJvmInfo <outputPath>]                             
+    [collectLogs <outputPath>]                                
+    [collectMetrics <outputPath>]
+```
+
+`<outputPath>` is the directory you want the final tarball to be written into.
+
+Options:
+1. `--local` option specifies the `collectInfo` command to run only on `localhost`.
+That means the command will only collect information about the `localhost`.
+
+1. `--max-threads threadNum` option configures how many threads to use for concurrently collecting information and transmitting tarballs.
+When the cluster has a large number of nodes, or large log files, the network IO for transmitting tarballs can be significant.
+Use this parameter to constrain the resource usage of this command. 
+
 ## Setup FAQ
 
 ### Q: I'm new to Alluxio and cannot set up Alluxio on my local machine. What should I do?

--- a/docs/en/operation/Troubleshooting.md
+++ b/docs/en/operation/Troubleshooting.md
@@ -60,10 +60,13 @@ evaluation.
 
 Alluxio has a `collectInfo` command that collect information to troubleshoot an Alluxio cluster. 
 `collectInfo` will run a set of sub-commands that each collects one aspect of system information, as explained below.
-In the end the collected information will be bundled into one tarball which contains all information regarding your Alluxio cluster.
-The tarball can then be shared with someone you trust to help troubleshoot your Alluxio cluster.
+In the end the collected information will be bundled into one tarball which contains a lot of information regarding your Alluxio cluster.
+The tarball size mostly depends on your cluster size and how much information you are collecting. 
+For example, `collectLog` operation can be costly if you have huge amounts of logs. Other commands 
+typically do not generate files larger than 1MB. The tarball will help you troubleshoot your cluster. 
+Or you can shared the tarball with someone you trust to help troubleshoot your Alluxio cluster.
 
-The `collectInfo` will SSH to each node and execute the set of sub-commands.
+The `collectInfo` command will SSH to each node and execute the set of sub-commands.
 In the end of execution the collected information will be written to files and tarballed.
 Each individual tarball will be collected to the issuing node.
 Then all the tarballs will be bundled into the final tarball, which contains all information about the Alluxio cluster. 
@@ -74,12 +77,17 @@ You should ALWAYS CHECK what is in the tarball and REMOVE the sensitive informat
 ### Collect Alluxio cluster information
 `collectAlluxioInfo` will run a set of Alluxio commands that collect information about the Alluxio cluster, like `bin/alluxio fsadmin report` etc.
 When the Alluxio cluster is not running, this command will fail to collect some information.
+> NOTE: The configuration parameters will be collected with `alluxio getConf --master`, which obfuscates the credential fields passed to 
+Alluxio as properties.
 
 ### Collect Alluxio configuration files
 `collectConfig` will collect all the configuration files under `${alluxio.work.dir}/conf`.
+> WARNING: If you put credential fields in the configuration files, DO NOT share the collected tarball with anybody unless 
+you have manually obfuscated them in the tarball!
 
 ### Collect Alluxio logs
 `collectLog` will collect all the logs under `${alluxio.work.dir}/logs`.
+> NOTE: Roughly estimate how much log you are collecting before executing this command!
 
 ### Collect Alluxio metrics
 `collectMetrics` will collect Alluxio metrics served at `http://${alluxio.master.hostname}:${alluxio.master.web.port}/metrics/json/` by default.
@@ -92,7 +100,12 @@ This will be done multiple times to see if the JVMs are making progress.
 
 ### Collect system information
 `collectEnv` will run a set of bash commands to collect information about the running node.
-This runs system troubleshooting commands like `env`, `hostname`, `top` etc.
+This runs system troubleshooting commands like `env`, `hostname`, `top`, `ps` etc.
+> WARNING: If you stored credential fields in environment variables like AWS_ACCESS_KEY or in process start parameters
+like -Daws.access.key=XXX, DO NOT share the collected tarball with anybody unless you have manually obfuscated them in the tarball!
+
+### Collect all information mentioned above
+`all` will run all the sub-commands above.
 
 ### Command options
 

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -168,8 +168,17 @@ public class CollectInfo extends AbstractShell {
 
     // Validate command args
     if (args.length < 2) {
+<<<<<<< HEAD
       printHelp(String.format("Command requires at least %s arguments (%s provided)%n",
               2, argv.length));
+||||||| merged common ancestors
+      System.out.format("Command %s requires at least %s arguments (%s provided)%n",
+              2, argv.length);
+      shell.printUsage();
+=======
+      printHelp(String.format("Command %s requires at least %s arguments (%s provided)%n",
+              2, argv.length));
+>>>>>>> improve description and log
       System.exit(-1);
     }
 

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -30,6 +30,7 @@ import com.google.common.io.Files;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -129,6 +130,17 @@ public class CollectInfo extends AbstractShell {
   }
 
   /**
+   * Prints the help message.
+   *
+   * @param message message before standard usage information
+   */
+  public static void printHelp(String message) {
+    System.err.println(message);
+    HelpFormatter help = new HelpFormatter();
+    help.printHelp(USAGE, OPTIONS);
+  }
+
+  /**
    * Main method, starts a new CollectInfo shell.
    * CollectInfo will SSH to all hosts and invoke {@link CollectInfo} with --local option.
    * Then collect the tarballs generated on each of the hosts to the localhost.
@@ -156,31 +168,9 @@ public class CollectInfo extends AbstractShell {
 
     // Validate command args
     if (args.length < 2) {
-<<<<<<< HEAD
-<<<<<<< HEAD
       printHelp(String.format("Command requires at least %s arguments (%s provided)%n",
               2, argv.length));
-||||||| merged common ancestors
-      System.out.format("Command %s requires at least %s arguments (%s provided)%n",
-              2, argv.length);
-      shell.printUsage();
-=======
-      printHelp(String.format("Command %s requires at least %s arguments (%s provided)%n",
-              2, argv.length));
->>>>>>> improve description and log
-||||||| merged common ancestors
-      printHelp(String.format("Command %s requires at least %s arguments (%s provided)%n",
-              2, argv.length));
-=======
-      System.out.format("Command %s requires at least %s arguments (%s provided)%n",
-              2, argv.length);
-      shell.printUsage();
->>>>>>> resolve comments
       System.exit(-1);
-    } else if (shell.findCommand(args[0]) == null) {
-      System.out.format("Command %s is not recognized.%n", args[0]);
-      shell.printUsage();
-      System.exit(-2);
     }
 
     // Choose mode based on option
@@ -391,8 +381,7 @@ public class CollectInfo extends AbstractShell {
 
     if (cmd == null) {
       // Unknown command (we did not find the cmd in our dict)
-      System.err.format("%s is an unknown command.%n", subCommand);
-      printUsage();
+      printHelp(String.format("%s is an unknown command.%n", subCommand));
       return 1;
     }
     int ret = run(argv);

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -30,7 +30,6 @@ import com.google.common.io.Files;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -130,17 +129,6 @@ public class CollectInfo extends AbstractShell {
   }
 
   /**
-   * Prints the help message.
-   *
-   * @param message message before standard usage information
-   */
-  public static void printHelp(String message) {
-    System.err.println(message);
-    HelpFormatter help = new HelpFormatter();
-    help.printHelp(USAGE, OPTIONS);
-  }
-
-  /**
    * Main method, starts a new CollectInfo shell.
    * CollectInfo will SSH to all hosts and invoke {@link CollectInfo} with --local option.
    * Then collect the tarballs generated on each of the hosts to the localhost.
@@ -169,6 +157,7 @@ public class CollectInfo extends AbstractShell {
     // Validate command args
     if (args.length < 2) {
 <<<<<<< HEAD
+<<<<<<< HEAD
       printHelp(String.format("Command requires at least %s arguments (%s provided)%n",
               2, argv.length));
 ||||||| merged common ancestors
@@ -179,7 +168,19 @@ public class CollectInfo extends AbstractShell {
       printHelp(String.format("Command %s requires at least %s arguments (%s provided)%n",
               2, argv.length));
 >>>>>>> improve description and log
+||||||| merged common ancestors
+      printHelp(String.format("Command %s requires at least %s arguments (%s provided)%n",
+              2, argv.length));
+=======
+      System.out.format("Command %s requires at least %s arguments (%s provided)%n",
+              2, argv.length);
+      shell.printUsage();
+>>>>>>> resolve comments
       System.exit(-1);
+    } else if (shell.findCommand(args[0]) == null) {
+      System.out.format("Command %s is not recognized.%n", args[0]);
+      shell.printUsage();
+      System.exit(-2);
     }
 
     // Choose mode based on option
@@ -390,7 +391,8 @@ public class CollectInfo extends AbstractShell {
 
     if (cmd == null) {
       // Unknown command (we did not find the cmd in our dict)
-      printHelp(String.format("%s is an unknown command.%n", subCommand));
+      System.err.format("%s is an unknown command.%n", subCommand);
+      printUsage();
       return 1;
     }
     int ret = run(argv);


### PR DESCRIPTION
This adds `collectInfo` command to `Troubleshooting.md`.

The improvements to command printouts are addressed in #11037 