### PR TITLE
Make the addition of client metrics heartbeats asynchronous

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -231,15 +231,6 @@ public class FileSystemContext implements Closeable {
         .setMasterInquireClient(masterInquireClient).build();
     mMetricsEnabled = getClusterConf().getBoolean(PropertyKey.USER_METRICS_COLLECTION_ENABLED);
     if (mMetricsEnabled) {
-      try {
-        InetSocketAddress masterAddr = masterInquireClient.getPrimaryRpcAddress();
-        mMasterClientContext.loadConf(masterAddr, true, true);
-      } catch (UnavailableException e) {
-        LOG.error("Failed to get master address during initialization", e);
-      } catch (AlluxioStatusException ae) {
-        LOG.error("Failed to load configuration from "
-            + "meta master during initialization", ae);
-      }
       MetricsSystem.startSinks(getClusterConf().get(PropertyKey.METRICS_CONF_FILE));
       MetricsHeartbeatContext.addHeartbeat(getClientContext(), masterInquireClient);
     }

--- a/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
@@ -11,9 +11,13 @@
 
 package alluxio.client.metrics;
 
+import alluxio.ClientContext;
 import alluxio.Constants;
-import alluxio.conf.AlluxioConfiguration;
+import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.ClientMetrics;
+import alluxio.master.MasterClientContext;
+import alluxio.master.MasterInquireClient;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.logging.SamplingLogger;
 
@@ -22,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,31 +44,35 @@ public final class ClientMasterSync {
   private static final Logger SAMPLING_LOG =
       new SamplingLogger(LoggerFactory.getLogger(ClientMasterSync.class), 30 * Constants.SECOND_MS);
 
+  private final String mApplicationId;
+  private final MasterInquireClient mInquireClient;
+  private final ClientContext mContext;
+
   /**
    * Client for communicating to metrics master.
    */
-  private final MetricsMasterClient mMasterClient;
-  private final String mApplicationId;
-  private final AlluxioConfiguration mConf;
+  private RetryHandlingMetricsMasterClient mMasterClient;
 
   /**
    * Constructs a new {@link ClientMasterSync}.
    *
    * @param appId the application id to send with metrics
-   * @param masterClient the master client
-   * @param conf Alluxio configuration
+   * @param ctx client context
+   * @param inquireClient the master inquire client
    */
-  public ClientMasterSync(String appId, MetricsMasterClient masterClient,
-      AlluxioConfiguration conf) {
-    mMasterClient = Preconditions.checkNotNull(masterClient, "masterClient");
+  public ClientMasterSync(String appId, ClientContext ctx, MasterInquireClient inquireClient) {
     mApplicationId = Preconditions.checkNotNull(appId);
-    mConf = conf;
+    mInquireClient = inquireClient;
+    mContext = ctx;
   }
 
   /**
    * Sends metrics to the master keyed with appId and client hostname.
    */
   public synchronized void heartbeat() {
+    if (mMasterClient == null) {
+      loadConfAndInitClient();
+    }
     // TODO(zac): Support per FileSystem instance metrics
     // Currently we only support JVM-level metrics. A list is used here because in the near
     // future we will support sending per filesystem client-level metrics.
@@ -84,5 +93,33 @@ public final class ClientMasterSync {
       // WARN instead of ERROR as metrics are not critical to the application function
       SAMPLING_LOG.warn("Failed to send metrics to master: {}", e.toString());
     }
+  }
+
+  /**
+   * Close the metrics master client.
+   */
+  public synchronized void close() {
+    if (mMasterClient != null) {
+      mMasterClient.close();
+    }
+  }
+
+  /**
+   * Loads configuration and initialize metrics master client.
+   */
+  private void loadConfAndInitClient() {
+    try {
+      InetSocketAddress masterAddr = mInquireClient.getPrimaryRpcAddress();
+      mContext.loadConf(masterAddr, true, true);
+    } catch (UnavailableException e) {
+      SAMPLING_LOG.error("Failed to get master address during initialization: {}", e.toString());
+    } catch (AlluxioStatusException ae) {
+      SAMPLING_LOG.error("Failed to load configuration from "
+          + "meta master during initialization: {}", ae.toString());
+    }
+    mMasterClient = new RetryHandlingMetricsMasterClient(MasterClientContext
+        .newBuilder(mContext)
+        .setMasterInquireClient(mInquireClient)
+        .build());
   }
 }


### PR DESCRIPTION
When client metrics is enabled, the master starts up takes four more minutes. The four more minutes are taken by `PollingMasterInquireClient.getPrimaryRpcAddress`  in `FileSystemContext.initContext`. `getPrimaryRpcAddress()` retries 44 times and takes 2 minutes each call which heavily delays the master starts up. The primary rpc address is used for load configuration from the leading master and initialize metrics heartbeat.

This PR put the load configuration logics in the metrics heartbeat thread, so that client metrics logic in FileSystemContext will not block actual operations.