### PR TITLE
Add worker client relogin

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -28,6 +28,7 @@ import alluxio.grpc.RemoveBlockRequest;
 import alluxio.grpc.RemoveBlockResponse;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
+import alluxio.security.user.UserState;
 
 import io.grpc.stub.StreamObserver;
 import io.grpc.StatusRuntimeException;
@@ -35,9 +36,6 @@ import io.netty.channel.EventLoopGroup;
 
 import java.io.Closeable;
 import java.io.IOException;
-
-import javax.annotation.Nullable;
-import javax.security.auth.Subject;
 
 /**
  * gRPC client for worker communication.
@@ -55,10 +53,10 @@ public interface BlockWorkerClient extends Closeable {
      * @param address the address of the worker
      * @return a new {@link BlockWorkerClient}
      */
-    public static BlockWorkerClient create(@Nullable Subject subject, GrpcServerAddress address,
+    public static BlockWorkerClient create(UserState userState, GrpcServerAddress address,
         AlluxioConfiguration alluxioConf, EventLoopGroup workerGroup)
         throws IOException {
-      return new DefaultBlockWorkerClient(subject, address, alluxioConf, workerGroup);
+      return new DefaultBlockWorkerClient(userState, address, alluxioConf, workerGroup);
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -12,6 +12,7 @@
 package alluxio.client.block.stream;
 
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.UnauthenticatedException;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.conf.AlluxioConfiguration;
@@ -38,6 +39,9 @@ import alluxio.grpc.RemoveBlockResponse;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
 import alluxio.grpc.GrpcSerializationUtils;
+import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
+import alluxio.security.user.UserState;
 import alluxio.util.network.NettyUtils;
 
 import com.google.common.base.Preconditions;
@@ -73,24 +77,42 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   /**
    * Creates a client instance for communicating with block worker.
    *
-   * @param subject     the user subject, can be null if the user is not available
+   * @param userState     the user state
    * @param address     the address of the worker
    * @param alluxioConf Alluxio configuration
    * @param workerGroup The netty {@link EventLoopGroup} the channels are will utilize
    */
-  public DefaultBlockWorkerClient(Subject subject, GrpcServerAddress address,
+  public DefaultBlockWorkerClient(UserState userState, GrpcServerAddress address,
       AlluxioConfiguration alluxioConf, EventLoopGroup workerGroup) throws IOException {
-    try {
-      // Disables channel pooling for data streaming to achieve better throughput.
-      // Channel is still reused due to client pooling.
-      mStreamingChannel = buildChannel(subject, address,
-          GrpcChannelKey.PoolingStrategy.DISABLED, alluxioConf, workerGroup);
-      mStreamingChannel.intercept(new StreamSerializationClientInterceptor());
-      // Uses default pooling strategy for RPC calls for better scalability.
-      mRpcChannel = buildChannel(subject, address,
-          GrpcChannelKey.PoolingStrategy.DEFAULT, alluxioConf, workerGroup);
-    } catch (StatusRuntimeException e) {
-      throw AlluxioStatusException.fromStatusRuntimeException(e);
+    RetryPolicy retryPolicy = RetryUtils.defaultClientRetry(
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_MAX_DURATION),
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS),
+        alluxioConf.getDuration(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS));
+    UnauthenticatedException lastException = null;
+    // TODO(feng): unify worker client with AbstractClient
+    while (retryPolicy.attempt()) {
+      try {
+        // Disables channel pooling for data streaming to achieve better throughput.
+        // Channel is still reused due to client pooling.
+        mStreamingChannel = buildChannel(userState.getSubject(), address,
+            GrpcChannelKey.PoolingStrategy.DISABLED, alluxioConf, workerGroup);
+        mStreamingChannel.intercept(new StreamSerializationClientInterceptor());
+        // Uses default pooling strategy for RPC calls for better scalability.
+        mRpcChannel = buildChannel(userState.getSubject(), address,
+            GrpcChannelKey.PoolingStrategy.DEFAULT, alluxioConf, workerGroup);
+        lastException = null;
+        break;
+      } catch (StatusRuntimeException e) {
+        close();
+        throw AlluxioStatusException.fromStatusRuntimeException(e);
+      } catch (UnauthenticatedException e) {
+        close();
+        userState.relogin();
+        lastException = e;
+      }
+    }
+    if (lastException != null) {
+      throw lastException;
     }
     mStreamingAsyncStub = BlockWorkerGrpc.newStub(mStreamingChannel);
     mRpcBlockingStub = BlockWorkerGrpc.newBlockingStub(mRpcChannel);
@@ -112,8 +134,16 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   @Override
   public void close() throws IOException {
     try (Closer closer = Closer.create()) {
-      closer.register(() -> mStreamingChannel.shutdown());
-      closer.register(() -> mRpcChannel.shutdown());
+      closer.register(() -> {
+        if (mStreamingChannel != null) {
+          mStreamingChannel.shutdown();
+        }
+      });
+      closer.register(() -> {
+        if (mRpcChannel != null) {
+          mRpcChannel.shutdown();
+        }
+      });
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -504,7 +504,7 @@ public final class FileSystemContext implements Closeable {
     final ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool> poolMap =
         mBlockWorkerClientPool;
     return new CloseableResource<BlockWorkerClient>(poolMap.computeIfAbsent(key,
-        k -> new BlockWorkerClientPool(context.getSubject(), serverAddress,
+        k -> new BlockWorkerClientPool(context.getUserState(), serverAddress,
             context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_SIZE),
             context.getClusterConf(), mWorkerGroup))
         .acquire()) {


### PR DESCRIPTION
Currently only master client does relogin when needed. There is a slight chance that worker client will run into credential expiration therefore the same relogin logic should be also in the worker client. In the future we should unify the two clients.