### PR TITLE
Fix speedcore sync error behavior on attach

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -135,6 +135,7 @@ public class AlluxioCatalog implements Journaled {
         return status;
       } catch (Exception e) {
         // Failed to connect to and sync the udb.
+        syncError = true;
         throw new IOException(String
             .format("Failed to connect underDb for Alluxio db '%s': %s", dbName,
                 e.getMessage()), e);


### PR DESCRIPTION
This code was not applying detachDatabase when .sync() crashed.

Fixes a regression from: #10897 