### PR TITLE
Process worker metrics asynchronously

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1555,6 +1555,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METRICS_SERVICE_THREADS =
+      new Builder(Name.MASTER_METRICS_SERVICE_THREADS)
+          .setDefaultValue(5)
+          .setDescription("The number of threads in metrics master executor pool "
+              + "for parallel processing metrics submitted by workers or clients "
+              + "and update cluster metrics.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METRICS_TIME_SERIES_INTERVAL =
       new Builder(Name.MASTER_METRICS_TIME_SERIES_INTERVAL)
           .setDefaultValue("5min")
@@ -4363,6 +4372,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.inode.inherit.owner.and.group";
     public static final String MASTER_PERSISTENCE_CHECKER_INTERVAL_MS =
         "alluxio.master.persistence.checker.interval";
+    public static final String MASTER_METRICS_SERVICE_THREADS =
+        "alluxio.master.metrics.service.threads";
     public static final String MASTER_METRICS_TIME_SERIES_INTERVAL =
         "alluxio.master.metrics.time.series.interval";
     public static final String MASTER_PERSISTENCE_INITIAL_INTERVAL_MS =

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -63,7 +63,8 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
    */
   DefaultMetricsMaster(CoreMasterContext masterContext) {
     this(masterContext, new SystemClock(),
-        ExecutorServiceFactories.cachedThreadPool(Constants.METRICS_MASTER_NAME));
+        ExecutorServiceFactories.fixedThreadPool(Constants.METRICS_MASTER_NAME,
+            ServerConfiguration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS)));
   }
 
   /**
@@ -176,7 +177,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
 
   @Override
   public void clientHeartbeat(String source, List<Metric> metrics) {
-    mMetricsStore.putClientMetrics(source, metrics);
+    getExecutorService().submit(() -> mMetricsStore.putClientMetrics(source, metrics));
   }
 
   @Override
@@ -186,7 +187,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
 
   @Override
   public void workerHeartbeat(String source, List<Metric> metrics) {
-    mMetricsStore.putWorkerMetrics(source, metrics);
+    getExecutorService().submit(() -> mMetricsStore.putWorkerMetrics(source, metrics));
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/10470
Previously we process worker metrics synchronously in the
MasterWorkerInfo lock and also the WorkerMetrics lock. This will
(1) Make each worker heartbeat takes longer. Worker heartbeat need to
wait for the submitted metrics to be processed.
(2) Make worker heartbeats block each other. We can only process one
worker metrics at a time.

Process worker metrics asynchronously will help unblock worker
heartbeats.

pr-link: Alluxio/alluxio#10485
change-id: cid-5f0e458dde3273c716477df5cc2bbef750542703