### PR TITLE
Fix coalesce max files behavior

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -96,14 +96,15 @@ public final class CompactDefinition
     Map<WorkerInfo, ArrayList<CompactTask>> assignments = Maps.newHashMap();
     int maxNumFiles = config.getMaxNumFiles();
     long groupMinSize = config.getMinFileSize();
-    if (totalFileSize / groupMinSize > maxNumFiles) {
-      groupMinSize = Math.round(totalFileSize / maxNumFiles);
-    }
 
     if (!files.isEmpty() && config.getPartitionInfo() != null) {
       // adjust the group minimum size for source compression ratio
       groupMinSize *= COMPRESSION_RATIO.get(
           config.getPartitionInfo().getFormat(files.get(0).getName()));
+    }
+
+    if (totalFileSize / groupMinSize > maxNumFiles) {
+      groupMinSize = Math.round(totalFileSize / maxNumFiles);
     }
 
     // Files to be compacted are grouped into different groups,

--- a/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
@@ -12,6 +12,8 @@
 package alluxio.job.plan.transform;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
@@ -45,7 +47,10 @@ public class CompactDefinitionSelectExecutorsTest extends SelectExecutorsTest {
     int numCompactedFiles = 100;
     int totalFiles = 5000;
 
-    CompactConfig config = new CompactConfig(null, INPUT_DIR, OUTPUT_DIR, "test",
+    PartitionInfo mockPartitionInfo = mock(PartitionInfo.class);
+    when(mockPartitionInfo.getFormat(any())).thenReturn(Format.CSV);
+
+    CompactConfig config = new CompactConfig(mockPartitionInfo, INPUT_DIR, OUTPUT_DIR, "test",
         numCompactedFiles, 2 * FileUtils.ONE_GB);
 
     List<URIStatus> inputFiles = new ArrayList<>();


### PR DESCRIPTION
The compression ratio for the compact job was not applied correctly, resulting in unexpected file sizes.