### PR TITLE
Fix K8s format journal in HA mode

### DIFF
--- a/integration/kubernetes/alluxio-fuse-client.yaml.template
+++ b/integration/kubernetes/alluxio-fuse-client.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-fuse-client
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse-client
@@ -25,7 +25,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.3
+      chart: alluxio-0.5.4
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse-client
@@ -33,7 +33,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse-client

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-fuse
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse
@@ -26,7 +26,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.3
+      chart: alluxio-0.5.4
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -43,3 +43,8 @@
 - Changed values.yaml structure for ports and update configmap
 - Define alluxio.master.hostname individually for each Pod in env variable, and update configmap
 - Moved a few duplicated blocks into _helpers.tpl
+
+0.5.4
+
+- Updated the journal formatting Job logic
+- Misc formatting and parameters updates

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.5.3
+version: 0.5.4
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -119,6 +119,28 @@ resources:
     {{- end }}
 {{- end -}}
 
+{{- define "alluxio.journal.format.resources" -}}
+resources:
+  limits:
+    {{- if .Values.journal.format.resources.limits }}
+      {{- if .Values.journal.format.resources.limits.cpu  }}
+    cpu: {{ .Values.journal.format.resources.limits.cpu }}
+      {{- end }}
+      {{- if .Values.journal.format.resources.limits.memory  }}
+    memory: {{ .Values.journal.format.resources.limits.memory }}
+      {{- end }}
+    {{- end }}
+  requests:
+    {{- if .Values.journal.format.resources.requests }}
+      {{- if .Values.journal.format.resources.requests.cpu  }}
+    cpu: {{ .Values.journal.format.resources.requests.cpu }}
+      {{- end }}
+      {{- if .Values.journal.format.resources.requests.memory  }}
+    memory: {{ .Values.journal.format.resources.requests.memory }}
+      {{- end }}
+    {{- end }}
+{{- end -}}
+
 {{- define "alluxio.master.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.master }}
             - name: secret-{{ $key }}-volume

--- a/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
@@ -20,6 +20,7 @@
 {{- $release := .Release }}
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
+{{- $chart := include "alluxio.chart" . }}
 {{- range $i := until $masterCount }}
 apiVersion: batch/v1
 kind: Job
@@ -28,7 +29,7 @@ metadata:
   labels:
     name: {{ $fullName }}-format-master-{{ $i }}
     app: {{ $name }}
-    chart: {{ $name }}
+    chart: {{ $chart }}
     release: {{ $release.Name }}
     heritage: {{ $release.Service }}
     role: alluxio-master
@@ -44,8 +45,8 @@ spec:
           securityContext:
             runAsUser: {{ $root.Values.user }}
             runAsGroup: {{ $root.Values.group }}
-          {{- if $root.Values.master.resources  }}
-{{ include "alluxio.master.resources" $root | indent 10 }}
+          {{- if $root.Values.journal.format.resources }}
+{{ include "alluxio.journal.format.resources" $root | indent 10 }}
           {{- end }}
           command: ["/opt/alluxio/bin/alluxio"]
           args: ["formatJournal"]
@@ -59,34 +60,39 @@ spec:
           {{- end }}
           volumeMounts:
           {{- if $needJournalVolume }}
-          - name: alluxio-journal
-            mountPath: {{ $root.Values.journal.folder }}
+            - name: alluxio-journal
+              mountPath: {{ $root.Values.journal.folder }}
           {{- end }}
           {{- if $root.Values.secrets }}
             {{- if $root.Values.secrets.master }}
               {{- range $key, $val := $root.Values.secrets.master }}
-          - name: secret-{{ $key }}-volume
-            mountPath: /secrets/{{ $val }}
-            readOnly: true
+            - name: secret-{{ $key }}-volume
+              mountPath: /secrets/{{ $val }}
+              readOnly: true
               {{- end }}
             {{- end }}
           {{- end }}
           {{- if $root.Values.mounts }}
             {{- range $root.Values.mounts }}
-          - name: "{{ .name }}"
-            mountPath: "{{ .path }}"
+            - name: "{{ .name }}"
+              mountPath: "{{ .path }}"
             {{- end }}
           {{- end }}
-      restartPolicy: OnFailure
+      restartPolicy: Never
       volumes:
       {{- if $needJournalVolume }}
-      - name: alluxio-journal
-        persistentVolumeClaim:
-          claimName: {{ printf "alluxio-journal-%v-master-%v" $fullName $i }}
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: {{ printf "alluxio-journal-%v-master-%v" $fullName $i }}
       {{- end}}
       {{- if $root.Values.secrets }}
         {{- if $root.Values.secrets.master }}
-        {{- include "alluxio.master.secretVolumeMounts" $root }}
+          {{- range $key, $val := $root.Values.secrets.master }}
+        - name: secret-{{ $key }}-volume
+          secret:
+            secretName: {{ $key }}
+            defaultMode: 256
+          {{- end }}
         {{- end }}
       {{- end }}
 ---

--- a/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
@@ -9,6 +9,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+{{ $root := . -}}
 {{- $masterCount := int .Values.master.count }}
 {{- $isSingleMaster := eq $masterCount 1 }}
 {{- $isEmbedded := (eq .Values.journal.type "EMBEDDED") }}
@@ -17,89 +18,76 @@
 {{- $isSingleUfsLocal := and $isUfsLocal $isSingleMaster }}
 {{- $needJournalVolume := or $isEmbedded $isUfsLocal }}
 {{- $release := .Release }}
+{{- $name := include "alluxio.name" . }}
+{{- $fullName := include "alluxio.fullname" . }}
+{{- range $i := until $masterCount }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "alluxio.fullname" . }}-format-master
+  name: {{ $fullName }}-format-master-{{ $i }}
   labels:
-    name: {{ template "alluxio.fullname" . }}-format-master
-    app: {{ template "alluxio.name" . }}
-    chart: {{ template "alluxio.chart" . }}
+    name: {{ $fullName }}-format-master-{{ $i }}
+    app: {{ $name }}
+    chart: {{ $name }}
     release: {{ $release.Name }}
     heritage: {{ $release.Service }}
     role: alluxio-master
 spec:
-  activeDeadlineSeconds: {{ .Values.journal.format.job.activeDeadlineSeconds }}
-  ttlSecondsAfterFinished: {{ .Values.journal.format.job.ttlSecondsAfterFinished }}
+  activeDeadlineSeconds: {{ $root.Values.journal.format.job.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ $root.Values.journal.format.job.ttlSecondsAfterFinished }}
   template:
     spec:
       containers:
         - name: alluxio-master
-          image: {{ .Values.image }}:{{ .Values.imageTag }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- if .Values.master.resources  }}
-          resources:
-            {{- if .Values.master.resources.limits }}
-            limits:
-              cpu: {{ .Values.master.resources.limits.cpu }}
-              memory: {{ .Values.master.resources.limits.memory }}
-            {{- end }}
-            {{- if .Values.master.resources.requests }}
-            requests:
-              cpu: {{ .Values.master.resources.requests.cpu }}
-              memory: {{ .Values.master.resources.requests.memory }}
-            {{- end }}
+          image: {{ $root.Values.image }}:{{ $root.Values.imageTag }}
+          imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+          securityContext:
+            runAsUser: {{ $root.Values.user }}
+            runAsGroup: {{ $root.Values.group }}
+          {{- if $root.Values.master.resources  }}
+{{ include "alluxio.master.resources" $root | indent 10 }}
           {{- end }}
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["formatMasters"]
+          args: ["formatJournal"]
           envFrom:
             - configMapRef:
-                name: {{ template "alluxio.fullname" . }}-config
+                name: {{ $fullName }}-config
+          {{- if $isHaEmbedded }}
+          env:
+            - name: ALLUXIO_MASTER_HOSTNAME
+              value: {{ printf "%v-master-%v" $fullName $i }}
+          {{- end }}
           volumeMounts:
           {{- if $needJournalVolume }}
           - name: alluxio-journal
-            mountPath: {{ .Values.journal.folder }}
+            mountPath: {{ $root.Values.journal.folder }}
           {{- end }}
-          {{- if .Values.secrets }}
-            {{- if .Values.secrets.master }}
-              {{- range $key, $val := .Values.secrets.master }}
+          {{- if $root.Values.secrets }}
+            {{- if $root.Values.secrets.master }}
+              {{- range $key, $val := $root.Values.secrets.master }}
           - name: secret-{{ $key }}-volume
             mountPath: /secrets/{{ $val }}
             readOnly: true
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- if .Values.mounts }}
-            {{- range .Values.mounts }}
+          {{- if $root.Values.mounts }}
+            {{- range $root.Values.mounts }}
           - name: "{{ .name }}"
             mountPath: "{{ .path }}"
             {{- end }}
           {{- end }}
       restartPolicy: OnFailure
       volumes:
-      {{- if $isSingleUfsLocal }}
+      {{- if $needJournalVolume }}
       - name: alluxio-journal
         persistentVolumeClaim:
-          claimName: alluxio-pv-claim
-      {{- end }}
-      {{- if $isHaEmbedded }}
-      - name: alluxio-journal
-        emptyDir: {}
+          claimName: {{ printf "alluxio-journal-%v-master-%v" $fullName $i }}
       {{- end}}
-      {{- if .Values.secrets }}
-        {{- if .Values.secrets.master }}
-          {{- range $key, $val := .Values.secrets.master }}
-      - name: secret-{{ $key }}-volume
-        secret:
-          secretName: {{ $key }}
-          defaultMode: 256
-          {{- end }}
+      {{- if $root.Values.secrets }}
+        {{- if $root.Values.secrets.master }}
+        {{- include "alluxio.master.secretVolumeMounts" $root }}
         {{- end }}
       {{- end }}
-      {{- if .Values.mounts }}
-        {{- range .Values.mounts }}
-      - name: "{{ .name }}"
-        persistentVolumeClaim:
-          claimName: "{{ .name }}"
-        {{- end }}
-      {{- end }}
+---
+{{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -202,7 +202,8 @@ spec:
         name: alluxio-journal
       spec:
         storageClassName: {{ .Values.journal.storageClass }}
-        accessModes: {{ .Values.journal.accessModes }}
+        accessModes:
+{{ toYaml .Values.journal.accessModes | indent 8 -}}
         resources:
           requests:
             storage: {{ .Values.journal.size }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -201,9 +201,8 @@ spec:
     - metadata:
         name: alluxio-journal
       spec:
-        storageClassName: standard
-        accessModes:
-          - ReadWriteMany
+        storageClassName: {{ .Values.journal.storageClass }}
+        accessModes: {{ .Values.journal.accessModes }}
         resources:
           requests:
             storage: {{ .Values.journal.size }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -203,7 +203,7 @@ spec:
       spec:
         storageClassName: standard
         accessModes:
-          - ReadWriteOnce
+          - ReadWriteMany
         resources:
           requests:
             storage: {{ .Values.journal.size }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -108,7 +108,8 @@ jobMaster:
 journal:
   storageClass: "standard"
   size: 1Gi
-  accessModes: ["ReadWriteMany"] # Use ReadWriteMany as the format job will access it
+  accessModes:
+    - ReadWriteMany # Use ReadWriteMany as the format job will access it
   type: "UFS" # "UFS" or "EMBEDDED"
   ufsType: "local" # Ignored if type is "EMBEDDED". "local" or "HDFS"
   folder: "/journal" # Master journal folder

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -106,9 +106,9 @@ jobMaster:
 #   type: "EMBEDDED"
 #   folder: "/journal"
 journal:
-  pvcName: alluxio-pv-claim
   storageClass: "standard"
   size: 1Gi
+  accessModes: ["ReadWriteMany"] # Use ReadWriteMany as the format job will access it
   type: "UFS" # "UFS" or "EMBEDDED"
   ufsType: "local" # Ignored if type is "EMBEDDED". "local" or "HDFS"
   folder: "/journal" # Master journal folder
@@ -117,6 +117,13 @@ journal:
     job:
       activeDeadlineSeconds: 30
       ttlSecondsAfterFinished: 10
+    resources:
+      limits:
+        cpu: "1"
+        memory: "1G"
+      requests:
+        cpu: "1"
+        memory: "1G"
 
 
 ## Worker ##

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -109,7 +109,7 @@ journal:
   storageClass: "standard"
   size: 1Gi
   accessModes:
-    - ReadWriteMany # Use ReadWriteMany as the format job will access it
+    - ReadWriteOnce
   type: "UFS" # "UFS" or "EMBEDDED"
   ufsType: "local" # Ignored if type is "EMBEDDED". "local" or "HDFS"
   folder: "/journal" # Master journal folder

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio
+    chart: alluxio-0.5.3
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -51,13 +51,13 @@ spec:
             - name: ALLUXIO_MASTER_HOSTNAME
               value: alluxio-master-0
           volumeMounts:
-          - name: alluxio-journal
-            mountPath: /journal
-      restartPolicy: OnFailure
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: Never
       volumes:
-      - name: alluxio-journal
-        persistentVolumeClaim:
-          claimName: alluxio-journal-alluxio-master-0
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-journal-alluxio-master-0
 ---
 apiVersion: batch/v1
 kind: Job
@@ -66,7 +66,7 @@ metadata:
   labels:
     name: alluxio-format-master-1
     app: alluxio
-    chart: alluxio
+    chart: alluxio-0.5.3
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -98,13 +98,13 @@ spec:
             - name: ALLUXIO_MASTER_HOSTNAME
               value: alluxio-master-1
           volumeMounts:
-          - name: alluxio-journal
-            mountPath: /journal
-      restartPolicy: OnFailure
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: Never
       volumes:
-      - name: alluxio-journal
-        persistentVolumeClaim:
-          claimName: alluxio-journal-alluxio-master-1
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-journal-alluxio-master-1
 ---
 apiVersion: batch/v1
 kind: Job
@@ -113,7 +113,7 @@ metadata:
   labels:
     name: alluxio-format-master-2
     app: alluxio
-    chart: alluxio
+    chart: alluxio-0.5.3
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -145,12 +145,12 @@ spec:
             - name: ALLUXIO_MASTER_HOSTNAME
               value: alluxio-master-2
           volumeMounts:
-          - name: alluxio-journal
-            mountPath: /journal
-      restartPolicy: OnFailure
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: Never
       volumes:
-      - name: alluxio-journal
-        persistentVolumeClaim:
-          claimName: alluxio-journal-alluxio-master-2
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-journal-alluxio-master-2
 ---
 

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -66,7 +66,7 @@ metadata:
   labels:
     name: alluxio-format-master-1
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -113,7 +113,7 @@ metadata:
   labels:
     name: alluxio-format-master-2
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -10,14 +10,16 @@
 #
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
+
+
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: alluxio-format-master
+  name: alluxio-format-master-0
   labels:
-    name: alluxio-format-master
+    name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -30,6 +32,9 @@ spec:
         - name: alluxio-master
           image: alluxio/alluxio:2.2.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -38,15 +43,114 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["formatMasters"]
+          args: ["formatJournal"]
           envFrom:
             - configMapRef:
                 name: alluxio-config
+          env:
+            - name: ALLUXIO_MASTER_HOSTNAME
+              value: alluxio-master-0
           volumeMounts:
           - name: alluxio-journal
             mountPath: /journal
       restartPolicy: OnFailure
       volumes:
       - name: alluxio-journal
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: alluxio-journal-alluxio-master-0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master-1
+  labels:
+    name: alluxio-format-master-1
+    app: alluxio
+    chart: alluxio
+    release: alluxio
+    heritage: Tiller
+    role: alluxio-master
+spec:
+  activeDeadlineSeconds: 30
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.2.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["formatJournal"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          env:
+            - name: ALLUXIO_MASTER_HOSTNAME
+              value: alluxio-master-1
+          volumeMounts:
+          - name: alluxio-journal
+            mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+      - name: alluxio-journal
+        persistentVolumeClaim:
+          claimName: alluxio-journal-alluxio-master-1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alluxio-format-master-2
+  labels:
+    name: alluxio-format-master-2
+    app: alluxio
+    chart: alluxio
+    release: alluxio
+    heritage: Tiller
+    role: alluxio-master
+spec:
+  activeDeadlineSeconds: 30
+  ttlSecondsAfterFinished: 10
+  template:
+    spec:
+      containers:
+        - name: alluxio-master
+          image: alluxio/alluxio:2.2.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+            limits:
+              cpu: 1
+              memory: 1G
+            requests:
+              cpu: 1
+              memory: 1G
+          command: ["/opt/alluxio/bin/alluxio"]
+          args: ["formatJournal"]
+          envFrom:
+            - configMapRef:
+                name: alluxio-config
+          env:
+            - name: ALLUXIO_MASTER_HOSTNAME
+              value: alluxio-master-2
+          volumeMounts:
+          - name: alluxio-journal
+            mountPath: /journal
+      restartPolicy: OnFailure
+      volumes:
+      - name: alluxio-journal
+        persistentVolumeClaim:
+          claimName: alluxio-journal-alluxio-master-2
+---
 

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -49,7 +49,7 @@ metadata:
   name: alluxio-master-1
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -80,7 +80,7 @@ metadata:
   name: alluxio-master-2
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -130,8 +130,7 @@ spec:
         name: alluxio-journal
       spec:
         storageClassName: standard
-        accessModes:
-          - ReadWriteMany
+        accessModes: [ReadWriteMany]
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -130,7 +130,8 @@ spec:
         name: alluxio-journal
       spec:
         storageClassName: standard
-        accessModes: [ReadWriteMany]
+        accessModes:
+        - ReadWriteMany
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -131,7 +131,7 @@ spec:
       spec:
         storageClassName: standard
         accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -131,7 +131,7 @@ spec:
       spec:
         storageClassName: standard
         accessModes:
-          - ReadWriteOnce
+          - ReadWriteMany
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio
+    chart: alluxio-0.5.3
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -48,13 +48,14 @@ spec:
             - configMapRef:
                 name: alluxio-config
           volumeMounts:
-          - name: secret-alluxio-hdfs-config-volume
-            mountPath: /secrets/hdfsConfig
-            readOnly: true
-      restartPolicy: OnFailure
-      volumes:
             - name: secret-alluxio-hdfs-config-volume
               mountPath: /secrets/hdfsConfig
               readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: secret-alluxio-hdfs-config-volume
+          secret:
+            secretName: alluxio-hdfs-config
+            defaultMode: 256
 ---
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -10,14 +10,16 @@
 #
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
+
+
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: alluxio-format-master
+  name: alluxio-format-master-0
   labels:
-    name: alluxio-format-master
+    name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -30,6 +32,9 @@ spec:
         - name: alluxio-master
           image: alluxio/alluxio:2.2.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -38,7 +43,7 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["formatMasters"]
+          args: ["formatJournal"]
           envFrom:
             - configMapRef:
                 name: alluxio-config
@@ -48,8 +53,8 @@ spec:
             readOnly: true
       restartPolicy: OnFailure
       volumes:
-      - name: secret-alluxio-hdfs-config-volume
-        secret:
-          secretName: alluxio-hdfs-config
-          defaultMode: 256
+            - name: secret-alluxio-hdfs-config-volume
+              mountPath: /secrets/hdfsConfig
+              readOnly: true
+---
 

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -10,14 +10,16 @@
 #
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
+
+
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: alluxio-format-master
+  name: alluxio-format-master-0
   labels:
-    name: alluxio-format-master
+    name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -30,6 +32,9 @@ spec:
         - name: alluxio-master
           image: alluxio/alluxio:2.2.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           resources:
             limits:
               cpu: 1
@@ -38,7 +43,7 @@ spec:
               cpu: 1
               memory: 1G
           command: ["/opt/alluxio/bin/alluxio"]
-          args: ["formatMasters"]
+          args: ["formatJournal"]
           envFrom:
             - configMapRef:
                 name: alluxio-config
@@ -49,5 +54,6 @@ spec:
       volumes:
       - name: alluxio-journal
         persistentVolumeClaim:
-          claimName: alluxio-pv-claim
+          claimName: alluxio-journal-alluxio-master-0
+---
 

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio
+    chart: alluxio-0.5.3
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -48,12 +48,12 @@ spec:
             - configMapRef:
                 name: alluxio-config
           volumeMounts:
-          - name: alluxio-journal
-            mountPath: /journal
-      restartPolicy: OnFailure
+            - name: alluxio-journal
+              mountPath: /journal
+      restartPolicy: Never
       volumes:
-      - name: alluxio-journal
-        persistentVolumeClaim:
-          claimName: alluxio-journal-alluxio-master-0
+        - name: alluxio-journal
+          persistentVolumeClaim:
+            claimName: alluxio-journal-alluxio-master-0
 ---
 

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -116,7 +116,8 @@ spec:
         name: alluxio-journal
       spec:
         storageClassName: standard
-        accessModes: [ReadWriteMany]
+        accessModes:
+        - ReadWriteMany
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -117,7 +117,7 @@ spec:
       spec:
         storageClassName: standard
         accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -117,7 +117,7 @@ spec:
       spec:
         storageClassName: standard
         accessModes:
-          - ReadWriteOnce
+          - ReadWriteMany
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -116,8 +116,7 @@ spec:
         name: alluxio-journal
       spec:
         storageClassName: standard
-        accessModes:
-          - ReadWriteMany
+        accessModes: [ReadWriteMany]
         resources:
           requests:
             storage: 1Gi

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.3
+    chart: alluxio-0.5.4
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.3
+        chart: alluxio-0.5.4
         release: alluxio
         heritage: Tiller
         role: alluxio-worker


### PR DESCRIPTION
After PR #10686 we use PVs for master journals created by `volumeClaimTemplates`. This changed how we should format journals. Now each master has its own journal PV.
https://github.com/Alluxio/alluxio/pull/10686

In Alluxio docker image there's no SSH capability (https://github.com/Alluxio/alluxio/issues/10945), so commands like `alluxio formatMasters` cannot work. We need to invoke `formatJournal` directly on each master.

Previously we use a Job to invoke `formatMasters` when there's only master (in HA mode the journal volumes are emptyDir), now we need multiple Jobs to each handle one master in HA mode.