### PR TITLE
Enable location fallback by default

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -533,9 +533,8 @@ public class AbstractFileSystemTest {
     List<String> ufsLocations = Arrays.asList("worker0", "worker3");
     List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
 
-    List<WorkerNetAddress> expectedWorkers = Collections.EMPTY_LIST;
-
-    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+    // When no matching, all workers will be returned
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, allWorkers);
   }
 
   @Test
@@ -564,9 +563,8 @@ public class AbstractFileSystemTest {
     List<String> ufsLocations = Arrays.asList();
     List<WorkerNetAddress> allWorkers = Arrays.asList(worker1, worker2);
 
-    List<WorkerNetAddress> expectedWorkers = Collections.EMPTY_LIST;
-
-    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, expectedWorkers);
+    // When no matching & no ufs locations, all workers will be returned
+    verifyBlockLocations(blockWorkers, ufsLocations, allWorkers, allWorkers);
   }
 
   @Test

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3480,7 +3480,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_UFS_BLOCK_LOCATION_ALL_FALLBACK_ENABLED =
       new Builder(Name.USER_UFS_BLOCK_LOCATION_ALL_FALLBACK_ENABLED)
-          .setDefaultValue(false)
+          .setDefaultValue(true)
           .setDescription("Whether to return all workers as block location if ufs block locations "
               + "are not co-located with any Alluxio workers or is empty.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)


### PR DESCRIPTION
Some applications (e.g. Presto) require the block locations not empty otherwise the jobs will fail. When the path doesn't have alluxio locations or ufs locations, always return the full worker locations.

