### PR TITLE
Reduce getWorkerInfoList RPCs on client and job servers

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -155,14 +155,14 @@ public final class AlluxioBlockStore {
     // Note that, it is possible that the blocks have been written as UFS blocks
     if (options.getStatus().isPersisted()
         || options.getStatus().getPersistenceState().equals("TO_BE_PERSISTED")) {
-      blockWorkerInfo = mContext.getEligibleWorkers();
+      blockWorkerInfo = mContext.getCachedWorkers();
       if (blockWorkerInfo.isEmpty()) {
         throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
       }
       workerPool = blockWorkerInfo.stream().map(BlockWorkerInfo::getNetAddress).collect(toSet());
     } else {
       if (locations.isEmpty()) {
-        blockWorkerInfo = mContext.getEligibleWorkers();
+        blockWorkerInfo = mContext.getCachedWorkers();
         if (blockWorkerInfo.isEmpty()) {
           throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
         }
@@ -285,7 +285,7 @@ public final class AlluxioBlockStore {
         PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED);
     GetWorkerOptions workerOptions = GetWorkerOptions.defaults()
         .setBlockInfo(new BlockInfo().setBlockId(blockId).setLength(blockSize))
-        .setBlockWorkerInfos(new ArrayList<>(mContext.getEligibleWorkers()));
+        .setBlockWorkerInfos(new ArrayList<>(mContext.getCachedWorkers()));
 
     // The number of initial copies depends on the write type: if ASYNC_THROUGH, it is the property
     // "alluxio.user.file.replication.durable" before data has been persisted; otherwise
@@ -296,7 +296,7 @@ public final class AlluxioBlockStore {
     if (initialReplicas <= 1) {
       address = locationPolicy.getWorker(workerOptions);
       if (address == null) {
-        if (mContext.getEligibleWorkers().isEmpty()) {
+        if (mContext.getCachedWorkers().isEmpty()) {
           throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
         }
         throw new UnavailableException(

--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -25,14 +25,11 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.collections.Pair;
-import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.network.TieredIdentityFactory;
-import alluxio.refresh.RefreshPolicy;
-import alluxio.refresh.TimeoutRefresh;
 import alluxio.resource.CloseableResource;
 import alluxio.util.FormatUtils;
 import alluxio.wire.BlockInfo;
@@ -69,11 +66,6 @@ public final class AlluxioBlockStore {
   private final FileSystemContext mContext;
   private final TieredIdentity mTieredIdentity;
 
-  /** Cached map for workers. */
-  private List<BlockWorkerInfo> mWorkerInfoList = null;
-  /** The policy to refresh workers list. */
-  private final RefreshPolicy mWorkerRefreshPolicy;
-
   /**
    * Creates an Alluxio block store with default local hostname.
    *
@@ -95,9 +87,6 @@ public final class AlluxioBlockStore {
   AlluxioBlockStore(FileSystemContext context, TieredIdentity tieredIdentity) {
     mContext = context;
     mTieredIdentity = tieredIdentity;
-    mWorkerRefreshPolicy =
-        new TimeoutRefresh(mContext.getClusterConf()
-            .getMs(PropertyKey.USER_WORKER_LIST_REFRESH_INTERVAL));
   }
 
   /**
@@ -110,28 +99,6 @@ public final class AlluxioBlockStore {
     try (CloseableResource<BlockMasterClient> masterClientResource =
         mContext.acquireBlockMasterClientResource()) {
       return masterClientResource.get().getBlockInfo(blockId);
-    }
-  }
-
-  /**
-   * @return the info of all block workers eligible for reads and writes
-   */
-  public synchronized List<BlockWorkerInfo> getEligibleWorkers() throws IOException {
-    if (mWorkerInfoList == null || mWorkerRefreshPolicy.attempt()) {
-      mWorkerInfoList = getAllWorkers();
-    }
-    return mWorkerInfoList;
-  }
-
-  /**
-   * @return the info of all block workers
-   */
-  public List<BlockWorkerInfo> getAllWorkers() throws IOException {
-    try (CloseableResource<BlockMasterClient> masterClientResource =
-        mContext.acquireBlockMasterClientResource()) {
-      return masterClientResource.get().getWorkerInfoList().stream()
-          .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes()))
-          .collect(toList());
     }
   }
 
@@ -188,14 +155,14 @@ public final class AlluxioBlockStore {
     // Note that, it is possible that the blocks have been written as UFS blocks
     if (options.getStatus().isPersisted()
         || options.getStatus().getPersistenceState().equals("TO_BE_PERSISTED")) {
-      blockWorkerInfo = getEligibleWorkers();
+      blockWorkerInfo = mContext.getEligibleWorkers();
       if (blockWorkerInfo.isEmpty()) {
         throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
       }
       workerPool = blockWorkerInfo.stream().map(BlockWorkerInfo::getNetAddress).collect(toSet());
     } else {
       if (locations.isEmpty()) {
-        blockWorkerInfo = getEligibleWorkers();
+        blockWorkerInfo = mContext.getEligibleWorkers();
         if (blockWorkerInfo.isEmpty()) {
           throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
         }
@@ -318,7 +285,7 @@ public final class AlluxioBlockStore {
         PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED);
     GetWorkerOptions workerOptions = GetWorkerOptions.defaults()
         .setBlockInfo(new BlockInfo().setBlockId(blockId).setLength(blockSize))
-        .setBlockWorkerInfos(new ArrayList<>(getEligibleWorkers()));
+        .setBlockWorkerInfos(new ArrayList<>(mContext.getEligibleWorkers()));
 
     // The number of initial copies depends on the write type: if ASYNC_THROUGH, it is the property
     // "alluxio.user.file.replication.durable" before data has been persisted; otherwise
@@ -329,7 +296,7 @@ public final class AlluxioBlockStore {
     if (initialReplicas <= 1) {
       address = locationPolicy.getWorker(workerOptions);
       if (address == null) {
-        if (getEligibleWorkers().isEmpty()) {
+        if (mContext.getEligibleWorkers().isEmpty()) {
           throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
         }
         throw new UnavailableException(

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -107,7 +107,7 @@ public class AlluxioFileOutStream extends FileOutStream {
         mUnderStorageOutputStream = null;
       } else { // Write is through to the under storage, create mUnderStorageOutputStream.
         GetWorkerOptions getWorkerOptions = GetWorkerOptions.defaults()
-            .setBlockWorkerInfos(mBlockStore.getEligibleWorkers())
+            .setBlockWorkerInfos(mContext.getEligibleWorkers())
             .setBlockInfo(new BlockInfo()
                 .setBlockId(-1)
                 .setLength(0)); // not storing data to Alluxio, so block size is 0

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -107,7 +107,7 @@ public class AlluxioFileOutStream extends FileOutStream {
         mUnderStorageOutputStream = null;
       } else { // Write is through to the under storage, create mUnderStorageOutputStream.
         GetWorkerOptions getWorkerOptions = GetWorkerOptions.defaults()
-            .setBlockWorkerInfos(mContext.getEligibleWorkers())
+            .setBlockWorkerInfos(mContext.getCachedWorkers())
             .setBlockInfo(new BlockInfo()
                 .setBlockId(-1)
                 .setLength(0)); // not storing data to Alluxio, so block size is 0

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -240,7 +240,7 @@ public class BaseFileSystem implements FileSystem {
   }
 
   private Map<String, WorkerNetAddress> getHostWorkerMap() throws IOException {
-    List<BlockWorkerInfo> workers = mFsContext.getEligibleWorkers();
+    List<BlockWorkerInfo> workers = mFsContext.getCachedWorkers();
     return workers.stream().collect(
         toMap(worker -> worker.getNetAddress().getHost(), BlockWorkerInfo::getNetAddress,
             (worker1, worker2) -> worker1));

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -240,7 +240,7 @@ public class BaseFileSystem implements FileSystem {
   }
 
   private Map<String, WorkerNetAddress> getHostWorkerMap() throws IOException {
-    List<BlockWorkerInfo> workers = mBlockStore.getEligibleWorkers();
+    List<BlockWorkerInfo> workers = mFsContext.getEligibleWorkers();
     return workers.stream().collect(
         toMap(worker -> worker.getNetAddress().getHost(), BlockWorkerInfo::getNetAddress,
             (worker1, worker2) -> worker1));

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -579,6 +579,11 @@ public class FileSystemContext implements Closeable {
   }
 
   /**
+   * Gets the cached worker information list.
+   * This method is relatively cheap as the result is cached, but may not
+   * be update to date. If up-to-date worker info list is required, please
+   * use {@link #getAllWorkers()}.
+   *
    * @return the info of all block workers eligible for reads and writes
    */
   public synchronized List<BlockWorkerInfo> getCachedWorkers() throws IOException {
@@ -589,6 +594,10 @@ public class FileSystemContext implements Closeable {
   }
 
   /**
+   * Gets the worker information list.
+   * This method is more expensive than {@link #getCachedWorkers()}.
+   * Used when more up-to-date data is needed.
+   *
    * @return the info of all block workers
    */
   private List<BlockWorkerInfo> getAllWorkers() throws IOException {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -581,7 +581,7 @@ public class FileSystemContext implements Closeable {
   /**
    * @return the info of all block workers eligible for reads and writes
    */
-  public synchronized List<BlockWorkerInfo> getEligibleWorkers() throws IOException {
+  public synchronized List<BlockWorkerInfo> getCachedWorkers() throws IOException {
     if (mWorkerInfoList == null || mWorkerRefreshPolicy.attempt()) {
       mWorkerInfoList = getAllWorkers();
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -581,8 +581,8 @@ public class FileSystemContext implements Closeable {
   /**
    * Gets the cached worker information list.
    * This method is relatively cheap as the result is cached, but may not
-   * be update to date. If up-to-date worker info list is required, please
-   * use {@link #getAllWorkers()}.
+   * be up-to-date. If up-to-date worker info list is required,
+   * use {@link #getAllWorkers()} instead.
    *
    * @return the info of all block workers eligible for reads and writes
    */

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -591,7 +591,7 @@ public class FileSystemContext implements Closeable {
   /**
    * @return the info of all block workers
    */
-  public List<BlockWorkerInfo> getAllWorkers() throws IOException {
+  private List<BlockWorkerInfo> getAllWorkers() throws IOException {
     try (CloseableResource<BlockMasterClient> masterClientResource =
              acquireBlockMasterClientResource()) {
       return masterClientResource.get().getWorkerInfoList().stream()

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -181,7 +181,7 @@ public final class AlluxioBlockStoreTest {
     when(mWorkerClient.openLocalBlock(any(StreamObserver.class)))
         .thenReturn(mStreamObserver);
     when(mStreamObserver.isReady()).thenReturn(true);
-    when(mContext.getEligibleWorkers()).thenReturn(Lists.newArrayList(
+    when(mContext.getCachedWorkers()).thenReturn(Lists.newArrayList(
         new BlockWorkerInfo(new WorkerNetAddress(), -1, -1)));
   }
 
@@ -274,7 +274,7 @@ public final class AlluxioBlockStoreTest {
           }
         });
 
-    when(mContext.getEligibleWorkers()).thenReturn(Lists
+    when(mContext.getCachedWorkers()).thenReturn(Lists
         .newArrayList(new BlockWorkerInfo(WORKER_NET_ADDRESS_LOCAL, -1, -1),
             new BlockWorkerInfo(WORKER_NET_ADDRESS_REMOTE, -1, -1)));
     OutStreamOptions options =
@@ -302,7 +302,7 @@ public final class AlluxioBlockStoreTest {
     ((MockBlockLocationPolicy) options.getUfsReadLocationPolicy())
         .setHosts(Arrays.asList(worker1, worker2));
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-    when(mContext.getEligibleWorkers()).thenReturn(
+    when(mContext.getCachedWorkers()).thenReturn(
         Lists.newArrayList(new BlockWorkerInfo(worker1, -1, -1),
             new BlockWorkerInfo(worker2, -1, -1)));
 
@@ -320,7 +320,7 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf),
             sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-    when(mContext.getEligibleWorkers()).thenReturn(Collections.emptyList());
+    when(mContext.getCachedWorkers()).thenReturn(Collections.emptyList());
     mException.expect(UnavailableException.class);
     mException.expectMessage(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
     mBlockStore.getInStream(BLOCK_ID, options).getAddress();
@@ -472,7 +472,7 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
-    when(mContext.getEligibleWorkers()).thenReturn(
+    when(mContext.getCachedWorkers()).thenReturn(
         Arrays.stream(workers)
             .map(x -> new BlockWorkerInfo(x, -1, -1)).collect((Collectors.toList())));
     Map<WorkerNetAddress, Long> failedWorkerAddresses = failedWorkers.entrySet().stream()
@@ -511,7 +511,7 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
-    when(mContext.getEligibleWorkers()).thenReturn(Arrays.stream(workers)
+    when(mContext.getCachedWorkers()).thenReturn(Arrays.stream(workers)
         .map(x -> new BlockWorkerInfo(x, -1, -1)).collect((Collectors.toList())));
     Map<WorkerNetAddress, Long> failedWorkerAddresses = failedWorkers.entrySet().stream()
         .map(x -> new AbstractMap.SimpleImmutableEntry<>(workers[x.getKey()], x.getValue()))

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -48,7 +48,6 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
-import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.collect.ImmutableMap;
@@ -158,7 +157,6 @@ public final class AlluxioBlockStoreTest {
   @Before
   public void before() throws Exception {
     mMasterClient = PowerMockito.mock(BlockMasterClient.class);
-    when(mMasterClient.getWorkerInfoList()).thenReturn(Lists.newArrayList(new WorkerInfo()));
     mWorkerClient = PowerMockito.mock(BlockWorkerClient.class);
 
     mClientContext = ClientContext.create(sConf);
@@ -183,6 +181,8 @@ public final class AlluxioBlockStoreTest {
     when(mWorkerClient.openLocalBlock(any(StreamObserver.class)))
         .thenReturn(mStreamObserver);
     when(mStreamObserver.isReady()).thenReturn(true);
+    when(mContext.getEligibleWorkers()).thenReturn(Lists.newArrayList(
+        new BlockWorkerInfo(new WorkerNetAddress(), -1, -1)));
   }
 
   @Test
@@ -274,9 +274,9 @@ public final class AlluxioBlockStoreTest {
           }
         });
 
-    when(mMasterClient.getWorkerInfoList()).thenReturn(Lists
-        .newArrayList(new alluxio.wire.WorkerInfo().setAddress(WORKER_NET_ADDRESS_LOCAL),
-            new alluxio.wire.WorkerInfo().setAddress(WORKER_NET_ADDRESS_REMOTE)));
+    when(mContext.getEligibleWorkers()).thenReturn(Lists
+        .newArrayList(new BlockWorkerInfo(WORKER_NET_ADDRESS_LOCAL, -1, -1),
+            new BlockWorkerInfo(WORKER_NET_ADDRESS_REMOTE, -1, -1)));
     OutStreamOptions options =
         OutStreamOptions.defaults(mClientContext).setBlockSizeBytes(BLOCK_LENGTH).setLocationPolicy(
             new MockBlockLocationPolicy(
@@ -302,8 +302,9 @@ public final class AlluxioBlockStoreTest {
     ((MockBlockLocationPolicy) options.getUfsReadLocationPolicy())
         .setHosts(Arrays.asList(worker1, worker2));
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-    when(mMasterClient.getWorkerInfoList()).thenReturn(
-        Arrays.asList(new WorkerInfo().setAddress(worker1), new WorkerInfo().setAddress(worker2)));
+    when(mContext.getEligibleWorkers()).thenReturn(
+        Lists.newArrayList(new BlockWorkerInfo(worker1, -1, -1),
+            new BlockWorkerInfo(worker2, -1, -1)));
 
     // Location policy chooses worker1 first.
     assertEquals(worker1, mBlockStore.getInStream(BLOCK_ID, options).getAddress());
@@ -319,8 +320,7 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf),
             sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-    when(mMasterClient.getWorkerInfoList()).thenReturn(Collections.emptyList());
-
+    when(mContext.getEligibleWorkers()).thenReturn(Collections.emptyList());
     mException.expect(UnavailableException.class);
     mException.expectMessage(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
     mBlockStore.getInStream(BLOCK_ID, options).getAddress();
@@ -472,8 +472,9 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
-    when(mMasterClient.getWorkerInfoList()).thenReturn(Arrays.stream(workers)
-        .map(x -> new WorkerInfo().setAddress(x)).collect((Collectors.toList())));
+    when(mContext.getEligibleWorkers()).thenReturn(
+        Arrays.stream(workers)
+            .map(x -> new BlockWorkerInfo(x, -1, -1)).collect((Collectors.toList())));
     Map<WorkerNetAddress, Long> failedWorkerAddresses = failedWorkers.entrySet().stream()
         .map(x -> new AbstractMap.SimpleImmutableEntry<>(workers[x.getKey()], x.getValue()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -510,8 +511,8 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
-    when(mMasterClient.getWorkerInfoList()).thenReturn(Arrays.stream(workers)
-        .map(x -> new WorkerInfo().setAddress(x)).collect((Collectors.toList())));
+    when(mContext.getEligibleWorkers()).thenReturn(Arrays.stream(workers)
+        .map(x -> new BlockWorkerInfo(x, -1, -1)).collect((Collectors.toList())));
     Map<WorkerNetAddress, Long> failedWorkerAddresses = failedWorkers.entrySet().stream()
         .map(x -> new AbstractMap.SimpleImmutableEntry<>(workers[x.getKey()], x.getValue()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -130,7 +130,7 @@ public final class AlluxioFileInStreamTest {
     mBlockStore = mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mContext)).thenReturn(mBlockStore);
-    when(mContext.getEligibleWorkers()).thenReturn(new ArrayList<>());
+    when(mContext.getCachedWorkers()).thenReturn(new ArrayList<>());
 
     // Set up BufferedBlockInStreams and caching streams
     mInStreams = new ArrayList<>();
@@ -143,7 +143,7 @@ public final class AlluxioFileInStreamTest {
       final byte[] input = BufferUtils
           .getIncreasingByteArray((int) (i * BLOCK_LENGTH), (int) getBlockLength(i));
       mInStreams.add(new TestBlockInStream(input, i, input.length, false, mBlockSource));
-      when(mContext.getEligibleWorkers())
+      when(mContext.getCachedWorkers())
           .thenReturn(Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress(), 0, 0)));
       when(mBlockStore.getInStream(eq((long) i), any(InStreamOptions.class), any()))
           .thenAnswer(invocation -> {

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -130,7 +130,7 @@ public final class AlluxioFileInStreamTest {
     mBlockStore = mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mContext)).thenReturn(mBlockStore);
-    PowerMockito.when(mBlockStore.getEligibleWorkers()).thenReturn(new ArrayList<>());
+    when(mContext.getEligibleWorkers()).thenReturn(new ArrayList<>());
 
     // Set up BufferedBlockInStreams and caching streams
     mInStreams = new ArrayList<>();
@@ -143,7 +143,7 @@ public final class AlluxioFileInStreamTest {
       final byte[] input = BufferUtils
           .getIncreasingByteArray((int) (i * BLOCK_LENGTH), (int) getBlockLength(i));
       mInStreams.add(new TestBlockInStream(input, i, input.length, false, mBlockSource));
-      when(mBlockStore.getEligibleWorkers())
+      when(mContext.getEligibleWorkers())
           .thenReturn(Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress(), 0, 0)));
       when(mBlockStore.getInStream(eq((long) i), any(InStreamOptions.class), any()))
           .thenAnswer(invocation -> {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -164,7 +164,7 @@ public class FileOutStreamTest {
         new BlockWorkerInfo(new WorkerNetAddress().setHost("localhost")
             .setTieredIdentity(TieredIdentityFactory.fromString("node=localhost", sConf))
             .setRpcPort(1).setDataPort(2).setWebPort(3), Constants.GB, 0);
-    when(mFileSystemContext.getEligibleWorkers()).thenReturn(Lists.newArrayList(workerInfo));
+    when(mFileSystemContext.getCachedWorkers()).thenReturn(Lists.newArrayList(workerInfo));
     mAlluxioOutStreamMap = outStreamMap;
 
     // Create an under storage stream so that we can check whether it has been flushed

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -164,7 +164,7 @@ public class FileOutStreamTest {
         new BlockWorkerInfo(new WorkerNetAddress().setHost("localhost")
             .setTieredIdentity(TieredIdentityFactory.fromString("node=localhost", sConf))
             .setRpcPort(1).setDataPort(2).setWebPort(3), Constants.GB, 0);
-    when(mBlockStore.getEligibleWorkers()).thenReturn(Lists.newArrayList(workerInfo));
+    when(mFileSystemContext.getEligibleWorkers()).thenReturn(Lists.newArrayList(workerInfo));
     mAlluxioOutStreamMap = outStreamMap;
 
     // Create an under storage stream so that we can check whether it has been flushed

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -616,7 +616,7 @@ public class AbstractFileSystemTest {
     doReturn(new URIStatus(fileInfo)).when(spyFs).getStatus(uri);
     List<BlockWorkerInfo> eligibleWorkerInfos = allWorkers.stream().map(worker ->
         new BlockWorkerInfo(worker, 0, 0)).collect(toList());
-    PowerMockito.when(blockStore.getEligibleWorkers()).thenReturn(eligibleWorkerInfos);
+    when(fsContext.getEligibleWorkers()).thenReturn(eligibleWorkerInfos);
     List<HostAndPort> expectedWorkerNames = expectedWorkers.stream()
         .map(addr -> HostAndPort.fromParts(addr.getHost(), addr.getDataPort())).collect(toList());
     FileSystem alluxioHadoopFs = new FileSystem(spyFs);

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -616,7 +616,7 @@ public class AbstractFileSystemTest {
     doReturn(new URIStatus(fileInfo)).when(spyFs).getStatus(uri);
     List<BlockWorkerInfo> eligibleWorkerInfos = allWorkers.stream().map(worker ->
         new BlockWorkerInfo(worker, 0, 0)).collect(toList());
-    when(fsContext.getEligibleWorkers()).thenReturn(eligibleWorkerInfos);
+    when(fsContext.getCachedWorkers()).thenReturn(eligibleWorkerInfos);
     List<HostAndPort> expectedWorkerNames = expectedWorkers.stream()
         .map(addr -> HostAndPort.fromParts(addr.getHost(), addr.getDataPort())).collect(toList());
     FileSystem alluxioHadoopFs = new FileSystem(spyFs);

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -70,7 +70,7 @@ public final class LoadDefinition
     // Filter out workers which have no local job worker available.
     List<String> missingJobWorkerHosts = new ArrayList<>();
     List<BlockWorkerInfo> workers = new ArrayList<>();
-    for (BlockWorkerInfo worker : context.getFsContext().getEligibleWorkers()) {
+    for (BlockWorkerInfo worker : context.getFsContext().getCachedWorkers()) {
       if (jobWorkersByAddress.containsKey(worker.getNetAddress().getHost())) {
         workers.add(worker);
       } else {

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -13,7 +13,6 @@ package alluxio.job.plan.load;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.collections.Pair;
 import alluxio.exception.status.FailedPreconditionException;
@@ -71,7 +70,7 @@ public final class LoadDefinition
     // Filter out workers which have no local job worker available.
     List<String> missingJobWorkerHosts = new ArrayList<>();
     List<BlockWorkerInfo> workers = new ArrayList<>();
-    for (BlockWorkerInfo worker : context.getFsContext().getAllWorkers()) {
+    for (BlockWorkerInfo worker : context.getFsContext().getEligibleWorkers()) {
       if (jobWorkersByAddress.containsKey(worker.getNetAddress().getHost())) {
         workers.add(worker);
       } else {

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -71,8 +71,7 @@ public final class LoadDefinition
     // Filter out workers which have no local job worker available.
     List<String> missingJobWorkerHosts = new ArrayList<>();
     List<BlockWorkerInfo> workers = new ArrayList<>();
-    for (BlockWorkerInfo worker :
-        AlluxioBlockStore.create(context.getFsContext()).getAllWorkers()) {
+    for (BlockWorkerInfo worker : context.getFsContext().getAllWorkers()) {
       if (jobWorkersByAddress.containsKey(worker.getNetAddress().getHost())) {
         workers.add(worker);
       } else {

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -180,7 +180,7 @@ public final class MigrateDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       hostnameToWorker.put(workerInfo.getAddress().getHost(), workerInfo);
     }
-    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getEligibleWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getCachedWorkers();
     // Assign each file to the worker with the most block locality.
     for (URIStatus status : allPathStatuses) {
       if (status.isFolder()) {

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -181,8 +181,7 @@ public final class MigrateDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       hostnameToWorker.put(workerInfo.getAddress().getHost(), workerInfo);
     }
-    List<BlockWorkerInfo> alluxioWorkerInfoList =
-        AlluxioBlockStore.create(context.getFsContext()).getAllWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getAllWorkers();
     // Assign each file to the worker with the most block locality.
     for (URIStatus status : allPathStatuses) {
       if (status.isFolder()) {

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -14,7 +14,6 @@ package alluxio.job.plan.migrate;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.WriteType;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
@@ -181,7 +180,7 @@ public final class MigrateDefinition
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       hostnameToWorker.put(workerInfo.getAddress().getHost(), workerInfo);
     }
-    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getAllWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getEligibleWorkers();
     // Assign each file to the worker with the most block locality.
     for (URIStatus status : allPathStatuses) {
       if (status.isFolder()) {

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -75,7 +75,7 @@ public final class PersistDefinition
     }
 
     AlluxioURI uri = new AlluxioURI(config.getFilePath());
-    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getEligibleWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getCachedWorkers();
     BlockWorkerInfo workerWithMostBlocks = JobUtils.getWorkerWithMostBlocks(alluxioWorkerInfoList,
         context.getFileSystem().getStatus(uri).getFileBlockInfos());
 

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -76,8 +76,7 @@ public final class PersistDefinition
     }
 
     AlluxioURI uri = new AlluxioURI(config.getFilePath());
-    List<BlockWorkerInfo> alluxioWorkerInfoList =
-        AlluxioBlockStore.create(context.getFsContext()).getAllWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getAllWorkers();
     BlockWorkerInfo workerWithMostBlocks = JobUtils.getWorkerWithMostBlocks(alluxioWorkerInfoList,
         context.getFileSystem().getStatus(uri).getFileBlockInfos());
 

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -13,7 +13,6 @@ package alluxio.job.plan.persist;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.URIStatus;
@@ -76,7 +75,7 @@ public final class PersistDefinition
     }
 
     AlluxioURI uri = new AlluxioURI(config.getFilePath());
-    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getAllWorkers();
+    List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getEligibleWorkers();
     BlockWorkerInfo workerWithMostBlocks = JobUtils.getWorkerWithMostBlocks(alluxioWorkerInfoList,
         context.getFileSystem().getStatus(uri).getFileBlockInfos());
 

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -104,7 +104,7 @@ public final class EvictDefinition
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getEligibleWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -104,7 +104,7 @@ public final class EvictDefinition
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getEligibleWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getCachedWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/EvictDefinition.java
@@ -101,12 +101,10 @@ public final class EvictDefinition
   @Override
   public SerializableVoid runTask(EvictConfig config, SerializableVoid args, RunTaskContext context)
       throws Exception {
-    AlluxioBlockStore blockStore = AlluxioBlockStore.create(context.getFsContext());
-
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = blockStore.getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getAllWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -87,12 +87,10 @@ public final class MoveDefinition
   @Override
   public SerializableVoid runTask(MoveConfig config, SerializableVoid args, RunTaskContext context)
       throws Exception {
-    AlluxioBlockStore blockStore = AlluxioBlockStore.create(context.getFsContext());
-
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = blockStore.getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getAllWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -89,7 +89,7 @@ public final class MoveDefinition
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getEligibleWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getCachedWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -13,7 +13,6 @@ package alluxio.job.plan.replicate;
 
 import alluxio.collections.Pair;
 import alluxio.conf.ServerConfiguration;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.exception.status.NotFoundException;
@@ -90,7 +89,7 @@ public final class MoveDefinition
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getFsContext().getEligibleWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -111,7 +111,7 @@ public final class JobUtils {
 
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getEligibleWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -111,7 +111,7 @@ public final class JobUtils {
 
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getEligibleWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getCachedWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -111,7 +111,7 @@ public final class JobUtils {
 
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
         ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = blockStore.getAllWorkers();
+    List<BlockWorkerInfo> workerInfoList = context.getAllWorkers();
     WorkerNetAddress localNetAddress = null;
 
     for (BlockWorkerInfo workerInfo : workerInfoList) {

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -85,7 +85,7 @@ public class LoadDefinitionTest {
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(any(FileSystemContext.class)))
         .thenReturn(mMockBlockStore);
-    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(BLOCK_WORKERS);
+    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(BLOCK_WORKERS);
     PowerMockito.when(mMockFsContext.getClientContext())
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
     PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(ServerConfiguration.global());
@@ -117,7 +117,7 @@ public class LoadDefinitionTest {
   public void skipJobWorkersWithoutLocalBlockWorkers() throws Exception {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0));
-    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
     Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
@@ -146,7 +146,7 @@ public class LoadDefinitionTest {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0),
             new BlockWorkerInfo(new WorkerNetAddress().setHost("otherhost"), 0, 0));
-    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 1);
     LoadConfig config = new LoadConfig(TEST_URI, 2); // set replication to 2
     try {

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -85,7 +85,7 @@ public class LoadDefinitionTest {
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(any(FileSystemContext.class)))
         .thenReturn(mMockBlockStore);
-    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(BLOCK_WORKERS);
+    Mockito.when(mMockFsContext.getCachedWorkers()).thenReturn(BLOCK_WORKERS);
     PowerMockito.when(mMockFsContext.getClientContext())
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
     PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(ServerConfiguration.global());
@@ -117,7 +117,7 @@ public class LoadDefinitionTest {
   public void skipJobWorkersWithoutLocalBlockWorkers() throws Exception {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0));
-    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getCachedWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
     Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
@@ -146,7 +146,7 @@ public class LoadDefinitionTest {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0),
             new BlockWorkerInfo(new WorkerNetAddress().setHost("otherhost"), 0, 0));
-    Mockito.when(mMockFsContext.getEligibleWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getCachedWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 1);
     LoadConfig config = new LoadConfig(TEST_URI, 2); // set replication to 2
     try {

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -85,7 +85,7 @@ public class LoadDefinitionTest {
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(any(FileSystemContext.class)))
         .thenReturn(mMockBlockStore);
-    Mockito.when(mMockBlockStore.getAllWorkers()).thenReturn(BLOCK_WORKERS);
+    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(BLOCK_WORKERS);
     PowerMockito.when(mMockFsContext.getClientContext())
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
     PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(ServerConfiguration.global());
@@ -117,7 +117,7 @@ public class LoadDefinitionTest {
   public void skipJobWorkersWithoutLocalBlockWorkers() throws Exception {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0));
-    Mockito.when(mMockBlockStore.getAllWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 10);
     LoadConfig config = new LoadConfig(TEST_URI, 1);
     Set<Pair<WorkerInfo, ArrayList<LoadTask>>> assignments =
@@ -146,7 +146,7 @@ public class LoadDefinitionTest {
     List<BlockWorkerInfo> blockWorkers =
         Arrays.asList(new BlockWorkerInfo(new WorkerNetAddress().setHost("host0"), 0, 0),
             new BlockWorkerInfo(new WorkerNetAddress().setHost("otherhost"), 0, 0));
-    Mockito.when(mMockBlockStore.getAllWorkers()).thenReturn(blockWorkers);
+    Mockito.when(mMockFsContext.getAllWorkers()).thenReturn(blockWorkers);
     createFileWithNoLocations(TEST_URI, 1);
     LoadConfig config = new LoadConfig(TEST_URI, 2); // set replication to 2
     try {

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -74,7 +74,7 @@ public final class MigrateDefinitionSelectExecutorsTest extends SelectExecutorsT
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
-    when(mMockFileSystemContext.getAllWorkers()).thenReturn(BLOCK_WORKERS);
+    when(mMockFileSystemContext.getEligibleWorkers()).thenReturn(BLOCK_WORKERS);
     createDirectory("/");
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -74,7 +74,7 @@ public final class MigrateDefinitionSelectExecutorsTest extends SelectExecutorsT
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
-    when(mMockBlockStore.getAllWorkers()).thenReturn(BLOCK_WORKERS);
+    when(mMockFileSystemContext.getAllWorkers()).thenReturn(BLOCK_WORKERS);
     createDirectory("/");
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -74,7 +74,7 @@ public final class MigrateDefinitionSelectExecutorsTest extends SelectExecutorsT
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
-    when(mMockFileSystemContext.getEligibleWorkers()).thenReturn(BLOCK_WORKERS);
+    when(mMockFileSystemContext.getCachedWorkers()).thenReturn(BLOCK_WORKERS);
     createDirectory("/");
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -158,7 +158,7 @@ public final class ReplicateDefinitionTest {
                 new FileBlockInfo().setBlockInfo(new BlockInfo().setBlockId(TEST_BLOCK_ID)))));
     when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(status);
 
-    when(mMockFileSystemContext.getAllWorkers()).thenReturn(blockWorkers);
+    when(mMockFileSystemContext.getEligibleWorkers()).thenReturn(blockWorkers);
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
     when(

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -158,7 +158,7 @@ public final class ReplicateDefinitionTest {
                 new FileBlockInfo().setBlockInfo(new BlockInfo().setBlockId(TEST_BLOCK_ID)))));
     when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(status);
 
-    when(mMockFileSystemContext.getEligibleWorkers()).thenReturn(blockWorkers);
+    when(mMockFileSystemContext.getCachedWorkers()).thenReturn(blockWorkers);
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
     when(

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -158,7 +158,7 @@ public final class ReplicateDefinitionTest {
                 new FileBlockInfo().setBlockInfo(new BlockInfo().setBlockId(TEST_BLOCK_ID)))));
     when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(status);
 
-    when(mMockBlockStore.getAllWorkers()).thenReturn(blockWorkers);
+    when(mMockFileSystemContext.getAllWorkers()).thenReturn(blockWorkers);
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
     when(

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -146,7 +146,7 @@ public final class LogLevel {
         targetInfoList.add(new TargetInfo(masterHost, masterPort, ROLE_MASTER));
       } else if (target.equals(ROLE_WORKERS)) {
         List<BlockWorkerInfo> workerInfoList =
-            FileSystemContext.create(ClientContext.create(conf)).getEligibleWorkers();
+            FileSystemContext.create(ClientContext.create(conf)).getCachedWorkers();
         for (BlockWorkerInfo workerInfo : workerInfoList) {
           WorkerNetAddress netAddress = workerInfo.getNetAddress();
           targetInfoList.add(

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -146,9 +146,8 @@ public final class LogLevel {
         int masterPort = NetworkAddressUtils.getPort(ServiceType.MASTER_WEB, conf);
         targetInfoList.add(new TargetInfo(masterHost, masterPort, ROLE_MASTER));
       } else if (target.equals(ROLE_WORKERS)) {
-        AlluxioBlockStore alluxioBlockStore =
-            AlluxioBlockStore.create(FileSystemContext.create(ClientContext.create(conf)));
-        List<BlockWorkerInfo> workerInfoList = alluxioBlockStore.getAllWorkers();
+        List<BlockWorkerInfo> workerInfoList =
+            FileSystemContext.create(ClientContext.create(conf)).getAllWorkers();
         for (BlockWorkerInfo workerInfo : workerInfoList) {
           WorkerNetAddress netAddress = workerInfo.getNetAddress();
           targetInfoList.add(

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -14,7 +14,6 @@ package alluxio.cli;
 import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.annotation.PublicApi;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
@@ -147,7 +146,7 @@ public final class LogLevel {
         targetInfoList.add(new TargetInfo(masterHost, masterPort, ROLE_MASTER));
       } else if (target.equals(ROLE_WORKERS)) {
         List<BlockWorkerInfo> workerInfoList =
-            FileSystemContext.create(ClientContext.create(conf)).getAllWorkers();
+            FileSystemContext.create(ClientContext.create(conf)).getEligibleWorkers();
         for (BlockWorkerInfo workerInfo : workerInfoList) {
           WorkerNetAddress netAddress = workerInfo.getNetAddress();
           targetInfoList.add(

--- a/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
@@ -15,7 +15,6 @@ import alluxio.cli.CommandUtils;
 import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.cli.fsadmin.command.AbstractFsAdminCommand;
 import alluxio.cli.fsadmin.command.Context;
-import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.file.FileSystemContext;

--- a/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
@@ -121,7 +121,7 @@ public final class ClearCommand extends AbstractFsAdminCommand {
       int globalParallelism = FileSystemShellUtils
           .getIntArg(cl, PARALLELISM_OPTION, DEFAULT_PARALLELISM);
       try (FileSystemContext context = FileSystemContext.create(mAlluxioConf)) {
-        List<WorkerNetAddress> addressList = context.getEligibleWorkers().stream()
+        List<WorkerNetAddress> addressList = context.getCachedWorkers().stream()
             .map(BlockWorkerInfo::getNetAddress).collect(Collectors.toList());
 
         if (cl.hasOption(WORKERS_OPTION_NAME)) {

--- a/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/metrics/ClearCommand.java
@@ -122,8 +122,7 @@ public final class ClearCommand extends AbstractFsAdminCommand {
       int globalParallelism = FileSystemShellUtils
           .getIntArg(cl, PARALLELISM_OPTION, DEFAULT_PARALLELISM);
       try (FileSystemContext context = FileSystemContext.create(mAlluxioConf)) {
-        AlluxioBlockStore store = AlluxioBlockStore.create(FileSystemContext.create(mAlluxioConf));
-        List<WorkerNetAddress> addressList = store.getEligibleWorkers().stream()
+        List<WorkerNetAddress> addressList = context.getEligibleWorkers().stream()
             .map(BlockWorkerInfo::getNetAddress).collect(Collectors.toList());
 
         if (cl.hasOption(WORKERS_OPTION_NAME)) {

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -143,15 +143,15 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
    * Wait for a number of workers to register. This call will block until the block master
    * detects the required number of workers or if the timeout is exceeded.
    *
-   * @param store the block store object which references the correct block master
+   * @param context the file system context
    * @param numWorkers the number of workers to wait for
    * @param timeoutMs the number of milliseconds to wait before timing out
    */
-  private void waitForWorkerRegistration(final AlluxioBlockStore store, final int numWorkers,
+  private void waitForWorkerRegistration(final FileSystemContext context, final int numWorkers,
       int timeoutMs) throws TimeoutException, InterruptedException {
     CommonUtils.waitFor("Worker to register.", () -> {
       try {
-        return store.getEligibleWorkers().size() >= numWorkers;
+        return context.getEligibleWorkers().size() >= numWorkers;
       } catch (Exception e) {
         return false;
       }
@@ -170,8 +170,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      waitForWorkerRegistration(AlluxioBlockStore
-              .create(FileSystemContext.create(ServerConfiguration.global())), 1,
+      waitForWorkerRegistration(FileSystemContext.create(ServerConfiguration.global()), 1,
           CLUSTER_WAIT_TIMEOUT_MS);
       faultTestDataCheck(answer);
       faultTestDataCreation(new AlluxioURI("/data_kills_" + kills), answer);
@@ -185,8 +184,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      waitForWorkerRegistration(AlluxioBlockStore
-              .create(FileSystemContext.create(ServerConfiguration.global())), 1,
+      waitForWorkerRegistration(FileSystemContext.create(ServerConfiguration.global()), 1,
           CLUSTER_WAIT_TIMEOUT_MS);
 
       if (kills % 2 != 0) {
@@ -272,9 +270,9 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      AlluxioBlockStore store =
-          AlluxioBlockStore.create(FileSystemContext.create(ServerConfiguration.global()));
-      waitForWorkerRegistration(store, 1, 1 * Constants.MINUTE_MS);
+      FileSystemContext context = FileSystemContext.create(ServerConfiguration.global());
+      AlluxioBlockStore store = AlluxioBlockStore.create(context);
+      waitForWorkerRegistration(context, 1, 1 * Constants.MINUTE_MS);
       // If worker is successfully re-registered, the capacity bytes should not change.
       long capacityFound = store.getCapacityBytes();
       assertEquals(WORKER_CAPACITY_BYTES, capacityFound);

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -151,7 +151,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       int timeoutMs) throws TimeoutException, InterruptedException {
     CommonUtils.waitFor("Worker to register.", () -> {
       try {
-        return context.getEligibleWorkers().size() >= numWorkers;
+        return context.getCachedWorkers().size() >= numWorkers;
       } catch (Exception e) {
         return false;
       }

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -197,7 +197,7 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
     AlluxioBlockStore store = AlluxioBlockStore.create(fsContext);
     URIStatus status =  mResource.get().getClient().getStatus(filePath);
     List<FileBlockInfo> blocks = status.getFileBlockInfos();
-    List<BlockWorkerInfo> workers = fsContext.getAllWorkers();
+    List<BlockWorkerInfo> workers = fsContext.getEligibleWorkers();
 
     for (FileBlockInfo block : blocks) {
       BlockInfo blockInfo = block.getBlockInfo();

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -197,7 +197,7 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
     AlluxioBlockStore store = AlluxioBlockStore.create(fsContext);
     URIStatus status =  mResource.get().getClient().getStatus(filePath);
     List<FileBlockInfo> blocks = status.getFileBlockInfos();
-    List<BlockWorkerInfo> workers = store.getAllWorkers();
+    List<BlockWorkerInfo> workers = fsContext.getAllWorkers();
 
     for (FileBlockInfo block : blocks) {
       BlockInfo blockInfo = block.getBlockInfo();

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -197,7 +197,7 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
     AlluxioBlockStore store = AlluxioBlockStore.create(fsContext);
     URIStatus status =  mResource.get().getClient().getStatus(filePath);
     List<FileBlockInfo> blocks = status.getFileBlockInfos();
-    List<BlockWorkerInfo> workers = fsContext.getEligibleWorkers();
+    List<BlockWorkerInfo> workers = fsContext.getCachedWorkers();
 
     for (FileBlockInfo block : blocks) {
       BlockInfo blockInfo = block.getBlockInfo();


### PR DESCRIPTION
`AlluxioBlockStore` was originally a singleton before 2.0, so `AlluxioBlockStore.getWorkerInfoList` can keep worker info cached across Input and Output Streams. However after 2.0, `AlluxioBlockStore` becomes instance class and the cached worker info list can only benefit its owner stream, causing performance issues due to too many unnecessary client-master RPCs when reading / writing many small files, as described https://github.com/Alluxio/alluxio/issues/10959

This PR moves `getWorkerInfoList` and `getAllWorkers` to `FileSystemContext` as the shared state.

This PR also changes the job servers to use cached worker info list instead of keep getting the most updated worker info list.

Fix #10959  and close #9977