### PR TITLE
Fix generate tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -201,7 +201,6 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/kubernetes/helm-chart/alluxio/Chart.yaml",
 		"integration/kubernetes/helm-chart/alluxio/values.yaml",
 		"integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl",
-		"integration/kubernetes/helm-chart/alluxio/templates/service-account.yaml",
 		"integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml",
 		"integration/kubernetes/helm-chart/alluxio/templates/format/master.yaml",
 		"integration/kubernetes/helm-chart/alluxio/templates/fuse/client-daemonset.yaml",


### PR DESCRIPTION
#10960 claims that the file is unused. 

But the file is currently being copied over in the tarball. Remove this dependency.

