### PR TITLE
Remove extra resources created by Helm deployment

### DIFF
--- a/integration/kubernetes/alluxio-fuse-client.yaml.template
+++ b/integration/kubernetes/alluxio-fuse-client.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-fuse-client
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse-client
@@ -25,7 +25,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.4
+      chart: alluxio-0.5.5
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse-client
@@ -33,7 +33,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse-client

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -11,7 +11,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/integration/kubernetes/alluxio-fuse.yaml.template
+++ b/integration/kubernetes/alluxio-fuse.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-fuse
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-fuse
@@ -25,7 +25,7 @@ spec:
   selector:
     matchLabels:
       app: alluxio
-      chart: alluxio-0.5.4
+      chart: alluxio-0.5.5
       release: alluxio
       heritage: Tiller
       role: alluxio-fuse
@@ -33,7 +33,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-fuse

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -48,3 +48,7 @@
 
 - Updated the journal formatting Job logic
 - Misc formatting and parameters updates
+
+0.5.5
+
+- Removed extra resources created by Helm install https://github.com/Alluxio/alluxio/issues/10321

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.5.4
+version: 0.5.5
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/client-daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/client-daemonset.yaml
@@ -9,6 +9,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+{{ if .Values.fuse.clientEnabled -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -57,3 +58,4 @@ spec:
           hostPath:
             path: /alluxio-fuse
             type: Directory
+{{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -9,7 +9,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
+{{ if .Values.fuse.enabled -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -195,3 +195,4 @@ spec:
             {{- end }} 
           {{- end }} 
         {{- end }}
+{{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/job/format-journal-job.yaml
@@ -9,6 +9,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+{{ if .Values.journal.format.runFormat -}}
 {{ $root := . -}}
 {{- $masterCount := int .Values.master.count }}
 {{- $isSingleMaster := eq $masterCount 1 }}
@@ -96,4 +97,5 @@ spec:
         {{- end }}
       {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -115,6 +115,7 @@ journal:
   folder: "/journal" # Master journal folder
   # Configuration for journal formatting job
   format:
+    runFormat: false # Change to true to format journal
     job:
       activeDeadlineSeconds: 30
       ttlSecondsAfterFinished: 10
@@ -198,6 +199,9 @@ fuse:
   image: alluxio/alluxio-fuse
   imageTag: 2.3.0-SNAPSHOT
   imagePullPolicy: IfNotPresent
+  # Change both to true to deploy FUSE
+  enabled: false
+  clientEnabled: false
   # Properties for the jobWorker component
   properties:
   # Customize the MaxDirectMemorySize

--- a/integration/kubernetes/helm-generate.sh
+++ b/integration/kubernetes/helm-generate.sh
@@ -55,7 +55,7 @@ function generateMasterTemplates {
 
 function generateFormatJournalJobTemplates {
   echo "Generating format journal job templates into $dir"
-  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ -x templates/job/format-journal-job.yaml -f $dir/config.yaml > "$dir/job/alluxio-format-journal-job.yaml.template"
+  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ --set journal.format.runFormat=true -x templates/job/format-journal-job.yaml -f $dir/config.yaml > "$dir/job/alluxio-format-journal-job.yaml.template"
 
 }
 
@@ -66,8 +66,8 @@ function generateWorkerTemplates {
 
 function generateFuseTemplates {
   echo "Generating fuse templates"
-  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ -x templates/fuse/daemonset.yaml -f $dir/config.yaml > "alluxio-fuse.yaml.template"
-  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ -x templates/fuse/client-daemonset.yaml -f $dir/config.yaml > "alluxio-fuse-client.yaml.template"
+  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ --set fuse.enabled=true -x templates/fuse/daemonset.yaml -f $dir/config.yaml > "alluxio-fuse.yaml.template"
+  helm template --name ${RELEASE_NAME} helm-chart/alluxio/ --set fuse.clientEnabled=true -x templates/fuse/client-daemonset.yaml -f $dir/config.yaml > "alluxio-fuse-client.yaml.template"
 }
 
 function generateMasterServiceTemplates {

--- a/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.2.0-SNAPSHOT
+          image: alluxio/alluxio:2.3.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:
         - name: alluxio-master
-          image: alluxio/alluxio:2.2.0-SNAPSHOT
+          image: alluxio/alluxio:2.3.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000

--- a/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -66,7 +66,7 @@ metadata:
   labels:
     name: alluxio-format-master-1
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -113,7 +113,7 @@ metadata:
   labels:
     name: alluxio-format-master-2
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -49,7 +49,7 @@ metadata:
   name: alluxio-master-1
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -80,7 +80,7 @@ metadata:
   name: alluxio-master-2
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-worker

--- a/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/alluxio-configmap.yaml.template
@@ -23,7 +23,7 @@ metadata:
   labels:
     name: alluxio-config
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
 data:

--- a/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/job/alluxio-format-journal-job.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     name: alluxio-format-master-0
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-service.yaml.template
@@ -18,7 +18,7 @@ metadata:
   name: alluxio-master-0
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/master/alluxio-master-statefulset.yaml.template
@@ -18,7 +18,7 @@ metadata:
   labels:
     name: alluxio-master
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-master
@@ -35,7 +35,7 @@ spec:
       labels:
         name: alluxio-master
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-master

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-daemonset.yaml.template
@@ -17,7 +17,7 @@ metadata:
   name: alluxio-worker
   labels:
     app: alluxio
-    chart: alluxio-0.5.4
+    chart: alluxio-0.5.5
     release: alluxio
     heritage: Tiller
     role: alluxio-worker
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         app: alluxio
-        chart: alluxio-0.5.4
+        chart: alluxio-0.5.5
         release: alluxio
         heritage: Tiller
         role: alluxio-worker


### PR DESCRIPTION
This resolves https://github.com/Alluxio/alluxio/issues/10321

Added switched for fuse/fuse-client/jobs. The templates will be turned to empty on Helm deployment and generated for `kubectl` manual control.