### PR TITLE
Add buckets for client cache on local page store

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -72,7 +72,8 @@ public interface PageStore extends AutoCloseable {
         PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, PageStoreType.class);
     switch (storeType) {
       case LOCAL:
-        options = new LocalPageStoreOptions();
+        options = new LocalPageStoreOptions()
+            .setFileBuckets(conf.getInt(PropertyKey.USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS));
         break;
       case ROCKS:
         options = new RocksPageStoreOptions();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
@@ -33,11 +33,18 @@ public class LocalPageStoreOptions extends PageStoreOptions {
   private int mBufferSize;
 
   /**
+   * The number of file buckets. It is recommended to set this to a high value if the number of
+   * unique files is expected to be high (# files / file buckets <= 100,000).
+   */
+  private int mFileBuckets;
+
+  /**
    * Creates a new instance of {@link LocalPageStoreOptions}.
    */
   public LocalPageStoreOptions() {
     mBufferPoolSize = 32;
     mBufferSize = Constants.MB;
+    mFileBuckets = 1000;
   }
 
   /**
@@ -72,6 +79,22 @@ public class LocalPageStoreOptions extends PageStoreOptions {
     return mBufferSize;
   }
 
+  /**
+   * @param fileBuckets the number of buckets to place files in
+   * @return the updated options
+   */
+  public LocalPageStoreOptions setFileBuckets(int fileBuckets) {
+    mFileBuckets = fileBuckets;
+    return this;
+  }
+
+  /**
+   * @return the number of buckets to place files in
+   */
+  public int getFileBuckets() {
+    return mFileBuckets;
+  }
+
   @Override
   public PageStoreType getType() {
     return PageStoreType.LOCAL;
@@ -80,12 +103,13 @@ public class LocalPageStoreOptions extends PageStoreOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("BufferPoolSize", mBufferPoolSize)
-        .add("BufferSize", mBufferSize)
-        .add("RootDir", mRootDir)
-        .add("PageSize", mPageSize)
-        .add("CacheSize", mCacheSize)
         .add("AlluxioVersion", mAlluxioVersion)
+        .add("BufferPoolSize", mBufferPoolSize)
+        .add("CacheSize", mCacheSize)
+        .add("BufferSize", mBufferSize)
+        .add("FileBuckets", mFileBuckets)
+        .add("PageSize", mPageSize)
+        .add("RootDir", mRootDir)
         .toString();
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
@@ -24,6 +24,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class LocalPageStoreTest {
 
@@ -51,7 +53,34 @@ public class LocalPageStoreTest {
     helloWorldTest(pageStore);
   }
 
-  void helloWorldTest(PageStore store) throws Exception {
+  @Test
+  public void testSingleFileBucket() throws Exception {
+    mOptions.setFileBuckets(1);
+    LocalPageStore pageStore = new LocalPageStore(mOptions);
+    long numFiles = 100;
+    for (int i = 0; i < numFiles; i++) {
+      PageId id = new PageId(Integer.toString(i), 0);
+      pageStore.put(id, "test".getBytes());
+    }
+    assertEquals(1, Files.list(
+        Paths.get(mOptions.getRootDir(), Long.toString(mOptions.getPageSize()))).count());
+  }
+
+  @Test
+  public void testMultiFileBucket() throws Exception {
+    int numBuckets = 10;
+    mOptions.setFileBuckets(numBuckets);
+    LocalPageStore pageStore = new LocalPageStore(mOptions);
+    long numFiles = numBuckets * 10;
+    for (int i = 0; i < numFiles; i++) {
+      PageId id = new PageId(Integer.toString(i), 0);
+      pageStore.put(id, "test".getBytes());
+    }
+    assertEquals(10, Files.list(
+        Paths.get(mOptions.getRootDir(), Long.toString(mOptions.getPageSize()))).count());
+  }
+
+  private void helloWorldTest(PageStore store) throws Exception {
     String msg = "Hello, World!";
     PageId id = new PageId("0", 0);
     store.put(id, msg.getBytes());

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3233,6 +3233,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS =
+      new Builder(Name.USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS)
+          .setDefaultValue("1000")
+          .setDescription("The number of file buckets for the local page store of the client-side "
+              + "cache. It is recommended to set this to a high value if the number of unique "
+              + "files is expected to be high (# files / file buckets <= 100,000).")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_SIZE =
       new Builder(Name.USER_CLIENT_CACHE_SIZE)
           .setDefaultValue("512MB")
@@ -4650,6 +4659,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.dir";
     public static final String USER_CLIENT_CACHE_PAGE_SIZE =
         "alluxio.user.client.cache.page.size";
+    public static final String USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS =
+        "alluxio.user.client.cache.local.store.file.buckets";
     public static final String USER_CLIENT_CACHE_SIZE =
         "alluxio.user.client.cache.size";
     public static final String USER_CLIENT_CACHE_STORE_TYPE =


### PR DESCRIPTION
Adds a new configuration property that allows users to set the number of buckets to place files in the local page cache. Older local page caches are not compatible. Changing the number of buckets will invalidate older caches.