### PR TITLE
Fix "In Alluxio" calculation for DuCommand

### DIFF
--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -81,9 +81,19 @@
       <artifactId>alluxio-job-client</artifactId>
       <version>${project.version}</version>
     </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-      </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+    </dependency>
+
+      <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/shell/src/main/java/alluxio/cli/fs/command/DuCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DuCommand.java
@@ -121,7 +121,7 @@ public final class DuCommand extends AbstractFileSystemCommand {
           long size = status.getLength();
           totalSize += size;
           sizeInMem += size * status.getInMemoryPercentage();
-          sizeInAlluxio += size * status.getInMemoryPercentage();
+          sizeInAlluxio += size * status.getInAlluxioPercentage();
         }
       }
       String sizeMessage = readable ? FormatUtils.getSizeFromBytes(totalSize)

--- a/shell/src/main/java/alluxio/cli/fs/command/DuCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DuCommand.java
@@ -110,7 +110,7 @@ public final class DuCommand extends AbstractFileSystemCommand {
    * @param summarize whether to display the aggregate summary lengths
    * @param addMemory whether to display the memory size and percentage information
    */
-  private void getSizeInfo(AlluxioURI path, List<URIStatus> statuses,
+  protected static void getSizeInfo(AlluxioURI path, List<URIStatus> statuses,
       boolean readable, boolean summarize, boolean addMemory) {
     if (summarize) {
       long totalSize = 0;
@@ -155,7 +155,7 @@ public final class DuCommand extends AbstractFileSystemCommand {
    * @param totalSize the total size to calculate percentage information
    * @return the formatted value and percentage information
    */
-  private String getFormattedValues(boolean readable, long size, long totalSize) {
+  private static String getFormattedValues(boolean readable, long size, long totalSize) {
     // If size is 1, total size is 5, and readable is true, it will
     // return a string as "1B (20%)"
     int percent = totalSize == 0 ? 0 : (int) (size * 100 / totalSize);
@@ -172,7 +172,7 @@ public final class DuCommand extends AbstractFileSystemCommand {
    * @param inMemMessage the in memory size message to print
    * @param path the path to print
    */
-  private void printInfo(String sizeMessage,
+  private static void printInfo(String sizeMessage,
       String inAlluxioMessage, String inMemMessage, String path) {
     System.out.println(inMemMessage.isEmpty()
         ? String.format(SHORT_INFO_FORMAT, sizeMessage, inAlluxioMessage, path)

--- a/shell/src/test/java/alluxio/cli/fs/command/DuCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fs/command/DuCommandTest.java
@@ -1,0 +1,121 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.fs.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import alluxio.AlluxioURI;
+import alluxio.SystemOutRule;
+import alluxio.client.file.URIStatus;
+import alluxio.wire.FileInfo;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class DuCommandTest {
+
+  private static final Pattern OUTPUT_PERCENT = Pattern.compile("[(]([0-9].*?)[%][)]");
+
+  ByteArrayOutputStream mOutput = new ByteArrayOutputStream();
+
+  @Rule
+  public SystemOutRule mRule = new SystemOutRule(mOutput);
+
+  @Before
+  public void before() {
+    mOutput.reset();
+  }
+
+  @Test
+  public void allInMem() {
+    AlluxioURI rootpath = new AlluxioURI("/");
+    List<FileInfo> infos = new ArrayList<>();
+    infos.add(
+        new FileInfo().setLength(10).setInAlluxioPercentage(100).setInMemoryPercentage(100));
+    infos.add(
+        new FileInfo().setLength(30).setInAlluxioPercentage(100).setInMemoryPercentage(100));
+    infos.add(
+        new FileInfo().setLength(20).setInAlluxioPercentage(100).setInMemoryPercentage(100));
+
+    List<URIStatus> statuses = infos.stream().map(URIStatus::new).collect(Collectors.toList());
+    DuCommand.getSizeInfo(rootpath, statuses, false, true, true);
+    String output = mOutput.toString().trim();
+    assertPercentage(output, 100, 100);
+  }
+
+  @Test
+  public void noneInMem() {
+    AlluxioURI rootpath = new AlluxioURI("/");
+    List<FileInfo> infos = new ArrayList<>();
+    infos.add(
+        new FileInfo().setLength(10).setInAlluxioPercentage(100).setInMemoryPercentage(0));
+    infos.add(
+        new FileInfo().setLength(30).setInAlluxioPercentage(100).setInMemoryPercentage(0));
+    infos.add(
+        new FileInfo().setLength(20).setInAlluxioPercentage(100).setInMemoryPercentage(0));
+
+    List<URIStatus> statuses = infos.stream().map(URIStatus::new).collect(Collectors.toList());
+    DuCommand.getSizeInfo(rootpath, statuses, false, true, true);
+    String output = mOutput.toString().trim();
+    assertPercentage(output, 100, 0);
+  }
+
+  @Test
+  public void someInMem() {
+    AlluxioURI rootpath = new AlluxioURI("/");
+    List<FileInfo> infos = new ArrayList<>();
+    infos.add(
+        new FileInfo().setLength(10).setInAlluxioPercentage(100).setInMemoryPercentage(50));
+    infos.add(
+        new FileInfo().setLength(30).setInAlluxioPercentage(100).setInMemoryPercentage(100));
+    infos.add(
+        new FileInfo().setLength(20).setInAlluxioPercentage(50).setInMemoryPercentage(0));
+
+    List<URIStatus> statuses = infos.stream().map(URIStatus::new).collect(Collectors.toList());
+    DuCommand.getSizeInfo(rootpath, statuses, false, true, true);
+    String output = mOutput.toString().trim();
+    assertPercentage(output, 83, 58);
+  }
+
+  /**
+   * Matches the output of the du command using a regex pattern.
+   *
+   * The input string to the
+   * @param output the output string from du. If it only has one percentage in the output, it is
+   *               assumed to be the in-alluxio percentage, otherwise it assumed there is both
+   *               in-alluxio and in-memory
+   * @param inAlluxio the expected inAlluxio percentage (0-100)
+   * @param inMem the expected inMem percentage (0-100). Set as a negative value to ignore matching
+   */
+  private static void assertPercentage(String output, int inAlluxio, int inMem) {
+    Matcher matches = OUTPUT_PERCENT.matcher(output);
+    if (!matches.find()) {
+      fail("no group matches for output did not match regex pattern.");
+    }
+    assertEquals(inAlluxio, Integer.parseInt(matches.group(1)));
+
+    if (matches.find() && inMem >= 0) {
+      assertEquals(inMem, Integer.parseInt(matches.group(1)));
+    } else if (inMem >= 0) {
+      fail("Expected to match inMem percentage but did not");
+    }
+  }
+}


### PR DESCRIPTION
Previously, we were always using the "InMemoryPercentage" to calculate the
total amount in Alluxio. This is incorrect. We will now use the proper value
