### PR TITLE
Fix path pattern in local page store

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -68,8 +68,9 @@ public class LocalPageStore implements PageStore {
     mPageSize = options.getPageSize();
     mFileBuckets = options.getFileBuckets();
     Path rootDir = Paths.get(mRoot);
+    // pattern encoding root_path/page_size(ulong)/bucket(uint)/file_id(str)/page_idx(ulong)/
     mPagePattern = Pattern.compile(
-        String.format("%s/%d/(\\d+)/(\\d+)/(\\d+)", Pattern.quote(rootDir.toString()), mPageSize));
+        String.format("%s/%d/(\\d+)/([^/]+)/(\\d+)", Pattern.quote(rootDir.toString()), mPageSize));
     try {
       boolean invalidPage = false;
 
@@ -161,6 +162,7 @@ public class LocalPageStore implements PageStore {
   }
 
   private Path getFilePath(PageId pageId) {
+    // TODO(feng): encode fileId with URLEncoder to escape invalid characters for file name
     return Paths.get(mRoot, Long.toString(mPageSize), getFileBucket(pageId.getFileId()),
         pageId.getFileId(), Long.toString(pageId.getPageIndex()));
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 
 @RunWith(Parameterized.class)
 public class PageStoreTest {
@@ -140,6 +141,23 @@ public class PageStoreTest {
     Set<PageInfo> pages = new HashSet<>(count);
     for (int i = 0; i < count; i++) {
       PageId id = new PageId("0", i);
+      mPageStore.put(id, data);
+      pages.add(new PageInfo(id, data.length));
+    }
+    mPageStore.close();
+    try (PageStore store = PageStore.create(mOptions)) {
+      assertEquals(pages, new HashSet<>(store.getPages()));
+    }
+  }
+
+  @Test
+  public void getPagesUUID() throws Exception {
+    int len = 32;
+    int count = 16;
+    byte[] data = BufferUtils.getIncreasingByteArray(len);
+    Set<PageInfo> pages = new HashSet<>(count);
+    for (int i = 0; i < count; i++) {
+      PageId id = new PageId(UUID.randomUUID().toString(), i);
       mPageStore.put(id, data);
       pages.add(new PageInfo(id, data.length));
     }


### PR DESCRIPTION
The file id in the `LocalPageStore` accepts any string. This fix updates the regex for extracting the ids from path so it accepts more than just digits.