### PR TITLE
Add additional metrics for client cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -22,7 +22,6 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.BufferUtils;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -85,6 +85,7 @@ public class LocalCacheFileInStream extends FileInStream {
         throw new RuntimeException(e);
       }
     }).get();
+    Metrics.registerGauges();
   }
 
   /**
@@ -104,6 +105,7 @@ public class LocalCacheFileInStream extends FileInStream {
     mCacheManager = cacheManager;
     // Lazy init of status object
     mStatus = status;
+    Metrics.registerGauges();
   }
 
   @Override
@@ -162,7 +164,7 @@ public class LocalCacheFileInStream extends FileInStream {
             System.arraycopy(page, currentPageOffset, b, off + bytesRead, bytesLeftInPage);
             bytesRead += bytesLeftInPage;
             mPosition += bytesLeftInPage;
-            Metrics.BYTES_REQUESTED_EXTERNAL.inc(bytesLeftInPage);
+            Metrics.BYTES_REQUESTED_EXTERNAL.mark(bytesLeftInPage);
           }
         }
       }
@@ -237,7 +239,7 @@ public class LocalCacheFileInStream extends FileInStream {
           System.arraycopy(page, currentPageOffset, b, off + bytesRead, bytesLeftInPage);
           bytesRead += bytesLeftInPage;
           currentPosition += bytesLeftInPage;
-          Metrics.BYTES_REQUESTED_EXTERNAL.inc(bytesLeftInPage);
+          Metrics.BYTES_REQUESTED_EXTERNAL.mark(bytesLeftInPage);
         }
       }
     }
@@ -344,7 +346,22 @@ public class LocalCacheFileInStream extends FileInStream {
     private static final Meter BYTES_READ_EXTERNAL =
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_EXTERNAL.getName());
     /** Cache misses. */
-    private static final Counter BYTES_REQUESTED_EXTERNAL =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName());
+    private static final Meter BYTES_REQUESTED_EXTERNAL =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName());
+
+    private static void registerGauges() {
+      // Cache hit rate = Cache hits / (Cache hits + Cache misses).
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricsSystem.getMetricName(MetricKey.CLIENT_CACHE_HIT_RATE.getName()),
+          () -> {
+            long cacheHits = BYTES_READ_CACHE.getCount();
+            long cacheMisses = BYTES_REQUESTED_EXTERNAL.getCount();
+            long total = cacheHits + cacheMisses;
+            if (total > 0) {
+              return cacheHits / (1.0 * total);
+            }
+            return 0;
+          });
+    }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -20,6 +20,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -115,6 +116,7 @@ public class LocalCacheManager implements CacheManager {
     for (int i = 0; i < LOCK_SIZE; i++) {
       mPageLocks[i] = new ReentrantReadWriteLock();
     }
+    Metrics.registerGauges(mCacheSize, mPageStore);
   }
 
   /**
@@ -259,6 +261,7 @@ public class LocalCacheManager implements CacheManager {
           mMetaStore.removePage(pageId);
         } catch (PageNotFoundException e) {
           LOG.error("Failed to delete page {}: {}", pageId, e);
+          Metrics.DELETE_ERRORS.inc();
           return false;
         }
       }
@@ -286,10 +289,11 @@ public class LocalCacheManager implements CacheManager {
       mPageStore.put(pageId, page);
     } catch (IOException e) {
       LOG.error("Failed to add page {}: {}", pageId, e);
+      Metrics.PUT_ERRORS.inc();
       return false;
     }
     mEvictor.updateOnPut(pageId);
-    Metrics.BYTES_WRITTEN_CACHE.inc(page.length);
+    Metrics.BYTES_WRITTEN_CACHE.mark(page.length);
     return true;
   }
 
@@ -306,10 +310,12 @@ public class LocalCacheManager implements CacheManager {
       mPageStore.delete(pageId, pageInfo.getPageSize());
     } catch (IOException | PageNotFoundException e) {
       LOG.error("Failed to delete page {}: {}", pageId, e);
+      Metrics.DELETE_ERRORS.inc();
       return false;
     }
     mEvictor.updateOnDelete(pageId);
-    Metrics.BYTES_EVICTED_CACHE.inc(pageInfo.getPageSize());
+    Metrics.BYTES_EVICTED_CACHE.mark(pageInfo.getPageSize());
+    Metrics.PAGES_EVICTED_CACHE.mark();
     return true;
   }
 
@@ -320,6 +326,7 @@ public class LocalCacheManager implements CacheManager {
       ret = mPageStore.get(pageId, offset);
     } catch (IOException | PageNotFoundException e) {
       LOG.error("Failed to get existing page {}: {}", pageId, e);
+      Metrics.GET_ERRORS.inc();
       return null;
     }
     mEvictor.updateOnGet(pageId);
@@ -328,10 +335,31 @@ public class LocalCacheManager implements CacheManager {
 
   private static final class Metrics {
     /** Bytes written to the cache. */
-    private static final Counter BYTES_WRITTEN_CACHE =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_BYTES_WRITTEN_CACHE.getName());
+    private static final Meter BYTES_WRITTEN_CACHE =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_WRITTEN_CACHE.getName());
     /** Bytes evicted from the cache. */
-    private static final Counter BYTES_EVICTED_CACHE =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_BYTES_EVICTED.getName());
+    private static final Meter BYTES_EVICTED_CACHE =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_EVICTED.getName());
+    /** Pages evicted from the cache. */
+    private static final Meter PAGES_EVICTED_CACHE =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_PAGES_EVICTED.getName());
+    /** Errors when deleting pages. */
+    private static final Counter DELETE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_ERRORS.getName());
+    /** Errors when getting pages. */
+    private static final Counter GET_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_ERRORS.getName());
+    /** Errors when adding pages. */
+    private static final Counter PUT_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_ERRORS.getName());
+
+    private static void registerGauges(long cacheSize, PageStore pageStore) {
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricsSystem.getMetricName(MetricKey.CLIENT_CACHE_SPACE_AVAILABLE.getName()),
+          () -> cacheSize - pageStore.bytes());
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricsSystem.getMetricName(MetricKey.CLIENT_CACHE_SPACE_USED.getName()),
+          pageStore::bytes);
+    }
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -84,7 +84,7 @@ public class LocalCacheFileInStreamTest {
 
   @Before
   public void before() {
-    MetricsSystem.resetCountersAndGauges();
+    MetricsSystem.clearAllMetrics();
   }
 
   @Test
@@ -250,7 +250,7 @@ public class LocalCacheFileInStreamTest {
     stream.read(cacheMiss);
     Assert.assertEquals(0,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).getCount());
-    Assert.assertEquals(readSize, MetricsSystem.counter(
+    Assert.assertEquals(readSize, MetricsSystem.meter(
         MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName()).getCount());
     Assert.assertEquals(fileSize,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_EXTERNAL.getName()).getCount());
@@ -259,7 +259,7 @@ public class LocalCacheFileInStreamTest {
     stream.read();
     Assert.assertEquals(1,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).getCount());
-    Assert.assertEquals(readSize, MetricsSystem.counter(
+    Assert.assertEquals(readSize, MetricsSystem.meter(
         MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName()).getCount());
     Assert.assertEquals(fileSize,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_EXTERNAL.getName()).getCount());

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -773,18 +773,18 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(true)
           .build();
-  // Client local cache metrics
+  // Client cache metrics
   public static final MetricKey CLIENT_CACHE_BYTES_READ_CACHE =
       new Builder(Name.CLIENT_CACHE_BYTES_READ_CACHE)
-          .setDescription("Total number of bytes read from the local cache.")
-          .setMetricType(MetricType.COUNTER)
+          .setDescription("Total number of bytes read from the client cache.")
+          .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_BYTES_READ_EXTERNAL =
       new Builder(Name.CLIENT_CACHE_BYTES_READ_EXTERNAL)
           .setDescription("Total number of bytes read from external storage due to a cache miss "
-              + "on the local cache.")
-          .setMetricType(MetricType.COUNTER)
+              + "on the client cache.")
+          .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL =
@@ -792,21 +792,64 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of bytes the user requested to read which resulted in a "
               + "cache miss. This number may be smaller than "
               + Name.CLIENT_CACHE_BYTES_READ_EXTERNAL + " due to chunk reads.")
-          .setMetricType(MetricType.COUNTER)
+          .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_BYTES_EVICTED =
       new Builder(Name.CLIENT_CACHE_BYTES_EVICTED)
-          .setDescription("Total number of bytes evicted from the local cache.")
-          .setMetricType(MetricType.COUNTER)
+          .setDescription("Total number of bytes evicted from the client cache.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_PAGES_EVICTED =
+      new Builder(Name.CLIENT_CACHE_PAGES_EVICTED)
+          .setDescription("Total number of pages evicted from the client cache.")
+          .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_BYTES_WRITTEN_CACHE =
       new Builder(Name.CLIENT_CACHE_BYTES_WRITTEN_CACHE)
-          .setDescription("Total number of bytes written to the local cache.")
+          .setDescription("Total number of bytes written to the client cache.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_HIT_RATE =
+      new Builder(Name.CLIENT_CACHE_HIT_RATE)
+          .setDescription("Cache hit rate: (# bytes read from cache) / (# bytes requested).")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_SPACE_AVAILABLE =
+      new Builder(Name.CLIENT_CACHE_SPACE_AVAILABLE)
+          .setDescription("Amount of bytes available in the client cache.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_SPACE_USED =
+      new Builder(Name.CLIENT_CACHE_SPACE_USED)
+          .setDescription("Amount of bytes used by the client cache.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_DELETE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_DELETE_ERRORS)
+          .setDescription("Number of failures when deleting cached data in the client cache.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_GET_ERRORS =
+      new Builder(Name.CLIENT_CACHE_GET_ERRORS)
+          .setDescription("Number of failures when getting cached data in the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_PUT_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_ERRORS)
+          .setDescription("Number of failures when putting cached data in the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+
 
   /**
    * Registers the given key to the global key map.
@@ -1005,8 +1048,15 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL
         = "Client.CacheBytesRequestedExternal";
     public static final String CLIENT_CACHE_BYTES_EVICTED = "Client.CacheBytesEvicted";
+    public static final String CLIENT_CACHE_PAGES_EVICTED = "Client.CachePagesEvicted";
     public static final String CLIENT_CACHE_BYTES_WRITTEN_CACHE
         = "Client.CacheBytesWrittenCache";
+    public static final String CLIENT_CACHE_HIT_RATE = "Client.CacheHitRate";
+    public static final String CLIENT_CACHE_SPACE_AVAILABLE = "Client.CacheSpaceAvailable";
+    public static final String CLIENT_CACHE_SPACE_USED = "Client.CacheSpaceUsed";
+    public static final String CLIENT_CACHE_DELETE_ERRORS = "Client.CacheDeleteErrors";
+    public static final String CLIENT_CACHE_GET_ERRORS = "Client.CacheGetErrors";
+    public static final String CLIENT_CACHE_PUT_ERRORS = "Client.CachePutErrors";
 
     private Name() {} // prevent instantiation
   }

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -850,7 +850,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
 
-
   /**
    * Registers the given key to the global key map.
    *


### PR DESCRIPTION
Adds page eviction rate, cache hit rate, space utilization, and error counts.